### PR TITLE
fennel-language-server: init at 2022-10-26

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10924,6 +10924,14 @@
     githubId = 152312;
     name = "Periklis Tsirakidis";
   };
+
+  perigord = {
+    name = "Perigord";
+    email = "perigordtruffle7318@gmmail.com";
+    github = "Trouble-Truffle";
+    githubId = 90542764;
+  };
+
   petercommand = {
     email = "petercommand@gmail.com";
     github = "petercommand";

--- a/pkgs/development/tools/fennel-language-server/default.nix
+++ b/pkgs/development/tools/fennel-language-server/default.nix
@@ -1,0 +1,24 @@
+{lib
+,rustPlatform
+,fetchFromGitHub
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "fennel-language-server";
+  version = "2022-10-26";
+
+  src = fetchFromGitHub {
+    owner = "rydesun";
+    repo = pname;
+    rev = "e97098400910263cccc7aa826651e1b6745492ee";
+    sha256 = "sha256-AwNJsTwiFjQx24iJgwtVffpi+VmfudxvhSSykE0rYYM=";
+  };
+  cargoSha256 = "sha256-6sA2iI6ANrYo63OH9UhunUZRC1/262h4EbGvDDkgKiQ=";
+
+  meta = with lib; {
+    description = "Fennel language server protocol (LSP) support";
+    homepage = "https://github.com/rydesun/fennel-language-server";
+    platforms = rustPlatform.rust.rustc.meta.platforms;
+    license = with licenses; [mit];
+    maintainers = with maintainers; [ perigord ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7065,6 +7065,8 @@ with pkgs;
 
   ferm = callPackage ../tools/networking/ferm { };
 
+  fennel = callPackage ../development/tools/fennel-language-server { };
+
   feroxbuster = callPackage ../tools/security/feroxbuster {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes
 Language Server for Fennel (https://github.com/rydesun/fennel-language-server)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
