### PR TITLE
zig: fix build on darwin

### DIFF
--- a/pkgs/development/compilers/zig/default.nix
+++ b/pkgs/development/compilers/zig/default.nix
@@ -7,6 +7,14 @@
 , zlib
 }:
 
+let
+  zig_0_10_0 = fetchFromGitHub {
+    owner = "ziglang";
+    repo = "zig";
+    rev = "0.10.0";
+    hash = "sha256-DNs937N7PLQimuM2anya4npYXcj6cyH+dRS7AiOX7tw=";
+  };
+in
 stdenv.mkDerivation rec {
   pname = "zig";
   version = "0.9.1";
@@ -18,8 +26,20 @@ stdenv.mkDerivation rec {
     hash = "sha256-x2c4c9RSrNWGqEngio4ArW7dJjW0gg+8nqBwPcR721k=";
   };
 
-  # Fix index out of bounds reading RPATH (cherry-picked from 0.10-dev)
-  patches = [ ./rpath.patch ];
+  patches = [
+    # Fix index out of bounds reading RPATH (cherry-picked from 0.10-dev)
+    ./rpath.patch
+    # Fix build on macOS 13 (cherry-picked from 0.10-dev)
+    ./ventura.patch
+  ];
+
+  # TODO: remove on next upgrade
+  prePatch = ''
+    cp -R ${zig_0_10_0}/lib/libc/include/any-macos.13-any lib/libc/include/any-macos.13-any
+    cp -R ${zig_0_10_0}/lib/libc/include/aarch64-macos.13-none lib/libc/include/aarch64-macos.13-gnu
+    cp -R ${zig_0_10_0}/lib/libc/include/x86_64-macos.13-none lib/libc/include/x86_64-macos.13-gnu
+    cp ${zig_0_10_0}/lib/libc/darwin/libSystem.13.tbd lib/libc/darwin/
+  '';
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/compilers/zig/ventura.patch
+++ b/pkgs/development/compilers/zig/ventura.patch
@@ -1,0 +1,50 @@
+From 98285b17b3887de37b630da66f09a44f42ddbe01 Mon Sep 17 00:00:00 2001
+From: Jakub Konka <kubkon@jakubkonka.com>
+Date: Tue, 25 Oct 2022 11:46:42 +0200
+Subject: [PATCH] darwin: bump max macOS version to 13.0
+
+---
+ lib/std/target.zig | 4 ++--
+ src/target.zig     | 2 ++
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/lib/std/target.zig b/lib/std/target.zig
+index d791e3b0350..7fbad5baa3c 100644
+--- a/lib/std/target.zig
++++ b/lib/std/target.zig
+@@ -277,13 +277,13 @@ pub const Target = struct {
+                         .aarch64 => VersionRange{
+                             .semver = .{
+                                 .min = .{ .major = 11, .minor = 6 },
+-                                .max = .{ .major = 12, .minor = 0 },
++                                .max = .{ .major = 13, .minor = 0 },
+                             },
+                         },
+                         .x86_64 => VersionRange{
+                             .semver = .{
+                                 .min = .{ .major = 10, .minor = 13 },
+-                                .max = .{ .major = 12, .minor = 0 },
++                                .max = .{ .major = 13, .minor = 0 },
+                             },
+                         },
+                         else => unreachable,
+diff --git a/src/target.zig b/src/target.zig
+index 9e2d26dac65..fc585912c45 100644
+--- a/src/target.zig
++++ b/src/target.zig
+@@ -18,6 +18,7 @@ pub const available_libcs = [_]ArchOsAbi{
+     .{ .arch = .aarch64, .os = .windows, .abi = .gnu },
+     .{ .arch = .aarch64, .os = .macos, .abi = .gnu, .os_ver = .{ .major = 11, .minor = 0 } },
+     .{ .arch = .aarch64, .os = .macos, .abi = .gnu, .os_ver = .{ .major = 12, .minor = 0 } },
++    .{ .arch = .aarch64, .os = .macos, .abi = .gnu, .os_ver = .{ .major = 13, .minor = 0 } },
+     .{ .arch = .armeb, .os = .linux, .abi = .gnueabi },
+     .{ .arch = .armeb, .os = .linux, .abi = .gnueabihf },
+     .{ .arch = .armeb, .os = .linux, .abi = .musleabi },
+@@ -73,6 +74,7 @@ pub const available_libcs = [_]ArchOsAbi{
+     .{ .arch = .x86_64, .os = .macos, .abi = .gnu, .os_ver = .{ .major = 10, .minor = 0 } },
+     .{ .arch = .x86_64, .os = .macos, .abi = .gnu, .os_ver = .{ .major = 11, .minor = 0 } },
+     .{ .arch = .x86_64, .os = .macos, .abi = .gnu, .os_ver = .{ .major = 12, .minor = 0 } },
++    .{ .arch = .x86_64, .os = .macos, .abi = .gnu, .os_ver = .{ .major = 13, .minor = 0 } },
+ };
+ 
+ pub fn libCGenericName(target: std.Target) [:0]const u8 {


### PR DESCRIPTION
###### Description of changes

It's very unfortunate to have to fix it on 0.9.1 rather than upgrade to 0.10.0 (blocked by #194634), but let's do it.

Closes #205713.
Closes #208890.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
