### PR TITLE
glibc: allow use ld-nix.so.conf

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -74,6 +74,9 @@ stdenv.mkDerivation ({
       /* Don't use /etc/ld.so.cache, for non-NixOS systems.  */
       ./dont-use-system-ld-so-cache.patch
 
+      /* Don't use /etc/ld.so.conf, for non-NixOS systems.  */
+      ./dont-use-system-ld-so-conf.patch
+
       /* Don't use /etc/ld.so.preload, but /etc/ld-nix.so.preload.  */
       ./dont-use-system-ld-so-preload.patch
 

--- a/pkgs/development/libraries/glibc/dont-use-system-ld-so-cache.patch
+++ b/pkgs/development/libraries/glibc/dont-use-system-ld-so-cache.patch
@@ -1,8 +1,8 @@
 diff --git a/elf/Makefile b/elf/Makefile
-index 5d666b1b..a5017e9c 100644
+index 5bdf0a38..bf3cb9a7 100644
 --- a/elf/Makefile
 +++ b/elf/Makefile
-@@ -669,14 +669,14 @@ $(objpfx)sln: $(sln-modules:%=$(objpfx)%.o)
+@@ -1317,14 +1317,14 @@ $(objpfx)sln: $(sln-modules:%=$(objpfx)%.o)
  
  $(objpfx)ldconfig: $(ldconfig-modules:%=$(objpfx)%.o)
  
@@ -21,10 +21,10 @@ index 5d666b1b..a5017e9c 100644
 +CFLAGS-rtld.c += $(PREFIX-FLAGS)
 +CFLAGS-dl-usage.c += $(PREFIX-FLAGS) \
    -D'RTLD="$(rtlddir)/$(rtld-installed-name)"'
- 
- cpp-srcs-left := $(all-rtld-routines:=.os)
+ CFLAGS-dl-diagnostics.c += $(SYSCONF-FLAGS) \
+   -D'PREFIX="$(prefix)"' \
 diff --git a/elf/dl-diagnostics.c b/elf/dl-diagnostics.c
-index bef224b3..8e166b12 100644
+index d29bdd69..c7124a65 100644
 --- a/elf/dl-diagnostics.c
 +++ b/elf/dl-diagnostics.c
 @@ -205,7 +205,7 @@ print_paths (void)
@@ -33,24 +33,11 @@ index bef224b3..8e166b12 100644
    _dl_diagnostics_print_labeled_string ("path.rtld", RTLD);
 -  _dl_diagnostics_print_labeled_string ("path.sysconfdir", SYSCONFDIR);
 +  _dl_diagnostics_print_labeled_string ("path.sysconfdir", PREFIX "/etc");
-
+ 
    unsigned int index = 0;
    static const char *system_dirs = SYSTEM_DIRS "\0";
-diff --git a/elf/ldconfig.c b/elf/ldconfig.c
-index 28ed637a..6f07b79a 100644
---- a/elf/ldconfig.c
-+++ b/elf/ldconfig.c
-@@ -57,7 +57,7 @@
- #define TLS_HWCAP_BIT 63
- 
- #ifndef LD_SO_CONF
--# define LD_SO_CONF SYSCONFDIR "/ld.so.conf"
-+# define LD_SO_CONF PREFIX "/etc/ld.so.conf"
- #endif
- 
- /* Get libc version number.  */
 diff --git a/sysdeps/generic/dl-cache.h b/sysdeps/generic/dl-cache.h
-index 964d50a4..2224d651 100644
+index df385dca..b907c214 100644
 --- a/sysdeps/generic/dl-cache.h
 +++ b/sysdeps/generic/dl-cache.h
 @@ -35,7 +35,7 @@
@@ -58,7 +45,7 @@ index 964d50a4..2224d651 100644
  
  #ifndef LD_SO_CACHE
 -# define LD_SO_CACHE SYSCONFDIR "/ld.so.cache"
-+# define LD_SO_CACHE PREFIX "/etc/ld.so.cache"
++# define LD_SO_CACHE "/etc/ld-nix.so.cache"
  #endif
  
  #ifndef add_system_dir

--- a/pkgs/development/libraries/glibc/dont-use-system-ld-so-conf.patch
+++ b/pkgs/development/libraries/glibc/dont-use-system-ld-so-conf.patch
@@ -1,0 +1,57 @@
+diff --git a/elf/ldconfig.c b/elf/ldconfig.c
+index 57bb95eb..1f4f663c 100644
+--- a/elf/ldconfig.c
++++ b/elf/ldconfig.c
+@@ -57,7 +57,7 @@
+ #define TLS_HWCAP_BIT 63
+ 
+ #ifndef LD_SO_CONF
+-# define LD_SO_CONF SYSCONFDIR "/ld.so.conf"
++# define LD_SO_CONF "/ld-nix.so.conf"
+ #endif
+ 
+ /* Get libc version number.  */
+diff --git a/elf/tst-glibc-hwcaps-prepend-cache.c b/elf/tst-glibc-hwcaps-prepend-cache.c
+index d70d27bb..e797361b 100644
+--- a/elf/tst-glibc-hwcaps-prepend-cache.c
++++ b/elf/tst-glibc-hwcaps-prepend-cache.c
+@@ -46,7 +46,7 @@ do_test (void)
+ 
+   /* Install the default implementation of libmarkermod1.so.  */
+   xmkdirp ("/etc", 0777);
+-  support_write_file_string ("/etc/ld.so.conf", "/glibc-test/lib\n");
++  support_write_file_string ("/etc/ld-nix.so.conf", "/glibc-test/lib\n");
+   xmkdirp ("/glibc-test/lib/glibc-hwcaps/prepend2", 0777);
+   xmkdirp ("/glibc-test/lib/glibc-hwcaps/prepend3", 0777);
+   {
+diff --git a/elf/tst-ldconfig-ld_so_conf-update.c b/elf/tst-ldconfig-ld_so_conf-update.c
+index 76064589..f627a118 100644
+--- a/elf/tst-ldconfig-ld_so_conf-update.c
++++ b/elf/tst-ldconfig-ld_so_conf-update.c
+@@ -33,7 +33,7 @@
+ 
+ #define DSO "libldconfig-ld-mod.so"
+ #define DSO_DIR "/tmp/tst-ldconfig"
+-#define CONF "/etc/ld.so.conf"
++#define CONF "/etc/ld-nix.so.conf"
+ 
+ 
+ static void
+@@ -84,7 +84,7 @@ do_test (void)
+ 
+   FILE *fp = xfopen (CONF, "a+");
+   if (!fp)
+-    FAIL_EXIT1 ("creating /etc/ld.so.conf failed: %m");
++    FAIL_EXIT1 ("creating /etc/ld-nix.so.conf failed: %m");
+   xfclose (fp);
+ 
+   /* Run ldconfig.  */
+@@ -97,7 +97,7 @@ do_test (void)
+   /* Add tst-ldconfig directory to /etc/ld.so.conf.  */
+   fp = xfopen (CONF, "w");
+   if (!(fwrite (DSO_DIR, 1, sizeof (DSO_DIR), fp)))
+-    FAIL_EXIT1 ("updating /etc/ld.so.conf failed: %m");
++    FAIL_EXIT1 ("updating /etc/ld-nix.so.conf failed: %m");
+   xfclose (fp);
+ 
+   /* Try to dlopen the same DSO again, we expect this to still fail.  */

--- a/pkgs/development/libraries/glibc/dont-use-system-ld-so-preload.patch
+++ b/pkgs/development/libraries/glibc/dont-use-system-ld-so-preload.patch
@@ -1,7 +1,8 @@
-diff -ru glibc-2.20-orig/elf/rtld.c glibc-2.20/elf/rtld.c
---- glibc-2.20-orig/elf/rtld.c	2014-09-07 10:09:09.000000000 +0200
-+++ glibc-2.20/elf/rtld.c	2014-10-27 11:32:25.203043157 +0100
-@@ -1513,7 +1513,7 @@
+diff --git a/elf/rtld.c b/elf/rtld.c
+index 8dafaf61..d52bc63e 100644
+--- a/elf/rtld.c
++++ b/elf/rtld.c
+@@ -1862,7 +1862,7 @@ dl_main (const ElfW(Phdr) *phdr,
       open().  So we do this first.  If it succeeds we do almost twice
       the work but this does not matter, since it is not for production
       use.  */


### PR DESCRIPTION
###### Description of changes
This PR allows libraries to be loaded via the `/etc/ld-nix.so.conf' configuration file. Loading of NSS modules is supported.

Example.
Add to nixos configuration:
```
  environment.etc."ld-nix.so.conf".text = ''
    ${pkgs.tcb.out}/lib
  '';
```
Generate cache:
```
sudo ldconfig -f /etc/ld-nix.so.conf -C /etc/ld-nix.so.cache
```
Checking loaded libraries:
```
ldconfig -p | grep tcb
        libtcb.so.0 (libc6,x86-64) => /nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libtcb.so.0
        libtcb.so (libc6,x86-64) => /nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libtcb.so
        libnss_tcb.so.2 (libc6,x86-64) => /nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libnss_tcb.so.2
```
```
LD_DEBUG=all passwd
...
      2800:     symbol=_nss_tcb_setsgent;  lookup in file=/nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libnss_tcb.so.2 [0]
      2800:     symbol=_nss_tcb_setsgent;  lookup in file=/nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libtcb.so.0 [0]
      2800:     symbol=_nss_tcb_setsgent;  lookup in file=/nix/store/56r5i30jq456xnlqk2kfhy4g0v2i2l51-glibc-2.35-224/lib/libc.so.6 [0]
      2800:     symbol=_nss_tcb_setsgent;  lookup in file=/nix/store/56r5i30jq456xnlqk2kfhy4g0v2i2l51-glibc-2.35-224/lib/ld-linux-x86-64.so.2 [0]
      2800:     /nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libnss_tcb.so.2: error: symbol lookup error: undefined symbol: _nss_tcb_setsgent (fatal)
      2800:     symbol=_nss_tcb_setspent;  lookup in file=/nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libnss_tcb.so.2 [0]
      2800:     binding file /nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libnss_tcb.so.2 [0] to /nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libnss_tcb.so.2 [0]: normal symbol `_nss_tcb_setspent'
      2799:
      2799:     file=libnss_tcb.so.2 [0];  dynamically loaded by /nix/store/56r5i30jq456xnlqk2kfhy4g0v2i2l51-glibc-2.35-224/lib/libc.so.6 [0]
      2799:     find library=libnss_tcb.so.2 [0]; searching
      2799:      search cache=/etc/ld-nix.so.cache
      2799:       trying file=/nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libnss_tcb.so.2
      2799:
      2799:     file=libnss_tcb.so.2 [0];  generating link map
      2799:       dynamic: 0x00007fe30f6b2cf0  base: 0x00007fe30f6af000   size: 0x0000000000004010
      2799:         entry: 0x00007fe30f6af000  phdr: 0x00007fe30f6af040  phnum:                 11
      2799:
      2799:     checking for version `GLIBC_2.3' in file /nix/store/56r5i30jq456xnlqk2kfhy4g0v2i2l51-glibc-2.35-224/lib/ld-linux-x86-64.so.2 [0] required by file /nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libnss_tcb.so.2 [0]
      2799:     checking for version `GLIBC_2.8' in file /nix/store/56r5i30jq456xnlqk2kfhy4g0v2i2l51-glibc-2.35-224/lib/libc.so.6 [0] required by file /nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libnss_tcb.so.2 [0]
      2799:     checking for version `GLIBC_2.4' in file /nix/store/56r5i30jq456xnlqk2kfhy4g0v2i2l51-glibc-2.35-224/lib/libc.so.6 [0] required by file /nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libnss_tcb.so.2 [0]
      2799:     checking for version `GLIBC_2.2.5' in file /nix/store/56r5i30jq456xnlqk2kfhy4g0v2i2l51-glibc-2.35-224/lib/libc.so.6 [0] required by file /nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libnss_tcb.so.2 [0]
      2799:     object=/nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libnss_tcb.so.2 [0]
      2799:      scope 0: passwd /nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libtcb.so.0 /nix/store/kxxs803rx6rckidqa3q5kqhhgf7428vj-linux-pam-1.5.2/lib/libpam.so.0 /nix/store/kxxs803rx6rckidqa3q5kqhhgf7428vj-linux-pam-1.5.2/lib/libpam_misc.so.0 /nix/store/56r5i30jq456xnlqk2kfhy4g0v2i2l51-glibc-2.35-224/lib/libc.so.6 /nix/store/mmxwcw9kacp494jz54dpzzxc71yc3m0n-audit-2.8.5/lib/libaudit.so.1 /nix/store/56r5i30jq456xnlqk2kfhy4g0v2i2l51-glibc-2.35-224/lib/ld-linux-x86-64.so.2
      2799:      scope 1: /nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libnss_tcb.so.2 /nix/store/smm8bwymb7wm5lhw1l0fjb5s88dbsb7f-tcb-1.2/lib/libtcb.so.0 /nix/store/56r5i30jq456xnlqk2kfhy4g0v2i2l51-glibc-2.35-224/lib/libc.so.6 /nix/store/56r5i30jq456xnlqk2kfhy4g0v2i2l51-glibc-2.35-224/lib/ld-linux-x86-64.so.2
      2799:
      2799:
...
```

cc @flokli @NickCao @SuperSandro2000 @trofi 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
