### PR TITLE
arrow-cpp: Use minimal aws-sdk-cpp, reducing closure 1.0G → 417M

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -65,6 +65,17 @@ let
     hash = "sha256-cO5t/mgsbBhbSefx8EMGTyxmgTjhZ8mFujkFQ3p/JS0=";
   };
 
+  aws-sdk-cpp-arrow = aws-sdk-cpp.override {
+    apis = [
+      "cognito-identity"
+      "config"
+      "identity-management"
+      "s3"
+      "sts"
+      "transfer"
+    ];
+  };
+
 in
 stdenv.mkDerivation rec {
   pname = "arrow-cpp";
@@ -144,7 +155,7 @@ stdenv.mkDerivation rec {
     grpc
     openssl
     protobuf
-  ] ++ lib.optionals enableS3 [ aws-sdk-cpp openssl ]
+  ] ++ lib.optionals enableS3 [ aws-sdk-cpp-arrow openssl ]
   ++ lib.optionals enableGcs [
     crc32c
     curl
@@ -205,7 +216,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals stdenv.isDarwin [
     "-DCMAKE_INSTALL_RPATH=@loader_path/../lib" # needed for tools executables
   ] ++ lib.optional (!stdenv.isx86_64) "-DARROW_USE_SIMD=OFF"
-  ++ lib.optional enableS3 "-DAWSSDK_CORE_HEADER_FILE=${aws-sdk-cpp}/include/aws/core/Aws.h"
+  ++ lib.optional enableS3 "-DAWSSDK_CORE_HEADER_FILE=${aws-sdk-cpp-arrow}/include/aws/core/Aws.h"
   ++ lib.optionals enableGcs [ "-DCMAKE_CXX_STANDARD=${grpc.cxxStandard}" ];
 
   doInstallCheck = true;


### PR DESCRIPTION
###### Description of changes

This is only one of two pkgs in nixpkgs that use aws-sdk-cpp, the other being nix, and that already does what this PR does: overrides for a smaller closure. The combination of large size reduction, 230 dependents, and no other direct dependents of the full package makes this, to me, an ideal case for an override.

Note that the added size from aws-sdk-cpp itself in the closure is reduced from 631 MiB → 21 MiB.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Note I have not manually tested any AWS-specific functionality in arrow-cpp, since I don’t know how.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

<details>
<summary>results of running <code>git switch nixos-unstable; git switch -c x; git cherry-pick arrow-cpp-shrink-closure; nixpkgs-review rev -b nixos-unstable HEAD</code> (there are failures, but as far as I can tell, they are already broken; I ran against nixos-unstable to reduce rebuilds)</summary>

```
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs nixos-unstable:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
 + 245eff71712...9813adc7f7c nixos-unstable -> refs/nixpkgs-review/0  (forced update)
$ git worktree add /home/user/.cache/nixpkgs-review/rev-7d25283cee0d920bf09607f54e8864af90bae7ef/nixpkgs 9813adc7f7c0edd738c6bdd8431439688bb0cb3d
Preparing worktree (detached HEAD 9813adc7f7c)
Updating files: 100% (33102/33102), done.
HEAD is now at 9813adc7f7c Merge pull request #208885 from marsam/update-millet
$ nix-env --option system x86_64-linux -f /home/user/.cache/nixpkgs-review/rev-7d25283cee0d920bf09607f54e8864af90bae7ef/nixpkgs -qaP --xml --out-path --sh
ow-trace
$ git merge --no-commit --no-ff 7d25283cee0d920bf09607f54e8864af90bae7ef
Automatic merge went well; stopped before committing as requested
When finished, apply stashed changes with `git stash pop`
$ nix-env --option system x86_64-linux -f /home/user/.cache/nixpkgs-review/rev-7d25283cee0d920bf09607f54e8864af90bae7ef/nixpkgs -qaP --xml --out-path --sh
ow-trace --meta
230 packages updated:
arrow-cpp arrow-glib caffe caffe caffe caffe cloudcompare databricks-sql-cli easyocr entwine-unstable gdal gdal gdal gmt gplates grass homeassistant-test-environment_canada intensity-normalization libLAS mapcache mapnik-unstable MapProxy mapserver merkaartor mod_tile-unstable mysql-workbench napari openai OpenOrienteering-Mapper paraview parquet-tools pdal perl5.34.1-Tirex perl5.36.0-Tirex postgis postgis postgis postgis postgis postgis python3.10-apache-beam python3.10-aplpy python3.10-asf-search python3.10-autofaiss python3.10-batchgenerators python3.10-boxx python3.10-bpycv python3.10-bsuite python3.10-cartopy python3.10-casa-formats-io python3.10-clifford python3.10-dalle-mini python3.10-dask python3.10-dask-gateway python3.10-dask-glm python3.10-dask-image python3.10-dask-jobqueue python3.10-dask-ml python3.10-dask-mpi python3.10-dask-yarn python3.10-databricks-sql-connector python3.10-datafusion python3.10-datasets python3.10-datashader python3.10-db-dtypes python3.10-devito python3.10-distributed python3.10-dm-sonnet python3.10-dremel3dpy python3.10-easyocr python3.10-embedding-reader python3.10-env-canada python3.10-fiona python3.10-geopandas python3.10-glymur python3.10-google-cloud-bigquery python3.10-handout python3.10-ibis-framework python3.10-image-match python3.10-imagecorruptions python3.10-imageio python3.10-imgaug python3.10-intake python3.10-intake-parquet python3.10-intensity-normalization python3.10-mask-rcnn python3.10-moviepy python3.10-napari python3.10-napari-console python3.10-napari-svg python3.10-openai python3.10-osmnx python3.10-pandas-stubs python3.10-pims python3.10-plotnine python3.10-psd-tools python3.10-pyarrow python3.10-pyFFTW python3.10-pygmt python3.10-python-mapnik-unstable python3.10-qiskit python3.10-qiskit-machine-learning python3.10-rasterio python3.10-recordlinkage python3.10-rl-coach python3.10-rlax python3.10-runway-python python3.10-scikit-image python3.10-shap python3.10-slicedimage python3.10-spacy-transformers python3.10-sparse python3.10-spectral-cube python3.10-stanza python3.10-streamz python3.10-stumpy python3.10-stytra python3.10-sunpy python3.10-tensorflow-datasets python3.10-tensorly python3.10-test-tube python3.10-tifffile python3.10-tokenizers python3.10-transformers python3.10-vqgan-jax-unstable python3.10-whisper-unstable python3.10-wktutils python3.10-worldengine python3.10-zcs python3.9-apache-beam python3.9-aplpy python3.9-asf-search python3.9-autofaiss python3.9-batchgenerators python3.9-boxx python3.9-bpycv python3.9-bsuite python3.9-cartopy python3.9-casa-formats-io python3.9-clifford python3.9-dalle-mini python3.9-dask python3.9-dask-gateway python3.9-dask-glm python3.9-dask-image python3.9-dask-jobqueue python3.9-dask-ml python3.9-dask-mpi python3.9-dask-yarn python3.9-databricks-sql-connector python3.9-datafusion python3.9-datasets python3.9-datashader python3.9-db-dtypes python3.9-devito python3.9-distributed python3.9-dm-sonnet python3.9-dremel3dpy python3.9-easyocr python3.9-embedding-reader python3.9-env-canada python3.9-fiona python3.9-geopandas python3.9-glymur python3.9-google-cloud-bigquery python3.9-handout python3.9-ibis-framework python3.9-image-match python3.9-imagecorruptions python3.9-imageio python3.9-imgaug python3.9-intake python3.9-intake-parquet python3.9-intensity-normalization python3.9-mask-rcnn python3.9-moviepy python3.9-napari python3.9-napari-console python3.9-napari-svg python3.9-openai python3.9-osmnx python3.9-pandas-stubs python3.9-pims python3.9-plotnine python3.9-psd-tools python3.9-pyarrow python3.9-pyFFTW python3.9-pygmt python3.9-python-mapnik-unstable python3.9-qiskit python3.9-qiskit-machine-learning python3.9-rasterio python3.9-recordlinkage python3.9-rl-coach python3.9-rlax python3.9-runway-python python3.9-scikit-image python3.9-shap python3.9-slicedimage python3.9-spacy-transformers python3.9-sparse python3.9-spectral-cube python3.9-stanza python3.9-streamz python3.9-stumpy python3.9-stytra python3.9-sunpy python3.9-tensorflow-datasets python3.9-tensorly python3.9-test-tube python3.9-tifffile python3.9-tokenizers python3.9-transformers python3.9-vqgan-jax-unstable python3.9-whisper-unstable python3.9-wktutils python3.9-worldengine python3.9-zcs pytrainer qgis qgis qmapshack saga streamlit sumo t-rex tartube tartube udig whisper-unstable

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/user/.cache/nixpkgs-review/rev-7d25283c
ee0d920bf09607f54e8864af90bae7ef/build.nix
error: builder for '/nix/store/idf3jfiy10fc6ignlk64a8japc5lq6x5-python3.9-dalle-mini-0.1.1.drv' failed with exit code 1;
       last 10 log lines:
       >   File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
       >   File "<frozen importlib._bootstrap_external>", line 850, in exec_module
       >   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
       >   File "/nix/store/y3n2gvfwb958zgv6lm8kjr754c0f3v4d-python3.9-dalle-mini-0.1.1/lib/python3.9/site-packages/dalle_mini/__init__.py", line 3, in <module
>
       >     from .model import DalleBart, DalleBartProcessor
       >   File "/nix/store/y3n2gvfwb958zgv6lm8kjr754c0f3v4d-python3.9-dalle-mini-0.1.1/lib/python3.9/site-packages/dalle_mini/model/__init__.py", line 2, in <
module>
       >     from .modeling import DalleBart
       >   File "/nix/store/y3n2gvfwb958zgv6lm8kjr754c0f3v4d-python3.9-dalle-mini-0.1.1/lib/python3.9/site-packages/dalle_mini/model/modeling.py", line 33, in
<module>
       >     from transformers.generation_flax_utils import FlaxSampleOutput
       > ImportError: cannot import name 'FlaxSampleOutput' from 'transformers.generation_flax_utils' (/nix/store/xk80f31hj46jhjx2y30vddd8c40h9k1f-python3.9-tr
ansformers-4.25.1/lib/python3.9/site-packages/transformers/generation_flax_utils.py)
       For full logs, run 'nix log /nix/store/idf3jfiy10fc6ignlk64a8japc5lq6x5-python3.9-dalle-mini-0.1.1.drv'.
error: builder for '/nix/store/dvijhzic937wa32hri6a02sd9xr3vvjr-python3.10-dalle-mini-0.1.1.drv' failed with exit code 1;
       last 10 log lines:
       >   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
       >   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
       >   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
       >   File "/nix/store/hwlh5lavqwdhrs7kv9jbrh8j2nwh04wy-python3.10-dalle-mini-0.1.1/lib/python3.10/site-packages/dalle_mini/__init__.py", line 3, in <modu
le>
       >     from .model import DalleBart, DalleBartProcessor
       >   File "/nix/store/hwlh5lavqwdhrs7kv9jbrh8j2nwh04wy-python3.10-dalle-mini-0.1.1/lib/python3.10/site-packages/dalle_mini/model/__init__.py", line 2, in
 <module>
       >     from .modeling import DalleBart
       >   File "/nix/store/hwlh5lavqwdhrs7kv9jbrh8j2nwh04wy-python3.10-dalle-mini-0.1.1/lib/python3.10/site-packages/dalle_mini/model/modeling.py", line 33, i
n <module>
       >     from transformers.generation_flax_utils import FlaxSampleOutput
       > ImportError: cannot import name 'FlaxSampleOutput' from 'transformers.generation_flax_utils' (/nix/store/g6yg2cs44s52bwc2xw62r6x9239ixfdw-python3.10-t
ransformers-4.25.1/lib/python3.10/site-packages/transformers/generation_flax_utils.py)
       For full logs, run 'nix log /nix/store/dvijhzic937wa32hri6a02sd9xr3vvjr-python3.10-dalle-mini-0.1.1.drv'.
error: builder for '/nix/store/7fhs8pcjj72p9pkn813i8jjpfd1gx6mk-gdal-3.6.1.drv' failed with exit code 2;
       last 10 log lines:
       > [ 94%] Built target ogr_MVT
       > [ 94%] Built target gdal_netCDF
       > [ 94%] Built target ogr_GeoPackage
       > [ 94%] Built target ogr_GMLAS
       > [ 94%] Built target ogr_Arrow
       > [ 94%] Built target ogr_Parquet
       > [ 94%] Built target gcore
       > make[2]: *** No rule to make target '/nix/store/ggb5lnmxyk9ggpgj1myxpjyibzwlig3j-mysql-8.0.31/lib/mysql/libmysqlclient.so', needed by 'libgdal.so.32.3
.6.1'.  Stop.
       > make[1]: *** [CMakeFiles/Makefile2:3589: CMakeFiles/GDAL.dir/all] Error 2
       > make: *** [Makefile:136: all] Error 2
       For full logs, run 'nix log /nix/store/7fhs8pcjj72p9pkn813i8jjpfd1gx6mk-gdal-3.6.1.drv'.
error: 1 dependencies of derivation '/nix/store/rhm4mhnli262w2wylkmk04rw26l1ak1y-mysql-workbench-8.0.30.drv' failed to build
error: builder for '/nix/store/la6v7g1565kkacba9mf4g4hc7nfabp2l-t-rex-0.14.3.drv' failed with exit code 101;
       last 10 log lines:
       >   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
       >   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
       >   cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
       >   cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
       >   cargo:rustc-cfg=gdal_sys_3_6_1
       >
       >   --- stderr
       >   thread 'main' panicked at 'No pre-built bindings available for GDAL version 3.6. Use `--features bindgen` to generate your own bindings.', /build/t-
rex-0.14.3-vendor.tar.gz/gdal-sys/build.rs:220:17
       >   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
       > warning: build failed, waiting for other jobs to finish...
       For full logs, run 'nix log /nix/store/la6v7g1565kkacba9mf4g4hc7nfabp2l-t-rex-0.14.3.drv'.
error: builder for '/nix/store/ncjr6a9jbx7cq9ajzz0ivkqclb2wsxrf-perl5.36.0-Tirex-0.7.0.drv' failed with exit code 2;
       last 10 log lines:
       >                  from metatilehandler.h:22,
       >                  from renderd.h:13,
       >                  from renderd.cc:10:
       > /nix/store/5m20sdpb4yfc1p2qdc14piz7dlxyy1n5-mapnik-unstable-2022-10-18/include/mapnik/color.hpp:33:10: fatal error: boost/operators.hpp: No such file
or directory
       >    33 | #include <boost/operators.hpp>
       >       |          ^~~~~~~~~~~~~~~~~~~~~
       > compilation terminated.
       > make[1]: *** [<builtin>: renderd.o] Error 1
       > make[1]: Leaving directory '/build/source/backend-mapnik'
       > make: *** [Makefile:3: build] Error 2
       For full logs, run 'nix log /nix/store/ncjr6a9jbx7cq9ajzz0ivkqclb2wsxrf-perl5.36.0-Tirex-0.7.0.drv'.
error: builder for '/nix/store/5pybz0rn640hwlq2vdjd95c4p5cmij39-perl5.34.1-Tirex-0.7.0.drv' failed with exit code 2;
       last 10 log lines:
       >                  from metatilehandler.h:22,
       >                  from renderd.h:13,
       >                  from renderd.cc:10:
       > /nix/store/5m20sdpb4yfc1p2qdc14piz7dlxyy1n5-mapnik-unstable-2022-10-18/include/mapnik/color.hpp:33:10: fatal error: boost/operators.hpp: No such file
or directory
       >    33 | #include <boost/operators.hpp>
       >       |          ^~~~~~~~~~~~~~~~~~~~~
       > compilation terminated.
       > make[1]: *** [<builtin>: renderd.o] Error 1
       > make[1]: Leaving directory '/build/source/backend-mapnik'
       > make: *** [Makefile:3: build] Error 2
       For full logs, run 'nix log /nix/store/5pybz0rn640hwlq2vdjd95c4p5cmij39-perl5.34.1-Tirex-0.7.0.drv'.
error: builder for '/nix/store/7a5h6pfzj6jbqdhs96683g2bx3ajyk39-python3.10-sunpy-4.0.5.drv' failed with exit code 2;
       last 10 log lines:
       > ../../nix/store/96mm3zbb0f3gdxd2fv7ml4xsskxw90q8-python3.10-pytest-7.1.3/lib/python3.10/site-packages/_pytest/config/__init__.py:1253
       >   /nix/store/96mm3zbb0f3gdxd2fv7ml4xsskxw90q8-python3.10-pytest-7.1.3/lib/python3.10/site-packages/_pytest/config/__init__.py:1253: PytestConfigWarnin
g: Unknown config option: mpl-use-full-test-name
       >
       >     self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
       >
       > -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
       > =========================== short test summary info ============================
       > ERROR sunpy/time/tests/test_timerange.py - astropy.utils.exceptions.AstropyWa...
       > !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
       > =========== 7 skipped, 73 deselected, 2 warnings, 1 error in 56.14s ============
       For full logs, run 'nix log /nix/store/7a5h6pfzj6jbqdhs96683g2bx3ajyk39-python3.10-sunpy-4.0.5.drv'.
error: builder for '/nix/store/lvyzq837lxdrsvwh12qy4q72r7g96vbv-python3.9-sunpy-4.0.5.drv' failed with exit code 2;
       last 10 log lines:
       > ../../nix/store/dh5g1pq81lf3qbf510ik1s6bkfs7nw44-python3.9-pytest-7.1.3/lib/python3.9/site-packages/_pytest/config/__init__.py:1253
       >   /nix/store/dh5g1pq81lf3qbf510ik1s6bkfs7nw44-python3.9-pytest-7.1.3/lib/python3.9/site-packages/_pytest/config/__init__.py:1253: PytestConfigWarning:
 Unknown config option: mpl-use-full-test-name
       >
       >     self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
       >
       > -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
       > =========================== short test summary info ============================
       > ERROR sunpy/time/tests/test_timerange.py - astropy.utils.exceptions.AstropyWa...
       > !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
       > ====== 7 skipped, 73 deselected, 2 warnings, 1 error in 68.29s (0:01:08) =======
       For full logs, run 'nix log /nix/store/lvyzq837lxdrsvwh12qy4q72r7g96vbv-python3.9-sunpy-4.0.5.drv'.
error: builder for '/nix/store/pihcp46bfa8ppbiafajl25y78hdwxhrh-python3.9-dm-sonnet-2.0.0.drv' failed with exit code 1;
       last 10 log lines:
       >     from sonnet.src import once
       >   File "/nix/store/qclspw9xakzzv4lvlyj5gq9bck3wfvp4-python3.9-dm-sonnet-2.0.0/lib/python3.9/site-packages/sonnet/src/once.py", line 23, in <module>
       >     from sonnet.src import utils
       >   File "/nix/store/qclspw9xakzzv4lvlyj5gq9bck3wfvp4-python3.9-dm-sonnet-2.0.0/lib/python3.9/site-packages/sonnet/src/utils.py", line 29, in <module>
       >     from sonnet.src import initializers
       >   File "/nix/store/qclspw9xakzzv4lvlyj5gq9bck3wfvp4-python3.9-dm-sonnet-2.0.0/lib/python3.9/site-packages/sonnet/src/initializers.py", line 26, in <mo
dule>
       >     from sonnet.src import types
       >   File "/nix/store/qclspw9xakzzv4lvlyj5gq9bck3wfvp4-python3.9-dm-sonnet-2.0.0/lib/python3.9/site-packages/sonnet/src/types.py", line 23, in <module>
       >     import tensorflow as tf
       > ModuleNotFoundError: No module named 'tensorflow'
       For full logs, run 'nix log /nix/store/pihcp46bfa8ppbiafajl25y78hdwxhrh-python3.9-dm-sonnet-2.0.0.drv'.
error: builder for '/nix/store/9hhlz1l9ad9v4p08k3zdzwzb1wka21kp-python3.10-dm-sonnet-2.0.0.drv' failed with exit code 1;
       last 10 log lines:
       >     from sonnet.src import once
       >   File "/nix/store/6ywlbsv0svj72nmz74cxy0jcr51mrzra-python3.10-dm-sonnet-2.0.0/lib/python3.10/site-packages/sonnet/src/once.py", line 23, in <module>
       >     from sonnet.src import utils
       >   File "/nix/store/6ywlbsv0svj72nmz74cxy0jcr51mrzra-python3.10-dm-sonnet-2.0.0/lib/python3.10/site-packages/sonnet/src/utils.py", line 29, in <module>
       >     from sonnet.src import initializers
       >   File "/nix/store/6ywlbsv0svj72nmz74cxy0jcr51mrzra-python3.10-dm-sonnet-2.0.0/lib/python3.10/site-packages/sonnet/src/initializers.py", line 26, in <
module>
       >     from sonnet.src import types
       >   File "/nix/store/6ywlbsv0svj72nmz74cxy0jcr51mrzra-python3.10-dm-sonnet-2.0.0/lib/python3.10/site-packages/sonnet/src/types.py", line 23, in <module>
       >     import tensorflow as tf
       > ModuleNotFoundError: No module named 'tensorflow'
       For full logs, run 'nix log /nix/store/9hhlz1l9ad9v4p08k3zdzwzb1wka21kp-python3.10-dm-sonnet-2.0.0.drv'.
error: 10 dependencies of derivation '/nix/store/yw7a10jb2gwxn8rj7hffc1zzsrkrd843-env.drv' failed to build
error: 1 dependencies of derivation '/nix/store/8sld6z6xwlbvansdyazfkrr3qyiyqdjw-review-shell.drv' failed to build
20 packages marked as broken and skipped:
intensity-normalization postgis python310Packages.caffe python310Packages.caffeWithCuda python310Packages.imgaug python310Packages.intensity-normalization python310Packages.mask-rcnn python310Packages.qiskit python310Packages.qiskit-machine-learning python310Packages.rl-coach python310Packages.rlax python310Packages.worldengine python39Packages.imgaug python39Packages.intensity-normalization python39Packages.mask-rcnn python39Packages.qiskit python39Packages.qiskit-machine-learning python39Packages.rl-coach python39Packages.rlax python39Packages.worldengine

10 packages failed to build:
mysql-workbench perl534Packages.Tirex perl536Packages.Tirex python310Packages.dalle-mini python310Packages.dm-sonnet python310Packages.sunpy python39Packages.dalle-mini python39Packages.dm-sonnet python39Packages.sunpy t-rex

195 packages built:
apacheHttpdPackages.mod_tile arrow-cpp arrow-glib cloudcompare databricks-sql-cli easyocr entwine gdal gmt gplates grass home-assistant-component-tests.environment_canada libLAS mapcache mapnik mapproxy mapserver merkaartor napari openai openai-whisper openorienteering-mapper paraview parquet-tools pdal postgresql11Packages.postgis postgresql12Packages.postgis postgresql13Packages.postgis postgresql14Packages.postgis postgresql15Packages.postgis python310Packages.apache-beam python310Packages.aplpy python310Packages.asf-search python310Packages.autofaiss python310Packages.batchgenerators python310Packages.boxx python310Packages.bpycv python310Packages.bsuite python310Packages.cartopy python310Packages.casa-formats-io python310Packages.clifford python310Packages.dask python310Packages.dask-gateway python310Packages.dask-glm python310Packages.dask-image python310Packages.dask-jobqueue python310Packages.dask-ml python310Packages.dask-mpi python310Packages.dask-yarn python310Packages.databricks-sql-connector python310Packages.datafusion python310Packages.datasets python310Packages.datashader python310Packages.db-dtypes python310Packages.devito python310Packages.distributed python310Packages.dremel3dpy python310Packages.embedding-reader python310Packages.env-canada python310Packages.fiona python310Packages.geopandas python310Packages.glymur python310Packages.google-cloud-bigquery python310Packages.handout python310Packages.ibis-framework python310Packages.image-match python310Packages.imagecorruptions python310Packages.imageio python310Packages.intake python310Packages.intake-parquet python310Packages.moviepy python310Packages.napari-console python310Packages.napari-svg python310Packages.osmnx python310Packages.pandas-stubspython310Packages.pims python310Packages.plotnine python310Packages.psd-tools python310Packages.pyarrow python310Packages.pyfftw python310Packages.pygmt python310Packages.python-mapnik python310Packages.rasterio python310Packages.recordlinkage python310Packages.runway-python python310Packages.scikitimage python310Packages.shap python310Packages.slicedimage python310Packages.spacy-transformers python310Packages.sparse python310Packages.spectral-cube python310Packages.stanza python310Packages.streamz python310Packages.stumpy python310Packages.stytra python310Packages.tensorflow-datasets python310Packages.tensorly python310Packages.test-tube python310Packages.tifffile python310Packages.tokenizers python310Packages.transformers python310Packages.vqgan-jax python310Packages.wktutils python310Packages.zcs python39Packages.apache-beam python39Packages.aplpy python39Packages.asf-search python39Packages.autofaiss python39Packages.batchgenerators python39Packages.boxx python39Packages.bpycv python39Packages.bsuite python39Packages.caffe python39Packages.caffeWithCuda python39Packages.cartopy python39Packages.casa-formats-io python39Packages.clifford python39Packages.dask python39Packages.dask-gateway python39Packages.dask-glm python39Packages.dask-image python39Packages.dask-jobqueue python39Packages.dask-ml python39Packages.dask-mpi python39Packages.dask-yarn python39Packages.databricks-sql-connector python39Packages.datafusion python39Packages.datasets python39Packages.datashader python39Packages.db-dtypes python39Packages.devito python39Packages.distributed python39Packages.dremel3dpy python39Packages.easyocr python39Packages.embedding-reader python39Packages.env-canada python39Packages.fiona python39Packages.gdal python39Packages.geopandas python39Packages.glymur python39Packages.google-cloud-bigquery python39Packages.handout python39Packages.ibis-framework python39Packages.image-match python39Packages.imagecorruptions python39Packages.imageio python39Packages.intake python39Packages.intake-parquet python39Packages.moviepy python39Packages.napari python39Packages.napari-console python39Packages.napari-svg python39Packages.openai python39Packages.openai-whisper python39Packages.osmnx python39Packages.pandas-stubs python39Packages.pims python39Packages.plotnine python39Packages.psd-tools python39Packages.pyarrow python39Packages.pyfftw python39Packages.pygmt python39Packages.python-mapnik python39Packages.rasterio python39Packages.recordlinkage python39Packages.runway-python python39Packages.scikitimage python39Packages.shap python39Packages.slicedimage python39Packages.spacy-transformers python39Packages.sparse python39Packages.spectral-cube python39Packages.stanza python39Packages.streamz python39Packages.stumpy python39Packages.stytra python39Packages.tensorflow-datasets python39Packages.tensorly python39Packages.test-tube python39Packages.tifffile python39Packages.tokenizers python39Packages.transformers python39Packages.vqgan-jax python39Packages.wktutils python39Packages.zcs pytrainer qgis qgis-ltr qmapshack saga streamlit sumo tartube tartube-yt-dlp udig

error: build log of '/nix/store/rhm4mhnli262w2wylkmk04rw26l1ak1y-mysql-workbench-8.0.30.drv' is not available
error: build log of '/nix/store/lngzn6cfj5xfa2nb88n8f51vnjwkfjl1-mysql-workbench-8.0.30' is not available
$ /nix/store/gzd5wpvq9b5q5l3hvwpihgrhcrrllgi0-nix-2.11.1/bin/nix-shell /home/user/.cache/nixpkgs-review/rev-7d25283cee0d920bf09607f54e8864af90bae7ef/shell
.nix
error: Package ‘databricks-sql-cli-0.1.4’ in /home/user/.cache/nixpkgs-review/rev-7d25283cee0d920bf09607f54e8864af90bae7ef/nixpkgs/pkgs/applications/misc/
databricks-sql-cli/default.nix:59 has an unfree license (‘databricks’), refusing to evaluate.

       a) To temporarily allow unfree packages, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_UNFREE=1

        Note: For `nix shell`, `nix build`, `nix develop` or any other Nix 2.4+
        (Flake) command, `--impure` must be passed in order to read this
        environment variable.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowUnfree = true; }
       in configuration.nix to override this.

       Alternatively you can configure a predicate to allow specific packages:
         { nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
             "databricks-sql-cli"
           ];
         }

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowUnfree = true; }
       to ~/.config/nixpkgs/config.nix.
(use '--show-trace' to show detailed location information)
$ git worktree prune
```
</details>