### PR TITLE
pkgsStatic.htop: fix build

### DIFF
--- a/pkgs/tools/system/htop/default.nix
+++ b/pkgs/tools/system/htop/default.nix
@@ -2,7 +2,8 @@
 , ncurses
 , IOKit
 , sensorsSupport ? stdenv.isLinux, lm_sensors
-, systemdSupport ? stdenv.isLinux, systemd
+, systemdSupport ? stdenv.isLinux && !stdenv.hostPlatform.isStatic
+, systemd
 }:
 
 assert systemdSupport -> stdenv.isLinux;
@@ -33,8 +34,7 @@ stdenv.mkDerivation rec {
   postFixup =
     let
       optionalPatch = pred: so: lib.optionalString pred "patchelf --add-needed ${so} $out/bin/htop";
-    in
-    ''
+    in lib.optionalString (!stdenv.hostPlatform.isStatic) ''
       ${optionalPatch sensorsSupport "${lm_sensors}/lib/libsensors.so"}
       ${optionalPatch systemdSupport "${systemd}/lib/libsystemd.so"}
     '';


### PR DESCRIPTION



maintainers: $@{x.github} $@{x.github} $@{x.github}
build log on x86_64 NixOS: https://gist.github.com/e5790d26d06814e3e7a36f2a4705f4cc
