### PR TITLE
aaxtomp3: use resholve not PATH

### DIFF
--- a/pkgs/applications/audio/aaxtomp3/osh.patch
+++ b/pkgs/applications/audio/aaxtomp3/osh.patch
@@ -1,0 +1,15 @@
+diff --git a/AAXtoMP3 b/AAXtoMP3
+index 90566ad..71e94da 100755
+--- a/AAXtoMP3
++++ b/AAXtoMP3
+@@ -200,8 +200,8 @@ progressbar() {
+ 
+   #draw progressbar with one # for every 5% and blank spaces for the missing part.
+   progressbar=""
+-  for (( n=0; n<(percentage/5); n++ )) ; do progressbar="$progressbar#"; done
+-  for (( n=0; n<(20-(percentage/5)); n++ )) ; do progressbar="$progressbar "; done
++  for (( n=0; n< (percentage/5); n++ )) ; do progressbar="$progressbar#"; done
++  for (( n=0; n< (20-(percentage/5)); n++ )) ; do progressbar="$progressbar "; done
+ 
+   #print progressbar
+   echo -ne "Chapter splitting: |$progressbar| $print_percentage% ($part/$total chapters)\r"


### PR DESCRIPTION
###### Description of changes

Instead of wrapping out binary, we can patch the script to point
directly into /nix/store/. While doing this, we added a few dependencies
we missed and found an osh parsing bug that has been reported upstream.

See oilshell/oil#1446

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
