### PR TITLE
litemdview: init at 0.0.32

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16304,6 +16304,15 @@
       fingerprint = "69C9 876B 5797 1B2E 11C5  7C39 80A1 F76F C9F9 54AE";
     }];
   };
+  WhiteBlackGoose = {
+    email = "wbg@angouri.org";
+    github = "WhiteBlackGoose";
+    githubId = 31178401;
+    name = "WhiteBlackGoose";
+    keys = [{
+      fingerprint = "640B EDDE 9734 310A BFA3  B257 52ED AE6A 3995 AFAB";
+    }];
+  };
   wuyoli = {
     name = "wuyoli";
     email = "wuyoli@tilde.team";

--- a/pkgs/applications/graphics/litemdview/default.nix
+++ b/pkgs/applications/graphics/litemdview/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchFromGitea
+, gtkmm3
+, autoreconfHook
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "litemdview";
+  # litemdview -v
+  version = "0.0.32";
+
+  src = fetchFromGitea {
+    domain = "notabug.org";
+    owner = "g0tsu";
+    repo = "litemdview";
+    rev = "litemdview-0.0.32";
+    hash = "sha256-XGjP+7i3mYCEzPYwVY+75DARdXJFY4vUWHFpPeoNqAE=";
+  };
+
+  buildInputs = [
+    gtkmm3
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  meta = with lib; {
+    homepage = "https://notabug.org/g0tsu/litemdview";
+    description = "A suckless markdown viewer";
+    longDescription = ''
+      LiteMDview is a lightweight, extremely fast markdown viewer with lots of useful features. One of them is ability to use your prefered text editor to edit markdown files, every time you save the file, litemdview reloads those changes (I call it live-reload). It has a convinient navigation through local directories, has support for a basic "git-like" folders hierarchy as well as vimwiki projects.
+
+      Features:
+
+
+        - Does not use any of those bloated gecko(servo)-blink engines
+        - Lightweight and fast
+        - Live reload
+        - Convinient key bindings
+        - Supports text zooming
+        - Supports images
+        - Supports links
+        - Navigation history
+        - Cool name which associates with 1337, at least for me :)
+        - Builtin markdown css themes
+        - Supports emoji™️
+        - vimwiki support
+        - Basic html support (very simple offline documents in html)
+        - Syntax highlighting
+    '';
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ WhiteBlackGoose ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32451,6 +32451,8 @@ with pkgs;
 
   synology-cloud-sync-decryption-tool = callPackage ../applications/networking/synology-cloud-sync-decryption-tool { };
 
+  litemdview = callPackage ../applications/graphics/litemdview { };
+
   maestral = with python3Packages; toPythonApplication maestral;
 
   maestral-gui = libsForQt5.callPackage ../applications/networking/maestral-qt { };


### PR DESCRIPTION
Minimalist suckless markdown viewer. Serves
the same purpose and people as nsxiv, zathura.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a new package: [litemdview](https://notabug.org/g0tsu/litemdview). Amazing suckless markdown viewer, similar to zathura and nsxiv in its purpose.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I haven't found any new packages in `rl-2305.section.md` file, so not sure if I should add this one to any release notes.

Tested the correctness as follows:
```
nix-shell -p litemdview -I nixpkgs=~/prj/nixpkgs/nixpkgs
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
