### PR TITLE
pythonInterpreters.pypy27_prebuilt: fix install check on darwin

### DIFF
--- a/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
@@ -12,6 +12,8 @@
 , sqlite
 , tcl-8_5
 , tk-8_5
+, tcl-8_6
+, tk-8_6
 , zlib
 # For the Python package set
 , packageOverrides ? (self: super: {})
@@ -69,9 +71,13 @@ in with passthru; stdenv.mkDerivation {
     gdbm
     ncurses6
     sqlite
+    zlib
+  ] ++ lib.optionals stdenv.isLinux [
     tcl-8_5
     tk-8_5
-    zlib
+  ] ++ lib.optionals stdenv.isDarwin [
+    tcl-8_6
+    tk-8_6
   ];
 
   nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
@@ -108,10 +114,19 @@ in with passthru; stdenv.mkDerivation {
         @rpath/lib${executable}-c.dylib \
         $out/lib/lib${executable}-c.dylib \
         $out/bin/${executable}
+    install_name_tool \
+      -change \
+        /opt/homebrew${lib.optionalString stdenv.isx86_64 "_x86_64"}/opt/tcl-tk/lib/libtcl8.6.dylib \
+        ${tcl-8_6}/lib/libtcl8.6.dylib \
+        $out/lib_pypy/_tkinter/*.so
+    install_name_tool \
+      -change \
+        /opt/homebrew${lib.optionalString stdenv.isx86_64 "_x86_64"}/opt/tcl-tk/lib/libtk8.6.dylib \
+        ${tk-8_6}/lib/libtk8.6.dylib \
+        $out/lib_pypy/_tkinter/*.so
   '';
 
-  # Native libraries are not working in darwin
-  doInstallCheck = !stdenv.isDarwin;
+  doInstallCheck = true;
 
   # Check whether importing of (extension) modules functions
   installCheckPhase = let


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
