### PR TITLE
mitmproxy: fix fetchFromGitHub rev

### DIFF
--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -47,8 +47,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "mitmproxy";
     repo = "mitmproxy";
-    rev = "refs/tags/v${version}";
-    sha256 = "sha256-nW/WfiY6uF67qNa95tvNvSv/alP2WmzTk34LEBma/04=";
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-CINKvRnBspciS+wefJB8gzBE13L8CjbYCkmLmTTeYlA=";
   };
 
   propagatedBuildInputs = [
@@ -110,6 +110,10 @@ buildPythonPackage rec {
     "test_flowview"
     # ValueError: Exceeds the limit (4300) for integer string conversion
     "test_roundtrip_big_integer"
+
+    "test_wireguard"
+    "test_commands_exist"
+    "test_statusbar"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
###### Description of changes

mitmproxy was bumped from 8.1.1 to 9.0.1 in #205027, but the actual version built is still 8.1.1:

```
% nix shell nixpkgs\#mitmproxy -c which mitmproxy    
/nix/store/q9wrx1y46vylgylp1g95xmw76ms5cls8-python3.10-mitmproxy-9.0.1/bin/mitmproxy
% nix shell nixpkgs\#mitmproxy -c mitmproxy --version
Mitmproxy: 8.1.1
Python:    3.10.9
OpenSSL:   OpenSSL 1.1.1s  1 Nov 2022
Platform:  Linux-5.15.75-x86_64-with-glibc2.35
% nix shell nixpkgs\#mitmproxy -c mitmweb --mode wireguard
/nix/store/q9wrx1y46vylgylp1g95xmw76ms5cls8-python3.10-mitmproxy-9.0.1/bin/mitmweb: Invalid mode specification: wireguard
```

I think this is because the mitmproxy repo tags releases without “v” starting in 9.0.0, though I have no idea why fetchFromGitHub with “v9.0.1” was getting the old version, since that tag doesn’t exist. Maybe it’s because I’m still on NixOS 22.05, and mitmproxy is still 8.1.1 in nixos-22.05 and nixos-22.11?

This patch fetches the correct version of mitmproxy, making it possible to use the new WireGuard mode, though it introduces a few failing tests that I don’t know how to fix.

```
% nix shell github:delan/nixpkgs/4572ff0cb21bb8798443f6104efc0dce05777681\#mitmproxy -c which mitmproxy 
/nix/store/dk355vm0qrh29131c1bq5k1q4rr5kwj4-python3.10-mitmproxy-9.0.1/bin/mitmproxy
% nix shell github:delan/nixpkgs/4572ff0cb21bb8798443f6104efc0dce05777681\#mitmproxy -c mitmproxy --version
Mitmproxy: 9.0.1
Python:    3.10.9
OpenSSL:   OpenSSL 1.1.1s  1 Nov 2022
Platform:  Linux-5.15.75-x86_64-with-glibc2.35
% nix shell github:delan/nixpkgs/4572ff0cb21bb8798443f6104efc0dce05777681\#mitmproxy -c mitmweb --mode wireguard
[20:54:30.642] WireGuard server listening at *:51820.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (**22.05 only**)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] ~~For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~~
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
