### PR TITLE
rubyPackages.nokogiri: 1.13.9 -> 1.13.10

### DIFF
--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -2124,10 +2124,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0cam1455nmi3fzzpa9ixn2hsim10fbprmj62ajpd6d02mwdprwwn";
+      sha256 = "sha256-0+4A8mwVF2PaFpHH/Ghx3dA+Uy90+FEB9aztwtCZ6Vg=";
       type = "gem";
     };
-    version = "1.13.9";
+    version = "1.13.10";
   };
   octokit = {
     dependencies = ["faraday" "sawyer"];


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2022-23476.

https://github.com/sparklemotion/nokogiri/releases/tag/v1.13.10
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>54 packages built:</summary>
  <ul>
    <li>rubyPackages.actionview</li>
    <li>rubyPackages.cocoapods-coverage</li>
    <li>rubyPackages.cocoapods-testing</li>
    <li>rubyPackages.github-pages</li>
    <li>rubyPackages.html-pipeline</li>
    <li>rubyPackages.jbuilder</li>
    <li>rubyPackages.jekyll-mentions</li>
    <li>rubyPackages.jekyll-webmention_io</li>
    <li>rubyPackages.jemoji</li>
    <li>rubyPackages.loofah</li>
    <li>rubyPackages.nokogiri</li>
    <li>rubyPackages.rails-dom-testing</li>
    <li>rubyPackages.rails-html-sanitizer</li>
    <li>rubyPackages.reverse_markdown</li>
    <li>rubyPackages.slather</li>
    <li>rubyPackages.solargraph</li>
    <li>rubyPackages.webmention</li>
    <li>rubyPackages.xctasks</li>
    <li>rubyPackages_3_0.actionview</li>
    <li>rubyPackages_3_0.cocoapods-coverage</li>
    <li>rubyPackages_3_0.cocoapods-testing</li>
    <li>rubyPackages_3_0.github-pages</li>
    <li>rubyPackages_3_0.html-pipeline</li>
    <li>rubyPackages_3_0.jbuilder</li>
    <li>rubyPackages_3_0.jekyll-mentions</li>
    <li>rubyPackages_3_0.jekyll-webmention_io</li>
    <li>rubyPackages_3_0.jemoji</li>
    <li>rubyPackages_3_0.loofah</li>
    <li>rubyPackages_3_0.nokogiri</li>
    <li>rubyPackages_3_0.rails-dom-testing</li>
    <li>rubyPackages_3_0.rails-html-sanitizer</li>
    <li>rubyPackages_3_0.reverse_markdown</li>
    <li>rubyPackages_3_0.slather</li>
    <li>rubyPackages_3_0.solargraph</li>
    <li>rubyPackages_3_0.webmention</li>
    <li>rubyPackages_3_0.xctasks</li>
    <li>rubyPackages_3_1.actionview</li>
    <li>rubyPackages_3_1.cocoapods-coverage</li>
    <li>rubyPackages_3_1.cocoapods-testing</li>
    <li>rubyPackages_3_1.github-pages</li>
    <li>rubyPackages_3_1.html-pipeline</li>
    <li>rubyPackages_3_1.jbuilder</li>
    <li>rubyPackages_3_1.jekyll-mentions</li>
    <li>rubyPackages_3_1.jekyll-webmention_io</li>
    <li>rubyPackages_3_1.jemoji</li>
    <li>rubyPackages_3_1.loofah</li>
    <li>rubyPackages_3_1.nokogiri</li>
    <li>rubyPackages_3_1.rails-dom-testing</li>
    <li>rubyPackages_3_1.rails-html-sanitizer</li>
    <li>rubyPackages_3_1.reverse_markdown</li>
    <li>rubyPackages_3_1.slather</li>
    <li>rubyPackages_3_1.solargraph</li>
    <li>rubyPackages_3_1.webmention</li>
    <li>rubyPackages_3_1.xctasks</li>
  </ul>
</details>