### PR TITLE
nova-filters: migrate to scons; sconsPackages.scons_3_0_1: drop

### DIFF
--- a/pkgs/applications/audio/nova-filters/default.nix
+++ b/pkgs/applications/audio/nova-filters/default.nix
@@ -1,21 +1,22 @@
-{lib, stdenv, fetchurl, sconsPackages, boost, ladspaH, pkg-config }:
+{ lib, stdenv, fetchurl, scons, boost, ladspaH, pkg-config }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   version = "0.2-2";
   pname = "nova-filters";
 
   src = fetchurl {
-    url = "https://klingt.org/~tim/nova-filters/nova-filters_0.2-2.tar.gz";
+    url = "https://klingt.org/~tim/nova-filters/nova-filters_${version}.tar.gz";
     sha256 = "16064vvl2w5lz4xi3lyjk4xx7fphwsxc14ajykvndiz170q32s6i";
   };
 
-  nativeBuildInputs = [ pkg-config sconsPackages.scons_3_0_1 ];
+  nativeBuildInputs = [ pkg-config scons ];
   buildInputs = [ boost ladspaH ];
 
-  patchPhase = ''
+  postPatch = ''
     # remove TERM:
     sed -i -e '4d' SConstruct
     sed -i "s@mfpmath=sse@mfpmath=sse -I ${boost.dev}/include@g" SConstruct
+    sed -i "s/Options/Variables/g" SConstruct
     sed -i "s@ladspa.h@${ladspaH}/include/ladspa.h@g" filters.cpp
     sed -i "s@LADSPA_HINT_SAMPLE_RATE, 0, 0.5@LADSPA_HINT_SAMPLE_RATE, 0.0001, 0.5@g" filters.cpp
     sed -i "s/= check/= detail::filter_base<internal_type, checked>::check/" nova/source/dsp/filter.hpp
@@ -24,7 +25,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     broken = (stdenv.isLinux && stdenv.isAarch64);
     description = "LADSPA plugins based on filters of nova";
-    homepage = "http://klingt.org/~tim/nova-filters/";
+    homepage = "https://tim.klingt.org/";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.magnetophon ];
     platforms = platforms.linux;

--- a/pkgs/development/tools/build-managers/scons/default.nix
+++ b/pkgs/development/tools/build-managers/scons/default.nix
@@ -5,10 +5,6 @@ let
     python = python3;
   };
 in {
-  scons_3_0_1 = (mkScons {
-    version = "3.0.1";
-    sha256 = "0wzid419mlwqw9llrg8gsx4nkzhqy16m4m40r0xnh6cwscw5wir4";
-  }).override { python = python2; };
   scons_3_1_2 = (mkScons {
     version = "3.1.2";
     sha256 = "1yzq2gg9zwz9rvfn42v5jzl3g4qf1khhny6zfbi2hib55zvg60bq";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

See https://github.com/NixOS/nixpkgs/pull/201859.

Also removing `sconsPackages.scons_3_0_1` since there are no more packages that depends on it in nixpkgs (`nova-filters` is the last one).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
