### PR TITLE
fmtoy: unstable-2021-12-24 -> unstable-2022-12-23

### DIFF
--- a/pkgs/tools/audio/fmtoy/default.nix
+++ b/pkgs/tools/audio/fmtoy/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fmtoy";
-  version = "unstable-2021-12-24";
+  version = "unstable-2022-12-23";
 
   src = fetchFromGitHub {
     owner = "vampirefrog";
     repo = "fmtoy";
-    rev = "0de6703b3373eb5bf19fd3deaae889286f330c21";
-    sha256 = "0sr6klkmjd2hd2kyb9y0x986d6lsy8bziizfc6cmhkqcq92fh45c";
+    rev = "78b61b5e9bc0c6874962dc4040456581c9999b36";
+    sha256 = "r5zbr6TCxzDiQvDsLQu/QwNfem1K4Ahaji0yIz/2yl0=";
   };
 
   postPatch = ''
@@ -63,9 +63,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/vampirefrog/fmtoy";
     description = "Tools for FM voices for Yamaha YM chips (OPL, OPM and OPN series)";
-    # Unknown license situation
+    # Unclear if gpl3Only or gpl3Plus
     # https://github.com/vampirefrog/fmtoy/issues/1
-    license = licenses.unfree;
+    license = licenses.gpl3;
     maintainers = with maintainers; [ OPNA2608 ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
###### Description of changes

License now clarified as `gpl3`, unclear of `Only` or `Plus`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
