### PR TITLE
digital: init at 0.29

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3475,6 +3475,13 @@
     githubId = 10042482;
     name = "Louis Pearson";
   };
+  Dettorer = {
+    name = "Paul Hervot";
+    email = "paul.hervot@dettorer.net";
+    matrix = "@dettorer:matrix.org";
+    github = "Dettorer";
+    githubId = 2761682;
+  };
   devhell = {
     email = ''"^"@regexmail.net'';
     github = "devhell";

--- a/pkgs/applications/science/electronics/digital/default.nix
+++ b/pkgs/applications/science/electronics/digital/default.nix
@@ -1,0 +1,99 @@
+{ lib, stdenv, fetchFromGitHub, makeDesktopItem, copyDesktopItems, makeWrapper
+, jre, maven, git
+}:
+
+let
+  pkgDescription = "A digital logic designer and circuit simulator.";
+  version = "0.29";
+  buildDate = "2022-02-11T18:10:34+01:00"; # v0.29 commit date
+
+  desktopItem = makeDesktopItem {
+    type = "Application";
+    name = "Digital";
+    desktopName = pkgDescription;
+    comment = "Easy-to-use digital logic designer and circuit simulator";
+    exec = "digital";
+    icon = "digital";
+    categories = [ "Education" "Electronics" ];
+    mimeTypes = [ "text/x-digital" ];
+    terminal = false;
+    keywords = [ "simulator" "digital" "circuits" ];
+  };
+
+  # Use the "no-git-rev" maven profile, which deactivates the plugin that
+  # inspect the .git folder to find the version number we are building, we then
+  # provide that version number manually as a property.
+  # (see https://github.com/hneemann/Digital/issues/289#issuecomment-513721481)
+  mvnOptions = "-Pno-git-rev -Dgit.commit.id.describe=${version} -Dproject.build.outputTimestamp=${buildDate}";
+in
+stdenv.mkDerivation rec {
+  pname = "digital";
+  inherit version jre;
+
+  src = fetchFromGitHub {
+    owner = "hneemann";
+    repo = "Digital";
+    rev = "287dd939d6f2d4d02c0d883c6178c3425c28d39c";
+    sha256 = "o5gaExUTTbk6WgQVw7/IeXhpNkj1BLkwD752snQqjIg=";
+  };
+
+  # Use fixed dates in the pom.xml and upgrade the jar and assembly plugins to
+  # a version where they support reproducible builds
+  patches = [ ./pom.xml.patch ];
+
+  # Fetching maven dependencies from "central" needs the network at build phase,
+  # we do that in this extra derivation that explicitely specifies its
+  # outputHash to ensure determinism.
+  mavenDeps = stdenv.mkDerivation {
+    name = "${pname}-${version}-maven-deps";
+    inherit src nativeBuildInputs version patches postPatch;
+    dontFixup = true;
+    buildPhase = ''
+      mvn package ${mvnOptions} -Dmaven.repo.local=$out
+    '';
+    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with
+    # lastModified timestamps inside
+    installPhase = ''
+      find $out -type f \
+        -name \*.lastUpdated -or \
+        -name resolver-status.properties -or \
+        -name _remote.repositories \
+        -delete
+    '';
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "X5ppGUVwNQrMnjzD4Kin1Xmt4O3x+qr7jK4jr6E8tCI=";
+  };
+
+  nativeBuildInputs = [ copyDesktopItems maven makeWrapper ];
+
+  postPatch = ''
+    substituteInPlace pom.xml --subst-var-by buildDate "${buildDate}"
+  '';
+
+  buildPhase = ''
+    mvn package --offline ${mvnOptions} -Dmaven.repo.local=${mavenDeps}
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/java
+
+    classpath=$(find ${mavenDeps} -name "*.jar" -printf ':%h/%f');
+    install -Dm644 target/Digital.jar $out/share/java
+
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+      --add-flags "-classpath $out/share/java/${pname}-${version}.jar:''${classpath#:}" \
+      --add-flags "-jar $out/share/java/Digital.jar"
+  '';
+
+  desktopItems = [ desktopItem ];
+
+  meta = with lib; {
+    homepage = "https://github.com/hneemann/Digital";
+    description = pkgDescription;
+    license = licenses.gpl3Only;
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ Dettorer ];
+  };
+}

--- a/pkgs/applications/science/electronics/digital/pom.xml.patch
+++ b/pkgs/applications/science/electronics/digital/pom.xml.patch
@@ -1,0 +1,30 @@
+diff --git a/pom.xml b/pom.xml
+index d5f8330b4..58ed18b63 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -129,7 +130,7 @@
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-jar-plugin</artifactId>
+-                <version>2.5</version>
++                <version>3.2.0</version>
+                 <configuration>
+                     <archive>
+                         <manifest>
+@@ -188,6 +189,7 @@
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-assembly-plugin</artifactId>
++                <version>3.2.0</version>
+                 <configuration>
+                     <finalName>Digital</finalName>
+                     <appendAssemblyId>false</appendAssemblyId>
+@@ -202,7 +204,7 @@
+                         </manifest>
+                         <manifestEntries>
+                             <Build-SCM-Revision>${git.commit.id.describe}</Build-SCM-Revision>
+-                            <Build-Time>${maven.build.timestamp}</Build-Time>
++                            <Build-Time>@buildDate@</Build-Time>
+                             <SplashScreen-Image>icons/splash.png</SplashScreen-Image>
+                         </manifestEntries>
+                     </archive>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28321,6 +28321,8 @@ with pkgs;
 
   dia = callPackage ../applications/graphics/dia { };
 
+  digital = callPackage ../applications/science/electronics/digital {};
+
   direwolf = callPackage ../applications/radio/direwolf {
     hamlib = hamlib_4;
   };


### PR DESCRIPTION
###### Description of changes

Add the [Digital](https://github.com/hneemann/Digital) application, a digital logic designer and circuit simulator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Since this application uses maven as its build system, I used an extra derivation with an explicit `outputHash` that fetches the dependencies from central, then did the actual building in the main derivation, using the extra one as the dependency store for offline building. I had some trouble with automatic dates added by maven and some plugins that were not reproducible-ready, everything seems completely deterministic now even with `sandbox = true` in my /etc/nix/nix.conf. I am not experimented with maven so I could have missed some non-reproducible bits, but I did rebuilds for a few hours using the following script and no differences where found at any point:

```bash
nix-collect-garbage -d
nix build --keep-failed '.#digital'
while nix build --rebuild --keep-failed '.#digital'; do
    sleep 5m
done
```