### PR TITLE
qmake2cmake: init at 1.0.2

### DIFF
--- a/pkgs/tools/misc/qmake2cmake/default.nix
+++ b/pkgs/tools/misc/qmake2cmake/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchgit
+, packaging
+, portalocker
+, sympy
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "qmake2cmake";
+  version = "1.0.2";
+
+  src = fetchgit {
+    url = "https://codereview.qt-project.org/qt/qmake2cmake";
+    rev = "v${version}";
+    hash = "sha256-Ibi7tIaMI44POfoRfKsgTMR3u+Li5UzeHBUNylnc9dw=";
+  };
+
+  patches = [
+    ./fix-locations.patch
+  ];
+
+  propagatedBuildInputs = [
+    packaging
+    portalocker
+    sympy
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Tool to convert qmake .pro files to CMakeLists.txt";
+    homepage = "https://wiki.qt.io/Qmake2cmake";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ wegank ];
+  };
+}

--- a/pkgs/tools/misc/qmake2cmake/fix-locations.patch
+++ b/pkgs/tools/misc/qmake2cmake/fix-locations.patch
@@ -1,0 +1,36 @@
+diff --git a/src/qmake2cmake/condition_simplifier_cache.py b/src/qmake2cmake/condition_simplifier_cache.py
+index 86c8e83..9d1ac00 100755
+--- a/src/qmake2cmake/condition_simplifier_cache.py
++++ b/src/qmake2cmake/condition_simplifier_cache.py
+@@ -29,8 +29,7 @@ def get_current_file_path() -> str:
+ 
+ 
+ def get_cache_location() -> str:
+-    this_file = get_current_file_path()
+-    dir_path = os.path.dirname(this_file)
++    dir_path = os.getcwd()
+     cache_path = os.path.join(dir_path, ".pro2cmake_cache", "cache.json")
+     return cache_path
+ 
+diff --git a/src/qmake2cmake/run_pro2cmake.py b/src/qmake2cmake/run_pro2cmake.py
+index fd3e11a..bdbadb0 100755
+--- a/src/qmake2cmake/run_pro2cmake.py
++++ b/src/qmake2cmake/run_pro2cmake.py
+@@ -194,7 +194,6 @@ def run(all_files: typing.List[str], pro2cmake: str, args: argparse.Namespace) -
+     ) -> typing.Tuple[int, str, str]:
+         filename, index, total = data
+         pro2cmake_args = []
+-        pro2cmake_args.append(sys.executable)
+         pro2cmake_args.append(pro2cmake)
+         if args.min_qt_version:
+             pro2cmake_args += ["--min-qt-version", args.min_qt_version]
+@@ -257,8 +256,7 @@ def run(all_files: typing.List[str], pro2cmake: str, args: argparse.Namespace) -
+ def main() -> None:
+     args = parse_command_line()
+ 
+-    script_path = os.path.dirname(os.path.abspath(__file__))
+-    pro2cmake = os.path.join(script_path, "pro2cmake.py")
++    pro2cmake = os.path.join(os.path.dirname(sys.argv[0]), "qmake2cmake")
+     base_path = args.path
+ 
+     all_files = find_all_pro_files(base_path, args)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37587,6 +37587,8 @@ with pkgs;
 
   qMasterPassword = qt6Packages.callPackage ../applications/misc/qMasterPassword { };
 
+  qmake2cmake = python3Packages.callPackage ../tools/misc/qmake2cmake { };
+
   qtrvsim = libsForQt5.callPackage ../applications/science/computer-architecture/qtrvsim { };
 
   qdl = callPackage ../tools/misc/qdl { };


### PR DESCRIPTION
###### Description of changes

https://www.qt.io/blog/introducing-qmake2cmake

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
