### PR TITLE
rWrapper and rstudioWrapper: adding .site files

### DIFF
--- a/pkgs/development/r-modules/wrapper-rstudio.nix
+++ b/pkgs/development/r-modules/wrapper-rstudio.nix
@@ -1,35 +1,14 @@
 { lib
 , runCommand
-, R
+, rWrapper
 , rstudio
 , makeWrapper
 , wrapQtAppsHook
-, writeTextDir
 , symlinkJoin
 , recommendedPackages
 , packages
 , fontconfig
-, rprofileSite
-, renvironSite
 }:
-let
-  rprofile-site = writeTextDir "Rprofile.site" ''
-      # Rprofile.site
-      # See https://stat.ethz.ch/R-manual/R-devel/library/base/html/Startup.html
-      # See https://support.posit.co/hc/en-us/articles/360047157094-Managing-R-with-Rprofile-Renviron-Rprofile-site-Renviron-site-rsession-conf-and-repos-conf
-      ${rprofileSite}
-    '';
-  renviron-site = writeTextDir "Renviron.site" ''
-      # Renviron.site
-      # See https://stat.ethz.ch/R-manual/R-devel/library/base/html/Startup.html
-      # See https://support.posit.co/hc/en-us/articles/360047157094-Managing-R-with-Rprofile-Renviron-Rprofile-site-Renviron-site-rsession-conf-and-repos-conf
-      ${renvironSite}
-    '';
-  rsetup = symlinkJoin {
-    name = "r-initialization";
-    paths = [ rprofile-site renviron-site ];
-  };
-in
 runCommand (rstudio.name + "-wrapper")
 {
   preferLocalBuild = true;
@@ -38,7 +17,7 @@ runCommand (rstudio.name + "-wrapper")
   nativeBuildInputs = [ (if rstudio.server then makeWrapper else wrapQtAppsHook) ];
   dontWrapQtApps = true;
 
-  buildInputs = [ R rstudio ] ++ recommendedPackages ++ packages;
+  buildInputs = [ rWrapper rstudio ] ++ recommendedPackages ++ packages;
 
   # rWrapper points R to a specific set of packages by using a wrapper
   # (as in https://nixos.org/nixpkgs/manual/#r-packages) which sets
@@ -59,9 +38,6 @@ runCommand (rstudio.name + "-wrapper")
       echo -n $R_LIBS_SITE | sed -e 's/:/", "/g' >> $out/$fixLibsR
       echo -n "\"))" >> $out/$fixLibsR
       echo >> $out/$fixLibsR
-      makeWrapper "${R}/bin/R" "$out/bin/R" \
-        --set "R_PROFILE" "${rsetup}/Rprofile.site" \
-        --set "R_ENVIRON" "${rsetup}/Renviron.site"
     '' +
     (if
       rstudio.server then ''

--- a/pkgs/development/r-modules/wrapper.nix
+++ b/pkgs/development/r-modules/wrapper.nix
@@ -33,12 +33,10 @@ symlinkJoin {
       rm "$out/bin/$exe"
 
       makeWrapper "${R}/bin/$exe" "$out/bin/$exe" \
-        --prefix "R_LIBS_SITE" ":" "$R_LIBS_SITE"
+        --prefix "R_LIBS_SITE" ":" "$R_LIBS_SITE" \
+        --set "R_PROFILE" "${rsetup}/Rprofile.site" \
+        --set "R_ENVIRON" "${rsetup}/Renviron.site"
     done
-
-    makeWrapper "${R}/bin/R" "$out/bin/R" \
-      --set "R_PROFILE" "${rsetup}/Rprofile.site" \
-      --set "R_ENVIRON" "${rsetup}/Renviron.site"
   '';
 
   # Make the list of recommended R packages accessible to other packages such as rpy2

--- a/pkgs/development/r-modules/wrapper.nix
+++ b/pkgs/development/r-modules/wrapper.nix
@@ -1,4 +1,22 @@
-{ symlinkJoin, R, makeWrapper, recommendedPackages, packages }:
+{ symlinkJoin, R, writeTextDir, makeWrapper, recommendedPackages, packages, rprofileSite, renvironSite }:
+let
+  rprofile-site = writeTextDir "Rprofile.site" ''
+      # Rprofile.site
+      # See https://stat.ethz.ch/R-manual/R-devel/library/base/html/Startup.html
+      # See https://support.posit.co/hc/en-us/articles/360047157094-Managing-R-with-Rprofile-Renviron-Rprofile-site-Renviron-site-rsession-conf-and-repos-conf
+      ${rprofileSite}
+    '';
+  renviron-site = writeTextDir "Renviron.site" ''
+      # Renviron.site
+      # See https://stat.ethz.ch/R-manual/R-devel/library/base/html/Startup.html
+      # See https://support.posit.co/hc/en-us/articles/360047157094-Managing-R-with-Rprofile-Renviron-Rprofile-site-Renviron-site-rsession-conf-and-repos-conf
+      ${renvironSite}
+    '';
+  rsetup = symlinkJoin {
+    name = "r-initialization";
+    paths = [ rprofile-site renviron-site ];
+  };
+in
 symlinkJoin {
   name = R.name + "-wrapper";
   preferLocalBuild = true;
@@ -17,6 +35,10 @@ symlinkJoin {
       makeWrapper "${R}/bin/$exe" "$out/bin/$exe" \
         --prefix "R_LIBS_SITE" ":" "$R_LIBS_SITE"
     done
+
+    makeWrapper "${R}/bin/R" "$out/bin/R" \
+      --set "R_PROFILE" "${rsetup}/Rprofile.site" \
+      --set "R_ENVIRON" "${rsetup}/Renviron.site"
   '';
 
   # Make the list of recommended R packages accessible to other packages such as rpy2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23716,6 +23716,8 @@ with pkgs;
     ];
     # Override this attribute to register additional libraries.
     packages = [];
+    rprofileSite = "";
+    renvironSite = "";
   };
 
   rstudioWrapper = libsForQt5.callPackage ../development/r-modules/wrapper-rstudio.nix {
@@ -23725,6 +23727,8 @@ with pkgs;
     ];
     # Override this attribute to register additional libraries.
     packages = [];
+    rprofileSite = "";
+    renvironSite = "";
   };
 
   rstudioServerWrapper = rstudioWrapper.override { rstudio = rstudio-server; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23727,8 +23727,6 @@ with pkgs;
     ];
     # Override this attribute to register additional libraries.
     packages = [];
-    rprofileSite = "";
-    renvironSite = "";
   };
 
   rstudioServerWrapper = rstudioWrapper.override { rstudio = rstudio-server; };


### PR DESCRIPTION
###### Description of changes

Added arguments to set Rprofite.site and Renviron.site in rWrapper and rstudioWrapper. These files are used in the R initialization process to control the behavior of R sessions. See:
 - [Initialization at Start of an R Session](https://stat.ethz.ch/R-manual/R-devel/library/base/html/Startup.html)
 - [Managing R](https://support.posit.co/hc/en-us/articles/360047157094-Managing-R-with-Rprofile-Renviron-Rprofile-site-Renviron-site-rsession-conf-and-repos-conf)

@cfhammill, @alexvorobiev, @jbedo 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
