### PR TITLE
etebase-server: 0.10.0 -> 0.11.0

### DIFF
--- a/pkgs/servers/etebase/default.nix
+++ b/pkgs/servers/etebase/default.nix
@@ -1,7 +1,18 @@
-{ lib, fetchFromGitHub, buildPythonPackage, aiofiles, django_3
-, fastapi, msgpack, pynacl, redis, typing-extensions
-, withLdap ? true, python-ldap
-, withPostgres ? true, psycopg2 }:
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, aiofiles
+, django_3
+, fastapi
+, msgpack
+, pynacl
+, redis
+, typing-extensions
+, withLdap ? true
+, python-ldap
+, withPostgres ? true
+, psycopg2
+}:
 
 buildPythonPackage rec {
   pname = "etebase-server";
@@ -11,8 +22,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "etesync";
     repo = "server";
-    rev = version;
-    sha256 = "sha256-+MSNX+CFmIQII+SFjM2TQKCgRMOTdsOIVAP8ur4WjQY=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-+MSNX+CFmIQII+SFjM2TQKCgRMOTdsOIVAP8ur4WjQY=";
   };
 
   patches = [ ./secret.patch ];
@@ -25,8 +36,11 @@ buildPythonPackage rec {
     pynacl
     redis
     typing-extensions
-  ] ++ lib.optional withLdap python-ldap
-    ++ lib.optional withPostgres psycopg2;
+  ] ++ lib.optional withLdap [
+    python-ldap
+  ] ++ lib.optional withPostgres [
+    psycopg2
+  ];
 
   installPhase = ''
     mkdir -p $out/bin $out/lib
@@ -38,7 +52,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/etesync/server";
-    description = "An Etebase (EteSync 2.0) server so you can run your own.";
+    description = "An Etebase (EteSync 2.0) server so you can run your own";
+    changelog = "https://github.com/etesync/server/blob/${version}/ChangeLog.md";
     license = licenses.agpl3Only;
     maintainers = with maintainers; [ felschr ];
   };

--- a/pkgs/servers/etebase/default.nix
+++ b/pkgs/servers/etebase/default.nix
@@ -5,14 +5,14 @@
 
 buildPythonPackage rec {
   pname = "etebase-server";
-  version = "0.10.0";
+  version = "0.11.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "etesync";
     repo = "server";
-    rev = "v${version}";
-    sha256 = "sha256-z6aiXSWdLcDfOpqC5epsclXWxJq59MqWDQOnnFqGwz4=";
+    rev = version;
+    sha256 = "sha256-+MSNX+CFmIQII+SFjM2TQKCgRMOTdsOIVAP8ur4WjQY=";
   };
 
   patches = [ ./secret.patch ];


### PR DESCRIPTION
###### Description of changes

Update etebase-server to latest release. No breaking changes.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).