### PR TITLE
spyder: add patch fix startup error

### DIFF
--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -56,6 +56,10 @@ buildPythonPackage rec {
     hash = "sha256-nZ+rw5qALSdu+nbaAtGA7PLW6XjcjeZvuPd4a5WtZkw=";
   };
 
+  patches = [
+    ./dont-clear-pythonpath.patch
+  ];
+
   nativeBuildInputs = [
     pyqtwebengine.wrapQtAppsHook
   ];

--- a/pkgs/development/python-modules/spyder/dont-clear-pythonpath.patch
+++ b/pkgs/development/python-modules/spyder/dont-clear-pythonpath.patch
@@ -1,0 +1,24 @@
+Don't remove sys.path entries that come from PYTHONPATH, or else the app cannot
+be used in Nixpkgs.
+
+Author: Bjørn Forsman <bjorn.forsman@gmail.com>
+diff -uNr spyder-5.4.0.orig/spyder/app/start.py spyder-5.4.0/spyder/app/start.py
+--- spyder-5.4.0.orig/spyder/app/start.py	2022-08-30 02:02:28.000000000 +0200
++++ spyder-5.4.0/spyder/app/start.py	2023-01-02 11:38:28.138744879 +0100
+@@ -6,16 +6,8 @@
+ # (see spyder/__init__.py for details)
+ # -----------------------------------------------------------------------------
+ 
+-# Remove PYTHONPATH paths from sys.path before other imports to protect against
+-# shadowed standard libraries.
+ import os
+ import sys
+-if os.environ.get('PYTHONPATH'):
+-    for path in os.environ['PYTHONPATH'].split(os.pathsep):
+-        try:
+-            sys.path.remove(path.rstrip(os.sep))
+-        except ValueError:
+-            pass
+ 
+ # Standard library imports
+ import ctypes


### PR DESCRIPTION
###### Description of changes

Upstream clears out all sys.path entries that come from PYTHONPATH,
which completely breaks Nixpkgs packaging. Patch out that code to fix
running spyder.

Before:

```
  $ spyder
  Traceback (most recent call last):
    File "/nix/store/icbklw22yrzy7s8k2ai8chkhrvna8pxr-python3.10-spyder-5.4.0/bin/..spyder-wrapped-wrapped", line 6, in <module>
      from spyder.app.start import main
    File "/nix/store/icbklw22yrzy7s8k2ai8chkhrvna8pxr-python3.10-spyder-5.4.0/lib/python3.10/site-packages/spyder/app/start.py", line 42, in <module>
      import zmq
  ModuleNotFoundError: No module named 'zmq'
  (exit with error code 1)
```

After:

```
  $ spyder
  (succeeds startup)
```

Note that once the GUI is up, it complains (inside GUI) that we've got
wrong version of 2 deps and
"ModuleNotFoundError: No module named 'spyder_kernels'".

Fixes https://github.com/NixOS/nixpkgs/issues/208567

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
