### PR TITLE
proxysql: fix build after #201859

### DIFF
--- a/pkgs/servers/sql/proxysql/default.nix
+++ b/pkgs/servers/sql/proxysql/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, applyPatches
 , fetchFromGitHub
 , autoconf
 , automake
@@ -23,9 +24,10 @@
 , openssl
 , pcre
 , perl
-, python2
+, python3
 , re2
 , zlib
+, texinfo
 }:
 
 stdenv.mkDerivation rec {
@@ -50,7 +52,8 @@ stdenv.mkDerivation rec {
     cmake
     libtool
     perl
-    python2
+    python3
+    texinfo  # for makeinfo
   ];
 
   buildInputs = [
@@ -64,6 +67,10 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
+
+  # otherwise, it looks for …-1.15
+  ACLOCAL = "aclocal";
+  AUTOMAKE = "automake";
 
   GIT_VERSION = version;
 
@@ -94,18 +101,27 @@ stdenv.mkDerivation rec {
     }
 
     ${lib.concatMapStringsSep "\n"
-      (x: ''replace_dep "${x.f}" "${x.p.src}" "${x.p.pname or (builtins.parseDrvName x.p.name).name}" "${x.p.name}"'') [
-        { f = "curl"; p = curl; }
-        { f = "libconfig"; p = libconfig; }
-        { f = "libdaemon"; p = libdaemon; }
-        { f = "libev"; p = libev; }
-        { f = "libinjection"; p = libinjection; }
-        { f = "libmicrohttpd"; p = libmicrohttpd_0_9_69; }
-        { f = "libssl"; p = openssl; }
-        { f = "lz4"; p = lz4; }
-        { f = "pcre"; p = pcre; }
-        { f = "re2"; p = re2; }
-    ]}
+      (x: ''replace_dep "${x.f}" "${x.p.src}" "${x.p.pname or (builtins.parseDrvName x.p.name).name}" "${x.p.name}"'') (
+        map (x: {
+          inherit (x) f;
+          p = x.p // {
+            src = applyPatches {
+              inherit (x.p) src patches;
+            };
+          };
+        }) [
+          { f = "curl"; p = curl; }
+          { f = "libconfig"; p = libconfig; }
+          { f = "libdaemon"; p = libdaemon; }
+          { f = "libev"; p = libev; }
+          { f = "libinjection"; p = libinjection; }
+          { f = "libmicrohttpd"; p = libmicrohttpd_0_9_69; }
+          { f = "libssl"; p = openssl; }
+          { f = "lz4"; p = lz4; }
+          { f = "pcre"; p = pcre; }
+          { f = "re2"; p = re2; }
+        ]
+      )}
 
     pushd libhttpserver
     tar xf libhttpserver-0.18.1.tar.gz


### PR DESCRIPTION
###### Description of changes
- by not pulling in python2 directly
- by applying patches to sources we "unvendor", so e.g. libinjection builds

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).