### PR TITLE
pulumi: 3.49.0 -> 3.50.2

### DIFF
--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -14,19 +14,19 @@
 
 buildGoModule rec {
   pname = "pulumi";
-  version = "3.49.0";
+  version = "3.50.2";
 
   # Used in pulumi-language packages, which inherit this prop
-  sdkVendorHash = "sha256-gM3VpX6r/BScUyvk/XefAfbx0qYzdzSBGaWZN+89BS8=";
+  sdkVendorHash = "sha256-+qnB55zIrxYkzeGrHJtBceam3shSMqc3TO4UNHbR8Z4=";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-WO+bTkTIAyaXl3nYwsMUTdovsYibivfGsKz6A7wj2zM=";
+    hash = "sha256-sdFy9gdjKhxLANvVMy7fVa+lamlF9XbW+yOYsgPzCqY=";
   };
 
-  vendorSha256 = "sha256-q7ZusTYD8l2RyiwP/Wf6dP6AoosWEwpaylbdhfE5cUA=";
+  vendorSha256 = "sha256-2zm95UfvXu5gbTxG5dcaQI1XOj80BuJaUS+HGnd1cN0=";
 
   sourceRoot = "source/pkg";
 
@@ -76,6 +76,13 @@ buildGoModule rec {
     buildFlagsArray+=("-run" "[^(${lib.concatStringsSep "|" disabledTests})]")
   '' + lib.optionalString stdenv.isDarwin ''
     export PULUMI_HOME=$(mktemp -d)
+  '';
+
+  postPatch = ''
+    # Relies on dir structure which is not present at nix package build time
+    substituteInPlace testing/integration/program_test.go \
+      --replace "TestGoModEdits" \
+                "SkipTestGoModEdits"
   '';
 
   # Allow tests that bind or connect to localhost on macOS.


### PR DESCRIPTION
###### Description of changes

Upgraded `pulumi` from 3.49.0 to 3.50.2

A new test was introduced in `pulumi` repo, which relies on a specific directory structure and `go.mod` being in that structure.
Due to my limited knowledge of where/how nix runs the tests, as well as what exactly these new tests are testing, I added some logic to skip this new test.

The new code, which introduced this new test can be found here. https://github.com/pulumi/pulumi/commit/6642fb5f1a407673872eeced96df6fc0af417431

Not sure if this is merge worthy, or does this test logic need to be fixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - with the tests inherited from pulumi repo, which run during build
- [x] Tested compilation of all pulumiPackages that depend on this change
- [x] Tested basic functionality of all binary files in `./result/bin/`, by calling the built binaries
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).... I think.