### PR TITLE
shim: init at 15.7

### DIFF
--- a/pkgs/tools/misc/shim/default.nix
+++ b/pkgs/tools/misc/shim/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, lib, elfutils, vendorCertFile ? null
+, defaultLoader ? null }:
+
+let
+
+  inherit (stdenv.targetPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+
+  target = {
+    x86_64-linux = "shimx64.efi";
+    aarch64-linux = "shimaa64.efi";
+  }.${system} or throwSystem;
+in stdenv.mkDerivation rec {
+  pname = "shim";
+  version = "15.7";
+
+  src = fetchFromGitHub {
+    owner = "rhboot";
+    repo = pname;
+    rev = version;
+    hash = "sha256-CfUuq0anbXlCVo9r9NIb76oJzDqaPMIhL9cmXK1iqXo=";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ elfutils ];
+
+  NIX_CFLAGS_COMPILE = [ "-I${toString elfutils.dev}/include" ];
+
+  makeFlags =
+    lib.optional (vendorCertFile != null) "VENDOR_CERT_FILE=${vendorCertFile}"
+    ++ lib.optional (defaultLoader != null) "DEFAULT_LOADER=${defaultLoader}"
+    ++ [ target ];
+
+  installPhase = ''
+    mkdir -p $out/share/shim
+    install -m 644 ${target} $out/share/shim/
+  '';
+
+  meta = with lib; {
+    description = "UEFI shim loader";
+    homepage = "https://github.com/rhboot/shim";
+    license = licenses.bsd1;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    maintainers = with maintainers; [ baloo raitobezarius ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11617,6 +11617,8 @@ with pkgs;
 
   shiv = with python3Packages; toPythonApplication shiv;
 
+  shim-unsigned = callPackage ../tools/misc/shim { };
+
   shocco = callPackage ../tools/text/shocco { };
 
   shopify-cli = callPackage ../development/web/shopify-cli { };


### PR DESCRIPTION
###### Description of changes

This provides a derivation for the UEFI shim, This is intended to be submitted for signature as a follow up.

cc  @RaitoBezarius 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
