### PR TITLE
dokuwiki: Combine mechanism for plugins and templates

### DIFF
--- a/nixos/tests/dokuwiki.nix
+++ b/nixos/tests/dokuwiki.nix
@@ -142,6 +142,14 @@ in {
               "curl -sSfL 'http://site2.local/doku.php?id=plugin-list' | (! grep 'plugin:tag')",
           )
 
+          # Test if theme is applied and working correctly (no weired relative PHP import errors)
+          machine.succeed(
+            "curl -sSfL 'http://site1.local/doku.php' | grep 'bootstrap3/images/logo.png'",
+            "curl -sSfL 'http://site1.local/lib/exe/css.php' | grep 'bootstrap3'",
+            "curl -sSfL 'http://site1.local/lib/tpl/bootstrap3/css.php'",
+          )
+
+
         # Just to ensure both Webserver configurations are consistent in allowing that
         with subtest("Rewriting"):
           machine.succeed(

--- a/pkgs/servers/web-apps/dokuwiki/default.nix
+++ b/pkgs/servers/web-apps/dokuwiki/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, writeText, nixosTests }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, writeText
+, nixosTests
+, dokuwiki
+}:
 
 stdenv.mkDerivation rec {
   pname = "dokuwiki";
@@ -38,15 +44,41 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/dokuwiki
     cp -r * $out/share/dokuwiki
     cp ${preload} $out/share/dokuwiki/inc/preload.php
     cp ${phpLocalConfig} $out/share/dokuwiki/conf/local.php
     cp ${phpPluginsLocalConfig} $out/share/dokuwiki/conf/plugins.local.php
+
+    runHook postInstall
   '';
 
-  passthru.tests = {
-    inherit (nixosTests) dokuwiki;
+  passthru = {
+    combine = { basePackage ? dokuwiki
+      , plugins ? []
+      , templates ? []
+      , localConfig ? null
+      , pluginsConfig ? null
+      , aclConfig ? null
+      , pname ? (p: "${p.pname}-combined")
+    }: let
+      isNotEmpty = x: lib.optionalString (! builtins.elem x [ null "" ]);
+    in basePackage.overrideAttrs (prev: {
+      pname = if builtins.isFunction pname then pname prev else pname;
+
+      postInstall = prev.postInstall or "" + ''
+        ${lib.concatMapStringsSep "\n" (tpl: "cp -r ${toString tpl} $out/share/dokuwiki/lib/tpl/${tpl.name}") templates}
+        ${lib.concatMapStringsSep "\n" (plugin: "cp -r ${toString plugin} $out/share/dokuwiki/lib/plugins/${plugin.name}") plugins}
+        ${isNotEmpty localConfig "ln -sf ${localConfig} $out/share/dokuwiki/conf/local.php" }
+        ${isNotEmpty pluginsConfig "ln -sf ${pluginsConfig} $out/share/dokuwiki/conf/plugins.local.php" }
+        ${isNotEmpty aclConfig "ln -sf ${aclConfig} $out/share/dokuwiki/acl.auth.php" }
+      '';
+    });
+    tests = {
+      inherit (nixosTests) dokuwiki;
+    };
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Copy templates and plugins into Dokuwiki instead of linking to address template compatibility. As noted by @sinavir[^1], (some) templates would fail due to relative PHP imports.

This is derived from #208299 in an attempt to split multiple changes into simpler, standalone, PRs.

[^1]: https://github.com/NixOS/nixpkgs/pull/208299#issuecomment-1370413116
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
