### PR TITLE
runescape-launcher: Switch to openssl_1_1

### DIFF
--- a/pkgs/games/runescape-launcher/default.nix
+++ b/pkgs/games/runescape-launcher/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, buildFHSUserEnv, dpkg, glibc, gcc-unwrapped, autoPatchelfHook, fetchurl, wrapGAppsHook
 , gnome2, xorg
-, libSM, libXxf86vm, libX11, glib, pango, cairo, gtk2-x11, zlib, openssl
+, libSM, libXxf86vm, libX11, glib, pango, cairo, gtk2-x11, zlib, openssl_1_1
 , libpulseaudio
 , SDL2, xorg_sys_opengl, libGL
 }:
@@ -34,7 +34,7 @@ let
       cairo
       gtk2-x11
       zlib
-      openssl
+      openssl_1_1
     ];
 
     runtimeDependencies = [
@@ -42,7 +42,7 @@ let
       libGL
       SDL2
       xorg_sys_opengl
-      openssl
+      openssl_1_1
       zlib
     ];
 
@@ -96,7 +96,7 @@ in
     targetPkgs = pkgs: [
       runescape
       dpkg glibc gcc-unwrapped
-      libSM libXxf86vm libX11 glib pango cairo gtk2-x11 zlib openssl
+      libSM libXxf86vm libX11 glib pango cairo gtk2-x11 zlib openssl_1_1
       libpulseaudio
       xorg.libX11
       SDL2 xorg_sys_opengl libGL


### PR DESCRIPTION
###### Description of changes

The Runescape launcher requires 1.1.x versions of openssl libs (specifically libssl.so.1.1 and libcrypto.so.1.1). The default
openssl package being v3.x.y was too new and caused the build to fail:

```
➜ NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#runescape
error: builder for '/nix/store/dbfd14rn10q1zzzrgsa4q5sj7ay4ix74-runescape-launcher-2.2.9.drv' failed with exit code 1;
       last 10 log lines:
       >     libssl.so.1.1 -> not found!
       > setting RPATH to: /nix/store/ww063smpzmc6jmhflflqs35g7gp1j9fx-libpulseaudio-16.1/lib:/nix/store/i027wgp2ny82nazj51f54vww5yy2ji4m-libGL-1.5.0/lib:/nix/store/4llb4ymwy2p7nwlq7imivwk7n2373zdq-SDL2-2.24.2/lib:/nix/store/ab7iw88gv02cagydszf1hv5hvzyngkqj-xorg-sys-opengl-3/lib:/nix/store/10vrgdkvgnp04wmfw0ky48g08x8qc3ry-openssl-3.0.7-bin/lib:/nix/store/zaflwh2nwzj1f0wngd7hqm3nvlf3yhsx-zlib-1.2.13/lib:/nix/store/dqsgifv5pjfja5qzh9rjih1vqmfj86n9-libSM-1.2.3/lib:/nix/store/5w2y5c19p1a1a38q741b0b9k8k2zbr66-libXxf86vm-1.1.4/lib:/nix/store/3zk3527zglm18ykrvgjdhgz3a4zrfapr-libX11-1.8.1/lib:/nix/store/61qy7d70070djqcg135l22v18a5py758-glib-2.74.3/lib:/nix/store/f5aabxaygxrmdnz62s61ypiid2xbczw2-pango-1.50.12/lib:/nix/store/gxi7vciip7198vgjpkn754kbyip6azni-gdk-pixbuf-2.42.10/lib:/nix/store/n2vak5lsywj8kgyp7r9361pnc150p0vf-cairo-1.16.0/lib:/nix/store/wz14i9kz0ick2an8v2391x67d6iw65kn-gtk+-2.24.33/lib:/nix/store/9vfggw8qmvdxhb1yj9yf8crqndg5xc08-libcap-2.66-lib/lib
       > setting interpreter of /nix/store/r9y8rw36jasf8l0d8xz6iivrga3dcz0x-runescape-launcher-2.2.9/bin/runescape-launcher
       > searching for dependencies of /nix/store/r9y8rw36jasf8l0d8xz6iivrga3dcz0x-runescape-launcher-2.2.9/bin/runescape-launcher
       > setting RPATH to: /nix/store/ww063smpzmc6jmhflflqs35g7gp1j9fx-libpulseaudio-16.1/lib:/nix/store/i027wgp2ny82nazj51f54vww5yy2ji4m-libGL-1.5.0/lib:/nix/store/4llb4ymwy2p7nwlq7imivwk7n2373zdq-SDL2-2.24.2/lib:/nix/store/ab7iw88gv02cagydszf1hv5hvzyngkqj-xorg-sys-opengl-3/lib:/nix/store/10vrgdkvgnp04wmfw0ky48g08x8qc3ry-openssl-3.0.7-bin/lib:/nix/store/zaflwh2nwzj1f0wngd7hqm3nvlf3yhsx-zlib-1.2.13/lib
       > auto-patchelf: 2 dependencies could not be satisfied
       > error: auto-patchelf could not satisfy dependency libcrypto.so.1.1 wanted by /nix/store/r9y8rw36jasf8l0d8xz6iivrga3dcz0x-runescape-launcher-2.2.9/share/games/runescape-launcher/runescape
       > error: auto-patchelf could not satisfy dependency libssl.so.1.1 wanted by /nix/store/r9y8rw36jasf8l0d8xz6iivrga3dcz0x-runescape-launcher-2.2.9/share/games/runescape-launcher/runescape
       > auto-patchelf failed to find all the required dependencies.
       > Add the missing dependencies to --libs or use `--ignore-missing="foo.so.1 bar.so etc.so"`.
       For full logs, run 'nix log /nix/store/dbfd14rn10q1zzzrgsa4q5sj7ay4ix74-runescape-launcher-2.2.9.drv'.
error: 1 dependencies of derivation '/nix/store/1ywl322vc6qm6gvwfiyrlp0vbqlv1m9j-RuneScape.drv' failed to build
```

Using `openssl_1_1` instead fixes the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).