### PR TITLE
Add gnat12 package for x86_64-darwin

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-gnat-extra-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-gnat-extra-flags.sh
@@ -1,0 +1,23 @@
+# See add-flags.sh in cc-wrapper for comments.
+var_templates_list=(
+    NIX_GNATMAKE_CARGS
+)
+
+accumulateRoles
+
+for var in "${var_templates_list[@]}"; do
+    mangleVarList "$var" ${role_suffixes[@]+"${role_suffixes[@]}"}
+done
+
+# `-B@out@/bin' forces cc to use wrapped as instead of the system one.
+NIX_GNATMAKE_CARGS_@suffixSalt@="$NIX_GNATMAKE_CARGS_@suffixSalt@ -B@out@/bin/"
+
+# Only add darwin min version flag if a default darwin min version is set,
+# which is a signal that we're targetting darwin.
+if [ "@darwinMinVersion@" ]; then
+    mangleVarSingle @darwinMinVersionVariable@ ${role_suffixes[@]+"${role_suffixes[@]}"}
+
+    NIX_GNATMAKE_CARGS_@suffixSalt@="-m@darwinPlatformForCC@-version-min=${@darwinMinVersionVariable@_@suffixSalt@:-@darwinMinVersion@} $NIX_GNATMAKE_CARGS_@suffixSalt@"
+fi
+
+export NIX_GNAT_WRAPPER_EXTRA_FLAGS_SET_@suffixSalt@=1

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -236,10 +236,15 @@ stdenv.mkDerivation {
       fi
     ''
 
+    # No need to wrap gnat, gnatkr, gnatname or gnatprep; we can just symlink them in
     + optionalString cc.langAda or false ''
-      wrap ${targetPrefix}gnatmake ${./gnat-wrapper.sh} $ccPath/${targetPrefix}gnatmake
-      wrap ${targetPrefix}gnatbind ${./gnat-wrapper.sh} $ccPath/${targetPrefix}gnatbind
-      wrap ${targetPrefix}gnatlink ${./gnat-wrapper.sh} $ccPath/${targetPrefix}gnatlink
+      for cmd in gnatbind gnatchop gnatclean gnatlink gnatls gnatmake; do
+        wrap ${targetPrefix}$cmd ${./gnat-wrapper.sh} $ccPath/${targetPrefix}$cmd
+      done
+
+      for cmd in gnat gnatkr gnatname gnatprep; do
+        ln -s $ccPath/${targetPrefix}$cmd $out/bin/${targetPrefix}$cmd
+      done
 
       # this symlink points to the unwrapped gnat's output "out". It is used by
       # our custom gprconfig compiler description to find GNAT's ada runtime. See

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -519,6 +519,10 @@ stdenv.mkDerivation {
       substituteAll ${../wrapper-common/utils.bash} $out/nix-support/utils.bash
     ''
 
+    + optionalString cc.langAda or false ''
+      substituteAll ${./add-gnat-extra-flags.sh} $out/nix-support/add-gnat-extra-flags.sh
+    ''
+
     ##
     ## General Clang support
     ## Needs to go after ^ because the for loop eats \n and makes this file an invalid script

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -29,6 +29,9 @@ if [ -z "${NIX_CC_WRAPPER_FLAGS_SET_@suffixSalt@:-}" ]; then
     source @out@/nix-support/add-flags.sh
 fi
 
+if [ -z "${NIX_GNAT_WRAPPER_EXTRA_FLAGS_SET_@suffixSalt@:-}" ]; then
+    source @out@/nix-support/add-gnat-extra-flags.sh
+fi
 
 # Parse command line options and set several variables.
 # For instance, figure out if linker flags should be passed.
@@ -126,7 +129,7 @@ fi
 
 if [ "$(basename $0)x" = "gnatmakex" ]; then
     extraBefore=("--GNATBIND=@out@/bin/gnatbind" "--GNATLINK=@out@/bin/gnatlink")
-    extraAfter=($NIX_GNATFLAGS_COMPILE_@suffixSalt@)
+    extraAfter=($NIX_GNATFLAGS_COMPILE_@suffixSalt@ -cargs $NIX_GNATMAKE_CARGS_@suffixSalt@)
 fi
 
 if [ "$(basename $0)x" = "gnatbindx" ]; then

--- a/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/gnat-wrapper.sh
@@ -127,20 +127,32 @@ if [ "$NIX_ENFORCE_NO_NATIVE_@suffixSalt@" = 1 ]; then
     params=(${rest+"${rest[@]}"})
 fi
 
-if [ "$(basename $0)x" = "gnatmakex" ]; then
-    extraBefore=("--GNATBIND=@out@/bin/gnatbind" "--GNATLINK=@out@/bin/gnatlink")
-    extraAfter=($NIX_GNATFLAGS_COMPILE_@suffixSalt@ -cargs $NIX_GNATMAKE_CARGS_@suffixSalt@)
-fi
-
-if [ "$(basename $0)x" = "gnatbindx" ]; then
-    extraBefore=()
-    extraAfter=($NIX_GNATFLAGS_COMPILE_@suffixSalt@)
-fi
-
-if [ "$(basename $0)x" = "gnatlinkx" ]; then
-    extraBefore=()
-    extraAfter=("--GCC=@out@/bin/gcc")
-fi
+case "$(basename $0)x" in
+    "gnatbindx")
+        extraBefore=()
+        extraAfter=($NIX_GNATFLAGS_COMPILE_@suffixSalt@)
+        ;;
+    "gnatchopx")
+        extraBefore=("--GCC=@out@/bin/gcc")
+        extraAfter=()
+        ;;
+    "gnatcleanx")
+        extraBefore=($NIX_GNATFLAGS_COMPILE_@suffixSalt@)
+        extraAfter=()
+        ;;
+    "gnatlinkx")
+        extraBefore=()
+        extraAfter=("--GCC=@out@/bin/gcc")
+        ;;
+    "gnatlsx")
+        extraBefore=()
+        extraAfter=($NIX_GNATFLAGS_COMPILE_@suffixSalt@)
+        ;;
+    "gnatmakex")
+        extraBefore=("--GNATBIND=@out@/bin/gnatbind" "--GNATLINK=@out@/bin/gnatlink")
+        extraAfter=($NIX_GNATFLAGS_COMPILE_@suffixSalt@ -cargs $NIX_GNATMAKE_CARGS_@suffixSalt@)
+        ;;
+esac
 
 # As a very special hack, if the arguments are just `-v', then don't
 # add anything.  This is to prevent `gcc -v' (which normally prints

--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -185,7 +185,7 @@ stdenv.mkDerivation ({
 
   preConfigure = (import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit crossStageStatic enableMultilib;
+    inherit version targetPlatform hostPlatform buildPlatform gnatboot langAda langGo langJit crossStageStatic enableMultilib;
   }) + ''
     ln -sf ${libxcrypt}/include/crypt.h libsanitizer/sanitizer_common/crypt.h
   '';

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -189,7 +189,7 @@ stdenv.mkDerivation ({
 
   preConfigure = (import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit crossStageStatic enableMultilib;
+    inherit version targetPlatform hostPlatform buildPlatform gnatboot langAda langGo langJit crossStageStatic enableMultilib;
   }) + ''
     ln -sf ${libxcrypt}/include/crypt.h libsanitizer/sanitizer_common/crypt.h
   '';

--- a/pkgs/development/compilers/gcc/12/default.nix
+++ b/pkgs/development/compilers/gcc/12/default.nix
@@ -112,6 +112,9 @@ let majorVersion = "12";
       # Fix detection of bootstrap compiler Ada support (cctools as) on Nix Darwin
       ++ optional (stdenv.isDarwin && langAda) ../ada-cctools-as-detection-configure.patch
 
+      # Use absolute path in GNAT dylib install names on Darwin
+      ++ optional (stdenv.isDarwin && langAda) ../gnat-darwin-dylib-install-name.patch
+
       # Obtain latest patch with ../update-mcfgthread-patches.sh
       ++ optional (!crossStageStatic && targetPlatform.isMinGW && threadsCross.model == "mcf") ./Added-mcf-thread-model-support-from-mcfgthread.patch;
 

--- a/pkgs/development/compilers/gcc/12/default.nix
+++ b/pkgs/development/compilers/gcc/12/default.nix
@@ -109,6 +109,9 @@ let majorVersion = "12";
         })
       ]
 
+      # Fix detection of bootstrap compiler Ada support (cctools as) on Nix Darwin
+      ++ optional (stdenv.isDarwin && langAda) ../ada-cctools-as-detection-configure.patch
+
       # Obtain latest patch with ../update-mcfgthread-patches.sh
       ++ optional (!crossStageStatic && targetPlatform.isMinGW && threadsCross.model == "mcf") ./Added-mcf-thread-model-support-from-mcfgthread.patch;
 
@@ -227,7 +230,7 @@ stdenv.mkDerivation ({
 
   preConfigure = (import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit crossStageStatic enableMultilib;
+    inherit version targetPlatform hostPlatform buildPlatform gnatboot langAda langGo langJit crossStageStatic enableMultilib;
   }) + ''
     ln -sf ${libxcrypt}/include/crypt.h libsanitizer/sanitizer_common/crypt.h
   '';

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -192,7 +192,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform langJava langGo crossStageStatic enableMultilib;
+    inherit version targetPlatform hostPlatform buildPlatform langJava langGo crossStageStatic enableMultilib;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -212,7 +212,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform langJava langGo crossStageStatic enableMultilib;
+    inherit version targetPlatform hostPlatform buildPlatform langJava langGo crossStageStatic enableMultilib;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -223,7 +223,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform gnatboot langJava langAda langGo crossStageStatic enableMultilib;
+    inherit version targetPlatform hostPlatform buildPlatform gnatboot langJava langAda langGo crossStageStatic enableMultilib;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -191,7 +191,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform langGo crossStageStatic enableMultilib;
+    inherit version targetPlatform hostPlatform buildPlatform langGo crossStageStatic enableMultilib;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -173,7 +173,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform langGo crossStageStatic enableMultilib;
+    inherit version targetPlatform hostPlatform buildPlatform langGo crossStageStatic enableMultilib;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -186,7 +186,7 @@ stdenv.mkDerivation ({
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;
-    inherit version targetPlatform hostPlatform gnatboot langAda langGo langJit crossStageStatic enableMultilib;
+    inherit version targetPlatform hostPlatform buildPlatform gnatboot langAda langGo langJit crossStageStatic enableMultilib;
   };
 
   dontDisableStatic = true;

--- a/pkgs/development/compilers/gcc/ada-cctools-as-detection-configure.patch
+++ b/pkgs/development/compilers/gcc/ada-cctools-as-detection-configure.patch
@@ -1,0 +1,33 @@
+As originally implemented, the error message check
+described in the configure script
+breaks detection of Ada compiler support on x86_64-darwin,
+because the assembler in the version of cctools currently used
+unconditionally emits a deprecation message to stdout,
+with no way to disable it.
+
+Furthermore, GCC 3.4 was the minimum version needed to build GNAT
+as far back as GCC 4.4 (see the GCC git repo, tags/releases/gcc-4.4.0,
+gcc/doc/install.texi, lines 2052-2053 [1]);
+GCC 3.4 is newer than any of the broken GCC versions
+that the configure script works around
+(see the part of the comment in the configure script
+before the context in the patch below),
+and GCC 4.4 is older than any GCC that Nix currently packages (GCC 4.8).
+
+We therefore choose to not check for error messages,
+and just check for an error code.
+There's no harm in still checking for an object file being created, though.
+
+[1]: https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/doc/install.texi;h=6bdfbece981f7fb6c26da672d45e5d3ba7879c69;hb=b7fc996728085c0591ea7c5d0e1c84a8f6a29bd8#l2052
+--- a/configure        2022-08-19 18:09:52.000000000 +1000
++++ b/configure        2022-12-26 17:30:49.000000000 +1100
+@@ -5622,8 +5622,7 @@
+ # Other compilers, like HP Tru64 UNIX cc, exit successfully when
+ # given a .adb file, but produce no object file.  So we must check
+ # if an object file was really produced to guard against this.
+-errors=`(${CC} -c conftest.adb) 2>&1 || echo failure`
+-if test x"$errors" = x && test -f conftest.$ac_objext; then
++if ${CC} -c conftest.adb && test -f conftest.$ac_objext; then
+   acx_cv_cc_gcc_supports_ada=yes
+ fi
+ rm -f conftest.*

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -1,4 +1,4 @@
-{ lib, version, hostPlatform, targetPlatform
+{ lib, version, buildPlatform, hostPlatform, targetPlatform
 , gnatboot ? null
 , langAda ? false
 , langJava ? false
@@ -22,6 +22,31 @@ in lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
   export lib=$out;
 '' + lib.optionalString langAda ''
   export PATH=${gnatboot}/bin:$PATH
+''
+
+# On x86_64-darwin, the gnatboot bootstrap compiler that we need to build a
+# native GCC with Ada support emits assembly that is accepted by the Clang
+# integrated assembler, but not by the GNU assembler in cctools-port that Nix
+# usually in the x86_64-darwin stdenv.  In particular, x86_64-darwin gnatboot
+# emits MOVQ as the mnemonic for quadword interunit moves, such as between XMM
+# and general registers (e.g "movq %xmm0, %rbp"); the cctools-port assembler,
+# however, only recognises MOVD for such moves.
+#
+# Therefore, for native x86_64-darwin builds that support Ada, we have to use
+# the Clang integrated assembler to build (at least stage 1 of) GCC, but have to
+# target GCC at the cctools-port GNU assembler.  In the wrapped x86_64-darwin
+# gnatboot, the former is provided as `as`, while the latter is provided as
+# `gas`.
+#
++ lib.optionalString (
+    langAda
+    && buildPlatform == hostPlatform
+    && hostPlatform == targetPlatform
+    && targetPlatform.isx86_64
+    && targetPlatform.isDarwin
+  ) ''
+  export AS_FOR_BUILD=${gnatboot}/bin/as
+  export AS_FOR_TARGET=${gnatboot}/bin/gas
 ''
 
 # NOTE 2020/3/18: This environment variable prevents configure scripts from

--- a/pkgs/development/compilers/gcc/gnat-darwin-dylib-install-name.patch
+++ b/pkgs/development/compilers/gcc/gnat-darwin-dylib-install-name.patch
@@ -1,0 +1,19 @@
+--- a/gcc/ada/gcc-interface/Makefile.in	2022-08-19 18:09:52.000000000 +1000
++++ b/gcc/ada/gcc-interface/Makefile.in	2023-01-11 01:54:06.000000000 +1100
+@@ -795,14 +795,14 @@
+ 		-o libgnat$(hyphen)$(LIBRARY_VERSION)$(soext) \
+ 		$(GNATRTL_NONTASKING_OBJS) $(LIBGNAT_OBJS) \
+ 		$(SO_OPTS) \
+-		-Wl,-install_name,@rpath/libgnat$(hyphen)$(LIBRARY_VERSION)$(soext) \
++		-Wl,-install_name,$(ADA_RTL_DSO_DIR)/libgnat$(hyphen)$(LIBRARY_VERSION)$(soext) \
+ 		$(MISCLIB)
+ 	cd $(RTSDIR); `echo "$(GCC_FOR_TARGET)" \
+                 | sed -e 's,\./xgcc,../../xgcc,' -e 's,-B\./,-B../../,'` -dynamiclib $(PICFLAG_FOR_TARGET) \
+ 		-o libgnarl$(hyphen)$(LIBRARY_VERSION)$(soext) \
+ 		$(GNATRTL_TASKING_OBJS) \
+ 		$(SO_OPTS) \
+-		-Wl,-install_name,@rpath/libgnarl$(hyphen)$(LIBRARY_VERSION)$(soext) \
++		-Wl,-install_name,$(ADA_RTL_DSO_DIR)/libgnarl$(hyphen)$(LIBRARY_VERSION)$(soext) \
+ 		$(THREADSLIB) -Wl,libgnat$(hyphen)$(LIBRARY_VERSION)$(soext)
+ 	cd $(RTSDIR); $(LN_S) libgnat$(hyphen)$(LIBRARY_VERSION)$(soext) \
+ 		libgnat$(soext)

--- a/pkgs/development/compilers/gnatboot/default.nix
+++ b/pkgs/development/compilers/gnatboot/default.nix
@@ -4,34 +4,53 @@
 }:
 
 let
-  versionMap = {
+  throwUnsupportedSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
+
+  versionMap = rec {
     "11" = {
-      version = "11.2.0-4";
-      hash = "sha256-8fMBJp6igH+Md5jE4LMubDmC4GLt4A+bZG/Xcz2LAJQ=";
-    };
+      gccVersion = "11.2.0";
+      alireRevision = "4";
+    } // {
+      x86_64-darwin = {
+        hash = "sha256-FmBgD20PPQlX/ddhJliCTb/PRmKxe9z7TFPa2/SK4GY=";
+        upstreamTriplet = "x86_64-apple-darwin19.6.0";
+      };
+      x86_64-linux = {
+        hash = "sha256-8fMBJp6igH+Md5jE4LMubDmC4GLt4A+bZG/Xcz2LAJQ=";
+        upstreamTriplet = "x86_64-pc-linux-gnu";
+      };
+    }.${stdenv.hostPlatform.system} or throwUnsupportedSystem;
     "12" = {
-      version = "12.1.0-2";
-      hash = "sha256-EPDPOOjWJnJsUM7GGxj20/PXumjfLoMIEFX1EDtvWVY=";
-    };
+      gccVersion = "12.1.0";
+      alireRevision = "2";
+    } // {
+      x86_64-darwin = {
+        hash = "sha256-zrcVFvFZMlGUtkG0p1wST6kGInRI64Icdsvkcf25yVs=";
+        upstreamTriplet = "x86_64-apple-darwin19.6.0";
+      };
+      x86_64-linux = {
+        hash = "sha256-EPDPOOjWJnJsUM7GGxj20/PXumjfLoMIEFX1EDtvWVY=";
+        upstreamTriplet = "x86_64-pc-linux-gnu";
+      };
+    }.${stdenv.hostPlatform.system} or throwUnsupportedSystem;
   };
 
 in with versionMap.${majorVersion};
 
 stdenv.mkDerivation rec {
   pname = "gnatboot";
-  inherit version;
+  inherit gccVersion alireRevision;
+
+  version = "${gccVersion}-${alireRevision}";
 
   src = fetchzip {
-    url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-${version}/gnat-x86_64-linux-${version}.tar.gz";
+    url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-${version}/gnat-${stdenv.hostPlatform.system}-${version}.tar.gz";
     inherit hash;
   };
 
   nativeBuildInputs = [
-    autoPatchelfHook
     dejagnu
-    elfutils
     expat
-    glibc
     gmp
     guile
     libipt
@@ -42,11 +61,69 @@ stdenv.mkDerivation rec {
     sourceHighlight
     xz
     zlib
+  ] ++ lib.optional stdenv.buildPlatform.isLinux [
+    autoPatchelfHook
+    elfutils
+    glibc
   ];
+
+  postPatch = lib.optionalString (stdenv.hostPlatform.isDarwin) ''
+    substituteInPlace lib/gcc/${upstreamTriplet}/${gccVersion}/install-tools/mkheaders.conf \
+      --replace "SYSTEM_HEADER_DIR=\"/usr/include\"" "SYSTEM_HEADER_DIR=\"/include\""
+  ''
+  # The included fixincl binary that is called during header fixup has a
+  # hardcoded execvp("/usr/bin/sed", ...) call, but /usr/bin/sed isn't
+  # available in the Nix Darwin stdenv.  Fortunately, execvp() will search the
+  # PATH environment variable for the executable if its first argument does not
+  # contain a slash, so we can just change the string to "sed" and zero the
+  # other bytes.
+  + ''
+     sed -i "s,/usr/bin/sed,sed\x00\x00\x00\x00\x00\x00\x00\x00\x00," libexec/gcc/${upstreamTriplet}/${gccVersion}/install-tools/fixincl
+  '';
 
   installPhase = ''
     mkdir -p $out
     cp -ar * $out/
+  ''
+
+  # So far with the Darwin gnatboot binary packages, there have been two
+  # types of dylib path references to other dylibs that need fixups:
+  #
+  # 1.  Dylibs in $out/lib with paths starting with
+  #     /Users/runner/.../gcc/install that refer to other dylibs in $out/lib
+  # 2.  Dylibs in $out/lib/gcc/*/*/adalib with paths starting with
+  #     @rpath that refer to other dylibs in $out/lib/gcc/*/*/adalib
+  #
+  # Additionally, per Section 14.4 Fixed Headers in the GCC 12.2.0 manual [2],
+  # we have to update the fixed header files in current Alire GCC package, since it
+  # was built against macOS 10.15 (Darwin 19.6.0), but Nix currently
+  # builds against macOS 10.12, and the two header file structures differ.
+  # For example, the current Alire GCC package has a fixed <stdio.h>
+  # from macOS 10.15 that contains a #include <_stdio.h>, but neither the Alire
+  # GCC package nor macOS 10.12 have such a header (<xlocale/_stdio.h> and
+  # <secure/_stdio.h> in 10.12 are not equivalent; indeed, 10.15 <_stdio.h>
+  # says it contains code shared by <stdio.h> and <xlocale/_stdio.h>).
+  #
+  # [2]: https://gcc.gnu.org/onlinedocs/gcc-12.2.0/gcc/Fixed-Headers.html
+
+  + lib.optionalString (stdenv.hostPlatform.isDarwin) ''
+    upstreamBuildPrefix="/Users/runner/work/GNAT-FSF-builds/GNAT-FSF-builds/sbx/x86_64-darwin/gcc/install"
+    for i in "$out"/lib/*.dylib "$out"/lib/gcc/*/*/adalib/*.dylib; do
+      if [[ -f "$i" && ! -h "$i" ]]; then
+        install_name_tool -id "$i" "$i" || true
+        for old_path in $(otool -L "$i" | grep "$upstreamBuildPrefix" | awk '{print $1}'); do
+          new_path=`echo "$old_path" | sed "s,$upstreamBuildPrefix,$out,"`
+          install_name_tool -change "$old_path" "$new_path" "$i" || true
+        done
+        for old_path in $(otool -L "$i" | grep "@rpath" | awk '{print $1}'); do
+          new_path=$(echo "$old_path" | sed "s,@rpath,$(dirname "$i"),")
+          install_name_tool -change "$old_path" "$new_path" "$i" || true
+        done
+      fi
+    done
+
+    "$out"/libexec/gcc/${upstreamTriplet}/${gccVersion}/install-tools/mkheaders -v -v \
+      "$out" "${stdenv.cc.libc}"
   '';
 
   passthru = {
@@ -54,6 +131,7 @@ stdenv.mkDerivation rec {
     langCC = false;
     langFortran = false;
     langAda = true;
+    isGNU = true;
   };
 
   meta = with lib; {
@@ -61,6 +139,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.gnu.org/software/gnat";
     license = licenses.gpl3;
     maintainers = with maintainers; [ ethindp ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, makeWrapper, binutils-unwrapped, cctools, llvm, clang-unwrapped }:
+{ lib, stdenv, makeWrapper, binutils-unwrapped, cctools, llvm, clang-unwrapped, dualAs ? false }:
 
 # Make sure both underlying packages claim to have prepended their binaries
 # with the same targetPrefix.
@@ -15,7 +15,7 @@ in
 
 # TODO: loop over targetPrefixed binaries too
 stdenv.mkDerivation {
-  pname = "${targetPrefix}cctools-binutils-darwin";
+  pname = "${targetPrefix}cctools-binutils-darwin" + lib.optionalString dualAs "-dualas";
   inherit (cctools) version;
   outputs = [ "out" "man" ];
   buildCommand = ''
@@ -59,9 +59,33 @@ stdenv.mkDerivation {
     rm $out/bin/${targetPrefix}as
     makeWrapper "${clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
       --add-flags "-x assembler -integrated-as -c"
+  ''
+  # x86-64 Darwin gnatboot emits assembly
+  # with MOVQ as the mnemonic for quadword interunit moves
+  # such as `movq %rbp, %xmm0`.
+  # The clang integrated assembler recognises this as valid,
+  # but unfortunately the cctools-port GNU assembler does not;
+  # it instead uses MOVD as the mnemonic.
+  # The assembly that a GCC build emits is determined at build time
+  # and cannot be changed afterwards.
+  #
+  # To build GNAT on x86-64 Darwin, therefore,
+  # we need both the clang _and_ the cctools-port assemblers to be available:
+  # the former to build at least the stage1 compiler,
+  # and the latter at least to be detectable
+  # as the target for the final compiler.
+  #
+  # We choose to match the Aarch64 case above,
+  # wrapping the clang integrated assembler as `as`.
+  # It then seems sensible to wrap the cctools GNU assembler as `gas`.
+  #
+  + lib.optionalString (stdenv.isx86_64 && dualAs) ''
+    mv $out/bin/${targetPrefix}as $out/bin/${targetPrefix}gas
+    makeWrapper "${clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
+      --add-flags "-x assembler -integrated-as -c"
   '';
 
-  nativeBuildInputs = lib.optionals stdenv.isAarch64 [ makeWrapper ];
+  nativeBuildInputs = lib.optionals (stdenv.isAarch64 || dualAs) [ makeWrapper ];
 
   passthru = {
     inherit targetPrefix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16919,6 +16919,11 @@ with pkgs;
     bintools = bintools-unwrapped;
   };
 
+  bintoolsDualAs = wrapBintoolsWith {
+    bintools = darwin.binutilsDualAs-unwrapped;
+    wrapGas = true;
+  };
+
   bison = callPackage ../development/tools/parsing/bison { };
 
   bisoncpp = callPackage ../development/tools/parsing/bisonc++ { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14491,6 +14491,13 @@ with pkgs;
          && stdenv.buildPlatform == stdenv.hostPlatform
       then buildPackages.gnatboot12
       else buildPackages.gnat12;
+    stdenv =
+      if stdenv.hostPlatform == stdenv.targetPlatform
+         && stdenv.buildPlatform == stdenv.hostPlatform
+         && stdenv.buildPlatform.isDarwin
+         && stdenv.buildPlatform.isx86_64
+      then overrideCC stdenv gnatboot12
+      else stdenv;
   });
 
   gnatboot = gnatboot12;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14495,7 +14495,11 @@ with pkgs;
 
   gnatboot = gnatboot12;
   gnatboot11 = wrapCC (callPackage ../development/compilers/gnatboot { majorVersion = "11"; });
-  gnatboot12 = wrapCC (callPackage ../development/compilers/gnatboot { majorVersion = "12"; });
+  gnatboot12 = wrapCCWith ({
+    cc = callPackage ../development/compilers/gnatboot { majorVersion = "12"; };
+  } // lib.optionalAttrs (stdenv.hostPlatform.isDarwin) {
+    bintools = bintoolsDualAs;
+  });
 
   gnu-smalltalk = callPackage ../development/compilers/gnu-smalltalk { };
 

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -89,6 +89,20 @@ impure-cmds // appleSourcePackages // chooseLibs // {
     bintools = self.binutils-unwrapped;
   };
 
+  binutilsDualAs-unwrapped = callPackage ../os-specific/darwin/binutils {
+    inherit (pkgs) binutils-unwrapped;
+    inherit (pkgs.llvmPackages) llvm clang-unwrapped;
+    dualAs = true;
+  };
+
+  binutilsDualAs = pkgs.wrapBintoolsWith {
+    libc =
+      if stdenv.targetPlatform != stdenv.hostPlatform
+      then pkgs.libcCross
+      else pkgs.stdenv.cc.libc;
+    bintools = self.binutilsDualAs-unwrapped;
+  };
+
   binutilsNoLibc = pkgs.wrapBintoolsWith {
     libc = preLibcCrossHeaders;
     bintools = self.binutils-unwrapped;


### PR DESCRIPTION
###### Description of changes

- Add gnatboot12 package for x86_64-darwin (to bootstrap gnat12 for x86_64-darwin)
- Add x86_64-darwin bintools package with both the clang integrated assembler and the cctools-port assembler to enable gnatboot12 to build gnat12 for x86_64-darwin (see commits for explanation)
- Add gnat12 package for x86_64-darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Test results from nixpkgs-review 

- x86_64-darwin
  - 7 packages built:
    bintoolsDualAs gnat gnatboot gnatboot11 gprbuild gprbuild-boot xmlada
  - 21 packages failed to build:
    emacsPackages.ada-mode gnat10 gnat11 gnat6 gnat9 gnatcoll-core gnatcoll-db2ada gnatcoll-gmp gnatcoll-iconv gnatcoll-lzma gnatcoll-omp gnatcoll-postgres gnatcoll-python3 gnatcoll-readline gnatcoll-sql gnatcoll-sqlite gnatcoll-syslog gnatcoll-xref gnatcoll-zlib gnatinspect spark2014
    - _None of the packages that failed to build were previously able to be built on x86_64-darwin_; author's intention is for future PRs to get as many of them to build as possible.
- x86_64-linux
  - 36 packages built:
    coreboot-toolchain.aarch64 coreboot-toolchain.arm coreboot-toolchain.i386 coreboot-toolchain.nds32le coreboot-toolchain.ppc64 coreboot-toolchain.riscv coreboot-toolchain.x64 emacsPackages.ada-mode ghdl ghdl-llvm gnat gnat11 gnatboot gnatboot11 gnatcoll-core gnatcoll-db2ada gnatcoll-gmp gnatcoll-iconv gnatcoll-lzma gnatcoll-omp gnatcoll-postgres gnatcoll-python3 gnatcoll-readline gnatcoll-sql gnatcoll-sqlite gnatcoll-syslog gnatcoll-xref gnatcoll-zlib gnatinspect gprbuild gprbuild-boot python310Packages.myhdl python39Packages.myhdl spark2014 xmlada yosys-ghdl
  - 1 package marked as broken and skipped:
    bintoolsDualAs
    - Package only intended and needed for x86_64-darwin
  - 3 packages failed to build:
   gnat10 gnat6 gnat9
    - _None of the packages that failed to build were able to build before this PR_ (see https://github.com/NixOS/nixpkgs/pull/182414#issuecomment-1204432909 and #201637).




<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
