### PR TITLE
maintainers: make email optional

### DIFF
--- a/lib/tests/maintainer-module.nix
+++ b/lib/tests/maintainer-module.nix
@@ -7,7 +7,8 @@ in {
       type = types.str;
     };
     email = lib.mkOption {
-      type = types.str;
+      type = types.nullOr types.str;
+      default = null;
     };
     matrix = lib.mkOption {
       type = types.nullOr types.str;

--- a/lib/tests/maintainers.nix
+++ b/lib/tests/maintainers.nix
@@ -1,5 +1,6 @@
 # to run these tests (and the others)
 # nix-build nixpkgs/lib/tests/release.nix
+# These tests should stay in sync with the comment in maintainers/maintainers-list.nix
 { # The pkgs used for dependencies for the testing itself
   pkgs ? import ../.. {}
 , lib ? pkgs.lib

--- a/lib/tests/maintainers.nix
+++ b/lib/tests/maintainers.nix
@@ -20,7 +20,7 @@ let
         ];
       }).config;
 
-      checkGithubId = lib.optional (checkedAttrs.github != null && checkedAttrs.githubId == null) ''
+      checks = lib.optional (checkedAttrs.github != null && checkedAttrs.githubId == null) ''
         echo ${lib.escapeShellArg (lib.showOption prefix)}': If `github` is specified, `githubId` must be too.'
         # Calling this too often would hit non-authenticated API limits, but this
         # shouldn't happen since such errors will get fixed rather quickly
@@ -28,8 +28,10 @@ let
         id=$(jq -r '.id' <<< "$info")
         echo "The GitHub ID for GitHub user ${checkedAttrs.github} is $id:"
         echo -e "    githubId = $id;\n"
+      '' ++ lib.optional (checkedAttrs.email == null && checkedAttrs.github == null && checkedAttrs.matrix == null) ''
+        echo ${lib.escapeShellArg (lib.showOption prefix)}': At least one of `email`, `github` or `matrix` must be specified, so that users know how to reach you.'
       '';
-    in lib.deepSeq checkedAttrs checkGithubId;
+    in lib.deepSeq checkedAttrs checks;
 
   missingGithubIds = lib.concatLists (lib.mapAttrsToList checkMaintainer lib.maintainers);
 

--- a/lib/tests/maintainers.nix
+++ b/lib/tests/maintainers.nix
@@ -30,6 +30,8 @@ let
         echo -e "    githubId = $id;\n"
       '' ++ lib.optional (checkedAttrs.email == null && checkedAttrs.github == null && checkedAttrs.matrix == null) ''
         echo ${lib.escapeShellArg (lib.showOption prefix)}': At least one of `email`, `github` or `matrix` must be specified, so that users know how to reach you.'
+      '' ++ lib.optional (checkedAttrs.email != null && lib.hasSuffix "noreply.github.com" checkedAttrs.email) ''
+        echo ${lib.escapeShellArg (lib.showOption prefix)}': If an email address is given, it should allow people to reach you. If you do not want that, you can just provide `github` or `matrix` instead.'
       '';
     in lib.deepSeq checkedAttrs checks;
 

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3,12 +3,13 @@
     handle = {
       # Required
       name = "Your name";
-      email = "address@example.org";
 
-      # Optional
+      # Optional, but at least one of email, matrix or githubId must be given
+      email = "address@example.org";
       matrix = "@user:example.org";
       github = "GithubUsername";
       githubId = your-github-id;
+
       keys = [{
         fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
       }];
@@ -24,6 +25,9 @@
     - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),
     - `githubId` is your GitHub user ID, which can be found at `https://api.github.com/users/<userhandle>`,
     - `keys` is a list of your PGP/GPG key fingerprints.
+
+    Specifying a GitHub account ensures that you automatically get a review request on
+    pull requests that modify a package for which you are a maintainer.
 
     `handle == github` is strongly preferred whenever `github` is an acceptable attribute name and is short and convenient.
 

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -105,13 +105,11 @@
   };
   _1000teslas = {
     name = "Kevin Tran";
-    email = "47207223+1000teslas@users.noreply.github.com";
     github = "1000teslas";
     githubId = 47207223;
   };
   _2gn = {
     name = "Hiram Tanner";
-    email = "101851090+2gn@users.noreply.github.com";
     github = "2gn";
     githubId = 101851090;
   };
@@ -916,7 +914,6 @@
     name = "Anders Sildnes";
   };
   andys8 = {
-    email = "andys8@users.noreply.github.com";
     github = "andys8";
     githubId = 13085980;
     name = "Andy";
@@ -1102,7 +1099,6 @@
     name = "Blaž Hrastnik";
   };
   arcnmx = {
-    email = "arcnmx@users.noreply.github.com";
     github = "arcnmx";
     githubId = 13426784;
     name = "arcnmx";
@@ -2581,7 +2577,6 @@
     }];
   };
   christophcharles = {
-    email = "23055925+christophcharles@users.noreply.github.com";
     github = "christophcharles";
     githubId = 23055925;
     name = "Christoph Charles";
@@ -3250,7 +3245,6 @@
     name = "Daniel Șerbănescu";
   };
   datafoo = {
-    email = "34766150+datafoo@users.noreply.github.com";
     github = "datafoo";
     githubId = 34766150;
     name = "datafoo";
@@ -3401,7 +3395,6 @@
     githubId = 1153808;
   };
   deliciouslytyped = {
-    email = "47436522+deliciouslytyped@users.noreply.github.com";
     github = "deliciouslytyped";
     githubId = 47436522;
     name = "deliciouslytyped";
@@ -3565,7 +3558,6 @@
     name = "David Leung";
   };
   DianaOlympos = {
-    email = "DianaOlympos@noreply.github.com";
     github = "DianaOlympos";
     githubId = 15774340;
     name = "Thomas Depierre";
@@ -3590,7 +3582,6 @@
   };
   diogox = {
     name = "Diogo Xavier";
-    email = "13244408+diogox@users.noreply.github.com";
     github = "diogox";
     githubId = 13244408;
   };
@@ -3815,7 +3806,6 @@
     name = "Dominik Ritter";
   };
   drperceptron = {
-    email = "92106371+drperceptron@users.noreply.github.com";
     github = "drperceptron";
     githubId = 92106371;
     name = "Dr Perceptron";
@@ -4262,7 +4252,6 @@
     name = "Ente";
   };
   Enzime = {
-    email = "enzime@users.noreply.github.com";
     github = "Enzime";
     githubId = 10492681;
     name = "Michael Hoang";
@@ -4393,7 +4382,6 @@
     name = "Ertugrul Söylemez";
   };
   esclear = {
-    email = "esclear@users.noreply.github.com";
     github = "esclear";
     githubId = 7432848;
     name = "Daniel Albert";
@@ -4801,7 +4789,6 @@
     name = "Florian Klink";
   };
   florentc = {
-    email = "florentc@users.noreply.github.com";
     github = "florentc";
     githubId = 1149048;
     name = "Florent Ch.";
@@ -4923,7 +4910,6 @@
     name = "Frede Emil";
   };
   freezeboy = {
-    email = "freezeboy@users.noreply.github.com";
     github = "freezeboy";
     githubId = 13279982;
     name = "freezeboy";
@@ -5483,7 +5469,6 @@
     name = "Guillaume Koenig";
   };
   guserav = {
-    email = "guserav@users.noreply.github.com";
     github = "guserav";
     githubId = 28863828;
     name = "guserav";
@@ -5972,7 +5957,6 @@
     name = "Imran Hossain";
   };
   iagoq = {
-    email = "18238046+iagocq@users.noreply.github.com";
     github = "iagocq";
     githubId = 18238046;
     name = "Iago Manoel Brito";
@@ -6040,7 +6024,6 @@
     name = "Dominic Steinitz";
   };
   ifurther = {
-    email = "55025025+ifurther@users.noreply.github.com";
     github = "ifurther";
     githubId = 55025025;
     name = "Feather Lin";
@@ -6297,7 +6280,6 @@
     }];
   };
   ivankovnatsky = {
-    email = "75213+ivankovnatsky@users.noreply.github.com";
     github = "ivankovnatsky";
     githubId = 75213;
     name = "Ivan Kovnatsky";
@@ -6897,7 +6879,6 @@
     name = "Jocelyn Thode";
   };
   joedevivo = {
-     email = "55951+joedevivo@users.noreply.github.com";
      github = "joedevivo";
      githubId = 55951;
      name = "Joe DeVivo";
@@ -7556,7 +7537,6 @@
     name = "Kid";
   };
   kidsan = {
-    email = "8798449+Kidsan@users.noreply.github.com";
     github = "kidsan";
     githubId = 8798449;
     name = "kidsan";
@@ -8825,7 +8805,6 @@
     githubId = 22586596;
   };
   marsam = {
-    email = "marsam@users.noreply.github.com";
     github = "marsam";
     githubId = 65531;
     name = "Mario Rodas";
@@ -9069,7 +9048,6 @@
     name = "Mateusz Mazur";
   };
   mbaeten = {
-    email = "mbaeten@users.noreply.github.com";
     github = "mbaeten";
     githubId = 2649304;
     name = "M. Baeten";
@@ -9287,7 +9265,6 @@
     name = "Maximilian Güntner";
   };
   mh = {
-    email = "68288772+markus-heinrich@users.noreply.github.com";
     github = "markus-heinrich";
     githubId = 68288772;
     name = "Markus Heinrich";
@@ -9305,7 +9282,6 @@
     name = "Max Hofer";
   };
   miangraham = {
-    email = "miangraham@users.noreply.github.com";
     github = "miangraham";
     githubId = 704580;
     name = "M. Ian Graham";
@@ -9588,7 +9564,6 @@
   };
   mlvzk = {
     name = "mlvzk";
-    email = "mlvzk@users.noreply.github.com";
     github = "mlvzk";
     githubId = 44906333;
   };
@@ -9605,7 +9580,6 @@
     name = "Henri Bourcereau";
   };
   mmesch = {
-    email = "mmesch@noreply.github.com";
     github = "MMesch";
     githubId = 2597803;
     name = "Matthias Meschede";
@@ -10009,7 +9983,6 @@
     name = "Roman Naumann";
   };
   naphta = {
-    email = "naphta@noreply.github.com";
     github = "naphta";
     githubId = 6709831;
     name = "Jake Hill";
@@ -10024,7 +9997,6 @@
     }];
   };
   nat-418 = {
-    email = "93013864+nat-418@users.noreply.github.com";
     github = "nat-418";
     githubId = 93013864;
     name = "nat-418";
@@ -10042,7 +10014,6 @@
     name = "Nathan Bijnens";
   };
   nathyong = {
-    email = "nathyong@noreply.github.com";
     github = "nathyong";
     githubId = 818502;
     name = "Nathan Yong";
@@ -10064,7 +10035,6 @@
   };
   nazarewk = {
     name = "Krzysztof Nazarewski";
-    email = "3494992+nazarewk@users.noreply.github.com";
     matrix = "@nazarewk:matrix.org";
     github = "nazarewk";
     githubId = 3494992;
@@ -10073,7 +10043,6 @@
     }];
   };
   nbr = {
-    email = "nbr@users.noreply.github.com";
     github = "nbr";
     githubId = 3819225;
     name = "Nick Braga";
@@ -10352,7 +10321,6 @@
   };
   nitsky = {
     name = "nitsky";
-    email = "492793+nitsky@users.noreply.github.com";
     github = "nitsky";
     githubId = 492793;
   };
@@ -10663,7 +10631,6 @@
     name = "Ole Jørgen Brønner";
   };
   ollieB = {
-    email = "1237862+oliverbunting@users.noreply.github.com";
     github = "oliverbunting";
     githubId = 1237862;
     name = "Ollie Bunting";
@@ -10681,7 +10648,6 @@
     name = "Owen Lynch";
   };
   omasanori = {
-    email = "167209+omasanori@users.noreply.github.com";
     github = "omasanori";
     githubId = 167209;
     name = "Masanori Ogino";
@@ -11453,7 +11419,6 @@
     githubId = 51489;
   };
   polykernel = {
-    email = "81340136+polykernel@users.noreply.github.com";
     github = "polykernel";
     githubId = 81340136;
     name = "polykernel";
@@ -11901,7 +11866,6 @@
   };
   rbreslow = {
     name = "Rocky Breslow";
-    email = "1774125+rbreslow@users.noreply.github.com";
     github = "rbreslow";
     githubId = 1774125;
     keys = [{
@@ -11994,7 +11958,6 @@
     name = "Ricky Elrod";
   };
   rembo10 = {
-    email = "rembo10@users.noreply.github.com";
     github = "rembo10";
     githubId = 801525;
     name = "rembo10";
@@ -12006,7 +11969,6 @@
     name = "Renato Garcia";
   };
   rencire = {
-    email = "546296+rencire@users.noreply.github.com";
     github = "rencire";
     githubId = 546296;
     name = "Eric Ren";
@@ -12343,7 +12305,6 @@
   };
   rople380 = {
     name = "rople380";
-    email = "55679162+rople380@users.noreply.github.com";
     github = "rople380";
     githubId = 55679162;
     keys = [{
@@ -12480,7 +12441,6 @@
     name = "Ryan Artecona";
   };
   ryanorendorff = {
-    email = "12442942+ryanorendorff@users.noreply.github.com";
     github = "ryanorendorff";
     githubId = 12442942;
     name = "Ryan Orendorff";
@@ -12692,7 +12652,6 @@
   };
   sbond75 = {
     name = "sbond75";
-    email = "43617712+sbond75@users.noreply.github.com";
     github = "sbond75";
     githubId = 43617712;
   };
@@ -12716,7 +12675,6 @@
   };
   sioodmy = {
     name = "Antoni Sokołowski";
-    email = "81568712+sioodmy@users.noreply.github.com";
     github = "sioodmy";
     githubId = 81568712;
   };
@@ -12745,7 +12703,6 @@
     name = "schneefux";
   };
   schnusch = {
-    email = "schnusch@users.noreply.github.com";
     github = "schnusch";
     githubId = 5104601;
     name = "schnusch";
@@ -12767,7 +12724,6 @@
   };
   scoder12 = {
     name = "Spencer Pogorzelski";
-    email = "34356756+Scoder12@users.noreply.github.com";
     github = "Scoder12";
     githubId = 34356756;
   };
@@ -12952,7 +12908,6 @@
     name = "Sebastian Graf";
   };
   shadaj = {
-    email = "shadaj@users.noreply.github.com";
     github = "shadaj";
     githubId = 543055;
     name = "Shadaj Laddad";
@@ -12978,7 +12933,6 @@
   };
   ShamrockLee = {
     name = "Shamrock Lee";
-    email = "44064051+ShamrockLee@users.noreply.github.com";
     github = "ShamrockLee";
     githubId = 44064051;
   };
@@ -13170,7 +13124,6 @@
     name = "Simon Vandel Sillesen";
   };
   sir4ur0n = {
-    email = "sir4ur0n@users.noreply.github.com";
     github = "sir4ur0n";
     githubId = 1204125;
     name = "sir4ur0n";
@@ -13234,7 +13187,6 @@
     name = "Sven Keidel";
   };
   skykanin = {
-    email = "skykanin@users.noreply.github.com";
     github = "skykanin";
     githubId = 3789764;
     name = "skykanin";
@@ -13314,7 +13266,6 @@
     githubId = 85608760;
   };
   snicket2100 = {
-    email = "57048005+snicket2100@users.noreply.github.com";
     github = "snicket2100";
     githubId = 57048005;
     name = "snicket2100";
@@ -13443,7 +13394,6 @@
     name = "Sergei Khoma";
   };
   srgom = {
-    email = "srgom@users.noreply.github.com";
     github = "SRGOM";
     githubId = 8103619;
     name = "SRGOM";
@@ -13540,7 +13490,6 @@
   };
   stephenwithph = {
     name = "StephenWithPH";
-    email = "StephenWithPH@users.noreply.github.com";
     github = "StephenWithPH";
     githubId = 2990492;
   };
@@ -13982,7 +13931,6 @@
     name = "techknowlogick";
   };
   Technical27 = {
-    email = "38222826+Technical27@users.noreply.github.com";
     github = "Technical27";
     githubId = 38222826;
     name = "Aamaruvi Yogamani";
@@ -15275,7 +15223,6 @@
     name = "Willi Butz";
   };
   willcohen = {
-    email = "willcohen@users.noreply.github.com";
     github = "willcohen";
     githubId = 5185341;
     name = "Will Cohen";
@@ -15305,7 +15252,6 @@
     name = "Alexander Krimm";
   };
   wishfort36 = {
-    email = "42300264+wishfort36@users.noreply.github.com";
     github = "wishfort36";
     githubId = 42300264;
     name = "wishfort36";
@@ -15428,7 +15374,6 @@
     githubId = 52174714;
   };
   wyndon = {
-    email = "72203260+wyndon@users.noreply.github.com";
     matrix = "@wyndon:envs.net";
     github = "wyndon";
     githubId = 72203260;
@@ -15466,7 +15411,6 @@
   };
   xdhampus = {
     name = "Hampus";
-    email = "16954508+xdHampus@users.noreply.github.com";
     github = "xdHampus";
     githubId = 16954508;
   };
@@ -15527,7 +15471,6 @@
     name = "Guillermo NWDD";
   };
   xrelkd = {
-    email = "46590321+xrelkd@users.noreply.github.com";
     github = "xrelkd";
     githubId = 46590321;
     name = "xrelkd";
@@ -15545,7 +15488,6 @@
     name = "Marti Serra";
   };
   xworld21 = {
-    email = "1962985+xworld21@users.noreply.github.com";
     github = "xworld21";
     githubId = 1962985;
     name = "Vincenzo Mantova";
@@ -15575,7 +15517,6 @@
     name = "Yana Timoshenko";
   };
   yarny = {
-    email = "41838844+Yarny0@users.noreply.github.com";
     github = "Yarny0";
     githubId = 41838844;
     name = "Yarny";
@@ -15857,7 +15798,6 @@
     name = "Alexandre Macabies";
   };
   zowoq = {
-    email = "59103226+zowoq@users.noreply.github.com";
     github = "zowoq";
     githubId = 59103226;
     name = "zowoq";
@@ -15984,7 +15924,6 @@
   };
   ymatsiuk = {
     name = "Yurii Matsiuk";
-    email = "ymatsiuk@users.noreply.github.com";
     github = "ymatsiuk";
     githubId = 24990891;
     keys = [{
@@ -15993,13 +15932,11 @@
   };
   ymeister = {
     name = "Yuri Meister";
-    email = "47071325+ymeister@users.noreply.github.com";
     github = "ymeister";
     githubId = 47071325;
   };
   cpcloud = {
     name = "Phillip Cloud";
-    email = "417981+cpcloud@users.noreply.github.com";
     github = "cpcloud";
     githubId = 417981;
   };
@@ -16017,7 +15954,6 @@
   };
   tfmoraes = {
     name = "Thiago Franco de Moraes";
-    email = "351108+tfmoraes@users.noreply.github.com";
     github = "tfmoraes";
     githubId = 351108;
   };
@@ -16029,7 +15965,6 @@
   };
   deinferno = {
     name = "deinferno";
-    email = "14363193+deinferno@users.noreply.github.com";
     github = "deinferno";
     githubId = 14363193;
   };
@@ -16105,14 +16040,12 @@
     githubId = 14004487;
   };
   bb2020 = {
-    email = "bb2020@users.noreply.github.com";
     github = "bb2020";
     githubId = 19290397;
     name = "Tunc Uzlu";
   };
   pulsation = {
     name = "Philippe Sam-Long";
-    email = "1838397+pulsation@users.noreply.github.com";
     github = "pulsation";
     githubId = 1838397;
   };
@@ -16167,7 +16100,6 @@
   };
   zeri = {
     name = "zeri";
-    email = "68825133+zeri42@users.noreply.github.com";
     matrix = "@zeri:matrix.org";
     github = "zeri42";
     githubId = 68825133;


### PR DESCRIPTION
Not giving an email address is fine as long as the maintainer is reachable through other means, such as GitHub or Matrix. On the other hand, an `@noreply.github.com`/`@users.noreply.github.com` email is useless.

This does not break https://search.nixos.org because we already treat email as optional.