### PR TITLE
appimage-run: Create desktop entry

### DIFF
--- a/pkgs/tools/package-management/appimage-run/default.nix
+++ b/pkgs/tools/package-management/appimage-run/default.nix
@@ -1,13 +1,29 @@
-{ appimageTools, buildFHSUserEnv, extraPkgs ? pkgs: [], appimage-run-tests ? null }:
+{ appimageTools, buildFHSUserEnv, makeDesktopItem, extraPkgs ? pkgs: [], appimage-run-tests ? null }:
 
 let
-  fhsArgs = appimageTools.defaultFhsEnvArgs;
-in buildFHSUserEnv (fhsArgs // {
   name = "appimage-run";
+
+  fhsArgs = appimageTools.defaultFhsEnvArgs;
+
+  desktopItem = makeDesktopItem {
+    inherit name;
+    exec = name;
+    desktopName = name;
+    genericName = "AppImage runner";
+    noDisplay = true;
+    mimeTypes = ["application/vnd.appimage" "application/x-iso9660-appimage"];
+    categories = ["PackageManager" "Utility"];
+  };
+in buildFHSUserEnv (fhsArgs // {
+  inherit name;
 
   targetPkgs = pkgs: [ appimageTools.appimage-exec ]
     ++ fhsArgs.targetPkgs pkgs ++ extraPkgs pkgs;
   runScript = "appimage-exec.sh";
+
+  extraInstallCommands = ''
+    cp --recursive "${desktopItem}/share" "$out/"
+  '';
 
   passthru.tests.appimage-run = appimage-run-tests;
 })

--- a/pkgs/tools/package-management/appimage-run/test.nix
+++ b/pkgs/tools/package-management/appimage-run/test.nix
@@ -17,14 +17,17 @@ in
   ''
     export HOME=$(mktemp -d)
     set -x
+
     # regression test for #101137, must come first
     LANG=fr_FR appimage-run ${sample-appImage} --list ${sample-appImage}
+
     # regression test for #108426
     cp ${sample-appImage} foo.appImage
     LANG=fr_FR appimage-run ${sample-appImage} --list foo.appImage
     cp ${owdtest} owdtest.AppImage.gz
     gunzip owdtest.AppImage.gz
     appimage-run owdtest.AppImage
+
     set +x
     touch $out
   ''

--- a/pkgs/tools/package-management/appimage-run/test.nix
+++ b/pkgs/tools/package-management/appimage-run/test.nix
@@ -1,4 +1,4 @@
-{ runCommand, fetchurl, appimage-run, glibcLocales, file }:
+{ runCommand, fetchurl, appimage-run, glibcLocales, file, xdg-utils }:
 let
   # any AppImage usable on cli, really
   sample-appImage = fetchurl {
@@ -11,7 +11,7 @@ let
   };
 in
   runCommand "appimage-run-tests" {
-    buildInputs = [ appimage-run glibcLocales file ];
+    buildInputs = [ appimage-run glibcLocales file xdg-utils ];
     meta.platforms = [ "x86_64-linux" ];
   }
   ''
@@ -28,7 +28,10 @@ in
     gunzip owdtest.AppImage.gz
     appimage-run owdtest.AppImage
 
+    # Verify desktop entry
+    XDG_DATA_DIRS="${appimage-run}/share"
+    [[ "$(xdg-mime query default application/vnd.appimage)" == '${appimage-run.name}.desktop' ]]
+
     set +x
     touch $out
   ''
-


### PR DESCRIPTION
###### Description of changes

Adds an `appimage-run.desktop` file to enable running appimage files in applications like GNOME Files (aka Nautilus) and `xdg-open`.

Thanks  [@jtojnar](https://discourse.nixos.org/t/how-to-test-desktop-item-mime-types/24510) and @dramforever for help with the tests!

cc @bignaux @jtojnar @symphorien @tilpner @timokau Would any of you be willing to review this?

To test:

1. Add `(pkgs.callPackage "/path/to/nixpkgs/pkgs/tools/package-management/appimage-run" {})` to `environment.systemPackages`
2. Run `nixos-rebuild switch`
3. Reboot to make sure GNOME Files knows about the new association
4. Double-click a `.AppImage` file

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).