### PR TITLE
gcc-arm-embedded-12: init at 12.2.rel1

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/12/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/12/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchurl
+, ncurses5
+, python38
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gcc-arm-embedded";
+  version = "12.2.rel1";
+
+  platform = {
+    aarch64-linux = "aarch64";
+    x86_64-darwin = "darwin-x86_64";
+    x86_64-linux  = "x86_64";
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  src = fetchurl {
+    url = "https://developer.arm.com/-/media/Files/downloads/gnu/${version}/binrel/arm-gnu-toolchain-${version}-${platform}-arm-none-eabi.tar.xz";
+    sha256 = {
+      aarch64-linux = "131ydgndff7dyhkivfchbk43lv3cv2p172knkqilx64aapvk5qvy";
+      x86_64-darwin = "00i9gd1ny00681pwinh6ng9x45xsyrnwc6hm2vr348z9gasyxh00";
+      x86_64-linux  = "0rv8r5zh0a5621v0xygxi8f6932qgwinw2s9vnniasp9z7897gl4";
+    }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontPatchELF = true;
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r * $out
+  '';
+
+  preFixup = ''
+    find $out -type f | while read f; do
+      patchelf "$f" > /dev/null 2>&1 || continue
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
+      patchelf --set-rpath ${lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python38 ]} "$f" || true
+    done
+  '';
+
+  meta = with lib; {
+    description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors";
+    homepage = "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm";
+    license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
+    maintainers = with maintainers; [ prusnak ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14520,7 +14520,8 @@ with pkgs;
   gcc-arm-embedded-9 = callPackage ../development/compilers/gcc-arm-embedded/9 {};
   gcc-arm-embedded-10 = callPackage ../development/compilers/gcc-arm-embedded/10 {};
   gcc-arm-embedded-11 = callPackage ../development/compilers/gcc-arm-embedded/11 {};
-  gcc-arm-embedded = gcc-arm-embedded-11;
+  gcc-arm-embedded-12 = callPackage ../development/compilers/gcc-arm-embedded/12 {};
+  gcc-arm-embedded = gcc-arm-embedded-12;
 
   # Has to match the default gcc so that there are no linking errors when
   # using C/C++ libraries in D packages


### PR DESCRIPTION
###### Description of changes
Add package for `gcc-arm-embedded-12`.
Package `gcc-arm-embedded` updated to point to version 12.

Tested on `x86_64-linux` on a bigger embedded project, no problems.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).