### PR TITLE
vaultenv: 0.14 -> 0.15.1.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2142,12 +2142,6 @@ self: super: {
   # https://github.com/zellige/hs-geojson/issues/29
   geojson = dontCheck super.geojson;
 
-  # Doesn't support aeson >= 2.0
-  # https://github.com/channable/vaultenv/issues/118
-  vaultenv = super.vaultenv.overrideScope (self: super: {
-    aeson = self.aeson_1_5_6_0;
-  });
-
   # Support network >= 3.1.2
   # https://github.com/erebe/wstunnel/pull/107
   wstunnel = appendPatch (fetchpatch {

--- a/pkgs/development/tools/haskell/vaultenv/default.nix
+++ b/pkgs/development/tools/haskell/vaultenv/default.nix
@@ -19,6 +19,7 @@
 , parser-combinators
 , retry
 , lib
+, quickcheck-instances
 , text
 , unix
 , unordered-containers
@@ -28,13 +29,13 @@
 }:
 mkDerivation rec {
   pname = "vaultenv";
-  version = "0.14.0";
+  version = "0.15.1";
 
   src = fetchFromGitHub {
     owner = "channable";
     repo = "vaultenv";
     rev = "v${version}";
-    sha256 = "sha256-sH4iaKQXgwI/WISXzMR7xqh9Dyx61U/gjYn7exgUetI=";
+    sha256 = "sha256-yoYkAypH+HQSVTvd/qKNFkL5krbB5mZw3ec9ojvy+Pw=";
   };
 
   buildTools = [ hpack ];
@@ -86,6 +87,7 @@ mkDerivation rec {
     optparse-applicative
     parser-combinators
     retry
+    quickcheck-instances
     text
     unix
     unordered-containers
@@ -96,8 +98,4 @@ mkDerivation rec {
   description = "Runs processes with secrets from HashiCorp Vault";
   license = lib.licenses.bsd3;
   maintainers = with lib.maintainers; [ lnl7 manveru ];
-
-  # Does not compile on ghc92
-  hydraPlatforms = lib.platforms.none;
-  broken = true;
 }


### PR DESCRIPTION
###### Description of changes

Fixes the build with GHC 9.2.x.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

