### PR TITLE
vdrift: unstable-2017-12-09 -> unstable-2021-09-05

### DIFF
--- a/pkgs/games/vdrift/default.nix
+++ b/pkgs/games/vdrift/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , fetchsvn
 , pkg-config
 , sconsPackages
@@ -17,12 +16,12 @@
 
 , data ? fetchsvn {
     url = "svn://svn.code.sf.net/p/vdrift/code/vdrift-data";
-    rev = "1386";
-    sha256 = "0ka6zir9hg0md5p03dl461jkvbk05ywyw233hnc3ka6shz3vazi1";
+    rev = "1446";
+    sha256 = "sha256-KEu49GAOfenPyuaUItt6W9pkuqUNpXgmTSFuc7ThljQ=";
   }
 }:
 let
-  version = "unstable-2017-12-09";
+  version = "unstable-2021-09-05";
   bin = stdenv.mkDerivation {
     pname = "vdrift";
     inherit version;
@@ -30,8 +29,8 @@ let
     src = fetchFromGitHub {
       owner = "vdrift";
       repo = "vdrift";
-      rev = "12d444ed18395be8827a21b96cc7974252fce6d1";
-      sha256 = "001wq3c4n9wzxqfpq40b1jcl16sxbqv2zbkpy9rq2wf9h417q6hg";
+      rev = "7e9e00c8612b2014d491f026dd86b03f9fb04dcd";
+      sha256 = "sha256-DrzRF4WzwEXCNALq0jz8nHWZ1oYTEsdrvSYVYI1WkTI=";
     };
 
     nativeBuildInputs = [ pkg-config sconsPackages.scons_latest ];
@@ -39,16 +38,6 @@ let
 
     patches = [
       ./0001-Ignore-missing-data-for-installation.patch
-      (fetchpatch {
-        name = "scons-python-3-fixes.patch";
-        url = "https://github.com/VDrift/vdrift/commit/2f1f72f2a7ce992b0aad30dc55509b966d1bb63d.patch";
-        sha256 = "sha256-gpIB95b1s+wpThbNMFXyftBPXkZs9SIjuCcvt068uR8=";
-      })
-      (fetchpatch {
-        name = "sconstruct-python-3-fix.patch";
-        url = "https://github.com/VDrift/vdrift/commit/7d04c723a165109e015204642f4984a1a4452ccb.patch";
-        sha256 = "sha256-ASEV46HnR90HXqI9SgHmkH2bPy5Y+vWN57vEN4hJMts=";
-      })
     ];
 
     buildPhase = ''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Got it to work after the #209320 merge.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
