### PR TITLE
python3Packages.pykep: init at 2.6

### DIFF
--- a/pkgs/development/python-modules/pykep/default.nix
+++ b/pkgs/development/python-modules/pykep/default.nix
@@ -1,0 +1,116 @@
+{ lib
+, stdenv
+, toPythonModule
+, fetchFromGitHub
+, cmake
+, boost
+
+# Python package dependencies:
+, matplotlib
+, numba
+, scikit-learn
+, scipy
+}:
+
+let
+  version = "2.6";
+  src = fetchFromGitHub {
+    owner = "esa";
+    repo = "pykep";
+    rev = "v${version}";
+    sha256 = "sha256-iqCge8WX3WEFbf4BmCHU0EV3HFv1O8L7CNNt2q88yfc=";
+  };
+
+  mkMetaWithSuffix = suffix: with lib; {
+    description = "scientific library providing basic tools for research in interplanetary trajectory design (${suffix})";
+    homepage = "https://esa.github.io/pykep";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ nh2 ];
+  };
+
+  # Note [split-pykep]:
+  #
+  # The package is split into 2 parts: The C++ "keplerian_toolbox",
+  # and the Python "pykep", controlled by the CMake variables
+  #     -DPYKEP_BUILD_KEP_TOOLBOX=yes/no
+  #     -DPYKEP_BUILD_PYKEP=yes/no
+  # as described on:
+  # https://esa.github.io/pykep/installation.html#installation-from-source
+  #
+  # > They cannot be on at the same time, and only one must be chosen.
+  # see: # https://github.com/esa/pykep/blob/6425e53f0efd74997a7ad6873791f355e2ae2e93/CMakeLists.txt#L19-L20
+  #
+  # The dependencies are taken from:
+  # https://esa.github.io/pykep/installation.html#dependencies
+
+  keplerian_toolbox = stdenv.mkDerivation rec {
+    pname = "keplerian_toolbox";
+
+    inherit version;
+    inherit src;
+
+    cmakeFlags = [
+      # From:
+      #     https://esa.github.io/pykep/installation.html#installation-from-source
+      "-DBoost_NO_BOOST_CMAKE=ON"
+
+      # Part 1 from [split-pykep]
+      "-DPYKEP_BUILD_KEP_TOOLBOX=yes"
+      "-DPYKEP_BUILD_PYKEP=no"
+      "-DPYKEP_BUILD_SPICE=yes"
+    ];
+
+    nativeBuildInputs = [
+      cmake
+    ];
+
+    buildInputs = [
+      boost
+    ];
+
+    doCheck = true;
+
+    meta = mkMetaWithSuffix "C++ part";
+  };
+
+  pykep = toPythonModule (stdenv.mkDerivation rec {
+    pname = "pykep";
+
+    inherit version;
+    inherit src;
+
+    cmakeFlags = [
+      # From:
+      #     https://esa.github.io/pykep/installation.html#installation-from-source
+      "-DBoost_NO_BOOST_CMAKE=ON"
+
+      # Part 2 from https://esa.github.io/pykep/installation.html#installation-from-source
+      "-DPYKEP_BUILD_KEP_TOOLBOX=no"
+      "-DPYKEP_BUILD_PYKEP=yes"
+      "-DPYKEP_BUILD_TESTS=no"
+    ];
+
+    nativeBuildInputs = [
+      cmake
+    ];
+
+    buildInputs = [
+      keplerian_toolbox
+    ];
+
+    propagatedBuildInputs = [
+      boost
+      matplotlib
+      numba
+      scikit-learn
+      scipy
+    ];
+
+    doCheck = true;
+
+    pythonImportsCheck = [ "pykep" ];
+
+    meta = mkMetaWithSuffix "C++ part";
+  });
+in
+  pykep

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8025,6 +8025,8 @@ self: super: with self; {
 
   pykerberos = callPackage ../development/python-modules/pykerberos { };
 
+  pykep = callPackage ../development/python-modules/pykep { };
+
   pykeyatome = callPackage ../development/python-modules/pykeyatome { };
 
   pykira = callPackage ../development/python-modules/pykira { };


### PR DESCRIPTION
###### Description of changes

Adds `pykep`: https://esa.github.io/pykep/index.html

Similar to `pygmo`, also from ESA.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
    - I built it on `nixos-21.11`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
    - [x] `pythonImportsCheck`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
