### PR TITLE
paperless-ngx: fix build

### DIFF
--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -258,6 +258,7 @@ in
         PrivateNetwork = false;
       };
       environment = env;
+      after = [ "paperless-scheduler.service" ];
     };
 
     # Reading the user-provided password file requires root access

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -212,14 +212,14 @@ in
 
     systemd.services.paperless-scheduler = {
       description = "Paperless Celery Beat";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "paperless-consumer.service" "paperless-web.service" "paperless-task-queue.service" ];
       serviceConfig = defaultServiceConfig // {
         User = cfg.user;
         ExecStart = "${pkg}/bin/celery --app paperless beat --loglevel INFO";
         Restart = "on-failure";
       };
       environment = env;
-      wantedBy = [ "multi-user.target" ];
-      wants = [ "paperless-consumer.service" "paperless-web.service" "paperless-task-queue.service" ];
 
       preStart = ''
         ln -sf ${manage} ${cfg.dataDir}/paperless-manage
@@ -248,6 +248,7 @@ in
 
     systemd.services.paperless-task-queue = {
       description = "Paperless Celery Workers";
+      after = [ "paperless-scheduler.service" ];
       serviceConfig = defaultServiceConfig // {
         User = cfg.user;
         ExecStart = "${pkg}/bin/celery --app paperless worker --loglevel INFO";
@@ -258,7 +259,6 @@ in
         PrivateNetwork = false;
       };
       environment = env;
-      after = [ "paperless-scheduler.service" ];
     };
 
     # Reading the user-provided password file requires root access
@@ -276,20 +276,24 @@ in
 
     systemd.services.paperless-consumer = {
       description = "Paperless document consumer";
+      # Bind to `paperless-scheduler` so that the consumer never runs
+      # during migrations
+      bindsTo = [ "paperless-scheduler.service" ];
+      after = [ "paperless-scheduler.service" ];
       serviceConfig = defaultServiceConfig // {
         User = cfg.user;
         ExecStart = "${pkg}/bin/paperless-ngx document_consumer";
         Restart = "on-failure";
       };
       environment = env;
-      # Bind to `paperless-scheduler` so that the consumer never runs
-      # during migrations
-      bindsTo = [ "paperless-scheduler.service" ];
-      after = [ "paperless-scheduler.service" ];
     };
 
     systemd.services.paperless-web = {
       description = "Paperless web server";
+      # Bind to `paperless-scheduler` so that the web server never runs
+      # during migrations
+      bindsTo = [ "paperless-scheduler.service" ];
+      after = [ "paperless-scheduler.service" ];
       serviceConfig = defaultServiceConfig // {
         User = cfg.user;
         ExecStart = ''
@@ -313,10 +317,6 @@ in
       # Allow the web interface to access the private /tmp directory of the server.
       # This is required to support uploading files via the web interface.
       unitConfig.JoinsNamespaceOf = "paperless-task-queue.service";
-      # Bind to `paperless-scheduler` so that the web server never runs
-      # during migrations
-      bindsTo = [ "paperless-scheduler.service" ];
-      after = [ "paperless-scheduler.service" ];
     };
 
     users = optionalAttrs (cfg.user == defaultUser) {

--- a/nixos/tests/paperless.nix
+++ b/nixos/tests/paperless.nix
@@ -26,6 +26,10 @@ import ./make-test-python.nix ({ lib, ... }: {
         # Wait until server accepts connections
         machine.wait_until_succeeds("curl -fs localhost:28981")
 
+    # Required for consuming documents via the web interface
+    with subtest("Task-queue gets ready"):
+        machine.wait_for_unit("paperless-task-queue.service")
+
     with subtest("Add a document via the web interface"):
         machine.succeed(
             "convert -size 400x40 xc:white -font 'DejaVu-Sans' -pointsize 20 -fill black "

--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -10,6 +10,7 @@
 , qpdf
 , tesseract5
 , unpaper
+, poppler_utils
 , liberation_ttf
 , fetchFromGitHub
 }:
@@ -75,6 +76,7 @@ let
     qpdf
     tesseract5
     unpaper
+    poppler_utils
   ];
 in
 python.pkgs.pythonPackages.buildPythonApplication rec {


### PR DESCRIPTION
###### Description of changes

Build of `paperless-ngx` fails on current master with:

```
―― TestBarcode.test_scan_file_for_separating_barcodes_pillow_transcode_error ―――
[gw27] linux -- Python 3.10.9 /nix/store/al6g1zbk8li6p8mcyp0h60d08jaahf8c-python3-3.10.9/bin/python3.10
self = <documents.tests.test_barcodes.TestBarcode testMethod=test_scan_file_for_separating_barcodes_pillow_transcode_error>

    def test_scan_file_for_separating_barcodes_pillow_transcode_error(self):
        """
        GIVEN:
            - A PDF containing an image which cannot be transcoded to a PIL image
        WHEN:
            - The image tries to be transcoded to a PIL image, but fails
        THEN:
            - The barcode reader is still called
        """

        def _build_device_n_pdf(self, save_path: str):
            # Based on the pikepdf tests
            # https://github.com/pikepdf/pikepdf/blob/abb35ebe17d579d76abe08265e00cf8890a12a95/tests/test_image_access.py
            pdf = pikepdf.new()
            pdf.add_blank_page(page_size=(72, 72))
            imobj = pikepdf.Stream(
                pdf,
                bytes(range(0, 256)),
                BitsPerComponent=8,
                ColorSpace=pikepdf.Array(
                    [
                        pikepdf.Name.DeviceN,
                        pikepdf.Array([pikepdf.Name.Black]),
                        pikepdf.Name.DeviceCMYK,
                        pikepdf.Stream(
                            pdf,
                            b"{0 0 0 4 -1 roll}",  # Colorspace conversion function
                            FunctionType=4,
                            Domain=[0.0, 1.0],
                            Range=[0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
                        ),
                    ],
                ),
                Width=16,
                Height=16,
                Type=pikepdf.Name.XObject,
                Subtype=pikepdf.Name.Image,
            )
            pim = pikepdf.PdfImage(imobj)
            self.assertEqual(pim.mode, "DeviceN")
            self.assertTrue(pim.is_device_n)

            pdf.pages[0].Contents = pikepdf.Stream(pdf, b"72 0 0 72 0 0 cm /Im0 Do")
            pdf.pages[0].Resources = pikepdf.Dictionary(
                XObject=pikepdf.Dictionary(Im0=imobj),
            )
            pdf.save(save_path)

        with tempfile.NamedTemporaryFile(suffix="pdf") as device_n_pdf:
            # Build an offending file
            _build_device_n_pdf(self, str(device_n_pdf.name))
            with mock.patch("documents.barcodes.barcode_reader") as reader:
                reader.return_value = list()

                _, _ = barcodes.scan_file_for_separating_barcodes(
                    str(device_n_pdf.name),
                )

>               reader.assert_called()

src/documents/tests/test_barcodes.py:280:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <MagicMock name='barcode_reader' id='140737330582848'>

    def assert_called(self):
        """assert that the mock was called at least once
        """
        if self.call_count == 0:
            msg = ("Expected '%s' to have been called." %
                   (self._mock_name or 'mock'))
>           raise AssertionError(msg)
E           AssertionError: Expected 'barcode_reader' to have been called.

/nix/store/al6g1zbk8li6p8mcyp0h60d08jaahf8c-python3-3.10.9/lib/python3.10/unittest/mock.py:898: AssertionError
----------------------------- Captured stderr call -----------------------------
[2023-01-02 08:45:26,070] [WARNING] [paperless.barcodes] Falling back to pdf2image because:
[2023-01-02 08:45:26,074] [WARNING] [paperless.barcodes] Exception during barcode scanning: Unable to get page count. Is poppler installed and in PATH?
------------------------------ Captured log call -------------------------------
DEBUG    paperless.barcodes:barcodes.py:71 Detected mime type: application/pdf
WARNING  paperless.barcodes:barcodes.py:171 Falling back to pdf2image because:
WARNING  paperless.barcodes:barcodes.py:181 Exception during barcode scanning: Unable to get page count. Is poppler installed and in PATH?
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
