### PR TITLE
Fix gitlab-runner NixOS module

### DIFF
--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -9,14 +9,14 @@ let
   The hash is recorded in the runner's name because we can't do better yet
   See https://gitlab.com/gitlab-org/gitlab-runner/-/issues/29350 for more details
   */
-  genRunnerName = service: let
+  genRunnerName = name: service: let
       hash = substring 0 12 (hashString "md5" (unsafeDiscardStringContext (toJSON service)));
-    in if service ? description
+    in if service ? description && service.description != null
     then "${hash} ${service.description}"
     else "${name}_${config.networking.hostName}_${hash}";
 
   hashedServices = mapAttrs'
-    (name: service: nameValuePair (genRunnerName service) service) cfg.services;
+    (name: service: nameValuePair (genRunnerName name service) service) cfg.services;
   configPath = ''"$HOME"/.gitlab-runner/config.toml'';
   configureScript = pkgs.writeShellApplication {
     name = "gitlab-runner-configure";
@@ -38,7 +38,7 @@ let
     '' else ''
       export CONFIG_FILE=${configPath}
 
-      mkdir -p "$(dirname "${configPath}")"
+      mkdir -p "$(dirname ${configPath})"
       touch ${configPath}
 
       # update global options

--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -534,9 +534,9 @@ in {
     };
   };
   config = mkIf cfg.enable {
-    warnings = (mapAttrsToList
+    warnings = mapAttrsToList
       (n: v: "services.gitlab-runner.services.${n}.`registrationConfigFile` points to a file in Nix Store. You should use quoted absolute path to prevent this.")
-      (filterAttrs (n: v: isStorePath v.registrationConfigFile) cfg.services));
+      (filterAttrs (n: v: isStorePath v.registrationConfigFile) cfg.services);
 
     environment.systemPackages = [ cfg.package ];
     systemd.services.gitlab-runner = {
@@ -570,7 +570,7 @@ in {
         ExecStartPre = "!${configureScript}/bin/gitlab-runner-configure";
         ExecStart = "${startScript}/bin/gitlab-runner-start";
         ExecReload = "!${configureScript}/bin/gitlab-runner-configure";
-      } // optionalAttrs (cfg.gracefulTermination) {
+      } // optionalAttrs cfg.gracefulTermination {
         TimeoutStopSec = "${cfg.gracefulTimeout}";
         KillSignal = "SIGQUIT";
         KillMode = "process";


### PR DESCRIPTION
###### Description of changes

#197286 broke gitlab-runner module and it doesn't seem it's been tested at all.

The `description` option defaults to null, so without explicit description the module doesn't even evaluate:

```
error: cannot coerce null to a string

       at /nix/store/d02gi2ddx87l037ghfpxg8z7nxkd6f7n-source/nixos/modules/services/continuous-integration/gitlab-runner.nix:15:19:

           14|     in if service ? description
           15|     then "${hash} ${service.description}"
             |                   ^
           16|     else "${name}_${config.networking.hostName}_${hash}";
```

After fixing the condition it still fails to evaluate:

```
error: undefined variable 'name'

       at /nix/store/imscfhwicav9qk3rr0lyg9r8mcxqkn04-source/wip/gitlab-runner.nix:16:13:

           15|     then "${hash} ${service.description}"
           16|     else "${name}_${config.networking.hostName}_${hash}";
             |             ^
           17|
```

With the second issue fixed (or after adding a description as workaround attempt), it fails to build:

```
In /nix/store/m6816c9dasxfi4287rz70aagi9069g7z-gitlab-runner-configure/bin/gitlab-runner-configure line 10:
mkdir -p "$(dirname ""$HOME"/.gitlab-runner/config.toml")"
                      ^---^ SC2027 (warning): The surrounding quotes actually unquote this. Remove or escape them.
                      ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mkdir -p "$(dirname """$HOME""/.gitlab-runner/config.toml")"

For more information:
  https://www.shellcheck.net/wiki/SC2027 -- The surrounding quotes actually u...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

This PR fixes all three issues and makes the module build, which I have actually tested. Second commit fixes style issues flagged by `statix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
