### PR TITLE
prometheus-xmpp-alerts: Fix broken binary

### DIFF
--- a/pkgs/servers/monitoring/prometheus/xmpp-alerts.nix
+++ b/pkgs/servers/monitoring/prometheus/xmpp-alerts.nix
@@ -2,6 +2,9 @@
 , fetchFromGitHub
 , python3Packages
 , prometheus-alertmanager
+, fetchpatch
+, runCommand
+, prometheus-xmpp-alerts
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -14,6 +17,16 @@ python3Packages.buildPythonApplication rec {
     rev = "v${version}";
     sha256 = "sha256-PwShGS1rbfZCK5OS6Cnn+mduOpWAD4fC69mcGB5GB1c=";
   };
+
+  patches = [
+    # Required until https://github.com/jelmer/prometheus-xmpp-alerts/pull/33 is merged
+    # and contained in a release
+    (fetchpatch {
+      name = "Fix-outdated-entrypoint-definiton.patch";
+      url = "https://github.com/jelmer/prometheus-xmpp-alerts/commit/c41dd41dbd3c781b874bcf0708f6976e6252b621.patch";
+      hash = "sha256-G7fRLSXbkI5EDgGf4n9xSVs54IPD0ev8rTEFffRvLY0=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace setup.cfg \
@@ -38,6 +51,14 @@ python3Packages.buildPythonApplication rec {
   ];
 
   pythonImportsCheck = [ "prometheus_xmpp" ];
+
+  passthru.tests = {
+    binaryWorks = runCommand "${pname}-binary-test" {} ''
+      # Running with --help to avoid it erroring due to a missing config file
+      ${prometheus-xmpp-alerts}/bin/prometheus-xmpp-alerts --help | tee $out
+      grep "usage: prometheus-xmpp-alerts" $out
+    '';
+  };
 
   meta = {
     description = "XMPP Web hook for Prometheus";


### PR DESCRIPTION
###### Description of changes

The binary was broken after the update to 0.5.6 (#205559) due to a regression in upstream (the module name was changed but not updated in the appropriate entrypoint). A patch is applied until fixed in upstream (See jelmer/prometheus-xmpp-alerts#33). A very simple test should detect future regressions like this and prevent breaking the package and associated module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
