### PR TITLE
Fix/update rapid photo downloader

### DIFF
--- a/pkgs/applications/graphics/rapid-photo-downloader/default.nix
+++ b/pkgs/applications/graphics/rapid-photo-downloader/default.nix
@@ -6,11 +6,11 @@
 
 mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "rapid-photo-downloader";
-  version = "0.9.18";
+  version = "0.9.34";
 
   src = fetchurl {
     url = "https://launchpad.net/rapid/pyqt/${version}/+download/${pname}-${version}.tar.gz";
-    sha256 = "15p7sssg6vmqbm5xnc4j5dr89d7gl7y5qyq44a240yl5aqkjnybw";
+    sha256 = "JFWshKilHtkVAO2q0a+1D3rf8qQ39BBTYKwWMR77J54=";
   };
 
   # Disable version check and fix install tests
@@ -55,11 +55,14 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
     psutil
     pyxdg
     arrow
+    babel
     python-dateutil
     easygui
     colour
+    packaging
     pymediainfo
     sortedcontainers
+    show-in-file-manager
     rawkit
     requests
     colorlog

--- a/pkgs/applications/graphics/rapid-photo-downloader/default.nix
+++ b/pkgs/applications/graphics/rapid-photo-downloader/default.nix
@@ -69,7 +69,7 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
 
   preFixup = ''
     makeWrapperArgs+=(
-      --set GI_TYPELIB_PATH "$GI_TYPELIB_PATH"
+      --set GI_TYPELIB_PATH "$GI_TYPELIB_PATH:${lib.makeSearchPath "lib/girepository-1.0" [ libnotify gdk-pixbuf libgudev udisks gexiv2 gst_all_1.gstreamer.out ]}"
       --set PYTHONPATH "$PYTHONPATH"
       --prefix PATH : "${lib.makeBinPath [ exiftool vmtouch ]}"
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libmediainfo ]}"

--- a/pkgs/development/python-modules/show-in-file-manager/default.nix
+++ b/pkgs/development/python-modules/show-in-file-manager/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchPypi, buildPythonPackage
+, python3Packages
+}:
+
+buildPythonPackage rec {
+  pname = "show-in-file-manager";
+  version = "1.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "FdFuSodbniF7A40C8CnDgAxKatZF4/c8nhB+omurOts=";
+  };
+
+  buildInputs = with python3Packages; [
+    pyxdg
+    packaging
+  ];
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python package to open the system file manager and optionally select files in it.";
+    homepage = "https://github.com/damonlynch/showinfilemanager";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8994,6 +8994,8 @@ in {
 
   sharkiqpy = callPackage ../development/python-modules/sharkiqpy { };
 
+  show-in-file-manager = callPackage ../development/python-modules/show-in-file-manager { };
+
   sh = callPackage ../development/python-modules/sh { };
 
   shellescape = callPackage ../development/python-modules/shellescape { };


### PR DESCRIPTION
###### Description of changes

Changelog for rapid-photo-downloader is at https://damonlynch.net/rapid/changelog.html

show-in-file-manager is described here:

    https://pypi.org/project/show-in-file-manager/

It is a Python package to open the system file manager and optionally select files in it. I've set the maintainer to the one of rapid-photo-downloader, as it seems to be used exclusively there right now.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Haven't run nixpkgs-review, as it seems unnecessary (nothing can depend on show-in-file-manager or rapid-photo-downloader). Have done basic tests with rapid-photo-downloader (including downloading photos). This is my first pull request, did it to my best understanding of contribution guidelines.