### PR TITLE
borgmatic: expose backup frequency interval

### DIFF
--- a/nixos/modules/services/backup/borgmatic.nix
+++ b/nixos/modules/services/backup/borgmatic.nix
@@ -14,9 +14,9 @@ in {
       default = "daily";
       type = types.str;
       description = lib.mdDoc ''
-        Frequency at which borgmatic should be run. See 
-	https://man7.org/linux/man-pages/man7/systemd.time.7.html for 
-	options.
+        Frequency at which borgmatic should be run. See
+        https://man7.org/linux/man-pages/man7/systemd.time.7.html for
+        options.
       '';
     };
 

--- a/nixos/modules/services/backup/borgmatic.nix
+++ b/nixos/modules/services/backup/borgmatic.nix
@@ -10,6 +10,16 @@ in {
   options.services.borgmatic = {
     enable = mkEnableOption (lib.mdDoc "borgmatic");
 
+    frequency = mkOption {
+      default = "daily";
+      type = types.str;
+      description = lib.mdDoc ''
+        Frequency at which borgmatic should be run. See 
+	https://man7.org/linux/man-pages/man7/systemd.time.7.html for 
+	options.
+      '';
+    };
+
     settings = mkOption {
       description = lib.mdDoc ''
         See https://torsion.org/borgmatic/docs/reference/configuration/
@@ -53,6 +63,8 @@ in {
     environment.etc."borgmatic/config.yaml".source = cfgfile;
 
     systemd.packages = [ pkgs.borgmatic ];
+
+    systemd.services.borgmatic.startAt = cfg.frequency;
 
   };
 }

--- a/nixos/modules/services/backup/borgmatic.nix
+++ b/nixos/modules/services/backup/borgmatic.nix
@@ -15,7 +15,7 @@ in {
       type = types.str;
       description = lib.mdDoc ''
         Frequency at which borgmatic should be run. See
-        https://man7.org/linux/man-pages/man7/systemd.time.7.html for
+        {manpage}`systemd.time(7)` for
         options.
       '';
     };

--- a/pkgs/tools/backup/borgmatic/default.nix
+++ b/pkgs/tools/backup/borgmatic/default.nix
@@ -34,10 +34,10 @@ python3Packages.buildPythonApplication rec {
 
     mkdir -p $out/lib/systemd/system
     substitute sample/systemd/borgmatic.service \
-               $out/lib/systemd/system/borgmatic.service \
-               --replace /root/.local/bin/borgmatic $out/bin/borgmatic \
-               --replace systemd-inhibit ${systemd}/bin/systemd-inhibit \
-               --replace sleep ${coreutils}/bin/sleep
+      $out/lib/systemd/system/borgmatic.service \
+      --replace /root/.local/bin/borgmatic $out/bin/borgmatic \
+      --replace systemd-inhibit ${systemd}/bin/systemd-inhibit \
+      --replace sleep ${coreutils}/bin/sleep
   '';
 
   passthru.tests.version = testers.testVersion { package = borgmatic; };

--- a/pkgs/tools/backup/borgmatic/default.nix
+++ b/pkgs/tools/backup/borgmatic/default.nix
@@ -33,7 +33,6 @@ python3Packages.buildPythonApplication rec {
       --bash <($out/bin/borgmatic --bash-completion)
 
     mkdir -p $out/lib/systemd/system
-    cp sample/systemd/borgmatic.timer $out/lib/systemd/system/
     substitute sample/systemd/borgmatic.service \
                $out/lib/systemd/system/borgmatic.service \
                --replace /root/.local/bin/borgmatic $out/bin/borgmatic \


### PR DESCRIPTION
###### Description of changes
The previous default Borgmatic systemd files defaults to daily backups. This exposes the option to supply a different backup frequency (e.g. hourly).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
