### PR TITLE
tubekit: init at 4

### DIFF
--- a/pkgs/applications/networking/cluster/tubekit/default.nix
+++ b/pkgs/applications/networking/cluster/tubekit/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "tubekit";
+  version = "4";
+
+  src = fetchFromGitHub {
+    owner = "reconquest";
+    repo = "tubekit";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-sq91uR8ITMOv8hivwKQR02mMlJpjDHw6RxiwVUrpwnY=";
+  };
+
+  vendorHash = "sha256-qrGzmr1dZPn5r2WBJA7FT7RTqP2sxnrXgbrnKlnpF0Y=";
+
+  meta = with lib; {
+    description = "Kubectl alternative with quick context switching";
+    homepage = "https://github.com/reconquest/tubekit";
+    license = licenses.mit;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ farcaller ];
+  };
+}

--- a/pkgs/applications/networking/cluster/tubekit/wrapper.nix
+++ b/pkgs/applications/networking/cluster/tubekit/wrapper.nix
@@ -1,0 +1,17 @@
+{ lib
+, runCommand
+, makeWrapper
+, tubekit-unwrapped
+, pname ? "tubekit"
+, version ? tubekit-unwrapped.version
+, kubectl
+}:
+runCommand "${pname}-${version}"
+{
+  inherit pname version;
+  inherit (tubekit-unwrapped) src meta;
+  nativeBuildInputs = [ makeWrapper ];
+} ''
+  mkdir -p $out/bin
+  makeWrapper ${tubekit-unwrapped}/bin/tubectl $out/bin/tubectl --set-default TUBEKIT_KUBECTL ${kubectl}/bin/kubectl
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38628,4 +38628,8 @@ with pkgs;
   jfrog-cli = callPackage ../tools/misc/jfrog-cli { };
 
   ov = callPackage ../tools/text/ov { };
+
+  tubekit = callPackage ../applications/networking/cluster/tubekit/wrapper.nix { };
+
+  tubekit-unwrapped = callPackage ../applications/networking/cluster/tubekit { };
 }


### PR DESCRIPTION
###### Description of changes

Add [tubekit](https://github.com/reconquest/tubekit), the kubectl wrapper with quick context switching.

I originally wrapped in a flake upstream, but this makes it easier to install it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
