### PR TITLE
zimfw: init at 1.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6852,6 +6852,12 @@
     githubId = 3967312;
     name = "Jocelyn Thode";
   };
+  joedevivo = {
+     email = "55951+joedevivo@users.noreply.github.com";
+     github = "joedevivo";
+     githubId = 55951;
+     name = "Joe DeVivo";
+   };
   joelancaster = {
     email = "joe.a.lancas@gmail.com";
     github = "JoeLancaster";

--- a/pkgs/shells/zsh/zimfw/default.nix
+++ b/pkgs/shells/zsh/zimfw/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "zimfw";
+  version = "1.11.0";
+  src = fetchFromGitHub {
+    owner = "zimfw";
+    repo = "zimfw";
+    rev = "v${version}";
+    ## zim only needs this one file to be installed.
+    sparseCheckout = [ "zimfw.zsh" ];
+    sha256 = "sha256-BmzYAgP5Z77VqcpAB49cQLNuvQX1qcKmAh9BuXsy2pA=";
+  };
+  strictDeps = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r $src/zimfw.zsh $out/
+
+    runHook postInstall
+  '';
+
+  ## zim automates the downloading of any plugins you specify in the `.zimrc`
+  ## file. To do that with Nix, you'll need $ZIM_HOME to be writable.
+  ## `~/.cache/zim` is a good place for that. The problem is that zim also
+  ## looks for `zimfw.zsh` there, so we're going to tell it here to look for
+  ## the `zimfw.zsh` where we currently are.
+  postFixup = ''
+    substituteInPlace $out/zimfw.zsh \
+      --replace "\''${ZIM_HOME}/zimfw.zsh" "$out/zimfw.zsh"
+  '';
+
+  meta = with lib; {
+    description =
+      "The Zsh configuration framework with blazing speed and modular extensions";
+    homepage = "https://zimfw.sh";
+    license = licenses.mit;
+    maintainers = [ maintainers.joedevivo ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13496,6 +13496,8 @@ with pkgs;
 
   zim-tools = callPackage ../tools/text/zim-tools { };
 
+  zimfw = callPackage ../shells/zsh/zimfw { };
+
   zld = callPackage ../development/tools/zld { };
 
   par = callPackage ../tools/text/par { };


### PR DESCRIPTION
###### Description of changes

[zimfw](https://zimfw.sh) is a framework for zsh that is very lightweight and compiles zsh scripts for speed at runtime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
