### PR TITLE
lib.trivial: add earliestReleaseIsoDate and earliestReleaseIsoDateTime

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -69,7 +69,8 @@ let
     inherit (self.trivial) id const pipe concat or and bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
-      info showWarnings nixpkgsVersion version isInOldestRelease
+      info showWarnings nixpkgsVersion version
+      earliestReleaseIsoDate earliestReleaseIsoDateTime isInOldestRelease
       mod compare splitByAndCompare
       functionArgs setFunctionArgs isFunction toFunction
       toHexString toBaseDigits inPureEvalMode;

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -166,6 +166,26 @@ rec {
   /* Returns the current nixpkgs release number as string. */
   release = lib.strings.fileContents ../.version;
 
+  /* The earliest possible release date, in YYYY-MM-DD format.
+     (For example, 23.05 would be 2023-05-01).
+
+     This is useful if any derivations need hardcoded build dates, instead
+     of hardcoding things like 1970-01-01. */
+  earliestReleaseIsoDate = let
+    yyMm = let
+      split = lib.strings.splitString "." lib.trivial.release;
+    in
+      if builtins.length split == 2 then split else null;
+    yyyy = if yyMm == null then 1970 else
+      (lib.trivial.mod (lib.trivial.max (lib.strings.toIntBase10 (builtins.elemAt yyMm 0)) 0) 100) + 2000;
+    mm = if yyMm == null then 1 else
+      (lib.trivial.mod ((lib.trivial.max (lib.strings.toIntBase10 (builtins.elemAt yyMm 1)) 1) - 1) 12) + 1;
+  in
+    "${lib.strings.fixedWidthNumber 4 yyyy}-${lib.strings.fixedWidthNumber 2 mm}-01";
+
+  /** Like earliestReleaseIsoDate, but adds a constant suffix of T00:00:00Z. */
+  earliestReleaseIsoDateTime = "${lib.trivial.earliestReleaseDate}T00:00:00Z";
+
   /* The latest release that is supported, at the time of release branch-off,
      if applicable.
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

These trivial string constants are useful for hardcoding build dates other than 1970-01-01(T00:00:00Z).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
