### PR TITLE
espanso: 0.7.3 -> 2.1.8

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -272,6 +272,19 @@
       </listitem>
       <listitem>
         <para>
+          <literal>espanso</literal> has been updated from 0.7.3 to
+          2.1.8. Therefore, migration steps may need to be performed.
+          See
+          <link xlink:href="https://espanso.org/docs/migration/overview/">the
+          official migration instructions</link> for how to perform
+          these migrations. This also adds the
+          <literal>waylandSupport</literal> flag, which defaults to
+          <literal>true</literal>. If you want X11 support from espanso,
+          you will need to disable this.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The EC2 image module previously detected and activated
           swap-formatted instance store devices and partitions in
           stage-1 (initramfs). This behaviour has been removed. Users

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -71,6 +71,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The EC2 image module previously detected and automatically mounted ext3-formatted instance store devices and partitions in stage-1 (initramfs), storing `/tmp` on the first discovered device. This behaviour, which only catered to very specific use cases and could not be disabled, has been removed. Users relying on this should provide their own implementation, and probably use ext4 and perform the mount in stage-2.
 
+- `espanso` has been updated from 0.7.3 to 2.1.8. Therefore, migration steps may need to be performed. See [the official migration instructions](https://espanso.org/docs/migration/overview/) for how to perform these migrations. This also adds the `waylandSupport` flag, which defaults to `true`. If you want X11 support from espanso, you will need to disable this.
+
 - The EC2 image module previously detected and activated swap-formatted instance store devices and partitions in stage-1 (initramfs). This behaviour has been removed. Users relying on this should provide their own implementation.
 
 - Qt 5.12 and 5.14 have been removed, as the corresponding branches have been EOL upstream for a long time. This affected under 10 packages in nixpkgs, largely unmaintained upstream as well, however, out-of-tree package expressions may need to be updated manually.

--- a/pkgs/applications/office/espanso/default.nix
+++ b/pkgs/applications/office/espanso/default.nix
@@ -1,69 +1,89 @@
 { lib
 , fetchFromGitHub
 , rustPlatform
+, cargo-make
 , pkg-config
 , extra-cmake-modules
+, dbus
 , libX11
 , libXi
 , libXtst
 , libnotify
+, libxkbcommon
 , openssl
 , xclip
 , xdotool
+, setxkbmap
+, wl-clipboard
+, wxGTK32
 , makeWrapper
 , stdenv
 , AppKit
 , Cocoa
 , Foundation
+, waylandSupport ? true,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "espanso";
-  version = "0.7.3";
+  version = "2.1.8";
 
   src = fetchFromGitHub {
-    owner = "federico-terzi";
+    owner = "espanso";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1q47r43midkq9574gl8gdv3ylvrnbhdc39rrw4y4yk6jbdf5wwkm";
+    sha256 = "06wzrjdvssixgd9rnrv4cscbfiyvp5pjpnrih48r0ral3pj2hdg5";
   };
 
-  cargoSha256 = "0ba5skn5s6qh0blf6bvivzvqc2l8v488l9n3x98pmf6nygrikfdb";
+  cargoSha256 = "sha256-U2ccF7DM16TtX3Kc4w4iNV4WsswHJ0FpO3+sWCL1Li8=";
 
   nativeBuildInputs = [
     extra-cmake-modules
     pkg-config
     makeWrapper
+    cargo-make
+    wxGTK32
   ];
 
+  NO_X11 = lib.optionals waylandSupport "true";
+
   buildInputs = [
-    libX11
-    libXtst
     libXi
-    libnotify
-    xclip
+    libXtst
     openssl
   ] ++ lib.optionals stdenv.isLinux [
+    dbus
+    libnotify
+    libX11
+    libxkbcommon
+    xclip
     xdotool
+    wxGTK32
   ] ++ lib.optionals stdenv.isDarwin [
     AppKit
     Cocoa
     Foundation
+  ] ++ lib.optionals waylandSupport [
+    wl-clipboard
   ];
 
   # Some tests require networking
   doCheck = false;
 
+  preBuild = lib.optionalString waylandSupport ''
+    export NO_X11=true
+  '';
+
   postInstall = ''
     wrapProgram $out/bin/espanso \
-      --prefix PATH : ${lib.makeBinPath [ libnotify xclip ]}
+      --prefix PATH : ${lib.makeBinPath [ libnotify xclip wl-clipboard setxkbmap ]}
   '';
 
   meta = with lib; {
     description = "Cross-platform Text Expander written in Rust";
     homepage = "https://espanso.org";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ kimat ];
+    maintainers = with maintainers; [ kimat thehedgeh0g ];
     platforms = platforms.unix;
 
     longDescription = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4442,7 +4442,6 @@ with pkgs;
 
   espanso = callPackage ../applications/office/espanso {
     inherit (darwin.apple_sdk.frameworks) AppKit Cocoa Foundation;
-    openssl = openssl_1_1;
   };
 
   esphome = callPackage ../tools/misc/esphome { };


### PR DESCRIPTION
###### Description of changes
This is a major update of espanso, with breaking(but fixable) changes.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
