### PR TITLE
qbittorrent: add aarch64-darwin and x86_64-darwin to platforms

### DIFF
--- a/pkgs/applications/networking/p2p/qbittorrent/darwin.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/darwin.nix
@@ -1,0 +1,29 @@
+{ mkDerivation, lib, fetchurl, meta, version, pname, undmg, makeWrapper }:
+
+let appName = "qBittorrent";
+in mkDerivation {
+  inherit pname meta version;
+
+  src = fetchurl {
+    url = "https://phoenixnap.dl.sourceforge.net/project/qbittorrent/qbittorrent-mac/qbittorrent-${version}/qbittorrent-${version}.dmg";
+    sha256 = "sha256-9h+gFAEU0tKrltOjnOKLfylbbBunGZqvPzQogdP9uQM=";
+  };
+
+  nativeBuildInputs = [ undmg makeWrapper ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r "${appName}.app" $out/Applications
+
+    # wrap executable to $out/bin
+    mkdir -p $out/bin
+    makeWrapper "$out/Applications/${appName}.app/Contents/MacOS/${pname}" "$out/bin/${pname}"
+
+    runHook postInstall
+  '';
+}
+

--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -1,53 +1,28 @@
-{ mkDerivation, lib, fetchFromGitHub, pkg-config
-, boost, libtorrent-rasterbar, qtbase, qttools, qtsvg
+{ lib, callPackage, stdenv
 , debugSupport ? false
 , guiSupport ? true, dbus ? null # GUI (disable to run headless)
 , webuiSupport ? true # WebUI
 , trackerSearch ? true, python3 ? null
 }:
 
-assert guiSupport -> (dbus != null);
-assert trackerSearch -> (python3 != null);
-
 with lib;
-mkDerivation rec {
+let
   pname = "qbittorrent";
   version = "4.4.5";
 
-  src = fetchFromGitHub {
-    owner = "qbittorrent";
-    repo = "qBittorrent";
-    rev = "release-${version}";
-    sha256 = "sha256-EgRDNOJ4szdZA5ipOuGy2R0oVdjWcuqPU3ecU3ZNK3g=";
-  };
-
-  enableParallelBuilding = true;
-
-  # NOTE: 2018-05-31: CMake is working but it is not officially supported
-  nativeBuildInputs = [ pkg-config ];
-
-  buildInputs = [ boost libtorrent-rasterbar qtbase qttools qtsvg ]
-    ++ optional guiSupport dbus # D(esktop)-Bus depends on GUI support
-    ++ optional trackerSearch python3;
-
-  # Otherwise qm_gen.pri assumes lrelease-qt5, which does not exist.
-  QMAKE_LRELEASE = "lrelease";
-
-  configureFlags = [
-    "--with-boost-libdir=${boost.out}/lib"
-    "--with-boost=${boost.dev}" ]
-    ++ optionals (!guiSupport) [ "--disable-gui" "--enable-systemd" ] # Also place qbittorrent-nox systemd service files
-    ++ optional (!webuiSupport) "--disable-webui"
-    ++ optional debugSupport "--enable-debug";
-
-  qtWrapperArgs = optional trackerSearch "--prefix PATH : ${makeBinPath [ python3 ]}";
-
-  meta = {
+  meta = with lib; {
     description = "Featureful free software BitTorrent client";
     homepage    = "https://www.qbittorrent.org/";
     changelog   = "https://github.com/qbittorrent/qBittorrent/blob/release-${version}/Changelog";
     license     = licenses.gpl2Plus;
-    platforms   = platforms.linux;
+    platforms   = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ Anton-Latukha ];
   };
-}
+
+  package = (callPackage (if stdenv.isLinux then ./linux.nix else ./darwin.nix)
+    (if stdenv.isLinux then {
+      inherit version meta pname debugSupport guiSupport dbus webuiSupport trackerSearch python3;
+    } else {
+      inherit version meta pname;
+    }));
+in package

--- a/pkgs/applications/networking/p2p/qbittorrent/linux.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/linux.nix
@@ -1,0 +1,44 @@
+{ mkDerivation, fetchFromGitHub, pkg-config, lib
+, boost, libtorrent-rasterbar, qtbase, qttools, qtsvg
+, debugSupport ? false
+, guiSupport ? true, dbus ? null # GUI (disable to run headless)
+, webuiSupport ? true # WebUI
+, trackerSearch ? true, python3 ? null
+, meta, version, pname
+}:
+
+assert guiSupport -> (dbus != null);
+assert trackerSearch -> (python3 != null);
+
+with lib;
+mkDerivation {
+  inherit meta version pname;
+
+  src = fetchFromGitHub {
+    owner = "qbittorrent";
+    repo = "qBittorrent";
+    rev = "release-${version}";
+    sha256 = "sha256-EgRDNOJ4szdZA5ipOuGy2R0oVdjWcuqPU3ecU3ZNK3g=";
+  };
+
+  enableParallelBuilding = true;
+
+  # NOTE: 2018-05-31: CMake is working but it is not officially supported
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ boost libtorrent-rasterbar qtbase qttools qtsvg ]
+    ++ optional guiSupport dbus # D(esktop)-Bus depends on GUI support
+    ++ optional trackerSearch python3;
+
+  # Otherwise qm_gen.pri assumes lrelease-qt5, which does not exist.
+  QMAKE_LRELEASE = "lrelease";
+
+  configureFlags = [
+    "--with-boost-libdir=${boost.out}/lib"
+    "--with-boost=${boost.dev}" ]
+    ++ optionals (!guiSupport) [ "--disable-gui" "--enable-systemd" ] # Also place qbittorrent-nox systemd service files
+    ++ optional (!webuiSupport) "--disable-webui"
+    ++ optional debugSupport "--enable-debug";
+
+  qtWrapperArgs = optional trackerSearch "--prefix PATH : ${makeBinPath [ python3 ]}";
+}


### PR DESCRIPTION
###### Description of changes

Adds a Darwin target for the qBittorrent app (binary download from sourceforge).

Unsure if I should also update the version to 4.5.0 from 4.4.5, and if I should do so in a separate PR or another commit in this one (also if in this PR what should the title be?)

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
