### PR TITLE
gsmartcontrol: 1.1.3 -> 1.1.4

### DIFF
--- a/pkgs/tools/misc/gsmartcontrol/default.nix
+++ b/pkgs/tools/misc/gsmartcontrol/default.nix
@@ -1,17 +1,21 @@
 { fetchurl, lib, stdenv, smartmontools, autoreconfHook, gettext, gtkmm3, pkg-config, wrapGAppsHook, pcre-cpp, gnome }:
 
 stdenv.mkDerivation rec {
-  version="1.1.3";
   pname = "gsmartcontrol";
+  version = "1.1.4";
 
   src = fetchurl {
-    url = "mirror://sourceforge/gsmartcontrol/gsmartcontrol-${version}.tar.bz2";
-    sha256 = "1a8j7dkml9zvgpk83xcdajfz7g6mmpmm5k86dl5sjc24zb7n4kxn";
+    url = "https://github.com/ashaduri/gsmartcontrol/releases/download/v${version}/gsmartcontrol-${version}.tar.bz2";
+    sha256 = "sha256-/ECfK4qEzEC7ED1sgkAbnUwBgtWjsiPJOVnHrWYZGEc=";
   };
 
   patches = [
     ./fix-paths.patch
   ];
+
+  postPatch = ''
+    substituteInPlace data/org.gsmartcontrol.policy --replace "/usr/sbin" $out/bin
+  '';
 
   nativeBuildInputs = [ autoreconfHook gettext pkg-config wrapGAppsHook ];
   buildInputs = [ gtkmm3 pcre-cpp gnome.adwaita-icon-theme ];
@@ -35,7 +39,7 @@ stdenv.mkDerivation rec {
       It allows you to inspect the drive's SMART data to determine its health,
       as well as run various tests on it.
     '';
-    homepage = "https://gsmartcontrol.sourceforge.io/";
+    homepage = "https://gsmartcontrol.shaduri.dev/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [qknight];
     platforms = with lib.platforms; linux;

--- a/pkgs/tools/misc/gsmartcontrol/fix-paths.patch
+++ b/pkgs/tools/misc/gsmartcontrol/fix-paths.patch
@@ -1,14 +1,3 @@
-diff --git a/configure.ac b/configure.ac
---- a/configure.ac
-+++ b/configure.ac
-@@ -475,6 +475,7 @@
- 
- 
- AC_CONFIG_FILES([ data/gsmartcontrol.desktop data/gsmartcontrol.appdata.xml \
-+	data/org.gsmartcontrol.policy \
- 	data/nsis/distribution.txt data/nsis/gsmartcontrol.nsi \
- 	debian.dist/changelog \
- 	src/gsc_winres.rc src/gsmartcontrol.exe.manifest \
 diff --git a/data/gsmartcontrol-root.in b/data/gsmartcontrol-root.in
 --- a/data/gsmartcontrol-root.in
 +++ b/data/gsmartcontrol-root.in
@@ -29,20 +18,6 @@ diff --git a/data/gsmartcontrol-root.in b/data/gsmartcontrol-root.in
 +EXTRA_PATHS="/usr/bin:/usr/sbin:/usr/local/sbin:@prefix@/bin";
  export PATH="$EXTRA_PATHS:$PATH"
  
- 
-diff --git a/data/org.gsmartcontrol.policy b/data/org.gsmartcontrol.policy.in
-rename from data/org.gsmartcontrol.policy
-rename to data/org.gsmartcontrol.policy.in
---- a/data/org.gsmartcontrol.policy
-+++ b/data/org.gsmartcontrol.policy.in
-@@ -12,7 +12,7 @@
-       <allow_inactive>auth_admin</allow_inactive>
-       <allow_active>auth_admin</allow_active>
-     </defaults>
--    <annotate key="org.freedesktop.policykit.exec.path">/usr/sbin/gsmartcontrol</annotate>
-+    <annotate key="org.freedesktop.policykit.exec.path">@prefix@/bin/gsmartcontrol</annotate>
-     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
-   </action>
  
 diff --git a/src/Makefile.am b/src/Makefile.am
 --- a/src/Makefile.am


### PR DESCRIPTION
###### Description of changes

Version bump, because current version crashes with some gnome-related errors and also don't show smart data for my SATA SSD (no NVME support still). [Changelog](https://github.com/ashaduri/gsmartcontrol/releases/tag/v1.1.4)
Repo moved from sourceforge to github and that trick with making policy file into *.in template seems to stop working, so I replaced it with substituteInPlace.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
