### PR TITLE
qdmr: init at 0.11.2, added janik as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6415,6 +6415,13 @@
     githubId = 20176306;
     name = "jammerful";
   };
+  janik = {
+    name = "Janik";
+    email = "janik@aq0.de";
+    matrix = "@janik0:matrix.org";
+    github = "Janik-Haag";
+    githubId = 80165193;
+  };
   jansol = {
     email = "jan.solanti@paivola.fi";
     github = "jansol";

--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -77,6 +77,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://dm3mat.darc.de/qdmr/">QDMR</link>, a
+          gui application and command line tool for programming cheap
+          DMR radios
+          <link linkend="opt-programs.qdmr.enable">programs.qdmr</link>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://v2raya.org">v2rayA</link>, a Linux
           web GUI client of Project V which supports V2Ray, Xray, SS,
           SSR, Trojan and Pingtunnel. Available as

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -28,6 +28,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [mmsd](https://gitlab.com/kop316/mmsd), a lower level daemon that transmits and recieves MMSes. Available as [services.mmsd](#opt-services.mmsd.enable).
 
+- [QDMR](https://dm3mat.darc.de/qdmr/), a gui application and command line tool for programming cheap DMR radios [programs.qdmr](#opt-programs.qdmr.enable)
+
 - [v2rayA](https://v2raya.org), a Linux web GUI client of Project V which supports V2Ray, Xray, SS, SSR, Trojan and Pingtunnel. Available as [services.v2raya](options.html#opt-services.v2raya.enable).
 
 - [ulogd](https://www.netfilter.org/projects/ulogd/index.html), a userspace logging daemon for netfilter/iptables related logging. Available as [services.ulogd](options.html#opt-services.ulogd.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -214,6 +214,7 @@
   ./programs/partition-manager.nix
   ./programs/plotinus.nix
   ./programs/proxychains.nix
+  ./programs/qdmr.nix
   ./programs/qt5ct.nix
   ./programs/rog-control-center.nix
   ./programs/rust-motd.nix

--- a/nixos/modules/programs/qdmr.nix
+++ b/nixos/modules/programs/qdmr.nix
@@ -1,0 +1,25 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.qdmr;
+in {
+  meta.maintainers = [ lib.maintainers.janik ];
+
+  options = {
+    programs.qdmr = {
+      enable = lib.mkEnableOption (lib.mdDoc "QDMR - a GUI application and command line tool for programming DMR radios");
+      package = lib.mkPackageOptionMD pkgs "qdmr" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    services.udev.packages = [ cfg.package ];
+    users.groups.wireshark = {};
+  };
+}

--- a/pkgs/applications/radio/qdmr/default.nix
+++ b/pkgs/applications/radio/qdmr/default.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+  writeText,
+  cmake,
+  libxslt,
+  docbook_xsl_ns,
+  wrapQtAppsHook,
+  libusb1,
+  libyamlcpp,
+  qtlocation,
+  qtserialport,
+  qttools,
+  qtbase,
+}:
+
+let
+  inherit (stdenv) isLinux;
+in
+
+stdenv.mkDerivation rec {
+  pname = "qdmr";
+  version = "0.11.2";
+
+  src = fetchFromGitHub {
+    owner = "hmatuschek";
+    repo = "qdmr";
+    rev = "v${version}";
+    sha256 = "sha256-zT31tzsm5OM99vz8DzGCdPmnemiwiJpKccYwECnUgOQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    libxslt
+    wrapQtAppsHook
+    installShellFiles
+  ];
+
+  buildInputs = [
+    libyamlcpp
+    libusb1
+    qtlocation
+    qtserialport
+    qttools
+    qtbase
+  ];
+
+  postPatch = lib.optionalString isLinux ''
+    substituteInPlace doc/docbook_man.debian.xsl \
+      --replace /usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook\.xsl ${docbook_xsl_ns}/xml/xsl/docbook/manpages/docbook.xsl
+  '';
+
+  cmakeFlags = [ "-DBUILD_MAN=ON" ];
+
+  postInstall = ''
+    installManPage doc/dmrconf.1 doc/qdmr.1
+    mkdir -p "$out/etc/udev/rules.d"
+    cp ${src}/dist/99-qdmr.rules $out/etc/udev/rules.d/
+  '';
+
+  meta = {
+    description = "A codeplug programming tool for DMR radios";
+    homepage = "https://dm3mat.darc.de/qdmr/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ janik _0x4A6F ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -688,6 +688,8 @@ with pkgs;
 
   ebook2cw = callPackage ../applications/radio/ebook2cw { };
 
+  qdmr = libsForQt5.callPackage ../applications/radio/qdmr { };
+
   edwin = callPackage ../data/fonts/edwin { };
 
   etBook = callPackage ../data/fonts/et-book { };


### PR DESCRIPTION
###### Description of changes

Added [qdmr](https://dm3mat.darc.de/qdmr/) to nixpkgs 
Closes #191508

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

