### PR TITLE
ocamlPackages.dns: 6.3.0 → 6.4.1

### DIFF
--- a/pkgs/development/ocaml-modules/cohttp/async.nix
+++ b/pkgs/development/ocaml-modules/cohttp/async.nix
@@ -28,6 +28,8 @@ buildDunePackage {
     src
     ;
 
+  duneVersion = "3";
+
   buildInputs = [ ppx_sexp_conv ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -9,6 +9,7 @@ buildDunePackage rec {
   version = "5.0.0";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-cohttp/releases/download/v${version}/cohttp-${version}.tbz";

--- a/pkgs/development/ocaml-modules/cohttp/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt-unix.nix
@@ -9,6 +9,8 @@ buildDunePackage {
   pname = "cohttp-lwt-unix";
   inherit (cohttp-lwt) version src;
 
+  duneVersion = "3";
+
   buildInputs = [ cmdliner ppx_sexp_conv ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/cohttp/lwt.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt.nix
@@ -7,6 +7,8 @@ buildDunePackage {
     src
     ;
 
+  duneVersion = "3";
+
   buildInputs = [ ppx_sexp_conv ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/cohttp/mirage.nix
+++ b/pkgs/development/ocaml-modules/cohttp/mirage.nix
@@ -10,6 +10,8 @@ buildDunePackage {
 
   inherit (cohttp) version src;
 
+  duneVersion = "3";
+
   nativeBuildInputs = [ ppx_sexp_conv ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/conduit/async.nix
+++ b/pkgs/development/ocaml-modules/conduit/async.nix
@@ -9,6 +9,8 @@ buildDunePackage {
     src
     ;
 
+  duneVersion = "3";
+
   buildInputs = [ ppx_sexp_conv ppx_here ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -7,7 +7,8 @@ buildDunePackage rec {
   pname = "conduit";
   version = "6.1.0";
 
-  minimalOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-conduit/releases/download/v${version}/conduit-${version}.tbz";

--- a/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
@@ -6,6 +6,7 @@
 buildDunePackage {
   pname = "conduit-lwt-unix";
   inherit (conduit-lwt) version src;
+  duneVersion = "3";
 
   buildInputs = [ ppx_sexp_conv ];
 

--- a/pkgs/development/ocaml-modules/conduit/lwt.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt.nix
@@ -3,6 +3,7 @@
 buildDunePackage {
   pname = "conduit-lwt";
   inherit (conduit) version src;
+  duneVersion = "3";
 
   buildInputs = [ ppx_sexp_conv ];
 

--- a/pkgs/development/ocaml-modules/conduit/mirage.nix
+++ b/pkgs/development/ocaml-modules/conduit/mirage.nix
@@ -9,6 +9,7 @@ buildDunePackage {
   pname = "conduit-mirage";
 
   inherit (conduit-lwt) version src;
+  duneVersion = "3";
 
   nativeBuildInputs = [ ppx_sexp_conv ];
 

--- a/pkgs/development/ocaml-modules/curly/default.nix
+++ b/pkgs/development/ocaml-modules/curly/default.nix
@@ -6,13 +6,13 @@ buildDunePackage rec {
   pname = "curly";
   version = "0.2.0";
 
-  minimumOCamlVersion = "4.02";
+  minimalOCamlVersion = "4.02";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/rgrinberg/curly/releases/download/${version}/curly-${version}.tbz";
-    sha256 = "07vqdrklar0d5i83ip7sjw2c1v18a9m3anw07vmi5ay29pxzal6k";
+    hash = "sha256-01D1+03CqxLrPoBbNWpSKOzABJf63DhQLA1kRWdueB8=";
   };
 
   propagatedBuildInputs = [ result ];

--- a/pkgs/development/ocaml-modules/dns/certify.nix
+++ b/pkgs/development/ocaml-modules/dns/certify.nix
@@ -8,6 +8,7 @@ buildDunePackage {
   pname = "dns-certify";
 
   inherit (dns) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     dns

--- a/pkgs/development/ocaml-modules/dns/cli.nix
+++ b/pkgs/development/ocaml-modules/dns/cli.nix
@@ -10,6 +10,7 @@ buildDunePackage {
   minimalOCamlVersion = "4.08";
 
   inherit (dns) version src;
+  duneVersion = "3";
 
   # no need to propagate as this is primarily
   # an executable package

--- a/pkgs/development/ocaml-modules/dns/client.nix
+++ b/pkgs/development/ocaml-modules/dns/client.nix
@@ -10,6 +10,7 @@
 buildDunePackage {
   pname = "dns-client";
   inherit (dns) src version;
+  duneVersion = "3";
 
   propagatedBuildInputs = [ cstruct fmt logs dns randomconv domain-name ipaddr
                             lwt mirage-random mirage-time mirage-clock

--- a/pkgs/development/ocaml-modules/dns/default.nix
+++ b/pkgs/development/ocaml-modules/dns/default.nix
@@ -5,13 +5,14 @@
 
 buildDunePackage rec {
   pname = "dns";
-  version = "6.3.0";
+  version = "6.4.1";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-dns/releases/download/v${version}/dns-${version}.tbz";
-    sha256 = "sha256-3EAjenN9EIi4PsXCZDevmEPDaS4xbESbcbB7pFgwc1E=";
+    hash = "sha256-omG0fKZAHGc+4ERC8cyK47jeEkiBZkB+1fz46j6SDno=";
   };
 
   propagatedBuildInputs = [ fmt logs ptime domain-name gmap cstruct ipaddr lru duration metrics base64 ];

--- a/pkgs/development/ocaml-modules/dns/dnssec.nix
+++ b/pkgs/development/ocaml-modules/dns/dnssec.nix
@@ -7,6 +7,7 @@ buildDunePackage {
   pname = "dnssec";
 
   inherit (dns) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     cstruct

--- a/pkgs/development/ocaml-modules/dns/mirage.nix
+++ b/pkgs/development/ocaml-modules/dns/mirage.nix
@@ -4,6 +4,7 @@ buildDunePackage {
   pname = "dns-mirage";
 
   inherit (dns) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     dns

--- a/pkgs/development/ocaml-modules/dns/resolver.nix
+++ b/pkgs/development/ocaml-modules/dns/resolver.nix
@@ -8,6 +8,7 @@ buildDunePackage {
   pname = "dns-resolver";
 
   inherit (dns) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     dns

--- a/pkgs/development/ocaml-modules/dns/server.nix
+++ b/pkgs/development/ocaml-modules/dns/server.nix
@@ -7,6 +7,7 @@ buildDunePackage {
   pname = "dns-server";
 
   inherit (dns) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     dns

--- a/pkgs/development/ocaml-modules/dns/stub.nix
+++ b/pkgs/development/ocaml-modules/dns/stub.nix
@@ -7,6 +7,7 @@ buildDunePackage {
   pname = "dns-stub";
 
   inherit (dns) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     dns

--- a/pkgs/development/ocaml-modules/dns/tsig.nix
+++ b/pkgs/development/ocaml-modules/dns/tsig.nix
@@ -4,6 +4,7 @@ buildDunePackage {
   pname = "dns-tsig";
 
   inherit (dns) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     mirage-crypto

--- a/pkgs/development/ocaml-modules/git/default.nix
+++ b/pkgs/development/ocaml-modules/git/default.nix
@@ -11,6 +11,7 @@ buildDunePackage rec {
   version = "3.10.1";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-git/releases/download/${version}/git-${version}.tbz";

--- a/pkgs/development/ocaml-modules/graphql/cohttp.nix
+++ b/pkgs/development/ocaml-modules/graphql/cohttp.nix
@@ -8,7 +8,7 @@ buildDunePackage rec {
 
   inherit (graphql) version src;
 
-  useDune2 = true;
+  duneVersion = "3";
 
   nativeBuildInputs = [ ocaml-crunch ];
   propagatedBuildInputs = [ astring cohttp digestif graphql ocplib-endian ];

--- a/pkgs/development/ocaml-modules/graphql/default.nix
+++ b/pkgs/development/ocaml-modules/graphql/default.nix
@@ -5,6 +5,8 @@ buildDunePackage rec {
 
   inherit (graphql_parser) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ graphql_parser rresult yojson ];
 
   checkInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/graphql/lwt.nix
+++ b/pkgs/development/ocaml-modules/graphql/lwt.nix
@@ -5,6 +5,8 @@ buildDunePackage rec {
 
   inherit (graphql) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ graphql ocaml_lwt ];
 
   checkInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/graphql/parser.nix
+++ b/pkgs/development/ocaml-modules/graphql/parser.nix
@@ -5,6 +5,7 @@ buildDunePackage rec {
   version = "0.14.0";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/andreas/ocaml-graphql-server/releases/download/${version}/graphql-${version}.tbz";

--- a/pkgs/development/ocaml-modules/happy-eyeballs/default.nix
+++ b/pkgs/development/ocaml-modules/happy-eyeballs/default.nix
@@ -4,13 +4,13 @@
 
 buildDunePackage rec {
   pname = "happy-eyeballs";
-  version = "0.3.0";
+  version = "0.4.0";
 
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/roburio/happy-eyeballs/releases/download/v${version}/happy-eyeballs-${version}.tbz";
-    sha256 = "17mnid1gvq1ml1zmqzn0m6jmrqw4kqdrjqrdsrphl5kxxyhs03m6";
+    hash = "sha256-gR9q4J/DnYJz8oYmk/wy17h4F6wxbllba/gkor5i1nQ=";
   };
 
   strictDeps = true;

--- a/pkgs/development/ocaml-modules/happy-eyeballs/lwt.nix
+++ b/pkgs/development/ocaml-modules/happy-eyeballs/lwt.nix
@@ -17,6 +17,7 @@ buildDunePackage {
   inherit (happy-eyeballs) src version;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   strictDeps = true;
 

--- a/pkgs/development/ocaml-modules/happy-eyeballs/mirage.nix
+++ b/pkgs/development/ocaml-modules/happy-eyeballs/mirage.nix
@@ -19,6 +19,7 @@ buildDunePackage {
   inherit (happy-eyeballs) src version;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   strictDeps = true;
 

--- a/pkgs/development/ocaml-modules/letsencrypt/app.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/app.nix
@@ -17,12 +17,12 @@
 
 buildDunePackage {
   pname = "letsencrypt-app";
+  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   inherit (letsencrypt)
     src
     version
-    useDune2
-    minimumOCamlVersion
     ;
 
   buildInputs = [

--- a/pkgs/development/ocaml-modules/letsencrypt/default.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/default.nix
@@ -25,11 +25,11 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v${version}/letsencrypt-v${version}.tbz";
-    sha256 = "f90875f5c9bdcab4c8be5ec7ebe9ea763030fa708e02857300996bb16e7c2070";
+    hash = "sha256-+Qh19cm9yrTIvl7H6+nqdjAw+nCOAoVzAJlrsW58IHA=";
   };
 
-  minimumOCamlVersion = "4.08";
-  useDune2 = true;
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   buildInputs = [
     fmt

--- a/pkgs/development/ocaml-modules/letsencrypt/dns.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/dns.nix
@@ -11,12 +11,12 @@
 
 buildDunePackage {
   pname = "letsencrypt-dns";
+  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   inherit (letsencrypt)
     version
     src
-    useDune2
-    minimumOCamlVersion
     ;
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/mimic/default.nix
+++ b/pkgs/development/ocaml-modules/mimic/default.nix
@@ -8,6 +8,7 @@ buildDunePackage rec {
   version = "0.0.6";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/dinosaure/mimic/releases/download/${version}/mimic-${version}.tbz";

--- a/pkgs/development/ocaml-modules/mimic/happy-eyeballs.nix
+++ b/pkgs/development/ocaml-modules/mimic/happy-eyeballs.nix
@@ -6,6 +6,7 @@ buildDunePackage {
   inherit (mimic) src version;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   strictDeps = true;
 

--- a/pkgs/development/ocaml-modules/resto/acl.nix
+++ b/pkgs/development/ocaml-modules/resto/acl.nix
@@ -5,6 +5,7 @@ buildDunePackage {
   inherit (resto) src version meta doCheck;
 
   minimalOCamlVersion = "4.10";
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     resto

--- a/pkgs/development/ocaml-modules/resto/cohttp-client.nix
+++ b/pkgs/development/ocaml-modules/resto/cohttp-client.nix
@@ -9,6 +9,7 @@
 buildDunePackage {
   pname = "resto-cohttp-client";
   inherit (resto) src version meta doCheck;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     resto

--- a/pkgs/development/ocaml-modules/resto/cohttp-self-serving-client.nix
+++ b/pkgs/development/ocaml-modules/resto/cohttp-self-serving-client.nix
@@ -13,6 +13,7 @@
 buildDunePackage {
   pname = "resto-cohttp-self-serving-client";
   inherit (resto) src version meta doCheck;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     resto

--- a/pkgs/development/ocaml-modules/resto/cohttp-server.nix
+++ b/pkgs/development/ocaml-modules/resto/cohttp-server.nix
@@ -12,6 +12,7 @@
 buildDunePackage {
   pname = "resto-cohttp-server";
   inherit (resto) src version meta doCheck;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     resto

--- a/pkgs/development/ocaml-modules/resto/cohttp.nix
+++ b/pkgs/development/ocaml-modules/resto/cohttp.nix
@@ -3,6 +3,7 @@
 buildDunePackage {
   pname = "resto-cohttp";
   inherit (resto) src version meta doCheck;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     resto

--- a/pkgs/development/ocaml-modules/resto/default.nix
+++ b/pkgs/development/ocaml-modules/resto/default.nix
@@ -3,6 +3,7 @@
 buildDunePackage rec {
   pname = "resto";
   version = "1.0";
+  duneVersion = "3";
   src = fetchFromGitLab {
     owner = "nomadic-labs";
     repo = "resto";

--- a/pkgs/development/ocaml-modules/resto/directory.nix
+++ b/pkgs/development/ocaml-modules/resto/directory.nix
@@ -3,6 +3,7 @@
 buildDunePackage {
   pname = "resto-directory";
   inherit (resto) src version meta doCheck;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     resto

--- a/pkgs/development/ocaml-modules/resto/json.nix
+++ b/pkgs/development/ocaml-modules/resto/json.nix
@@ -3,6 +3,7 @@
 buildDunePackage {
   pname = "resto-json";
   inherit (resto) src version meta doCheck;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     resto

--- a/pkgs/development/ocaml-modules/telegraml/default.nix
+++ b/pkgs/development/ocaml-modules/telegraml/default.nix
@@ -10,6 +10,7 @@
 buildDunePackage rec {
   pname = "telegraml";
   version = "unstable-2021-06-17";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "nv-vn";

--- a/pkgs/development/ocaml-modules/webmachine/default.nix
+++ b/pkgs/development/ocaml-modules/webmachine/default.nix
@@ -6,9 +6,9 @@
 buildDunePackage rec {
   pname = "webmachine";
   version = "0.7.0";
-  useDune2 = true;
+  duneVersion = "3";
 
-  minimumOCamlVersion = "4.04";
+  minimalOCamlVersion = "4.03";
 
   src = fetchFromGitHub {
     owner = "inhabitedtype";
@@ -24,7 +24,7 @@ buildDunePackage rec {
   doCheck = true;
 
   meta = {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/inhabitedtype/ocaml-webmachine";
     license = lib.licenses.bsd3;
     description = "A REST toolkit for OCaml";
     maintainers = [ lib.maintainers.vbgl ];

--- a/pkgs/development/tools/ocaml/dune-release/default.nix
+++ b/pkgs/development/tools/ocaml/dune-release/default.nix
@@ -11,6 +11,7 @@ let runtimeInputs = [ opam findlib git mercurial bzip2 gnutar coreutils ];
 in buildDunePackage rec {
   pname = "dune-release";
   version = "1.6.2";
+  duneVersion = "3";
 
   minimalOCamlVersion = "4.06";
 


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/ocaml-dns/blob/v6.4.1/CHANGES.md#v641-2022-12-02
https://github.com/roburio/happy-eyeballs/blob/v0.4.0/CHANGES.md#v040-2022-12-02

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
