### PR TITLE
nixos/i2pd: add ssu2 options, addressbook subscriptions, remove deprecated options

### DIFF
--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -114,6 +114,8 @@ let
       ++ (optionalNullString "ifname" cfg.ifname)
       ++ (optionalNullString "ifname4" cfg.ifname4)
       ++ (optionalNullString "ifname6" cfg.ifname6)
+      ++ (optionalNullString "address4" cfg.address4)
+      ++ (optionalNullString "address6" cfg.address6)
       ++ [
       (sec "limits")
       (intOpt "transittunnels" cfg.limits.transittunnels)
@@ -284,6 +286,22 @@ in
         default = null;
         description = lib.mdDoc ''
           Your external IP or hostname.
+        '';
+      };
+
+      address4 = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = lib.mdDoc ''
+          Local IPv4 address to bind transport sockets to.
+        '';
+      };
+
+      address6 = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = lib.mdDoc ''
+          Local IPv6 address to bind transport sockets to.
         '';
       };
 

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -111,8 +111,6 @@ let
       ++ (optionalNullString "datadir" cfg.dataDir)
       ++ (optionalNullInt "share" cfg.share)
       ++ (optionalNullBool "ssu" cfg.ssu)
-      ++ (optionalNullBool "ntcp" cfg.ntcp)
-      ++ (optionalNullString "ntcpproxy" cfg.ntcpProxy)
       ++ (optionalNullString "ifname" cfg.ifname)
       ++ (optionalNullString "ifname4" cfg.ifname4)
       ++ (optionalNullString "ifname6" cfg.ifname6)
@@ -121,9 +119,6 @@ let
       (intOpt "transittunnels" cfg.limits.transittunnels)
       (intOpt "coresize" cfg.limits.coreSize)
       (intOpt "openfiles" cfg.limits.openFiles)
-      (intOpt "ntcphard" cfg.limits.ntcpHard)
-      (intOpt "ntcpsoft" cfg.limits.ntcpSoft)
-      (intOpt "ntcpthreads" cfg.limits.ntcpThreads)
       (sec "upnp")
       (boolOpt "enabled" cfg.upnp.enable)
       (sec "precomputation")
@@ -340,15 +335,6 @@ in
         '';
       };
 
-      ntcpProxy = mkOption {
-        type = with types; nullOr str;
-        default = null;
-        description = lib.mdDoc ''
-          Proxy URL for NTCP transport.
-        '';
-      };
-
-      ntcp = mkEnableTrueOption "ntcp";
       ssu = mkEnableOption (lib.mdDoc "SSU");
 
       ssu2.enable = mkEnableTrueOption "SSU2";
@@ -541,30 +527,6 @@ in
         default = 0;
         description = lib.mdDoc ''
           Maximum number of open files (0 - use system default).
-        '';
-      };
-
-      limits.ntcpHard = mkOption {
-        type = types.int;
-        default = 0;
-        description = lib.mdDoc ''
-          Maximum number of active transit sessions.
-        '';
-      };
-
-      limits.ntcpSoft = mkOption {
-        type = types.int;
-        default = 0;
-        description = lib.mdDoc ''
-          Threshold to start probabalistic backoff with ntcp sessions (default: use system limit).
-        '';
-      };
-
-      limits.ntcpThreads = mkOption {
-        type = types.int;
-        default = 1;
-        description = lib.mdDoc ''
-          Maximum number of threads used by NTCP DH worker.
         '';
       };
 

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -154,7 +154,8 @@ let
       (sec "ntcp2")
       (boolOpt "enabled" cfg.ntcp2.enable)
       (boolOpt "published" cfg.ntcp2.published)
-      (intOpt "port" cfg.ntcp2.port)
+    ] ++ (optionalNullInt "port" cfg.ntcp2.port)
+      ++ [
       (sec "ssu2")
       (boolOpt "enabled" cfg.ssu2.enable)
       (boolOpt "published" cfg.ssu2.published)
@@ -511,10 +512,11 @@ in
       ntcp2.enable = mkEnableTrueOption "NTCP2";
       ntcp2.published = mkEnableOption (lib.mdDoc "NTCP2 publication");
       ntcp2.port = mkOption {
-        type = types.port;
-        default = 0;
+        type = with types; nullOr port;
+        default = null;
         description = lib.mdDoc ''
-          Port to listen for incoming NTCP2 connections (0=auto).
+          Port to listen for incoming NTCP2 connections.
+          Router defaults to the I2P listen port.
         '';
       };
 

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -155,6 +155,11 @@ let
       (boolOpt "enabled" cfg.ntcp2.enable)
       (boolOpt "published" cfg.ntcp2.published)
       (intOpt "port" cfg.ntcp2.port)
+      (sec "ssu2")
+      (boolOpt "enabled" cfg.ssu2.enable)
+      (boolOpt "published" cfg.ssu2.published)
+    ] ++ (optionalNullInt "port" cfg.ssu2.port)
+      ++ [
       (sec "addressbook")
       (strOpt "defaulturl" cfg.addressbook.defaulturl)
     ] ++ (optionalEmptyList "subscriptions" cfg.addressbook.subscriptions)
@@ -344,6 +349,17 @@ in
 
       ntcp = mkEnableTrueOption "ntcp";
       ssu = mkEnableTrueOption "ssu";
+
+      ssu2.enable = mkEnableTrueOption "SSU2";
+      ssu2.published = mkEnableTrueOption (lib.mdDoc "SSU2 publication");
+      ssu2.port = mkOption {
+        type = with types; nullOr port;
+        default = null;
+        description = lib.mdDoc ''
+          Port to listen for incoming SSU2 connections.
+          Router defaults to the I2P listen port or port + 1 if {command}`ssu` is enabled.
+        '';
+      };
 
       notransit = mkEnableOption (lib.mdDoc "notransit") // {
         description = lib.mdDoc ''

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -464,6 +464,8 @@ in
           "http://inr.i2p/export/alive-hosts.txt"
           "http://i2p-projekt.i2p/hosts.txt"
           "http://stats.i2p/cgi-bin/newhosts.txt"
+          "http://reg.i2p/hosts.txt"
+          "http://identiguy.i2p/hosts.txt"
         ];
         description = lib.mdDoc ''
           AddressBook subscription URLs

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -348,7 +348,7 @@ in
       };
 
       ntcp = mkEnableTrueOption "ntcp";
-      ssu = mkEnableTrueOption "ssu";
+      ssu = mkEnableOption (lib.mdDoc "SSU");
 
       ssu2.enable = mkEnableTrueOption "SSU2";
       ssu2.published = mkEnableTrueOption (lib.mdDoc "SSU2 publication");


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Follow the [latest upstream changes](https://github.com/PurpleI2P/i2pd/blob/5dfe483152149cf5dcae9c906585ed3f027f0c02/contrib/i2pd.conf) of default configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
