### PR TITLE
captive-browser: Use buildGoModule

### DIFF
--- a/pkgs/applications/networking/browsers/captive-browser/default.nix
+++ b/pkgs/applications/networking/browsers/captive-browser/default.nix
@@ -1,16 +1,28 @@
-{ lib, fetchFromGitHub, buildGoPackage }:
+{ lib, fetchFromGitHub, buildGoModule, fetchpatch }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "captive-browser";
-  version = "2021-08-01";
-  goPackagePath = pname;
+  version = "unstable-2021-08-01";
 
   src = fetchFromGitHub {
-    owner  = "FiloSottile";
-    repo   = "captive-browser";
-    rev    = "9c707dc32afc6e4146e19b43a3406329c64b6f3c";
+    owner = "FiloSottile";
+    repo = "captive-browser";
+    rev = "9c707dc32afc6e4146e19b43a3406329c64b6f3c";
     sha256 = "sha256-65lPo5tpE0M/VyyvlzlcVSuHX4AhhVuqK0UF4BIAH/Y=";
   };
+
+  vendorHash = "sha256-2MFdQ2GIDAdLPuwAiGPO9wU3mm2BDXdyTwoVA1xVlcQ=";
+  deleteVendor = true;
+
+  patches = [
+    # Add go modules support
+    (fetchpatch {
+      url = "https://github.com/FiloSottile/captive-browser/commit/ef50837778ef4eaf38b19887e79c8b6fa830c342.patch";
+      hash = "sha256-w+jDFeO94pMu4ir+G5CzqYlXxYOm9+YfyzbU3sbTyiY=";
+    })
+  ];
+
+  ldflags = [ "-s" "-w" ];
 
   meta = with lib; {
     description = "Dedicated Chrome instance to log into captive portals without messing with DNS settings";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
