### PR TITLE
gnucash: exec Finance::Quote helpers directly

### DIFF
--- a/pkgs/applications/office/gnucash/0004-exec-fq-helpers.patch
+++ b/pkgs/applications/office/gnucash/0004-exec-fq-helpers.patch
@@ -1,0 +1,23 @@
+diff --git a/gnucash/price-quotes.scm b/gnucash/price-quotes.scm
+index 8e3ff255f..a6b805fa5 100644
+--- a/gnucash/price-quotes.scm
++++ b/gnucash/price-quotes.scm
+@@ -44,7 +44,7 @@
+     (define (start-program)
+       (set! program
+         (gnc-spawn-process-async
+-         (list "perl" "-w" gnc:*finance-quote-check*) #t)))
++         (list gnc:*finance-quote-check*) #t)))
+ 
+     (define (get-sources)
+       (when program
+@@ -119,7 +119,7 @@
+ 
+     (define (start-quoter)
+       (set! quoter
+-        (gnc-spawn-process-async (list "perl" "-w" gnc:*finance-quote-helper*) #t)))
++        (gnc-spawn-process-async (list gnc:*finance-quote-helper*) #t)))
+ 
+     (define (get-quotes)
+       (when quoter
+

--- a/pkgs/applications/office/gnucash/default.nix
+++ b/pkgs/applications/office/gnucash/default.nix
@@ -72,6 +72,8 @@ stdenv.mkDerivation rec {
     ./0002-disable-gnc-fq-update.patch
     # this patch prevents the building of gnucash-valgrind
     ./0003-remove-valgrind.patch
+    # this patch makes gnucash exec the Finance::Quote helpers directly
+    ./0004-exec-fq-helpers.patch
   ];
 
   # this needs to be an environment variable and not a cmake flag to suppress


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Patch to exec the Finance::Quote helper scripts directly instead of through `perl`. Currently, these scripts are executed as `["perl" "-w" "$script"]`, but this fails as the scripts are wrapped with binaries.

Fixes #176230

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
