### PR TITLE
vlang: 2022.20 -> 2023.01

### DIFF
--- a/pkgs/development/compilers/vlang/default.nix
+++ b/pkgs/development/compilers/vlang/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "vlang";
     repo = "v";
     rev = version;
-    sha256 = "G/8SF0g/YY0kmDdVSTzuI5ksrrwaFuhxZILIIGRdbyw=";
+    sha256 = "sha256-baHN9m2vrjPH0cIf7WoHcH5JH1HUFNpabQklY0jjKgQ=";
   };
 
   # Required for bootstrap.
@@ -53,11 +53,7 @@ stdenv.mkDerivation rec {
     export CFLAGS="-I${staticBoehmgc.dev}/include"
     export LDFLAGS="-L${staticBoehmgc}/lib"
 
-    # Monkeypatch the source code like an animal to use BoehmGC static files,
-    # instead of the "thirdparty" one.
-    # We should replace "#flag @VEXEROOT/thirdparty/tcc/lib/libgc.a"
-    # to "#flag ${staticBoehmgc}/lib/libgc.a"
-    # in file vlib/builtin/builtin_d_gcboehm.c.v
+    # patch the code to use our static compiled BoehmGC
     sed -i "s|@VEXEROOT/thirdparty/tcc/lib/libgc.a|${staticBoehmgc}/lib/libgc.a|" vlib/builtin/builtin_d_gcboehm.c.v
   '';
 
@@ -115,13 +111,12 @@ stdenv.mkDerivation rec {
     - `freetype`
     If you want to build web apps (using `net.http` or `net.websocket`) you will need `openssl`.
   */
-  meta = with lib;
-    {
-      homepage = "https://vlang.io/";
-      description = "Simple, fast, safe, compiled language for developing maintainable software";
-      license = licenses.mit;
-      maintainers = with maintainers; [ Madouura ];
-      mainProgram = "v";
-      platforms = platforms.all;
-    };
+  meta = with lib; {
+    homepage = "https://vlang.io/";
+    description = "Simple, fast, safe, compiled language for developing maintainable software";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Madouura ];
+    mainProgram = "v";
+    platforms = platforms.unix;
+  };
 }


### PR DESCRIPTION
This is my first package on nixpkgs, fell free to raise any issues, especially concerning the form :smiley: 

###### Description of changes

- Bump from 2022.20 to 2023.01
- Make optionals dependencies optional
- Bypass autodetection on Makefile (which would build for wrong system)
- Add boehmgc as a static lib and patch it in sources
- Patches unknown shebangs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
