### PR TITLE
lib.path.difference: init

### DIFF
--- a/lib/path/default.nix
+++ b/lib/path/default.nix
@@ -118,11 +118,11 @@ let
   # (generally `/`) and a subpath
   deconstructPath =
     let
-      go = components: path:
+      recurse = components: path:
         # If the parent of a path is the path itself, then it's a filesystem root
         if path == dirOf path then { root = path; inherit components; }
-        else go ([ (baseNameOf path) ] ++ components) (dirOf path);
-    in go [];
+        else recurse ([ (baseNameOf path) ] ++ components) (dirOf path);
+    in recurse [];
 
 in /* No rec! Add dependencies on this file at the top. */ {
 
@@ -206,7 +206,7 @@ in /* No rec! Add dependencies on this file at the top. */ {
 
       commonAncestorLength =
         let
-          go = index:
+          recurse = index:
             let firstComponent = elemAt firstPath.components index; in
             if all (path:
                 # If all paths have another level of components
@@ -214,12 +214,12 @@ in /* No rec! Add dependencies on this file at the top. */ {
                 # And they all match
                 && elemAt path.components index == firstComponent
               ) deconstructedPaths
-            then go (index + 1)
+            then recurse (index + 1)
             else index;
         in
           # Ensure that we have a common root before trying to find a common ancestor
           # If we didn't do this one could evaluate `relativePaths` without an error even when there's no common root
-          seq commonRoot (go 0);
+          seq commonRoot (recurse 0);
 
       commonAncestor = commonRoot
         + ("/" + joinRelPath (take commonAncestorLength firstPath.components));

--- a/lib/path/default.nix
+++ b/lib/path/default.nix
@@ -197,7 +197,11 @@ in /* No rec! Add dependencies on this file at the top. */ {
           trigger = foldl'
             (skip: path:
               if path.root == firstPath.root then skip
-              else throw "lib.path.difference: Path ${firstPath.name} = ${toString firstPath.value} (root ${toString firstPath.root}) has a different filesystem root than path ${toString path.name} = ${toString path.value} (root ${toString path.root})")
+              else throw ''
+                lib.path.difference: Filesystem roots must be the same for all paths, but paths with different roots were given:
+                  ${firstPath.name} = ${toString firstPath.value} (root ${toString firstPath.root})
+                  ${toString path.name} = ${toString path.value} (root ${toString path.root})''
+            )
             null
             deconstructedPaths;
           fallbackAbort =

--- a/lib/path/default.nix
+++ b/lib/path/default.nix
@@ -175,9 +175,9 @@ in /* No rec! Add dependencies on this file at the top. */ {
   /* Determine the difference between multiple paths, including the longest
     common prefix and the individual suffixes between them
 
-    The input is an attribute set of paths, where the keys are only for naming
-    and can be picked arbitrarily. The returned attribute set contains two
-    attributes:
+    The input is an attribute set of paths, where the keys are only for user
+    convenience and can be chosen arbitrarily. The returned attribute set
+    contains two attributes:
 
     - `commonPrefix`: A path value containing the common prefix between all the
       given paths.

--- a/lib/path/default.nix
+++ b/lib/path/default.nix
@@ -182,7 +182,11 @@ in /* No rec! Add dependencies on this file at the top. */ {
         deconstructPath value // { inherit name value; }
       ) paths;
 
-      first = head deconstructed;
+      first =
+        assert assertMsg
+          (paths != {})
+          "lib.path.difference: An empty attribute set was given, but was expecting a non-empty attribute set";
+        head deconstructed;
 
       # The common root to all paths, errors if there are different roots
       commonRoot =
@@ -227,9 +231,6 @@ in /* No rec! Add dependencies on this file at the top. */ {
     assert assertMsg
       (isAttrs paths)
       "lib.path.difference: The given argument is of type ${typeOf paths}, but an attribute set was expected";
-    assert assertMsg
-      (paths != {})
-      "lib.path.difference: An empty attribute set was given, but was expecting a non-empty attribute set";
     {
       inherit commonAncestor subpaths;
     };

--- a/lib/path/tests/unit.nix
+++ b/lib/path/tests/unit.nix
@@ -3,7 +3,7 @@
 { libpath }:
 let
   lib = import libpath;
-  inherit (lib.path) append subpath;
+  inherit (lib.path) append difference subpath;
 
   cases = lib.runTests {
     # Test examples from the lib.path.append documentation
@@ -39,6 +39,38 @@ let
       expr = (builtins.tryEval (append /foo "../bar")).success;
       expected = false;
     };
+
+    # Test examples from the documentation
+    testDifferenceExample1 = {
+      expr = difference { foo = ./foo; bar = ./bar; };
+      expected = { commonPrefix = ./.; suffix = { foo = "./foo"; bar = "./bar"; }; };
+    };
+    testDifferenceExample2 = {
+      expr = difference { foo = ./foo; bar = ./.; };
+      expected = { commonPrefix = ./.; suffix = { foo = "./foo"; bar = "./."; }; };
+    };
+    testDifferenceExample3 = {
+      expr = difference { foo = ./foo; bar = ./foo; };
+      expected = { commonPrefix = ./foo; suffix = { foo = "./."; bar = "./."; }; };
+    };
+    testDifferenceExample4 = {
+      expr = difference { foo = ./foo; bar = ./foo/bar; };
+      expected = { commonPrefix = ./foo; suffix = { foo = "./."; bar = "./bar"; }; };
+    };
+    # Test that the invalid cases cause throws
+    testDifferenceNonAttrset = {
+      expr = (builtins.tryEval (difference 10).commonPrefix).success;
+      expected = false;
+    };
+    testDifferenceEmpty = {
+      expr = (builtins.tryEval (difference { }).commonPrefix).success;
+      expected = false;
+    };
+    testDifferenceNonPath = {
+      expr = (builtins.tryEval (difference { a = 10; }).commonPrefix).success;
+      expected = false;
+    };
+    # We can't test for multiple roots with the current Nix version though
 
     # Test examples from the lib.path.subpath.isValid documentation
     testSubpathIsValidExample1 = {


### PR DESCRIPTION
###### Description of changes

Calculates the difference between a set of paths, meaning the common ancestor and the individual subpaths of them. Example:

```nix
path.difference { x = /a/b/c/d; y = /a/b/u/v; }

-> { commonPrefix = /a/b; suffix = { x = "./c/d"; y = "./u/v"; }; }
```

Notably this implementation doesn't rely on calling `toString` on paths, which makes the implementation rather tricky. This implementation also ensures that the given paths have a matching filesystem root, otherwise it throws an error. The [lazy trees PR](https://github.com/NixOS/nix/pull/6530) is the only known case where this could happen:

```nix
let
  lazyPath = (fetchTree { url = ./.; type = "git"; }).outPath;
in (import ./. {}).lib.path.difference {
  x = ./.;
  y = lazyPath;
}
```

```
error: lib.path.difference: Path x = /home/tweagysil/antithesis/nixpkgs (root /) has a different filesystem
  root than path y = /home/tweagysil/antithesis/nixpkgs/ (root /home/tweagysil/antithesis/nixpkgs/
```

Originally implemented in #200718. Relates to other work in [the path library effort](https://github.com/NixOS/nixpkgs/issues/210426).

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles: 

###### Things done

- [ ] Documentation
- [ ] Tests