### PR TITLE
darkstat: 3.0.719 -> 3.0.721

### DIFF
--- a/pkgs/tools/networking/darkstat/default.nix
+++ b/pkgs/tools/networking/darkstat/default.nix
@@ -1,12 +1,21 @@
-{ lib, stdenv, fetchpatch, fetchurl, libpcap, zlib }:
+{ lib
+, stdenv
+, autoreconfHook
+, fetchFromGitHub
+, fetchpatch
+, libpcap
+, zlib
+}:
 
 stdenv.mkDerivation rec {
-  version = "3.0.719";
   pname = "darkstat";
+  version = "3.0.721";
 
-  src = fetchurl {
-    url = "${meta.homepage}/${pname}-${version}.tar.bz2";
-    sha256 = "1mzddlim6dhd7jhr4smh0n2fa511nvyjhlx76b03vx7phnar1bxf";
+  src = fetchFromGitHub {
+    owner = "emikulic";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-kKj4fCgphoe3lojJfARwpITxQh7E6ehUew9FVEW63uQ=";
   };
 
   patches = [
@@ -18,7 +27,14 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  buildInputs = [ libpcap zlib ];
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    libpcap
+    zlib
+  ];
 
   enableParallelBuilding = true;
 
@@ -34,7 +50,8 @@ stdenv.mkDerivation rec {
       - Supports IPv6.
     '';
     homepage = "http://unix4lyfe.org/darkstat";
-    license = licenses.gpl2;
+    changelog = "https://github.com/emikulic/darkstat/releases/tag/3.0.721";
+    license = licenses.gpl2Only;
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/tools/networking/darkstat/default.nix
+++ b/pkgs/tools/networking/darkstat/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
       - Supports IPv6.
     '';
     homepage = "http://unix4lyfe.org/darkstat";
-    changelog = "https://github.com/emikulic/darkstat/releases/tag/3.0.721";
+    changelog = "https://github.com/emikulic/darkstat/releases/tag/${version}";
     license = licenses.gpl2Only;
     platforms = with platforms; unix;
   };


### PR DESCRIPTION
Diff: https://github.com/emikulic/darkstat/compare/refs/tags/3.0.719...3.0.721

Changelog: https://github.com/emikulic/darkstat/releases/tag/3.0.721

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
