### PR TITLE
vanilla-dmz: Expose themes under DMZ-{White,Black} names

### DIFF
--- a/pkgs/data/icons/vanilla-dmz/default.nix
+++ b/pkgs/data/icons/vanilla-dmz/default.nix
@@ -25,18 +25,30 @@ stdenvNoCC.mkDerivation rec {
   dontDropIconThemeCache = true;
 
   buildPhase = ''
-    cd DMZ-White/pngs; ./make.sh; cd -
-    cd DMZ-Black/pngs; ./make.sh; cd -
+    runHook preBuild
+
+    for theme in DMZ-{White,Black}; do
+      pushd $theme/pngs
+      ./make.sh
+      popd
+    done
+
+    runHook postBuild
   '';
 
   installPhase = ''
-    install -d $out/share/icons/Vanilla-DMZ/cursors
-    cp -a DMZ-White/xcursors/* $out/share/icons/Vanilla-DMZ/cursors
-    install -Dm644 DMZ-White/index.theme $out/share/icons/Vanilla-DMZ/index.theme
+    runHook preInstall
 
-    install -d $out/share/icons/Vanilla-DMZ-AA/cursors
-    cp -a DMZ-Black/xcursors/* $out/share/icons/Vanilla-DMZ-AA/cursors
-    install -Dm644 DMZ-Black/index.theme $out/share/icons/Vanilla-DMZ-AA/index.theme
+    for theme in DMZ-{White,Black}; do
+      mkdir -p $out/share/icons/$theme/cursors
+      cp -a $theme/xcursors/* $out/share/icons/$theme/cursors/
+      install -m644 $theme/index.theme $out/share/icons/$theme/index.theme
+    done
+
+    ln -s $out/share/icons/{DMZ-White,Vanilla-DMZ}
+    ln -s $out/share/icons/{DMZ-Black,Vanilla-DMZ-AA}
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

[Mir](https://github.com/NixOS/nixpkgs/pull/207534#pullrequestreview-1231577239) and maybe other applications down the Lomiri stack expect these themes to be called `DMZ-White` and `DMZ-Black`, which are also the names of the folders we enter & build these themes in. I don't know why they are called `Vanilla-DMZ` and `Vanilla-DMZ-AA` (I've checked repology, it's also not consistent across other distros) so I'm keeping the Vanilla names via symlinks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
