### PR TITLE
rare: relax legendary-gl

### DIFF
--- a/pkgs/games/rare/default.nix
+++ b/pkgs/games/rare/default.nix
@@ -1,5 +1,15 @@
-{ lib, fetchFromGitHub, buildPythonApplication, qt5
-, legendary-gl, pypresence, pyqt5, python, qtawesome, requests, typing-extensions }:
+{ lib
+, fetchFromGitHub
+, buildPythonApplication
+, qt5
+, legendary-gl
+, pypresence
+, pyqt5
+, python
+, qtawesome
+, requests
+, typing-extensions
+}:
 
 buildPythonApplication rec {
   pname = "rare";
@@ -25,7 +35,11 @@ buildPythonApplication rec {
     typing-extensions
   ];
 
-  patches = [ ./fix-instance.patch ];
+  patches = [
+    ./fix-instance.patch
+    # Not able to run pythonRelaxDepsHook because of https://github.com/NixOS/nixpkgs/issues/198342
+    ./legendary-gl-version.patch
+  ];
 
   dontWrapQtApps = true;
 

--- a/pkgs/games/rare/legendary-gl-version.patch
+++ b/pkgs/games/rare/legendary-gl-version.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 2416360..08de818 100644
+--- a/setup.py
++++ b/setup.py
+@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
+ 
+ requirements = [
+     "requests<3.0",
+-    "legendary-gl==0.20.31",
++    "legendary-gl~=0.20.31",
+     "setuptools",
+     "wheel",
+     "PyQt5",


### PR DESCRIPTION
Not able to run pythonRelaxDepsHook because of https://github.com/NixOS/nixpkgs/issues/198342 (The wheel name start with Rare). As the dependency version must match, this is limiting the merge of #199882, so the patch will allow compatible releases for the moment.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
