### PR TITLE
pkgs/graalvm: add graaljs installable

### DIFF
--- a/pkgs/development/compilers/graalvm/community-edition/update.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/update.nix
@@ -67,6 +67,7 @@ let
       "ruby-installable-svm" = ".jar";
       "wasm-installable-svm" = ".jar";
       "python-installable-svm" = ".jar";
+      "js-installable-svm" = ".jar";
     }.${productName};
 
   # getProductSuffix :: String -> String
@@ -77,6 +78,7 @@ let
       "ruby-installable-svm" = "https://github.com/oracle/truffleruby/releases/download";
       "wasm-installable-svm" = "https://github.com/graalvm/graalvm-ce-builds/releases/download";
       "python-installable-svm" = "https://github.com/graalvm/graalpython/releases/download";
+      "js-installable-svm" = "https://github.com/oracle/graaljs/releases/download";
     }.${productName};
 
   # getDevUrl :: String


### PR DESCRIPTION
###### Description of changes

GraalVM no longer ships with JS support out of the box, but provides an installable as of v22.2.0 (see https://www.graalvm.org/release-notes/22_2/#platform-updates).

This allows to add back js support by including `js-installable-svm` in `products` in `mkGraal`, e.g.

```
graalvmCEPackages.mkGraal {
    config = {
      x86_64-linux = {
        products = [ "graalvm-ce" "native-image-installable-svm" "js-installable-svm" ];
        arch = "linux-amd64";
      };
    };
  defaultVersion = "22.3.0";
  javaVersion = "17";
};
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
