### PR TITLE
notesnook: init at 2.5.7

### DIFF
--- a/pkgs/applications/misc/notesnook/default.nix
+++ b/pkgs/applications/misc/notesnook/default.nix
@@ -1,0 +1,76 @@
+{ lib, stdenv, appimageTools, fetchurl, undmg }:
+
+let
+  pname = "notesnook";
+  version = "2.5.7";
+
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+
+  suffix = {
+    x86_64-linux = "linux_x86_64.AppImage";
+    x86_64-darwin = "mac_x64.dmg";
+    aarch64-darwin = "mac_arm64.dmg";
+  }.${system} or throwSystem;
+
+  src = fetchurl {
+    url = "https://github.com/streetwriters/notesnook/releases/download/v${version}/notesnook_${suffix}";
+    hash = {
+      x86_64-linux = "sha256-M/59pjhuKF/MOMpT9/qrlThHO0V8e49cfiaWMkEWHNg=";
+      x86_64-darwin = "sha256-cluIizmweIMU6RIFxoEQ3DYChRVEuVLxrPjwfFfeq1w=";
+      aarch64-darwin = "sha256-cbBnKrb8poyDL1D+32UrOl3RXt8Msncw440qra9+Gs0=";
+    }.${system} or throwSystem;
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version src;
+  };
+
+  meta = with lib; {
+    description = "A fully open source & end-to-end encrypted note taking alternative to Evernote.";
+    longDescription = ''
+      Notesnook is a free (as in speech) & open source note taking app
+      focused on user privacy & ease of use. To ensure zero knowledge
+      principles, Notesnook encrypts everything on your device using
+      XChaCha20-Poly1305 & Argon2.
+    '';
+    homepage = "https://notesnook.com";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ j0lol ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  };
+
+  linux = appimageTools.wrapType2 rec {
+    inherit pname version src meta;
+
+    profile = ''
+      export LC_ALL=C.UTF-8
+    '';
+
+    multiPkgs = null; # no 32bit needed
+    extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
+    extraInstallCommands = ''
+      mv $out/bin/{${pname}-${version},${pname}}
+      install -Dm444 ${appimageContents}/notesnook.desktop -t $out/share/applications
+      install -Dm444 ${appimageContents}/notesnook.png -t $out/share/pixmaps
+      substituteInPlace $out/share/applications/notesnook.desktop \
+        --replace 'Exec=AppRun --no-sandbox %U' 'Exec=${pname}'
+    '';
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit pname version src meta;
+
+    nativeBuildInputs = [ undmg ];
+
+    sourceRoot = "Notesnook.app";
+
+    installPhase = ''
+      mkdir -p $out/Applications/Notesnook.app
+      cp -R . $out/Applications/Notesnook.app
+    '';
+  };
+in
+if stdenv.isDarwin
+then darwin
+else linux

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9018,6 +9018,8 @@ with pkgs;
 
   node2nix = nodePackages.node2nix;
 
+  notesnook = callPackage ../applications/misc/notesnook { };
+
   openipmi = callPackage ../tools/system/openipmi { };
 
   ox = callPackage ../applications/editors/ox { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://notesnook.com/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
