### PR TITLE
lib/generators: add RFC42-style libconfig format

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -402,6 +402,139 @@ rec {
 ${expr "" v}
 </plist>'';
 
+  /* Generates a libconfig configuration file.
+   *
+   * Currently quite close to fully-featured, though there are probably some
+   * oversights not covered by the test (./tests/misc.nix) and automated validator. (//pkgs/pkgs-lib)
+   *
+   * https://hyperrealm.github.io/libconfig/libconfig_manual.html
+   */
+  toLibconfig = { }:
+    v:
+    let
+      isFloat = builtins.isFloat or (x: false);
+      isHexString = str: builtins.match "^[+-]?0x[0-9a-fA-F]+$" str != null;
+      isOctalString = str: builtins.match "^[+-]?0[1-7][0-7]*$" str != null;
+      isLongString = str: builtins.match "^[+-]?[0-9]+L$" str != null;
+      isNumber = x: (isHexString x) || (isOctalString x) || (isLongString x);
+
+      # > An array may have zero or more elements, but the elements must
+      # > all be *scalar* values of the same type.
+      isArray = x: let
+        typed = builtins.groupBy type x;
+        filtered = builtins.removeAttrs typed [ "null" "aggregate" ];
+      in
+        # > ... *scalar* values..
+        !(typed ? aggregate) &&
+        # > ..of the same type
+        lib.length (builtins.attrNames filtered) <= 1;
+
+      type = x:
+        with builtins;
+        if x == null then
+          "null"
+        # > A scalar type (integer, 64-bit integer, floating point, boolean, or string)
+        else if isBool x then
+          "bool"
+        else if isInt x then
+          "int"
+        else if isFloat x then
+          "float"
+        else if isString x then
+          if isHexString x then
+            "hex"
+          else if isOctalString x then
+            "octal"
+          else if isLongString x then
+            "long"
+          else
+            "string"
+        else
+          # > An aggregate type (a group, array, or list),
+          "aggregate";
+
+      expr = ind: x:
+        with builtins;
+        if x == null then
+          ""
+        else if isBool x then
+          bool ind x
+        else if isInt x then
+          num ind x
+        else if isFloat x then
+          num ind x
+        else if isString x then
+          if isNumber x then
+            lit ind x
+          else
+            str ind x
+        else if isPath x then
+          path ind x
+        else if isList x then
+          list ind x
+        else if isAttrs x then
+          attrs ind x
+        else
+          abort "generators.toLibconfig: should never happen (v = ${v})";
+
+      literal = ind: x: ind + x;
+
+      bool = ind: x: literal ind (if x then "true" else "false");
+      num = ind: x: literal ind (toString x);
+      str = ind: x: literal ind ''"${x}"'';
+      key = ind: x: literal ind "${x}: ";
+      path = ind: x: literal ind (toString x);
+      lit = ind: x: literal ind "${x}";
+
+      indent = ind: expr "\t${ind}";
+
+      item = ind:
+        libStr.concatMapStringsSep ''
+          ,
+        '' (indent ind);
+
+      list = ind: x:
+        if isArray x then
+          libStr.concatStringsSep "\n" [
+            (literal ind "[")
+            (item ind x)
+            (literal ind "]")
+            ""
+          ]
+        else
+          libStr.concatStringsSep "\n" [
+            (literal ind "(")
+            (item ind x)
+            (literal ind ")")
+            ""
+          ];
+
+      attrs = ind: x:
+        libStr.concatStringsSep "\n" [
+          (literal ind "{")
+          (attr false ind x)
+          (literal ind "}")
+          ""
+        ];
+
+      attr = top: ind: x:
+        let
+          attrFilter = name: value: name != "_module" && value != null;
+          newInd = if top then ind else "\t${ind}";
+        in libStr.concatStringsSep "\n" (lib.flatten (lib.mapAttrsToList
+          (name: value:
+            lib.optional (attrFilter name value) [
+              (key newInd name)
+              (expr newInd value)
+            ]) x));
+
+    in (if v != null && builtins.isAttrs v then
+      attr true "" v
+    else
+      abort
+      "generators.toLibconfig: top-level value must be an attrset (was ${v})");
+
+
   /* Translate a simple Nix expression to Dhall notation.
    * Note that integers are translated to Integer and never
    * the Natural type.

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -433,6 +433,36 @@ rec {
           };
         in valueType;
       generate = name: value:
-        pkgs.writeText name (lib.generators.toLibconfig { } value);
+        let
+          output = pkgs.writeText name (lib.generators.toLibconfig { } value);
+          validator = pkgs.runCommandCC "libconfig-validator" { buildInputs = [ pkgs.libconfig ]; } ''
+          $CC -lconfig -x c - -o "$out" <<EOF
+//    Copyright (C) 2005-2023  Mark A Lindner, ckie
+//    SPDX-License-Identifier: LGPL-2.1-or-later
+#include <stdio.h>
+#include <libconfig.h>
+int main(int argc, char **argv)
+{
+  config_t cfg;
+  config_init(&cfg);
+  if (argc != 1)
+  {
+     fprintf(stderr, "USAGE: validator <path-to-validate>");
+  }
+  if(! config_read_file(&cfg, argv[1]))
+  {
+    fprintf(stderr, "[libconfig] %s:%d - %s\n", config_error_file(&cfg),
+            config_error_line(&cfg), config_error_text(&cfg));
+    config_destroy(&cfg);
+    return 1;
+  }
+  printf("[libconfig] validation ok\n");
+}
+EOF
+        '';
+        in pkgs.runCommandLocal "validated-${name}" {} ''
+          ${validator} ${output}
+          cp ${output} "$out"
+        '';
     };
 }

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -417,4 +417,22 @@ rec {
       '';
     };
 
+    libconfig = { }: {
+      type = with lib.types;
+        let
+          valueType = nullOr (oneOf [
+            bool
+            int
+            float
+            str
+            path
+            (attrsOf valueType)
+            (listOf valueType)
+          ]) // {
+            description = "Libconfig value";
+          };
+        in valueType;
+      generate = name: value:
+        pkgs.writeText name (lib.generators.toLibconfig { } value);
+    };
 }


### PR DESCRIPTION
###### Description of changes

Hey again. I've split out the `libconfig` serializer from https://github.com/NixOS/nixpkgs/pull/167388 and took the time to acknowledge a few more edge-cases, as well as adding a test and auto-validator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
