### PR TITLE
gtk3: 3.24.35 -> 3.24.36

### DIFF
--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -2,7 +2,6 @@
 , stdenv
 , substituteAll
 , fetchurl
-, fetchpatch2
 , pkg-config
 , gettext
 , docbook-xsl-nons
@@ -61,7 +60,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gtk+3";
-  version = "3.24.35";
+  version = "3.24.36";
 
   outputs = [ "out" "dev" ] ++ lib.optional withGtkDoc "devdoc";
   outputBin = "dev";
@@ -73,22 +72,12 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtk+/${lib.versions.majorMinor version}/gtk+-${version}.tar.xz";
-    sha256 = "sha256-7BD+bXEu8LPGO1+TJjnJ0a6Z/OlPUA9vBpZWKf72C9E=";
+    sha256 = "sha256-J6bvFXdDNQyAf/6lm6odcCJtvt6CpelT/9WOpgWf5pE=";
   };
 
   patches = [
     ./patches/3.0-immodules.cache.patch
     ./patches/3.0-Xft-setting-fallback-compute-DPI-properly.patch
-
-    # Add accidentally non-dist’d build file.
-    # https://gitlab.gnome.org/GNOME/gtk/-/commit/b2ad8d2abafbd94c7e58e5e1b98c92e6b6fa6d9a
-    (fetchpatch2 {
-      url = "https://gitlab.gnome.org/GNOME/gtk/-/commit/66a199806ceb3daa5e2c7d3a5b45a86007cec46a.patch";
-      includes = [
-        "gdk/wayland/cursor/meson.build"
-      ];
-      sha256 = "cOOcSB3yphff2+7l7YpFbGSswWjV8lJ2tk+Vjgl1ras=";
-    })
   ] ++ lib.optionals stdenv.isDarwin [
     # X11 module requires <gio/gdesktopappinfo.h> which is not installed on Darwin
     # let’s drop that dependency in similar way to how other parts of the library do it


### PR DESCRIPTION
###### Description of changes
https://gitlab.gnome.org/GNOME/gtk/-/compare/3.24.35...3.24.36

This bring a fix where cursors would be missing on wayland:


- [gtk#5365](https://gitlab.gnome.org/GNOME/gtk/-/issues/5365) ("Updating GTK3 breaks cursors on Wayland completely")
- [gtk!5262](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5262) ("wayland: Look for cursor themes in $HOME")
- [gtk!5329](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5329) ("Revert "wayland: Look for cursor themes in $HOME"" - also contains revert for [gtk!5192](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5192) "Make wayland load cursors on demand")

supersedes #207113

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
