### PR TITLE
zsh-forgit: 22.12.0 -> 23.01.0

### DIFF
--- a/pkgs/shells/zsh/zsh-forgit/default.nix
+++ b/pkgs/shells/zsh/zsh-forgit/default.nix
@@ -1,14 +1,25 @@
-{ stdenv, lib, bash, fetchFromGitHub, makeWrapper, fzf, git }:
+{ stdenv
+, lib
+, bash
+, coreutils
+, findutils
+, fetchFromGitHub
+, fzf
+, git
+, gnugrep
+, gnused
+, makeWrapper
+}:
 
 stdenv.mkDerivation rec {
   pname = "zsh-forgit";
-  version = "22.12.0";
+  version = "23.01.0";
 
   src = fetchFromGitHub {
     owner = "wfxr";
     repo = "forgit";
     rev = version;
-    sha256 = "0juBNUJW4SU3Cl6ouD+xMYzlCJOL7NAYpueZ6V56/ck=";
+    sha256 = "sha256-guAjxFhtybbRyRRXDELDHrM2Xzmi96wPxD2nhL9Ifmk=";
   };
 
   strictDeps = true;
@@ -16,9 +27,6 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace forgit.plugin.zsh \
       --replace "\$INSTALL_DIR/bin/git-forgit" "$out/bin/git-forgit"
-
-    substituteInPlace bin/git-forgit \
-      --replace "/bin/bash" "${bash}/bin/bash"
   '';
 
   dontBuild = true;
@@ -31,7 +39,7 @@ stdenv.mkDerivation rec {
     install -D bin/git-forgit $out/bin/git-forgit
     install -D forgit.plugin.zsh $out/share/zsh/${pname}/forgit.plugin.zsh
     wrapProgram $out/bin/git-forgit \
-      --prefix PATH : ${lib.makeBinPath [ fzf git ]}
+      --prefix PATH : ${lib.makeBinPath [ bash coreutils findutils fzf git gnugrep gnused ]}
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Description of changes

Update zsh-forgit to the latest version: https://github.com/wfxr/forgit/releases/tag/23.01.0. This release contains a few bug fixes, and one new feature.

Significantly, `SHELL=/bin/bash` was replaced with `SHELL="$(which bash)"`, so we can remove one of the calls to `substituteInPlace`, and update the call to `makeBinPath` (I have also added some other packages there, that were missing).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
