### PR TITLE
runescape-launcher: fix clicking web links in the launcher

### DIFF
--- a/pkgs/games/runescape-launcher/default.nix
+++ b/pkgs/games/runescape-launcher/default.nix
@@ -19,6 +19,7 @@
 , pango
 , SDL2
 , wrapGAppsHook
+, xdg-utils
 , xorg
 , xorg_sys_opengl
 , zlib
@@ -61,6 +62,7 @@ let
       libpulseaudio
       SDL2
       openssl_1_1
+      xdg-utils # The launcher uses `xdg-open` to open HTTP URLs in the user's browser
       xorg_sys_opengl
       zlib
     ];
@@ -128,6 +130,7 @@ in
       openssl_1_1
       pango
       SDL2
+      xdg-utils
       xorg.libX11
       xorg_sys_opengl
       zlib

--- a/pkgs/games/runescape-launcher/default.nix
+++ b/pkgs/games/runescape-launcher/default.nix
@@ -1,8 +1,27 @@
-{ stdenv, lib, buildFHSUserEnv, dpkg, glibc, gcc-unwrapped, autoPatchelfHook, fetchurl, wrapGAppsHook
-, gnome2, xorg
-, libSM, libXxf86vm, libX11, glib, pango, cairo, gtk2-x11, zlib, openssl_1_1
+{ stdenv
+, lib
+, autoPatchelfHook
+, buildFHSUserEnv
+, cairo
+, dpkg
+, fetchurl
+, gcc-unwrapped
+, glib
+, glibc
+, gnome2
+, gtk2-x11
+, libGL
 , libpulseaudio
-, SDL2, xorg_sys_opengl, libGL
+, libSM
+, libXxf86vm
+, libX11
+, openssl_1_1
+, pango
+, SDL2
+, wrapGAppsHook
+, xorg
+, xorg_sys_opengl
+, zlib
 }:
 let
 
@@ -19,30 +38,30 @@ let
 
     nativeBuildInputs = [
       autoPatchelfHook
-      wrapGAppsHook
       dpkg
+      wrapGAppsHook
     ];
 
     buildInputs = [
-      glibc
+      cairo
       gcc-unwrapped
+      glib
+      glibc
+      gtk2-x11
       libSM
       libXxf86vm
       libX11
-      glib
-      pango
-      cairo
-      gtk2-x11
-      zlib
       openssl_1_1
+      pango
+      zlib
     ];
 
     runtimeDependencies = [
-      libpulseaudio
       libGL
+      libpulseaudio
       SDL2
-      xorg_sys_opengl
       openssl_1_1
+      xorg_sys_opengl
       zlib
     ];
 
@@ -95,11 +114,23 @@ in
     name = "RuneScape";
     targetPkgs = pkgs: [
       runescape
-      dpkg glibc gcc-unwrapped
-      libSM libXxf86vm libX11 glib pango cairo gtk2-x11 zlib openssl_1_1
+      cairo
+      dpkg
+      gcc-unwrapped
+      glib
+      glibc
+      gtk2-x11
+      libGL
       libpulseaudio
+      libSM
+      libXxf86vm
+      libX11
+      openssl_1_1
+      pango
+      SDL2
       xorg.libX11
-      SDL2 xorg_sys_opengl libGL
+      xorg_sys_opengl
+      zlib
     ];
     multiPkgs = pkgs: [ libGL ];
     runScript = "runescape-launcher";


### PR DESCRIPTION
###### Description of changes

This PR fixes the behaviour of clicking web links in the runescape launcher. The launcher attempts to call `xdg-open <url>` when clicking a link in the UI, which will fail if `xdg-open` is not installed. This PR installs `xdg-open` into the environment, and clicking links now works.

This PR includes a commit that organises the list of installed packages, so it can be difficult to review all changes. The commit to review that installs `xdg-open` is 409eff0adba49bcf9fade2bf4b0821eb628bb962.

~~**Note:** The build of this derivation will fail until https://github.com/NixOS/nixpkgs/pull/208642 is merged.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
