### PR TITLE
rust: bring back 1.65 for aarch64-linux

### DIFF
--- a/pkgs/development/compilers/rust/1_65.nix
+++ b/pkgs/development/compilers/rust/1_65.nix
@@ -1,0 +1,64 @@
+# New rust versions should first go to staging.
+# Things to check after updating:
+# 1. Rustc should produce rust binaries on x86_64-linux, aarch64-linux and x86_64-darwin:
+#    i.e. nix-shell -p fd or @GrahamcOfBorg build fd on github
+#    This testing can be also done by other volunteers as part of the pull
+#    request review, in case platforms cannot be covered.
+# 2. The LLVM version used for building should match with rust upstream.
+#    Check the version number in the src/llvm-project git submodule in:
+#    https://github.com/rust-lang/rust/blob/<version-tag>/.gitmodules
+# 3. Firefox and Thunderbird should still build on x86_64-linux.
+
+{ stdenv, lib
+, buildPackages
+, newScope, callPackage
+, CoreFoundation, Security, SystemConfiguration
+, pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
+, makeRustPlatform
+, llvmPackages_11
+, llvmPackages_14, llvm_14
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.65.0";
+  rustcSha256 = "sha256-WCi7Z/Z36r+MOEAgWCsM56+IThyEOJSE9/jQDdgsADg=";
+
+  llvmSharedForBuild = pkgsBuildBuild.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };
+  llvmSharedForHost = pkgsBuildHost.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };
+  llvmSharedForTarget = pkgsBuildTarget.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };
+
+  llvmBootstrapForDarwin = llvmPackages_11;
+
+  # For use at runtime
+  llvmShared = llvm_14.override { enableSharedLibraries = true; };
+
+  # Expose llvmPackages used for rustc from rustc via passthru for LTO in Firefox
+  llvmPackages = llvmPackages_14;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapVersion = "1.64.0";
+
+  # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
+  bootstrapHashes = {
+    i686-unknown-linux-gnu = "177b4f95c8cdaa34bb29e69950cbfe236e123757078af4792779c43ee3818199";
+    x86_64-unknown-linux-gnu = "a893977f238291370ab96726a74b6b9ae854dc75fbf5730954d901a93843bf9b";
+    x86_64-unknown-linux-musl = "d5c4293a8fe1b34d857bec4124229c39711f8759aa2f6108c8b6c22a308f96bb";
+    arm-unknown-linux-gnueabihf = "0d7c9c746f7b98f1f99e4cf720f9a32b2f5cdf22cb1d9f677b41c1dca62f14f8";
+    armv7-unknown-linux-gnueabihf = "0be29740f565ca8835ba260691274585733a7f4130ec872bfa37654a08013828";
+    aarch64-unknown-linux-gnu = "7d8860572431bd4ee1b9cd0cd77cf7ff29fdd5b91ed7c92a820f872de6ced558";
+    aarch64-unknown-linux-musl = "9e7cfd960fb8ad3e1f51ef667c56032d3d4d9d9f573a06bbcf65a7c7a96ab430";
+    x86_64-apple-darwin = "b6003d49fb857ff8dc105a3ccba98b851cd3e7d874005acb92284fd1113adc0d";
+    aarch64-apple-darwin = "e1a37dc5991304716e260144311fd291d8fb514042e45c244c582b3454477038";
+    powerpc64le-unknown-linux-gnu = "9d4591033eac22093d107991a68fffccea087b26bb54115d46cc544fbf5ef66c";
+    riscv64gc-unknown-linux-gnu = "f63981d9c1057cb20cf30871757d42475a1cd0c187b3dcce5fabb0cce0f80c5b";
+    mips64el-unknown-linux-gnuabi64 = "47488e4c53cca5c99b5837474a880f6c2368a7fe8368560dd8077bddb94959b5";
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_65;
+
+  rustcPatches = [
+  ];
+}
+
+(builtins.removeAttrs args [ "fetchpatch" "pkgsBuildHost" "llvmPackages_11" "llvmPackages_14" "llvm_14"])

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15391,7 +15391,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_14 = llvmPackages_14.libllvm;
   };
-  rust = rust_1_66;
+  rust = if (stdenv.isAarch64 && stdenv.isLinux) then rust_1_65 else rust_1_66;
 
   mrustc = callPackage ../development/compilers/mrustc { };
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
@@ -15401,7 +15401,7 @@ with pkgs;
   };
 
   rustPackages_1_66 = rust_1_66.packages.stable;
-  rustPackages = rustPackages_1_66;
+  rustPackages = rust.packages.stable;
 
   inherit (rustPackages) cargo clippy rustc rustPlatform;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15383,6 +15383,10 @@ with pkgs;
     inherit (darwin) apple_sdk;
   };
 
+  rust_1_65 = callPackage ../development/compilers/rust/1_65.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
+    llvm_14 = llvmPackages_14.libllvm;
+  };
   rust_1_66 = callPackage ../development/compilers/rust/1_66.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_14 = llvmPackages_14.libllvm;


### PR DESCRIPTION
###### Description of changes

`rustc` failds to build on staging for aarch64-linux: https://hydra.nixos.org/build/203858528/nixlog/7, I wasn't able to fix the build, so I brought back 1.65 as a temporary solution

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
