### PR TITLE
azpainter: 3.0.4 → 3.0.6

### DIFF
--- a/pkgs/applications/graphics/azpainter/default.nix
+++ b/pkgs/applications/graphics/azpainter/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitLab
-, desktop-file-utils, shared-mime-info
+, desktop-file-utils, shared-mime-info, ninja, pkg-config
 , libiconv
 , libX11, libXcursor, libXext, libXi
 , freetype, fontconfig
@@ -9,18 +9,20 @@
 
 stdenv.mkDerivation rec {
   pname = "azpainter";
-  version = "3.0.4";
+  version = "3.0.6";
 
   src = fetchFromGitLab {
     owner = "azelpg";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-2gTTF1ti9bO24d75mhwyvJISSgMKdmp+oJVmgzEQHdY=";
+    hash = "sha256-/shmLdZ4mCBZAeUuqJtCiUjeI8B5f/8dIGPqmXMjZ1I=";
   };
 
   nativeBuildInputs = [
     desktop-file-utils # for update-desktop-database
     shared-mime-info   # for update-mime-info
+    ninja
+    pkg-config
   ];
 
   buildInputs = [
@@ -29,6 +31,10 @@ stdenv.mkDerivation rec {
     libjpeg libpng libtiff libwebp
     zlib
   ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
+
+  preBuild = ''
+    cd build
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Description of changes
[Changelog](https://gitlab.com/azelpg/azpainter/-/commit/81770eab1da17da4b00eacd49f9bbf63b1f13ef5)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
