### PR TITLE
Ocaml packages fix build on darwin

### DIFF
--- a/pkgs/development/ocaml-modules/bjack/default.nix
+++ b/pkgs/development/ocaml-modules/bjack/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, libsamplerate, libjack2 }:
+{ lib, stdenv, buildDunePackage, fetchFromGitHub, Accelerate, CoreAudio, dune-configurator, libsamplerate, libjack2 }:
 
 buildDunePackage rec {
   pname = "bjack";
@@ -13,7 +13,7 @@ buildDunePackage rec {
     sha256 = "1gf31a8i9byp6npn0x6gydcickn6sf5dnzmqr2c1b9jn2nl7334c";
   };
 
-  buildInputs = [ dune-configurator ];
+  buildInputs = [ dune-configurator ] ++ lib.optionals stdenv.isDarwin [ Accelerate CoreAudio ];
   propagatedBuildInputs = [ libsamplerate libjack2 ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-av.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-av.nix
@@ -1,6 +1,10 @@
 { lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
+, AudioToolbox
 , ffmpeg-base ? callPackage ./base.nix { }
-, ffmpeg-avutil, ffmpeg-avcodec, ffmpeg }:
+, ffmpeg-avutil, ffmpeg-avcodec, ffmpeg
+, stdenv
+, VideoToolbox
+}:
 
 buildDunePackage {
   pname = "ffmpeg-av";
@@ -10,7 +14,7 @@ buildDunePackage {
   inherit (ffmpeg-base) version src useDune2;
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ dune-configurator ];
+  buildInputs = [ dune-configurator ] ++ lib.optionals stdenv.isDarwin [ AudioToolbox VideoToolbox ];
   propagatedBuildInputs = [ ffmpeg-avutil ffmpeg-avcodec ffmpeg.dev ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avcodec.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avcodec.nix
@@ -1,6 +1,9 @@
 { lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
+, AudioToolbox
 , ffmpeg-base ? callPackage ./base.nix { }
 , ffmpeg-avutil, ffmpeg
+, stdenv
+, VideoToolbox
 }:
 
 buildDunePackage {
@@ -11,7 +14,8 @@ buildDunePackage {
   inherit (ffmpeg-base) version src useDune2;
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ dune-configurator ];
+  buildInputs = [ dune-configurator ]
+    ++ lib.optionals stdenv.isDarwin [ AudioToolbox VideoToolbox ];
   propagatedBuildInputs = [ ffmpeg-avutil ffmpeg.dev ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avdevice.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avdevice.nix
@@ -1,6 +1,14 @@
 { lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
+, AppKit
+, AudioToolbox
+, Cocoa
+, CoreImage
+, ForceFeedback
 , ffmpeg-base ? callPackage ./base.nix { }
 , ffmpeg-av, ffmpeg
+, OpenGL
+, stdenv
+, VideoToolbox
 }:
 
 buildDunePackage {
@@ -11,7 +19,8 @@ buildDunePackage {
   inherit (ffmpeg-base) version src useDune2;
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ dune-configurator ];
+  buildInputs = [ dune-configurator ]
+    ++ lib.optionals stdenv.isDarwin [ AppKit AudioToolbox Cocoa CoreImage ForceFeedback OpenGL VideoToolbox ];
   propagatedBuildInputs = [ ffmpeg-av ffmpeg.dev ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avfilter.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avfilter.nix
@@ -1,6 +1,11 @@
 { lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
+, AppKit
+, CoreImage
 , ffmpeg-base ? callPackage ./base.nix { }
 , ffmpeg-avutil, ffmpeg
+, OpenGL
+, stdenv
+, VideoToolbox
 }:
 
 buildDunePackage {
@@ -11,7 +16,8 @@ buildDunePackage {
   inherit (ffmpeg-base) version src useDune2;
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ dune-configurator ];
+  buildInputs = [ dune-configurator ]
+    ++ lib.optionals stdenv.isDarwin [ AppKit CoreImage OpenGL VideoToolbox ];
   propagatedBuildInputs = [ ffmpeg-avutil ffmpeg.dev ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avutil.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avutil.nix
@@ -1,4 +1,5 @@
-{ lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
+{ lib, stdenv, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
+, AudioToolbox, VideoToolbox
 , ffmpeg-base ? callPackage ./base.nix { }
 , ffmpeg
 }:
@@ -11,7 +12,7 @@ buildDunePackage {
   inherit (ffmpeg-base) version src useDune2;
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ dune-configurator ];
+  buildInputs = [ dune-configurator ] ++ lib.optionals stdenv.isDarwin [ AudioToolbox VideoToolbox ];
   propagatedBuildInputs = [ ffmpeg.dev ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swresample.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swresample.nix
@@ -1,6 +1,8 @@
 { lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
 , ffmpeg-base ? callPackage ./base.nix { }
 , ffmpeg-avutil, ffmpeg-avcodec, ffmpeg
+, stdenv
+, VideoToolbox
 }:
 
 buildDunePackage {
@@ -11,7 +13,7 @@ buildDunePackage {
   inherit (ffmpeg-base) version src useDune2;
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ dune-configurator ];
+  buildInputs = [ dune-configurator ] ++ lib.optionals stdenv.isDarwin [ VideoToolbox ];
   propagatedBuildInputs = [ ffmpeg-avutil ffmpeg-avcodec ffmpeg.dev ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swscale.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swscale.nix
@@ -1,6 +1,8 @@
 { lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
 , ffmpeg-base ? callPackage ./base.nix { }
 , ffmpeg-avutil, ffmpeg
+, stdenv
+, VideoToolbox
 }:
 
 buildDunePackage {
@@ -11,7 +13,7 @@ buildDunePackage {
   inherit (ffmpeg-base) version src useDune2;
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ dune-configurator ];
+  buildInputs = [ dune-configurator ] ++ lib.optionals stdenv.isDarwin [ VideoToolbox ];
   propagatedBuildInputs = [ ffmpeg-avutil ffmpeg.dev ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/gstreamer/default.nix
+++ b/pkgs/development/ocaml-modules/gstreamer/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, pkg-config, glib, gst_all_1 }:
+{ lib, stdenv, buildDunePackage, fetchFromGitHub, dune-configurator, AppKit, Foundation, pkg-config, glib, gst_all_1 }:
 
 buildDunePackage rec {
   pname = "gstreamer";
@@ -12,7 +12,7 @@ buildDunePackage rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ dune-configurator ];
+  buildInputs = [ dune-configurator ] ++ lib.optionals stdenv.isDarwin [ AppKit Foundation ];
   propagatedBuildInputs = [ glib.dev gst_all_1.gstreamer.dev gst_all_1.gst-plugins-base ];
 
   CFLAGS_COMPILE = [

--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, makeWrapper, fetchzip, ocaml, findlib, tcl, tk }:
+{ stdenv, lib, makeWrapper, fetchzip, Cocoa, ocaml, findlib, tcl, tk }:
 
 let
  params =
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-labltk";
 
   nativeBuildInputs = [ ocaml findlib makeWrapper ];
-  buildInputs = [ tcl tk ];
+  buildInputs = [ tcl tk ] ++ lib.optionals stdenv.isDarwin [ Cocoa ];
 
   configureFlags = [ "--use-findlib" "--installbindir" "$(out)/bin" ];
   dontAddPrefix = true;

--- a/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitLab, libvirt, autoreconfHook, pkg-config, ocaml, findlib, perl }:
+{ lib, stdenv, fetchFromGitLab, libvirt, AppKit, Foundation, autoreconfHook, pkg-config, ocaml, findlib, perl }:
 
 lib.throwIfNot (lib.versionAtLeast ocaml.version "4.02")
   "libvirt is not available for OCaml ${ocaml.version}"
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ libvirt ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config findlib perl ocaml ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    Foundation
+    AppKit
+  ];
 
   strictDeps = true;
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -86,7 +86,9 @@ let
 
     bitv = callPackage ../development/ocaml-modules/bitv { };
 
-    bjack = callPackage ../development/ocaml-modules/bjack { };
+    bjack = callPackage ../development/ocaml-modules/bjack {
+      inherit (pkgs.darwin.apple_sdk.frameworks) Accelerate CoreAudio;
+    };
 
     bls12-381 = callPackage ../development/ocaml-modules/bls12-381 { };
     bls12-381-gen = callPackage ../development/ocaml-modules/bls12-381/gen.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -454,6 +454,7 @@ let
     };
     ffmpeg-avcodec = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avcodec.nix {
       inherit (pkgs) ffmpeg;
+      inherit (pkgs.darwin.apple_sdk.frameworks) AudioToolbox VideoToolbox;
     };
     ffmpeg-avfilter = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avfilter.nix {
       inherit (pkgs) ffmpeg;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -522,7 +522,9 @@ let
       inherit (pkgs) gsl;
     };
 
-    gstreamer = callPackage ../development/ocaml-modules/gstreamer { };
+    gstreamer = callPackage ../development/ocaml-modules/gstreamer {
+      inherit (pkgs.darwin.apple_sdk.frameworks) AppKit Foundation;
+    };
 
     h2 = callPackage ../development/ocaml-modules/h2 { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -469,6 +469,7 @@ let
     };
     ffmpeg-av = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-av.nix {
       inherit (pkgs) ffmpeg;
+      inherit (pkgs.darwin.apple_sdk.frameworks) AudioToolbox VideoToolbox;
     };
     ffmpeg-avdevice = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avdevice.nix {
       inherit (pkgs) ffmpeg;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -703,7 +703,9 @@ let
       then callPackage ../development/ocaml-modules/lablgtk-extras { }
       else callPackage ../development/ocaml-modules/lablgtk-extras/1.4.nix { };
 
-    labltk = callPackage ../development/ocaml-modules/labltk { };
+    labltk = callPackage ../development/ocaml-modules/labltk {
+      inherit (pkgs.darwin.apple_sdk.frameworks) Cocoa;
+    };
 
     lacaml = callPackage ../development/ocaml-modules/lacaml { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -473,6 +473,7 @@ let
     };
     ffmpeg-avdevice = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avdevice.nix {
       inherit (pkgs) ffmpeg;
+      inherit (pkgs.darwin.apple_sdk.frameworks) AppKit AudioToolbox Cocoa CoreImage ForceFeedback OpenGL VideoToolbox;
     };
 
     fiber = callPackage ../development/ocaml-modules/fiber { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -448,6 +448,7 @@ let
     ffmpeg = callPackage ../development/ocaml-modules/ffmpeg { };
     ffmpeg-avutil = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avutil.nix {
       inherit (pkgs) ffmpeg;
+      inherit (pkgs.darwin.apple_sdk.frameworks) AudioToolbox VideoToolbox;
     };
     ffmpeg-avcodec = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avcodec.nix {
       inherit (pkgs) ffmpeg;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -994,7 +994,9 @@ let
     ocamlgraph = callPackage ../development/ocaml-modules/ocamlgraph { };
     ocamlgraph_gtk = callPackage ../development/ocaml-modules/ocamlgraph/gtk.nix { };
 
-    ocaml_libvirt = callPackage ../development/ocaml-modules/ocaml-libvirt { };
+    ocaml_libvirt = callPackage ../development/ocaml-modules/ocaml-libvirt {
+      inherit (pkgs.darwin.apple_sdk.frameworks) Foundation AppKit;
+    };
 
     ocamlify = callPackage ../development/tools/ocaml/ocamlify { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -458,6 +458,7 @@ let
     };
     ffmpeg-avfilter = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avfilter.nix {
       inherit (pkgs) ffmpeg;
+      inherit (pkgs.darwin.apple_sdk.frameworks) AppKit CoreImage OpenGL VideoToolbox;
     };
     ffmpeg-swscale = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-swscale.nix {
       inherit (pkgs) ffmpeg;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -466,6 +466,7 @@ let
     };
     ffmpeg-swresample = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-swresample.nix {
       inherit (pkgs) ffmpeg;
+      inherit (pkgs.darwin.apple_sdk.frameworks) VideoToolbox;
     };
     ffmpeg-av = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-av.nix {
       inherit (pkgs) ffmpeg;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -462,6 +462,7 @@ let
     };
     ffmpeg-swscale = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-swscale.nix {
       inherit (pkgs) ffmpeg;
+      inherit (pkgs.darwin.apple_sdk.frameworks) VideoToolbox;
     };
     ffmpeg-swresample = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-swresample.nix {
       inherit (pkgs) ffmpeg;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

While testing https://github.com/NixOS/nixpkgs/pull/197367 I saw that many other package was broken with the same kind of error so I did a pass to fix the same error in multiple packages.
build log before this PR:
```
error: builder for '/nix/store/vihic2dgbd98lrl0sas2c647c6fz7dsz-ocaml-libvirt-0.6.1.5.drv' failed with exit code 2;
       last 10 log lines:
       > like 'CDEFLMPSUVYZX', is deprecated.
       > Use the equivalent signed form: +C+D+E+F+L+M+P+S+U+V+Y+Z+X-3.
       > Hint: Enabling or disabling a warning by its mnemonic name requires a + or - prefix.
       > Hint: Did you make a spelling mistake when using a mnemonic name?
       > ocamlmklib -o mllibvirt libvirt_c.o libvirt.cmo libvirt_version.cmo -L/nix/store/nv200j8plka6f5knmnsx8wqx7736pq43-libvirt-8.10.0/lib -lvirt
       > ld: file not found: /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation for architecture x86_64
       > clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
       > make[1]: *** [Makefile:68: mllibvirt.cma] Error 2
       > make[1]: Leaving directory '/private/tmp/nix-build-ocaml-libvirt-0.6.1.5.drv-0/source/libvirt'
       > make: *** [Makefile:31: all] Error 1
       For full logs, run 'nix log /nix/store/vihic2dgbd98lrl0sas2c647c6fz7dsz-ocaml-libvirt-0.6.1.5.drv'.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
copied from what is done with cairo2

For reviewer:
```
nix build .#ocamlPackages.bjack .#ocamlPackages.ffmpeg .#ocamlPackages.ffmpeg-av .#ocamlPackages.ffmpeg-avcodec .#ocamlPackages.ffmpeg-avdevice .#ocamlPackages.ffmpeg-avfilter .#ocamlPackages.ffmpeg-avutil .#ocamlPackages.ffmpeg-swresample .#ocamlPackages.ffmpeg-swscale .#ocamlPackages.gstreamer .#ocamlPackages.labltk .#ocamlPackages.ocaml_libvirt
```
(might be quicker than nixpkgs-review)

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
