### PR TITLE
[rose-pine-gtk] unstable-2021-02-22 -> unstable-2022-09-01 (new variants)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13907,6 +13907,13 @@
       fingerprint = "D2A2 F0A1 E7A8 5E6F B711  DEE5 63A4 4817 A52E AB7B";
     }];
   };
+  the-argus = {
+    email = "i.mcfarlane2002@gmail.com";
+    github = "the-argus";
+    name = "Ian McFarlane";
+    githubId = 70479099;
+    matrix = "@eyes1238:matrix.org";
+  };
   TheBrainScrambler = {
     email = "esthromeris@riseup.net";
     github = "TheBrainScrambler";

--- a/pkgs/data/icons/rose-pine/default.nix
+++ b/pkgs/data/icons/rose-pine/default.nix
@@ -3,36 +3,36 @@
   lib,
   fetchFromGitHub,
 }:
-  stdenv.mkDerivation rec {
-    pname = "rose-pine-icon-theme";
-    version = "unstable-2022-09-01";
+stdenv.mkDerivation rec {
+  pname = "rose-pine-icon-theme";
+  version = "unstable-2022-09-01";
 
-    src = fetchFromGitHub {
-      owner = "rose-pine";
-      repo = "gtk";
-      rev = "7a4c40989fd42fd8d4a797f460c79fc4a085c304";
-      sha256 = "0q74wjyrsjyym770i3sqs071bvanwmm727xzv50wk6kzvpyqgi67";
-    };
+  src = fetchFromGitHub {
+    owner = "rose-pine";
+    repo = "gtk";
+    rev = "7a4c40989fd42fd8d4a797f460c79fc4a085c304";
+    sha256 = "0q74wjyrsjyym770i3sqs071bvanwmm727xzv50wk6kzvpyqgi67";
+  };
 
-    # avoid the makefile which is only for the theme maintainers
-    dontBuild = true;
+  # avoid the makefile which is only for the theme maintainers
+  dontBuild = true;
 
-    installPhase = ''
-      runHook preInstall
+  installPhase = ''
+    runHook preInstall
 
-      mkdir -p $out/share/icons
-      mv icons/rose-pine-icons $out/share/icons/rose-pine
-      mv icons/rose-pine-dawn-icons $out/share/icons/rose-pine-dawn
-      mv icons/rose-pine-moon-icons $out/share/icons/rose-pine-moon
+    mkdir -p $out/share/icons
+    mv icons/rose-pine-icons $out/share/icons/rose-pine
+    mv icons/rose-pine-dawn-icons $out/share/icons/rose-pine-dawn
+    mv icons/rose-pine-moon-icons $out/share/icons/rose-pine-moon
 
-      runHook postInstall
-    '';
+    runHook postInstall
+  '';
 
-    meta = with lib; {
-      description = "Rosé Pine icon theme for GTK";
-      homepage = "https://github.com/rose-pine/gtk";
-      license = licenses.gpl3Only;
-      platforms = platforms.linux;
-      maintainers = with maintainers; [romildo the-argus];
-    };
-  }
+  meta = with lib; {
+    description = "Rosé Pine icon theme for GTK";
+    homepage = "https://github.com/rose-pine/gtk";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [romildo the-argus];
+  };
+}

--- a/pkgs/data/icons/rose-pine/default.nix
+++ b/pkgs/data/icons/rose-pine/default.nix
@@ -2,21 +2,9 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  variant ? "default",
-}: let
-  source-locations = {
-    default = "icons/rose-pine-icons";
-    moon = "icons/rose-pine-moon-icons";
-    dawn = "icons/rose-pine-dawn-icons";
-  };
-
-  source-location =
-    if builtins.hasAttr variant source-locations
-    then source-locations.${variant}
-    else abort "unknown rose-pine variant ${variant}";
-in
+}:
   stdenv.mkDerivation rec {
-    pname = "rose-pine-${variant}-icon-theme";
+    pname = "rose-pine-icon-theme";
     version = "unstable-2022-09-01";
 
     src = fetchFromGitHub {
@@ -33,7 +21,9 @@ in
       runHook preInstall
 
       mkdir -p $out/share/icons
-      mv ${source-location} $out/share/icons/rose-pine
+      mv icons/rose-pine-icons $out/share/icons/rose-pine
+      mv icons/rose-pine-dawn-icons $out/share/icons/rose-pine-dawn
+      mv icons/rose-pine-moon-icons $out/share/icons/rose-pine-moon
 
       runHook postInstall
     '';

--- a/pkgs/data/icons/rose-pine/default.nix
+++ b/pkgs/data/icons/rose-pine/default.nix
@@ -1,9 +1,10 @@
-{
-  stdenv,
-  lib,
-  fetchFromGitHub,
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, gtk3
 }:
-stdenv.mkDerivation rec {
+
+stdenvNoCC.mkDerivation rec {
   pname = "rose-pine-icon-theme";
   version = "unstable-2022-09-01";
 
@@ -13,6 +14,10 @@ stdenv.mkDerivation rec {
     rev = "7a4c40989fd42fd8d4a797f460c79fc4a085c304";
     sha256 = "0q74wjyrsjyym770i3sqs071bvanwmm727xzv50wk6kzvpyqgi67";
   };
+
+  nativeBuildInputs = [
+    gtk3
+  ];
 
   # avoid the makefile which is only for the theme maintainers
   dontBuild = true;
@@ -24,6 +29,10 @@ stdenv.mkDerivation rec {
     mv icons/rose-pine-icons $out/share/icons/rose-pine
     mv icons/rose-pine-dawn-icons $out/share/icons/rose-pine-dawn
     mv icons/rose-pine-moon-icons $out/share/icons/rose-pine-moon
+
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache $theme
+    done
 
     runHook postInstall
   '';

--- a/pkgs/data/icons/rose-pine/default.nix
+++ b/pkgs/data/icons/rose-pine/default.nix
@@ -1,0 +1,48 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  variant ? "default",
+}: let
+  source-locations = {
+    default = "icons/rose-pine-icons";
+    moon = "icons/rose-pine-moon-icons";
+    dawn = "icons/rose-pine-dawn-icons";
+  };
+
+  source-location =
+    if builtins.hasAttr variant source-locations
+    then source-locations.${variant}
+    else abort "unknown rose-pine variant ${variant}";
+in
+  stdenv.mkDerivation rec {
+    pname = "rose-pine-${variant}-icon-theme";
+    version = "unstable-2022-09-01";
+
+    src = fetchFromGitHub {
+      owner = "rose-pine";
+      repo = "gtk";
+      rev = "7a4c40989fd42fd8d4a797f460c79fc4a085c304";
+      sha256 = "0q74wjyrsjyym770i3sqs071bvanwmm727xzv50wk6kzvpyqgi67";
+    };
+
+    # avoid the makefile which is only for the theme maintainers
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/icons
+      mv ${source-location} $out/share/icons/rose-pine
+
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "Rosé Pine icon theme for GTK";
+      homepage = "https://github.com/rose-pine/gtk";
+      license = licenses.gpl3Only;
+      platforms = platforms.linux;
+      maintainers = [maintainers.romildo];
+    };
+  }

--- a/pkgs/data/icons/rose-pine/default.nix
+++ b/pkgs/data/icons/rose-pine/default.nix
@@ -43,6 +43,6 @@ in
       homepage = "https://github.com/rose-pine/gtk";
       license = licenses.gpl3Only;
       platforms = platforms.linux;
-      maintainers = [maintainers.romildo];
+      maintainers = with maintainers; [romildo the-argus];
     };
   }

--- a/pkgs/data/themes/rose-pine-gtk/default.nix
+++ b/pkgs/data/themes/rose-pine-gtk/default.nix
@@ -4,20 +4,8 @@
   lib,
   gnome-themes-extra,
   gtk-engine-murrine,
-  gtk_engines,
-  variant ? "default",
-}: let
-  source-locations = {
-    default = "gtk3/rose-pine-gtk";
-    moon = "gtk3/rose-pine-moon-gtk";
-    dawn = "gtk3/rose-pine-dawn-gtk";
-  };
-
-  source-location =
-    if builtins.hasAttr variant source-locations
-    then source-locations.${variant}
-    else abort "unknown rose-pine variant ${variant}";
-in
+  gtk_engines
+}:
   stdenv.mkDerivation rec {
     pname = "rose-pine-${variant}-gtk-theme";
     version = "unstable-2022-09-01";
@@ -45,12 +33,10 @@ in
       runHook preInstall
 
       mkdir -p $out/share/themes
-      mv ${source-location} $out/share/themes/rose-pine
-      ${
-        if variant == "moon"
-        then "mv gnome_shell/moon/gnome-shell $out/share/themes/rose-pine"
-        else ""
-      }
+      mv gtk3/rose-pine-gtk $out/share/themes/rose-pine
+      mv gtk3/rose-pine-moon-gtk $out/share/themes/rose-pine-moon
+      mv gtk3/rose-pine-dawn-gtk $out/share/themes/rose-pine-dawn
+      mv gnome_shell/moon/gnome-shell $out/share/themes/rose-pine-moon
 
       runHook postInstall
     '';

--- a/pkgs/data/themes/rose-pine-gtk/default.nix
+++ b/pkgs/data/themes/rose-pine-gtk/default.nix
@@ -4,48 +4,48 @@
   lib,
   gnome-themes-extra,
   gtk-engine-murrine,
-  gtk_engines
+  gtk_engines,
 }:
-  stdenv.mkDerivation rec {
-    pname = "rose-pine-${variant}-gtk-theme";
-    version = "unstable-2022-09-01";
+stdenv.mkDerivation rec {
+  pname = "rose-pine-${variant}-gtk-theme";
+  version = "unstable-2022-09-01";
 
-    src = fetchFromGitHub {
-      owner = "rose-pine";
-      repo = "gtk";
-      rev = "7a4c40989fd42fd8d4a797f460c79fc4a085c304";
-      sha256 = "0q74wjyrsjyym770i3sqs071bvanwmm727xzv50wk6kzvpyqgi67";
-    };
+  src = fetchFromGitHub {
+    owner = "rose-pine";
+    repo = "gtk";
+    rev = "7a4c40989fd42fd8d4a797f460c79fc4a085c304";
+    sha256 = "0q74wjyrsjyym770i3sqs071bvanwmm727xzv50wk6kzvpyqgi67";
+  };
 
-    buildInputs = [
-      gnome-themes-extra # adwaita engine for Gtk2
-      gtk_engines # pixmap engine for Gtk2
-    ];
+  buildInputs = [
+    gnome-themes-extra # adwaita engine for Gtk2
+    gtk_engines # pixmap engine for Gtk2
+  ];
 
-    propagatedUserEnvPkgs = [
-      gtk-engine-murrine # murrine engine for Gtk2
-    ];
+  propagatedUserEnvPkgs = [
+    gtk-engine-murrine # murrine engine for Gtk2
+  ];
 
-    # avoid the makefile which is only for theme maintainers
-    dontBuild = true;
+  # avoid the makefile which is only for theme maintainers
+  dontBuild = true;
 
-    installPhase = ''
-      runHook preInstall
+  installPhase = ''
+    runHook preInstall
 
-      mkdir -p $out/share/themes
-      mv gtk3/rose-pine-gtk $out/share/themes/rose-pine
-      mv gtk3/rose-pine-moon-gtk $out/share/themes/rose-pine-moon
-      mv gtk3/rose-pine-dawn-gtk $out/share/themes/rose-pine-dawn
-      mv gnome_shell/moon/gnome-shell $out/share/themes/rose-pine-moon
+    mkdir -p $out/share/themes
+    mv gtk3/rose-pine-gtk $out/share/themes/rose-pine
+    mv gtk3/rose-pine-moon-gtk $out/share/themes/rose-pine-moon
+    mv gtk3/rose-pine-dawn-gtk $out/share/themes/rose-pine-dawn
+    mv gnome_shell/moon/gnome-shell $out/share/themes/rose-pine-moon
 
-      runHook postInstall
-    '';
+    runHook postInstall
+  '';
 
-    meta = with lib; {
-      description = "Rosé Pine theme for GTK";
-      homepage = "https://github.com/rose-pine/gtk";
-      license = licenses.gpl3Only;
-      platforms = platforms.linux;
-      maintainers = with maintainers; [romildo the-argus];
-    };
-  }
+  meta = with lib; {
+    description = "Rosé Pine theme for GTK";
+    homepage = "https://github.com/rose-pine/gtk";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [romildo the-argus];
+  };
+}

--- a/pkgs/data/themes/rose-pine-gtk/default.nix
+++ b/pkgs/data/themes/rose-pine-gtk/default.nix
@@ -1,12 +1,12 @@
-{
-  stdenv,
-  fetchFromGitHub,
-  lib,
-  gnome-themes-extra,
-  gtk-engine-murrine,
-  gtk_engines,
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, gnome-themes-extra
+, gtk-engine-murrine
+, gtk_engines
 }:
-stdenv.mkDerivation rec {
+
+stdenvNoCC.mkDerivation rec {
   pname = "rose-pine-gtk-theme";
   version = "unstable-2022-09-01";
 

--- a/pkgs/data/themes/rose-pine-gtk/default.nix
+++ b/pkgs/data/themes/rose-pine-gtk/default.nix
@@ -7,7 +7,7 @@
   gtk_engines,
 }:
 stdenv.mkDerivation rec {
-  pname = "rose-pine-${variant}-gtk-theme";
+  pname = "rose-pine-gtk-theme";
   version = "unstable-2022-09-01";
 
   src = fetchFromGitHub {

--- a/pkgs/data/themes/rose-pine-gtk/default.nix
+++ b/pkgs/data/themes/rose-pine-gtk/default.nix
@@ -4,17 +4,28 @@
 , gnome-themes-extra
 , gtk-engine-murrine
 , gtk_engines
-}:
+, variant ? "default"
+}: let
+  source-locations = {
+    default = "gtk3/rose-pine-gtk";
+    moon = "gtk3/rose-pine-moon-gtk";
+    dawn = "gtk3/rose-pine-dawn-gtk";
+  };
 
+  source-location =
+    if builtins.hasAttr variant source-locations
+    then source-locations.${variant}
+    else abort "unknown rose-pine variant ${variant}";
+in
 stdenv.mkDerivation rec {
-  pname = "rose-pine-gtk-theme";
-  version = "unstable-2021-02-22";
+  pname = "rose-pine-${variant}-gtk-theme";
+  version = "unstable-2022-09-01";
 
   src = fetchFromGitHub {
     owner = "rose-pine";
     repo = "gtk";
-    rev = "9cd2dd449f911973ec549231a57a070d256da9fd";
-    sha256 = "0lqx8dmv754ix3xbg7h440x964n0bg4lb06vbzvsydnbx79h7lvy";
+    rev = "7a4c40989fd42fd8d4a797f460c79fc4a085c304";
+    sha256 = "0q74wjyrsjyym770i3sqs071bvanwmm727xzv50wk6kzvpyqgi67";
   };
 
   buildInputs = [
@@ -26,11 +37,20 @@ stdenv.mkDerivation rec {
     gtk-engine-murrine # murrine engine for Gtk2
   ];
 
+  # avoid the makefile which is only for theme maintainers
+  dontBuild = true;
+
   installPhase = ''
     runHook preInstall
+
     mkdir -p $out/share/themes
-    cp -a Rose-Pine $out/share/themes
-    rm $out/share/themes/*/LICENSE
+    mv ${source-location} $out/share/themes/rose-pine
+    ${
+    if variant == "moon"
+    then "mv gnome_shell/moon/gnome-shell $out/share/themes/rose-pine"
+    else ""
+    }
+
     runHook postInstall
   '';
 

--- a/pkgs/data/themes/rose-pine-gtk/default.nix
+++ b/pkgs/data/themes/rose-pine-gtk/default.nix
@@ -59,6 +59,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/rose-pine/gtk";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
-    maintainers = [ maintainers.romildo ];
+    maintainers = with maintainers; [ romildo the-argus ];
   };
 }

--- a/pkgs/data/themes/rose-pine-gtk/default.nix
+++ b/pkgs/data/themes/rose-pine-gtk/default.nix
@@ -1,10 +1,11 @@
-{ stdenv
-, fetchFromGitHub
-, lib
-, gnome-themes-extra
-, gtk-engine-murrine
-, gtk_engines
-, variant ? "default"
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  gnome-themes-extra,
+  gtk-engine-murrine,
+  gtk_engines,
+  variant ? "default",
 }: let
   source-locations = {
     default = "gtk3/rose-pine-gtk";
@@ -17,48 +18,48 @@
     then source-locations.${variant}
     else abort "unknown rose-pine variant ${variant}";
 in
-stdenv.mkDerivation rec {
-  pname = "rose-pine-${variant}-gtk-theme";
-  version = "unstable-2022-09-01";
+  stdenv.mkDerivation rec {
+    pname = "rose-pine-${variant}-gtk-theme";
+    version = "unstable-2022-09-01";
 
-  src = fetchFromGitHub {
-    owner = "rose-pine";
-    repo = "gtk";
-    rev = "7a4c40989fd42fd8d4a797f460c79fc4a085c304";
-    sha256 = "0q74wjyrsjyym770i3sqs071bvanwmm727xzv50wk6kzvpyqgi67";
-  };
+    src = fetchFromGitHub {
+      owner = "rose-pine";
+      repo = "gtk";
+      rev = "7a4c40989fd42fd8d4a797f460c79fc4a085c304";
+      sha256 = "0q74wjyrsjyym770i3sqs071bvanwmm727xzv50wk6kzvpyqgi67";
+    };
 
-  buildInputs = [
-    gnome-themes-extra # adwaita engine for Gtk2
-    gtk_engines # pixmap engine for Gtk2
-  ];
+    buildInputs = [
+      gnome-themes-extra # adwaita engine for Gtk2
+      gtk_engines # pixmap engine for Gtk2
+    ];
 
-  propagatedUserEnvPkgs = [
-    gtk-engine-murrine # murrine engine for Gtk2
-  ];
+    propagatedUserEnvPkgs = [
+      gtk-engine-murrine # murrine engine for Gtk2
+    ];
 
-  # avoid the makefile which is only for theme maintainers
-  dontBuild = true;
+    # avoid the makefile which is only for theme maintainers
+    dontBuild = true;
 
-  installPhase = ''
-    runHook preInstall
+    installPhase = ''
+      runHook preInstall
 
-    mkdir -p $out/share/themes
-    mv ${source-location} $out/share/themes/rose-pine
-    ${
-    if variant == "moon"
-    then "mv gnome_shell/moon/gnome-shell $out/share/themes/rose-pine"
-    else ""
-    }
+      mkdir -p $out/share/themes
+      mv ${source-location} $out/share/themes/rose-pine
+      ${
+        if variant == "moon"
+        then "mv gnome_shell/moon/gnome-shell $out/share/themes/rose-pine"
+        else ""
+      }
 
-    runHook postInstall
-  '';
+      runHook postInstall
+    '';
 
-  meta = with lib; {
-    description = "Rosé Pine theme for GTK";
-    homepage = "https://github.com/rose-pine/gtk";
-    license = licenses.gpl3Only;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ romildo the-argus ];
-  };
-}
+    meta = with lib; {
+      description = "Rosé Pine theme for GTK";
+      homepage = "https://github.com/rose-pine/gtk";
+      license = licenses.gpl3Only;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [romildo the-argus];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27195,11 +27195,7 @@ with pkgs;
   roapi-http = callPackage ../servers/roapi/http.nix { };
 
   rose-pine-gtk-theme = callPackage ../data/themes/rose-pine-gtk { };
-  rose-pine-dawn-gtk-theme = callPackage ../data/themes/rose-pine-gtk { variant = "dawn"; };
-  rose-pine-moon-gtk-theme = callPackage ../data/themes/rose-pine-gtk { variant = "moon"; };
   rose-pine-icon-theme = callPackage ../data/icons/rose-pine { };
-  rose-pine-dawn-icon-theme = callPackage ../data/icons/rose-pine { variant = "dawn"; };
-  rose-pine-moon-icon-theme = callPackage ../data/icons/rose-pine { variant = "moon"; };
 
   route159 = callPackage ../data/fonts/route159 { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27195,6 +27195,11 @@ with pkgs;
   roapi-http = callPackage ../servers/roapi/http.nix { };
 
   rose-pine-gtk-theme = callPackage ../data/themes/rose-pine-gtk { };
+  rose-pine-dawn-gtk-theme = callPackage ../data/themes/rose-pine-gtk { variant = "dawn"; };
+  rose-pine-moon-gtk-theme = callPackage ../data/themes/rose-pine-gtk { variant = "moon"; };
+  rose-pine-icon-theme = callPackage ../data/icons/rose-pine { };
+  rose-pine-dawn-icon-theme = callPackage ../data/icons/rose-pine { variant = "dawn"; };
+  rose-pine-moon-icon-theme = callPackage ../data/icons/rose-pine { variant = "moon"; };
 
   route159 = callPackage ../data/fonts/route159 { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Upstream changes:
- add gnome-shell theme for rose pine moon
- add gtk4 theme (unused in this package)

My changes:
- added ``rose-pine-icon-theme``
- bumped the rev and sha256 of rose-pine-gtk-theme

related issue: #208893 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
