### PR TITLE
chrony: update build configuration

### DIFF
--- a/pkgs/tools/networking/chrony/default.nix
+++ b/pkgs/tools/networking/chrony/default.nix
@@ -1,5 +1,7 @@
-{ lib, stdenv, fetchurl, pkg-config, libcap, readline, texinfo, nss, nspr
-, libseccomp, pps-tools, gnutls }:
+{ lib, stdenv, fetchurl, pkg-config
+, gnutls, libedit, nspr, nss, readline, texinfo
+, libcap, libseccomp, pps-tools
+}:
 
 stdenv.mkDerivation rec {
   pname = "chrony";
@@ -7,21 +9,32 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://download.tuxfamily.org/chrony/${pname}-${version}.tar.gz";
-    sha256 = "sha256-nQ2oiahl8ImlohYQ/7ZxPjyUOM4wOmO0nC+26v9biAQ=";
+    hash = "sha256-nQ2oiahl8ImlohYQ/7ZxPjyUOM4wOmO0nC+26v9biAQ=";
   };
+
+  outputs = [ "out" "man" ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gnutls libedit nspr nss readline texinfo ]
+    ++ lib.optionals stdenv.isLinux [ libcap libseccomp pps-tools ];
+
+  configureFlags = [
+    "--enable-ntp-signd"
+    "--sbindir=$(out)/bin"
+    "--chronyrundir=/run/chrony"
+  ] ++ lib.optional stdenv.isLinux "--enable-scfilter";
+
+  patches = [
+    # Cleanup the installation script
+    ./makefile.patch
+  ];
 
   postPatch = ''
     patchShebangs test
   '';
 
-  buildInputs = [ readline texinfo nss nspr gnutls ]
-    ++ lib.optionals stdenv.isLinux [ libcap libseccomp pps-tools ];
-  nativeBuildInputs = [ pkg-config ];
-
   hardeningEnable = [ "pie" ];
-
-  configureFlags = [ "--chronyvardir=$(out)/var/lib/chrony" "--enable-ntp-signd" ]
-    ++ lib.optional stdenv.isLinux "--enable-scfilter";
 
   meta = with lib; {
     description = "Sets your computer's clock from time servers on the Net";

--- a/pkgs/tools/networking/chrony/makefile.patch
+++ b/pkgs/tools/networking/chrony/makefile.patch
@@ -1,0 +1,23 @@
+diff --git a/Makefile.in b/Makefile.in
+index ef100a4..47f54f4 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -23,7 +23,7 @@
+ 
+ SYSCONFDIR = @SYSCONFDIR@
+ BINDIR = @BINDIR@
+-SBINDIR = @SBINDIR@
++SBINDIR = @BINDIR@
+ LOCALSTATEDIR = @LOCALSTATEDIR@
+ CHRONYVARDIR = @CHRONYVARDIR@
+ DESTDIR =
+@@ -86,9 +86,7 @@ getdate :
+ 
+ install: chronyd chronyc
+ 	[ -d $(DESTDIR)$(SYSCONFDIR) ] || mkdir -p $(DESTDIR)$(SYSCONFDIR)
+-	[ -d $(DESTDIR)$(SBINDIR) ] || mkdir -p $(DESTDIR)$(SBINDIR)
+ 	[ -d $(DESTDIR)$(BINDIR) ] || mkdir -p $(DESTDIR)$(BINDIR)
+-	[ -d $(DESTDIR)$(CHRONYVARDIR) ] || mkdir -p $(DESTDIR)$(CHRONYVARDIR)
+ 	if [ -f $(DESTDIR)$(SBINDIR)/chronyd ]; then rm -f $(DESTDIR)$(SBINDIR)/chronyd ; fi
+ 	if [ -f $(DESTDIR)$(BINDIR)/chronyc ]; then rm -f $(DESTDIR)$(BINDIR)/chronyc ; fi
+ 	cp chronyd $(DESTDIR)$(SBINDIR)/chronyd


### PR DESCRIPTION
###### Description of changes
Updated build configuration:
 - Cleanup build configuration.
 - Added editline support.
 - Changed location `/run` directory.
 - Added `man` output.
 - Removed symlinks from `/sbin` directory.

cc @SuperSandro2000

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
