### PR TITLE
[Backport release-22.11] wordpressPackages.plugins.civicrm: init at 5.56.0

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/default.nix
+++ b/pkgs/servers/web-apps/wordpress/packages/default.nix
@@ -2,7 +2,7 @@
 # Licensed under: MIT
 # Slightly modified
 
-{ lib, newScope, plugins, themes, languages }:
+{ lib, newScope, plugins, themes, languages, callPackage }:
 
 let packages = self:
   let
@@ -82,4 +82,4 @@ let packages = self:
   } // lib.mapAttrs (type: pkgs: lib.makeExtensible (_: lib.mapAttrs (pname: data: self.mkOfficialWordpressDerivation { type = lib.removeSuffix "s" type; inherit pname data; }) pkgs)) generatedJson;
 
 # This creates an extensible scope.
-in (lib.makeExtensible (_: (lib.makeScope newScope packages))).extend (selfWP: superWP: {})
+in lib.recursiveUpdate ((lib.makeExtensible (_: (lib.makeScope newScope packages))).extend (selfWP: superWP: {})) (callPackage ./thirdparty.nix {})

--- a/pkgs/servers/web-apps/wordpress/packages/thirdparty.nix
+++ b/pkgs/servers/web-apps/wordpress/packages/thirdparty.nix
@@ -1,0 +1,8 @@
+{fetchzip}: {
+  plugins.civicrm = fetchzip rec {
+    name = "civicrm";
+    version = "5.56.0";
+    url = "https://storage.googleapis.com/${name}/${name}-stable/${version}/${name}-${version}-wordpress.zip";
+    hash = "sha256-XsNFxVL0LF+OHlsqjjTV41x9ERLwMDq9BnKKP3Px2aI=";
+  };
+}


### PR DESCRIPTION


###### Description of changes
There are a number of third party wordpress components that cannot be trivially fetched via wp4nix. As such, we have broken out a file that contains these derivations and merges them back into wordpressPackages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
