### PR TITLE
[22.11] steamtinkerlaunch: init at 11.11

### DIFF
--- a/pkgs/tools/games/steamtinkerlaunch/default.nix
+++ b/pkgs/tools/games/steamtinkerlaunch/default.nix
@@ -1,0 +1,62 @@
+{ bash
+, gawk
+, git
+, gnugrep
+, fetchFromGitHub
+, installShellFiles
+, lib
+, makeWrapper
+, stdenv
+, unixtools
+, unzip
+, wget
+, xdotool
+, xorg
+, yad
+}:
+
+stdenv.mkDerivation rec {
+  pname = "steamtinkerlaunch";
+  version = "11.11";
+
+  src = fetchFromGitHub {
+    owner = "sonic2kk";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-rWENtgV6spokzkhnmrrzsAQ19dROJ50ofEulU5Jx5IE=";
+  };
+
+  # hardcode PROGCMD because #150841
+  postPatch = ''
+    substituteInPlace steamtinkerlaunch --replace 'PROGCMD="''${0##*/}"' 'PROGCMD="steamtinkerlaunch"'
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installFlags = [ "PREFIX=\${out}" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/steamtinkerlaunch --prefix PATH : ${lib.makeBinPath [
+      bash
+      gawk
+      git
+      gnugrep
+      unixtools.xxd
+      unzip
+      wget
+      xdotool
+      xorg.xprop
+      xorg.xrandr
+      xorg.xwininfo
+      yad
+    ]}
+  '';
+
+  meta = with lib; {
+    description = "Linux wrapper tool for use with the Steam client for custom launch options and 3rd party programs";
+    homepage = "https://github.com/sonic2kk/steamtinkerlaunch";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ urandom ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1440,6 +1440,8 @@ with pkgs;
 
   spectre-cli = callPackage ../tools/security/spectre-cli { };
 
+  steamtinkerlaunch = callPackage ../tools/games/steamtinkerlaunch {};
+
   sx-go = callPackage ../tools/security/sx-go { };
 
   systeroid = callPackage ../tools/system/systeroid { };


### PR DESCRIPTION
###### Description of changes

Cherry-pick of #200157. @urandom2 @SuperSandro2000 

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).