### PR TITLE
lib: Fix mismatched quotes in `lib.*` doc comments

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -88,7 +88,7 @@ rec {
         else { ${elemAt attrPath n} = atDepth (n + 1); };
     in atDepth 0;
 
-  /* Like `attrByPath', but without a default value. If it doesn't find the
+  /* Like `attrByPath`, but without a default value. If it doesn't find the
      path it will throw an error.
 
      Example:
@@ -274,7 +274,7 @@ rec {
     # The set to get the named attributes from
     attrs: genAttrs names (name: attrs.${name});
 
-  /* Collect each attribute named `attr' from a list of attribute
+  /* Collect each attribute named `attr` from a list of attribute
      sets.  Sets that don't contain the named attribute are ignored.
 
      Example:
@@ -357,8 +357,8 @@ rec {
     ) {} list_of_attrs;
 
 
-  /* Recursively collect sets that verify a given predicate named `pred'
-     from the set `attrs'.  The recursion is stopped when the predicate is
+  /* Recursively collect sets that verify a given predicate named `pred`
+     from the set `attrs`.  The recursion is stopped when the predicate is
      verified.
 
      Example:
@@ -439,9 +439,9 @@ rec {
       listToAttrs (map (attr: { name = attr; value = f attr set.${attr}; }) (attrNames set)));
 
 
-  /* Like `mapAttrs', but allows the name of each attribute to be
+  /* Like `mapAttrs`, but allows the name of each attribute to be
      changed in addition to the value.  The applied function should
-     return both the new name and value as a `nameValuePair'.
+     return both the new name and value as a `nameValuePair`.
 
      Example:
        mapAttrs' (name: value: nameValuePair ("foo_" + name) ("bar-" + value))
@@ -479,7 +479,7 @@ rec {
     map (name: f name attrs.${name}) (attrNames attrs);
 
 
-  /* Like `mapAttrs', except that it recursively applies itself to
+  /* Like `mapAttrs`, except that it recursively applies itself to
      attribute sets.  Also, the first argument of the argument
      function is a *list* of the names of the containing attributes.
 
@@ -499,9 +499,9 @@ rec {
     mapAttrsRecursiveCond (as: true) f set;
 
 
-  /* Like `mapAttrsRecursive', but it takes an additional predicate
+  /* Like `mapAttrsRecursive`, but it takes an additional predicate
      function that tells it whether to recurse into an attribute
-     set.  If it returns false, `mapAttrsRecursiveCond' does not
+     set.  If it returns false, `mapAttrsRecursiveCond` does not
      recurse, but does apply the map function.  If it returns true, it
      does recurse, and does not apply the map function.
 
@@ -655,7 +655,7 @@ rec {
 
   /* Merge sets of attributes and combine each attribute value in to a list.
 
-     Like `lib.attrsets.zipAttrsWith' with `(name: values: values)' as the function.
+     Like `lib.attrsets.zipAttrsWith` with `(name: values: values)` as the function.
 
      Example:
        zipAttrs [{a = "x";} {a = "y"; b = "z";}]

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -3,13 +3,13 @@
 rec {
 
 
-  /* `overrideDerivation drv f' takes a derivation (i.e., the result
-     of a call to the builtin function `derivation') and returns a new
+  /* `overrideDerivation drv f` takes a derivation (i.e., the result
+     of a call to the builtin function `derivation`) and returns a new
      derivation in which the attributes of the original are overridden
-     according to the function `f'.  The function `f' is called with
+     according to the function `f`.  The function `f` is called with
      the original derivation attributes.
 
-     `overrideDerivation' allows certain "ad-hoc" customisation
+     `overrideDerivation` allows certain "ad-hoc" customisation
      scenarios (e.g. in ~/.config/nixpkgs/config.nix).  For instance,
      if you want to "patch" the derivation returned by a package
      function in Nixpkgs to build another version than what the
@@ -104,10 +104,10 @@ rec {
       else result;
 
 
-  /* Call the package function in the file `fn' with the required
+  /* Call the package function in the file `fn` with the required
     arguments automatically.  The function is called with the
-    arguments `args', but any missing arguments are obtained from
-    `autoArgs'.  This function is intended to be partially
+    arguments `args`, but any missing arguments are obtained from
+    `autoArgs`.  This function is intended to be partially
     parameterised, e.g.,
 
       callPackage = callPackageWith pkgs;
@@ -116,9 +116,9 @@ rec {
         libbar = callPackage ./bar.nix { };
       };
 
-    If the `libbar' function expects an argument named `libfoo', it is
+    If the `libbar` function expects an argument named `libfoo`, it is
     automatically passed as an argument.  Overrides or missing
-    arguments can be supplied in `args', e.g.
+    arguments can be supplied in `args`, e.g.
 
       libbar = callPackage ./bar.nix {
         libfoo = null;
@@ -255,13 +255,13 @@ rec {
     in lib.deepSeq drv' drv';
 
   /* Make a set of packages with a common scope. All packages called
-     with the provided `callPackage' will be evaluated with the same
+     with the provided `callPackage` will be evaluated with the same
      arguments. Any package in the set may depend on any other. The
      `overrideScope'` function allows subsequent modification of the package
      set in a consistent way, i.e. all packages in the set will be
      called with the overridden packages. The package sets may be
      hierarchical: the packages in the set are called with the scope
-     provided by `newScope' and the set provides a `newScope' attribute
+     provided by `newScope` and the set provides a `newScope` attribute
      which can form the parent scope for later package sets. */
   makeScope = newScope: f:
     let self = f self // {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,7 +1,7 @@
 /* Library of low-level helper functions for nix expressions.
  *
  * Please implement (mostly) exhaustive unit tests
- * for new functions in `./tests.nix'.
+ * for new functions in `./tests.nix`.
  */
 let
 

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -242,7 +242,7 @@ rec {
 
   /* Return a singleton list or an empty list, depending on a boolean
      value.  Useful when building lists with optional elements
-     (e.g. `++ optional (system == "i686-linux") firefox').
+     (e.g. `++ optional (system == "i686-linux") firefox`).
 
      Type: optional :: bool -> a -> [a]
 
@@ -283,7 +283,7 @@ rec {
   */
   toList = x: if isList x then x else [x];
 
-  /* Return a list of integers from `first' up to and including `last'.
+  /* Return a list of integers from `first` up to and including `last`.
 
      Type: range :: int -> int -> [int]
 
@@ -320,7 +320,7 @@ rec {
     ) { right = []; wrong = []; });
 
   /* Splits the elements of a list into many lists, using the return value of a predicate.
-     Predicate should return a string which becomes keys of attrset `groupBy' returns.
+     Predicate should return a string which becomes keys of attrset `groupBy` returns.
 
      `groupBy'` allows to customise the combining function and initial value
 

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -27,7 +27,7 @@ rec {
   setName = name: drv: drv // {inherit name;};
 
 
-  /* Like `setName', but takes the previous name as an argument.
+  /* Like `setName`, but takes the previous name as an argument.
 
      Example:
        updateName (oldName: oldName + "-experimental") somePkg


### PR DESCRIPTION
###### Description of changes

These caused problems for automated rich text generation such as [teu5us/nix-lib-html-reference](https://github.com/teu5us/nix-lib-html-reference) ([sample output](https://teu5us.github.io/nix-lib.html#customisation-functions)).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
