### PR TITLE
release.nix: don't block on aarch64-darwin boostrap tools

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -130,7 +130,8 @@ let
               jobs.tests.patch-shebangs.x86_64-linux
               */
             ]
-            ++ lib.collect lib.isDerivation jobs.stdenvBootstrapTools
+            # FIXME: reintroduce aarch64-darwin after this builds again
+            ++ lib.collect lib.isDerivation (removeAttrs jobs.stdenvBootstrapTools [ "aarch64-darwin" ])
             ++ lib.optionals supportDarwin.x86_64 [
               jobs.stdenv.x86_64-darwin
               jobs.cargo.x86_64-darwin


### PR DESCRIPTION
They haven't worked for several months, so let's not start blocking now: https://hydra.nixos.org/job/nixpkgs/nixpkgs-unstable-aarch64-darwin/stdenvBootstrapTools.aarch64-darwin.dist

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
