### PR TITLE
pinta: 2.0.2 -> 2.1

### DIFF
--- a/pkgs/applications/graphics/pinta/default.nix
+++ b/pkgs/applications/graphics/pinta/default.nix
@@ -10,12 +10,15 @@
 
 buildDotnetModule rec {
   pname = "Pinta";
-  version = "2.0.2";
+  version = "2.1";
 
   nativeBuildInputs = [
     intltool
     wrapGAppsHook
   ];
+
+  dotnet-sdk = dotnetCorePackages.sdk_7_0;
+  dotnet-runtime = dotnetCorePackages.runtime_7_0;
 
   runtimeDeps = [ gtk3 ];
   buildInputs = runtimeDeps;
@@ -33,7 +36,7 @@ buildDotnetModule rec {
     owner = "PintaProject";
     repo = "Pinta";
     rev = version;
-    sha256 = "sha256-Bvzs1beq7I1+10w9pmMePqGCz2TPDp5UK5Wa9hbKERU=";
+    hash = "sha256-hugV4I13wZhPnVTUlGlaVxdjpGRvWDnfRVXgV+oy+sE=";
   };
 
   # https://github.com/NixOS/nixpkgs/issues/38991
@@ -61,8 +64,11 @@ buildDotnetModule rec {
     mv "$out/bin/Pinta" "$out/bin/pinta"
 
     # Copy runtime icons
-    mkdir -p $out/share/icons/hicolor/16x16/
-    cp -r Pinta.Resources/icons/hicolor/16x16/* $out/share/icons/hicolor/16x16/
+    for i in "Pinta.Resources/icons/hicolor/"*; do
+      res="$(basename $i)"
+      mkdir -p "$out/share/icons/hicolor/$res"
+      cp -rv "Pinta.Resources/icons/hicolor/$res/"* "$out/share/icons/hicolor/$res/"
+    done
 
     # Install
     dotnet build installer/linux/install.proj \

--- a/pkgs/applications/graphics/pinta/deps.nix
+++ b/pkgs/applications/graphics/pinta/deps.nix
@@ -2,14 +2,18 @@
 # Please dont edit it manually, your changes might get overwritten!
 
 { fetchNuGet }: [
-  (fetchNuGet { pname = "AtkSharp"; version = "3.24.24.34"; sha256 = "1jn1vgi9xm0jp7769k6sbdi8d273kigjrsh93i6s4c03hqxv7cqs"; })
-  (fetchNuGet { pname = "CairoSharp"; version = "3.24.24.34"; sha256 = "0pydn1k0cam1gclg9sc1sbnmbyzh28qlc5qanyxcylwghink3kgz"; })
-  (fetchNuGet { pname = "GdkSharp"; version = "3.24.24.34"; sha256 = "0r0x0yib7chwsyrbpvicrfwldwqx5lyqq4p86zaxpmzd6zdaj0x5"; })
-  (fetchNuGet { pname = "GioSharp"; version = "3.24.24.34"; sha256 = "02hxvgjd4w9jpzbkk7qf9q9bkvyp5hfzwxfqp10vg5lpl9yl3xpx"; })
-  (fetchNuGet { pname = "GLibSharp"; version = "3.24.24.34"; sha256 = "0kvp033fgdwc8p2abfp5z9pzq66cvwbnjfvr4v4bkpy5s5h181kq"; })
-  (fetchNuGet { pname = "GtkSharp"; version = "3.24.24.34"; sha256 = "0028hzmmqyfx87qqmaf9cgb5psn7gkbmqvixcid67x1d6mzxjicb"; })
+  (fetchNuGet { pname = "AtkSharp"; version = "3.24.24.38"; sha256 = "12dv3j8nzhjb5c0093djajdnv8n7m0q7vq2d5ry2v4xk9wqzxpr7"; })
+  (fetchNuGet { pname = "CairoSharp"; version = "3.24.24.38"; sha256 = "0n3y5w088k81apxik9amfvjdwcic4k2ixxvnrk9cw6d2wh1d5r8d"; })
+  (fetchNuGet { pname = "GdkSharp"; version = "3.24.24.38"; sha256 = "0c5gzg106bnnc4wwwhch6lja68623a9hk8r2sjcv35hl5dh21616"; })
+  (fetchNuGet { pname = "GioSharp"; version = "3.24.24.38"; sha256 = "1b3irarxjbbpf24fw2avdglcslb5653gn6m829yhlcm5ay37pds4"; })
+  (fetchNuGet { pname = "GLibSharp"; version = "3.24.24.38"; sha256 = "1a0ixdq1gdb46gkb2nnlydsi10bjrbd3risfyaphsy8fbsyzrzvm"; })
+  (fetchNuGet { pname = "GtkSharp"; version = "3.24.24.38"; sha256 = "0cn8aggci6n088y5giiaxmyzv01rcz37r8pm738q2bsb57zppz2j"; })
+  (fetchNuGet { pname = "Microsoft.Bcl.AsyncInterfaces"; version = "6.0.0"; sha256 = "15gqy2m14fdlvy1g59207h5kisznm355kbw010gy19vh47z8gpz3"; })
   (fetchNuGet { pname = "NGettext"; version = "0.6.7"; sha256 = "1lnq1lgd80xqn80qwq5ipfjnd7nl1ghinjc3krnd546r0c7hwqky"; })
-  (fetchNuGet { pname = "PangoSharp"; version = "3.24.24.34"; sha256 = "1r0h14cklglfpv1lhv93cxmzi2w7d5s03gzpq3j5dmrz43flg9zw"; })
+  (fetchNuGet { pname = "PangoSharp"; version = "3.24.24.38"; sha256 = "0cma8j4cy4j3fw0nvsxlqi0azjkvfjsw0wb6k6b2k21rdpy5rbbn"; })
   (fetchNuGet { pname = "ParagonClipper"; version = "6.4.2"; sha256 = "0pam44f7iayqjz8nh1x29gxdd4dj00i7m5883cpa64i192pgl94c"; })
-  (fetchNuGet { pname = "SharpZipLib"; version = "1.3.3"; sha256 = "1gij11wfj1mqm10631cjpnhzw882bnzx699jzwhdqakxm1610q8x"; })
+  (fetchNuGet { pname = "SharpZipLib"; version = "1.4.1"; sha256 = "1dh1jhgzc9bzd2hvyjp2nblavf0619djniyzalx7kvrbsxhrdjb6"; })
+  (fetchNuGet { pname = "System.Reflection.Emit"; version = "4.7.0"; sha256 = "121l1z2ypwg02yz84dy6gr82phpys0njk7yask3sihgy214w43qp"; })
+  (fetchNuGet { pname = "System.Security.Principal.Windows"; version = "4.7.0"; sha256 = "1a56ls5a9sr3ya0nr086sdpa9qv0abv31dd6fp27maqa9zclqq5d"; })
+  (fetchNuGet { pname = "Tmds.DBus"; version = "0.11.0"; sha256 = "067s9i5mjxlmw0nid3fblr9d0hy1b6zrjzhhi48rf4cs2j72pl64"; })
 ]


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

New release: https://github.com/PintaProject/Pinta/releases/tag/2.1

From the new features, I could not get the `webp` support via [webp-pixbuf-loader](https://github.com/aruiz/webp-pixbuf-loader/) to work, but this is not strictly necessary for this bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
