### PR TITLE
spark2014: fix incomplete install (#208830)

### DIFF
--- a/pkgs/development/libraries/ada/spark2014/default.nix
+++ b/pkgs/development/libraries/ada/spark2014/default.nix
@@ -5,7 +5,6 @@
 , gnatcoll-core
 , gprbuild
 , python3
-, why3
 , ocaml
 , ocamlPackages
 , makeWrapper
@@ -53,11 +52,9 @@ stdenv.mkDerivation rec {
     make setup
   '';
 
-  postInstall = ''
+  installPhase = ''
+    make install-all
     cp -a ./install/. $out
-    # help gnatprove to locate why3server
-    wrapProgram "$out/bin/gnatprove" \
-        --prefix PATH : "${why3}/lib/why3"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
The previous installPhase was only using `make install`, while the real target needed is `make install-all`. This installs many missing tools under `$out/libexec/`, such as the missing `gnatwhy3` binary, which was the root cause of #208830.

With this, gnatprove can now successfully discharge and prove things with solvers like Z3, etc.

And, because it also includes `why3server`, we don't need to use wrapProgram on it anymore, either!

Closes #208830