### PR TITLE
aws-sso-creds: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7868,6 +7868,15 @@
     }];
     name = "Yaroslav Bolyukin";
   };
+  lafrenierejm = {
+    email = "joseph@lafreniere.xyz";
+    github = "lafrenierejm";
+    githubId = 11155300;
+    keys = [{
+      fingerprint = "0375 DD9A EDD1 68A3 ADA3  9EBA EE23 6AA0 141E FCA3";
+    }];
+    name = "Joseph LaFreniere";
+  };
   laikq = {
     email = "gwen@quasebarth.de";
     github = "laikq";

--- a/pkgs/tools/admin/aws-sso-creds/default.nix
+++ b/pkgs/tools/admin/aws-sso-creds/default.nix
@@ -1,0 +1,33 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, makeWrapper
+, xdg-utils
+}:
+buildGoModule rec {
+  pname = "aws-sso-creds";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "jaxxstorm";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-iyTdVvbqewLPLJB0LjeMB0HvLTi4B3B/HDCvgSlZoNE=";
+  };
+  vendorSha256 = "sha256-SIsM3S9i5YKj8DvE90DxxinqZkav+1gIha1xZiDBuHQ=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/aws-sso-creds \
+      --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/jaxxstorm/aws-sso-creds";
+    description = "Get AWS SSO temporary creds from an SSO profile";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lafrenierejm ];
+    mainProgram = "aws-sso-creds";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2684,6 +2684,8 @@ with pkgs;
 
   aws-sso-cli = callPackage ../tools/admin/aws-sso-cli { };
 
+  aws-sso-creds = callPackage ../tools/admin/aws-sso-creds { };
+
   aws-vault = callPackage ../tools/admin/aws-vault { };
 
   aws-workspaces = callPackage ../applications/networking/remote/aws-workspaces { };


### PR DESCRIPTION
###### Description of changes

From the package's homepage <https://github.com/jaxxstorm/aws-sso-creds>:

`aws-sso-creds` is a helper utility to retrieve [temporary credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) when using [AWS SSO](https://aws.amazon.com/single-sign-on/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
