### PR TITLE
darwin.builder: Instruct user not to disable firewall

### DIFF
--- a/doc/builders/special/darwin-builder.section.md
+++ b/doc/builders/special/darwin-builder.section.md
@@ -20,6 +20,19 @@ To launch the builder, run the following flake:
 $ nix run nixpkgs#darwin.builder
 ```
 
+> Note: The first time you run this macOS will ask you if you want to open your
+> firewall to accept incoming connections.  You can deny that request because it
+> is not necessary to open your firewall to use the builder.
+>
+> This weird behavior is due to an inconsistency in macOS where it only permits
+> unprivileged processes (e.g. `qemu`) to bind to privileged ports (e.g. port
+> 22 for SSH) if they bind the port on all IP addresses (`0.0.0.0`) but not to
+> specific IP addresses (e.g. `127.0.0.1`).  For more details, see:
+> [Binding on priviledged ports on macOS](https://developer.apple.com/forums/thread/674179).
+>
+> This means that the `qemu` VM has to gratuitously request access to all
+> network interfaces even though it only needs to bind to `127.0.0.1`.
+
 That will prompt you to enter your `sudo` password:
 
 ```


### PR DESCRIPTION
It turns out that it's not necessary to disable the firewall because `qemu` by default binds to all ports (`0.0.0.0`), including `127.0.0.1`.

Ideally, we would configure `qemu` to bind to `127.0.0.1` so that the user would not even be prompted to disable their firewall, but that doesn't work for unprivileged services on macOS.

You heard that right.  On macOS an unprivileged service can bind to `0.0.0.0:22` but not `127.0.0.1:22`. See:

https://developer.apple.com/forums/thread/674179

… so right now the lesser evil is just telling users to not disable the firewall rather than requiring them to run the script with `sudo`.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
