### PR TITLE
kubo-migrator: add migration from 12 to 13

### DIFF
--- a/pkgs/applications/networking/kubo-migrator/all-migrations.nix
+++ b/pkgs/applications/networking/kubo-migrator/all-migrations.nix
@@ -36,8 +36,9 @@ let
   };
 
   # Concatenation of the latest repo version and the version of that migration
-  version = "12.1.0.2";
+  version = "13.1.0.0";
 
+  fs-repo-12-to-13 = fs-repo-common "fs-repo-12-to-13" "1.0.0";
   fs-repo-11-to-12 = fs-repo-common "fs-repo-11-to-12" "1.0.2";
   fs-repo-10-to-11 = fs-repo-common "fs-repo-10-to-11" "1.0.1";
   fs-repo-9-to-10  = fs-repo-common "fs-repo-9-to-10"  "1.0.1";
@@ -52,6 +53,7 @@ let
   fs-repo-0-to-1   = fs-repo-common "fs-repo-0-to-1"   "1.0.1";
 
   all-migrations = [
+    fs-repo-12-to-13
     fs-repo-11-to-12
     fs-repo-10-to-11
     fs-repo-9-to-10

--- a/pkgs/applications/networking/kubo-migrator/all-migrations.nix
+++ b/pkgs/applications/networking/kubo-migrator/all-migrations.nix
@@ -15,6 +15,19 @@ let
     inherit (kubo-migrator-unwrapped) src;
     sourceRoot = "source/${pname}";
     vendorSha256 = null;
+    # Fix build on Go 1.17 and later: panic: qtls.ClientHelloInfo doesn't match
+    # See https://github.com/ipfs/fs-repo-migrations/pull/163
+    postPatch = lib.optionalString (lib.elem pname [ "fs-repo-10-to-11" "fs-repo-11-to-12" ]) ''
+      substituteInPlace 'vendor/github.com/marten-seemann/qtls-go1-15/common.go' \
+        --replace \
+          '"container/list"' \
+          '"container/list"
+          "context"' \
+        --replace \
+          'config *Config' \
+          'config *Config
+          ctx context.Context'
+    '';
     doCheck = false;
     meta = kubo-migrator-unwrapped.meta // {
       mainProgram = pname;

--- a/pkgs/applications/networking/kubo-migrator/unwrapped.nix
+++ b/pkgs/applications/networking/kubo-migrator/unwrapped.nix
@@ -15,13 +15,13 @@ buildGoModule rec {
     # The fs-repo-migrations code itself is the same between
     # the two versions but the migration code, which is built
     # into separate binaries, is not.
-    rev = "fs-repo-11-to-12/v1.0.2";
-    sha256 = "sha256-CG4utwH+/+Igw+SP3imhl39wijlB53UGtkJG5Mwh+Ik=";
+    rev = "fs-repo-12-to-13/v1.0.0";
+    hash = "sha256-QQone7E2Be+jVfnrwqQ1Ny4jo6mSDHhaY3ErkNdn2f8=";
   };
 
   sourceRoot = "source/fs-repo-migrations";
 
-  vendorSha256 = "sha256-/DqkBBtR/nU8gk3TFqNKY5zQU6BFMc3N8Ti+38mi/jk=";
+  vendorHash = "sha256-/DqkBBtR/nU8gk3TFqNKY5zQU6BFMc3N8Ti+38mi/jk=";
 
   doCheck = false;
 


### PR DESCRIPTION
###### Description of changes
https://github.com/ipfs/fs-repo-migrations/releases/tag/fs-repo-12-to-13%2Fv1.0.0
This will be used to upgrade the Kubo repo when updating to Kubo 0.18.

Two old migrations were broken since Go 1.16 was removed from Nixpkgs.
Upstream is not interested in fixing the migrations to work with newer Go versions: https://github.com/ipfs/fs-repo-migrations/pull/163#issuecomment-1397311134.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).