### PR TITLE
python3Packages.slack-bolt: init at 1.16.1

### DIFF
--- a/pkgs/development/python-modules/boddle/default.nix
+++ b/pkgs/development/python-modules/boddle/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, bottle
+}:
+
+buildPythonPackage rec {
+  pname = "boddle";
+  version = "0.2.9";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "keredson";
+    repo = pname;
+
+    # upstream doesn't tag releases
+    # https://github.com/keredson/boddle/issues/14
+    rev = "74413e4c5b39a37ea1694fab07b459ccd2998390";
+    hash = "sha256-iyxgdUM3NEbDaRd8ogCsxyNPF0nMuIV2S4FiFAZJXrY=";
+  };
+
+  propagatedBuildInputs = [ bottle ];
+
+  pythonImportsCheck = [
+    "boddle"
+  ];
+
+  meta = with lib; {
+    description = "Unit testing tool for Python's bottle library";
+    homepage = "https://github.com/keredson/boddle";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/development/python-modules/slack-bolt/default.nix
+++ b/pkgs/development/python-modules/slack-bolt/default.nix
@@ -1,0 +1,118 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, aiohttp
+, boddle
+, boto3
+, bottle
+, chalice
+, cherrypy
+, django
+, falcon
+, fastapi
+, flask
+, flask-sockets
+, mock
+, moto
+, pyramid
+, pytest-asyncio
+, sanic
+, sanic-testing
+, slack-sdk
+, starlette
+, tornado
+, uvicorn
+, websockets
+}:
+
+buildPythonPackage rec {
+  pname = "slack-bolt";
+  version = "1.16.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "slackapi";
+    repo = "bolt-python";
+    rev = "v${version}";
+    hash = "sha256-xzEsTx+44ae++WxArxO2rhCsot+ELuhc0aZ44MXY0c4=";
+  };
+
+  propagatedBuildInputs = [ slack-sdk ];
+
+  pythonImportsCheck = [
+    "slack_bolt"
+  ];
+
+  passthru.optional-dependencies = {
+    async = [
+      aiohttp
+      websockets
+    ];
+    adapter = [
+      boddle
+      boto3
+      bottle
+      cherrypy
+      django
+      falcon
+      fastapi
+      flask
+      flask-sockets
+      pyramid
+      starlette
+      tornado
+      uvicorn
+    ] ++ lib.optionals (!stdenv.isDarwin) [
+      # server types that are broken on darwin
+      chalice
+      moto
+      sanic
+      sanic-testing
+    ];
+  };
+
+  nativeCheckInputs = [
+    mock
+    pytestCheckHook
+    pytest-asyncio
+  ] ++ passthru.optional-dependencies.async
+  ++ passthru.optional-dependencies.adapter;
+
+  disabledTestPaths = [
+    # disable tests that require credentials
+    "tests/slack_bolt_async/oauth/test_async_oauth_flow.py"
+    "tests/slack_bolt/oauth/test_oauth_flow.py"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # disable tests that test broken things on darwin
+    "tests/adapter_tests_async/test_async_sanic.py"
+    "tests/adapter_tests/aws/test_aws_chalice.py"
+    "tests/adapter_tests/aws/test_aws_lambda.py"
+    "tests/adapter_tests/aws/test_lambda_s3_oauth_flow.py"
+  ];
+
+  # disable tests that test auth or end to end integration
+  disabledTests = [
+    "test_events"
+    "test_interactions"
+    "test_lazy_listeners"
+    "test_oauth"
+  ];
+
+  # patch out pytest-runner
+  preBuild = ''
+    sed -i '/pytest-runner/d' ./setup.py
+  '';
+
+  meta = with lib; {
+    description = "A framework to build Slack apps";
+    homepage = "https://github.com/slackapi/bolt-python";
+    changelog = "https://github.com/slackapi/bolt-python/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10541,6 +10541,8 @@ self: super: with self; {
 
   skytemple-ssb-debugger = callPackage ../development/python-modules/skytemple-ssb-debugger { };
 
+  slack-bolt = callPackage ../development/python-modules/slack-bolt { };
+
   slack-sdk = callPackage ../development/python-modules/slack-sdk { };
 
   slackclient = callPackage ../development/python-modules/slackclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1344,6 +1344,8 @@ self: super: with self; {
 
   bme680 = callPackage ../development/python-modules/bme680 { };
 
+  boddle = callPackage ../development/python-modules/boddle { };
+
   bokeh = callPackage ../development/python-modules/bokeh { };
 
   boltons = callPackage ../development/python-modules/boltons { };


### PR DESCRIPTION
###### Description of changes

I would like to include [`slack-bolt`](https://github.com/slackapi/bolt-python/) in nixpkgs to be able to create [Slack](https://slack.com/) bots and other applications using Slack's [Bolt](https://api.slack.com/tools/bolt) framework! This PR also includes adding [`boddle`](https://github.com/keredson/boddle) as a `checkInput`.

Previous PR for `boddle` here: #188832

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).