### PR TITLE
pypy{27,38,39}: 7.3.9 -> 7.3.11

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -296,6 +296,8 @@ in {
     sha256 = {
       aarch64-linux = "sha256-6pJNod7+kyXvdg4oiwT5hGFOQFWA9TIetqXI9Tm9QVo=";
       x86_64-linux = "sha256-uo7ZWKkFwHNaTP/yh1wlCJlU3AIOCH2YKw/6W52jFs0=";
+      aarch64-darwin = "sha256-zFaWq0+TzTSBweSZC13t17pgrAYC+hiQ02iImmxb93E=";
+      x86_64-darwin = "sha256-Vt7unCJkD1aGw1udZP2xzjq9BEWD5AePCxccov0qGY4=";
     }.${stdenv.system};
     pythonVersion = "2.7";
     inherit passthruFun;

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -264,13 +264,13 @@ in {
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "9";
+      patch = "11";
     };
 
-    sha256 = "sha256-Krqh6f4ewOIzyfvDd6DI6aBjQICo9PMOtomDAfZhjBI=";
+    sha256 = "sha256-sPMWb7Klqt/VzrnbXN1feSmg7MygK0omwNrgSS98qOo=";
     pythonVersion = "3.9";
     db = db.override { dbmSupport = !stdenv.isDarwin; };
-    python = __splicedPackages.python27;
+    python = __splicedPackages.pypy27;
     inherit passthruFun;
     inherit (darwin) libunwind;
     inherit (darwin.apple_sdk.frameworks) Security;

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -279,7 +279,7 @@ in {
   pypy38 = __splicedPackages.pypy39.override {
     self = __splicedPackages.pythonInterpreters.pypy38;
     pythonVersion = "3.8";
-    sha256 = "sha256-W12dklbxKhKa+DhOL1gb36s7wPu+OgpIDZwdLpVJDrE=";
+    sha256 = "sha256-TWdpv8pzc06GZv1wUDt86wam4lkRDmFzMbs4mcpOYFg=";
   };
 
   pypy37 = throw "pypy37 has been removed from nixpkgs since it is no longer supported upstream"; # Added 2023-01-04

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -293,7 +293,10 @@ in {
       patch = "11";
     };
 
-    sha256 = "sha256-uo7ZWKkFwHNaTP/yh1wlCJlU3AIOCH2YKw/6W52jFs0="; # linux64
+    sha256 = {
+      aarch64-linux = "sha256-6pJNod7+kyXvdg4oiwT5hGFOQFWA9TIetqXI9Tm9QVo=";
+      x86_64-linux = "sha256-uo7ZWKkFwHNaTP/yh1wlCJlU3AIOCH2YKw/6W52jFs0=";
+    }.${stdenv.system};
     pythonVersion = "2.7";
     inherit passthruFun;
   };

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -307,9 +307,9 @@ in {
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "9";
+      patch = "11";
     };
-    sha256 = "sha256-RoGMs9dLlrNHh1SDQ9Jm4lYrUx3brzMDg7qTD/GTDtU="; # linux64
+    sha256 = "sha256-1QYXLKEQcSdBdddOnFgcMWZDLQF5sDZHDjuejSDq5YE="; # linux64
     pythonVersion = "3.9";
     inherit passthruFun;
   };

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -281,11 +281,8 @@ in {
     pythonVersion = "3.8";
     sha256 = "sha256-W12dklbxKhKa+DhOL1gb36s7wPu+OgpIDZwdLpVJDrE=";
   };
-  pypy37 = __splicedPackages.pypy39.override {
-    self = __splicedPackages.pythonInterpreters.pypy37;
-    pythonVersion = "3.7";
-    sha256 = "sha256-cEJhY7GU7kYAmYbuptlCYJij/7VS2c29PfqmSkc3P0k=";
-  };
+
+  pypy37 = throw "pypy37 has been removed from nixpkgs since it is no longer supported upstream"; # Added 2023-01-04
 
   pypy27_prebuilt = callPackage ./pypy/prebuilt_2_7.nix {
     # Not included at top-level

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -247,13 +247,13 @@ in {
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "9";
+      patch = "11";
     };
 
-    sha256 = "sha256-ObCXKVb2VIzlgoAZ264SUDwy1svpGivs+I0+QsxSGXs=";
+    sha256 = "sha256-ERevtmgx2k6m852NIIR4enRon9AineC+MB+e2bJVCTw=";
     pythonVersion = "2.7";
     db = db.override { dbmSupport = !stdenv.isDarwin; };
-    python = __splicedPackages.python27;
+    python = __splicedPackages.pythonInterpreters.pypy27_prebuilt;
     inherit passthruFun;
     inherit (darwin) libunwind;
     inherit (darwin.apple_sdk.frameworks) Security;

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -293,10 +293,10 @@ in {
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "9";
+      patch = "11";
     };
 
-    sha256 = "sha256-FyqSiwCWp+ALfVj1I/VzAMNcPef4IkkeKnvIRTdcI/g="; # linux64
+    sha256 = "sha256-uo7ZWKkFwHNaTP/yh1wlCJlU3AIOCH2YKw/6W52jFs0="; # linux64
     pythonVersion = "2.7";
     inherit passthruFun;
   };

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -156,7 +156,7 @@ in with passthru; stdenv.mkDerivation rec {
     ln -s $out/${executable}-c/lib-python/${if isPy3k then "3" else pythonVersion} $out/lib/${libPrefix}
 
     ${lib.optionalString stdenv.isDarwin ''
-      install_name_tool -change @rpath/libpypy${optionalString isPy3k "3"}-c.dylib $out/lib/libpypy${optionalString isPy3k "3"}-c.dylib $out/bin/${executable}
+      install_name_tool -change @rpath/lib${executable}-c.dylib $out/lib/lib${executable}-c.dylib $out/bin/${executable}
     ''}
 
     # verify cffi modules

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -173,7 +173,7 @@ in with passthru; stdenv.mkDerivation rec {
     homepage = "http://pypy.org/";
     description = "Fast, compliant alternative implementation of the Python language (${pythonVersion})";
     license = licenses.mit;
-    platforms = [ "aarch64-linux" "i686-linux" "x86_64-linux" "x86_64-darwin" ];
+    platforms = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
     maintainers = with maintainers; [ andersk ];
   };
 }

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -174,6 +174,7 @@ in with passthru; stdenv.mkDerivation rec {
     description = "Fast, compliant alternative implementation of the Python language (${pythonVersion})";
     license = licenses.mit;
     platforms = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
+    broken = stdenv.isDarwin && stdenv.isAarch64;
     maintainers = with maintainers; [ andersk ];
   };
 }

--- a/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
@@ -1,11 +1,13 @@
 { lib
 , stdenv
 , fetchurl
+, autoPatchelfHook
 , python-setup-hook
 , self
-, which
 # Dependencies
 , bzip2
+, gdbm
+, sqlite
 , zlib
 , expat
 , ncurses6
@@ -48,6 +50,8 @@ let
 
   deps = [
     bzip2
+    gdbm
+    sqlite
     zlib
     expat
     ncurses6
@@ -68,9 +72,13 @@ in with passthru; stdenv.mkDerivation {
     inherit sha256;
   };
 
-  buildInputs = [ which ];
+  buildInputs = deps;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/lib
     echo "Moving files to $out"
     mv -t $out bin include lib-python lib_pypy site-packages
@@ -80,23 +88,20 @@ in with passthru; stdenv.mkDerivation {
 
     rm $out/bin/*.debug
 
-    echo "Patching binaries"
-    interpreter=$(patchelf --print-interpreter $(readlink -f $(which patchelf)))
-    patchelf --set-interpreter $interpreter \
-             --set-rpath $out/lib \
-             $out/bin/pypy*
-
-    pushd $out
-    find {lib,lib_pypy*} -name "*.so" -exec patchelf --remove-needed libncursesw.so.6 --replace-needed libtinfow.so.6 libncursesw.so.6 {} \;
-    find {lib,lib_pypy*} -name "*.so" -exec patchelf --set-rpath ${lib.makeLibraryPath deps}:$out/lib {} \;
-
     echo "Removing bytecode"
-    find . -name "__pycache__" -type d -depth -exec rm -rf {} \;
-    popd
+    find . -name "__pycache__" -type d -depth -delete
 
     # Include a sitecustomize.py file
     cp ${../sitecustomize.py} $out/${sitePackages}/sitecustomize.py
 
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    find $out/{lib,lib_pypy*} -name "*.so" \
+      -exec patchelf \
+        --replace-needed libtinfow.so.6 libncursesw.so.6 \
+        --replace-needed libgdbm.so.4 libgdbm_compat.so.4 {} \;
   '';
 
   doInstallCheck = true;

--- a/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
@@ -105,8 +105,8 @@ in with passthru; stdenv.mkDerivation {
   '' + lib.optionalString (stdenv.isDarwin) ''
     install_name_tool \
       -change \
-        @rpath/libpypy${optionalString isPy3k "3"}-c.dylib \
-        $out/lib/libpypy${optionalString isPy3k "3"}-c.dylib \
+        @rpath/lib${executable}-c.dylib \
+        $out/lib/lib${executable}-c.dylib \
         $out/bin/${executable}
   '';
 

--- a/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
@@ -55,11 +55,16 @@ let
     tk-8_5
   ];
 
+  downloadUrls = {
+    aarch64-linux = "https://downloads.python.org/pypy/pypy${pythonVersion}-v${version}-aarch64.tar.bz2";
+    x86_64-linux = "https://downloads.python.org/pypy/pypy${pythonVersion}-v${version}-linux64.tar.bz2";
+  };
+
 in with passthru; stdenv.mkDerivation {
   inherit pname version;
 
   src = fetchurl {
-    url = "https://downloads.python.org/pypy/pypy${pythonVersion}-v${version}-linux64.tar.bz2";
+    url = downloadUrls.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
     inherit sha256;
   };
 
@@ -124,7 +129,7 @@ in with passthru; stdenv.mkDerivation {
     homepage = "http://pypy.org/";
     description = "Fast, compliant alternative implementation of the Python language (${pythonVersion})";
     license = licenses.mit;
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.mapAttrsToList (arch: _: arch) downloadUrls;
   };
 
 }

--- a/pkgs/development/interpreters/python/pypy/tk_tcl_paths.patch
+++ b/pkgs/development/interpreters/python/pypy/tk_tcl_paths.patch
@@ -1,14 +1,18 @@
 --- a/lib_pypy/_tkinter/tklib_build.py
 +++ b/lib_pypy/_tkinter/tklib_build.py
-@@ -17,19 +17,14 @@ elif sys.platform == 'win32':
+@@ -17,23 +17,14 @@ elif sys.platform == 'win32':
      incdirs = []
      linklibs = ['tcl85', 'tk85']
      libdirs = []
 -elif sys.platform == 'darwin':
 -    # homebrew
+-    homebrew = os.environ.get('HOMEBREW_PREFIX', '')
 -    incdirs = ['/usr/local/opt/tcl-tk/include']
 -    linklibs = ['tcl8.6', 'tk8.6']
--    libdirs = ['/usr/local/opt/tcl-tk/lib']
+-    libdirs = []
+-    if homebrew:
+-        incdirs.append(homebrew + '/include')
+-        libdirs.append(homebrew + '/opt/tcl-tk/lib')
  else:
      # On some Linux distributions, the tcl and tk libraries are
      # stored in /usr/include, so we must check this case also


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

See https://github.com/NixOS/nixpkgs/pull/201859.

This will also make `pypy27` to be build with `pythonInterpreters.pypy27_prebuilt`, while `pypy39` will be `pypy27`. Since `pythonInterpreters.pypy27_prebuilt` is only available for `x86_64-linux` (edit: and `aarch64-linux`) right now, this will limit platform support. However, it is better to have fewer platforms working than no platform working (after #201859 is merged).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
