### PR TITLE
python3.pkgs.hypothesis: build offline documentation

### DIFF
--- a/pkgs/development/python-modules/chardet/default.nix
+++ b/pkgs/development/python-modules/chardet/default.nix
@@ -23,7 +23,8 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    hypothesis
+    # "hypothesis" indirectly depends on chardet to build its documentation.
+    (hypothesis.override { enableDocumentation = false; })
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -62,7 +62,8 @@ buildPythonPackage rec {
 
   checkInputs = [
     cryptography-vectors
-    hypothesis
+    # "hypothesis" indirectly depends on cryptography to build its documentation
+    (hypothesis.override { enableDocumentation = false; })
     iso8601
     pretend
     py

--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -9,11 +9,18 @@
 , pytest-xdist
 , sortedcontainers
 , pythonOlder
+, sphinxHook
+, sphinx-rtd-theme
+, sphinx-hoverxref
+, sphinx-codeautolink
+# Used to break internal dependency loop.
+, enableDocumentation ? true
 }:
 
 buildPythonPackage rec {
   pname = "hypothesis";
   version = "6.61.0";
+  outputs = [ "out" ] ++ lib.optional enableDocumentation "doc";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -25,7 +32,27 @@ buildPythonPackage rec {
     hash = "sha256-gTcdJaOgP8Nc4fN8UH6+sLedivq5ZNxMRULajFOVnSo=";
   };
 
+  # I tried to package sphinx-selective-exclude, but it throws
+  # error about "module 'sphinx' has no attribute 'directives'".
+  #
+  # It probably has to do with monkey-patching internals of Sphinx.
+  # On bright side, this extension does not introduces new commands,
+  # only changes "::only" command, so we probably okay with stock
+  # implementation.
+  #
+  # I wonder how upstream of "hypothesis" builds documentation.
+  postPatch = ''
+    sed -i -e '/sphinx_selective_exclude.eager_only/ d' docs/conf.py
+  '';
+
   postUnpack = "sourceRoot=$sourceRoot/hypothesis-python";
+
+  nativeBuildInputs = lib.optionals enableDocumentation [
+    sphinxHook
+    sphinx-rtd-theme
+    sphinx-hoverxref
+    sphinx-codeautolink
+  ];
 
   propagatedBuildInputs = [
     attrs

--- a/pkgs/development/python-modules/iso8601/default.nix
+++ b/pkgs/development/python-modules/iso8601/default.nix
@@ -25,7 +25,8 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    hypothesis
+    # "hypothesis" indirectly depends on iso8601 to build its documentation
+    (hypothesis.override { enableDocumentation = false; })
     pytestCheckHook
     pytz
   ];

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -77,7 +77,8 @@ in buildPythonPackage rec {
 
   checkInputs = [
     pytest
-    hypothesis
+    # "hypothesis" indirectly depends on numpy to build its documentation.
+    (hypothesis.override { enableDocumentation = false; })
     typing-extensions
   ];
 

--- a/pkgs/development/python-modules/sphinx-codeautolink/default.nix
+++ b/pkgs/development/python-modules/sphinx-codeautolink/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonImportsCheckHook
+# documentation build dependencies
+, sphinxHook
+, sphinx-rtd-theme
+, matplotlib
+, ipython
+# runtime dependencies
+, sphinx
+, beautifulsoup4
+# check dependencies
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-codeautolink";
+  version = "0.12.1";
+  outputs = [ "out" "doc" ];
+
+  src = fetchFromGitHub {
+    owner = "felix-hilden";
+    repo = "sphinx-codeautolink";
+    rev = "v${version}";
+    hash = "sha256-x81jhYknJ6lsLxR5ZyuYNNz/zt0kto6bNyaeZmPKDIE=";
+  };
+
+  nativeBuildInputs = [
+    pythonImportsCheckHook
+    sphinxHook
+    sphinx-rtd-theme
+    matplotlib
+    ipython
+  ];
+
+  sphinxRoot = "docs/src";
+
+  propagatedBuildInputs = [ sphinx beautifulsoup4 ];
+
+  checkInputs = [ pytest ];
+
+  pythonImportsCheck = [ "sphinx_codeautolink" ];
+
+  meta = with lib; {
+    description = "A sphinx extension that makes code examples clickable";
+    homepage = "https://github.com/felix-hilden/sphinx-codeautolink";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-hoverxref/default.nix
+++ b/pkgs/development/python-modules/sphinx-hoverxref/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, pythonImportsCheckHook
+# documentation build dependencies
+, sphinxHook
+, sphinx-notfound-page
+, sphinx-prompt
+, sphinx-rtd-theme
+, sphinx-tabs
+, sphinx-version-warning
+, sphinxcontrib-autoapi
+, sphinxcontrib-bibtex
+, sphinxemoji
+# runtime dependencies
+, sphinx
+, sphinx-jquery
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-hoverxref";
+  version = "1.3.0";
+  format = "flit";
+  outputs = [ "out" "doc" ];
+
+  src = fetchFromGitHub {
+    owner = "readthedocs";
+    repo = "sphinx-hoverxref";
+    rev = version;
+    hash = "sha256-DJ+mHu9IeEYEyf/SD+nDNtWpTf6z7tQzG0ogaECDpkU=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+    pythonImportsCheckHook
+
+    sphinxHook
+    sphinx-notfound-page
+    sphinx-prompt
+    sphinx-rtd-theme
+    sphinx-tabs
+    sphinx-version-warning
+    sphinxcontrib-autoapi
+    sphinxcontrib-bibtex
+    sphinxemoji
+  ];
+
+  propagatedBuildInputs = [ sphinx sphinx-jquery ];
+
+  pythonImportsCheck = [ "hoverxref" ];
+
+  meta = with lib; {
+    description = "A sphinx extension for creating tooltips on the cross references of the documentation";
+    longDescription = ''
+      sphinx-hoverxref is a Sphinx extension to show a floating window
+      (tooltips or modal dialogues) on the cross references of the
+      documentation embedding the content of the linked section on them.
+
+      With sphinx-hoverxref, you don’t need to click a link to see what’s
+      in there.
+    '';
+    homepage = "https://github.com/readthedocs/sphinx-hoverxref";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-jquery/default.nix
+++ b/pkgs/development/python-modules/sphinx-jquery/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, pythonImportsCheckHook
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-jquery";
+  version = "3.0.0";
+  format = "flit";
+
+  src = fetchFromGitHub {
+    owner = "sphinx-contrib";
+    repo = "jquery";
+    rev = "v${version}";
+    hash = "sha256-argG+jMUqLiWo4lKWAmHmUxotHl+ddJuJZ/zcUl9u5Q=";
+  };
+
+  nativeBuildInputs = [
+    pythonImportsCheckHook
+    flit-core
+  ];
+
+  propagatedBuildInputs = [ sphinx ];
+
+  pythonImportsCheck = [ "sphinxcontrib.jquery" ];
+
+  meta = with lib; {
+    description = "A sphinx extension that ensures that jQuery is installed for use in Sphinx themes or extensions";
+    homepage = "https://github.com/sphinx-contrib/jquery";
+    license = licenses.bsd0;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-notfound-page/default.nix
+++ b/pkgs/development/python-modules/sphinx-notfound-page/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, pythonImportsCheckHook
+# documentation build dependencies
+, sphinxHook
+, sphinx-prompt
+, sphinx-rtd-theme
+, sphinx-tabs
+, sphinxcontrib-autoapi
+, sphinxemoji
+# runtime dependencies
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-notfound-page";
+  version = "0.8.3";
+  format = "flit";
+  outputs = [ "out" "doc" ];
+
+  src = fetchFromGitHub {
+    owner = "readthedocs";
+    repo = "sphinx-notfound-page";
+    rev = version;
+    hash = "sha256-9iP6X2dqtMC3+CIrNI3fGDLL8xyXVAWNhN90DlMa9JU=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+    pythonImportsCheckHook
+    sphinxHook
+    sphinx-prompt
+    sphinx-rtd-theme
+    sphinx-tabs
+    sphinxcontrib-autoapi
+    sphinxemoji
+  ];
+
+  propagatedBuildInputs = [ sphinx ];
+
+  pythonImportsCheck = [ "notfound" ];
+
+  meta = with lib; {
+    description = "A sphinx extension to create a custom 404 page with absolute URLs hardcoded";
+    homepage = "https://github.com/readthedocs/sphinx-notfound-page";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-prompt/default.nix
+++ b/pkgs/development/python-modules/sphinx-prompt/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, sphinxHook
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-prompt";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "sbrunner";
+    repo = "sphinx-prompt";
+    rev = version;
+    hash = "sha256-ClUPAIyPrROJw4GXeakA8U443Vlhy3P/2vFnAtyrPHU=";
+  };
+
+  propagatedBuildInputs = [ sphinx ];
+
+  meta = with lib; {
+    description = "A sphinx extension for creating unselectable prompt";
+    homepage = "https://github.com/sbrunner/sphinx-prompt";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-tabs/default.nix
+++ b/pkgs/development/python-modules/sphinx-tabs/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonImportsCheckHook
+# documentation build dependencies
+, sphinxHook
+# runtime dependencies
+, sphinx
+, pygments
+, docutils
+# test dependencies
+, pytest
+, beautifulsoup4
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-tabs";
+  version = "3.4.1";
+  outputs = [ "out" "doc" ];
+
+  src = fetchFromGitHub {
+    owner = "executablebooks";
+    repo = "sphinx-tabs";
+    rev = "v${version}";
+    hash = "sha256-5lpo7NRCksXJOdbLSFjDxQV/BsxRBb93lA6tavz6YEs=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace 'docutils~=0.18.0' 'docutils'
+  '';
+
+  nativeBuildInputs = [
+    pythonImportsCheckHook
+    sphinxHook
+  ];
+
+  propagatedBuildInputs = [
+    sphinx
+    pygments
+    docutils
+  ];
+
+  checkInputs = [ pytest
+    beautifulsoup4
+  ];
+
+  pythonImportsCheck = [ "sphinx_tabs" ];
+
+  meta = with lib; {
+    description = "A sphinx extension for creating tabbed content when building HTML.";
+    homepage = "https://github.com/executablebooks/sphinx-tabs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-version-warning/default.nix
+++ b/pkgs/development/python-modules/sphinx-version-warning/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, pythonImportsCheckHook
+, sphinx
+, sphinxHook
+, sphinxcontrib-autoapi
+, sphinx-rtd-theme
+, sphinx-tabs
+, sphinx-prompt
+, sphinxemoji
+}:
+
+# Latest tagged release release "1.1.2" (Nov 2018) does not contain
+# documenation, it was added in commits Aug 10, 2019. Repository does not have
+# any activity since then.
+buildPythonPackage rec {
+  pname = "sphinx-version-warning";
+  version = "unstable-2019-08-10";
+  outputs = [ "out" "doc" ];
+
+  src = fetchFromGitHub {
+    owner = "humitos";
+    repo = "sphinx-version-warning";
+    rev = "a82156c2ea08e5feab406514d0ccd9d48a345f48";
+    hash = "sha256-WnJYMk1gPLT0dBn7lmxVDNVkLYkDCgQOtM9fQ3kc6k0=";
+  };
+
+  # It tries to write to file relative to it own location at runtime
+  # and gets permission denied, since Nix store is immutable.
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/humitos/sphinx-version-warning/commit/cb1b47becf2a0d3b2570ca9929f42f7d7e472b6f.patch";
+      hash = "sha256-Vj0QAHIBmc0VxE+TTmJePzvr5nc45Sn2qqM+C/pkgtM=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    pythonImportsCheckHook
+    sphinxHook
+    sphinxcontrib-autoapi
+    sphinx-rtd-theme
+    sphinx-tabs
+    sphinx-prompt
+    sphinxemoji
+  ];
+
+  propagatedBuildInputs = [ sphinx ];
+
+  pythonImportsCheck = [ "versionwarning" ];
+
+  meta = with lib; {
+    description = "A sphinx extension to show a warning banner at the top of your documentation";
+    homepage = "https://github.com/humitos/sphinx-version-warning";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kaction ];
+  };
+}

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -132,7 +132,8 @@ buildPythonPackage rec {
   checkInputs = [
     git
     glibcLocales
-    hypothesis
+    # "hypothesis" indirectly depends on twisted to build its documentation.
+    (hypothesis.override { enableDocumentation = false; })
     pyhamcrest
   ]
   ++ passthru.optional-dependencies.conch

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10672,6 +10672,8 @@ self: super: with self; {
 
   sphinx-multitoc-numbering = callPackage ../development/python-modules/sphinx-multitoc-numbering { };
 
+  sphinx-notfound-page = callPackage ../development/python-modules/sphinx-notfound-page { };
+
   sphinx-pytest = callPackage ../development/python-modules/sphinx-pytest { };
 
   sphinx-thebe = callPackage ../development/python-modules/sphinx-thebe { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10676,6 +10676,8 @@ self: super: with self; {
 
   sphinx-pytest = callPackage ../development/python-modules/sphinx-pytest { };
 
+  sphinx-prompt = callPackage ../development/python-modules/sphinx-prompt { };
+
   sphinx-thebe = callPackage ../development/python-modules/sphinx-thebe { };
 
   sphinx-togglebutton = callPackage ../development/python-modules/sphinx-togglebutton { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10656,6 +10656,8 @@ self: super: with self; {
 
   sphinx-book-theme = callPackage ../development/python-modules/sphinx-book-theme { };
 
+  sphinx-codeautolink = callPackage ../development/python-modules/sphinx-codeautolink { };
+
   sphinx-comments = callPackage ../development/python-modules/sphinx-comments { };
 
   sphinx-design = callPackage ../development/python-modules/sphinx-design { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10680,6 +10680,8 @@ self: super: with self; {
 
   sphinx-thebe = callPackage ../development/python-modules/sphinx-thebe { };
 
+  sphinx-tabs = callPackage ../development/python-modules/sphinx-tabs { };
+
   sphinx-togglebutton = callPackage ../development/python-modules/sphinx-togglebutton { };
 
   sphinxcontrib-actdiag = callPackage ../development/python-modules/sphinxcontrib-actdiag { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10744,6 +10744,8 @@ self: super: with self; {
 
   sphinx-argparse = callPackage ../development/python-modules/sphinx-argparse { };
 
+  sphinx-jquery = callPackage ../development/python-modules/sphinx-jquery { };
+
   sphinx-autobuild = callPackage ../development/python-modules/sphinx-autobuild { };
 
   sphinx-autodoc-typehints = callPackage ../development/python-modules/sphinx-autodoc-typehints { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10666,6 +10666,8 @@ self: super: with self; {
 
   sphinx-fortran = callPackage ../development/python-modules/sphinx-fortran { };
 
+  sphinx-hoverxref = callPackage ../development/python-modules/sphinx-hoverxref { };
+
   sphinx-jupyterbook-latex = callPackage ../development/python-modules/sphinx-jupyterbook-latex { };
 
   sphinx-multitoc-numbering = callPackage ../development/python-modules/sphinx-multitoc-numbering { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10784,6 +10784,8 @@ self: super: with self; {
 
   sphinx-testing = callPackage ../development/python-modules/sphinx-testing { };
 
+  sphinx-version-warning = callPackage ../development/python-modules/sphinx-version-warning { };
+
   sphinxext-opengraph = callPackage ../development/python-modules/sphinxext-opengraph { };
 
   spidev = callPackage ../development/python-modules/spidev { };


### PR DESCRIPTION
I wanted to build documentation for one package, but rabbit hole was
quite deep. Summary of commits:

- python3.pkgs.hypothesis: build offline documentation
- python3.pkgs.sphinx-codeautolink: init at 0.12.1
- python3.pkgs.sphinx-hoverxref: init at 1.3.0
- python3.pkgs.sphinx-jquery: init at 3.0.0
- python3.pkgs.sphinx-notfound-page: init at 0.8.3
- python3.pkgs.sphinx-prompt: init at 1.5.0
- python3.pkgs.sphinx-tabs: init at 3.4.1
- python3.pkgs.sphinx-version-warning: init at unstable-2019-08-10

###### Description of changes

Add `sphinxHook` into `python3.pkgs.hypothesis` derivation and package
new dependencies as necessary.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
