### PR TITLE
Fixed protobuf override

### DIFF
--- a/pkgs/development/libraries/protobuf/3.17.nix
+++ b/pkgs/development/libraries/protobuf/3.17.nix
@@ -1,6 +1,6 @@
-{ callPackage, ... }:
+{ callPackage, ... } @ args:
 
-callPackage ./generic-v3.nix {
+callPackage ./generic-v3.nix ({
   version = "3.17.3";
   sha256 = "08644kaxhpjs38q5q4fp01yr0wakg1ijha4g3lzp2ifg7y3c465d";
-}
+} // args)

--- a/pkgs/development/libraries/protobuf/3.19.nix
+++ b/pkgs/development/libraries/protobuf/3.19.nix
@@ -1,6 +1,6 @@
-{ callPackage, ... }:
+{ callPackage, ... } @ args:
 
-callPackage ./generic-v3.nix {
+callPackage ./generic-v3.nix ({
   version = "3.19.6";
   sha256 = "sha256-+ul9F8tyrwk2p25Dd9ragqwpYzdxdeGjpXhLAwKYWfM=";
-}
+} // args)

--- a/pkgs/development/libraries/protobuf/3.20.nix
+++ b/pkgs/development/libraries/protobuf/3.20.nix
@@ -1,6 +1,6 @@
-{ callPackage, abseil-cpp, ... }:
+{ callPackage, ... } @ args:
 
-callPackage ./generic-v3.nix {
+callPackage ./generic-v3.nix ({
   version = "3.20.3";
   sha256 = "sha256-u/1Yb8+mnDzc3OwirpGESuhjkuKPgqDAvlgo3uuzbbk=";
-}
+} // args)

--- a/pkgs/development/libraries/protobuf/3.21.nix
+++ b/pkgs/development/libraries/protobuf/3.21.nix
@@ -1,6 +1,6 @@
-{ callPackage, abseil-cpp, ... }:
+{ callPackage, ... } @ args:
 
-callPackage ./generic-v3-cmake.nix {
+callPackage ./generic-v3-cmake.nix ({
   version = "3.21.8";
   sha256 = "sha256-cSNHX18CvMmydpYWqfe6WWk9rGxIlFfY/85rfSyznU4=";
-}
+} // args)

--- a/pkgs/development/libraries/protobuf/3.8.nix
+++ b/pkgs/development/libraries/protobuf/3.8.nix
@@ -1,6 +1,6 @@
-{ callPackage, ... }:
+{ callPackage, ... } @ args:
 
-callPackage ./generic-v3.nix {
+callPackage ./generic-v3.nix ({
   version = "3.8.0";
   sha256 = "0vll02a6k46k720wfh25sl4hdai0130s3ix2l1wh6j1lm9pi7bm8";
-}
+} // args)


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR ensures that the arguments given to `protobuf.override { ... }` actually make it through to the resulting derivation. Currently, override arguments given to all protobuf versions are ignored.

I've tested, and with my changes, the derivation hashes for all versions of protobuf are identical, so this does not change the default derivations.

This addresses Issue #209395

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
