### PR TITLE
ocamlPackages.toml: 7.0.0 → 7.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/toml/default.nix
+++ b/pkgs/development/ocaml-modules/toml/default.nix
@@ -1,22 +1,18 @@
-{ lib, fetchFromGitHub, fetchpatch, buildDunePackage
+{ lib, fetchFromGitHub, buildDunePackage
 , iso8601, menhir
 }:
 
 buildDunePackage rec {
   pname = "toml";
-  version = "7.0.0";
+  version = "7.1.0";
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "ocaml-toml";
     repo = "to.ml";
     rev = version;
-    sha256 = "sha256-VEZQTFPwAGShCBGbKUiNOIY1zA/JdTpXU0ZIGNWopnQ=";
-  };
-
-  # Ensure compatibility with menhir ≥ 20211215
-  patches = fetchpatch {
-    url = "https://github.com/ocaml-toml/To.ml/commit/41172b739dff43424a12f7c1f0f64939e3660648.patch";
-    sha256 = "sha256:1333xkmm9qp5m3pp4y5w17k6rvmb30v62qyra6rfk1km2v28hqqq";
+    hash = "sha256-uk14Py7lEEDJhFsRRtStXqKlJLtx0o8eS9DEIes4SHw=";
   };
 
   nativeBuildInputs = [ menhir ];


### PR DESCRIPTION
###### Description of changes

https://github.com/ocaml-toml/To.ml/blob/7.1.0/CHANGES.md#710

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
