### PR TITLE
aerc: 0.13.0 → 0.14.0

### DIFF
--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -12,17 +12,17 @@
 
 buildGoModule rec {
   pname = "aerc";
-  version = "0.13.0";
+  version = "0.14.0";
 
   src = fetchFromSourcehut {
     owner = "~rjarry";
     repo = "aerc";
     rev = version;
-    hash = "sha256-pUp/hW4Kk3pixGfbQvphLJM9Dc/w01T1KPRewOicPqM=";
+    hash = "sha256-qC7lNqjgljUqRUp+S7vBVLPyRB3+Ie5UOxuio+Q88hg=";
   };
 
   proxyVendor = true;
-  vendorHash = "sha256-Nx+k0PLPIx7Ia0LobXUOw7oOFVz1FXV49haAkRAVOcM=";
+  vendorHash = "sha256-MVek3TQpE3AChGyQ4z01fLfkcGKJcckmFV21ww9zT7M=";
 
   doCheck = false;
 

--- a/pkgs/applications/networking/mailreaders/aerc/runtime-sharedir.patch
+++ b/pkgs/applications/networking/mailreaders/aerc/runtime-sharedir.patch
@@ -1,8 +1,8 @@
-diff --git a/config/aerc.conf b/config/aerc.conf
-index fbbf587..ede1a03 100644
---- a/config/aerc.conf
-+++ b/config/aerc.conf
-@@ -107,8 +107,7 @@ next-message-on-delete=true
+diff --git i/config/aerc.conf w/config/aerc.conf
+index 05ebbf4..db6877b 100644
+--- i/config/aerc.conf
++++ w/config/aerc.conf
+@@ -152,8 +152,7 @@
  #
  #   ${XDG_CONFIG_HOME:-~/.config}/aerc/stylesets
  #   ${XDG_DATA_HOME:-~/.local/share}/aerc/stylesets
@@ -10,9 +10,9 @@ index fbbf587..ede1a03 100644
 -#   /usr/share/aerc/stylesets
 +#   @out@/share/aerc/stylesets
  #
- # default: ""
- stylesets-dirs=
-@@ -254,8 +253,7 @@ new-email=
+ #stylesets-dirs=
+ 
+@@ -445,8 +444,7 @@ message/rfc822=colorize
  #
  #   ${XDG_CONFIG_HOME:-~/.config}/aerc/templates
  #   ${XDG_DATA_HOME:-~/.local/share}/aerc/templates
@@ -20,37 +20,27 @@ index fbbf587..ede1a03 100644
 -#   /usr/share/aerc/templates
 +#   @out@/share/aerc/templates
  #
- # default: ""
- template-dirs=
-diff --git a/config/config.go b/config/config.go
-index 2120310..92b7655 100644
---- a/config/config.go
-+++ b/config/config.go
-@@ -331,8 +331,8 @@ func buildDefaultDirs() []string {
+ #template-dirs=
+ 
+diff --git i/config/config.go w/config/config.go
+index 09fb5ef..c73a7ee 100644
+--- i/config/config.go
++++ w/config/config.go
+@@ -60,8 +60,7 @@ func buildDefaultDirs() []string {
  	}
  
  	// Add fixed fallback locations
 -	defaultDirs = append(defaultDirs, "/usr/local/share/aerc")
 -	defaultDirs = append(defaultDirs, "/usr/share/aerc")
-+	defaultDirs = append(defaultDirs, "@out@/local/share/aerc")
 +	defaultDirs = append(defaultDirs, "@out@/share/aerc")
  
  	return defaultDirs
  }
-diff --git a/doc/aerc-config.5.scd b/doc/aerc-config.5.scd
-index 885c4f8..77a853e 100644
---- a/doc/aerc-config.5.scd
-+++ b/doc/aerc-config.5.scd
-@@ -12,7 +12,7 @@ account credentials. We look for these files in your XDG config home plus
- "aerc", which defaults to ~/.config/aerc.
- 
- Examples of these config files are typically included with your installation of
--aerc and are usually installed in /usr/share/aerc.
-+aerc and are usually installed in @out@/share/aerc.
- 
- Each file uses the _ini_ format, and consists of sections with keys and values.
- A line beginning with # is considered a comment and ignored, as are empty lines.
-@@ -221,8 +221,7 @@ These options are configured in the *[ui]* section of aerc.conf.
+diff --git i/doc/aerc-config.5.scd w/doc/aerc-config.5.scd
+index d48e38a..39784c4 100644
+--- i/doc/aerc-config.5.scd
++++ w/doc/aerc-config.5.scd
+@@ -279,8 +279,7 @@ These options are configured in the *[ui]* section of _aerc.conf_.
  	```
  	${XDG_CONFIG_HOME:-~/.config}/aerc/stylesets
  	${XDG_DATA_HOME:-~/.local/share}/aerc/stylesets
@@ -59,26 +49,8 @@ index 885c4f8..77a853e 100644
 +	@out@/share/aerc/stylesets
  	```
  
- 	Default: ""
-@@ -381,7 +380,7 @@ against (non-case-sensitive) and a comma, e.g. subject,text will match a
- subject which contains "text". Use header,~regex to match against a regex.
- 
- aerc ships with some default filters installed in the share directory (usually
--_/usr/share/aerc/filters_). Note that these may have additional dependencies
-+_@out@/share/aerc/filters_). Note that these may have additional dependencies
- that aerc does not have alone.
- 
- ## TRIGGERS
-@@ -407,7 +406,7 @@ and forward commands can be called with the -T flag with the name of the
- template name.
- 
- aerc ships with some default templates installed in the share directory (usually
--_/usr/share/aerc/templates_).
-+_@out@/share/aerc/templates_).
- 
- These options are configured in the *[templates]* section of aerc.conf.
- 
-@@ -419,8 +418,7 @@ These options are configured in the *[templates]* section of aerc.conf.
+ *styleset-name* = _<string>_
+@@ -822,8 +821,7 @@ These options are configured in the *[templates]* section of _aerc.conf_.
  	```
  	${XDG_CONFIG_HOME:-~/.config}/aerc/templates
  	${XDG_DATA_HOME:-~/.local/share}/aerc/templates
@@ -87,4 +59,26 @@ index 885c4f8..77a853e 100644
 +	@out@/share/aerc/templates
  	```
  
- 	Default: ""
+ *new-message* = _<template_name>_
+diff --git i/doc/aerc-templates.7.scd w/doc/aerc-templates.7.scd
+index 6c9e319..0ef97ce 100644
+--- i/doc/aerc-templates.7.scd
++++ w/doc/aerc-templates.7.scd
+@@ -111,7 +111,7 @@ aerc provides the following additional functions:
+ 	Execute external command, provide the second argument to its stdin.
+ 
+ 	```
+-	{{exec `/usr/local/share/aerc/filters/html` .OriginalText}}
++	{{exec `@out@/share/aerc/filters/html` .OriginalText}}
+ 	```
+ 
+ *toLocal*
+@@ -142,7 +142,7 @@ aerc provides the following additional functions:
+ 	Example: Automatic HTML parsing for text/html mime type messages
+ 	```
+ 	{{if eq .OriginalMIMEType "text/html"}}
+-	{{exec `/usr/local/share/aerc/filters/html` .OriginalText | wrap 72 | quote}}
++	{{exec `@out@/share/aerc/filters/html` .OriginalText | wrap 72 | quote}}
+ 	{{else}}
+ 	{{wrap 72 .OriginalText | quote}}
+ 	{{end}}


### PR DESCRIPTION
###### Description of changes
[Changelog](https://git.sr.ht/~rjarry/aerc/refs/0.14.0)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
