### PR TITLE
teeworlds: build on macOS

### DIFF
--- a/pkgs/games/teeworlds/default.nix
+++ b/pkgs/games/teeworlds/default.nix
@@ -1,6 +1,8 @@
 { fetchFromGitHub, lib, stdenv, cmake, pkg-config, python3, alsa-lib
 , libX11, libGLU, SDL2, lua5_3, zlib, freetype, wavpack, icoutils
 , nixosTests
+, Carbon
+, Cocoa
 }:
 
 stdenv.mkDerivation rec {
@@ -15,26 +17,57 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # Can't use fetchpatch or fetchpatch2 because of https://github.com/NixOS/nixpkgs/issues/32084
+    # Using fetchurl instead is also not a good idea, see https://github.com/NixOS/nixpkgs/issues/32084#issuecomment-727223713
+    ./rename-VERSION-to-VERSION.txt.patch
+  ];
+
   postPatch = ''
     # set compiled-in DATA_DIR so resources can be found
     substituteInPlace src/engine/shared/storage.cpp \
       --replace '#define DATA_DIR "data"' \
                 '#define DATA_DIR "${placeholder "out"}/share/teeworlds/data"'
+
+    # Quote nonsense is a workaround for https://github.com/NixOS/nix/issues/661
+    substituteInPlace 'other/bundle/client/Info.plist.in' \
+      --replace ${"'"}''${TARGET_CLIENT}' 'teeworlds' \
+      --replace ${"'"}''${PROJECT_VERSION}' '${version}'
   '';
 
-  nativeBuildInputs = [ cmake pkg-config icoutils ];
-
-  buildInputs = [
-    python3 alsa-lib libX11 libGLU SDL2 lua5_3 zlib freetype wavpack
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ] ++ lib.optionals stdenv.isLinux [
+    icoutils
   ];
 
-  postInstall = ''
+  buildInputs = [
+    python3 libGLU SDL2 lua5_3 zlib freetype wavpack
+  ] ++ lib.optionals stdenv.isLinux [
+    alsa-lib
+    libX11
+  ] ++ lib.optionals stdenv.isDarwin [
+    Carbon
+    Cocoa
+  ];
+
+  postInstall = lib.optionalString stdenv.isLinux ''
     # Convert and install desktop icon
     mkdir -p $out/share/pixmaps
     icotool --extract --index 1 --output $out/share/pixmaps/teeworlds.png $src/other/icons/teeworlds.ico
 
     # Install menu item
     install -D $src/other/teeworlds.desktop $out/share/applications/teeworlds.desktop
+  '' + lib.optionalString stdenv.isDarwin ''
+    mkdir -p "$out/Applications/teeworlds.app/Contents/MacOS"
+    mkdir -p "$out/Applications/teeworlds.app/Contents/Resources"
+
+    cp '../other/icons/teeworlds.icns' "$out/Applications/teeworlds.app/Contents/Resources/"
+    cp '../other/bundle/client/Info.plist.in' "$out/Applications/teeworlds.app/Contents/Info.plist"
+    cp '../other/bundle/client/PkgInfo' "$out/Applications/teeworlds.app/Contents/"
+    ln -s "$out/bin/teeworlds" "$out/Applications/teeworlds.app/Contents/MacOS/"
+    ln -s "$out/share/teeworlds/data" "$out/Applications/teeworlds.app/Contents/Resources/data"
   '';
 
   passthru.tests.teeworlds = nixosTests.teeworlds;
@@ -52,6 +85,6 @@ stdenv.mkDerivation rec {
     homepage = "https://teeworlds.com/";
     license = "BSD-style, see `license.txt'";
     maintainers = with lib.maintainers; [ astsmtl Luflosi ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/games/teeworlds/default.nix
+++ b/pkgs/games/teeworlds/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
 
     homepage = "https://teeworlds.com/";
     license = "BSD-style, see `license.txt'";
-    maintainers = with lib.maintainers; [ astsmtl ];
+    maintainers = with lib.maintainers; [ astsmtl Luflosi ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/games/teeworlds/rename-VERSION-to-VERSION.txt.patch
+++ b/pkgs/games/teeworlds/rename-VERSION-to-VERSION.txt.patch
@@ -1,0 +1,33 @@
+From 86d6687ef07f7f05457a7f67537b650656b13820 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Robert=20M=C3=BCller?= <robert.mueller@uni-siegen.de>
+Date: Fri, 15 Oct 2021 23:45:50 +0200
+Subject: [PATCH] rename VERSION to VERSION.txt:
+
+Fixes compilation on systems with case insensitive file names where the standard library includes the version file source code.
+---
+ src/engine/external/json-parser/{VERSION => VERSION.txt} | 0
+ src/engine/external/pnglite/{VERSION => VERSION.txt}     | 0
+ src/engine/external/wavpack/{VERSION => VERSION.txt}     | 0
+ src/engine/external/zlib/{VERSION => VERSION.txt}        | 0
+ 4 files changed, 0 insertions(+), 0 deletions(-)
+ rename src/engine/external/json-parser/{VERSION => VERSION.txt} (100%)
+ rename src/engine/external/pnglite/{VERSION => VERSION.txt} (100%)
+ rename src/engine/external/wavpack/{VERSION => VERSION.txt} (100%)
+ rename src/engine/external/zlib/{VERSION => VERSION.txt} (100%)
+
+diff --git a/src/engine/external/json-parser/VERSION b/src/engine/external/json-parser/VERSION.txt
+similarity index 100%
+rename from src/engine/external/json-parser/VERSION
+rename to src/engine/external/json-parser/VERSION.txt
+diff --git a/src/engine/external/pnglite/VERSION b/src/engine/external/pnglite/VERSION.txt
+similarity index 100%
+rename from src/engine/external/pnglite/VERSION
+rename to src/engine/external/pnglite/VERSION.txt
+diff --git a/src/engine/external/wavpack/VERSION b/src/engine/external/wavpack/VERSION.txt
+similarity index 100%
+rename from src/engine/external/wavpack/VERSION
+rename to src/engine/external/wavpack/VERSION.txt
+diff --git a/src/engine/external/zlib/VERSION b/src/engine/external/zlib/VERSION.txt
+similarity index 100%
+rename from src/engine/external/zlib/VERSION
+rename to src/engine/external/zlib/VERSION.txt

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35402,7 +35402,9 @@ with pkgs;
 
   teetertorture = callPackage ../games/teetertorture { };
 
-  teeworlds = callPackage ../games/teeworlds { };
+  teeworlds = callPackage ../games/teeworlds {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
+  };
 
   tengine = callPackage ../servers/http/tengine {
     openssl = openssl_1_1;


### PR DESCRIPTION
###### Description of changes
Enable running teeworlds on macOS.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).