### PR TITLE
noseyparker: init at 0.11.0

### DIFF
--- a/pkgs/tools/security/noseyparker/default.nix
+++ b/pkgs/tools/security/noseyparker/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, cmake
+, openssl
+, pkg-config
+, hyperscan
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "noseyparker";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "praetorian-inc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-7hDrHYxVKduQl3kpLUHEXDPKTz1B74GjxKC5XEPYEmc=";
+  };
+
+  cargoSha256 = "sha256-JNpTt+Oar/090FyJbUo8MYBJuXKLOIfcm6kJIIgsKyo=";
+
+  OPENSSL_NO_VENDOR = 1;
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ openssl hyperscan ];
+
+  meta = with lib; {
+    description = "A command-line program that finds secrets and sensitive information in textual data and Git history";
+    homepage = "https://github.com/praetorian-inc/noseyparker";
+    changelog = "https://github.com/praetorian-inc/noseyparker/blob/v${version}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24286,6 +24286,8 @@ with pkgs;
 
   nix-tour = callPackage ../applications/misc/nix-tour {};
 
+  noseyparker = callPackage ../tools/security/noseyparker { };
+
   nosqli = callPackage ../tools/security/nosqli { };
 
   nsd = callPackage ../servers/dns/nsd (config.nsd or {});


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[praetorian-inc/noseyparker: Nosey Parker is a command-line program that finds secrets and sensitive information in textual data and Git history.](https://github.com/praetorian-inc/noseyparker)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
