### PR TITLE
keepass: 2.49 -> 2.52

### DIFF
--- a/pkgs/applications/misc/keepass/default.nix
+++ b/pkgs/applications/misc/keepass/default.nix
@@ -4,11 +4,11 @@ let
   inherit (builtins) add length readFile replaceStrings unsafeDiscardStringContext toString map;
 in buildDotnetPackage rec {
   pname = "keepass";
-  version = "2.49";
+  version = "2.52";
 
   src = fetchurl {
     url = "mirror://sourceforge/keepass/KeePass-${version}-Source.zip";
-    sha256 = "sha256-1hg4bRuQSG+UzEQGeQcSURTmTxt5ITGQqfg0IS7RWt0=";
+    sha256 = "sha256-6dGCfysen26VGHIHETuNGkqHbPyeWRIEopqJa6AMzXA=";
   };
 
   sourceRoot = ".";

--- a/pkgs/applications/misc/keepass/fix-paths.patch
+++ b/pkgs/applications/misc/keepass/fix-paths.patch
@@ -43,15 +43,15 @@ diff --git a/KeePass/Util/AppLocator.cs b/KeePass/Util/AppLocator.cs
 index af02803..8a32c9d 100644
 --- a/KeePass/Util/AppLocator.cs
 +++ b/KeePass/Util/AppLocator.cs
-@@ -429,7 +429,7 @@ namespace KeePass.Util
+@@ -468,7 +468,7 @@ namespace KeePass.Util
  			if(NativeLib.GetPlatformID() == PlatformID.MacOSX)
- 				strArgPrefix = string.Empty; // FR 3535696
+ 				strOpt = string.Empty; // FR 3535696
  
--			string str = NativeLib.RunConsoleApp("whereis", strArgPrefix + strApp);
-+			string str = NativeLib.RunConsoleApp("@whereis@", strArgPrefix + strApp);
- 			if(str == null) return null;
+-			string str = NativeLib.RunConsoleApp("whereis", strOpt + strApp);
++			string str = NativeLib.RunConsoleApp("@whereis@", strOpt + strApp);
+ 			if(string.IsNullOrEmpty(str)) return null;
  
- 			str = str.Trim();
+ 			int iSep = str.IndexOf(':');
 diff --git a/KeePass/Util/ClipboardUtil.Unix.cs b/KeePass/Util/ClipboardUtil.Unix.cs
 index ab49ee2..7f6c50f 100644
 --- a/KeePass/Util/ClipboardUtil.Unix.cs
@@ -108,14 +108,14 @@ diff --git a/KeePassLib/Native/NativeLib.cs b/KeePassLib/Native/NativeLib.cs
 index 2d227a3..243f4ee 100644
 --- a/KeePassLib/Native/NativeLib.cs
 +++ b/KeePassLib/Native/NativeLib.cs
-@@ -145,7 +145,7 @@ namespace KeePassLib.Native
- 			// Mono returns PlatformID.Unix on Mac OS X, workaround this
- 			if(m_platID.Value == PlatformID.Unix)
+@@ -143,7 +143,7 @@ namespace KeePassLib.Native
+ 			// Mono returns PlatformID.Unix on MacOS, workaround this
+ 			if(g_platID.Value == PlatformID.Unix)
  			{
 -				if((RunConsoleApp("uname", null) ?? string.Empty).Trim().Equals(
 +				if((RunConsoleApp("@uname@", null) ?? string.Empty).Trim().Equals(
  					"Darwin", StrUtil.CaseIgnoreCmp))
- 					m_platID = PlatformID.MacOSX;
+ 					g_platID = PlatformID.MacOSX;
  			}
 diff --git a/KeePassLib/Utility/MonoWorkarounds.cs b/KeePassLib/Utility/MonoWorkarounds.cs
 index e20bb3a..4fd875b 100644
@@ -130,7 +130,7 @@ index e20bb3a..4fd875b 100644
  
  		private static Dictionary<uint, bool> g_dForceReq = new Dictionary<uint, bool>();
  		private static Thread g_thFixClip = null;
-@@ -335,7 +335,7 @@ namespace KeePassLib.Utility
+@@ -356,7 +356,7 @@ namespace KeePassLib.Utility
  				// }
  				// else { Debug.Assert(false); }
  

--- a/pkgs/applications/misc/keepass/keepass-plugins.patch
+++ b/pkgs/applications/misc/keepass/keepass-plugins.patch
@@ -9,9 +9,9 @@ Subject: [PATCH] loadplugin
 
 diff --git a/KeePass/Forms/MainForm.cs b/KeePass/Forms/MainForm.cs
 index 347eaf5..b92e1e2 100644
---- a/KeePass/Forms/MainForm.cs
-+++ b/KeePass/Forms/MainForm.cs
-@@ -440,7 +440,$OUTPUT_LC$ @@ namespace KeePass.Forms
+--- a/KeePass/Forms/MainForm_Functions.cs
++++ b/KeePass/Forms/MainForm_Functions.cs
+@@ -312,7 +312,$OUTPUT_LC$ @@ namespace KeePass.Forms
  				ToolStripItemCollection tsicT = m_ctxTray.Items;
  				ToolStripItem tsiPrevT = m_ctxTrayOptions;
  


### PR DESCRIPTION
###### Description of changes

Update `keepass` to latest: 
https://keepass.info/news/n220909_2.52.html
https://keepass.info/news/n220506_2.51.html
https://keepass.info/news/n220109_2.50.html

Fixed some fuzz/offsets in the patches to ensure clean application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
