### PR TITLE
nixos/etc: skip resolv.conf in nixos-enter chroot

### DIFF
--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -13,8 +13,12 @@ sub atomicSymlink {
     my $tmp = "$target.tmp";
     unlink $tmp;
     symlink $source, $tmp or return 0;
-    rename $tmp, $target or return 0;
-    return 1;
+    if (rename $tmp, $target) {
+        return 1;
+    } else {
+        unlink $tmp;
+        return 0;
+    }
 }
 
 
@@ -87,6 +91,12 @@ my @copied;
 
 sub link {
     my $fn = substr $File::Find::name, length($etc) + 1 or next;
+
+    # nixos-enter sets up /etc/resolv.conf as a bind mount, so skip it.
+    if ($fn eq "resolv.conf" and $ENV{'IN_NIXOS_ENTER'}) {
+        return;
+    }
+
     my $target = "/etc/$fn";
     File::Path::make_path(dirname $target);
     $created{$fn} = 1;
@@ -103,7 +113,7 @@ sub link {
     if (-e "$_.mode") {
         my $mode = read_file("$_.mode"); chomp $mode;
         if ($mode eq "direct-symlink") {
-            atomicSymlink readlink("$static/$fn"), $target or warn;
+            atomicSymlink readlink("$static/$fn"), $target or warn "could not create symlink $target";
         } else {
             my $uid = read_file("$_.uid"); chomp $uid;
             my $gid = read_file("$_.gid"); chomp $gid;
@@ -112,12 +122,15 @@ sub link {
             $gid = getgrnam $gid unless $gid =~ /^\+/;
             chown int($uid), int($gid), "$target.tmp" or warn;
             chmod oct($mode), "$target.tmp" or warn;
-            rename "$target.tmp", $target or warn;
+            unless (rename "$target.tmp", $target) {
+                warn "could not create target $target";
+                unlink "$target.tmp";
+            }
         }
         push @copied, $fn;
         print CLEAN "$fn\n";
     } elsif (-l "$_") {
-        atomicSymlink "$static/$fn", $target or warn;
+        atomicSymlink "$static/$fn", $target or warn "could not create symlink $target";
     }
 }
 


### PR DESCRIPTION
nixos-enter [sets up](https://github.com/NixOS/nixpkgs/blob/41b390e0b3605b1709bf9d4407c4f14174a9f5bc/nixos/modules/installer/tools/nixos-enter.sh#L88) /etc/resolv.conf as a bind mount from the host system, so trying to activate a system that sets
`environment.etc."resolv.conf"` (e.g. with systemd-resolved enabled) results in an unhelpful warning.

Skip linking /etc/resolv.conf if we're in a nixos-enter environment, as determined by the [IN_NIXOS_ENTER](https://github.com/NixOS/nixpkgs/blob/41b390e0b3605b1709bf9d4407c4f14174a9f5bc/nixos/modules/installer/tools/nixos-enter.sh#L101) environment variable (its first use in nixpkgs!).

Make the warnings more helpful, indicating which file we failed to link.

Unlink temporary files manually in case of failure.