### PR TITLE
keybinder: 0.3.0 -> 0.3.1; disable python bindings

### DIFF
--- a/pkgs/development/libraries/keybinder/default.nix
+++ b/pkgs/development/libraries/keybinder/default.nix
@@ -1,10 +1,8 @@
 { lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, pkg-config, gnome
-, gtk-doc, gtk2, python2Packages, lua, gobject-introspection
+, gtk-doc, gtk2, lua, gobject-introspection
 }:
 
-let
-  inherit (python2Packages) python pygtk;
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "keybinder";
   version = "0.3.1";
 
@@ -16,13 +14,16 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config autoconf automake ];
+
   buildInputs = [
     libtool gnome.gnome-common gtk-doc gtk2
-    python pygtk lua gobject-introspection
+    lua gobject-introspection
   ];
 
+  configureFlags = [ "--disable-python" ];
+
   preConfigure = ''
-    ./autogen.sh --prefix="$out"
+    ./autogen.sh --prefix="$out" $configureFlags
   '';
 
   meta = with lib; {
@@ -36,8 +37,6 @@ in stdenv.mkDerivation rec {
       * A C library, ``libkeybinder``
       * Gobject-Introspection (gir)  generated bindings
       * Lua bindings, ``lua-keybinder``
-      * Python bindings, ``python-keybinder``
-      * An ``examples`` directory with programs in C, Lua, Python and Vala.
     '';
     homepage = "https://github.com/engla/keybinder/";
     license = licenses.gpl2Plus;

--- a/pkgs/development/libraries/keybinder/default.nix
+++ b/pkgs/development/libraries/keybinder/default.nix
@@ -6,13 +6,13 @@ let
   inherit (python2Packages) python pygtk;
 in stdenv.mkDerivation rec {
   pname = "keybinder";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "engla";
     repo = "keybinder";
     rev = "v${version}";
-    sha256 = "sha256-q/+hqhvXIknT+/5oENcWSr1OuF00kaZlXFUP1fdCMlk=";
+    sha256 = "sha256-elL6DZtzCwAtoyGZYP0jAma6tHPks2KAtrziWtBENGU=";
   };
 
   nativeBuildInputs = [ pkg-config autoconf automake ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Disable `python` bindings, since it depends on Python 2.

See reasoning: https://github.com/NixOS/nixpkgs/pull/201859

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
