### PR TITLE
Make kodi overrideAttrs and withPackages composable

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -1,14 +1,18 @@
 { callPackage, ... } @ args:
 let
   unwrapped = callPackage ./unwrapped.nix (removeAttrs args [ "callPackage" ]);
-  kodiPackages = callPackage ../../../top-level/kodi-packages.nix { kodi = unwrapped; };
 in
   unwrapped.overrideAttrs (oldAttrs: {
-    passthru = oldAttrs.passthru // {
-      packages = kodiPackages;
-      withPackages = func: callPackage ./wrapper.nix {
-        kodi = unwrapped;
-        addons = kodiPackages.requiredKodiAddons (func kodiPackages);
-      };
-    };
+    passthru =
+      let
+        finalKodi = oldAttrs.passthru.kodi;
+        kodiPackages = callPackage ../../../top-level/kodi-packages.nix { kodi = finalKodi; };
+      in
+        oldAttrs.passthru // {
+          packages = kodiPackages;
+          withPackages = func: callPackage ./wrapper.nix {
+            kodi = finalKodi;
+            addons = kodiPackages.requiredKodiAddons (func kodiPackages);
+          };
+        };
   })

--- a/pkgs/applications/video/kodi/unwrapped.nix
+++ b/pkgs/applications/video/kodi/unwrapped.nix
@@ -38,18 +38,7 @@ assert usbSupport -> !udevSupport; # libusb-compat-0_1 won't be used if udev is 
 assert gbmSupport || waylandSupport || x11Support;
 
 let
-  kodiReleaseDate = "20221204";
-  kodiVersion = "19.5";
-  rel = "Matrix";
-
-  kodi_src = fetchFromGitHub {
-    owner  = "xbmc";
-    repo   = "xbmc";
-    rev    = "${kodiVersion}-${rel}";
-    sha256 = "sha256-vprhEPxYpY3/AsUgvPNnhBlh0Dl73ekALAblHaUKzd0=";
-  };
-
-  ffmpeg = stdenv.mkDerivation rec {
+  ffmpeg = (kodi_src: rel: stdenv.mkDerivation rec {
     pname = "kodi-ffmpeg";
     version = "4.3.2"; # see https://github.com/xbmc/xbmc/blob/${kodiVersion}-${rel}/tools/depends/target/ffmpeg/FFMPEG-VERSION
     src = fetchFromGitHub {
@@ -72,7 +61,7 @@ let
     buildInputs = [ libidn libtasn1 p11-kit zlib libva ]
       ++ lib.optional vdpauSupport libvdpau;
     nativeBuildInputs = [ cmake nasm pkg-config gnutls ];
-  };
+  });
 
   # We can build these externally but FindLibDvd.cmake forces us to build it
   # them, so we currently just use them for the src.
@@ -101,11 +90,22 @@ let
     ++ lib.optional waylandSupport "wayland"
     ++ lib.optional x11Support "x11";
 
-in stdenv.mkDerivation {
+in stdenv.mkDerivation (finalAttrs: {
     pname = "kodi";
-    version = kodiVersion;
+    version = "19.5";
+    kodiReleaseName = "Matrix";
 
-    src = kodi_src;
+    src = fetchFromGitHub {
+      owner  = "xbmc";
+      repo   = "xbmc";
+      rev    = "${finalAttrs.version}-${finalAttrs.kodiReleaseName}";
+      sha256 = "sha256-vprhEPxYpY3/AsUgvPNnhBlh0Dl73ekALAblHaUKzd0=";
+    };
+
+    # make  derivations declared in the let binding available here, so
+    # they can be overridden
+    inherit libdvdcss libdvdnav libdvdread;
+    ffmpeg = ffmpeg finalAttrs.src finalAttrs.kodiReleaseName;
 
     # This is a backport of
     # https://github.com/xbmc/xbmc/commit/a6dedce7ba1f03bdd83b019941d1e369a06f7888
@@ -134,7 +134,7 @@ in stdenv.mkDerivation {
       libxcrypt libgcrypt libgpg-error libunistring
       libcrossguid libplist
       bluez giflib glib harfbuzz lcms2 libpthreadstubs
-      ffmpeg flatbuffers fstrcmp rapidjson
+      finalAttrs.ffmpeg flatbuffers fstrcmp rapidjson
       lirc
       mesa # for libEGL
     ]
@@ -183,10 +183,12 @@ in stdenv.mkDerivation {
 
     cmakeFlags = [
       "-DAPP_RENDER_SYSTEM=${if gbmSupport then "gles" else "gl"}"
-      "-Dlibdvdcss_URL=${libdvdcss}"
-      "-Dlibdvdnav_URL=${libdvdnav}"
-      "-Dlibdvdread_URL=${libdvdread}"
-      "-DGIT_VERSION=${kodiReleaseDate}"
+      "-Dlibdvdcss_URL=${finalAttrs.libdvdcss}"
+      "-Dlibdvdnav_URL=${finalAttrs.libdvdnav}"
+      "-Dlibdvdread_URL=${finalAttrs.libdvdread}"
+      # Upstream derives this from the git HEADs hash and date.
+      # LibreElec (minimal distro for kodi) uses the equivalent to this.
+      "-DGIT_VERSION=${finalAttrs.version}-${finalAttrs.kodiReleaseName}"
       "-DENABLE_EVENTCLIENTS=ON"
       "-DENABLE_INTERNAL_CROSSGUID=OFF"
       "-DENABLE_OPTICAL=ON"
@@ -246,7 +248,8 @@ in stdenv.mkDerivation {
 
     passthru = {
       pythonPackages = python3Packages;
-      ffmpeg = ffmpeg;
+      ffmpeg = finalAttrs.ffmpeg;
+      kodi = finalAttrs.finalPackage;
     };
 
     meta = with lib; {
@@ -256,4 +259,4 @@ in stdenv.mkDerivation {
       platforms   = platforms.linux;
       maintainers = teams.kodi.members;
     };
-}
+})

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -9,7 +9,7 @@ in
 let self = rec {
 
   addonDir = "/share/kodi/addons";
-  rel = "Matrix";
+  rel = kodi.kodiReleaseName;
 
   callPackage = newScope self;
 


### PR DESCRIPTION
###### Description of changes

When using a kodi derivation modified with `overrideAttrs` and adding extensions to it with `withPackages` the changes were discarded and the original unmodified kodi derivation was wrapped together with the extensions.
Fix this by switching kodi to use the `mkDerivation` with `finalAttrs` pattern (described in #119942 and https://nixos.org/manual/nixpkgs/stable/#mkderivation-recursive-attributes).

###### Things done #

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
For testing I've assebled a little flake
<details><summary>Test-Flake (expand)</summary>
<p>

```nix
{
  description = "test flake for nixpkgs kodi override";

  inputs = {
    nixpkgs.url = github:nixos/nixpkgs/release-22.11;
    flake-utils.url = "github:numtide/flake-utils";
    nix-flake-tests.url = "github:antifuchs/nix-flake-tests";
  };

  outputs = inputs@{ self, nixpkgs, flake-utils, nix-flake-tests }:
    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
      let
        pkgs = import nixpkgs
          {
            localSystem = "${system}";
            overlays = [
              (final: prev: {
                kodi = prev.kodi.overrideAttrs (o: {
                  pname = "test-kodi";
                });
              })
            ];
          };
      in
      {
        packages = {
          inherit (pkgs) kodi;
          kodi-with-addons = pkgs.kodi.withPackages (p: [ p.inputstreamhelper ]);
        };
        checks = {
          kodi = nix-flake-tests.lib.check {
            inherit pkgs;
            tests = {
              testNameStartsWithPName = rec {
                expected = "test-kodi-";
                expr = builtins.substring 0 (builtins.stringLength expected)
                  self.packages.${system}.kodi-with-addons.name;
              };
              testAddonGetsLinked = {
                expected = [ ]; # exact match of regex returns empty list
                expr = builtins.match ".*-kodi-inputstreamhelper-.*"
                  self.packages.${system}.kodi-with-addons.postBuild;
              };
            };
          };
        };
      }
    );
}

```

</p>
</details>

The resulting `kodi-with-addons` derivation includes both, the `pname` changed via `overrideAttrs` as well as the `postBuild` wrapping for the `inputstream` plugin added via `withPackages`.

Running it is possible, finds the plugin and doesn't have any signs of anything being wrong.


- Built on  #platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
