### PR TITLE
nixos/dhcpcd: don't solicit or accept ipv6 router advertisements if use static addresses

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -379,6 +379,13 @@
       </listitem>
       <listitem>
         <para>
+          <literal>services.dhcpcd</literal> service now don’t solicit
+          or accept IPv6 Router Advertisements on interfaces that use
+          static IPv6 addresses.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The module <literal>services.headscale</literal> was
           refactored to be compliant with
           <link xlink:href="https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md">RFC

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -104,6 +104,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `services.chronyd` is now started with additional systemd sandbox/hardening options for better security.
 
+- `services.dhcpcd` service now don't solicit or accept IPv6 Router Advertisements on interfaces that use static IPv6 addresses.
+
 - The module `services.headscale` was refactored to be compliant with [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md). To be precise, this means that the following things have changed:
 
   - Most settings has been migrated under [services.headscale.settings](#opt-services.headscale.settings) which is an attribute-set that

--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -33,6 +33,13 @@ let
     (if !config.networking.useDHCP && enableDHCP then
       map (i: i.name) (filter (i: i.useDHCP == true) interfaces) else null);
 
+  staticIPv6Addresses = map (i: i.name) (filter (i: i.ipv6.addresses != [ ]) interfaces);
+
+  noIPv6rs = concatStringsSep "\n" (map (name: ''
+    interface ${name}
+    noipv6rs
+  '') staticIPv6Addresses);
+
   # Config file adapted from the one that ships with dhcpcd.
   dhcpcdConf = pkgs.writeText "dhcpcd.conf"
     ''
@@ -75,6 +82,8 @@ let
       ''}
 
       ${cfg.extraConfig}
+
+      ${optionalString config.networking.enableIPv6 noIPv6rs}
     '';
 
   exitHook = pkgs.writeText "dhcpcd.exit-hook"


### PR DESCRIPTION
###### Description of changes
Don't solicit or accept IPv6 Router Advertisements if enabled static IPv6 addresses.

When using IPv6 address allocation via SLAAC and a static IPv6 address on the computer, the `dhcpcd` client gives these messages every 10 seconds:
```
jan 04 12:40:08 test-vm dhcpcd[5556]: enp1s0: requesting DHCPv6 information
jan 04 12:40:18 test-vm dhcpcd[5556]: enp1s0: requesting DHCPv6 information
jan 04 12:40:28 test-vm dhcpcd[5556]: enp1s0: requesting DHCPv6 information
jan 04 12:40:38 test-vm dhcpcd[5556]: enp1s0: requesting DHCPv6 information
jan 04 12:40:48 test-vm dhcpcd[5556]: enp1s0: requesting DHCPv6 information
jan 04 12:40:58 test-vm dhcpcd[5556]: enp1s0: requesting DHCPv6 information
jan 04 12:41:08 test-vm dhcpcd[5556]: enp1s0: requesting DHCPv6 information
jan 04 12:41:18 test-vm dhcpcd[5556]: enp1s0: requesting DHCPv6 information
jan 04 12:41:28 test-vm dhcpcd[5556]: enp1s0: requesting DHCPv6 information
jan 04 12:41:38 test-vm dhcpcd[5556]: enp1s0: requesting DHCPv6 information
jan 04 12:41:48 test-vm dhcpcd[5556]: enp1s0: requesting DHCPv6 information
```

cc @ncfavier @blitz @flokli

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
