### PR TITLE
ocamlPackages.tar: 2.0.1 → 2.2.2

### DIFF
--- a/pkgs/development/ocaml-modules/tar/default.nix
+++ b/pkgs/development/ocaml-modules/tar/default.nix
@@ -1,40 +1,38 @@
 { lib
-, fetchFromGitHub
+, fetchurl
 , buildDunePackage
 , camlp-streams
 , ppx_cstruct
 , cstruct
-, re
-, ppx_tools
+, decompress
 }:
 
 buildDunePackage rec {
   pname = "tar";
-  version = "2.0.1";
-  src = fetchFromGitHub {
-    owner = "mirage";
-    repo = "ocaml-tar";
-    rev = "v${version}";
-    sha256 = "1zr1ak164k1jm15xwqjf1iv77kdrrahak33wrxg7lifz9nnl0dms";
+  version = "2.2.2";
+  src = fetchurl {
+    url = "https://github.com/mirage/ocaml-tar/releases/download/v${version}/tar-${version}.tbz";
+    hash = "sha256-Q+41LPFZFHi9sXKFV3F13FZZNO3KXRSElEmr+nH58Uw=";
   };
 
-  useDune2 = true;
+  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [
     camlp-streams
-    ppx_cstruct
     cstruct
-    re
+    decompress
   ];
 
   buildInputs = [
-    ppx_tools
+    ppx_cstruct
   ];
 
   doCheck = true;
 
   meta = {
     description = "Decode and encode tar format files from Unix";
+    homepage = "https://github.com/mirage/ocaml-tar";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };

--- a/pkgs/development/ocaml-modules/tar/default.nix
+++ b/pkgs/development/ocaml-modules/tar/default.nix
@@ -31,7 +31,7 @@ buildDunePackage rec {
   doCheck = true;
 
   meta = {
-    description = "Decode and encode tar format files from Unix";
+    description = "Decode and encode tar format files in pure OCaml";
     homepage = "https://github.com/mirage/ocaml-tar";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];

--- a/pkgs/development/ocaml-modules/tar/unix.nix
+++ b/pkgs/development/ocaml-modules/tar/unix.nix
@@ -1,27 +1,22 @@
 { lib
 , buildDunePackage
 , tar
-, cstruct
 , cstruct-lwt
-, re
 , lwt
 }:
 
 buildDunePackage rec {
   pname = "tar-unix";
-  inherit (tar) version src useDune2 doCheck;
+  inherit (tar) version src doCheck;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     tar
-    cstruct
     cstruct-lwt
-    re
     lwt
   ];
 
-  meta = {
+  meta = tar.meta // {
     description = "Decode and encode tar format files from Unix";
-    license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.ulrikstrid ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Fixes & improvements: https://github.com/mirage/ocaml-tar/blob/v2.2.2/CHANGES.md

cc maintainer @ulrikstrid

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
