### PR TITLE
python310Packages.dask-awkward: init at 2023.1.0

### DIFF
--- a/pkgs/development/python-modules/dask-awkward/default.nix
+++ b/pkgs/development/python-modules/dask-awkward/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, awkward
+, dask
+, hatch-vcs
+, hatchling
+, pyarrow
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "dask-awkward";
+  version = "2023.1.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "dask-contrib";
+    repo = pname;
+    rev = version;
+    hash = "sha256-q0mBd4yelnNL7rMWfilituo9h/xmLLLndSCBdY2egEQ=";
+  };
+
+  nativeBuildInputs = [
+    hatch-vcs
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    awkward
+    dask
+  ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  checkInputs = [
+    pytestCheckHook
+    pyarrow
+  ];
+
+  pythonImportsCheck = [
+    "dask_awkward"
+  ];
+
+  pytestFlagsArray = [
+    # require internet
+    "--deselect=tests/test_parquet.py::test_remote_double"
+    "--deselect=tests/test_parquet.py::test_remote_single"
+  ];
+
+  meta = with lib; {
+    description = "Native Dask collection for awkward arrays, and the library to use it";
+    homepage = "https://github.com/dask-contrib/dask-awkward";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2171,6 +2171,8 @@ self: super: with self; {
 
   dask = callPackage ../development/python-modules/dask { };
 
+  dask-awkward = callPackage ../development/python-modules/dask-awkward { };
+
   dask-gateway = callPackage ../development/python-modules/dask-gateway { };
 
   dask-gateway-server = callPackage ../development/python-modules/dask-gateway-server { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
