### PR TITLE
secp256k1: unstable-2022-02-06 -> 0.2.0

### DIFF
--- a/pkgs/tools/security/secp256k1/default.nix
+++ b/pkgs/tools/security/secp256k1/default.nix
@@ -4,33 +4,26 @@
 , autoreconfHook
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "secp256k1";
 
-  version = "unstable-2022-02-06";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "bitcoin-core";
     repo = "secp256k1";
-    rev = "5dcc6f8dbdb1850570919fc9942d22f728dbc0af";
-    sha256 = "x9qG2S6tBSRseWaFIN9N2fRpY1vkv8idT3d3rfJnmaU=";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-wYJIMCoo6ryeQN4ZnvEkJ5/332+AkaOwgplDuQQC5MU=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
 
   configureFlags = [
     "--enable-benchmark=no"
-    "--enable-exhaustive-tests=no"
-    "--enable-experimental"
-    "--enable-module-ecdh"
     "--enable-module-recovery"
-    "--enable-module-schnorrsig"
-    "--enable-tests=yes"
   ];
 
   doCheck = true;
-
-  checkPhase = "./tests";
 
   meta = with lib; {
     description = "Optimized C library for EC operations on curve secp256k1";


### PR DESCRIPTION
###### Description of changes
Also,
- keep exhaustive tests because they test something different than the regular tests and finish faster than the regular tests
- remove unnecessary options. None of the modules are experimental (anymore) and the modules are enabled by default except recovery. This is demonstrated by the output of the configurePhase with this commit: 
  ```
  Build Options:
        with tests              = yes
        module ecdh             = yes
        module recovery         = yes
        module extrakeys        = yes
        module schnorrsig       = yes
  ```


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
