### PR TITLE
vlc: add aarch64-darwin and x86_64-darwin to platforms

### DIFF
--- a/pkgs/applications/video/vlc/darwin.nix
+++ b/pkgs/applications/video/vlc/darwin.nix
@@ -1,0 +1,39 @@
+{ version, meta, stdenv, fetchurl, lib, undmg, makeWrapper }:
+
+let
+  srcs = {
+    aarch64-darwin = fetchurl {
+      url =
+        "http://get.videolan.org/vlc/${version}/macosx/vlc-${version}-arm64.dmg";
+      sha256 = "sha256-mcJZvbxSIf1QgX9Ri3Dpv57hdeiQdDkDyYB7x3hmj0c=";
+    };
+    x86_64-darwin = fetchurl {
+      url =
+        "http://get.videolan.org/vlc/${version}/macosx/vlc-${version}-intel64.dmg";
+      sha256 = "sha256-iO3N/Os70vaANn2QCdOKDBR/p1jy3TleQ0EsHgjOHMs=";
+    };
+  };
+in stdenv.mkDerivation {
+  inherit version meta;
+
+  src = srcs.${stdenv.hostPlatform.system};
+
+  pname = "vlc";
+
+  nativeBuildInputs = [ undmg makeWrapper ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r "VLC.app" $out/Applications
+
+    # wrap executable to $out/bin
+    mkdir -p $out/bin
+    makeWrapper "$out/Applications/VLC.app/Contents/MacOS/VLC" "$out/bin/vlc"
+
+    runHook postInstall
+  '';
+}

--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -1,78 +1,7 @@
-{ lib
-, stdenv
-, fetchurl
-, fetchpatch
-, SDL
-, SDL_image
-, a52dec
-, alsa-lib
-, autoreconfHook
-, avahi
-, dbus
-, faad2
-, ffmpeg_4
-, flac
-, fluidsynth
-, freefont_ttf
-, fribidi
-, gnutls
-, libarchive
-, libass
-, libbluray
-, libcaca
-, libcddb
-, libdc1394
-, libdvbpsi
-, libdvdnav
-, libebml
-, libgcrypt
-, libgpg-error
-, libjack2
-, libkate
-, libmad
-, libmatroska
-, libmodplug
-, libmtp
-, liboggz
-, libopus
-, libplacebo
-, libpulseaudio
-, libraw1394
-, librsvg
-, libsamplerate
-, libspatialaudio
-, libssh2
-, libtheora
-, libtiger
-, libupnp
-, libv4l
-, libva
-, libvdpau
-, libvorbis
-, libxml2
-, live555
-, lua5
-, mpeg2dec
-, ncurses
-, perl
-, pkg-config
-, removeReferencesTo
-, samba
-, schroedinger
-, speex
-, srt
-, systemd
-, taglib
-, unzip
-, xorg
-, zlib
-, chromecastSupport ? true, libmicrodns, protobuf
-, jackSupport ? false
-, onlyLibVLC ? false
-, skins2Support ? !onlyLibVLC, freetype
-, waylandSupport ? true, wayland, wayland-protocols
-, withQt5 ? true, qtbase, qtsvg, qtwayland, qtx11extras, wrapQtAppsHook
-}:
+{ lib, stdenv, fetchurl, callPackage, chromecastSupport ? true
+, jackSupport ? false, onlyLibVLC ? false, skins2Support ? !onlyLibVLC
+, waylandSupport ? true, withQt5 ? true, libcaca, qtbase, qtsvg, qtx11extras
+, wrapQtAppsHook }:
 
 # chromecastSupport requires TCP port 8010 to be open for it to work.
 # If your firewall is enabled, make sure to have something like:
@@ -80,170 +9,22 @@
 
 let
   inherit (lib) optionalString optional optionals;
-in
-stdenv.mkDerivation rec {
-  pname = "${optionalString onlyLibVLC "lib"}vlc";
   version = "3.0.18";
-
-  src = fetchurl {
-    url = "http://get.videolan.org/vlc/${version}/vlc-${version}.tar.xz";
-    sha256 = "sha256-VwlEOcNl2KqLm0H6MIDMDu8r7+YCW7XO9yKszGJa7ew=";
-  };
-
-  # VLC uses a *ton* of libraries for various pieces of functionality, many of
-  # which are not included here for no other reason that nobody has mentioned
-  # needing them
-  buildInputs = [
-    SDL
-    SDL_image
-    a52dec
-    alsa-lib
-    avahi
-    dbus
-    faad2
-    ffmpeg_4
-    flac
-    fluidsynth
-    fribidi
-    gnutls
-    libarchive
-    libass
-    libbluray
-    libcaca
-    libcddb
-    libdc1394
-    libdvbpsi
-    libdvdnav
-    libdvdnav.libdvdread
-    libebml
-    libgcrypt
-    libgpg-error
-    libkate
-    libmad
-    libmatroska
-    libmtp
-    libmodplug
-    liboggz
-    libopus
-    libplacebo
-    libpulseaudio
-    libraw1394
-    librsvg
-    libsamplerate
-    libspatialaudio
-    libssh2
-    libtheora
-    libtiger
-    libupnp
-    libv4l
-    libva
-    libvdpau
-    libvorbis
-    libxml2
-    lua5
-    mpeg2dec
-    ncurses
-    samba
-    schroedinger
-    speex
-    srt
-    systemd
-    taglib
-    zlib
-  ]
-  ++ (with xorg; [
-    libSM
-    libXpm
-    libXv
-    libXvMC
-    xcbutilkeysyms
-  ])
-  ++ optional (!stdenv.hostPlatform.isAarch && !onlyLibVLC) live555
-  ++ optional jackSupport libjack2
-  ++ optionals chromecastSupport [ libmicrodns protobuf ]
-  ++ optionals skins2Support (with xorg; [
-    freetype
-    libXext
-    libXinerama
-    libXpm
-  ])
-  ++ optionals waylandSupport [ wayland wayland-protocols ]
-  ++ optionals withQt5 [ qtbase qtsvg qtx11extras ]
-  ++ optional (waylandSupport && withQt5) qtwayland;
-
-  nativeBuildInputs = [
-    autoreconfHook
-    perl
-    pkg-config
-    removeReferencesTo
-    unzip
-  ]
-  ++ optionals withQt5 [ wrapQtAppsHook ]
-  ++ optionals waylandSupport [ wayland wayland-protocols ];
-
-  enableParallelBuilding = true;
-
-  LIVE555_PREFIX = if stdenv.hostPlatform.isAarch then null else live555;
-
-  # vlc depends on a c11-gcc wrapper script which we don't have so we need to
-  # set the path to the compiler
-  BUILDCC = "${stdenv.cc}/bin/gcc";
-
-  patches = [
-    # patch to build with recent live555
-    # upstream issue: https://code.videolan.org/videolan/vlc/-/issues/25473
-    (fetchpatch {
-      url = "https://code.videolan.org/videolan/vlc/uploads/eb1c313d2d499b8a777314f789794f9d/0001-Add-lssl-and-lcrypto-to-liblive555_plugin_la_LIBADD.patch";
-      sha256 = "0kyi8q2zn2ww148ngbia9c7qjgdrijf4jlvxyxgrj29cb5iy1kda";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace modules/text_renderer/freetype/platform_fonts.h --replace \
-      /usr/share/fonts/truetype/freefont ${freefont_ttf}/share/fonts/truetype
-  '';
-
-  # - Touch plugins (plugins cache keyed off mtime and file size:
-  #     https://github.com/NixOS/nixpkgs/pull/35124#issuecomment-370552830
-  # - Remove references to the Qt development headers (used in error messages)
-  postFixup = ''
-    find $out/lib/vlc/plugins -exec touch -d @1 '{}' ';'
-    $out/lib/vlc/vlc-cache-gen $out/vlc/plugins
-  '' + optionalString withQt5 ''
-    remove-references-to -t "${qtbase.dev}" $out/lib/vlc/plugins/gui/libqt_plugin.so
-  '';
-
-  # Most of the libraries are auto-detected so we don't need to set a bunch of
-  # "--enable-foo" flags here
-  configureFlags = [
-    "--enable-srt" # Explicit enable srt to ensure the patch is applied.
-    "--with-kde-solid=$out/share/apps/solid/actions"
-  ]
-  ++ optional onlyLibVLC "--disable-vlc"
-  ++ optional skins2Support "--enable-skins2"
-  ++ optional waylandSupport "--enable-wayland"
-  ++ optionals chromecastSupport [
-    "--enable-sout"
-    "--enable-chromecast"
-    "--enable-microdns"
-  ];
-
-  # Remove runtime dependencies on libraries
-  postConfigure = ''
-    sed -i 's|^#define CONFIGURE_LINE.*$|#define CONFIGURE_LINE "<removed>"|g' config.h
-  '';
-
-  # Add missing SOFA files
-  # Given in EXTRA_DIST, but not in install-data target
-  postInstall = ''
-    cp -R share/hrtfs $out/share/vlc
-  '';
 
   meta = with lib; {
     description = "Cross-platform media player and streaming server";
     homepage = "http://www.videolan.org/vlc/";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ AndersonTorres ];
-    platforms = platforms.linux;
+    platforms = with platforms; (if onlyLibVLC then linux else linux ++ darwin);
   };
-}
+
+  package = (callPackage (if stdenv.isLinux then ./linux.nix else ./darwin.nix)
+    (if stdenv.isLinux then {
+      inherit version meta chromecastSupport jackSupport onlyLibVLC
+        skins2Support waylandSupport libcaca withQt5 qtbase qtsvg qtx11extras
+        wrapQtAppsHook;
+    } else {
+      inherit version meta;
+    }));
+in package

--- a/pkgs/applications/video/vlc/linux.nix
+++ b/pkgs/applications/video/vlc/linux.nix
@@ -1,0 +1,244 @@
+{ lib
+, meta
+, version
+, stdenv
+, fetchurl
+, fetchpatch
+, SDL
+, SDL_image
+, a52dec
+, alsa-lib
+, autoreconfHook
+, avahi
+, dbus
+, faad2
+, ffmpeg_4
+, flac
+, fluidsynth
+, freefont_ttf
+, fribidi
+, gnutls
+, libarchive
+, libass
+, libbluray
+, libcaca
+, libcddb
+, libdc1394
+, libdvbpsi
+, libdvdnav
+, libebml
+, libgcrypt
+, libgpg-error
+, libjack2
+, libkate
+, libmad
+, libmatroska
+, libmodplug
+, libmtp
+, liboggz
+, libopus
+, libplacebo
+, libpulseaudio
+, libraw1394
+, librsvg
+, libsamplerate
+, libspatialaudio
+, libssh2
+, libtheora
+, libtiger
+, libupnp
+, libv4l
+, libva
+, libvdpau
+, libvorbis
+, libxml2
+, live555
+, lua5
+, mpeg2dec
+, ncurses
+, perl
+, pkg-config
+, removeReferencesTo
+, samba
+, schroedinger
+, speex
+, srt
+, systemd
+, taglib
+, unzip
+, xorg
+, zlib
+, chromecastSupport ? true, libmicrodns, protobuf
+, jackSupport ? false
+, onlyLibVLC ? false
+, skins2Support ? !onlyLibVLC, freetype
+, waylandSupport ? true, wayland, wayland-protocols
+, withQt5 ? true, qtbase, qtsvg, qtwayland, qtx11extras, wrapQtAppsHook
+}:
+
+# chromecastSupport requires TCP port 8010 to be open for it to work.
+# If your firewall is enabled, make sure to have something like:
+#   networking.firewall.allowedTCPPorts = [ 8010 ];
+
+let
+  inherit (lib) optionalString optional optionals;
+in
+stdenv.mkDerivation rec {
+  inherit version meta;
+
+  pname = "${optionalString onlyLibVLC "lib"}vlc";
+
+  src = fetchurl {
+    url = "http://get.videolan.org/vlc/${version}/vlc-${version}.tar.xz";
+    sha256 = "sha256-VwlEOcNl2KqLm0H6MIDMDu8r7+YCW7XO9yKszGJa7ew=";
+  };
+
+  # VLC uses a *ton* of libraries for various pieces of functionality, many of
+  # which are not included here for no other reason that nobody has mentioned
+  # needing them
+  buildInputs = [
+    SDL
+    SDL_image
+    a52dec
+    alsa-lib
+    avahi
+    dbus
+    faad2
+    ffmpeg_4
+    flac
+    fluidsynth
+    fribidi
+    gnutls
+    libarchive
+    libass
+    libbluray
+    libcaca
+    libcddb
+    libdc1394
+    libdvbpsi
+    libdvdnav
+    libdvdnav.libdvdread
+    libebml
+    libgcrypt
+    libgpg-error
+    libkate
+    libmad
+    libmatroska
+    libmtp
+    libmodplug
+    liboggz
+    libopus
+    libplacebo
+    libpulseaudio
+    libraw1394
+    librsvg
+    libsamplerate
+    libspatialaudio
+    libssh2
+    libtheora
+    libtiger
+    libupnp
+    libv4l
+    libva
+    libvdpau
+    libvorbis
+    libxml2
+    lua5
+    mpeg2dec
+    ncurses
+    samba
+    schroedinger
+    speex
+    srt
+    systemd
+    taglib
+    zlib
+  ]
+  ++ (with xorg; [
+    libSM
+    libXpm
+    libXv
+    libXvMC
+    xcbutilkeysyms
+  ])
+  ++ optional (!stdenv.hostPlatform.isAarch && !onlyLibVLC) live555
+  ++ optional jackSupport libjack2
+  ++ optionals chromecastSupport [ libmicrodns protobuf ]
+  ++ optionals skins2Support (with xorg; [
+    freetype
+    libXext
+    libXinerama
+    libXpm
+  ])
+  ++ optionals waylandSupport [ wayland wayland-protocols ]
+  ++ optionals withQt5 [ qtbase qtsvg qtx11extras ]
+  ++ optional (waylandSupport && withQt5) qtwayland;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    perl
+    pkg-config
+    removeReferencesTo
+    unzip
+  ]
+  ++ optionals withQt5 [ wrapQtAppsHook ]
+  ++ optionals waylandSupport [ wayland wayland-protocols ];
+
+  enableParallelBuilding = true;
+
+  LIVE555_PREFIX = if stdenv.hostPlatform.isAarch then null else live555;
+
+  # vlc depends on a c11-gcc wrapper script which we don't have so we need to
+  # set the path to the compiler
+  BUILDCC = "${stdenv.cc}/bin/gcc";
+
+  patches = [
+    # patch to build with recent live555
+    # upstream issue: https://code.videolan.org/videolan/vlc/-/issues/25473
+    (fetchpatch {
+      url = "https://code.videolan.org/videolan/vlc/uploads/eb1c313d2d499b8a777314f789794f9d/0001-Add-lssl-and-lcrypto-to-liblive555_plugin_la_LIBADD.patch";
+      sha256 = "0kyi8q2zn2ww148ngbia9c7qjgdrijf4jlvxyxgrj29cb5iy1kda";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace modules/text_renderer/freetype/platform_fonts.h --replace \
+      /usr/share/fonts/truetype/freefont ${freefont_ttf}/share/fonts/truetype
+  '';
+
+  # - Touch plugins (plugins cache keyed off mtime and file size:
+  #     https://github.com/NixOS/nixpkgs/pull/35124#issuecomment-370552830
+  # - Remove references to the Qt development headers (used in error messages)
+  postFixup = ''
+    find $out/lib/vlc/plugins -exec touch -d @1 '{}' ';'
+    $out/lib/vlc/vlc-cache-gen $out/vlc/plugins
+  '' + optionalString withQt5 ''
+    remove-references-to -t "${qtbase.dev}" $out/lib/vlc/plugins/gui/libqt_plugin.so
+  '';
+
+  # Most of the libraries are auto-detected so we don't need to set a bunch of
+  # "--enable-foo" flags here
+  configureFlags = [
+    "--enable-srt" # Explicit enable srt to ensure the patch is applied.
+    "--with-kde-solid=$out/share/apps/solid/actions"
+  ]
+  ++ optional onlyLibVLC "--disable-vlc"
+  ++ optional skins2Support "--enable-skins2"
+  ++ optional waylandSupport "--enable-wayland"
+  ++ optionals chromecastSupport [
+    "--enable-sout"
+    "--enable-chromecast"
+    "--enable-microdns"
+  ];
+
+  # Remove runtime dependencies on libraries
+  postConfigure = ''
+    sed -i 's|^#define CONFIGURE_LINE.*$|#define CONFIGURE_LINE "<removed>"|g' config.h
+  '';
+
+  # Add missing SOFA files
+  # Given in EXTRA_DIST, but not in install-data target
+  postInstall = ''
+    cp -R share/hrtfs $out/share/vlc
+  '';
+}


### PR DESCRIPTION
###### Description of changes

Adds a darwin version of VLC.

Files formatted with nixfmt.

`nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` fails because it cannot find `ibtool` which is bundled with Xcode (it isn't a nix package, but it is on my system even though nix-shell doesn't find it.)

I did not add myself to the maintainers list.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).