### PR TITLE
libconfuse: add patch for CVE-2022-40320

### DIFF
--- a/pkgs/development/libraries/libconfuse/default.nix
+++ b/pkgs/development/libraries/libconfuse/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, flex }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, autoreconfHook
+, flex
+}:
 
 stdenv.mkDerivation rec {
   pname = "libconfuse";
@@ -10,6 +16,18 @@ stdenv.mkDerivation rec {
     repo = "libconfuse";
     owner = "martinh";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-40320.patch";
+      urls = [
+        "https://sources.debian.org/data/main/libc/libconfuse/3.3-3/debian/patches/CVE-2022-40320.patch"
+        # files on sources.debian.org can disappear
+        "https://web.archive.org/web/20230107133212/https://sources.debian.org/data/main/libc/libconfuse/3.3-3/debian/patches/CVE-2022-40320.patch"
+      ];
+      sha256 = "sha256-ftfE9JFz4nyRSOb2xHb9BAtgWn5Yv2WLm4RegDLtiBw=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace tests/Makefile.am \


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-40320

Upstream commit won't apply directly, minor adjustment already done by debian so pull theirs instead of bringing patch in-repo.

Personally tested this resolved the CVE's provided PoC.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
