### PR TITLE
lv_font_conv: init at 1.5.2

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -211,7 +211,6 @@
 , "localtunnel"
 , "lodash"
 , "lua-fmt"
-, "lv_font_conv"
 , "madoko"
 , "manta"
 , "markdownlint-cli"

--- a/pkgs/development/tools/misc/lv_font_conv/default.nix
+++ b/pkgs/development/tools/misc/lv_font_conv/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, python3
+, nix-update-script
+}:
+
+buildNpmPackage rec {
+  pname = "lv_font_conv";
+  version = "1.5.2";
+
+  src = fetchFromGitHub {
+    owner = "lvgl";
+    repo = pname;
+    rev = version;
+    hash = "sha256-7eTsmFSi4yvDz5zmBUD9r1sxKTDr+z5Vs3XKfzjyDYs=";
+  };
+
+  npmDepsHash = "sha256-D1gKMaODfqRtwPoXgUOz71LRVEKiFRaMblsdRVI7wo0=";
+
+  nativeBuildInputs = [
+    python3
+  ];
+
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
+
+  meta = with lib; {
+    description = "Converts fonts to the LVGL font format";
+    homepage = "https://github.com/lvgl/lv_font_conv";
+    changelog = "https://github.com/lvgl/lv_font_conv/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ raphaelr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17758,6 +17758,8 @@ with pkgs;
 
   lurk = callPackage ../development/tools/lurk { };
 
+  lv_font_conv = callPackage ../development/tools/misc/lv_font_conv { };
+
   malt = callPackage ../development/tools/profiling/malt {};
 
   massif-visualizer = libsForQt5.callPackage ../development/tools/analysis/massif-visualizer { };


### PR DESCRIPTION
###### Description of changes

Replaces the existing `nodePackages.lv_font_conv` with a standalone package.

Do we need an alias for this? If yes, where?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
