### PR TITLE
pkgsStatic.wpa_supplicant: fix build

### DIFF
--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchurl, openssl, pkg-config, libnl
 , nixosTests, wpa_supplicant_gui
-, dbusSupport ? true, dbus
+, dbusSupport ? !stdenv.hostPlatform.isStatic, dbus
 , withReadline ? true, readline
-, withPcsclite ? true, pcsclite
+, withPcsclite ? !stdenv.hostPlatform.isStatic, pcsclite
 , readOnlyModeSSIDs ? false
 }:
 
@@ -73,6 +73,15 @@ stdenv.mkDerivation rec {
     CONFIG_CTRL_IFACE_DBUS=y
     CONFIG_CTRL_IFACE_DBUS_NEW=y
     CONFIG_CTRL_IFACE_DBUS_INTRO=y
+  ''
+    # Upstream uses conditionals based on ifdef, so opposite of =y is
+    # not =n, as one may expect, but undefine.
+    #
+    # This config is sourced into makefile.
+    + optionalString (!dbusSupport) ''
+    undefine CONFIG_CTRL_IFACE_DBUS
+    undefine CONFIG_CTRL_IFACE_DBUS_NEW
+    undefine CONFIG_CTRL_IFACE_DBUS_INTRO
   '' + (if withReadline then ''
     CONFIG_READLINE=y
   '' else ''
@@ -104,13 +113,15 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/man/man5 $out/share/man/man8
     cp -v "doc/docbook/"*.5 $out/share/man/man5/
     cp -v "doc/docbook/"*.8 $out/share/man/man8/
-
+  ''
+  + lib.optionalString dbusSupport ''
     mkdir -p $out/share/dbus-1/system.d $out/share/dbus-1/system-services $out/etc/systemd/system
     cp -v "dbus/"*service $out/share/dbus-1/system-services
     sed -e "s@/sbin/wpa_supplicant@$out&@" -i "$out/share/dbus-1/system-services/"*
     cp -v dbus/dbus-wpa_supplicant.conf $out/share/dbus-1/system.d
     cp -v "systemd/"*.service $out/etc/systemd/system
-
+  ''
+  + ''
     rm $out/share/man/man8/wpa_priv.8
     install -Dm444 wpa_supplicant.conf $out/share/doc/wpa_supplicant/wpa_supplicant.conf.example
   '';


### PR DESCRIPTION
Static build has less features enabled, since full set pulls dependency
on system which does not support static build by design.
