### PR TITLE
python3Packages.shap: fix `pythonImportsCheck` typo

### DIFF
--- a/pkgs/development/python-modules/shap/default.nix
+++ b/pkgs/development/python-modules/shap/default.nix
@@ -130,7 +130,7 @@ buildPythonPackage rec {
 
   #pytestFlagsArray = ["-x" "-W" "ignore"]; # uncomment this to debug
 
-  pythonImportCheck = [
+  pythonImportsCheck = [
     "shap"
     "shap.explainers"
     "shap.explainers.other"


### PR DESCRIPTION
#### Copy of commit msg
Previously, the imports check wasn't executed due to a typo.