### PR TITLE
ctpv: init at v1.0

### DIFF
--- a/pkgs/applications/file-managers/lf/ctpv.nix
+++ b/pkgs/applications/file-managers/lf/ctpv.nix
@@ -1,0 +1,41 @@
+{ lib
+, pkgs
+, file
+, openssl
+, stdenv
+, fetchFromGitHub
+, waylandSupport ? stdenv.isLinux
+, x11Support ? stdenv.isLinux
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ctpv";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "NikitaIvanovV";
+    repo = "${pname}";
+    rev = "v${version}";
+    hash = "sha256-0OuskRCBVm8vMd2zH5u5EPABmCOlEv5N4ZZMdc7bAwM=";
+  };
+
+  nativeBuildInputs = [
+    file # libmagic
+    openssl
+  ];
+
+  buildInputs = with pkgs; [
+    ffmpegthumbnailer ffmpeg
+  ] ++ lib.optional waylandSupport [ chafa ]
+    ++ lib.optional x11Support [ ueberzug ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Image previews for lf (list files) file manager";
+    homepage = "https://github.com/NikitaIvanovV/ctpv";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.wesleyjrz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2264,6 +2264,8 @@ with pkgs;
 
   lf = callPackage ../applications/file-managers/lf { };
 
+  ctpv = callPackage ../applications/file-managers/lf/ctpv.nix { };
+
   llama = callPackage ../applications/file-managers/llama { };
 
   mc = callPackage ../applications/file-managers/mc {


### PR DESCRIPTION
###### Description of changes

This package servers as an image previewer for lf (list files) file manager, since there's no available alternative in the nixpkgs repo yet. I tried to add lfimg but I found this program much more simpler to implement as a package, you just need to add these lines into your `lfrc`:

```
set previewer ctpv
set cleaner ctpvclear
&ctpv -s $id
cmd on-quit $ctpv -e $id
```
![screenshot-20221231-203616](https://user-images.githubusercontent.com/60184588/210157619-1823771e-a28b-4262-9d10-6093bcd31604.png)

I haven't add all the optional dependencies to the package, just the necessary to display images and video thumbnails, which are `ueberzug`, `ffmpeg` and `ffmpegthumbnailer`. If the user is on Wayland, `chafa` will be installed instead of `ueberzug`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->