### PR TITLE
lima-bin: init binary derivation at 0.14.2

### DIFF
--- a/pkgs/applications/virtualization/lima/bin.nix
+++ b/pkgs/applications/virtualization/lima/bin.nix
@@ -1,0 +1,105 @@
+{ stdenvNoCC
+, lib
+, fetchurl
+, writeScript
+, installShellFiles
+, qemu
+, makeWrapper
+}:
+
+let
+  version = "0.14.2";
+
+  dist = {
+    aarch64-darwin = rec {
+      archSuffix = "Darwin-arm64";
+      url = "https://github.com/lima-vm/lima/releases/download/v${version}/lima-${version}-${archSuffix}.tar.gz";
+      sha256 = "8334d83ca9555271b9843040066057dd8462a774f60dfaedbe97fae3834c3894";
+    };
+
+    x86_64-darwin = rec {
+      archSuffix = "Darwin-x86_64";
+      url = "https://github.com/lima-vm/lima/releases/download/v${version}/lima-${version}-${archSuffix}.tar.gz";
+      sha256 = "3866113c92619f0041ff6fc68fef2bf16e751058b9237289b2bea8fb960bdab0";
+    };
+
+    aarch64-linux = rec {
+      archSuffix = "Linux-aarch64";
+      url = "https://github.com/lima-vm/lima/releases/download/v${version}/lima-${version}-${archSuffix}.tar.gz";
+      sha256 = "373be7ebcf5932570c384c6bfb159cd418011b98a18c26ba0467827dad302230";
+    };
+
+    x86_64-linux = rec {
+      archSuffix = "Linux-x86_64";
+      url = "https://github.com/lima-vm/lima/releases/download/v${version}/lima-${version}-${archSuffix}.tar.gz";
+      sha256 = "44cae71eae65673afcc22c557f6385aa98792aecbb43195de48217581ae39143";
+    };
+  };
+in
+stdenvNoCC.mkDerivation {
+  inherit version;
+  pname = "lima";
+  src = fetchurl {
+    inherit (dist.${stdenvNoCC.hostPlatform.system} or
+      (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}")) url sha256;
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ makeWrapper installShellFiles ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r bin share $out
+    wrapProgram $out/bin/limactl \
+      --prefix PATH : ${lib.makeBinPath [ qemu ]}
+    installShellCompletion --cmd limactl \
+      --bash <($out/bin/limactl completion bash) \
+      --fish <($out/bin/limactl completion fish) \
+      --zsh <($out/bin/limactl completion zsh)
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    USER=nix $out/bin/limactl validate $out/share/lima/examples/default.yaml
+    USER=nix $out/bin/limactl validate $out/share/lima/examples/experimental/vz.yaml
+  '';
+
+  passthru.updateScript =
+    let
+      lima-bin = builtins.toString ./bin.nix;
+    in
+    writeScript "update-lima-bin.sh" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts curl jq gawk
+
+      set -eou pipefail
+
+      LATEST_VERSION=$(curl -H "Accept: application/vnd.github+json" -Ls https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name | cut -c 2-)
+      curl -Ls -o SHA256SUMS https://github.com/lima-vm/lima/releases/download/v$LATEST_VERSION/SHA256SUMS
+      AARCH64_DARWIN_SHA256=$(cat SHA256SUMS | awk '/Darwin-arm64/{print $1}')
+      X86_64_DARWIN_SHA256=$(cat SHA256SUMS | awk '/Darwin-x86_64/{print $1}')
+      AARCH64_LINUX_SHA256=$(cat SHA256SUMS | awk '/Linux-aarch64/{print $1}')
+      X86_64_LINUX_SHA256=$(cat SHA256SUMS | awk '/Linux-x86_64/{print $1}')
+
+      # reset version first so that all platforms are always updated and in sync
+      update-source-version lima-bin 0 ${lib.fakeSha256} --file=${lima-bin} --system=aarch64-darwin
+      update-source-version lima-bin $LATEST_VERSION $AARCH64_DARWIN_SHA256 --file=${lima-bin} --system=aarch64-darwin
+      update-source-version lima-bin 0 ${lib.fakeSha256} --file=${lima-bin} --system=x86_64-darwin
+      update-source-version lima-bin $LATEST_VERSION $X86_64_DARWIN_SHA256 --file=${lima-bin} --system=x86_64-darwin
+      update-source-version lima-bin 0 ${lib.fakeSha256} --file=${lima-bin} --system=aarch64-linux
+      update-source-version lima-bin $LATEST_VERSION $AARCH64_LINUX_SHA256 --file=${lima-bin} --system=aarch64-linux
+      update-source-version lima-bin 0 ${lib.fakeSha256} --file=${lima-bin} --system=x86_64-linux
+      update-source-version lima-bin $LATEST_VERSION $X86_64_LINUX_SHA256 --file=${lima-bin} --system=x86_64-linux
+      rm SHA256SUMS
+    '';
+
+  meta = with lib; {
+    homepage = "https://github.com/lima-vm/lima";
+    description = "Linux virtual machines (on macOS, in most cases)";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tricktron ];
+  };
+}

--- a/pkgs/applications/virtualization/lima/bin.nix
+++ b/pkgs/applications/virtualization/lima/bin.nix
@@ -70,6 +70,10 @@ stdenvNoCC.mkDerivation {
     USER=nix $out/bin/limactl validate $out/share/lima/examples/experimental/vz.yaml
   '';
 
+  # Stripping removes entitlements of the binary on Darwin making it non-operational.
+  # Therefore, disable stripping on Darwin.
+  dontStrip = stdenvNoCC.isDarwin;
+
   passthru.updateScript =
     let
       lima-bin = builtins.toString ./bin.nix;

--- a/pkgs/applications/virtualization/lima/bin.nix
+++ b/pkgs/applications/virtualization/lima/bin.nix
@@ -4,7 +4,7 @@
 , writeScript
 , installShellFiles
 , qemu
-, makeWrapper
+, makeBinaryWrapper
 }:
 
 let
@@ -46,7 +46,7 @@ stdenvNoCC.mkDerivation {
 
   sourceRoot = ".";
 
-  nativeBuildInputs = [ makeWrapper installShellFiles ];
+  nativeBuildInputs = [ makeBinaryWrapper installShellFiles ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/virtualization/lima/bin.nix
+++ b/pkgs/applications/virtualization/lima/bin.nix
@@ -5,6 +5,7 @@
 , installShellFiles
 , qemu
 , makeBinaryWrapper
+, autoPatchelfHook
 }:
 
 let
@@ -46,12 +47,14 @@ stdenvNoCC.mkDerivation {
 
   sourceRoot = ".";
 
-  nativeBuildInputs = [ makeBinaryWrapper installShellFiles ];
+  nativeBuildInputs = [ makeBinaryWrapper installShellFiles ]
+    ++ lib.optionals stdenvNoCC.isLinux [ autoPatchelfHook ];
 
   installPhase = ''
     runHook preInstall
     mkdir -p $out
     cp -r bin share $out
+    chmod +x $out/bin/limactl
     wrapProgram $out/bin/limactl \
       --prefix PATH : ${lib.makeBinPath [ qemu ]}
     installShellCompletion --cmd limactl \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37333,6 +37333,8 @@ with pkgs;
     inherit (darwin) sigtool;
   };
 
+  lima-bin = callPackage ../applications/virtualization/lima/bin.nix { };
+
   logtop = callPackage ../tools/misc/logtop { };
 
   igraph = callPackage ../development/libraries/igraph { };


### PR DESCRIPTION
###### Description of changes

Adds lima binary derivation.

###### Why?

Lima added support for Apple's [Virtualization.framework](https://developer.apple.com/documentation/virtualization) aka vz in 0.14.0 which needs the apple sdk 13 to build it from source. In nixpkgs, we are currently on sdk 11 and I tried to make it work with sdk11 but failed. See https://github.com/NixOS/nixpkgs/pull/206285#issuecomment-1372010401.

Instead, it makes more sense to provide the lima binary, which this pr does.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
