### PR TITLE
vimPlugins: only commit nvim-treesitter updates when there are actually updates

### DIFF
--- a/pkgs/applications/editors/vim/plugins/update.py
+++ b/pkgs/applications/editors/vim/plugins/update.py
@@ -137,11 +137,15 @@ def main():
         subprocess.check_call([nvim_treesitter_dir.joinpath("update.py")])
 
         if editor.nixpkgs_repo:
-            msg = "vimPlugins.nvim-treesitter: update grammars"
-            print(f"committing to nixpkgs: {msg}")
             index = editor.nixpkgs_repo.index
-            index.add([str(nvim_treesitter_dir.joinpath("generated.nix"))])
-            index.commit(msg)
+            for diff in index.diff(None):
+                if diff.a_path == "pkgs/applications/editors/vim/plugins/nvim-treesitter/generated.nix":
+                    msg = "vimPlugins.nvim-treesitter: update grammars"
+                    print(f"committing to nixpkgs: {msg}")
+                    index.add([str(nvim_treesitter_dir.joinpath("generated.nix"))])
+                    index.commit(msg)
+                    return
+            print("no updates to nvim-treesitter grammars")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
###### Description of changes

https://github.com/NixOS/nixpkgs/pull/208664#issuecomment-1368528277: https://github.com/NixOS/nixpkgs/commit/60178cff85b503653fab18f54ed7d65c0fd59f90
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
