### PR TITLE
wordpressPackages.plugins: upgrade various

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -150,10 +150,10 @@
     "version": "3.7.0"
   },
   "wp-statistics": {
-    "path": "wp-statistics/tags/13.2.10",
-    "rev": "2838980",
-    "sha256": "02wg8y4zfx0h87k38dy21gfys1g99r4dswwv6g308vflcml68ma1",
-    "version": "13.2.10"
+    "path": "wp-statistics/tags/13.2.11",
+    "rev": "2841966",
+    "sha256": "0bdg63q9wq82rpj7lxiwsvbpxa03r2v1pngs2pxifd4632b7ikni",
+    "version": "13.2.11"
   },
   "wp-user-avatars": {
     "path": "wp-user-avatars/trunk",

--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -72,10 +72,10 @@
     "version": "5.0.18"
   },
   "mailpoet": {
-    "path": "mailpoet/tags/4.3.0",
-    "rev": "2836720",
-    "sha256": "0igaq34gq5ysk5ai39b641kx7rqsj052m6r55zl6z7xjpxhf37aw",
-    "version": "4.3.0"
+    "path": "mailpoet/tags/4.3.1",
+    "rev": "2843001",
+    "sha256": "0nnmfk1rxhf31makfc0v7mlh30799saxpf8agqdlavrmqpvypvzb",
+    "version": "4.3.1"
   },
   "merge-minify-refresh": {
     "path": "merge-minify-refresh/trunk",


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
