### PR TITLE
xtreemfs: unbreak on aarch64-linux

### DIFF
--- a/pkgs/tools/filesystems/xtreemfs/default.nix
+++ b/pkgs/tools/filesystems/xtreemfs/default.nix
@@ -9,7 +9,7 @@
 , cmake
 , file
 , fuse
-, jdk
+, jdk8
 , openssl
 , python3
 , valgrind
@@ -17,30 +17,49 @@
 }:
 
 stdenv.mkDerivation {
+  pname = "XtreemFS";
+  # using unstable release because stable (v1.5.1) has broken repl java plugin
+  version = "unstable-2015-06-17";
+
   src = fetchFromGitHub {
-    # using unstable release because stable (v1.5.1) has broken repl java plugin
     rev = "7ddcb081aa125b0cfb008dc98addd260b8353ab3";
     owner = "xtreemfs";
     repo = "xtreemfs";
     sha256 = "1hjmd32pla27zf98ghzz6r5ml8ry86m9dsryv1z01kxv5l95b3m0";
   };
 
-  pname = "XtreemFS";
-  version = "1.5.1.81";
-
   nativeBuildInputs = [ makeWrapper python3 ];
   buildInputs = [ which attr ];
 
   patches = [
     (fetchpatch {
+      name = "protobuf-add-arm64-atomicops.patch";
+      url = "https://github.com/protocolbuffers/protobuf/commit/2ca19bd8066821a56f193e7fca47139b25c617ad.patch";
+      stripLen = 1;
+      extraPrefix = "cpp/thirdparty/protobuf-2.5.0/";
+      sha256 = "sha256-hlL5ZiJhpO3fPpcSTV+yki4zahg/OhFdIZEGF1TNTe0=";
+    })
+    (fetchpatch {
+      name = "protobuf-add-aarch64-architecture-to-platform-macros.patch";
+      url = "https://github.com/protocolbuffers/protobuf/commit/f0b6a5cfeb5f6347c34975446bda08e0c20c9902.patch";
+      stripLen = 1;
+      extraPrefix = "cpp/thirdparty/protobuf-2.5.0/";
+      sha256 = "sha256-VRl303x9g5ES/LMODcAdhsPiEmQTq/qXhE/DfvLXF84=";
+    })
+    (fetchpatch {
+      name = "xtreemfs-fix-for-boost-version-1.66.patch";
+      url = "https://github.com/xtreemfs/xtreemfs/commit/aab843cb115ab0739edf7f58fd2d4553a05374a8.patch";
+      sha256 = "sha256-y/vXI/PT1TwSy8/73+RKIgKq4pZ9i22MBxr6jo/M5l8=";
+    })
+    (fetchpatch {
+      name = "xtreemfs-fix-for-openssl_1_1.patch";
       url = "https://github.com/xtreemfs/xtreemfs/commit/ebfdc2fff56c09f310159d92026883941e42a953.patch";
       sha256 = "075w00ad88qm6xpm5679m0gfzkrc53w17sk7ycybf4hzxjs29ygy";
-      name = "xtreemfs-fix-for-openssl_1_1";
     })
   ];
 
   preConfigure = ''
-    export JAVA_HOME=${jdk}
+    export JAVA_HOME=${jdk8}
     export ANT_HOME=${ant}
 
     export BOOST_INCLUDEDIR=${boost.dev}/include
@@ -90,7 +109,5 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [ raskin matejc ];
     platforms = lib.platforms.linux;
     license = lib.licenses.bsd3;
-    # never built on aarch64-linux since first introduction in nixpkgs
-    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13339,8 +13339,7 @@ with pkgs;
   };
 
   xtreemfs = callPackage ../tools/filesystems/xtreemfs {
-    boost = boost165;
-    jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
+    boost = boost17x;
   };
 
   xurls = callPackage ../tools/text/xurls {};


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
