### PR TITLE
python3.pkgs.sphinxHook: fix co-installability of generated documentation

### DIFF
--- a/pkgs/development/interpreters/python/hooks/sphinx-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/sphinx-hook.sh
@@ -57,7 +57,7 @@ installSphinxPhase() {
 
         else
             # shellcheck disable=2154
-            docdir="${doc:-$out}/share/doc/${pname}"
+            docdir="${doc:-$out}/share/doc/${name}"
 
             mkdir -p "$docdir"
 


### PR DESCRIPTION
Include full $name of the derivation into docdir, so documentation for
python package "foo" is installed into $out/share/doc/python3.10-foo-1.2.3
instead of just $out/share/doc/foo, where it may conflict with some
other package named "foo" and not-coinstallable with different
versions of the same python package.

Change from $name to $pname was introduced in [1ee5fca], probably as
unindented side-effect of adding support for formats other than html.

@mweinelt