### PR TITLE
libreddit: 0.25.1 -> 0.27.0

### DIFF
--- a/pkgs/servers/libreddit/default.nix
+++ b/pkgs/servers/libreddit/default.nix
@@ -3,21 +3,31 @@
 , nixosTests
 , rustPlatform
 , fetchFromGitHub
+, fetchpatch
 , Security
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "libreddit";
-  version = "0.25.1";
+  version = "0.27.0";
 
   src = fetchFromGitHub {
     owner = "libreddit";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-/K79EHjqkclyh1AmRaevYcyUD4XSrTfd5zjnpOmBNcE=";
+    hash = "sha256-+sSzYewqN3VjTl+wjgan3yxlFiuCg2rprJDpDktuQHo=";
   };
 
-  cargoSha256 = "sha256-KYuEy5MwgdiHHbDDNyb+NVYyXdvx1tCH7dQdPWCCfQo=";
+  cargoSha256 = "sha256-HhtslN6JV9DUBhuyesciZGGYVz7mvpdyxVps9xAc+Rs=";
+
+  patches = [
+    # https://github.com/libreddit/libreddit/pull/687
+    (fetchpatch {
+      name = "fix-cfg-test.patch";
+      url = "https://github.com/libreddit/libreddit/commit/dff91da8777dc42d38abf8b5d63addbd71fdabff.patch";
+      sha256 = "sha256-6np5gf8cyKotF7KJ19mCtRAF7SxDpNFpQCgdy/XDsng=";
+    })
+  ];
 
   buildInputs = lib.optionals stdenv.isDarwin [
     Security


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/libreddit/libreddit/releases/tag/v0.25.2
https://github.com/libreddit/libreddit/releases/tag/v0.25.3
https://github.com/libreddit/libreddit/releases/tag/v0.26.0
https://github.com/libreddit/libreddit/releases/tag/v0.27.0

Needed to patch a newly added test: https://github.com/libreddit/libreddit/pull/687

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
