### PR TITLE
python310Packages.reolink-aio: init at 0.1.1

### DIFF
--- a/pkgs/development/python-modules/reolink-aio/default.nix
+++ b/pkgs/development/python-modules/reolink-aio/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, aiohttp
+, aiounittest
+, buildPythonPackage
+, fetchFromGitHub
+, ffmpeg-python
+, pytestCheckHook
+, pythonOlder
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "reolink-aio";
+  version = "0.1.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "starkillerOG";
+    repo = "reolink_aio";
+    rev = "refs/tags/${version}";
+    sha256 = "sha256-KUsBCV8OVPj0QC1DKUBVRqtt1dpGq+JunuBZsZKfQno=";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    ffmpeg-python
+    requests
+  ];
+
+  checkInputs = [
+    aiounittest
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    # Packages in nixpkgs is different than the module name
+    substituteInPlace setup.py \
+      --replace "ffmpeg" "ffmpeg-python"
+  '';
+
+  pytestFlagsArray = [
+    "tests/test.py"
+  ];
+
+  disabledTests = [
+    # Tests require network access
+    "test1_settings"
+    "test2_states"
+    "test3_images"
+    "test4_properties"
+    "test_succes"
+  ];
+
+  pythonImportsCheck = [
+    "reolink_aio"
+  ];
+
+  meta = with lib; {
+    description = "Module to interact with the Reolink IP camera API";
+    homepage = "https://github.com/starkillerOG/reolink_aio";
+    changelog = "https://github.com/starkillerOG/reolink_aio/releases/tag/${version}";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/reolink/default.nix
+++ b/pkgs/development/python-modules/reolink/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "fwestenberg";
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-XUYTDHh0oTro6BT+h4LjRdMukOZTlWP+giFpjLciZNQ=";
+    hash = "sha256-XUYTDHh0oTro6BT+h4LjRdMukOZTlWP+giFpjLciZNQ=";
   };
 
   propagatedBuildInputs = [
@@ -61,8 +61,9 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "Python module to interact with the Reolink IP camera API";
+    description = "Module to interact with the Reolink IP camera API";
     homepage = "https://github.com/fwestenberg/reolink";
+    changelog = "https://github.com/fwestenberg/reolink/releases/tag/v${version}";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9755,6 +9755,8 @@ self: super: with self; {
 
   reolink = callPackage ../development/python-modules/reolink { };
 
+  reolink-aio = callPackage ../development/python-modules/reolink-aio { };
+
   reparser = callPackage ../development/python-modules/reparser { };
 
   repeated-test = callPackage ../development/python-modules/repeated-test { };


### PR DESCRIPTION
###### Description of changes
Module to interact with the Reolink IP camera API

https://github.com/starkillerOG/reolink_aio
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
