### PR TITLE
python3Packages.looker-sdk: init at 23.2.0

### DIFF
--- a/pkgs/development/python-modules/looker-sdk/default.nix
+++ b/pkgs/development/python-modules/looker-sdk/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, attrs
+, cattrs
+, exceptiongroup
+, pillow
+, pytest-mock
+, pyyaml
+, requests
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "looker-sdk";
+  version = "23.2.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "looker-open-source";
+    repo = "sdk-codegen";
+    rev = "sdk-v${version}";
+    hash = "sha256-b34eH27hn3DdN3RwC+lz0dIxIRfIl5RnS9SfJnSP7NM=";
+  };
+  sourceRoot = "source/python";
+
+  propagatedBuildInputs = [
+    attrs
+    cattrs
+    exceptiongroup
+    requests
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "looker_sdk"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pillow
+    pytest-mock
+    pyyaml
+  ];
+
+  # disable tests that attempt to actually communicate with the api
+  disabledTestPaths = [
+    "tests/integration/test_methods.py"
+    "tests/integration/test_netrc.py"
+    "tests/rtl/test_api_methods.py"
+  ];
+
+  meta = with lib; {
+    description = "Looker REST API SDK for Python";
+    homepage = "https://github.com/looker-open-source/sdk-codegen/tree/main/python";
+    changelog = "https://github.com/looker-open-source/sdk-codegen/blob/main/python/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5670,6 +5670,8 @@ self: super: with self; {
 
   lomond = callPackage ../development/python-modules/lomond { };
 
+  looker-sdk = callPackage ../development/python-modules/looker-sdk { };
+
   loopy = callPackage ../development/python-modules/loopy { };
 
   losant-rest = callPackage ../development/python-modules/losant-rest { };


### PR DESCRIPTION
###### Description of changes

I would like to be able to use the looker-sdk [python library](https://github.com/looker-open-source/sdk-codegen/tree/main/python) to interact with [Looker](https://www.looker.com/) from within nixpkgs!

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
