### PR TITLE
paperless-ngx: 1.10.2 -> 1.11.3

### DIFF
--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -81,12 +81,12 @@ let
 in
 python.pkgs.pythonPackages.buildPythonApplication rec {
   pname = "paperless-ngx";
-  version = "1.10.2";
+  version = "1.11.3";
 
   # Fetch the release tarball instead of a git ref because it contains the prebuilt frontend
   src = fetchurl {
     url = "https://github.com/paperless-ngx/paperless-ngx/releases/download/v${version}/${pname}-v${version}.tar.xz";
-    hash = "sha256-uOrRHHNqIYsDbzKcA7EsYZjadpLyAB4Ks+PU+BNsTWE=";
+    hash = "sha256-wGNkdczgV+UDd9ZO+BXMSWotpetE/+c/jJAAH+6SXps=";
   };
 
   format = "other";
@@ -99,6 +99,7 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
     attrs
     autobahn
     automat
+    bleach
     blessed
     celery
     certifi
@@ -128,6 +129,7 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
     httptools
     humanfriendly
     hyperlink
+    imagehash
     idna
     imap-tools
     img2pdf
@@ -138,6 +140,7 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
     langdetect
     lxml
     msgpack
+    nltk
     numpy
     ocrmypdf
     pathvalidate

--- a/pkgs/development/python-modules/imagehash/default.nix
+++ b/pkgs/development/python-modules/imagehash/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, numpy
+, six
+, scipy
+, pillow
+, pywavelets
+}:
+
+buildPythonPackage rec {
+  pname = "imagehash";
+  version = "4.3.1";
+
+  src = fetchFromGitHub {
+    owner = "JohannesBuchner";
+    repo = "imagehash";
+    rev = "v${version}";
+    hash = "sha256-Tsq10TZqnzNTuO4goKjdylN4Eqy7DNbHLjr5n3+nidM=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    six
+    scipy
+    pillow
+    pywavelets
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "A Python Perceptual Image Hashing Module";
+    homepage = "https://github.com/JohannesBuchner/imagehash";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ e1mo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4491,6 +4491,8 @@ self: super: with self; {
 
   imagecorruptions = callPackage ../development/python-modules/imagecorruptions { };
 
+  imagehash = callPackage ../development/python-modules/imagehash { };
+
   imageio = callPackage ../development/python-modules/imageio { };
 
   imageio-ffmpeg = callPackage ../development/python-modules/imageio-ffmpeg { };


### PR DESCRIPTION
###### Description of changes

paperless-ngx 1.11.0
> Notable Changes
> - Feature: frontend paperless mail
> - Feature: Ability to consume mails and eml files
https://github.com/paperless-ngx/paperless-ngx/releases/tag/v1.11.0

Other changes seem to mostly consist of bug-fixes or minor improvements. See <https://github.com/paperless-ngx/paperless-ngx/releases> for a full list.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
