### PR TITLE
zcash: 5.3.0 -> 5.3.2

### DIFF
--- a/pkgs/applications/blockchains/zcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/default.nix
@@ -1,17 +1,38 @@
-{ autoreconfHook, boost180, cargo, coreutils, curl, cxx-rs, db62, fetchFromGitHub
-, hexdump, lib, libevent, libsodium, makeWrapper, rust, rustPlatform
-, pkg-config, Security, stdenv, testers, utf8cpp, util-linux, zcash, zeromq
+{ autoreconfHook
+, boost
+, cargo
+, coreutils
+, curl
+, cxx-rs
+, db
+, fetchFromGitHub
+, git
+, hexdump
+, lib
+, libevent
+, libsodium
+, makeWrapper
+, rust
+, rustPlatform
+, pkg-config
+, Security
+, stdenv
+, testers
+, utf8cpp
+, util-linux
+, zcash
+, zeromq
 }:
 
 rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
   pname = "zcash";
-  version = "5.3.0";
+  version = "5.3.2";
 
   src = fetchFromGitHub {
     owner = "zcash";
     repo  = "zcash";
     rev = "v${version}";
-    hash = "sha256-mlABKZDYYC3y+KlXQVFqdcm46m8K9tbOCqk4lM4shp8=";
+    hash = "sha256-1pLQWRKodDJHpsqDZISUfempLf/MbbpnNEZ87qeMT1o=";
   };
 
   prePatch = lib.optionalString stdenv.isAarch64 ''
@@ -20,13 +41,21 @@ rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
       --replace "linker = \"aarch64-linux-gnu-gcc\"" ""
   '';
 
-  cargoHash = "sha256-6uhtOaBsgMw59Dy6yivZYUEWDsYfpInA7VmJrqxDS/4=";
+  cargoHash = "sha256-u9bulmUeoQibNJIB/DP3wosaPVUJeDs9K4DlR+zu3Ug=";
 
-  nativeBuildInputs = [ autoreconfHook cargo cxx-rs hexdump makeWrapper pkg-config ];
+  nativeBuildInputs = [
+    autoreconfHook
+    cargo
+    cxx-rs
+    git
+    hexdump
+    makeWrapper
+    pkg-config
+  ];
 
   buildInputs = [
-    boost180
-    db62
+    boost
+    db
     libevent
     libsodium
     utf8cpp
@@ -55,7 +84,7 @@ rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
 
   configureFlags = [
     "--disable-tests"
-    "--with-boost-libdir=${lib.getLib boost180}/lib"
+    "--with-boost=${boost}"
     "RUST_TARGET=${rust.toRustTargetSpec stdenv.hostPlatform}"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34296,9 +34296,12 @@ with pkgs;
     boost = boost175;
   };
 
-  zcash = callPackage ../applications/blockchains/zcash {
+  zcash = callPackage ../applications/blockchains/zcash rec {
     inherit (darwin.apple_sdk.frameworks) Security;
-    stdenv = llvmPackages_14.stdenv;
+
+    boost = boost181.override { inherit stdenv; };
+    db = db62.override { inherit stdenv; };
+    stdenv = llvmPackages_14.libcxxStdenv;
   };
 
   zecwallet-lite = callPackage ../applications/blockchains/zecwallet-lite { };


### PR DESCRIPTION
###### Description of changes

[Release notes](https://github.com/zcash/zcash/releases/tag/v5.3.2).

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).