### PR TITLE
pulumi: 3.49.0 -> 3.50.2

### DIFF
--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -14,7 +14,7 @@
 
 buildGoModule rec {
   pname = "pulumi";
-  version = "3.49.0";
+  version = "3.50.2";
 
   # Used in pulumi-language packages, which inherit this prop
   sdkVendorHash = "sha256-gM3VpX6r/BScUyvk/XefAfbx0qYzdzSBGaWZN+89BS8=";


### PR DESCRIPTION
###### Description of changes

Upgraded `pulumi` from 3.49.0 to 3.50.2

Surprisingly `sdkVendorHash` did not change for this new version. `pulumi-language-nodejs` and `pulumi-language-python` built fine.

Not to be confused with https://github.com/NixOS/nixpkgs/pull/207179 . `pulumi-bin` is a different package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - with the tests inherited from pulumi repo, which run during build
- [x] Tested compilation of all pulumiPackages that depend on this change
- [x] Tested basic functionality of all binary files in `./result/bin/`, by calling the built binaries
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
