### PR TITLE
haskell.compiler.ghcHEAD: support JS backend

### DIFF
--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -3,6 +3,7 @@
 , llvmPackages
 , symlinkJoin, makeWrapper, substituteAll
 , mkYarnModules
+, emscripten
 }:
 
 stdenv.mkDerivation rec {
@@ -115,6 +116,13 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru = {
+    # HACK: Make emscripten look more like a cc-wrapper to GHC
+    # when building the javascript backend.
+    targetPrefix = "em";
+    bintools = emscripten;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/emscripten-core/emscripten";

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -21,7 +21,9 @@
 
 , # If enabled, GHC will be built with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
-  enableIntegerSimple ? !(lib.meta.availableOn stdenv.hostPlatform gmp), gmp
+  enableIntegerSimple ? !(lib.meta.availableOn stdenv.hostPlatform gmp
+                          && lib.meta.availableOn stdenv.targetPlatform gmp)
+, gmp
 
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform

--- a/pkgs/development/compilers/ghc/8.8.4.nix
+++ b/pkgs/development/compilers/ghc/8.8.4.nix
@@ -20,7 +20,9 @@
 
 , # If enabled, GHC will be built with the GPL-free but slower integer-simple
   # library instead of the faster but GPLed integer-gmp library.
-  enableIntegerSimple ? !(lib.meta.availableOn stdenv.hostPlatform gmp), gmp
+  enableIntegerSimple ? !(lib.meta.availableOn stdenv.hostPlatform gmp
+                          && lib.meta.availableOn stdenv.targetPlatform gmp)
+, gmp
 
 , # If enabled, use -fPIC when compiling static libs.
   enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform

--- a/pkgs/development/compilers/ghc/9.0.2.nix
+++ b/pkgs/development/compilers/ghc/9.0.2.nix
@@ -23,7 +23,8 @@
 
 , # If enabled, GHC will be built with the GPL-free but slightly slower native
   # bignum backend instead of the faster but GPLed gmp backend.
-  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp)
+  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp
+                         && lib.meta.availableOn stdenv.targetPlatform gmp)
 , gmp
 
 , # If enabled, use -fPIC when compiling static libs.

--- a/pkgs/development/compilers/ghc/9.2.4.nix
+++ b/pkgs/development/compilers/ghc/9.2.4.nix
@@ -23,7 +23,8 @@
 
 , # If enabled, GHC will be built with the GPL-free but slightly slower native
   # bignum backend instead of the faster but GPLed gmp backend.
-  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp)
+  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp
+                         && lib.meta.availableOn stdenv.targetPlatform gmp)
 , gmp
 
 , # If enabled, use -fPIC when compiling static libs.

--- a/pkgs/development/compilers/ghc/9.2.5.nix
+++ b/pkgs/development/compilers/ghc/9.2.5.nix
@@ -23,7 +23,8 @@
 
 , # If enabled, GHC will be built with the GPL-free but slightly slower native
   # bignum backend instead of the faster but GPLed gmp backend.
-  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp)
+  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp
+                         && lib.meta.availableOn stdenv.targetPlatform gmp)
 , gmp
 
 , # If enabled, use -fPIC when compiling static libs.

--- a/pkgs/development/compilers/ghc/9.4.2.nix
+++ b/pkgs/development/compilers/ghc/9.4.2.nix
@@ -25,7 +25,8 @@
 
 , # If enabled, GHC will be built with the GPL-free but slightly slower native
   # bignum backend instead of the faster but GPLed gmp backend.
-  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp)
+  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp
+                         && lib.meta.availableOn stdenv.targetPlatform gmp)
 , gmp
 
 , # If enabled, use -fPIC when compiling static libs.

--- a/pkgs/development/compilers/ghc/9.4.3.nix
+++ b/pkgs/development/compilers/ghc/9.4.3.nix
@@ -25,7 +25,8 @@
 
 , # If enabled, GHC will be built with the GPL-free but slightly slower native
   # bignum backend instead of the faster but GPLed gmp backend.
-  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp)
+  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp
+                         && lib.meta.availableOn stdenv.targetPlatform gmp)
 , gmp
 
 , # If enabled, use -fPIC when compiling static libs.

--- a/pkgs/development/compilers/ghc/9.4.4.nix
+++ b/pkgs/development/compilers/ghc/9.4.4.nix
@@ -25,7 +25,8 @@
 
 , # If enabled, GHC will be built with the GPL-free but slightly slower native
   # bignum backend instead of the faster but GPLed gmp backend.
-  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp)
+  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp
+                         && lib.meta.availableOn stdenv.targetPlatform gmp)
 , gmp
 
 , # If enabled, use -fPIC when compiling static libs.

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -39,7 +39,8 @@
 , useLLVM ? !(stdenv.targetPlatform.isx86
               || stdenv.targetPlatform.isPower
               || stdenv.targetPlatform.isSparc
-              || (stdenv.targetPlatform.isAarch64 && stdenv.targetPlatform.isDarwin))
+              || (stdenv.targetPlatform.isAarch64 && stdenv.targetPlatform.isDarwin)
+              || stdenv.targetPlatform.isGhcjs)
 , # LLVM is conceptually a run-time-only depedendency, but for
   # non-x86, we need LLVM to bootstrap later stages, so it becomes a
   # build-time dependency too.
@@ -50,6 +51,7 @@
   # bignum backend instead of the faster but GPLed gmp backend.
   enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp
                          && lib.meta.availableOn stdenv.targetPlatform gmp)
+                       || stdenv.targetPlatform.isGhcjs
 , gmp
 
 , # If enabled, use -fPIC when compiling static libs.
@@ -63,7 +65,8 @@
   enableShared ? with stdenv.targetPlatform; !isWindows && !useiOSPrebuilt && !isStatic
 
 , # Whether to build terminfo.
-  enableTerminfo ? !stdenv.targetPlatform.isWindows
+  enableTerminfo ? !(stdenv.targetPlatform.isWindows
+                     || stdenv.targetPlatform.isGhcjs)
 
 , # Libdw.c only supports x86_64, i686 and s390x as of 2022-08-04
   enableDwarf ? (stdenv.targetPlatform.isx86 ||
@@ -196,17 +199,19 @@ let
 
   # Splicer will pull out correct variations
   libDeps = platform: lib.optional enableTerminfo ncurses
-    ++ [libffi]
+    ++ lib.optionals (!targetPlatform.isGhcjs) [libffi]
     # Bindist configure script fails w/o elfutils in linker search path
     # https://gitlab.haskell.org/ghc/ghc/-/issues/22081
     ++ lib.optional enableDwarf elfutils
     ++ lib.optional (!enableNativeBignum) gmp
-    ++ lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows) libiconv;
+    ++ lib.optional (platform.libc != "glibc" && !targetPlatform.isWindows && !targetPlatform.isGhcjs) libiconv;
 
   # TODO(@sternenseemann): is buildTarget LLVM unnecessary?
   # GHC doesn't seem to have {LLC,OPT}_HOST
   toolsForTarget = [
-    pkgsBuildTarget.targetPackages.stdenv.cc
+    (if targetPlatform.isGhcjs
+     then pkgsBuildTarget.emscripten
+     else pkgsBuildTarget.targetPackages.stdenv.cc)
   ] ++ lib.optional useLLVM buildTargetLlvmPackages.llvm;
 
   targetCC = builtins.head toolsForTarget;
@@ -246,7 +251,7 @@ in
 # C compiler, bintools and LLVM are used at build time, but will also leak into
 # the resulting GHC's settings file and used at runtime. This means that we are
 # currently only able to build GHC if hostPlatform == buildPlatform.
-assert targetCC == pkgsHostTarget.targetPackages.stdenv.cc;
+assert !targetPlatform.isGhcjs -> targetCC == pkgsHostTarget.targetPackages.stdenv.cc;
 assert buildTargetLlvmPackages.llvm == llvmPackages.llvm;
 assert stdenv.targetPlatform.isDarwin -> buildTargetLlvmPackages.clang == llvmPackages.clang;
 
@@ -329,6 +334,13 @@ stdenv.mkDerivation ({
                     '*-android*|*-gnueabi*|*-musleabi*)'
       done
   ''
+  # Need to make writable EM_CACHE for emscripten
+  # https://gitlab.haskell.org/ghc/ghc/-/wikis/javascript-backend#configure-fails-with-sub-word-sized-atomic-operations-not-available
+  + lib.optionalString targetPlatform.isGhcjs ''
+    export EM_CACHE="$(mktemp -d emcache.XXXXXXXXXX)"
+    cp -Lr ${targetCC /* == emscripten */}/share/emscripten/cache/* "$EM_CACHE/"
+    chmod u+rwX -R "$EM_CACHE"
+  ''
   # Create bash array hadrianFlagsArray for use in buildPhase. Do it in
   # preConfigure, so overrideAttrs can be used to modify it effectively.
   # hadrianSettings are passed via the command line so they are more visible
@@ -340,6 +352,8 @@ stdenv.mkDerivation ({
     )
   '';
 
+  ${if targetPlatform.isGhcjs then "configureScript" else null} = "emconfigure ./configure";
+
   # TODO(@Ericson2314): Always pass "--target" and always prefix.
   configurePlatforms = [ "build" "host" ]
     ++ lib.optional (targetPlatform != hostPlatform) "target";
@@ -348,7 +362,7 @@ stdenv.mkDerivation ({
   configureFlags = [
     "--datadir=$doc/share/doc/ghc"
     "--with-curses-includes=${ncurses.dev}/include" "--with-curses-libraries=${ncurses.out}/lib"
-  ] ++ lib.optionals (libffi != null) [
+  ] ++ lib.optionals (libffi != null && !targetPlatform.isGhcjs) [
     "--with-system-libffi"
     "--with-ffi-includes=${targetPackages.libffi.dev}/include"
     "--with-ffi-libraries=${targetPackages.libffi.out}/lib"
@@ -387,6 +401,9 @@ stdenv.mkDerivation ({
     autoSignDarwinBinariesHook
   ] ++ lib.optionals enableDocs [
     sphinx
+  ] ++ lib.optionals targetPlatform.isGhcjs [
+    # emscripten itself is added via depBuildTarget / targetCC
+    python3
   ];
 
   # For building runtime libs
@@ -445,7 +462,7 @@ stdenv.mkDerivation ({
   preInstall = ''
     pushd _build/bindist/*
 
-    ./configure $configureFlags "''${configureFlagsArray[@]}"
+    $configureScript $configureFlags "''${configureFlagsArray[@]}"
   '';
 
   postInstall = ''

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -48,7 +48,8 @@
 
 , # If enabled, GHC will be built with the GPL-free but slightly slower native
   # bignum backend instead of the faster but GPLed gmp backend.
-  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp)
+  enableNativeBignum ? !(lib.meta.availableOn stdenv.hostPlatform gmp
+                         && lib.meta.availableOn stdenv.targetPlatform gmp)
 , gmp
 
 , # If enabled, use -fPIC when compiling static libs.

--- a/pkgs/development/compilers/openjdk/19.nix
+++ b/pkgs/development/compilers/openjdk/19.nix
@@ -4,7 +4,9 @@
 , libXi, libXinerama, libXcursor, libXrandr, fontconfig, openjdk19-bootstrap
 , ensureNewerSourcesForZipFilesHook
 , setJavaClassPath
-, headless ? false
+# TODO(@sternenseemann): gtk3 fails to evaluate in pkgsCross.ghcjs.buildPackages
+# which should be fixable, this is a no-rebuild workaround for GHC.
+, headless ? stdenv.targetPlatform.isGhcjs
 , enableJavaFX ? openjfx.meta.available, openjfx
 , enableGnome2 ? true, gtk3, gnome_vfs, glib, GConf
 }:

--- a/pkgs/development/compilers/temurin-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux-base.nix
@@ -20,7 +20,9 @@
 # runtime dependencies
 , cups
 # runtime dependencies for GTK+ Look and Feel
-, gtkSupport ? true
+# TODO(@sternenseemann): gtk3 fails to evaluate in pkgsCross.ghcjs.buildPackages
+# which should be fixable, this is a no-rebuild workaround for GHC.
+, gtkSupport ? !stdenv.targetPlatform.isGhcjs
 , cairo
 , glib
 , gtk3

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -277,9 +277,9 @@ in {
       # https://github.com/xattr/xattr/issues/44 and
       # https://github.com/xattr/xattr/issues/55 are solved.
       inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
-      # 2022-08-04: Support range >= 10 && < 14
-      buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_12;
-      llvmPackages = pkgs.llvmPackages_12;
+      # 2022-08-04: Support range >= 10 && < 15
+      buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_14;
+      llvmPackages = pkgs.llvmPackages_14;
     };
 
     ghcjs = compiler.ghcjs810;


### PR DESCRIPTION
###### Description of changes

Was able to compile a test jsexe (impurely as the package set doesn't work yet, see the last commit for details)! 

To try it out, build `nix-build -A pkgsCross.ghcjs.buildPackages.haskell.compiler.ghcHEAD` on this branch.

Closes #208879.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
