### PR TITLE
vtk: Generate egg-info

### DIFF
--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -2,7 +2,7 @@
 { stdenv, lib, fetchurl, cmake, libGLU, libGL, libX11, xorgproto, libXt, libpng, libtiff
 , fetchpatch
 , enableQt ? false, qtbase, qtx11extras, qttools, qtdeclarative, qtEnv
-, enablePython ? false, pythonInterpreter ? throw "vtk: Python support requested, but no python interpreter was given."
+, enablePython ? false, python ? throw "vtk: Python support requested, but no python interpreter was given."
 # Darwin support
 , Cocoa, CoreServices, DiskArbitration, IOKit, CFNetwork, Security, GLUT, OpenGL
 , ApplicationServices, CoreText, IOSurface, ImageIO, xpc, libobjc
@@ -11,7 +11,7 @@
 let
   inherit (lib) optionalString optionals optional;
 
-  pythonMajor = lib.substring 0 1 pythonInterpreter.pythonVersion;
+  pythonMajor = lib.substring 0 1 python.pythonVersion;
 
 in stdenv.mkDerivation rec {
   pname = "vtk${optionalString enableQt "-qvtk"}";
@@ -47,7 +47,7 @@ in stdenv.mkDerivation rec {
       OpenGL
       GLUT
     ] ++ optionals enablePython [
-      pythonInterpreter
+      python
     ];
   propagatedBuildInputs = optionals stdenv.isDarwin [ libobjc ]
     ++ optionals stdenv.isLinux [ libX11 libGL ];
@@ -87,6 +87,13 @@ in stdenv.mkDerivation rec {
     sed -i 's|COMMAND vtkHashSource|COMMAND "DYLD_LIBRARY_PATH=''${VTK_BINARY_DIR}/lib" ''${VTK_BINARY_DIR}/bin/vtkHashSource-${majorVersion}|' ./Parallel/Core/CMakeLists.txt
     sed -i 's/fprintf(output, shift)/fprintf(output, "%s", shift)/' ./ThirdParty/libxml2/vtklibxml2/xmlschemas.c
     sed -i 's/fprintf(output, shift)/fprintf(output, "%s", shift)/g' ./ThirdParty/libxml2/vtklibxml2/xpath.c
+  '';
+
+  postInstall = optionalString enablePython ''
+    substitute \
+      ${./vtk.egg-info} \
+      $out/lib/python${python.pythonVersion}/site-packages/vtk-${version}.egg-info \
+      --subst-var-by VTK_VER "${version}"
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/vtk/vtk.egg-info
+++ b/pkgs/development/libraries/vtk/vtk.egg-info
@@ -1,0 +1,4 @@
+Metadata-Version: 2.1
+Version: @VTK_VER@
+Summary: VTK is an open-source toolkit for 3D computer graphics, image processing, and visualization
+Platform: UNKNOWN

--- a/pkgs/development/python-modules/mayavi/default.nix
+++ b/pkgs/development/python-modules/mayavi/default.nix
@@ -27,10 +27,6 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    # Discovery of 'vtk' in setuptools is not working properly, due to a missing
-    # .egg-info in the vtk package. It does however import and run just fine.
-    substituteInPlace mayavi/__init__.py --replace "'vtk'" ""
-
     # building the docs fails with the usual Qt xcb error, so skip:
     substituteInPlace setup.py \
       --replace "build.build.run(self)" "build.build.run(self); return"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11905,7 +11905,7 @@ self: super: with self; {
   vt-py = callPackage ../development/python-modules/vt-py { };
 
   vtk = toPythonModule (pkgs.vtk_9.override {
-    pythonInterpreter = python;
+    inherit python;
     enablePython = true;
   });
 


### PR DESCRIPTION
###### Description of changes

VTK's cmake build system fails to generate an `.egg-info` file, which
various libraries in the Python package system (e.g. `pkg_resources`)
would use to identify the package. Work around this by generating an
`egg-info` file ourselves.

This allows us to also drop a workaround in `mayavi`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
