### PR TITLE
ocamlPackages.brr: init at 0.0.4

### DIFF
--- a/pkgs/development/ocaml-modules/brr/default.nix
+++ b/pkgs/development/ocaml-modules/brr/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchurl
+, ocaml, findlib, ocamlbuild, topkg
+, js_of_ocaml-compiler
+, js_of_ocaml-toplevel
+, note
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-brr";
+  version = "0.0.4";
+  src = fetchurl {
+    url = "https://erratique.ch/software/brr/releases/brr-${version}.tbz";
+    hash = "sha256-v+Ik1tdRBVnNDqhmNoJuLelL3k5OhxIsUorGdTb9sbw=";
+  };
+  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  propagatedBuildInputs = [ js_of_ocaml-compiler js_of_ocaml-toplevel note ];
+  inherit (topkg) buildPhase installPhase;
+
+  meta = {
+    homepage = "https://erratique.ch/software/brr";
+    description = "A toolkit for programming browsers in OCaml";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/development/ocaml-modules/note/default.nix
+++ b/pkgs/development/ocaml-modules/note/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
+
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.08")
+  "note is not available for OCaml ${ocaml.version}"
+
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-note";
+  version = "0.0.2";
+  src = fetchurl {
+    url = "https://erratique.ch/software/note/releases/note-${version}.tbz";
+    hash = "sha256-b35XcaDUXQLqwkNfsJKX5A1q1pAhw/mgdwyOdacZiiY=";
+  };
+  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  inherit (topkg) buildPhase installPhase;
+
+  meta = {
+    homepage = "http://erratique.ch/software/note";
+    description = "An OCaml module for functional reactive programming";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/development/tools/ocaml/js_of_ocaml/toplevel.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/toplevel.nix
@@ -1,0 +1,12 @@
+{ lib, buildDunePackage, js_of_ocaml-compiler, ppxlib }:
+
+buildDunePackage {
+  duneVersion = "3";
+  pname = "js_of_ocaml-toplevel";
+  inherit (js_of_ocaml-compiler) src version;
+  buildInputs = [ ppxlib ];
+  propagatedBuildInputs = [ js_of_ocaml-compiler ];
+  meta = js_of_ocaml-compiler.meta // {
+    mainProgram = "jsoo_mktop";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -98,6 +98,8 @@ let
 
     brisk-reconciler = callPackage ../development/ocaml-modules/brisk-reconciler { };
 
+    brr = callPackage ../development/ocaml-modules/brr { };
+
     bwd = callPackage ../development/ocaml-modules/bwd { };
 
     bz2 = callPackage ../development/ocaml-modules/bz2 { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -660,6 +660,8 @@ let
 
     js_of_ocaml-ppx_deriving_json = callPackage ../development/tools/ocaml/js_of_ocaml/ppx_deriving_json.nix { };
 
+    js_of_ocaml-toplevel = callPackage ../development/tools/ocaml/js_of_ocaml/toplevel.nix {};
+
     js_of_ocaml-tyxml = callPackage ../development/tools/ocaml/js_of_ocaml/tyxml.nix {};
 
     jsonm = callPackage ../development/ocaml-modules/jsonm { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -944,6 +944,8 @@ let
 
     nonstd =  callPackage ../development/ocaml-modules/nonstd { };
 
+    note = callPackage ../development/ocaml-modules/note { };
+
     notty = callPackage ../development/ocaml-modules/notty { };
 
     npy = callPackage ../development/ocaml-modules/npy {


### PR DESCRIPTION
###### Description of changes

https://erratique.ch/software/brr

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
