### PR TITLE
lib.attrsets: Add genAttrs'

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -551,9 +551,20 @@ rec {
     list:
     listToAttrs (map (n: nameValuePair n (f n)) list);
 
-  # DEPRECATED
-  genAttrs = lib.warn
-    "lib.genAttrs is deprecated, use lib.mapListToAttrs instead" (flip mapListToAttrs);
+  /* Generate an attribute set by mapping a function over a list of
+     attribute names.
+
+     Example:
+       genAttrs [ "foo" "bar" ] (name: "x_" + name)
+       => { bar = "x_bar"; foo = "x_foo"; }
+
+     Type:
+       genAttrs :: [String] -> (String -> Any) -> AttrSet
+  */
+  # TODO: DEPRECATE ON RELEASE
+  genAttrs =
+  #  lib.warn "lib.genAttrs is deprecated, use lib.mapListToAttrs instead"
+  (flip mapListToAttrs);
 
   /* Generate an attribute set by mapping a `NameValuePair` over a list of values.
 

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -552,6 +552,22 @@ rec {
     f:
     listToAttrs (map (n: nameValuePair n (f n)) names);
 
+  /* Generate an attribute set by mapping a `NameValuePair` over a list of values.
+
+     Example:
+       genAttrs' (v: lib.nameValuePair "key-${v}" "val-${v}") [ "foo" "bar" ]
+       => { key-bar = "val-bar"; key-foo = "val-foo"; }
+
+     Type:
+       genAttrs' :: (Any -> NameValuePair) -> [Any] -> AttrSet
+  */
+  genAttrs' =
+    # A function, given a value, returns a new `nameValuePair`
+    f:
+    # Values to map into resources
+    list:
+    listToAttrs (map f list);
+
 
   /* Check whether the argument is a derivation. Any set with
      `{ type = "derivation"; }` counts as a derivation.

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -534,35 +534,38 @@ rec {
         in mapAttrs g;
     in recurse [] set;
 
-
   /* Generate an attribute set by mapping a function over a list of
      attribute names.
 
      Example:
-       genAttrs [ "foo" "bar" ] (name: "x_" + name)
-       => { foo = "x_foo"; bar = "x_bar"; }
+       mapListToAttrs [ "foo" "bar" ] (name: "x_" + name)
+       => { bar = "x_bar"; foo = "x_foo"; }
 
      Type:
-       genAttrs :: [ String ] -> (String -> Any) -> AttrSet
+       mapListToAttrs :: [String] -> (String -> Any) -> AttrSet
   */
-  genAttrs =
-    # Names of values in the resulting attribute set.
-    names:
-    # A function, given the name of the attribute, returns the attribute's value.
+  mapListToAttrs =
+    # A function, given a string, that produces a corresponding value
     f:
-    listToAttrs (map (n: nameValuePair n (f n)) names);
+    # The list of strings to map
+    list:
+    listToAttrs (map (n: nameValuePair n (f n)) list);
+
+  # DEPRECATED
+  genAttrs = lib.warn
+    "lib.genAttrs is deprecated, use lib.mapListToAttrs instead" (flip mapListToAttrs);
 
   /* Generate an attribute set by mapping a `NameValuePair` over a list of values.
 
      Example:
-       genAttrs' (v: lib.nameValuePair "key-${v}" "val-${v}") [ "foo" "bar" ]
+       mapListToAttrs' (v: lib.nameValuePair "key-${v}" "val-${v}") [ "foo" "bar" ]
        => { key-bar = "val-bar"; key-foo = "val-foo"; }
 
      Type:
-       genAttrs' :: (Any -> NameValuePair) -> [Any] -> AttrSet
+       mapListToAttrs' :: (Any -> NameValuePair) -> [Any] -> AttrSet
   */
-  genAttrs' =
-    # A function, given a value, returns a new `nameValuePair`
+  mapListToAttrs' =
+    # A function, given a value, returns a `nameValuePair`
     f:
     # Values to map into resources
     list:

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -538,11 +538,11 @@ rec {
      attribute names.
 
      Example:
-       mapListToAttrs [ "foo" "bar" ] (name: "x_" + name)
+       mapListToAttrs (name: "x_" + name) [ "foo" "bar" ]
        => { bar = "x_bar"; foo = "x_foo"; }
 
      Type:
-       mapListToAttrs :: [String] -> (String -> Any) -> AttrSet
+       mapListToAttrs :: (String -> Any) -> [String] -> AttrSet
   */
   mapListToAttrs =
     # A function, given a string, that produces a corresponding value

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -80,7 +80,7 @@ let
       getAttrFromPath attrVals attrValues getAttrs catAttrs filterAttrs
       filterAttrsRecursive foldAttrs collect nameValuePair mapAttrs
       mapAttrs' mapAttrsToList concatMapAttrs mapAttrsRecursive mapAttrsRecursiveCond
-      genAttrs genAttrs' isDerivation toDerivation optionalAttrs
+      genAttrs mapListToAttrs mapListToAttrs' isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting showAttrPath getOutput getBin
       getLib getDev getMan chooseDevOutputs zipWithNames zip

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -80,7 +80,7 @@ let
       getAttrFromPath attrVals attrValues getAttrs catAttrs filterAttrs
       filterAttrsRecursive foldAttrs collect nameValuePair mapAttrs
       mapAttrs' mapAttrsToList concatMapAttrs mapAttrsRecursive mapAttrsRecursiveCond
-      genAttrs isDerivation toDerivation optionalAttrs
+      genAttrs genAttrs' isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting showAttrPath getOutput getBin
       getLib getDev getMan chooseDevOutputs zipWithNames zip

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -514,8 +514,24 @@ runTests {
     };
   };
 
-  testGenAttrs' = {
-    expr = genAttrs' (v: nameValuePair "key-${v}" "val-${v}") [ "foo" "bar" ];
+  testGenAttrs = {
+    expr = genAttrs [ "foo" "bar" ] (v: "val-${v}");
+    expected = {
+      foo = "val-foo";
+      bar = "val-bar";
+    };
+  };
+
+  testMapListToAttrs = {
+    expr = mapListToAttrs (v: "val-${v}") [ "foo" "bar" ];
+    expected = {
+      foo = "val-foo";
+      bar = "val-bar";
+    };
+  };
+
+  testMapListToAttrs' = {
+    expr = mapListToAttrs' (v: nameValuePair "key-${v}" "val-${v}") [ "foo" "bar" ];
     expected = {
       key-foo = "val-foo";
       key-bar = "val-bar";

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -514,6 +514,14 @@ runTests {
     };
   };
 
+  testGenAttrs' = {
+    expr = genAttrs' (v: nameValuePair "key-${v}" "val-${v}") [ "foo" "bar" ];
+    expected = {
+      key-foo = "val-foo";
+      key-bar = "val-bar";
+    };
+  };
+
   # code from the example
   testRecursiveUpdateUntil = {
     expr = recursiveUpdateUntil (path: l: r: path == ["foo"]) {


### PR DESCRIPTION
Add a relatively simple function to allow creating attrsets from lists with configurable key names.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Create an additional library function I personally use often that I believe others could benefit from.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

I wasn't 100% sure how to order the two function arguments. In most cases, I see the primary parameter as the last parameter so as to allow for eta reductions, as with `mapAttrs'`, but `genAttrs` has the "names" list as the first parameter for some reason.

I also wasn't sure if I should add `map` as an inherit alongside `head`, `tail`, and `length` on line 5, since some functions are there but others aren't.