### PR TITLE
leiningen: 2.9.10 -> 2.10.0 

### DIFF
--- a/pkgs/development/tools/build-managers/leiningen/default.nix
+++ b/pkgs/development/tools/build-managers/leiningen/default.nix
@@ -3,16 +3,17 @@
 
 stdenv.mkDerivation rec {
   pname = "leiningen";
-  version = "2.9.10";
+  version = "2.10.0";
 
   src = fetchurl {
-    url = "https://raw.github.com/technomancy/leiningen/${version}/bin/lein-pkg";
-    sha256 = "0ckzivinbgg6gw1nss544hy160yixvd3k6pqyyxqanyzsq9lvf6v";
+    url = "https://codeberg.org/leiningen/leiningen/raw/tag/${version}/bin/lein-pkg";
+    hash = "sha256-sXV86UHky/Fcv2Sbe09BM2XmEtqJLSKEHsFyg5G7Zq8=";
   };
 
+  # Check https://codeberg.org/leiningen/leiningen/releases to get the URL for the new version
   jarsrc = fetchurl {
-    url = "https://github.com/technomancy/leiningen/releases/download/${version}/${pname}-${version}-standalone.jar";
-    sha256 = "1ja9q8lav83h5qhayjgc39f6yyvk1n5f6gfwznn561xm007m6a52";
+    url = "https://codeberg.org/attachments/43cebda5-a7c2-405b-b641-5143a00051b5";
+    hash = "sha256-0nKZutNAdawoZNC9BVn4NcbixHbAsKKDvL21dP2tuzQ=";
   };
 
   JARNAME = "${pname}-${version}-standalone.jar";
@@ -26,12 +27,18 @@ stdenv.mkDerivation rec {
   # never be picked up by set-java-classpath.sh
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin $out/share
     cp -v $src $out/bin/lein
     cp -v $jarsrc $out/share/$JARNAME
+
+    runHook postInstall
   '';
 
   fixupPhase = ''
+    runHook preFixup
+
     chmod +x $out/bin/lein
     patchShebangs $out/bin/lein
     substituteInPlace $out/bin/lein \
@@ -40,6 +47,8 @@ stdenv.mkDerivation rec {
       --prefix PATH ":" "${lib.makeBinPath [ rlwrap coreutils ]}" \
       --set LEIN_GPG ${gnupg}/bin/gpg \
       --set JAVA_CMD ${jdk}/bin/java
+
+    runHook postFixup
   '';
 
   meta = {
@@ -47,7 +56,7 @@ stdenv.mkDerivation rec {
     description = "Project automation for Clojure";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.epl10;
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = jdk.meta.platforms;
     maintainers = with lib.maintainers; [ ];
     mainProgram = "lein";
   };

--- a/pkgs/development/tools/build-managers/leiningen/default.nix
+++ b/pkgs/development/tools/build-managers/leiningen/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.epl10;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    maintainers = with lib.maintainers; [ thiagokokada ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "lein";
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bumping leiningen to the latest version. Also, the project moved to https://codeberg.org/leiningen/leiningen.

Also, dropping myself from maintainers since I am not using this anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
