### PR TITLE
prismlauncher: add support for gamemode + mangohud

### DIFF
--- a/pkgs/games/prismlauncher/default.nix
+++ b/pkgs/games/prismlauncher/default.nix
@@ -21,6 +21,10 @@
 , ghc_filesystem
 , msaClientID ? ""
 , jdks ? [ jdk17 jdk8 ]
+, withMangohud ? false
+, mangohud
+, withGamemode ? false
+, gamemode
 }:
 
 let
@@ -51,7 +55,10 @@ stdenv.mkDerivation rec {
     quazip
     ghc_filesystem
     tomlplusplus
-  ] ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland;
+  ]
+  ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland
+  ++ lib.optional withMangohud mangohud;
+
 
   cmakeFlags = lib.optionals (msaClientID != "") [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ]
     ++ lib.optionals (lib.versionAtLeast qtbase.version "6") [ "-DLauncher_QT_VERSION_MAJOR=6" ];
@@ -68,7 +75,7 @@ stdenv.mkDerivation rec {
   postInstall =
     let
       libpath = with xorg;
-        lib.makeLibraryPath [
+        lib.makeLibraryPath ([
           libX11
           libXext
           libXcursor
@@ -79,7 +86,8 @@ stdenv.mkDerivation rec {
           glfw
           openal
           stdenv.cc.cc.lib
-        ];
+        ]
+        ++ lib.optional withGamemode gamemode);
     in
     ''
       # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128


### PR DESCRIPTION
###### Description of changes

There were missing libraries/dependencies that needed to be added. The tick-boxes in the GUI are no longer greyed out for these features. I **haven't** tested the actual functionality so please tell me how it goes.
```nix
{
  environment.systemPackages = [
    (pkgs.prismlauncher.override {
      withGamemode = config.programs.gamemode.enable; # Or true depending if `config.gamemode` is in scope or not.
      withMangohud = true;
    })
  ];
}
```

Perhaps this should be enabled by default?

closes -> https://github.com/NixOS/nixpkgs/issues/208182

cc. @dacioromero
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
