### PR TITLE
darwin.builder: auto-login as the `builder` user

### DIFF
--- a/doc/builders/special/darwin-builder.section.md
+++ b/doc/builders/special/darwin-builder.section.md
@@ -28,19 +28,21 @@ Password:
 ```
 
 … so that it can install a private key used to `ssh` into the build server.
-After that the script will launch the virtual machine:
+After that the script will launch the virtual machine and automatically log you
+in as the `builder` user:
 
 ```
 <<< Welcome to NixOS 22.11.20220901.1bd8d11 (aarch64) - ttyAMA0 >>>
 
 Run 'nixos-help' for the NixOS manual.
 
-nixos login:
+nixos login: builder (automatic login)
+
+
+[builder@nixos:~]$
 ```
 
-> Note: When you need to stop the VM, type `Ctrl`-`a` + `c` to open the `qemu`
-> prompt and then type `system_powerdown` followed by `Enter`, or run `shutdown now`
-> as the `builder` user (e.g. `ssh -i keys/builder_ed25519 builder@localhost shutdown now`)
+> Note: When you need to stop the VM, run `shutdown now` as the builder user.
 
 To delegate builds to the remote builder, add the following options to your
 `nix.conf` file:

--- a/doc/builders/special/darwin-builder.section.md
+++ b/doc/builders/special/darwin-builder.section.md
@@ -42,7 +42,7 @@ nixos login: builder (automatic login)
 [builder@nixos:~]$
 ```
 
-> Note: When you need to stop the VM, run `shutdown now` as the builder user.
+> Note: When you need to stop the VM, run `shutdown now` as the `builder` user.
 
 To delegate builds to the remote builder, add the following options to your
 `nix.conf` file:

--- a/nixos/modules/profiles/macos-builder.nix
+++ b/nixos/modules/profiles/macos-builder.nix
@@ -59,10 +59,14 @@ in
     trusted-users = [ "root" user ];
   };
 
-  services.openssh = {
-    enable = true;
+  services = {
+    getty.autologinUser = "builder";
 
-    authorizedKeysFiles = [ "${keysDirectory}/%u_${keyType}.pub" ];
+    openssh = {
+      enable = true;
+
+      authorizedKeysFiles = [ "${keysDirectory}/%u_${keyType}.pub" ];
+    };
   };
 
   system.build.macos-builder-installer =

--- a/nixos/modules/profiles/macos-builder.nix
+++ b/nixos/modules/profiles/macos-builder.nix
@@ -60,7 +60,7 @@ in
   };
 
   services = {
-    getty.autologinUser = "builder";
+    getty.autologinUser = user;
 
     openssh = {
       enable = true;


### PR DESCRIPTION
… as suggested by @NiklasGollenstede in:

https://github.com/NixOS/nixpkgs/pull/206951#issuecomment-1369020601

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)

  - [x] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
