### PR TITLE
lukesmithxyz-bible-kjv: init at unstable-2022-06-01

### DIFF
--- a/pkgs/applications/misc/lukesmithxyz-bible/kjv.nix
+++ b/pkgs/applications/misc/lukesmithxyz-bible/kjv.nix
@@ -1,0 +1,29 @@
+{ lib
+, gawk
+, stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lukesmithxyz-bible-kjv";
+  version = "unstable-2022-06-01";
+
+  src = fetchFromGitHub {
+    owner = "lukesmithxyz";
+    repo = "kjv";
+    rev = "1b675c0396806a2a3d134c51fd11d9fed8ea3dc5";
+    hash = "sha256-ii5SGZmO99VYbKdebfEbN3rL7LLSSQ0jm5mGqX2G3o0=";
+  };
+
+  buildInputs = [ gawk ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Read the Word of God from your terminal + Apocrypha";
+    homepage = "https://lukesmith.xyz/articles/command-line-bibles";
+    license = licenses.unlicense;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.wesleyjrz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3322,6 +3322,8 @@ with pkgs;
 
   kjv = callPackage ../applications/misc/kjv { };
 
+  lukesmithxyz-bible-kjv = callPackage ../applications/misc/lukesmithxyz-bible/kjv.nix { };
+
   luigi = callPackage ../applications/networking/cluster/luigi { };
 
   m-cli = callPackage ../os-specific/darwin/m-cli { };


### PR DESCRIPTION
###### Description of changes

This is a CLI bible that uses `awk` and shell script to print books, chapters or verses of the bible. It's a fork of [layeh/kjv](https://github.com/layeh/kjv).

![screenshot-20230108-153405](https://user-images.githubusercontent.com/60184588/211213801-ea4821b6-9a1c-44fb-be0b-2cccd0c9bdbd.png)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
