### PR TITLE
nixos/release-notes 22.11: improve i18n notes

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -334,20 +334,30 @@
       </listitem>
       <listitem>
         <para>
-          <literal>i18n.supportedLocales</literal> is now only generated
-          with the locales set in <literal>i18n.defaultLocale</literal>
-          and <literal>i18n.extraLocaleSettings</literal>.
+          locales generated through
+          <literal>i18n.supportedLocales</literal> now only contain the
+          locales set in <literal>i18n.defaultLocale</literal> and
+          <literal>i18n.extraLocaleSettings</literal>.
         </para>
         <itemizedlist spacing="compact">
           <listitem>
             <para>
-              This reduces the final system closure size by up to 200MB.
+              Previously by default all locales where generated which
+              used about 200MB.
             </para>
           </listitem>
           <listitem>
             <para>
-              If you require all locales installed, set the option to
-              <literal>[ &quot;all&quot; ]</literal>.
+              If you set a different locale in your desktop environment
+              or <literal>LC_*</literal> variables then defined in the
+              above listed options, you need to adjust your config to
+              avoid breakages.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              If you require all locales installed, set
+              <literal>i18n.supportedLocales = [ &quot;all&quot; ]</literal>.
             </para>
           </listitem>
         </itemizedlist>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -98,9 +98,10 @@ In addition to numerous new and upgraded packages, this release includes the fol
   and [changelog](https://ngrok.com/docs/ngrok-agent/changelog). Notably, breaking changes are that the config file format has
   changed and support for single hyphen arguments was dropped.
 
-- `i18n.supportedLocales` is now only generated with the locales set in `i18n.defaultLocale` and `i18n.extraLocaleSettings`.
-  - This reduces the final system closure size by up to 200MB.
-  - If you require all locales installed, set the option to ``[ "all" ]``.
+- locales generated through `i18n.supportedLocales` now only contain the locales set in `i18n.defaultLocale` and `i18n.extraLocaleSettings`.
+  - Previously by default all locales where generated which used about 200MB.
+  - If you set a different locale in your desktop environment or `LC_*` variables then defined in the above listed options, you need to adjust your config to avoid breakages.
+  - If you require all locales installed, set ``i18n.supportedLocales = [ "all" ]``.
 
 - Deprecated settings `logrotate.paths` and `logrotate.extraConfig` have
   been removed. Please convert any uses to


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
