### PR TITLE
Package python3Packages.pre-commit-hook-ensure-sops

### DIFF
--- a/pkgs/tools/misc/pre-commit-hook-ensure-sops/default.nix
+++ b/pkgs/tools/misc/pre-commit-hook-ensure-sops/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+, fetchpatch
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "pre-commit-hook-ensure-sops";
+  version = "1.1";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "yuvipanda";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-8sMmHNzmYwOmHYSWoZ4rKb/2lKziFmT6ux+s+chd/Do=";
+  };
+
+  patches = [
+    # Add the command-line entrypoint to pyproject.toml
+    # Can be removed after v1.2 release that includes changes
+    (fetchpatch {
+      url =
+        "https://github.com/yuvipanda/pre-commit-hook-ensure-sops/commit/ed88126afa253df6009af7cbe5aa2369f963be1c.patch";
+      hash = "sha256-mMxAoC3WEciO799Rq8gZ2PJ6FT/GbeSpxlr1EPj7r4s=";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    python3Packages.ruamel-yaml
+  ];
+
+  pythonImportsCheck = [
+    "pre_commit_hook_ensure_sops"
+  ];
+
+  # Test entrypoint
+  checkPhase = ''
+    runHook preCheck
+    $out/bin/pre-commit-hook-ensure-sops --help
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "pre-commit hook to ensure that files that should be encrypted with sops are";
+    homepage = "https://github.com/yuvipanda/pre-commit-hook-ensure-sops";
+    maintainers = with maintainers; [ nialov ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11707,6 +11707,8 @@ with pkgs;
 
   pre-commit = callPackage ../tools/misc/pre-commit { };
 
+  pre-commit-hook-ensure-sops = callPackage ../tools/misc/pre-commit-hook-ensure-sops { };
+
   pretender = callPackage ../tools/security/pretender { };
 
   pretty-simple = callPackage ../development/tools/pretty-simple { };


### PR DESCRIPTION
###### Description of changes

`pre-commit-hook-ensure-sops` is a Python package, as the name implies, for
testing [`sops`](https://github.com/mozilla/sops)-using repositories for
leaking secrets i.e., committing unencrypted secrets that should be
(automatically) encrypted by `sops.` It is primarily implemented for use as a
`pre-commit` hook but the command-line entrypoint is generally usable for
checking `sops` files for unencrypted secrets or invalid structure.

After addition to `nixpkgs` it can be more cleanly used by e.g.,
`pre-commit-hooks.nix`
(<https://github.com/cachix/pre-commit-hooks.nix/pull/212>).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
