### PR TITLE
pkgsStatic.gsasl: fix build

### DIFF
--- a/pkgs/development/libraries/gsasl/default.nix
+++ b/pkgs/development/libraries/gsasl/default.nix
@@ -9,6 +9,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-ebho47mXbcSE1ZspygroiXvpbOTTbTKu1dk1p6Mwd1k=";
   };
 
+  # This is actually bug in musl. It is already fixed in trunc and
+  # this patch won't be necessary with musl > 1.2.3.
+  #
+  # https://git.musl-libc.org/cgit/musl/commit/?id=b50eb8c36c20f967bd0ed70c0b0db38a450886ba
+  patches = lib.optional stdenv.hostPlatform.isMusl ./gsasl.patch;
+
   buildInputs = [ libidn libkrb5 ];
 
   configureFlags = [ "--with-gssapi-impl=mit" ];

--- a/pkgs/development/libraries/gsasl/gsasl.patch
+++ b/pkgs/development/libraries/gsasl/gsasl.patch
@@ -1,0 +1,21 @@
+GNU libc and Musl libc have different ideas what
+
+    strverscmp("UNKNOWN", "2.2.0")
+
+should return. Hopefully nobody depend on this particular behaviour in
+practice.
+
+--- a/tests/version.c	1970-01-01 00:00:00.000000000 -0000
++++ b/tests/version.c	1970-01-01 00:00:00.000000000 -0000
+@@ -111,11 +111,5 @@
+       exit_code = EXIT_FAILURE;
+     }
+ 
+-  if (gsasl_check_version ("UNKNOWN"))
+-    {
+-      printf ("FAIL: gsasl_check_version (UNKNOWN)\n");
+-      exit_code = EXIT_FAILURE;
+-    }
+-
+   return exit_code;
+ }


### PR DESCRIPTION

GNU libc and Musl libc have different ideas what

    strverscmp("UNKNOWN", "2.2.0")

should return. Upstream of gsasl naturally relies on GNU libc behaviour, so I
patch-out this test for musl builds.

According to Musl maintainer, this is bug on musl side.
=> https://www.openwall.com/lists/musl/2022/11/06/2

maintainers: @rbvermaa @relrod @SuperSandro2000
build log on x86_64 NixOS: https://gist.github.com/247d9e9081144b3d2c3bae1f7564b002
