### PR TITLE
frawk: 0.4.6 -> 0.4.7

### DIFF
--- a/pkgs/tools/text/frawk/default.nix
+++ b/pkgs/tools/text/frawk/default.nix
@@ -10,14 +10,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "frawk";
-  version = "0.4.6";
+  version = "0.4.7";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-yEdfMikMcsQePxQL1+lma95O1x5z1B7aXAEf8apuGaU=";
+    sha256 = "sha256-fqOFFkw+mV9QLTH3K6Drk3kDqU4wrQTj7OQrtgYuD7M=";
   };
 
-  cargoSha256 = "sha256-osi77Fx8jSfIvAIpThgPbnuJVF/Ydr2/+ROHcDG5ZbA=";
+  cargoSha256 = "sha256-G39/CESjMouwPQJBdsmd+MBusGNQmyNjw3PJSFBCdSk=";
 
   buildInputs = [ libxml2 ncurses zlib ];
 
@@ -36,8 +36,8 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "A small programming language for writing short programs processing textual data";
     homepage = "https://github.com/ezrosent/frawk";
+    changelog = "https://github.com/ezrosent/frawk/releases/tag/v${version}";
     license = with licenses; [ mit /* or */ asl20 ];
     maintainers = with maintainers; [ figsoda ];
-    platforms = platforms.x86;
   };
 }


### PR DESCRIPTION
Changelog: https://github.com/ezrosent/frawk/releases/tag/v0.4.7

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
