### PR TITLE
darktable: 4.0.0 -> 4.2.0 & lensfun: 0.3.95 -> 0.3.3

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -27,6 +27,7 @@
 , libpng
 , librsvg
 , libtiff
+, libjxl
 , openexr_3
 , osm-gps-map
 , pkg-config
@@ -57,12 +58,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "4.0.0";
+  version = "4.2.0";
   pname = "darktable";
 
   src = fetchurl {
     url = "https://github.com/darktable-org/darktable/releases/download/release-${version}/darktable-${version}.tar.xz";
-    sha256 = "0bfcag6bj5vcmg4z4xjirs43iafcx89al6jl41i5mrhpjzszh5hl";
+    sha256 = "18b0917fdfe9b09f66c279a681cc3bd52894a566852bbf04b2e179ecfdb11af9";
   };
 
   nativeBuildInputs = [ cmake ninja llvm_13 pkg-config intltool perl desktop-file-utils wrapGAppsHook ];
@@ -83,6 +84,7 @@ stdenv.mkDerivation rec {
     libpng
     librsvg
     libtiff
+    libjxl
     openexr_3
     sqlite
     libxslt

--- a/pkgs/development/libraries/lensfun/default.nix
+++ b/pkgs/development/libraries/lensfun/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, glib, zlib, libpng, cmake }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, glib, zlib, libpng, cmake, libxml2, python3 }:
 
 let
-  version = "0.3.95";
+  version = "0.3.3";
   pname = "lensfun";
 
   # Fetch a more recent version of the repo containing a more recent lens
@@ -9,8 +9,8 @@ let
   lensfunDatabase = fetchFromGitHub {
     owner = "lensfun";
     repo = "lensfun";
-    rev = "4672d765a17bfef7bc994ca7008cb717c61045d5";
-    sha256 = "00x35xhpn55j7f8qzakb6wl1ccbljg1gqjb93jl9w3mha2bzsr41";
+    rev = "ec9412d27d5fa8f377848a59c768b12c243cb80d";
+    sha256 = "sha256-/u/3oQzac/dQrgFaiYvzT5uQ108XarkXnA2DByA5sic=";
   };
 
 in
@@ -21,16 +21,26 @@ stdenv.mkDerivation {
     owner = "lensfun";
     repo = "lensfun";
     rev = "v${version}";
-    sha256 = "0isli0arns8bmxqpbr1jnbnqh5wvspixdi51adm671f9ngng7x5r";
+    sha256 = "0ixf0f7qv0mc7zrw9w1sb60w833g4rqrfj8cjxwzv2vimqcksccz";
   };
 
   # replace database with a more recent snapshot
+  # the mastr branch uses version 2 profiles, while 0.3.3 requires version 1 profiles,
+  # so we run the conversion tool the project provides,
+  # then untar the verson 1 profiles into the source dir before we build
   prePatch = ''
-    rm -R ./data/db
-    cp -R ${lensfunDatabase}/data/db ./data
+    rm -R data/db
+    python3 ${lensfunDatabase}/tools/lensfun_convert_db_v2_to_v1.py $TMPDIR ${lensfunDatabase}/data/db
+    mkdir -p data/db
+    tar xvf $TMPDIR/db/version_1.tar -C data/db
+    date +%s > data/db/timestamp.txt
   '';
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [
+    cmake pkg-config
+    python3 python3.pkgs.lxml # For the db converison
+  ];
+
   buildInputs = [ glib zlib libpng ];
 
   cmakeFlags = [ "-DINSTALL_HELPER_SCRIPTS=OFF" ];


### PR DESCRIPTION
###### Description of changes
Update darktable to the latest release 4.2.0. Upgrade lensfun from an unreleased alpha version to the current release 0.3.3, you can find more discussion here: https://github.com/NixOS/nixpkgs/issues/207610#issuecomment-1366029071

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
