### PR TITLE
electrs: 0.9.10 -> 0.9.11

### DIFF
--- a/pkgs/applications/blockchains/electrs/default.nix
+++ b/pkgs/applications/blockchains/electrs/default.nix
@@ -12,16 +12,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "electrs";
-  version = "0.9.10";
+  version = "0.9.11";
 
   src = fetchFromGitHub {
     owner = "romanz";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-GqFtCK5hxnEfIfw3ITufeu26yueknuFZhLtGSXmJ8fE=";
+    hash = "sha256-iudHdsSjoPal+ORMB3lU7ejGYv69q/8HcxScZS8D/u8=";
   };
 
-  cargoHash = "sha256-p4t+G13XaCl7+IbX5YyBFF0PmARbw4XlRvnA0PRcjvQ=";
+  cargoHash = "sha256-Ft1AluPfV6BIRGEddrrIGNRmaZIzUsA2DN2TcghCnSQ=";
 
   # needed for librocksdb-sys
   nativeBuildInputs = [ rustPlatform.bindgenHook ];


### PR DESCRIPTION
* [x] Built and run on `x86_64-linux`.

cc @prusnak