### PR TITLE
Add 'cookbook', a simple recipe hoster

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13455,6 +13455,12 @@
     githubId = 48666;
     name = "Matthew \"strager\" Glazar";
   };
+  strangeglyph = {
+    email = "mail@strangegly.ph";
+    github = "strangeglyph";
+    githubId = 974869;
+    name = "strangeglyph";
+  };
   strikerlulu = {
     email = "strikerlulu7@gmail.com";
     github = "strikerlulu";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1117,6 +1117,7 @@
   ./services/web-apps/changedetection-io.nix
   ./services/web-apps/code-server.nix
   ./services/web-apps/convos.nix
+  ./services/web-apps/cookbook.nix
   ./services/web-apps/dex.nix
   ./services/web-apps/discourse.nix
   ./services/web-apps/documize.nix

--- a/nixos/modules/services/web-apps/cookbook.nix
+++ b/nixos/modules/services/web-apps/cookbook.nix
@@ -1,0 +1,121 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkIf mkMerge mkOption mkEnableOption mkPackageOptionMD mdDoc types;
+  cfg = config.services.cookbook;
+  cookbook-config-file = pkgs.writeText "config.json" (builtins.toJSON {
+    SECRET_KEY = cfg.config.secret;
+    COOKBOOK_LOCATION = cfg.config.recipes;
+    DEFAULT_LANG = cfg.config.default-language;
+    SITE_NAME = cfg.config.site-name;
+    BASE_URL = "https://${cfg.vhost}";
+  });
+in
+{
+  options.services.cookbook = {
+    enable = mkEnableOption (mdDoc "cookbook service");
+
+    vhost = mkOption {
+      type = types.str;
+      description = mdDoc "Domain to serve on.";
+    };
+
+    package = mkPackageOptionMD pkgs "cookbook" {
+      default = [ "python3Packages" "cookbook" ];
+    };
+
+    group = mkOption {
+      type = types.str;
+      description = mdDoc "Unix group that owns the socket that nginx and uwsgi will communicate with.";
+      default = "cookbook";
+    };
+
+    useACMEHost = mkOption {
+      type = types.nullOr types.str;
+      description = mdDoc "Add the cookbook domain to this domain's certificate's list.";
+      default = null;
+    };
+
+    config = {
+      site-name = mkOption {
+        type = types.str;
+        description = mdDoc "User-visible name of the website.";
+        default = "Cookbook";
+      };
+
+      default-language = mkOption {
+        type = types.str;
+        description = mdDoc "Default language to use when users first navigate to the service.";
+        default = "en";
+      };
+
+      recipes = mkOption {
+        type = types.path;
+        description = mdDoc "Path to the folder containing the recipes (can be read-only).";
+      };
+
+      secret = mkOption {
+        type = types.str;
+        description = mdDoc "A random string used to sign session cookies (keep this secret).";
+        example = "builtins.readFile .secrets/cookbook-secret";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    security.acme.certs = mkIf (cfg.useACMEHost != null) {
+      "${cfg.useACMEHost}".extraDomainNames = [ cfg.vhost ];
+    };
+
+    users.groups."${cfg.group}".members = [ "nginx" "uwsgi" ];
+
+    services.nginx = {
+      enable = true;
+      virtualHosts."${cfg.vhost}" = mkMerge [
+        (mkIf (cfg.useACMEHost != null) {
+          forceSSL = true;
+          useACMEHost = cfg.useACMEHost;
+        })
+        ({
+          locations = {
+            "/static/".alias = "${cfg.package}/static/";
+            "/images/" = {
+              alias = "${cfg.config.recipes}/images/";
+              extraConfig = ''
+                expires 7d;
+                add_header Cache-Control "public";
+              '';
+            };
+            "/" = {
+              extraConfig = ''
+                uwsgi_pass unix:${config.services.uwsgi.runDir}/cookbook.sock;
+              '';
+            };
+          };
+        })
+      ];
+    };
+
+    services.uwsgi = {
+      enable = true;
+      plugins = [ "python3" ];
+
+      instance = {
+        type = "emperor";
+        vassals.cookbook = {
+          type = "normal";
+          master = true;
+          workers = 5;
+          plugin = "python3";
+          chmod-socket = "664";
+          chown-socket = "uwsgi:${cfg.group}";
+          socket = "${config.services.uwsgi.runDir}/cookbook.sock";
+
+          pythonPackages = self: [ cfg.package ];
+          module = "cookbook:app";
+          env = [ "COOKBOOK_CONFIG=${cookbook-config-file}" ];
+        };
+      };
+    };
+  };
+}

--- a/pkgs/servers/cookbook/default.nix
+++ b/pkgs/servers/cookbook/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchFromGitHub, pythonPackages, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "cookbook";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "strangeglyph";
+    repo = "cookbook";
+    rev = "v${version}";
+    sha256 = "sha256-ylpQweY1uhzk8vINGGNrQpS/jkVnAWeY9YZfD/i3zdE=";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ flask ruamel-yaml ];
+
+  pythonImportsCheck = [ "flask" "ruamel.yaml" ];
+  doCheck = false; # the package provides no checks
+
+  postInstall = ''
+    cp -r $src/cookbook/static $out/static
+    echo "from cookbook import app" > $out/wsgi.py
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/strangeglyph/cookbook";
+    description = "Flask application to serve recipes";
+    license = licenses.mit;
+    maintainers = [ maintainers.strangeglyph ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1979,6 +1979,8 @@ self: super: with self; {
 
   convertdate = callPackage ../development/python-modules/convertdate { };
 
+  cookbook = callPackage ../servers/cookbook { };
+
   cookiecutter = callPackage ../development/python-modules/cookiecutter { };
 
   cookies = callPackage ../development/python-modules/cookies { };


### PR DESCRIPTION
###### Description of changes

Add cookbook as a package and a corresponding module.

[Cookbook](https://github.com/strangeglyph/cookbook) is a simple python web-app recipe hoster.

###### Things done
- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
