### PR TITLE
avr-gcc, simavr: fix build on Darwin

### DIFF
--- a/pkgs/development/compilers/gcc/11/avr-gcc-11.3-darwin.patch
+++ b/pkgs/development/compilers/gcc/11/avr-gcc-11.3-darwin.patch
@@ -1,0 +1,20 @@
+--- a/gcc/config/avr/avr.c	2022-10-08 19:18:33.000000000 +0200
++++ b/gcc/config/avr/avr.patched.c	2022-10-08 19:19:34.000000000 +0200
+@@ -10196,7 +10196,7 @@
+    to track need of __do_copy_data.  */
+ 
+ static void
+-avr_output_data_section_asm_op (const void *data)
++avr_output_data_section_asm_op (const char *data)
+ {
+   avr_need_copy_data_p = true;
+ 
+@@ -10209,7 +10209,7 @@
+    to track need of __do_clear_bss.  */
+ 
+ static void
+-avr_output_bss_section_asm_op (const void *data)
++avr_output_bss_section_asm_op (const char *data)
+ {
+   avr_need_clear_bss_p = true;
+ 

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -72,6 +72,8 @@ let majorVersion = "11";
           sha256 = "sha256-LFAXUEoYD7YeCG8V9mWanygyQOI7U5OhCRIKOVCCDAg=";
         })
       ]
+      # https://github.com/osx-cross/homebrew-avr/issues/280#issuecomment-1272381808
+      ++ optional (stdenv.isDarwin && targetPlatform.isAvr) ./avr-gcc-11.3-darwin.patch
 
       # Obtain latest patch with ../update-mcfgthread-patches.sh
       ++ optional (!crossStageStatic && targetPlatform.isMinGW && threadsCross.model == "mcf") ./Added-mcf-thread-model-support-from-mcfgthread.patch;

--- a/pkgs/development/tools/simavr/default.nix
+++ b/pkgs/development/tools/simavr/default.nix
@@ -1,9 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, libelf, which, pkg-config, freeglut
+{ lib, stdenv, makeSetupHook, fetchFromGitHub, libelf, which, pkg-config, freeglut
 , avrgcc, avrlibc
 , libGLU, libGL
 , GLUT }:
 
-stdenv.mkDerivation rec {
+let
+  setupHookDarwin = makeSetupHook {
+    name = "darwin-avr-gcc-hook";
+    substitutions = {
+      darwinSuffixSalt = stdenv.cc.suffixSalt;
+      avrSuffixSalt = avrgcc.suffixSalt;
+    };
+  } ./setup-hook-darwin.sh;
+in stdenv.mkDerivation rec {
   pname = "simavr";
   version = "1.7";
 
@@ -22,9 +30,8 @@ stdenv.mkDerivation rec {
     "AVR=avr-"
   ];
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=stringop-truncation" ];
-
-  nativeBuildInputs = [ which pkg-config avrgcc ];
+  nativeBuildInputs = [ which pkg-config avrgcc ]
+    ++ lib.optional stdenv.isDarwin setupHookDarwin;
   buildInputs = [ libelf freeglut libGLU libGL ]
     ++ lib.optional stdenv.isDarwin GLUT;
 
@@ -35,7 +42,6 @@ stdenv.mkDerivation rec {
   checkTarget = "-C tests run_tests";
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "A lean and mean Atmel AVR simulator";
     homepage    = "https://github.com/buserror/simavr";
     license     = licenses.gpl3;

--- a/pkgs/development/tools/simavr/setup-hook-darwin.sh
+++ b/pkgs/development/tools/simavr/setup-hook-darwin.sh
@@ -1,0 +1,34 @@
+
+fixupCFlagsForDarwin() {
+    # Because it’s getting called from a Darwin stdenv, avr-gcc will pick up on
+    # Darwin-specific flags, and it will barf and die on -iframework in
+    # particular. Strip them out, so simavr can compile its test firmware.
+    cflagsFilter='s|-F[^ ]*||g;s|-iframework [^ ]*||g;s|-isystem [^ ]*||g;s|  *| |g'
+
+    # The `CoreFoundation` reference is added by `linkSystemCoreFoundationFramework` in the
+    # Apple SDK’s setup hook. Remove that because avr-gcc will fail due to file not found.
+    ldFlagsFilter='s|/nix/store/[^-]*-apple-framework-CoreFoundation[^ ]*||g'
+
+    # `cc-wrapper.sh`` supports getting flags from a system-specific salt. While it is currently a
+    # tuple, that’s not considered a stable interface, so the derivation will provide them.
+    export NIX_CFLAGS_COMPILE_@darwinSuffixSalt@=${NIX_CFLAGS_COMPILE-}
+    export NIX_LDFLAGS_@darwinSuffixSalt@=${NIX_LDFLAGS-}
+
+    echo removing @darwinSuffixSalt@-specific flags from NIX_CFLAGS_COMPILE for @avrSuffixSalt@
+    export NIX_CFLAGS_COMPILE_@avrSuffixSalt@+="$(sed "$cflagsFilter" <<< "$NIX_CFLAGS_COMPILE")"
+    echo removing @darwinSuffixSalt@-specific flags from NIX_LDFLAGS for @avrSuffixSalt@
+    export NIX_LDFLAGS_@avrSuffixSalt@+="$(sed "$ldFlagsFilter;$cflagsFilter" <<< "$NIX_LDFLAGS")"
+
+    # Make sure the global flags aren’t accidentally influencing the platform-specific flags.
+    export NIX_CFLAGS_COMPILE=""
+    export NIX_LDFLAGS=""
+}
+
+# This is pretty hacky, but this hook _must_ run after `linkSystemCoreFoundationFramework`.
+function runFixupCFlagsForDarwinLast() {
+    preConfigureHooks+=(fixupCFlagsForDarwin)
+}
+
+if [ -z "${dontFixupCFlagsForDarwin-}" ]; then
+    postUnpackHooks+=(runFixupCFlagsForDarwinLast)
+fi


### PR DESCRIPTION
###### Description of changes

Fix issues preventing build of the AVR C compiler and simulator on Darwin.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
