### PR TITLE
lib.path.subpath.join: init

### DIFF
--- a/lib/path/tests/unit.nix
+++ b/lib/path/tests/unit.nix
@@ -107,6 +107,36 @@ let
       expected = true;
     };
 
+    # Test examples from the lib.path.subpath.join documentation
+    testSubpathJoinExample1 = {
+      expr = subpath.join [ "foo" "bar/baz" ];
+      expected = "./foo/bar/baz";
+    };
+    testSubpathJoinExample2 = {
+      expr = subpath.join [ "./foo" "." "bar//./baz/" ];
+      expected = "./foo/bar/baz";
+    };
+    testSubpathJoinExample3 = {
+      expr = subpath.join [ ];
+      expected = "./.";
+    };
+    testSubpathJoinExample4 = {
+      expr = (builtins.tryEval (subpath.join [ /foo ])).success;
+      expected = false;
+    };
+    testSubpathJoinExample5 = {
+      expr = (builtins.tryEval (subpath.join [ "" ])).success;
+      expected = false;
+    };
+    testSubpathJoinExample6 = {
+      expr = (builtins.tryEval (subpath.join [ "/foo" ])).success;
+      expected = false;
+    };
+    testSubpathJoinExample7 = {
+      expr = (builtins.tryEval (subpath.join [ "../foo" ])).success;
+      expected = false;
+    };
+
     # Test examples from the lib.path.subpath.normalise documentation
     testSubpathNormaliseExample1 = {
       expr = subpath.normalise "foo//bar";


### PR DESCRIPTION
###### Description of changes

This function can be used to safely join subpaths together, a bit like `concatStringsSep "/"`, but safer. Relates to other work in [the path library effort](https://github.com/NixOS/nixpkgs/issues/210426).

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles:

###### Things done

- [x] Wrote documentation
- [x] Added and ran tests