### PR TITLE
mame: 0.250 -> 0.251

### DIFF
--- a/pkgs/applications/emulators/mame/001-use-absolute-paths.diff
+++ b/pkgs/applications/emulators/mame/001-use-absolute-paths.diff
@@ -1,32 +1,29 @@
---- a/src/emu/emuopts.cpp	2022-10-29 15:05:18.591381088 +0200
-+++ b/src/emu/emuopts.cpp	2022-10-29 15:10:10.938037551 +0200
-@@ -39,16 +39,16 @@
+diff --git a/src/emu/emuopts.cpp b/src/emu/emuopts.cpp
+index 3defd33d0bb..33daacc4fc8 100644
+--- a/src/emu/emuopts.cpp
++++ b/src/emu/emuopts.cpp
+@@ -39,16 +39,16 @@ const options_entry emu_options::s_option_entries[] =
  	{ nullptr,                                           nullptr,     core_options::option_type::HEADER,     "CORE SEARCH PATH OPTIONS" },
- 	{ OPTION_PLUGINDATAPATH,                             ".",         core_options::option_type::STRING,     "path to base folder for plugin data (read/write)" },
- 	{ OPTION_MEDIAPATH ";rp;biospath;bp",                "roms",      core_options::option_type::STRING,     "path to ROM sets and hard disk images" },
--	{ OPTION_HASHPATH ";hash_directory;hash",            "hash",      core_options::option_type::STRING,     "path to software definition files" },
--	{ OPTION_SAMPLEPATH ";sp",                           "samples",   core_options::option_type::STRING,     "path to audio sample sets" },
--	{ OPTION_ARTPATH,                                    "artwork",   core_options::option_type::STRING,     "path to artwork files" },
--	{ OPTION_CTRLRPATH,                                  "ctrlr",     core_options::option_type::STRING,     "path to controller definitions" },
--	{ OPTION_INIPATH,                                    ".;ini;ini/presets",     core_options::option_type::STRING,     "path to ini files" },
--	{ OPTION_FONTPATH,                                   ".",         core_options::option_type::STRING,     "path to font files" },
-+	{ OPTION_HASHPATH ";hash_directory;hash",            "hash;@mamePath@/hash",      core_options::option_type::STRING,     "path to software definition files" },
-+	{ OPTION_SAMPLEPATH ";sp",                           "samples;@mamePath@/samples",   core_options::option_type::STRING,     "path to audio sample sets" },
-+	{ OPTION_ARTPATH,                                    "artwork;@mamePath@/artwork",   core_options::option_type::STRING,     "path to artwork files" },
-+	{ OPTION_CTRLRPATH,                                  "ctrlr;@mamePath@/ctrlr",     core_options::option_type::STRING,     "path to controller definitions" },
-+	{ OPTION_INIPATH,                                    ".;ini;ini/presets;@mamePath@/ini/presets",     core_options::option_type::STRING,     "path to ini files" },
-+	{ OPTION_FONTPATH,                                   ".;@mamePath@",         core_options::option_type::STRING,     "path to font files" },
- 	{ OPTION_CHEATPATH,                                  "cheat",     core_options::option_type::STRING,     "path to cheat files" },
- 	{ OPTION_CROSSHAIRPATH,                              "crosshair", core_options::option_type::STRING,     "path to crosshair files" },
--	{ OPTION_PLUGINSPATH,                                "plugins",   core_options::option_type::STRING,     "path to plugin files" },
--	{ OPTION_LANGUAGEPATH,                               "language",  core_options::option_type::STRING,     "path to UI translation files" },
-+	{ OPTION_PLUGINSPATH,                                "plugins;@mamePath@/plugins",   core_options::option_type::STRING,     "path to plugin files" },
-+	{ OPTION_LANGUAGEPATH,                               "language;@mamePath@/language",  core_options::option_type::STRING,     "path to UI translation files" },
- 	{ OPTION_SWPATH,                                     "software",  core_options::option_type::STRING,     "path to loose software" },
+ 	{ OPTION_PLUGINDATAPATH,                             ".",         core_options::option_type::PATH,       "path to base folder for plugin data (read/write)" },
+ 	{ OPTION_MEDIAPATH ";rp;biospath;bp",                "roms",      core_options::option_type::MULTIPATH,  "path to ROM sets and hard disk images" },
+-	{ OPTION_HASHPATH ";hash_directory;hash",            "hash",      core_options::option_type::MULTIPATH,  "path to software definition files" },
+-	{ OPTION_SAMPLEPATH ";sp",                           "samples",   core_options::option_type::MULTIPATH,  "path to audio sample sets" },
+-	{ OPTION_ARTPATH,                                    "artwork",   core_options::option_type::MULTIPATH,  "path to artwork files" },
+-	{ OPTION_CTRLRPATH,                                  "ctrlr",     core_options::option_type::MULTIPATH,  "path to controller definitions" },
+-	{ OPTION_INIPATH,                                    ".;ini;ini/presets",     core_options::option_type::MULTIPATH,     "path to ini files" },
+-	{ OPTION_FONTPATH,                                   ".",         core_options::option_type::MULTIPATH,  "path to font files" },
++	{ OPTION_HASHPATH ";hash_directory;hash",            "hash;@mamePath@/hash",      core_options::option_type::MULTIPATH,  "path to software definition files" },
++	{ OPTION_SAMPLEPATH ";sp",                           "samples;@mamePath@/samples",   core_options::option_type::MULTIPATH,  "path to audio sample sets" },
++	{ OPTION_ARTPATH,                                    "artwork;@mamePath@/artwork",   core_options::option_type::MULTIPATH,  "path to artwork files" },
++	{ OPTION_CTRLRPATH,                                  "ctrlr;@mamePath@/ctrlr",     core_options::option_type::MULTIPATH,  "path to controller definitions" },
++	{ OPTION_INIPATH,                                    ".;ini;ini/presets;@mamePath@/ini/presets",     core_options::option_type::MULTIPATH,     "path to ini files" },
++	{ OPTION_FONTPATH,                                   ".;@mamePath@",         core_options::option_type::MULTIPATH,  "path to font files" },
+ 	{ OPTION_CHEATPATH,                                  "cheat",     core_options::option_type::MULTIPATH,  "path to cheat files" },
+ 	{ OPTION_CROSSHAIRPATH,                              "crosshair", core_options::option_type::MULTIPATH,  "path to crosshair files" },
+-	{ OPTION_PLUGINSPATH,                                "plugins",   core_options::option_type::MULTIPATH,  "path to plugin files" },
+-	{ OPTION_LANGUAGEPATH,                               "language",  core_options::option_type::MULTIPATH,  "path to UI translation files" },
++	{ OPTION_PLUGINSPATH,                                "plugins;@mamePath@/plugins",   core_options::option_type::MULTIPATH,  "path to plugin files" },
++	{ OPTION_LANGUAGEPATH,                               "language;@mamePath@/language",  core_options::option_type::MULTIPATH,  "path to UI translation files" },
+ 	{ OPTION_SWPATH,                                     "software",  core_options::option_type::MULTIPATH,  "path to loose software" },
  
  	// output directory options
-@@ -1301,3 +1301,4 @@
- 	m_entry = entry;
- 	return entry;
- }
-+

--- a/pkgs/applications/emulators/mame/default.nix
+++ b/pkgs/applications/emulators/mame/default.nix
@@ -39,14 +39,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "mame";
-  version = "0.250";
+  version = "0.251";
   srcVersion = builtins.replaceStrings [ "." ] [ "" ] version;
 
   src = fetchFromGitHub {
     owner = "mamedev";
     repo = "mame";
     rev = "mame${srcVersion}";
-    sha256 = "sha256-jexs/1ovRk9Is5orD7hT9fN+dYm+WA+57aZ6JH7zjL4=";
+    hash = "sha256-x+QV4gunnERBHyYB2fXJ2LvMv437Z2omvk+fYkmZfqA=";
   };
 
   outputs = [ "out" "tools" ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
