### PR TITLE
openfec: fix runtime error on darwin

### DIFF
--- a/pkgs/development/libraries/openfec/default.nix
+++ b/pkgs/development/libraries/openfec/default.nix
@@ -27,6 +27,9 @@ stdenv.mkDerivation rec {
       find $dev/include -type f -a ! -iname '*.h' -delete
 
       install -D -m755 -t $out/lib ../bin/Release/libopenfec${so}
+    '' + lib.optionalString stdenv.isDarwin ''
+      install_name_tool -id $out/lib/libopenfec${so} $out/lib/libopenfec${so}
+    '' + ''
       ln -s libopenfec${so} $out/lib/libopenfec${so}.1
     '';
 


### PR DESCRIPTION
###### Description of changes

Prior to this PR, we have

```
$ otool -L result/lib/libopenfec.dylib
result/lib/libopenfec.dylib:
        /tmp/nix-build-openfec-1.4.2.drv-0/source/bin/Release/libopenfec.1.dylib (compatibility version 1.0.0, current version 1.4.2)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.60.1)
```

so any program depending on it will throw a runtime error on darwin.

In particular, this includes the configurePhase of roc-toolkit 0.2.1 (#208352).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
