### PR TITLE
bdf2psf: 1.211 -> 1.215

### DIFF
--- a/pkgs/tools/misc/bdf2psf/default.nix
+++ b/pkgs/tools/misc/bdf2psf/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "bdf2psf";
-  version = "1.211";
+  version = "1.215";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/c/console-setup/bdf2psf_${version}_all.deb";
-    sha256 = "sha256-Kzmqnctc2RUMbU3hVGmcfXFWiZhf5epaaj2eW4nVajU=";
+    sha256 = "+xqxI4qaIJc6z7BcVDcKg4dhc+xH56ZEspWf7UPdHnY=";
   };
 
   nativeBuildInputs = [ dpkg ];
@@ -19,12 +19,14 @@ stdenv.mkDerivation rec {
     dpkg-deb -x $src .
     runHook postUnpack
   '';
-  installPhase = "
+
+  installPhase = ''
     runHook preInstall
-    substituteInPlace usr/bin/bdf2psf --replace /usr/bin/perl ${perl}/bin/perl
-    mv usr $out
+    substituteInPlace usr/bin/bdf2psf --replace /usr/bin/perl "${perl}/bin/perl"
+    rm usr/share/doc/bdf2psf/changelog.gz
+    mv usr "$out"
     runHook postInstall
-  ";
+  '';
 
   meta = with lib; {
     description = "BDF to PSF converter";
@@ -34,6 +36,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ rnhmjoj vrthra ];
-    platforms = platforms.unix;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Description of changes

Version bump

Note: this is useless because bdf2psf tracks the console-setup package and is released even if the script is unchanged.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change (unnecessary as it's basically fixed-output)
- [x] Tested basic functionality of all binary files
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
