### PR TITLE
talloc: 2.3.3 -> 2.3.4

### DIFF
--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -13,12 +13,16 @@
 
 stdenv.mkDerivation rec {
   pname = "talloc";
-  version = "2.3.3";
+  version = "2.3.4";
 
   src = fetchurl {
     url = "mirror://samba/talloc/${pname}-${version}.tar.gz";
-    sha256 = "sha256-a+lbI2i9CvHEzXqIFG62zuoY5Gw//JMwv2JitA0diqo=";
+    sha256 = "sha256-F5+eviZeZ+SrLCbK0rfeS2p3xsIS+WaQM4KGnwa+ZQU=";
   };
+
+  patches = [
+    ./talloc-deterministic.patch
+  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -36,6 +40,11 @@ stdenv.mkDerivation rec {
     libxslt
     libxcrypt
   ];
+
+  preConfigure = ''
+    export PKGCONFIG="$PKG_CONFIG"
+    export PYTHONHASHSEED=1
+  '';
 
   wafPath = "buildtools/bin/waf";
 

--- a/pkgs/development/libraries/talloc/talloc-deterministic.patch
+++ b/pkgs/development/libraries/talloc/talloc-deterministic.patch
@@ -1,0 +1,18 @@
+--- a/talloc.c    2022-12-30 20:18:37
++++ b/talloc.c.new        2022-12-30 20:18:53
+@@ -387,13 +387,6 @@
+ }
+
+ #ifdef HAVE_CONSTRUCTOR_ATTRIBUTE
+-#define CONSTRUCTOR __attribute__((constructor))
+-#elif defined(HAVE_PRAGMA_INIT)
+-#define CONSTRUCTOR
+-#pragma init (talloc_lib_init)
+-#endif
+-#if defined(HAVE_CONSTRUCTOR_ATTRIBUTE) || defined(HAVE_PRAGMA_INIT)
+-void talloc_lib_init(void) CONSTRUCTOR;
+ void talloc_lib_init(void)
+ {
+        uint32_t random_value;
+
+

--- a/pkgs/development/python-modules/django-scim2/default.nix
+++ b/pkgs/development/python-modules/django-scim2/default.nix
@@ -4,10 +4,9 @@
 
 # propagates
 , django
-, dateutil
 , scim2-filter-parser
 , gssapi
-, ldap
+, ldap3
 , sssd
 
 # tests
@@ -28,10 +27,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     django
-    dateutil
     scim2-filter-parser
     gssapi
-    ldap
+    ldap3
     sssd
   ];
 

--- a/pkgs/servers/samba/4.x-fix-talloc-magic-randomization.patch
+++ b/pkgs/servers/samba/4.x-fix-talloc-magic-randomization.patch
@@ -1,0 +1,18 @@
+--- a/lib/talloc/talloc.c    2022-12-30 20:18:37
++++ b/lib/talloc/talloc.c.new        2022-12-30 20:18:53
+@@ -387,13 +387,6 @@
+ }
+
+ #ifdef HAVE_CONSTRUCTOR_ATTRIBUTE
+-#define CONSTRUCTOR __attribute__((constructor))
+-#elif defined(HAVE_PRAGMA_INIT)
+-#define CONSTRUCTOR
+-#pragma init (talloc_lib_init)
+-#endif
+-#if defined(HAVE_CONSTRUCTOR_ATTRIBUTE) || defined(HAVE_PRAGMA_INIT)
+-void talloc_lib_init(void) CONSTRUCTOR;
+ void talloc_lib_init(void)
+ {
+        uint32_t random_value;
+
+

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation rec {
     ./4.x-no-persistent-install-dynconfig.patch
     ./4.x-fix-makeflags-parsing.patch
     ./build-find-pre-built-heimdal-build-tools-in-case-of-.patch
+    ./4.x-fix-talloc-magic-randomization.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

this also addresses an issue with the initialization of `talloc` for `sssd`/ `samba` that was discussed in https://github.com/NixOS/nixpkgs/issues/205859 . These changes where derived from @kangaroo 's gist: https://gist.github.com/kangaroo/0bc1611503d03e407e2c70647e1359dc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
