### PR TITLE
nodejs: 14.21.1 -> 14.21.2, 16.18.1 -> 16.19.0, 18.12.1 -> 18.13.0, 19.2.0 -> 19.4.0

### DIFF
--- a/pkgs/development/web/nodejs/v14.nix
+++ b/pkgs/development/web/nodejs/v14.nix
@@ -8,7 +8,7 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "14.21.1";
-    sha256 = "sha256-PbldbKcolXvwkLYwGnqdLYBxSyoG2Jih22XG5Csdp6w=";
+    version = "14.21.2";
+    sha256 = "00zzl43iis8mr8x48hww5ncj8mj5dmpn05rq7ihpffkp2q7rmw6q";
     patches = lib.optional stdenv.isDarwin ./bypass-xcodebuild.diff;
   }

--- a/pkgs/development/web/nodejs/v16.nix
+++ b/pkgs/development/web/nodejs/v16.nix
@@ -10,8 +10,8 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "16.18.1";
-    sha256 = "sha256-H4BRqI+G9CBk9EFf56mA5ZsKUC7Mje9YP2MDvE1EUjg=";
+    version = "16.19.0";
+    sha256 = "01k72p0hp4lhlpz1syd9cbkm2gpfww0hn10xdpmzd4i3x8dfq7sg";
     patches = [
       ./disable-darwin-v8-system-instrumentation.patch
       ./bypass-darwin-xcrun-node16.patch

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -1,4 +1,4 @@
-{ callPackage, openssl, fetchpatch, python3, enableNpm ? true }:
+{ callPackage, openssl, python3, enableNpm ? true }:
 
 let
   buildNodejs = callPackage ./nodejs.nix {
@@ -10,17 +10,9 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "18.12.1";
-  sha256 = "sha256-T6QGRRvFJlmikOUs/bIWKnYL1UnaS4u+vmop8pbZON8=";
+  version = "18.13.0";
+  sha256 = "0s6sscynhw9limpp43f965rn9grdamcvsnd9wfb2h5qxw1icajpx";
   patches = [
-    (fetchpatch {
-      # Fixes cross compilation to aarch64-linux by reverting https://github.com/nodejs/node/pull/43200
-      name = "revert-arm64-pointer-auth.patch";
-      url = "https://github.com/nodejs/node/pull/43200/commits/d42c42cc8ac652ab387aa93205aed6ece8a5040a.patch";
-      sha256 = "sha256-ipGzg4lEoftTJbt6sW+0QJO/AZqHvUkFKe0qlum+iLY=";
-      revert = true;
-    })
-
     ./disable-darwin-v8-system-instrumentation.patch
     ./bypass-darwin-xcrun-node16.patch
   ] ++ npmPatches;

--- a/pkgs/development/web/nodejs/v19.nix
+++ b/pkgs/development/web/nodejs/v19.nix
@@ -6,15 +6,14 @@ let
     python = python3;
   };
 
-  npmPatches = callPackage ./npm-patches.nix { };
 in
 buildNodejs {
   inherit enableNpm;
-  version = "19.2.0";
-  sha256 = "sha256-CVaw/wHy9jg4J+kWpgSBWc4r2wUhf2VKj/9U6BFtwX4=";
+  version = "19.4.0";
+  sha256 = "0qdj67dgxbjpllm2z9vm46c50s3dqk8a34hbp81vsa7mf3b42182";
   patches = [
     ./revert-arm64-pointer-auth.patch
     ./disable-darwin-v8-system-instrumentation-node19.patch
     ./bypass-darwin-xcrun-node16.patch
-  ] ++ npmPatches;
+  ];
 }


### PR DESCRIPTION
###### Description of changes

* https://nodejs.org/en/blog/release/v19.4.0/
* https://nodejs.org/en/blog/release/v19.3.0/
* https://nodejs.org/en/blog/release/v18.13.0/
* https://nodejs.org/en/blog/release/v16.19.0/
* https://nodejs.org/en/blog/release/v14.21.2/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
