### PR TITLE
highlight-assertions: unstable-2022-11-24 -> 0.1.6

### DIFF
--- a/pkgs/development/tools/misc/highlight-assertions/default.nix
+++ b/pkgs/development/tools/misc/highlight-assertions/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "highlight-assertions";
-  version = "unstable-2022-11-24";
+  version = "0.1.6";
 
   src = fetchFromGitHub {
     owner = "thehamsta";
     repo = pname;
-    rev = "c738a51513285ded4fc16d68afcdb77761543f92";
-    sha256 = "sha256-vYXr0xFwRUwSEP++834A/4M1QB14Wx+qWwB9PUtn3uA=";
+    rev = "v${version}";
+    sha256 = "sha256-OVf8s7zuGj5//zWJIVBfHBoA6zD+l8lqVQGn2vHsvSQ=";
   };
 
-  cargoSha256 = "sha256-sezjd7tmVVDoRsrsTK2zKjHmrBcAQDHyHd/dR1q1za0=";
+  cargoSha256 = "sha256-cS4IbFuxZCKDIAcgiKzBF/qQ6mXZb9omvMeGcU+yWpk=";
 
   # requires nightly features
   RUSTC_BOOTSTRAP = 1;


### PR DESCRIPTION
Diff: https://github.com/thehamsta/highlight-assertions/compare/c738a51513285ded4fc16d68afcdb77761543f92...v0.1.6

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
