### PR TITLE
mastodon: pass dependencies as environment variables

### DIFF
--- a/pkgs/servers/mastodon/default.nix
+++ b/pkgs/servers/mastodon/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   # Putting the callPackage up in the arguments list also does not work.
   src = if srcOverride != null then srcOverride else callPackage ./source.nix {};
 
-  mastodon-gems = bundlerEnv {
+  mastodonGems = bundlerEnv {
     name = "${pname}-gems-${version}";
     inherit version;
     ruby = ruby_3_0;
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     '';
   };
 
-  mastodon-modules = stdenv.mkDerivation {
+  mastodonModules = stdenv.mkDerivation {
     pname = "${pname}-modules";
     inherit src version;
 
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
       sha256 = "sha256-fuU92fydoazSXBHwA+DG//gRgWVYQ1M3m2oNS2iwv4I=";
     };
 
-    nativeBuildInputs = [ fixup_yarn_lock nodejs-slim yarn mastodon-gems mastodon-gems.wrappedRuby ];
+    nativeBuildInputs = [ fixup_yarn_lock nodejs-slim yarn mastodonGems mastodonGems.wrappedRuby ];
 
     RAILS_ENV = "production";
     NODE_ENV = "production";
@@ -79,19 +79,19 @@ stdenv.mkDerivation rec {
     '';
   };
 
-  propagatedBuildInputs = [ imagemagick ffmpeg file mastodon-gems.wrappedRuby ];
-  buildInputs = [ mastodon-gems nodejs-slim ];
+  propagatedBuildInputs = [ imagemagick ffmpeg file mastodonGems.wrappedRuby ];
+  buildInputs = [ mastodonGems nodejs-slim ];
 
   buildPhase = ''
-    ln -s ${mastodon-modules}/node_modules node_modules
-    ln -s ${mastodon-modules}/public/assets public/assets
-    ln -s ${mastodon-modules}/public/packs public/packs
+    ln -s $mastodonModules/node_modules node_modules
+    ln -s $mastodonModules/public/assets public/assets
+    ln -s $mastodonModules/public/packs public/packs
 
     patchShebangs bin/
-    for b in $(ls ${mastodon-gems}/bin/)
+    for b in $(ls $mastodonGems/bin/)
     do
       if [ ! -f bin/$b ]; then
-        ln -s ${mastodon-gems}/bin/$b bin/$b
+        ln -s $mastodonGems/bin/$b bin/$b
       fi
     done
 


### PR DESCRIPTION
###### Description of changes

This makes it much easier to override components of the Mastodon derivation to e.g. use a fork. With this change, one can use something like the following to install a fork (with the appropriate files):

    let
      src = callPackage ./source.nix { };
    in
      (mastodon.override {
        pname = "hometown";
        version = import ./version.nix;
        srcOverride = src;
        dependenciesDir = ./.;
      }).overrideAttrs (oldAttrs: rec {
        yarnOfflineCache = fetchYarnDeps {
          yarnLock = "${src}/yarn.lock";
          sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
        };
        mastodonModules = oldAttrs.mastodonModules.overrideAttrs (oldModuleAttrs: {
          inherit yarnOfflineCache;
        });
      });

A spiritual successor to f949de4fbb5c5adb7f3ec085206f48a2efdd1d9a

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
