### PR TITLE
pynvml: Add patch for finding libnvidia-ml.so.1 on NixOS

### DIFF
--- a/pkgs/development/python-modules/pynvml/0001-locate-libnvidia-ml.so.1-on-NixOS.patch
+++ b/pkgs/development/python-modules/pynvml/0001-locate-libnvidia-ml.so.1-on-NixOS.patch
@@ -1,0 +1,17 @@
+diff --git a/pynvml/nvml.py b/pynvml/nvml.py
+index 56d908f..1de0b97 100644
+--- a/pynvml/nvml.py
++++ b/pynvml/nvml.py
+@@ -1475,7 +1475,11 @@ def _LoadNvmlLibrary():
+                             nvmlLib = CDLL(os.path.join(os.getenv("ProgramFiles", "C:/Program Files"), "NVIDIA Corporation/NVSMI/nvml.dll"))
+                     else:
+                         # assume linux
+-                        nvmlLib = CDLL("libnvidia-ml.so.1")
++                        try:
++                            nvmlLib = CDLL("libnvidia-ml.so.1")
++                        except OSError:
++                            # assume NixOS
++                            nvmlLib = CDLL("/run/opengl-driver/lib/libnvidia-ml.so.1")
+                 except OSError as ose:
+                     _nvmlCheckReturn(NVML_ERROR_LIBRARY_NOT_FOUND)
+                 if (nvmlLib == None):

--- a/pkgs/development/python-modules/pynvml/0001-locate-libnvidia-ml.so.1-on-NixOS.patch
+++ b/pkgs/development/python-modules/pynvml/0001-locate-libnvidia-ml.so.1-on-NixOS.patch
@@ -11,7 +11,7 @@ index 56d908f..1de0b97 100644
 +                            nvmlLib = CDLL("libnvidia-ml.so.1")
 +                        except OSError:
 +                            # assume NixOS
-+                            nvmlLib = CDLL("/run/opengl-driver/lib/libnvidia-ml.so.1")
++                            nvmlLib = CDLL("@driverLink@/lib/libnvidia-ml.so.1")
                  except OSError as ose:
                      _nvmlCheckReturn(NVML_ERROR_LIBRARY_NOT_FOUND)
                  if (nvmlLib == None):

--- a/pkgs/development/python-modules/pynvml/default.nix
+++ b/pkgs/development/python-modules/pynvml/default.nix
@@ -15,6 +15,10 @@ buildPythonPackage rec {
     sha256 = "b2e4a33b80569d093b513f5804db0c7f40cfc86f15a013ae7a8e99c5e175d5dd";
   };
 
+  patches = [
+    ./0001-locate-libnvidia-ml.so.1-on-NixOS.patch
+  ];
+
   propagatedBuildInputs = [ cudatoolkit ];
 
   doCheck = false;  # no tests in PyPi dist

--- a/pkgs/development/python-modules/pynvml/default.nix
+++ b/pkgs/development/python-modules/pynvml/default.nix
@@ -1,8 +1,10 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, substituteAll
 , pythonOlder
 , cudatoolkit
+, addOpenGLRunpath
 }:
 
 buildPythonPackage rec {
@@ -16,7 +18,10 @@ buildPythonPackage rec {
   };
 
   patches = [
-    ./0001-locate-libnvidia-ml.so.1-on-NixOS.patch
+    (substituteAll {
+      src = ./0001-locate-libnvidia-ml.so.1-on-NixOS.patch;
+      inherit (addOpenGLRunpath) driverLink;
+    })
   ];
 
   propagatedBuildInputs = [ cudatoolkit ];


### PR DESCRIPTION


###### Description of changes
This fixes loading the shared library used for interacting with Nvidia hardware. A similar package, nvidia-ml-py, already provides a patch for the same thing. This commit adds a similar patch for pynvml. We could not reuse the existing patch for the other package because the files being patched have different names despite the patch itself being nearly the same.

Fixes https://github.com/NixOS/nixpkgs/issues/209416

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
