### PR TITLE
python3Packages.lox: init at 0.11.0

### DIFF
--- a/pkgs/development/python-modules/lox/default.nix
+++ b/pkgs/development/python-modules/lox/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, sphinxHook
+, sphinx-rtd-theme
+, pytest-benchmark
+, pytest-mock
+, py
+, pathos
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "lox";
+  version = "0.11.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "BrianPugh";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-kXfFRIFI1OcbDc1LujbFo/Iqg7pgwtXLkIcIFA9nehs=";
+  };
+
+  # patch out pytest-runner and invalid pytest args
+  preBuild = ''
+    sed -i '/pytest-runner/d' ./setup.py
+    sed -i '/collect_ignore/d' ./setup.cfg
+  '';
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  nativeBuildInputs = [
+    sphinxHook
+    sphinx-rtd-theme
+  ];
+
+  nativeCheckInputs = [
+    py
+    pytestCheckHook
+    pytest-benchmark
+    pytest-mock
+  ];
+
+  propagatedBuildInputs = [
+    pathos
+    tqdm
+  ];
+
+  pythonImportsCheck = [
+    "lox"
+  ];
+
+  meta = with lib; {
+    description = "Threading and Multiprocessing made easy";
+    homepage = "https://github.com/BrianPugh/lox";
+    changelog = "https://github.com/BrianPugh/lox/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5674,6 +5674,8 @@ self: super: with self; {
 
   losant-rest = callPackage ../development/python-modules/losant-rest { };
 
+  lox = callPackage ../development/python-modules/lox { };
+
   lrcalc-python = callPackage ../development/python-modules/lrcalc-python { };
 
   lru-dict = callPackage ../development/python-modules/lru-dict { };


### PR DESCRIPTION
###### Description of changes

I would like to be able to use the [lox python library](https://github.com/BrianPugh/lox) for nicer syntactic sugar for multi-threading+processing from within nixpkgs!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
