### PR TITLE
convenient-test-manager: init at 1.2.1

### DIFF
--- a/pkgs/development/tools/convenient_test_manager/default.nix
+++ b/pkgs/development/tools/convenient_test_manager/default.nix
@@ -27,7 +27,7 @@ flutter.mkFlutterApp rec {
     categories = [ "Development" ];
   };
 
-  vendorHash = "sha256-0VZizwFlUfvrXLMn5iya2UMLcHhn5GtKaj2zekhqPS0=";
+  vendorHash = "sha256-iR/U2vQQqj95j1XkgW3/u7DQzwQrNmho9M4yLvefb4A=";
 
   nativeBuildInputs = [ copyDesktopItems ];
 

--- a/pkgs/development/tools/convenient_test_manager/default.nix
+++ b/pkgs/development/tools/convenient_test_manager/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, flutter
+, makeDesktopItem
+, libvlc
+, copyDesktopItems
+}:
+
+flutter.mkFlutterApp rec {
+  pname = "convenient-test-manager";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "fzyzcjy";
+    repo = "flutter_convenient_test";
+    rev = "v${version}";
+    sha256 = "sha256-f0+nATpBAd+3ELRq7dfKi9HCawgF3LAAs0UqYjnKCPw=";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = "${placeholder "out"}/bin/convenient_test_manager";
+    icon = "convenient_test_manager";
+    desktopName = "Convenient Test Manager";
+    genericName = "Flutter test runner";
+    categories = [ "Development" ];
+  };
+
+  vendorHash = "sha256-0VZizwFlUfvrXLMn5iya2UMLcHhn5GtKaj2zekhqPS0=";
+
+  nativeBuildInputs = [ copyDesktopItems ];
+
+  buildInputs = [ libvlc ];
+
+  sourceRoot = "source/packages/convenient_test_manager";
+  meta = with lib; {
+    description = "Companion app to the widely used Flutter convenient_test framework";
+    homepage = "https://github.com/fzyzcjy/flutter_convenient_test";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ gilice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15509,6 +15509,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  convenient_test_manager = callPackage ../development/tools/convenient_test_manager {};
+
   devserver = callPackage ../development/tools/rust/devserver {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
     openssl = openssl_1_1;


### PR DESCRIPTION
###### Description of changes
add convenient-test-manager
https://pub.dev/packages/convenient_test
https://github.com/fzyzcjy/flutter_convenient_test

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
