### PR TITLE
wordpressPackages.plugins.hkdev-maintenance-mode: init at 2.2.6

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -48,10 +48,16 @@
     "version": "1.0.1"
   },
   "gutenberg": {
-    "path": "gutenberg/tags/14.8.4",
-    "rev": "2841225",
-    "sha256": "1nyyqrf61l17crw6pjq5pf9wa657sm0r85b0lxp0vzlpsfsvvw47",
-    "version": "14.8.4"
+    "path": "gutenberg/tags/14.9.0",
+    "rev": "2843613",
+    "sha256": "1aa27nmks0b411n13qsgk0xhh82n8cjpqxj6r4v55lfr835rr4av",
+    "version": "14.9.0"
+  },
+  "hkdev-maintenance-mode": {
+    "path": "hkdev-maintenance-mode/trunk",
+    "rev": "2826725",
+    "sha256": "1y70wksgj07n2yd10sg7vf0nddjw9g3vhyfxfbm57m1bb0826zpd",
+    "version": "2.2.6"
   },
   "jetpack": {
     "path": "jetpack/tags/11.6",
@@ -102,10 +108,10 @@
     "version": "0.9.3"
   },
   "webp-converter-for-media": {
-    "path": "webp-converter-for-media/tags/5.6.1",
-    "rev": "2840699",
-    "sha256": "1srrlrwxkv00j0wj0br5xjzfgwa2n4n0qr6b7xyzavxf7v0lnm7q",
-    "version": "5.6.1"
+    "path": "webp-converter-for-media/tags/5.6.2",
+    "rev": "2843800",
+    "sha256": "0yki15slmvvnc9511gsg7kkvmnic3cb0p7iz2lm90j4pdchz0api",
+    "version": "5.6.2"
   },
   "webp-express": {
     "path": "webp-express/tags/0.25.5",
@@ -162,9 +168,9 @@
     "version": "1.4.1"
   },
   "wpforms-lite": {
-    "path": "wpforms-lite/tags/1.7.8",
-    "rev": "2815943",
-    "sha256": "0xqnjxlj2m6zpcasj3gksg9qzjm8pynjr8sar8xbgfz8ichs5m6m",
-    "version": "1.7.8"
+    "path": "wpforms-lite/tags/1.7.9",
+    "rev": "2844054",
+    "sha256": "1hhcl75cb7njgch0app9kifl9fjznan1m4gqa3yc6kdhicjb5sz6",
+    "version": "1.7.9"
   }
 }

--- a/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
@@ -8,6 +8,7 @@
 , "co-authors-plus"
 , "disable-xml-rpc"
 , "gutenberg"
+, "hkdev-maintenance-mode"
 , "jetpack"
 , "jetpack-lite"
 , "lightbox-photoswipe"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
