### PR TITLE
librest_1_0: pick up crash fix with libsoup 3

### DIFF
--- a/pkgs/development/libraries/librest/1.0.nix
+++ b/pkgs/development/libraries/librest/1.0.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, fetchpatch
 , fetchurl
 , meson
 , ninja
@@ -23,6 +24,18 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "kmalwQ7OOD4ZPft/+we1CcwfUVIauNrXavlu0UISwuM=";
   };
+
+  patches = [
+    # Pick up MR 30 (https://gitlab.gnome.org/GNOME/librest/-/merge_requests/30) to fix GOA crashes with libsoup 3
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/librest/-/commit/fbad64abe28a96f591a30e3a5d3189c10172a414.patch";
+      hash = "sha256-r8+h84Y/AdM1IOMRcBVwDvfqapqOY8ZtRXdOIQvFR9w=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/librest/-/commit/8049048a0f7d52b3f4101c7123797fed099d4cc8.patch";
+      hash = "sha256-AMhHKzzOoTIlkRwN4KfUwdhxlqvtRgiVjKRfnG7KZwc=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
###### Description of changes

During librest's migration to libsoup 3 a bug was introduced which causes the following assertion failure and subsequent abort when a librest request could not be completed due to a network failure:

  Rest:ERROR:../rest/rest-proxy-call.c:628:finish_call: assertion failed: (payload)

This picks up a merge request which contains the fix.

Also requesting backport to 22.11 as it libsoup 3 as well.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
