### PR TITLE
standardnotes: 3.23.69 -> 3.129.0

### DIFF
--- a/pkgs/applications/editors/standardnotes/default.nix
+++ b/pkgs/applications/editors/standardnotes/default.nix
@@ -1,26 +1,14 @@
-{ lib, stdenv, appimageTools, autoPatchelfHook, desktop-file-utils
+{ callPackage, lib, stdenv, appimageTools, autoPatchelfHook, desktop-file-utils
 , fetchurl, libsecret  }:
 
 let
-  version = "3.23.69";
+  srcjson = builtins.fromJSON (builtins.readFile ./src.json);
+  version = srcjson.version;
   pname = "standardnotes";
   name = "${pname}-${version}";
   throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
 
-  plat = {
-    i686-linux = "i386";
-    x86_64-linux = "x86_64";
-  }.${stdenv.hostPlatform.system} or throwSystem;
-
-  sha256 = {
-    i686-linux = "sha256-/A2LjV8ky20bcKgs0ijwldryi5VkyROwz49vWYXYQus=";
-    x86_64-linux = "sha256-fA9WH9qUtvAHF9hTFRtxQdpz2dpK0joD0zX9VYBo10g=";
-  }.${stdenv.hostPlatform.system} or throwSystem;
-
-  src = fetchurl {
-    url = "https://github.com/standardnotes/app/releases/download/%40standardnotes%2Fdesktop%40${version}/standard-notes-${version}-linux-${plat}.AppImage";
-    inherit sha256;
-  };
+  src = fetchurl (srcjson.appimage.${stdenv.hostPlatform.system} or throwSystem);
 
   appimageContents = appimageTools.extract {
     inherit name src;
@@ -47,6 +35,8 @@ in appimageTools.wrapType2 rec {
     ln -s ${appimageContents}/usr/share/icons share
   '';
 
+  passthru.updateScript = callPackage ./update.nix {};
+
   meta = with lib; {
     description = "A simple and private notes app";
     longDescription = ''
@@ -55,8 +45,8 @@ in appimageTools.wrapType2 rec {
     '';
     homepage = "https://standardnotes.org";
     license = licenses.agpl3;
-    maintainers = with maintainers; [ mgregoire chuangzhu ];
+    maintainers = with maintainers; [ mgregoire chuangzhu squalus ];
     sourceProvenance = [ sourceTypes.binaryNativeCode ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    platforms = builtins.attrNames srcjson.appimage;
   };
 }

--- a/pkgs/applications/editors/standardnotes/src.json
+++ b/pkgs/applications/editors/standardnotes/src.json
@@ -1,0 +1,17 @@
+{
+  "version": "3.129.0",
+  "appimage": {
+    "x86_64-linux": {
+      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.129.0/standard-notes-3.129.0-linux-x86_64.AppImage",
+      "hash": "sha512-JLO2jX9Us6BjqmTZIkVyxy2pqFM/eFGpwi6vXicMOgDB0UsgEMTK+Ww+9g+vJ1KbFRFmlt187qkdSNcevQPt7w=="
+    },
+    "aarch64-linux": {
+      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.129.0/standard-notes-3.129.0-linux-arm64.AppImage",
+      "hash": "sha512-LGUSRqMrJ+hVHyi/bjI/NkWRVsmY0Kh/wRY9RNJXm0C3dKQSFV8ca4GeY9+VCuJEecR4LGnWp4agS5jPybPP6w=="
+    },
+    "i686-linux": {
+      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.129.0/standard-notes-3.129.0-linux-i386.AppImage",
+      "hash": "sha512-XbQ4hn3QJ61hDC12cK95zsUowbyXPYArHZoRDx5trQ30phtQxtz6nV+pL00m4S9kYeEhsAwk1wXlRq9Ylbz2IA=="
+    }
+  }
+}

--- a/pkgs/applications/editors/standardnotes/update.nix
+++ b/pkgs/applications/editors/standardnotes/update.nix
@@ -1,0 +1,55 @@
+{ writeScript
+, lib, curl, runtimeShell, jq, coreutils, moreutils, nix, gnused }:
+
+writeScript "update-standardnotes" ''
+  #!${runtimeShell}
+  PATH=${lib.makeBinPath [ jq curl nix coreutils moreutils gnused ]}
+
+  set -euo pipefail
+  set -x
+
+  tmpDir=$(mktemp -d)
+  srcJson=pkgs/applications/editors/standardnotes/src.json
+  jsonPath="$tmpDir"/latest
+
+  oldVersion=$(jq -r .version < "$srcJson")
+
+  curl https://api.github.com/repos/standardnotes/app/releases/latest > "$jsonPath"
+
+  tagName=$(jq -r .tag_name < "$jsonPath")
+
+  if [[ ! "$tagName" =~ "desktop" ]]; then
+    echo "latest release '$tagName' not a desktop release"
+    exit 1
+  fi
+
+  newVersion=$(jq -r .tag_name < "$jsonPath" | sed s,@standardnotes/desktop@,,g)
+
+  if [[ "$oldVersion" == "$newVersion" ]]; then
+    echo "version did not change"
+    exit 0
+  fi
+
+  function getDownloadUrl() {
+    jq -r ".assets[] | select(.name==\"standard-notes-$newVersion-$1.AppImage\") | .browser_download_url" < "$jsonPath"
+  }
+
+  function setJsonKey() {
+    jq "$1 = \"$2\"" "$srcJson" | sponge "$srcJson"
+  }
+
+  function updatePlatform() {
+    nixPlatform="$1"
+    upstreamPlatform="$2"
+    url=$(getDownloadUrl "$upstreamPlatform")
+    hash=$(nix-prefetch-url "$url" --type sha512)
+    sriHash=$(nix hash to-sri --type sha512 $hash)
+    setJsonKey .appimage[\""$nixPlatform"\"].url "$url"
+    setJsonKey .appimage[\""$nixPlatform"\"].hash "$sriHash"
+  }
+
+  updatePlatform x86_64-linux linux-x86_64
+  updatePlatform aarch64-linux linux-arm64
+  updatePlatform i686-linux linux-i386
+  setJsonKey .version "$newVersion"
+''


### PR DESCRIPTION

###### Description of changes

- add updater script
- move source urls and hashes to separate json file
- add support for linux-aarch64

Manually tested on NixOS x86_64-linux.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
