### PR TITLE
ov: init at 0.13.0

### DIFF
--- a/pkgs/tools/text/ov/default.nix
+++ b/pkgs/tools/text/ov/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, pandoc
+, makeWrapper
+}:
+
+buildGoModule rec {
+  pname = "ov";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "noborus";
+    repo = "ov";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-vBPhCSor3wGCawz+097Lw29xgW6z5fV5PAMAq7TBiNM=";
+  };
+
+  vendorHash = "sha256-y3oSL1W2cjt6oUVbglHhun3XNCidqb7LTXtoA25+mpo=";
+
+  ldflags = [
+    "-X main.Version=v${version}"
+    "-X main.Revision=${src.rev}"
+  ];
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    pandoc
+    makeWrapper
+  ];
+
+  outputs = [ "out" "doc" ];
+
+  postInstall = ''
+    installShellCompletion --cmd ov \
+      --bash <($out/bin/ov completion bash) \
+      --fish <($out/bin/ov completion fish) \
+      --zsh <($out/bin/ov completion zsh)
+
+    mkdir -p $out/share/$name
+    cp $src/ov-less.yaml $out/share/$name/less-config.yaml
+    makeWrapper $out/bin/ov $out/bin/ov-less --add-flags "--config $out/share/$name/less-config.yaml"
+
+    mkdir -p $doc/share/doc/$name
+    pandoc -s < $src/README.md > $doc/share/doc/$name/README.html
+    mkdir -p $doc/share/$name
+    cp $src/ov.yaml $doc/share/$name/sample-config.yaml
+  '';
+
+  meta = with lib; {
+    description = "Feature-rich terminal-based text viewer";
+    homepage = "https://noborus.github.io/ov";
+    license = licenses.mit;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ farcaller ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38622,4 +38622,6 @@ with pkgs;
   tuner = callPackage ../applications/audio/tuner { };
 
   jfrog-cli = callPackage ../tools/misc/jfrog-cli { };
+
+  ov = callPackage ../tools/text/ov { };
 }


### PR DESCRIPTION

###### Description of changes

Adds the ov, an advanced pager (https://noborus.github.io/ov/). I've put it into tools/text next to the similar packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
