### PR TITLE
pkgsStatic.protobufc: fix build

### DIFF
--- a/pkgs/development/libraries/protobufc/default.nix
+++ b/pkgs/development/libraries/protobufc/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , autoreconfHook
 , pkg-config
 , protobuf
@@ -18,6 +19,14 @@ stdenv.mkDerivation rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-TJCLzxozuZ8ynrBQ2lKyk03N+QA/lbOwywUjDUdTlbM=";
   };
+
+  patches = [
+    # https://github.com/protobuf-c/protobuf-c/pull/534
+    (fetchpatch {
+      url = "https://github.com/protobuf-c/protobuf-c/commit/a6c9ea5207aeac61c57b446ddf5a6b68308881d8.patch";
+      hash = "sha256-wTb8+YbvrCrOVpgthI5SJdG/CpQcOzCX4Bv47FPY804=";
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 


### PR DESCRIPTION
Upstream effectively puts "-lprotobuf -lprotoc" as linking flags, while in fact
"protoc.a" depends on "protobuf.a", so flags should be in reverse order.

It is simpler to append one more "-lprotobuf" than to make patch to fix order.
That means that linker will scan "protobuf.a" twice, but price is neglectable.
