### PR TITLE
punes: 0.109 -> 0.110, add Qt6 variant

### DIFF
--- a/pkgs/applications/emulators/punes/default.nix
+++ b/pkgs/applications/emulators/punes/default.nix
@@ -1,13 +1,8 @@
-{ mkDerivation
-, stdenv
+{ stdenv
 , lib
 , fetchFromGitHub
 , fetchpatch
-, nix-update-script
-, qtbase
-, qtsvg
-, qttools
-, autoreconfHook
+, gitUpdater
 , cmake
 , pkg-config
 , ffmpeg
@@ -16,41 +11,63 @@
 , libX11
 , libXrandr
 , sndio
+, qtbase
+, qtsvg
+, qttools
+, wrapQtAppsHook
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "punes";
-  version = "0.109";
+  version = "0.110";
 
   src = fetchFromGitHub {
     owner = "punesemu";
     repo = "puNES";
     rev = "v${version}";
-    sha256 = "sha256-6aRtR/d8nhzmpN9QKSZ62jye7qjfO+FpRMCXkX4Yubk=";
+    sha256 = "sha256-+hL168r40aYUjyLbWFXWk9G2srrrG1TH1gLYMliHftU=";
   };
 
-  postPatch = ''
-    substituteInPlace configure.ac \
-      --replace '`$PKG_CONFIG --variable=host_bins Qt5Core`/lrelease' '${qttools.dev}/bin/lrelease'
-  '';
-
-  nativeBuildInputs = [ autoreconfHook cmake pkg-config qttools ];
-
-  buildInputs = [ ffmpeg qtbase qtsvg libGLU ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ alsa-lib libX11 libXrandr ]
-    ++ lib.optionals stdenv.hostPlatform.isBSD [ sndio ];
-
-  dontUseCmakeConfigure = true;
-
-  enableParallelBuilding = true;
-
-  configureFlags = [
-    "--prefix=${placeholder "out"}"
-    "--without-opengl-nvidia-cg"
-    "--with-ffmpeg"
+  patches = [
+    # Fixes compilation on aarch64
+    # Remove when version > 0.110
+    (fetchpatch {
+      url = "https://github.com/punesemu/puNES/commit/90dd5bc90412bbd199c2716f67a24aa88b24d80f.patch";
+      hash = "sha256-/KNpTds4qjwyaTUebWWPlVXfuxVh6M4zOInxUfYztJg=";
+    })
   ];
 
-  passthru.updateScript = nix-update-script { };
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qttools
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    ffmpeg
+    libGLU
+    qtbase
+    qtsvg
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    libX11
+    libXrandr
+  ] ++ lib.optionals stdenv.hostPlatform.isBSD [
+    sndio
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_GIT_INFO=OFF"
+    "-DENABLE_RELEASE=ON"
+    "-DENABLE_FFMPEG=ON"
+    "-DENABLE_OPENGL=ON"
+    "-DENABLE_QT6_LIBS=${if lib.versionAtLeast qtbase.version "6.0" then "ON" else "OFF"}"
+  ];
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
 
   meta = with lib; {
     description = "Qt-based Nintendo Entertainment System emulator and NSF/NSFe Music Player";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2107,6 +2107,8 @@ with pkgs;
 
   punes = libsForQt5.callPackage ../applications/emulators/punes { };
 
+  punes-qt6 = qt6Packages.callPackage ../applications/emulators/punes { };
+
   py65 = python3Packages.callPackage ../applications/emulators/py65 { };
 
   resim = callPackage ../applications/emulators/resim {};


### PR DESCRIPTION
###### Description of changes

https://github.com/punesemu/puNES/releases/tag/v0.110

Fully migrated to CMake now. Also adding Qt6 variant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
