### PR TITLE
build-dotnet-module: avoid `/run/user` for downloading packages 

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -190,7 +190,13 @@ stdenvNoCC.mkDerivation (args // {
             esac
         done
 
-        export tmp=$(mktemp -td "${pname}-tmp-XXXXXX")
+        if [[ ''${TMPDIR:-} == /run/user/* ]]; then
+           # /run/user is usually a tmpfs in RAM, which may be too small
+           # to store all downloaded dotnet packages
+           TMPDIR=
+        fi
+
+        export tmp=$(mktemp -d "deps-${pname}-XXXXXX")
         HOME=$tmp/home
 
         exitTrap() {


### PR DESCRIPTION
#### Copy of commit msg
Inside `nix-shell`, `TMPDIR` (used by `mktemp`) is set to `/run/user/<uid>` which is usually a tmpfs stored in RAM.

When fetching a large dotnet deps tree to this tmpdir from a nix-shell (e.g. via `btcpayserver/update.sh`), this can easily exceed system RAM and `fetch-deps` fails.

mktemp arg `-t` is deprecated and can be omitted.