### PR TITLE
dataexplorer: pin jdk17

### DIFF
--- a/pkgs/applications/science/electronics/dataexplorer/default.nix
+++ b/pkgs/applications/science/electronics/dataexplorer/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchurl
 , jdk
-, jre
 , ant
 , makeWrapper
 }:
@@ -37,11 +36,11 @@ stdenv.mkDerivation rec {
     # but it hardcodes bash shebang and does not pin the java path.
     # So we create our own wrapper, using similar cmdline args as upstream.
     mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/DataExplorer \
+    makeWrapper ${jdk}/bin/java $out/bin/DataExplorer \
       --add-flags "-Xms64m -Xmx3092m -jar $out/share/DataExplorer/DataExplorer.jar" \
       --set SWT_GTK3 0
 
-    makeWrapper ${jre}/bin/java $out/bin/DevicePropertiesEditor \
+    makeWrapper ${jdk}/bin/java $out/bin/DevicePropertiesEditor \
       --add-flags "-Xms32m -Xmx512m -classpath $out/share/DataExplorer/DataExplorer.jar gde.ui.dialog.edit.DevicePropertiesEditor" \
       --set SWT_GTK3 0 \
       --set LIBOVERLAY_SCROLLBAR 0

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36311,7 +36311,10 @@ with pkgs;
 
   csxcad = callPackage ../applications/science/electronics/csxcad { };
 
-  dataexplorer = callPackage ../applications/science/electronics/dataexplorer { };
+  dataexplorer = callPackage ../applications/science/electronics/dataexplorer {
+    # executable fails at startup for jdk > 17
+    jdk = jdk17;
+  };
 
   diylc = callPackage ../applications/science/electronics/diylc { };
 


### PR DESCRIPTION
###### Description of changes

Since the default jdk changed to jdk19, DataExplorer fails at startup:

```console
$ ./result/bin/DataExplorer
java.lang.NullPointerException: Cannot read field "width" because the return value of "gde.config.Settings.getWindow()" is null
	at gde.ui.DataExplorer.execute(DataExplorer.java:406)
	at gde.GDE.main(GDE.java:544)
```

Therefore, pin to jdk17, which is also the latest recommended version by upstream:

> The only requirement is the installation of a Java run-time of version
> 8 to Java 17 for the 32 bit versions and Java 11 to 17 for the 64 bit
> versions, such as IcedTea or open JDK.

https://www.nongnu.org/dataexplorer/index.html#Introduction

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).