### PR TITLE
nixos/iay: use `mkPackageOptionMD`

### DIFF
--- a/nixos/modules/programs/iay.nix
+++ b/nixos/modules/programs/iay.nix
@@ -2,11 +2,11 @@
 
 let
   cfg = config.programs.iay;
-  inherit (lib) mkEnableOption mkIf mkOption mkPackageOption optionalString types;
+  inherit (lib) mkEnableOption mkIf mkOption mkPackageOptionMD optionalString types;
 in {
   options.programs.iay = {
     enable = mkEnableOption (lib.mdDoc "iay");
-    package = mkPackageOption pkgs "iay" {};
+    package = mkPackageOptionMD pkgs "iay" {};
 
     minimalPrompt = mkOption {
       type = types.bool;


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/208407. Fixes the manual.