### PR TITLE
wlcs: init at 1.4.0

### DIFF
--- a/pkgs/development/tools/wlcs/default.nix
+++ b/pkgs/development/tools/wlcs/default.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, lib
+, gitUpdater
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, pkg-config
+, boost
+, gtest
+, wayland
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wlcs";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "MirServer";
+    repo = "wlcs";
+    rev = "v${version}";
+    hash = "sha256-ep5BHa9PgfB50gxJySaw0YAc1upBbncOiX9PCqHLbpE=";
+  };
+
+  patches = [
+    # Fixes pkg-config paths
+    # Remove when https://github.com/MirServer/wlcs/pull/258 merged & in a release
+    (fetchpatch {
+      name = "0001-wlcs-pkgsconfig-use-FULL-install-vars.patch";
+      url = "https://github.com/MirServer/wlcs/pull/258/commits/9002cb7323d94aba7fc1ce5927f445e9beb30d70.patch";
+      hash = "sha256-+uhFRKhG59w99oES4RA+L5hHyJ5pf4ij97pTokERPys=";
+    })
+    (fetchpatch {
+      name = "0002-wlcs-CMAKE_INSTALL_INCLUDEDIR-for-headers.patch";
+      url = "https://github.com/MirServer/wlcs/pull/258/commits/71263172c9ba57be9c05f1e07dd40d1f378ca6d0.patch";
+      hash = "sha256-nV/72W9DW3AvNGhUZ+tzmQZow3BkxEH3D6QFBZIGjj8=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    gtest
+    wayland
+  ];
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
+
+  meta = with lib; {
+    description = "Wayland Conformance Test Suite";
+    longDescription = ''
+      wlcs aspires to be a protocol-conformance-verifying test suite usable by Wayland
+      compositor implementors.
+
+      It is growing out of porting the existing Weston test suite to be run in Mir's
+      test suite, but it is designed to be usable by any compositor.
+
+      wlcs relies on compositors providing an integration module, providing wlcs with
+      API hooks to start a compositor, connect a client, move a window, and so on.
+      This makes both writing and debugging tests easier - the tests are (generally)
+      in the same address space as the compositor, so there is a consistent global
+      clock available, it's easier to poke around in compositor internals, and
+      standard debugging tools can follow control flow from the test client to the
+      compositor and back again.
+    '';
+    homepage = "https://github.com/MirServer/wlcs";
+    changelog = "https://github.com/MirServer/wlcs/releases/tag/v${version}";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ OPNA2608 ];
+    inherit (wayland.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33307,6 +33307,8 @@ with pkgs;
 
   wlclock = callPackage ../applications/misc/wlclock { };
 
+  wlcs = callPackage ../development/tools/wlcs { };
+
   wllvm = callPackage  ../development/tools/wllvm { };
 
   wmname = callPackage ../applications/misc/wmname { };


### PR DESCRIPTION
###### Description of changes

Packages [wlcs](https://github.com/MirServer/wlcs), the Wayland Conformance Test Suite.

No consumer of this yet, but [Mir](https://github.com/NixOS/nixpkgs/pull/207534) will be able to use this in its tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
