### PR TITLE
meshtastic: fix version and add to all-packages

### DIFF
--- a/pkgs/development/python-modules/meshtastic/default.nix
+++ b/pkgs/development/python-modules/meshtastic/default.nix
@@ -73,6 +73,15 @@ buildPythonPackage rec {
     "meshtastic"
   ];
 
+  patches = [
+    ./version.patch
+  ];
+
+  postPatch = ''
+    echo v${version}
+    substituteInPlace meshtastic/__main__.py meshtastic/util.py --replace %VERSION% ${version}
+  '';
+
   disabledTests = [
     # AttributeError: 'HardwareMessage'...
     "test_handleFromRadio_with_my_info"

--- a/pkgs/development/python-modules/meshtastic/default.nix
+++ b/pkgs/development/python-modules/meshtastic/default.nix
@@ -51,6 +51,7 @@ buildPythonPackage rec {
     setuptools
     tabulate
     timeago
+    pytap2
   ];
 
   passthru.optional-dependencies = {

--- a/pkgs/development/python-modules/meshtastic/version.patch
+++ b/pkgs/development/python-modules/meshtastic/version.patch
@@ -1,0 +1,43 @@
+diff --git a/meshtastic/__main__.py b/meshtastic/__main__.py
+index 6a2f31c..bc3e1b4 100644
+--- a/meshtastic/__main__.py
++++ b/meshtastic/__main__.py
+@@ -9,7 +9,6 @@ import platform
+ import sys
+ import time
+ 
+-import pkg_resources
+ import pyqrcode
+ import yaml
+ from google.protobuf.json_format import MessageToDict
+@@ -1351,7 +1350,7 @@ def initParser():
+ 
+     parser.set_defaults(deprecated=None)
+ 
+-    the_version = pkg_resources.get_distribution("meshtastic").version
++    the_version = "%VERSION%"
+     parser.add_argument("--version", action="version", version=f"{the_version}")
+ 
+     parser.add_argument(
+diff --git a/meshtastic/util.py b/meshtastic/util.py
+index 7a5dd10..81b5af9 100644
+--- a/meshtastic/util.py
++++ b/meshtastic/util.py
+@@ -269,7 +269,7 @@ def support_info():
+     print(f"   Machine: {platform.uname().machine}")
+     print(f"   Encoding (stdin): {sys.stdin.encoding}")
+     print(f"   Encoding (stdout): {sys.stdout.encoding}")
+-    the_version = pkg_resources.get_distribution("meshtastic").version
++    the_version = "%VERSION%"
+     pypi_version = check_if_newer_version()
+     if pypi_version:
+         print(
+@@ -599,7 +599,7 @@ def check_if_newer_version():
+         pypi_version = data["info"]["version"]
+     except Exception:
+         pass
+-    act_version = pkg_resources.get_distribution("meshtastic").version
++    act_version = "%VERSION%"
+     if pypi_version and pkg_resources.parse_version(
+         pypi_version
+     ) <= pkg_resources.parse_version(act_version):

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33542,6 +33542,8 @@ with pkgs;
 
   meshlab = libsForQt5.callPackage ../applications/graphics/meshlab { };
 
+  meshtastic = with python3Packages; toPythonApplication meshtastic;
+
   metadata-cleaner = callPackage ../applications/misc/metadata-cleaner { };
 
   metersLv2 = callPackage ../applications/audio/meters_lv2 { };


### PR DESCRIPTION
###### Description of changes
Patch out pkg_resources (https://setuptools.pypa.io/en/latest/pkg_resources.html)
Add meshtastic to all-packages, as it is mostly used as cli to control meshtastic devices.

###### Things done
- patch out pkg_resources and replace version with substituteInPlace ${version}
- Add meshtastic to all-packages

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
