### PR TITLE
pythonPackages.lookatme: reintroduce at 2.5.0

### DIFF
--- a/pkgs/development/python-modules/lookatme/default.nix
+++ b/pkgs/development/python-modules/lookatme/default.nix
@@ -1,0 +1,109 @@
+{ lib
+, python3
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, setuptools
+, click
+, pygments
+, urwid
+, pytest-mock
+, pytestCheckHook
+, six
+}:
+
+let
+  python3_ = python3.override {
+    packageOverrides = self: super: {
+      # Requires marshmallow<4,>=3.17.0
+      # Currently marshmallow is version 3.16.0 in nixpkgs
+      # Update of marshmallow to 3.19.0 breaks a bunch of other stuff
+      marshmallow = super.marshmallow.overridePythonAttrs (oldAttrs: rec {
+        name = "${oldAttrs.pname}-${version}";
+        version = "3.19.0";
+        src = fetchFromGitHub {
+          owner = "marshmallow-code";
+          repo = "marshmallow";
+          rev = "refs/tags/${version}";
+          sha256 = "sha256-b1brLHM48t45bwUXk7QreLLmvTzU0sX7Uoc1ZAgGkrE=";
+        };
+      });
+      # Requires mistune>=0.8,<1
+      mistune = super.mistune.overridePythonAttrs (oldAttrs: rec {
+        name = "${oldAttrs.pname}-${version}";
+        version = "0.8.4";
+        src = fetchFromGitHub {
+          owner = "lepture";
+          repo = "mistune";
+          rev = "refs/tags/v${version}";
+          sha256 = "sha256-H9L2cJZVWvcbcWAF8ZMLGJGE7DO1h2wNZCbeFA02p7g=";
+        };
+      });
+      # Requires PyYAML>=5,<6
+      pyyaml = super.pyyaml.overridePythonAttrs (oldAttrs: rec {
+        name = "${oldAttrs.pname}-${version}";
+        version = "5.4.1.1";
+        src = fetchFromGitHub {
+          owner = "yaml";
+          repo = "pyyaml";
+          rev = "refs/tags/${version}";
+          sha256 = "sha256-qLdAMqoyEXRIqcNuHBBtST8GWh5gmx5fBU/q3f4zaOw=";
+        };
+        checkPhase = ''
+          runHook preCheck
+          PYTHONPATH="tests/lib3:$PYTHONPATH" ${self.python.interpreter} -m test_all
+          runHook postCheck
+        '';
+      });
+    };
+  };
+in
+with python3_.pkgs;
+buildPythonPackage rec {
+  pname = "lookatme";
+  version = "2.5.0";
+  format = "setuptools";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "d0c-s4vage";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-mn28OLIlxk97aDow1dTBsMRxVTkCqVeiAtrlyh8zJTg=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    click
+    marshmallow
+    mistune
+    pygments
+    pyyaml
+    urwid
+  ];
+
+  pythonImportsCheck = [ "lookatme" ];
+
+  checkInputs = [
+    pytest-mock
+    pytestCheckHook
+    six
+  ];
+
+  # Tutorial added with recent version; tests are still flaky so let's disable them for now
+  disabledTests = [
+    "test_tutorial_basic"
+    "test_tutor"
+  ];
+
+  meta = with lib; {
+    description = "Interactive, extensible, terminal-based markdown presentation tool";
+    homepage = "https://lookatme.readthedocs.io/en/v${version}/";
+    changelog = "https://github.com/d0c-s4vage/lookatme/releases/tag/v${version}";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ ameer totoroot ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8790,6 +8790,8 @@ with pkgs;
 
   lolcat = callPackage ../tools/misc/lolcat { };
 
+  lookatme = python3Packages.callPackage ../development/python-modules/lookatme { };
+
   lottieconverter = callPackage ../tools/misc/lottieconverter { };
 
   loudgain = callPackage ../tools/audio/loudgain/default.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5466,6 +5466,8 @@ self: super: with self; {
 
   lomond = callPackage ../development/python-modules/lomond { };
 
+  lookatme = callPackage ../development/python-modules/lookatme { };
+
   loopy = callPackage ../development/python-modules/loopy { };
 
   losant-rest = callPackage ../development/python-modules/losant-rest { };


### PR DESCRIPTION
###### Description of changes

Add [lookatme](https://github.com/d0c-s4vage/lookatme), an interactive, extensible, terminal-based markdown presentation tool.

It got removed earlier this year in PR #170162 due to a Python2 dependency with click version 7.
The [dependencies got relaxed](https://github.com/d0c-s4vage/lookatme/pull/141), so click version 8 is now allowed as well.

I added the former maintainer @AmeerTaweel to lookatme's maintainers as well as myself as I've been using it now and then recently.
I also added tests. It builds fine on x86_64-linux, and I'll test building on x86_64-darwin soon as well.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
closes https://github.com/NixOS/nixpkgs/issues/208969