### PR TITLE
arubaotp-seed-extractor: init at unstable-22-12-2022

### DIFF
--- a/pkgs/tools/security/arubaotp-seed-extractor/default.nix
+++ b/pkgs/tools/security/arubaotp-seed-extractor/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "arubaotp-seed-extractor";
+  version = "unstable-22-12-2022";
+
+  src = fetchFromGitHub {
+    owner = "andry08";
+    repo = "ArubaOTP-seed-extractor";
+    rev = "534f78bb71594d5806fd2d7a8eade109b0e1d402";
+    hash = "sha256-1pv88OClskQOPtJaP7g0duXMe/X3M6Tk+ituZ9UxoIE=";
+  };
+
+  format = "other";
+
+  nativeBuildInputs = [
+    python3Packages.wrapPython
+  ];
+
+  pythonPath = with python3Packages; [
+    pycryptodome
+    pyotp
+    qrcode
+    requests
+  ];
+
+  installPhase = ''
+    libdir="$out/lib/${python3Packages.python.libPrefix}/site-packages/arubaotp-seed-extractor"
+    mkdir -p "$libdir"
+    cp scripts/* "$libdir"
+    chmod +x "$libdir/main.py"
+    wrapPythonProgramsIn "$libdir" "$pythonPath"
+    mkdir -p $out/bin
+    ln -s "$libdir/main.py" $out/bin/arubaotp-seed-extractor
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/andry08/ArubaOTP-seed-extractor";
+    description = "Extract TOTP seed instead of using ArubaOTP app";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1317,6 +1317,8 @@ with pkgs;
 
   arch-install-scripts = callPackage ../tools/misc/arch-install-scripts {};
 
+  arubaotp-seed-extractor = callPackage ../tools/security/arubaotp-seed-extractor { };
+
   audible-cli = callPackage ../tools/misc/audible-cli { };
 
   auditwheel = callPackage ../tools/package-management/auditwheel { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/andry08/ArubaOTP-seed-extractor

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
