### PR TITLE
grig: init at 0.9.0

### DIFF
--- a/pkgs/applications/radio/grig/default.nix
+++ b/pkgs/applications/radio/grig/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, wrapGAppsHook
+, gtk2
+, hamlib_4 }:
+
+stdenv.mkDerivation rec {
+  pname = "grig";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "fillods";
+    repo = "grig";
+    rev = "GRIG-${lib.replaceStrings ["."] ["_"] version}";
+    sha256 = "sha256-OgIgHW9NMW/xSSti3naIR8AQWUtNSv5bYdOcObStBlM=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config wrapGAppsHook ];
+  buildInputs = [ hamlib_4 gtk2 ];
+
+  meta = with lib; {
+    description = "A simple Ham Radio control (CAT) program based on Hamlib";
+    longDescription = ''
+      Grig is a graphical user interface for the Ham Radio Control Libraries.
+      It is intended to be simple and generic, presenting the user with the
+      same interface regardless of which radio they use.
+    '';
+    homepage = "https://groundstation.sourceforge.net/grig/";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ melling ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7734,6 +7734,8 @@ with pkgs;
 
   gridtracker = callPackage ../applications/radio/gridtracker { };
 
+  grig = callPackage ../applications/radio/grig { };
+
   grin = callPackage ../tools/text/grin { };
 
   gyb = callPackage ../tools/backup/gyb { };


### PR DESCRIPTION
###### Description of changes

Adds `grig`:

> Grig is a graphical user interface for the Ham Radio Control Libraries. It is intended to be simple and generic, presenting the user with the same interface regardless of which radio they use.

Latest release tagged earlier today after migration to GitHub: https://github.com/fillods/grig/issues/5

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
