### PR TITLE
ocamlPackages.biniou: 1.2.1 → 1.2.2

### DIFF
--- a/pkgs/development/ocaml-modules/biniou/default.nix
+++ b/pkgs/development/ocaml-modules/biniou/default.nix
@@ -1,29 +1,21 @@
-{ lib, fetchFromGitHub, buildDunePackage, easy-format }:
+{ lib, fetchurl, buildDunePackage, camlp-streams, easy-format }:
 
 buildDunePackage rec {
   pname = "biniou";
-  version = "1.2.1";
+  version = "1.2.2";
 
-  useDune2 = true;
-
-  src = fetchFromGitHub {
-    owner = "ocaml-community";
-    repo = pname;
-    rev = version;
-    sha256 = "0x2kiy809n1j0yf32l7hj102y628jp5jdrkbi3z7ld8jq04h1790";
+  src = fetchurl {
+    url = "https://github.com/mjambon/biniou/releases/download/${version}/biniou-${version}.tbz";
+    hash = "sha256-i/P/F80Oyy1rbR2UywjvCJ1Eyu+W6brmvmg51Cj6MY8=";
   };
 
-  propagatedBuildInputs = [ easy-format ];
+  propagatedBuildInputs = [ camlp-streams easy-format ];
 
   strictDeps = true;
 
-  postPatch = ''
-   patchShebangs .
-  '';
-
   meta = {
     description = "Binary data format designed for speed, safety, ease of use and backward compatibility as protocols evolve";
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/ocaml-community/biniou";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.vbgl ];
     mainProgram = "bdump";

--- a/pkgs/development/ocaml-modules/biniou/default.nix
+++ b/pkgs/development/ocaml-modules/biniou/default.nix
@@ -5,7 +5,7 @@ buildDunePackage rec {
   version = "1.2.2";
 
   src = fetchurl {
-    url = "https://github.com/mjambon/biniou/releases/download/${version}/biniou-${version}.tbz";
+    url = "https://github.com/ocaml-community/biniou/releases/download/${version}/biniou-${version}.tbz"
     hash = "sha256-i/P/F80Oyy1rbR2UywjvCJ1Eyu+W6brmvmg51Cj6MY8=";
   };
 

--- a/pkgs/development/ocaml-modules/biniou/default.nix
+++ b/pkgs/development/ocaml-modules/biniou/default.nix
@@ -5,7 +5,7 @@ buildDunePackage rec {
   version = "1.2.2";
 
   src = fetchurl {
-    url = "https://github.com/ocaml-community/biniou/releases/download/${version}/biniou-${version}.tbz"
+    url = "https://github.com/ocaml-community/biniou/releases/download/${version}/biniou-${version}.tbz";
     hash = "sha256-i/P/F80Oyy1rbR2UywjvCJ1Eyu+W6brmvmg51Cj6MY8=";
   };
 


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
