### PR TITLE
nixos/plasma5: add ark as a file archiver

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -505,6 +505,7 @@ in
             spectacle
             systemsettings
 
+            ark
             dolphin
             dolphin-plugins
             ffmpegthumbs

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -505,7 +505,6 @@ in
             spectacle
             systemsettings
 
-            ark
             dolphin
             dolphin-plugins
             ffmpegthumbs
@@ -513,6 +512,7 @@ in
             kio-extras
           ];
           optionalPackages = [
+            ark
             elisa
             gwenview
             okular


### PR DESCRIPTION
Since the default plasma desktop already got dolphin-plugins adding ark for archiving would make plasma desktop more complete as well