### PR TITLE
jxrlib: migrate to cmake

### DIFF
--- a/pkgs/development/libraries/jxrlib/default.nix
+++ b/pkgs/development/libraries/jxrlib/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, python3, fixDarwinDylibNames }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "jxrlib";
@@ -13,20 +13,24 @@ stdenv.mkDerivation rec {
     sha256 = "0rk3hbh00nw0wgbfbqk1szrlfg3yq7w6ar16napww3nrlm9cj65w";
   };
 
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace "cc" "$CC"
-  '' + lib.optionalString stdenv.isDarwin ''
-    substituteInPlace Makefile \
-      --replace '-shared' '-dynamiclib -undefined dynamic_lookup' \
-      --replace '.so' '.dylib'
-  '';
+  patches = [
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian-phototools-team/jxrlib/-/raw/df96f9b9c1fbe9cdc97589c337f8a948bc81c4d0/debian/patches/usecmake.patch";
+      sha256 = "sha256-BpCToLgA5856PZk5mXlwAy3Oh9aYP/2wvu2DXDTqufM=";
+    })
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian-phototools-team/jxrlib/-/raw/6c88037293aff8d5bc8a76ea32b36781c430ede3/debian/patches/bug803743.patch";
+      sha256 = "sha256-omIGa+ZrWjaH/IkBn4jgjufF/HEDKw69anVCX4hw+xQ=";
+    })
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian-phototools-team/jxrlib/-/raw/b23d49062ec6a9b2739c9dade86be525a72fc807/debian/patches/pkg-config.patch";
+      sha256 = "sha256-ZACaXEi+rbKIFBHtSBheyFfqV2HYsKKrT+SmTShyUhg=";
+    })
+  ];
 
-  nativeBuildInputs = [ python3 ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
+  nativeBuildInputs = [ cmake ];
 
   strictDeps = true;
-
-  makeFlags = [ "DIR_INSTALL=$(out)" "SHARED=1" ];
 
   meta = with lib; {
     description = "Implementation of the JPEG XR image codec standard";


### PR DESCRIPTION
###### Description of changes

Closes #206953.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
