### PR TITLE
freerdp: apply suggestions provided by upstream

### DIFF
--- a/pkgs/applications/networking/remote/freerdp/default.nix
+++ b/pkgs/applications/networking/remote/freerdp/default.nix
@@ -2,6 +2,8 @@
 , lib
 , fetchFromGitHub
 , cmake
+, docbook-xsl-nons
+, libxslt
 , pkg-config
 , alsa-lib
 , faac
@@ -15,13 +17,14 @@
 , libX11
 , libXcursor
 , libXdamage
+, libXdmcp
 , libXext
 , libXi
 , libXinerama
 , libXrandr
 , libXrender
-, libXv
 , libXtst
+, libXv
 , libxkbcommon
 , libxkbfile
 , wayland
@@ -30,7 +33,6 @@
 , gst-plugins-good
 , libunwind
 , orc
-, libxslt
 , cairo
 , libusb1
 , libpulseaudio
@@ -112,6 +114,7 @@ stdenv.mkDerivation rec {
     libX11
     libXcursor
     libXdamage
+    libXdmcp
     libXext
     libXi
     libXinerama
@@ -125,7 +128,6 @@ stdenv.mkDerivation rec {
     libusb1
     libxkbcommon
     libxkbfile
-    libxslt
     openh264
     openssl
     orc
@@ -147,16 +149,19 @@ stdenv.mkDerivation rec {
     faac
   ];
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ cmake libxslt docbook-xsl-nons pkg-config ];
 
   doCheck = true;
 
   # https://github.com/FreeRDP/FreeRDP/issues/8526#issuecomment-1357134746
-  cmakeFlags = [ "-Wno-dev" "-DCMAKE_INSTALL_LIBDIR=lib" ]
-    ++ lib.mapAttrsToList (k: v: "-D${k}=${cmFlag v}") {
+  cmakeFlags = [
+    "-Wno-dev"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DDOCBOOKXSL_DIR=${docbook-xsl-nons}/xml/xsl/docbook"
+  ]
+  ++ lib.mapAttrsToList (k: v: "-D${k}=${cmFlag v}") {
     BUILD_TESTING = false; # false is recommended by upstream
     WITH_CAIRO = (cairo != null);
-    WITH_CUNIT = doCheck;
     WITH_CUPS = (cups != null);
     WITH_FAAC = (withUnfree && faac != null);
     WITH_FAAD2 = (faad2 != null);


### PR DESCRIPTION
###### Description of changes

Apply recommendations provided by upstream as outlined in #206886.

wlfreerdp it is still nowhere near as stable as xfreerdp.

Fixes #206886

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
