### PR TITLE
cups-kyocera: build reversed `rastertokpsl` from source, add models

### DIFF
--- a/pkgs/misc/cups/drivers/kyocera/rastertokpsl.nix
+++ b/pkgs/misc/cups/drivers/kyocera/rastertokpsl.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, cups
+}:
+stdenv.mkDerivation {
+  pname = "rastertokpsl";
+  version = "2019-12-19";
+
+  src = fetchFromGitHub {
+    owner = "sv99";
+    repo = "rastertokpsl-re";
+    rev = "84dcb2bc0d9a6797eedcd56f2e603dde2fbbf290";
+    hash = "sha256-qPBZ0qKnY14rTaNa6vjyVB8c0aaXDSewia4n1a6xoyg=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ cups ];
+
+  installPhase = ''
+    runHook preInstall
+
+    pushd ..
+
+    install -d "$out/bin"
+    install -m 755 bin/rastertokpsl-re "$out/bin/rastertokpsl"
+
+    popd
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Reverse-engineered Kyocera KPSL CUPS filter for various GDI printers";
+    homepage = "https://github.com/sv99/rastertokpsl-re";
+    license = licenses.asl20;
+    maintainers = [ maintainers.veehaitch ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
###### Description of changes

The bundled binary `rastertokpsl` started to segfault when invoked by CUPS. Someone [1] took the effort and reversed it to provide a free and working replacement. The commit switches to this implementation.

Additionally, the commit now fetches the PPD files from another source (which I maintain, although there's hardly anything to maintain). This adds support for additional KPSL printers.

Tested using FS-1061DN.

[1] https://github.com/sv99/rastertokpsl-re

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

@vanzef @panicgh

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
