### PR TITLE
nixos/fishnet: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19417,6 +19417,12 @@
     githubId = 20295134;
     name = "Oliver Ni";
   };
+  oliviermarty = {
+    email = "omarty@google.com";
+    github = "OlivierMarty";
+    githubId = 4533890;
+    name = "Olivier Marty";
+  };
   ollieB = {
     github = "oliverbunting";
     githubId = 1237862;

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -94,6 +94,8 @@
 
 - [Corteza](https://cortezaproject.org/), a low-code platform. Available as [services.corteza](#opt-services.corteza.enable).
 
+- [fishnet](https://github.com/lichess-org/fishnet), distributed Stockfish analysis for [https://lichess.org](lichess.org).
+
 - [Warpgate](https://warpgate.null.page), a SSH, HTTPS, MySQL and Postgres bastion. Available as [services.warpgate](#opt-services.warpgate.enable). Note that you need to run `warpgate recover-access` to recover builtin admin account, as the initialisation script uses a throwaway value to initialise its database.
 
 - [TuneD](https://tuned-project.org/), a system tuning service for Linux. Available as [services.tuned](#opt-services.tuned.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -839,6 +839,7 @@
   ./services/misc/evdevremapkeys.nix
   ./services/misc/evremap.nix
   ./services/misc/felix.nix
+  ./services/misc/fishnet.nix
   ./services/misc/flaresolverr.nix
   ./services/misc/forgejo.nix
   ./services/misc/freeswitch.nix

--- a/nixos/modules/services/misc/fishnet.nix
+++ b/nixos/modules/services/misc/fishnet.nix
@@ -1,0 +1,140 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.fishnet;
+
+  format = pkgs.formats.ini {
+    # Skip null values.
+    mkKeyValue = k: v: lib.optionalString (v != null) (lib.generators.mkKeyValueDefault { } "=" k v);
+  };
+in
+{
+
+  ###### interface
+
+  options.services.fishnet = {
+    enable = lib.mkEnableOption "fishnet: distributed Stockfish analysis for lichess.org";
+
+    package = lib.mkPackageOption pkgs "fishnet" { };
+
+    # This option cannot be set from the ini configuration file (as of fishnet v2.7.1).
+    keyfile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to file containing the fishnet key.
+        See https://lichess.org/get-fishnet
+        Either settings.fishnet.key or keyfile must be set.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = format.type;
+
+        options.fishnet = {
+          key = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = ''
+              Fishnet key.
+              See https://lichess.org/get-fishnet
+              Either settings.fishnet.key or keyfile must be set.
+            '';
+          };
+
+          cores = lib.mkOption {
+            type = lib.types.either lib.types.int (
+              lib.types.enum [
+                "auto"
+                "all"
+              ]
+            );
+            default = "auto";
+            description = ''
+              Number of logical CPU cores to use for engine processes (or
+              "auto" for all cores but one, or "all" for all cores).
+            '';
+          };
+
+          systembacklog = lib.mkOption {
+            type = lib.types.str;
+            default = "0";
+            example = [
+              "2h"
+              "short"
+              "long"
+            ];
+            description = ''
+              Prefer to run low-priority jobs only if older than this duration.
+            '';
+          };
+
+          userbacklog = lib.mkOption {
+            type = lib.types.str;
+            default = "0";
+            example = [
+              "120s"
+              "short"
+              "long"
+            ];
+            description = ''
+              Prefer to run high-priority jobs only if older than this duration.
+            '';
+          };
+        };
+      };
+
+      default = { };
+
+      description = ''
+        Configuration for `fishnet`. See `fishnet -h`.
+      '';
+    };
+  };
+
+  ###### implementation
+
+  config = lib.mkIf cfg.enable {
+    assertions = lib.singleton {
+      assertion = (cfg.settings.fishnet.key == null) != (cfg.keyfile == null);
+      message = "Either settings.fishnet.key or keyfile must be set.";
+    };
+
+    systemd.services.fishnet = {
+      description = "Fishnet client";
+
+      serviceConfig =
+        let
+          stateDirectory = "fishnet";
+        in
+        {
+          ExecStart = "${cfg.package}/bin/fishnet --conf ${format.generate "fishnet.ini" cfg.settings} ${
+            lib.optionalString (cfg.keyfile != null) "--key-file ${lib.escapeShellArg cfg.keyfile}"
+          } --stats-file /var/lib/${stateDirectory}/fishnet-stats run";
+
+          ProtectHome = true;
+          DynamicUser = true;
+          StateDirectory = stateDirectory;
+
+          # From `fishnet systemd`, settings implied from DynamicUser were removed.
+          KillMode = "mixed";
+          Nice = 5;
+          CapabilityBoundingSet = "";
+          PrivateDevices = true;
+          DevicePolicy = "closed";
+          Restart = "on-failure";
+        };
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+
+  meta.maintainers = lib.maintainers.oliviermarty;
+}


### PR DESCRIPTION
###### Description of changes

Adds a module to run fishnet, a distributed Stockfish analysis for lichess.org.

Fixes #110678.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).