### PR TITLE
 nixos/activation-script: add option to diff system on user activation

### DIFF
--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -181,7 +181,13 @@ in
           exit $_status
         '';
       };
+    };
 
+    system.showSystemDiffOnRebuild = mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = lib.mdDoc "Whether to enable diffing the system against the currently activated one on a NixOS system activation";
     };
 
     environment.usrbinenv = mkOption {
@@ -200,6 +206,11 @@ in
   config = {
     system.activationScripts.stdio = ""; # obsolete
 
+    system.userActivationScripts.diff = lib.mkIf config.system.showSystemDiffOnRebuild ''
+      if [[ -e /run/current-system ]]; then
+        ${config.nix.package}/bin/nix ---extra-experimental-features 'nix-command' store diff-closures /run/current-system "$systemConfig" || true
+      fi
+    '';
 
     system.activationScripts.var = ''
       # Various log/runtime directories.

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -103,14 +103,9 @@ let
 in
 
 {
-
-  ###### interface
-
   options = {
-
     system.activationScripts = mkOption {
       default = {};
-
       example = literalExpression ''
         { stdio.text =
           '''
@@ -122,7 +117,6 @@ in
           ''';
         }
       '';
-
       description = lib.mdDoc ''
         A set of shell script fragments that are executed when a NixOS
         system configuration is activated.  Examples are updating
@@ -148,7 +142,6 @@ in
 
     system.userActivationScripts = mkOption {
       default = {};
-
       example = literalExpression ''
         { plasmaSetup = {
             text = '''
@@ -158,7 +151,6 @@ in
           };
         }
       '';
-
       description = lib.mdDoc ''
         A set of shell script fragments that are executed by a systemd user
         service when a NixOS system configuration is activated. Examples are
@@ -167,7 +159,6 @@ in
         {command}`nixos-rebuild`, it's important that they are
         idempotent and fast.
       '';
-
       type = with types; attrsOf (scriptType false);
 
       apply = set: {
@@ -206,28 +197,24 @@ in
     };
   };
 
-
-  ###### implementation
-
   config = {
-
     system.activationScripts.stdio = ""; # obsolete
 
-    system.activationScripts.var =
-      ''
-        # Various log/runtime directories.
 
-        mkdir -m 1777 -p /var/tmp
+    system.activationScripts.var = ''
+      # Various log/runtime directories.
 
-        # Empty, immutable home directory of many system accounts.
-        mkdir -p /var/empty
-        # Make sure it's really empty
-        ${pkgs.e2fsprogs}/bin/chattr -f -i /var/empty || true
-        find /var/empty -mindepth 1 -delete
-        chmod 0555 /var/empty
-        chown root:root /var/empty
-        ${pkgs.e2fsprogs}/bin/chattr -f +i /var/empty || true
-      '';
+      mkdir -m 1777 -p /var/tmp
+
+      # Empty, immutable home directory of many system accounts.
+      mkdir -p /var/empty
+      # Make sure it's really empty
+      ${pkgs.e2fsprogs}/bin/chattr -f -i /var/empty || true
+      find /var/empty -mindepth 1 -delete
+      chmod 0555 /var/empty
+      chown root:root /var/empty
+      ${pkgs.e2fsprogs}/bin/chattr -f +i /var/empty || true
+    '';
 
     system.activationScripts.usrbinenv = if config.environment.usrbinenv != null
       then ''
@@ -240,23 +227,22 @@ in
         rmdir --ignore-fail-on-non-empty /usr/bin /usr
       '';
 
-    system.activationScripts.specialfs =
-      ''
-        specialMount() {
-          local device="$1"
-          local mountPoint="$2"
-          local options="$3"
-          local fsType="$4"
+    system.activationScripts.specialfs = ''
+      specialMount() {
+        local device="$1"
+        local mountPoint="$2"
+        local options="$3"
+        local fsType="$4"
 
-          if mountpoint -q "$mountPoint"; then
-            local options="remount,$options"
-          else
-            mkdir -m 0755 -p "$mountPoint"
-          fi
-          mount -t "$fsType" -o "$options" "$device" "$mountPoint"
-        }
-        source ${config.system.build.earlyMountScript}
-      '';
+        if mountpoint -q "$mountPoint"; then
+          local options="remount,$options"
+        else
+          mkdir -m 0755 -p "$mountPoint"
+        fi
+        mount -t "$fsType" -o "$options" "$device" "$mountPoint"
+      }
+      source ${config.system.build.earlyMountScript}
+    '';
 
     systemd.user = {
       services.nixos-activation = {
@@ -268,5 +254,4 @@ in
       };
     };
   };
-
 }


### PR DESCRIPTION
###### Description of changes

Got the idea from https://discourse.nixos.org/t/nvd-simple-nix-nixos-version-diff-tool/12397/37 and added the nix diff-closure command as an option to always show what changed between the new activated system and the one that was activated before.

###### Things done

Tested this on my system but my system is special and verfriemelt.


<!--
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
