### PR TITLE
darwin.builder: prefer shutting down over halting VM

### DIFF
--- a/doc/builders/special/darwin-builder.section.md
+++ b/doc/builders/special/darwin-builder.section.md
@@ -39,7 +39,8 @@ nixos login:
 ```
 
 > Note: When you need to stop the VM, type `Ctrl`-`a` + `c` to open the `qemu`
-> prompt and then type `quit` followed by `Enter`
+> prompt and then type `system_powerdown` followed by `Enter`, or run `shutdown now`
+> as the `builder` user (e.g. `ssh -i keys/builder_ed25519 builder@localhost shutdown now`)
 
 To delegate builds to the remote builder, add the following options to your
 `nix.conf` file:

--- a/nixos/modules/profiles/macos-builder.nix
+++ b/nixos/modules/profiles/macos-builder.nix
@@ -122,6 +122,18 @@ in
     isNormalUser = true;
   };
 
+  security.polkit.enable = true;
+
+  security.polkit.extraConfig = ''
+    polkit.addRule(function(action, subject) {
+      if (action.id === "org.freedesktop.login1.power-off" && subject.user === "${user}") {
+        return "yes";
+      } else {
+        return "no";
+      }
+    })
+  '';
+
   virtualisation = {
     diskSize = 20 * 1024;
 

--- a/nixos/modules/profiles/macos-builder.nix
+++ b/nixos/modules/profiles/macos-builder.nix
@@ -9,7 +9,8 @@ let
 
 in
 
-{ imports = [
+{
+  imports = [
     ../virtualisation/qemu-vm.nix
 
     # Avoid a dependency on stateVersion
@@ -18,8 +19,7 @@ in
         ../virtualisation/nixos-containers.nix
         ../services/x11/desktop-managers/xterm.nix
       ];
-      config = {
-      };
+      config = { };
       options.boot.isContainer = lib.mkOption { default = false; internal = true; };
     }
   ];
@@ -98,11 +98,11 @@ in
       '';
 
     in
-      script.overrideAttrs (old: {
-        meta = (old.meta or { }) // {
-          platforms = lib.platforms.darwin;
-        };
-      });
+    script.overrideAttrs (old: {
+      meta = (old.meta or { }) // {
+        platforms = lib.platforms.darwin;
+      };
+    });
 
   system = {
     # To prevent gratuitous rebuilds on each change to Nixpkgs
@@ -118,7 +118,7 @@ in
     '');
   };
 
-  users.users."${user}"= {
+  users.users."${user}" = {
     isNormalUser = true;
   };
 


### PR DESCRIPTION
###### Description of changes

This is preferable because it prevents things like disk corruption (requiring the user to delete the disk image when starting up) that I consistently ran into.

Let me know if the commit structure/wording/etc should be changed (e.g. should I use `darwin.builder` instead of `doc/.../darwin-builder` in the last commit? Your initial commit just said `Add documentation`, and the last commit touching those docs just used `darwin.builder` *shrug*).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
