### PR TITLE
process-compose: 0.29.1 -> 0.29.7

### DIFF
--- a/pkgs/applications/misc/process-compose/default.nix
+++ b/pkgs/applications/misc/process-compose/default.nix
@@ -4,21 +4,39 @@
 , installShellFiles
 }:
 
+let config-module = "github.com/f1bonacc1/process-compose/src/config";
+in
 buildGoModule rec {
   pname = "process-compose";
-  version = "0.29.1";
+  version = "0.29.7";
 
   src = fetchFromGitHub {
     owner = "F1bonacc1";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-FB0PjvPBfbytIXwYs+eT9PMnKX/yymrajlJ42FDlMFs=";
+    hash = "sha256-gVXil6Gc65/6VMuONfVyxU6SSV0vCbJKXDvtG4a+pbU=";
+    # populate values that require us to use git. By doing this in postFetch we
+    # can delete .git afterwards and maintain better reproducibility of the src.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse --short HEAD > $out/COMMIT
+      # in format of 0000-00-00T00:00:00Z
+      date -u -d "@$(git log -1 --pretty=%ct)" "+%Y-%m-%dT%H:%M:%SZ" > $out/SOURCE_DATE_EPOCH
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
   };
 
+  # ldflags based on metadata from git and source
+  preBuild = ''
+    ldflags+=" -X ${config-module}.Commit=$(cat COMMIT)"
+    ldflags+=" -X ${config-module}.Date=$(cat SOURCE_DATE_EPOCH)"
+  '';
+
   ldflags = [
+    "-X ${config-module}.Version=v${version}"
     "-s"
     "-w"
-    "-X main.version=v${version}"
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

https://github.com/F1bonacc1/process-compose/releases/tag/v0.29.7

Set up new build flags as per the maintainers directions:
https://github.com/F1bonacc1/process-compose/pull/36

~AFAICT There is no good way of using `fetchFromGitHub` and get the proper commit/commit date data.~
~See: https://github.com/NixOS/nixpkgs/issues/106543~
~Please enlighten me if it's possible :)~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
