### PR TITLE
fuse: split outputs and clean up

### DIFF
--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -249,8 +249,8 @@ in
           };
       in
       { # These are mount related wrappers that require the +s permission.
-        fusermount  = mkSetuidRoot "${pkgs.fuse}/bin/fusermount";
-        fusermount3 = mkSetuidRoot "${pkgs.fuse3}/bin/fusermount3";
+        fusermount  = mkSetuidRoot "${lib.getBin pkgs.fuse}/bin/fusermount";
+        fusermount3 = mkSetuidRoot "${lib.getBin pkgs.fuse3}/bin/fusermount3";
         mount  = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/mount";
         umount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/umount";
       };

--- a/pkgs/applications/networking/sync/acd_cli/default.nix
+++ b/pkgs/applications/networking/sync/acd_cli/default.nix
@@ -18,7 +18,7 @@ buildPythonApplication rec {
   propagatedBuildInputs = [ appdirs colorama python-dateutil fusepy requests
                             requests-toolbelt setuptools sqlalchemy ];
 
-  makeWrapperArgs = [ "--prefix LIBFUSE_PATH : ${fuse}/lib/libfuse.so" ];
+  makeWrapperArgs = [ "--prefix LIBFUSE_PATH : ${lib.getLib fuse}/lib/libfuse.so" ];
 
   postFixup = ''
     function lnOverBin() {

--- a/pkgs/development/python-modules/fusepy/default.nix
+++ b/pkgs/development/python-modules/fusepy/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   # be able to find libfuse in /usr/local/lib.
   patchPhase = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     substituteInPlace fuse.py --replace \
-      "find_library('fuse')" "'${pkgs.fuse}/lib/libfuse.so'"
+      "find_library('fuse')" "'${lib.getLib pkgs.fuse}/lib/libfuse.so'"
   '';
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -1,15 +1,25 @@
 { version, hash }:
 
-{ lib, stdenv, fetchFromGitHub, fetchpatch
-, fusePackages, util-linux, gettext, shadow
-, meson, ninja, pkg-config
-, autoreconfHook
-, python3Packages, which
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  fusePackages,
+  util-linux,
+  gettext,
+  shadow,
+  meson,
+  ninja,
+  pkg-config,
+  autoreconfHook,
+  runtimeShell,
 }:
 
 let
   isFuse3 = lib.hasPrefix "3" version;
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "fuse";
   inherit version;
 
@@ -23,27 +33,46 @@ in stdenv.mkDerivation rec {
   preAutoreconf = "touch config.rpath";
 
   patches =
-    lib.optional
-      (!isFuse3 && (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isLoongArch64))
+    lib.optional (!isFuse3 && (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isLoongArch64))
       (fetchpatch {
         url = "https://github.com/libfuse/libfuse/commit/914871b20a901e3e1e981c92bc42b1c93b7ab81b.patch";
         sha256 = "1w4j6f1awjrycycpvmlv0x5v9gprllh4dnbjxl4dyl2jgbkaw6pa";
       })
-    ++ (if isFuse3
-      then [ ./fuse3-install.patch ./fuse3-Do-not-set-FUSERMOUNT_DIR.patch ]
-      else [
-        ./fuse2-Do-not-set-FUSERMOUNT_DIR.patch
-        (fetchpatch {
-          url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-fs/fuse/files/fuse-2.9.9-closefrom-glibc-2-34.patch?id=8a970396fca7aca2d5a761b8e7a8242f1eef14c9";
-          sha256 = "sha256-ELYBW/wxRcSMssv7ejCObrpsJHtOPJcGq33B9yHQII4=";
-        })
-      ]);
+    ++ (
+      if isFuse3 then
+        [
+          ./fuse3-install.patch
+          ./fuse3-Do-not-set-FUSERMOUNT_DIR.patch
+        ]
+      else
+        [
+          ./fuse2-Do-not-set-FUSERMOUNT_DIR.patch
+          (fetchpatch {
+            url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-fs/fuse/files/fuse-2.9.9-closefrom-glibc-2-34.patch?id=8a970396fca7aca2d5a761b8e7a8242f1eef14c9";
+            sha256 = "sha256-ELYBW/wxRcSMssv7ejCObrpsJHtOPJcGq33B9yHQII4=";
+          })
+        ]
+    );
 
-  nativeBuildInputs = if isFuse3
-    then [ meson ninja pkg-config ]
-    else [ autoreconfHook gettext ];
+  nativeBuildInputs =
+    if isFuse3 then
+      [
+        meson
+        ninja
+        pkg-config
+      ]
+    else
+      [
+        autoreconfHook
+        gettext
+      ];
 
-  outputs = [ "out" ] ++ lib.optional isFuse3 "common";
+  outputs = [
+    "bin"
+    "out"
+    "dev"
+    "man"
+  ] ++ lib.optional isFuse3 "udev";
 
   mesonFlags = lib.optionals isFuse3 [
     "-Dudevrulesdir=/udev/rules.d"
@@ -51,45 +80,50 @@ in stdenv.mkDerivation rec {
     "-Dinitscriptdir="
   ];
 
-  preConfigure = ''
-    export MOUNT_FUSE_PATH=$out/sbin
-    export INIT_D_PATH=$TMPDIR/etc/init.d
-    export UDEV_RULES_PATH=$out/etc/udev/rules.d
+  # Ensure that FUSE calls the setuid wrapper, not
+  # $out/bin/fusermount. It falls back to calling fusermount in
+  # $PATH, so it should also work on non-NixOS systems.
+  NIX_CFLAGS_COMPILE = ''-DFUSERMOUNT_DIR="/run/wrappers/bin"'';
 
-    # Ensure that FUSE calls the setuid wrapper, not
-    # $out/bin/fusermount. It falls back to calling fusermount in
-    # $PATH, so it should also work on non-NixOS systems.
-    export NIX_CFLAGS_COMPILE="-DFUSERMOUNT_DIR=\"/run/wrappers/bin\""
+  preConfigure =
+    ''
+      substituteInPlace lib/mount_util.c \
+        --replace-fail "/bin/mount" "${lib.getBin util-linux}/bin/mount" \
+        --replace-fail "/bin/umount" "${lib.getBin util-linux}/bin/umount"
+      substituteInPlace util/mount.fuse.c \
+        --replace-fail "/bin/sh" "${runtimeShell}"
+    ''
+    + lib.optionalString (!isFuse3) ''
+      export MOUNT_FUSE_PATH=$bin/bin
 
-    substituteInPlace lib/mount_util.c --replace "/bin/" "${util-linux}/bin/"
-    '' + (if isFuse3 then ''
-      # The configure phase will delete these files (temporary workaround for
-      # ./fuse3-install_man.patch)
-      install -D -m444 doc/fusermount3.1 $out/share/man/man1/fusermount3.1
-      install -D -m444 doc/mount.fuse3.8 $out/share/man/man8/mount.fuse3.8
-    '' else ''
-      substituteInPlace util/mount.fuse.c --replace '"su"' '"${shadow.su}/bin/su"'
-      sed -e 's@CONFIG_RPATH=/usr/share/gettext/config.rpath@CONFIG_RPATH=${gettext}/share/gettext/config.rpath@' -i makeconf.sh
+      # Do not install these files for fuse2 which are not useful for NixOS.
+      export INIT_D_PATH=$TMPDIR/etc/init.d
+      export UDEV_RULES_PATH=$TMPDIR/etc/udev/rules.d
+
+      # This is for `setuid=`, and needs root permission anyway.
+      # No need to use the SUID wrapper.
+      substituteInPlace util/mount.fuse.c \
+        --replace-fail '"su"' '"${lib.getBin shadow.su}/bin/su"'
+      substituteInPlace makeconf.sh \
+        --replace-fail 'CONFIG_RPATH=/usr/share/gettext/config.rpath' 'CONFIG_RPATH=${lib.getLib gettext}/share/gettext/config.rpath'
       ./makeconf.sh
-    '');
+    '';
 
-  nativeCheckInputs = [ which ] ++ (with python3Packages; [ python pytest ]);
+  # v2: no tests, v3: all tests get skipped in a sandbox
+  doCheck = false;
 
-  checkPhase = ''
-    python3 -m pytest test/
+  # Drop `/etc/fuse.conf` because it is a no-op config and
+  # would conflict with our fuse module.
+  postInstall = lib.optionalString isFuse3 ''
+    rm $out/etc/fuse.conf
+    mkdir $udev
+    mv $out/etc $udev
   '';
 
-  doCheck = false; # v2: no tests, v3: all tests get skipped in a sandbox
+  # Don't pull in SUID `fusermount{,3}` binaries into development environment.
+  propagatedBuildOutputs = [ "out" ];
 
-  postFixup = "cd $out\n" + (if isFuse3 then ''
-    install -D -m444 etc/fuse.conf $common/etc/fuse.conf
-    install -D -m444 etc/udev/rules.d/99-fuse3.rules $common/etc/udev/rules.d/99-fuse.rules
-  '' else ''
-    cp ${fusePackages.fuse_3.common}/etc/fuse.conf etc/fuse.conf
-    cp ${fusePackages.fuse_3.common}/etc/udev/rules.d/99-fuse.rules etc/udev/rules.d/99-fuse.rules
-  '');
-
-  meta = with lib; {
+  meta = {
     description = "Library that allows filesystems to be implemented in user space";
     longDescription = ''
       FUSE (Filesystem in Userspace) is an interface for userspace programs to
@@ -101,8 +135,15 @@ in stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/libfuse/libfuse";
     changelog = "https://github.com/libfuse/libfuse/releases/tag/fuse-${version}";
-    platforms = platforms.linux;
-    license = with licenses; [ gpl2Only lgpl21Only ];
-    maintainers = [ maintainers.primeos ];
+    platforms = lib.platforms.linux;
+    license = with lib.licenses; [
+      gpl2Only
+      lgpl21Only
+    ];
+    maintainers = with lib.maintainers; [
+      primeos
+      oxalica
+    ];
+    outputsToInstall = [ "bin" ];
   };
 }

--- a/pkgs/tools/filesystems/unionfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/unionfs-fuse/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace CMakeLists.txt \
-      --replace '/usr/local/include/osxfuse/fuse' '${fuse}/include/fuse'
+      --replace '/usr/local/include/osxfuse/fuse' '${lib.getDev fuse}/include/fuse'
   '';
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/tools/filesystems/xtreemfs/default.nix
+++ b/pkgs/tools/filesystems/xtreemfs/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation {
       --replace "/usr/local" "${valgrind}"
 
     substituteInPlace cpp/CMakeLists.txt \
-      --replace '"/lib64" "/usr/lib64"' '"${attr.out}/lib" "${fuse}/lib"'
+      --replace '"/lib64" "/usr/lib64"' '"${attr.out}/lib" "${lib.getLib fuse}/lib"'
 
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${fuse}/include"
     export NIX_CFLAGS_LINK="$NIX_CFLAGS_LINK -L${fuse}/lib"

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -500,6 +500,7 @@ mapAliases {
   fritzprofiles = throw "fritzprofiles was removed from nixpkgs, because it was removed as dependency of home-assistant for which it was pacakged."; # added 2024-01-05
   frostwire = throw "frostwire was removed, as it was broken due to reproducibility issues, use `frostwire-bin` package instead."; # added 2024-05-17
   fuse2fs = if stdenv.hostPlatform.isLinux then e2fsprogs.fuse2fs else null; # Added 2022-03-27 preserve, reason: convenience, arch has a package named fuse2fs too.
+  fuse-common = throw "fuse-common was removed, because the udev rule was early included by systemd-udevd and the config is done by NixOS module `programs.fuse`"; # added 2024-09-29
   futuresql = libsForQt5.futuresql; # added 2023-11-11
   fx_cast_bridge = fx-cast-bridge; # added 2023-07-26
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25841,7 +25841,6 @@ with pkgs;
   fuse = fuse2;
   fuse2 = lowPrio (if stdenv.hostPlatform.isDarwin then macfuse-stubs else fusePackages.fuse_2);
   fuse3 = fusePackages.fuse_3;
-  fuse-common = hiPrio fusePackages.fuse_3.common;
 
   fxload = callPackage ../os-specific/linux/fxload { };
 


### PR DESCRIPTION
###### Description of changes

`fuse` consists of the library and SUID binaries. They serve different scenarios. Packages depending on libfuse don't want to pull in binaries which shadow SUID ones like `fusermount` and cause troubles.

With outputs splitted, we can use `fuse.dev` in development environment without risking shadowing SUID binaries.

The `common` output and top-level `fuse-common` are removed because they are not useful since a long time ago (almost since the initial development of systemd-udevd [here](https://github.com/systemd/systemd/commit/d638611c44672dea8d8a498dbe84c7d650ef2194#diff-01dbf174a021215d234972fab41169ffb96fbf5710573534130ab7a5071c26a4R93)).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Tested my FUSE projects with new `fuse` and `fuse3`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
