### PR TITLE
busybox: 1.35.0 -> 1.36.0

### DIFF
--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -50,14 +50,14 @@ in
 
 stdenv.mkDerivation rec {
   pname = "busybox";
-  version = "1.35.0";
+  version = "1.36.0";
 
   # Note to whoever is updating busybox: please verify that:
   # nix-build pkgs/stdenv/linux/make-bootstrap-tools.nix -A test
   # still builds after the update.
   src = fetchurl {
     url = "https://busybox.net/downloads/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-+u6yRMNaNIozT0pZ5EYm7ocPsHtohNaMEK6LwZ+DppQ=";
+    sha256 = "sha256-VCdQyK98smMOIBeAtPmfPczusG9QW0eexoJBweavYaU=";
   };
 
   hardeningDisable = [ "format" "pie" ]
@@ -74,11 +74,6 @@ stdenv.mkDerivation rec {
       name = "CVE-2022-28391.patch";
       url = "https://git.alpinelinux.org/aports/plain/main/busybox/0002-nslookup-sanitize-all-printed-strings-with-printable.patch?id=ed92963eb55bbc8d938097b9ccb3e221a94653f4";
       sha256 = "sha256-vl1wPbsHtXY9naajjnTicQ7Uj3N+EQ8pRNnrdsiow+w=";
-    })
-    (fetchurl {
-      name = "CVE-2022-30065.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/busybox/CVE-2022-30065.patch?id=4ffd996b3f8298c7dd424b912c245864c816e354";
-      sha256 = "sha256-+WSYxI6eF8S0tya/S62f9Nc6jVMnHO0q1OyM69GlNTY=";
     })
   ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ./clang-cross.patch;
 


### PR DESCRIPTION
###### Description of changes

Release announcement on busybox homepage: https://busybox.net/

<details>
  <summary>Changes:</summary>
<pre>
Aaro Koskinen:
      devmem: add 128-bit width

Bernhard Reutner-Fischer (3):
      kbuild: fix building sha256
      kbuild: Prefer -Oz over -Os
      seedrng: manually inline seed_rng

Brandon Maier:
      xxd: fix typo in trivial usage

Dario Binacchi (2):
      fbset: abort on not handled options
      fbset: support setting pixel clock rate

David Leonard:
      tsort: new applet

Denys Vlasenko:
      Makefile.flags: add resolv to LDLIBS for linux compilers too (not only gnu ones)
      build system: detect if build host has no bzip2
      scripts/echo.c: fix NUL handling in "abc\0 def"
      libbb/loop: fix compile failure (name collision)
      libbb/loop: optionally use ioctl(LOOP_CONFIGURE) to set up loopdevs
      libbb/loop: restore the correct return value of set_loop()
      libbb/sha1: add config-selectable fully unrolled version, closes 14391
      libbb/sha1: add config-selectable partially unrolled version
      libbb/sha1: assembly versions for x86
      libbb/sha1: optional x86 hardware accelerated hashing
      libbb/sha256: optional x86 hardware accelerated hashing
      libbb: change xstrndup, xmemdup to take size_t as size parameter
      libbb: factor out fflush_stdout_and_exit(EXIT_SUCCESS)
      libbb: fflush_stdout_and_exit(0) still exits with _error_ (not 0!) if fflush fails
      libbb: fix fallout from nth_string() robustification, closes 14726
      libbb: introduce and use chdir_or_warn()
      libbb: invert the meaning of SETUP_ENV_NO_CHDIR -> SETUP_ENV_CHDIR
      tls: P256: remove NOP macro sp_256_norm_8()
      tls: include signature_algorithms extension in client hello message
      examples/var_service/dhcp_if: make helper scripts more talkative
      testsuite/mount.tests: accomodate umount failure seen on 5.18.0
      testsuite/sha1sum.tests: fix false positive failure
      shell: add comments about SIGINT-related problems
      shell: fix compile failures in some configs
      ash,hush: fix handling of SIGINT while waiting for interactive input
      ash: ^C with SIG_INGed SIGINT should not exit the shell
      ash: do not truncate failed tilde expansion on unknown user names
      ash: fix ifs cleanup on error paths
      ash: fix unsafe use of mempcpy
      ash: fix use-after-free in pattern substitution code
      awk: input numbers are never octal or hex (only program consts can be)
      bc: hopefully fix bug 14956 (use-after-free)
      cut: build fix for FEATURE_CUT_REGEX
      ifplugd: split -a into -a and -A, latter disables upping in iface creation
      init: do not set HOME
      ls: implement ls -sh (human-readable allocated blocks)
      md5/shaXsum: use FEATURE_COPYBUF_KB to size the buffer instead of fixed 4k
      mv: fix error in !VERBOSE configs
      nmeter: %[md] %[mw] - dirty file-backed pages, writeback pages
      powertop: fix cpuid asm: ebx saving/restoring is properly done by gcc
      sed: correctly handle 'w FILE' commands writing to the same file
      sed: fix double-free in FEATURE_CLEAN_UP=y configs
      sed: fix handling of escaped delimiters in s/// replacement
      sed: fix handling of escaped delimiters in s/// search pattern, closes 14541
      seedrng: chdir to the SEED_DIRECTORY - avoid concat_path_file's
      seedrng: do not hash in a constant string, it's not adding entropy
      seedrng: do not hash lengths, they are very predictable
      seedrng: do not try to continue on unexpected errors (just exit)
      seedrng: explain why we need locking and fsync'ing
      seedrng: include file/dir names in error messages
      seedrng: re-add fsync after unlink, and explain its purpose
      seedrng: reduce MAX_SEED_LEN from 512 to 256
      seedrng: remove redundant assignment
      seedrng: remove unnecessary zero-filling of local variables
      seedrng: restore error check on fsync
      seedrng: simplify read_new_seed() to not have error return
      seedrng: use more xfuncs where appropriate
      shaNNNsum: accept one-space "HASH FILENAME" format for -c, closes 14866
      sort: fix -k2M (wasn't skipping leading whitespace)
      sort: fix -s -r interaction: 'stable' order is not affected by -r
      sort: fix sort -s -u, closes 14871
      sort: support -h
      sulogin: increase util-linux compatibility
      sulogin: start _login_ shell only with -p
      sulogin: util-linux does not say "normal startup" on Ctrl-D
      taskset: fix printf format mismatch in !FEATURE_TASKSET_FANCY config. closes 14616
      top: fix display of large PID/PPID
      top: improve large PID display in memory ('s') mode
      tree: make it unicode-aware
      tree: unicode tweak (use normal space char, 0x20)
      udhcpc6: add missed big-endian conversions
      udhcpc6: align FF02__1_2[]
      udhcpc6: downgrade "opening listen socket" log level to 2
      udhcpc6: fix binding to network aliases
      udhcpc6: fix sending of renew messages
      udhcpc6: use a different default config script
      xargs: implement -o, closes 15146
      xxd -r: handle offsets
      xxd -r: without -p, stop at more than one whitespace, closes 14786
      xxd: fix use of non-initialized data
      xxd: use bb_simple_perror_msg... where appropriate

Emanuele Giacomelli:
      XXXsum: handle binary sums with " " in the path

Grob Grobmann:
      vi: add 'ZQ' quitting command

Henrique Rodrigues:
      ping: fix typo in --help text

Jason A. Donenfeld (10):
      seedrng: import SeedRNG utility for kernel RNG seed files
      seedrng: use libbb functions
      seedrng: hoist bb_strtoul out of min/max
      seedrng: remove some global variables
      seedrng: further reduce size
      seedrng: use predefined strings where possible
      seedrng: avoid needless runtime strlen() call
      seedrng: compress format strings with %s arguments
      seedrng: code-golf even smaller
      seedrng: prune header includes

Khem Raj:
      apply const trick to ptr_to_globals

Louis Sautier:
      pkill: add -e to display the name and PID of the process being killed

Ludwig Nussel:
      libbb: mark stack in assembly files read-only

Natanael Copa (2):
      awk: fix use after free (CVE-2022-30065)
      more: accept and ignore -e

Paul Fox:
      crond: implement support for setting PATH in crontab files

Peter Kaestle:
      unzip -l: add missed big-endian conversions date and time

Roger Knecht:
      tree: new applet

Ron Yorston (8):
      libbb: restore special handling of nomsg errors
      libbb: make '--help' handling more consistent
      lineedit: get PWD from ash
      ash,hush: use HOME for tab completion and prompts
      vi: fix regression in autoindent handling
      vi: handle autoindent in 'cc' command
      vi: improved handling of backspace in replace mode
      vi: fix backspace over tab in commands

Samuel Thibault:
      Fix non-Linux builds

Shawn Landden:
      ash: optional sleep builtin

Sören Tempel (3):
      ed: add support for -s command-line option as mandated by POSIX
      ash: don't read past end of var in subvareval for bash substitutions
      ash: fix use-after-free in bash pattern substitution

Timo Teräs:
      mkfs.vfat: fix volume label to be padded with space

Vincent Stehlé:
      fdisk: recognize EBBR protective partitions

Walter Lozano:
      Add support for long options to cmp

Xiaoming Ni (4):
      loop: fix a race when a free loop device is snatched
      loop: refactor: extract subfunction get_next_free_loop()
      loop: simplify code of LOOP_SET_FD failure
      loop: refactor: extract subfunction set_loopdev_params()
</pre>
</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

No new failures on the 144 dependents that I have built.