### PR TITLE
treewide: deprecate toplevel {build,host,target}Platform

### DIFF
--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -12,14 +12,14 @@ in {
       type        = types.package;
       default     = pkgs.steam.override {
         extraLibraries = pkgs: with config.hardware.opengl;
-          if pkgs.hostPlatform.is64bit
+          if pkgs.stdenv.hostPlatform.is64bit
           then [ package ] ++ extraPackages
           else [ package32 ] ++ extraPackages32;
       };
       defaultText = literalExpression ''
         pkgs.steam.override {
           extraLibraries = pkgs: with config.hardware.opengl;
-            if pkgs.hostPlatform.is64bit
+            if pkgs.stdenv.hostPlatform.is64bit
             then [ package ] ++ extraPackages
             else [ package32 ] ++ extraPackages32;
         }

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -819,10 +819,10 @@ in
 
         system-features = mkDefault (
           [ "nixos-test" "benchmark" "big-parallel" "kvm" ] ++
-          optionals (pkgs.hostPlatform ? gcc.arch) (
+          optionals (pkgs.stdenv.hostPlatform ? gcc.arch) (
             # a builder can run code for `gcc.arch` and inferior architectures
-            [ "gccarch-${pkgs.hostPlatform.gcc.arch}" ] ++
-            map (x: "gccarch-${x}") (systems.architectures.inferiors.${pkgs.hostPlatform.gcc.arch} or [])
+            [ "gccarch-${pkgs.stdenv.hostPlatform.gcc.arch}" ] ++
+            map (x: "gccarch-${x}") (systems.architectures.inferiors.${pkgs.stdenv.hostPlatform.gcc.arch} or [])
           )
         );
       }

--- a/nixos/tests/libvirtd.nix
+++ b/nixos/tests/libvirtd.nix
@@ -21,7 +21,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
   };
 
   testScript = let
-    nixosInstallISO = (import ../release.nix {}).iso_minimal.${pkgs.hostPlatform.system};
+    nixosInstallISO = (import ../release.nix {}).iso_minimal.${pkgs.stdenv.hostPlatform.system};
     virshShutdownCmd = if pkgs.stdenv.isx86_64 then "shutdown" else "destroy";
   in ''
     start_all()

--- a/pkgs/applications/blockchains/zcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/default.nix
@@ -1,5 +1,5 @@
 { autoreconfHook, boost180, cargo, coreutils, curl, cxx-rs, db62, fetchFromGitHub
-, hexdump, hostPlatform, lib, libevent, libsodium, makeWrapper, rust, rustPlatform
+, hexdump, lib, libevent, libsodium, makeWrapper, rust, rustPlatform
 , pkg-config, Security, stdenv, testers, utf8cpp, util-linux, zcash, zeromq
 }:
 
@@ -82,6 +82,6 @@ rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
     license = licenses.mit;
 
     # https://github.com/zcash/zcash/issues/4405
-    broken = hostPlatform.isAarch64 && hostPlatform.isDarwin;
+    broken = stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/applications/editors/emacs/generic.nix
+++ b/pkgs/applications/editors/emacs/generic.nix
@@ -13,7 +13,7 @@
 , alsa-lib, cairo, acl, gpm, m17n_lib, libotf
 , sigtool, jansson, harfbuzz, sqlite, nixosTests
 , recurseIntoAttrs, emacsPackagesFor
-, libgccjit, targetPlatform, makeWrapper # native-comp params
+, libgccjit, makeWrapper # native-comp params
 , fetchFromSavannah, fetchFromBitbucket
 
   # macOS dependencies for NS and macPort

--- a/pkgs/applications/misc/HentaiAtHome/default.nix
+++ b/pkgs/applications/misc/HentaiAtHome/default.nix
@@ -1,5 +1,4 @@
 { buildPackages
-, buildPlatform
 , fetchzip
 , javaOpts ? "-XX:+UseZGC"
 , jdk
@@ -23,7 +22,7 @@ stdenvNoCC.mkDerivation rec {
   nativeBuildInputs = [ jdk makeWrapper ];
 
   LANG = "en_US.UTF-8";
-  LOCALE_ARCHIVE = lib.optionalString (buildPlatform.libc == "glibc")
+  LOCALE_ARCHIVE = lib.optionalString (stdenvNoCC.buildPlatform.libc == "glibc")
     "${buildPackages.glibcLocales}/lib/locale/locale-archive";
 
   buildPhase = ''

--- a/pkgs/applications/science/logic/cedille/default.nix
+++ b/pkgs/applications/science/logic/cedille/default.nix
@@ -4,7 +4,6 @@
 , alex
 , happy
 , Agda
-, buildPlatform
 , buildPackages
 , ghcWithPackages
 }:
@@ -30,7 +29,7 @@ stdenv.mkDerivation rec {
 
   LANG = "en_US.UTF-8";
   LOCALE_ARCHIVE =
-    lib.optionalString (buildPlatform.libc == "glibc")
+    lib.optionalString (stdenv.buildPlatform.libc == "glibc")
       "${buildPackages.glibcLocales}/lib/locale/locale-archive";
 
   postPatch = ''

--- a/pkgs/applications/video/davinci-resolve/default.nix
+++ b/pkgs/applications/video/davinci-resolve/default.nix
@@ -3,7 +3,6 @@
 , cacert
 , curl
 , runCommandLocal
-, targetPlatform
 , unzip
 , appimage-run
 , addOpenGLRunpath
@@ -49,7 +48,7 @@ let
           SITEURL = "https://www.blackmagicdesign.com/api/register/us/download/${DOWNLOADID}";
 
           USERAGENT = builtins.concatStringsSep " " [
-            "User-Agent: Mozilla/5.0 (X11; Linux ${targetPlatform.linuxArch})"
+            "User-Agent: Mozilla/5.0 (X11; Linux ${stdenv.targetPlatform.linuxArch})"
             "AppleWebKit/537.36 (KHTML, like Gecko)"
             "Chrome/77.0.3865.75"
             "Safari/537.36"

--- a/pkgs/applications/video/losslesscut-bin/default.nix
+++ b/pkgs/applications/video/losslesscut-bin/default.nix
@@ -1,7 +1,7 @@
 { lib
+, stdenv
 , callPackage
 , buildPackages
-, hostPlatform
 }:
 
 let
@@ -34,9 +34,9 @@ let
   };
 in
 (
-  if hostPlatform.system == "aarch64-darwin" then aarch64-dmg
-  else if hostPlatform.isDarwin then x86_64-dmg
-  else if hostPlatform.isCygwin then x86_64-windows
+  if stdenv.hostPlatform.system == "aarch64-darwin" then aarch64-dmg
+  else if stdenv.hostPlatform.isDarwin then x86_64-dmg
+  else if stdenv.hostPlatform.isCygwin then x86_64-windows
   else x86_64-appimage
 ).overrideAttrs
   (oldAttrs: {

--- a/pkgs/build-support/flutter/default.nix
+++ b/pkgs/build-support/flutter/default.nix
@@ -26,7 +26,6 @@
 , git
 , dart
 , nukeReferences
-, targetPlatform
 , bash
 , curl
 , unzip
@@ -57,7 +56,7 @@ let
   self =
 (self: llvmPackages_13.stdenv.mkDerivation (args // {
   deps = stdenvNoCC.mkDerivation (lib.recursiveUpdate (getAttrsOrNull fetchAttrs args) {
-    name = "${self.name}-deps-flutter-v${flutter.unwrapped.version}-${targetPlatform.system}.tar.gz";
+    name = "${self.name}-deps-flutter-v${flutter.unwrapped.version}-${stdenvNoCC.targetPlatform.system}.tar.gz";
 
     nativeBuildInputs = flutterDeps ++ [
       nukeReferences

--- a/pkgs/build-support/rust/build-rust-crate/test/brotli-crates.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/brotli-crates.nix
@@ -1,6 +1,6 @@
-{ lib, buildPlatform, buildRustCrate, fetchgit }:
-let kernel = buildPlatform.parsed.kernel.name;
-    abi = buildPlatform.parsed.abi.name;
+{ lib, stdenv, buildRustCrate, fetchgit }:
+let kernel = stdenv.buildPlatform.parsed.kernel.name;
+    abi = stdenv.buildPlatform.parsed.abi.name;
     include = includedFiles: src: builtins.filterSource (path: type:
       lib.lists.any (f:
         let p = toString (src + ("/" + f)); in

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -452,7 +452,7 @@ self: super: {
   #
   # # Depends on itself for testing
   # doctest-discover = addBuildTool super.doctest-discover
-  #   (if pkgs.buildPlatform != pkgs.hostPlatform
+  #   (if pkgs.stdenv.buildPlatform != pkgs.stdenv.hostPlatform
   #    then self.buildHaskellPackages.doctest-discover
   #    else dontCheck super.doctest-discover);
   doctest-discover = dontCheck super.doctest-discover;

--- a/pkgs/development/libraries/science/math/tensorflow-lite/default.nix
+++ b/pkgs/development/libraries/science/math/tensorflow-lite/default.nix
@@ -6,7 +6,6 @@
 , fetchpatch
 , fetchurl
 , flatbuffers
-, hostPlatform
 , lib
 , zlib
 }:
@@ -160,7 +159,7 @@ stdenv.mkDerivation rec {
     mkdir "$out"
 
     # copy the static lib and binaries into the output dir
-    cp -r ./tensorflow/lite/tools/make/gen/linux_${hostPlatform.uname.processor}/{bin,lib} "$out"
+    cp -r ./tensorflow/lite/tools/make/gen/linux_${stdenv.hostPlatform.uname.processor}/{bin,lib} "$out"
 
     find ./tensorflow/lite -type f -name '*.h' | while read f; do
       path="$out/include/''${f/.\//}"

--- a/pkgs/development/python-modules/rfcat/default.nix
+++ b/pkgs/development/python-modules/rfcat/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchFromGitHub
 , future
@@ -6,7 +7,6 @@
 , numpy
 , pyserial
 , pyusb
-, hostPlatform
 , pytestCheckHook
 , pythonOlder
 }:
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     pyusb
   ];
 
-  postInstall = lib.optionalString hostPlatform.isLinux ''
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     mkdir -p $out/etc/udev/rules.d
     cp etc/udev/rules.d/20-rfcat.rules $out/etc/udev/rules.d
   '';

--- a/pkgs/games/BeatSaberModManager/default.nix
+++ b/pkgs/games/BeatSaberModManager/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   dotnet-sdk,
-  targetPlatform,
+  stdenv,
   substituteAll,
 
   buildDotnetModule,
@@ -34,7 +34,7 @@ buildDotnetModule rec {
   patches = [
     (substituteAll {
       src = ./add-runtime-identifier.patch;
-      runtimeIdentifier = dotnetCorePackages.systemToDotnetRid targetPlatform.system;
+      runtimeIdentifier = dotnetCorePackages.systemToDotnetRid stdenv.targetPlatform.system;
     })
   ];
 

--- a/pkgs/misc/dxvk/default.nix
+++ b/pkgs/misc/dxvk/default.nix
@@ -1,6 +1,5 @@
 { lib
 , pkgs
-, hostPlatform
 , stdenvNoCC
 , fetchFromGitHub
 , pkgsCross
@@ -8,7 +7,7 @@
 
 stdenvNoCC.mkDerivation (finalAttrs:
   let
-    inherit (hostPlatform.uname) system;
+    inherit (stdenvNoCC.hostPlatform.uname) system;
     # DXVK needs to be a separate derivation because it’s actually a set of DLLs for Windows that
     # needs to be built with a cross-compiler.
     dxvk32 = pkgsCross.mingw32.callPackage ./dxvk.nix {

--- a/pkgs/os-specific/darwin/xcode/default.nix
+++ b/pkgs/os-specific/darwin/xcode/default.nix
@@ -1,10 +1,10 @@
-{ buildPlatform, requireFile, targetPlatform, lib }:
+{ stdenv, requireFile, lib }:
 
 let requireXcode = version: sha256:
   let
     xip = "Xcode_" + version +  ".xip";
     # TODO(alexfmpe): Find out how to validate the .xip signature in Linux
-    unxip = if buildPlatform.isDarwin
+    unxip = if stdenv.buildPlatform.isDarwin
             then ''
               open -W ${xip}
               rm -rf ${xip}
@@ -66,6 +66,6 @@ in lib.makeExtensible (self: {
   xcode_12_1 = requireXcode "12.1" "1widy74dk43wx8iqgd7arzf6q4kzdmaz8pfwymzs8chnq9dqr3wp";
   xcode_12_2 = requireXcode "12.2" "17i0wf4pwrxwfgjw7rpw9mcd59nkmys1k5h2rqsw81snzyxy9j0v";
   xcode_12_3 = requireXcode "12.3" "0kwf1y4llysf1p0nsbqyzccn7d77my0ldagr5fi3by4k0xy3d189";
-  xcode = self."xcode_${lib.replaceStrings ["."] ["_"] (if (targetPlatform ? xcodeVer) then targetPlatform.xcodeVer else "12.3")}";
+  xcode = self."xcode_${lib.replaceStrings ["."] ["_"] (if (stdenv.targetPlatform ? xcodeVer) then stdenv.targetPlatform.xcodeVer else "12.3")}";
 })
 

--- a/pkgs/os-specific/darwin/xcode/sdk-pkgs.nix
+++ b/pkgs/os-specific/darwin/xcode/sdk-pkgs.nix
@@ -1,4 +1,4 @@
-{ targetPlatform
+{ stdenv
 , clang-unwrapped
 , binutils-unwrapped
 , runCommand
@@ -12,7 +12,7 @@
 
 let
 
-minSdkVersion = targetPlatform.minSdkVersion or "9.0";
+minSdkVersion = stdenv.targetPlatform.minSdkVersion or "9.0";
 
 in
 
@@ -22,8 +22,8 @@ rec {
     type = "derivation";
     outPath = xcode + "/Contents/Developer/Platforms/${platform}.platform/Developer/SDKs/${platform}${version}.sdk";
 
-    platform = targetPlatform.xcodePlatform;
-    version = targetPlatform.sdkVer;
+    platform = stdenv.targetPlatform.xcodePlatform;
+    version = stdenv.targetPlatform.sdkVer;
   };
 
   binutils = wrapBintoolsWith {
@@ -39,7 +39,7 @@ rec {
     extraBuildCommands = ''
       tr '\n' ' ' < $out/nix-support/cc-cflags > cc-cflags.tmp
       mv cc-cflags.tmp $out/nix-support/cc-cflags
-      echo "-target ${targetPlatform.config}" >> $out/nix-support/cc-cflags
+      echo "-target ${stdenv.targetPlatform.config}" >> $out/nix-support/cc-cflags
       echo "-isystem ${sdk}/usr/include${lib.optionalString (lib.versionAtLeast "10" sdk.version) " -isystem ${sdk}/usr/include/c++/4.2.1/ -stdlib=libstdc++"}" >> $out/nix-support/cc-cflags
       ${lib.optionalString (lib.versionAtLeast sdk.version "14") "echo -isystem ${xcode}/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 >> $out/nix-support/cc-cflags"}
     '';

--- a/pkgs/test/cross/default.nix
+++ b/pkgs/test/cross/default.nix
@@ -8,7 +8,7 @@ let
   ) lib.systems.examples;
 
   getExecutable = pkgs: pkgFun: exec:
-    "${pkgFun pkgs}${exec}${pkgs.hostPlatform.extensions.executable}";
+    "${pkgFun pkgs}${exec}${pkgs.stdenv.hostPlatform.extensions.executable}";
 
   compareTest = { emulator, pkgFun, hostPkgs, crossPkgs, exec, args ? [] }: let
     pkgName = (pkgFun hostPkgs).name;
@@ -55,7 +55,7 @@ let
 
   mapMultiPlatformTest = crossSystemFun: test: lib.mapAttrs (name: system: test rec {
     crossPkgs = import pkgs.path {
-      localSystem = { inherit (pkgs.hostPlatform) config; };
+      localSystem = { inherit (pkgs.stdenv.hostPlatform) config; };
       crossSystem = crossSystemFun system;
     };
 

--- a/pkgs/tools/compression/zfp/default.nix
+++ b/pkgs/tools/compression/zfp/default.nix
@@ -1,7 +1,7 @@
-{ cmake, cudatoolkit, fetchFromGitHub, gfortran, lib, llvmPackages, python3Packages, stdenv, targetPlatform
+{ cmake, cudatoolkit, fetchFromGitHub, gfortran, lib, llvmPackages, python3Packages, stdenv
 , enableCfp ? true
 , enableCuda ? false
-, enableFortran ? builtins.elem targetPlatform.system gfortran.meta.platforms
+, enableFortran ? builtins.elem stdenv.targetPlatform.system gfortran.meta.platforms
 , enableOpenMP ? true
 , enablePython ? true
 , enableUtilities ? true }:

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1764,6 +1764,7 @@ mapAliases ({
   zyn-fusion = zynaddsubfx; # Added 2022-08-05
 
   inherit (stdenv.hostPlatform) system; # Added 2021-10-22
+  inherit (stdenv) buildPlatform hostPlatform targetPlatform; # Added 2023-01-09
 
   # LLVM packages for (integration) testing that should not be used inside Nixpkgs:
   llvmPackages_git = recurseIntoAttrs (callPackage ../development/compilers/llvm/git {

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -138,14 +138,6 @@ let
     inherit stdenv;
   };
 
-  # The old identifiers for cross-compiling. These should eventually be removed,
-  # and the packages that rely on them refactored accordingly.
-  platformCompat = self: super: let
-    inherit (super.stdenv) buildPlatform hostPlatform targetPlatform;
-  in {
-    inherit buildPlatform hostPlatform targetPlatform;
-  };
-
   splice = self: super: import ./splice.nix lib self (adjacentPackages != null);
 
   allPackages = self: super:
@@ -282,7 +274,6 @@ let
   # previous bootstrapping phases which have already been overlayed.
   toFix = lib.foldl' (lib.flip lib.extends) (self: {}) ([
     stdenvBootstappingAndPlatforms
-    platformCompat
     stdenvAdapters
     trivialBuilders
     splice


### PR DESCRIPTION
deprecation was attempted in e51f736 https://github.com/NixOS/nixpkgs/pull/46059

but had to be reverted in 2a6e4ae https://github.com/NixOS/nixpkgs/pull/46517


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
