### PR TITLE
nixos/unifi: fix mongodb to a stable version

### DIFF
--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -33,8 +33,8 @@ in
 
     services.unifi.unifiPackage = mkOption {
       type = types.package;
-      default = pkgs.unifiLTS;
-      defaultText = literalExpression "pkgs.unifiLTS";
+      default = pkgs.unifi5;
+      defaultText = literalExpression "pkgs.unifi5";
       description = lib.mdDoc ''
         The unifi package to use.
       '';
@@ -42,10 +42,10 @@ in
 
     services.unifi.mongodbPackage = mkOption {
       type = types.package;
-      default = pkgs.mongodb;
+      default = pkgs.mongodb-4_2;
       defaultText = literalExpression "pkgs.mongodb";
       description = lib.mdDoc ''
-        The mongodb package to use.
+        The mongodb package to use. Please note: unifi7 officially only supports mongodb up until 3.6 but works with 4.2.
       '';
     };
 


### PR DESCRIPTION
###### Description of changes

Fix mongodb to a stable version, otherwise unifi might break on a next big update
just like https://github.com/NixOS/nixpkgs/pull/207382#issuecomment-1371303817

Also this requires an update of the unifi package. With the LTS version, newer mongodb versions aren't supported. The current supported version of unifi 7 is mongodb 3.6 acording to
https://community.ui.com/releases/UniFi-Network-Application-7-0-20/3e4a4099-c063-42f6-8e21-5fb2c99fcea9 which isn't even supplied by nixpkgs anymore.

`mongodb-4_2` isn't officially supported, but works. `mongodb-4_0` fails to build on current master, therefore I choose 4.2.

Tested in a VM on a fresh install.

For users who already upgraded, there is a chance the mongodb got corrupted under `/var/lib/unifi/data/db` (The default state dir is `/var/lib/unifi`). I had to repair it with the old `mongodb-3_4` package, because even the `mongodb-4_2` couldn't repair the database. 
I am not sure, whether this was due to `mongodb-6_0` already accessing the database (and possible corrupting it), or whether even users who upgrade from `mongodb-3_4` to `mongodb-4_2` will experience the database corruption.

Unfortunatly, the `mongodb-3_4` package got removed from `nixpkgs`, so one has to use an older `nixpkgs` version like so:

```
nix shell github:nixos/nixpkgs/677ed08a50931e38382dbef01cba08a8f7eac8f6#mongodb-3_4
mongod
```

Ping at maintainer: @erictapen @pennae @globin @patryk27

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
