### PR TITLE
qgis, qgis-ltr: disable qtwebkit by default and correctly link grass

### DIFF
--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -28,11 +28,12 @@
 , qtkeychain
 , qt3d
 , qscintilla
+, qtlocation
 , qtserialport
 , qtxmlpatterns
 , withGrass ? true
 , grass
-, withWebKit ? true
+, withWebKit ? false
 , qtwebkit
 , pdal
 , zstd
@@ -109,6 +110,7 @@ in mkDerivation rec {
     qca-qt5
     qtkeychain
     qscintilla
+    qtlocation
     qtserialport
     qtxmlpatterns
     qt3d

--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -134,7 +134,11 @@ in mkDerivation rec {
     "-DWITH_3D=True"
     "-DWITH_PDAL=TRUE"
   ] ++ lib.optional (!withWebKit) "-DWITH_QTWEBKIT=OFF"
-    ++ lib.optional withGrass "-DGRASS_PREFIX7=${grass}/grass78";
+    ++ lib.optional withGrass (let
+        gmajor = lib.versions.major grass.version;
+        gminor = lib.versions.minor grass.version;
+      in "-DGRASS_PREFIX${gmajor}=${grass}/grass${gmajor}${gminor}"
+    );
 
   dontWrapGApps = true; # wrapper params passed below
 

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -28,11 +28,12 @@
 , qtkeychain
 , qt3d
 , qscintilla
+, qtlocation
 , qtserialport
 , qtxmlpatterns
 , withGrass ? true
 , grass
-, withWebKit ? true
+, withWebKit ? false
 , qtwebkit
 , pdal
 , zstd
@@ -109,6 +110,7 @@ in mkDerivation rec {
     qca-qt5
     qtkeychain
     qscintilla
+    qtlocation
     qtserialport
     qtxmlpatterns
     qt3d

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -134,7 +134,11 @@ in mkDerivation rec {
     "-DWITH_3D=True"
     "-DWITH_PDAL=TRUE"
   ] ++ lib.optional (!withWebKit) "-DWITH_QTWEBKIT=OFF"
-    ++ lib.optional withGrass "-DGRASS_PREFIX7=${grass}/grass78";
+    ++ lib.optional withGrass (let
+        gmajor = lib.versions.major grass.version;
+        gminor = lib.versions.minor grass.version;
+      in "-DGRASS_PREFIX${gmajor}=${grass}/grass${gmajor}${gminor}"
+    );
 
   dontWrapGApps = true; # wrapper params passed below
 


### PR DESCRIPTION
###### Description of changes

Qtwebkit has been marked as having known vulnerabilities. https://github.com/NixOS/nixpkgs/issues/53079

Qtlocation was propagated from qtwebkit, so now it needs to be explicitly added. Without it, the build fails. [[qtwebkit definition](https://github.com/NixOS/nixpkgs/blob/fbe696daecc11816905841c59c97c61c4547cfa7/pkgs/development/libraries/qt-5/modules/qtwebkit.nix#L26)][[qtModule definition](https://github.com/NixOS/nixpkgs/blob/fbe696daecc11816905841c59c97c61c4547cfa7/pkgs/development/libraries/qt-5/qtModule.nix#L20)]

Also, the corresponding change done for archlinux https://github.com/archlinux/svntogit-community/commit/783d52696588264257eed9d32c9fd212d0fdeace

For the grass change. I am not too sure if it does anything, but the path was wrong. 



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
