### PR TITLE
python310Packages.levenshtein: don't use alias

### DIFF
--- a/pkgs/applications/audio/sublime-music/default.nix
+++ b/pkgs/applications/audio/sublime-music/default.nix
@@ -54,7 +54,7 @@ python3Packages.buildPythonApplication rec {
     mpv
     peewee
     pygobject3
-    python-Levenshtein
+    levenshtein
     python-dateutil
     requests
     semver

--- a/pkgs/applications/editors/apostrophe/default.nix
+++ b/pkgs/applications/editors/apostrophe/default.nix
@@ -7,7 +7,7 @@
 
 let
   pythonEnv = pythonPackages.python.withPackages(p: with p; [
-    regex setuptools python-Levenshtein pyenchant
+    regex setuptools levenshtein pyenchant
     pygobject3 pycairo pypandoc chardet
   ]);
 

--- a/pkgs/applications/misc/ulauncher/default.nix
+++ b/pkgs/applications/misc/ulauncher/default.nix
@@ -55,7 +55,7 @@ python3Packages.buildPythonApplication rec {
     dbus-python
     pygobject3
     pyinotify
-    python-Levenshtein
+    levenshtein
     pyxdg
     pycairo
     requests

--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -155,7 +155,7 @@ python.pkgs.pythonPackages.buildPythonApplication rec {
     python-dateutil
     python-dotenv
     python-gnupg
-    python-Levenshtein
+    levenshtein
     python-magic
     pytz
     pyyaml

--- a/pkgs/applications/office/paperwork/paperwork-backend.nix
+++ b/pkgs/applications/office/paperwork/paperwork-backend.nix
@@ -7,7 +7,7 @@
 , pycountry
 , whoosh
 , termcolor
-, python-Levenshtein
+, levenshtein
 , pygobject3
 , pyocr
 , natsort
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     pygobject3
     pyocr
     pypillowfight
-    python-Levenshtein
+    levenshtein
     poppler_gi
     scikit-learn
     termcolor

--- a/pkgs/applications/science/biology/truvari/default.nix
+++ b/pkgs/applications/science/biology/truvari/default.nix
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [
     pyvcf
-    python-Levenshtein
+    levenshtein
     progressbar2
     pysam
     pyfaidx

--- a/pkgs/development/python-modules/fire/default.nix
+++ b/pkgs/development/python-modules/fire/default.nix
@@ -4,7 +4,7 @@
 , six
 , hypothesis
 , mock
-, python-Levenshtein
+, levenshtein
 , pytestCheckHook
 , termcolor
 , pythonOlder
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   checkInputs = [
     hypothesis
     mock
-    python-Levenshtein
+    levenshtein
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/fuzzywuzzy/default.nix
+++ b/pkgs/development/python-modules/fuzzywuzzy/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, python-Levenshtein, pycodestyle, hypothesis, pytest }:
+{ lib, buildPythonPackage, fetchPypi, levenshtein, pycodestyle, hypothesis, pytest }:
 
 buildPythonPackage rec {
   pname = "fuzzywuzzy";
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "1s00zn75y2dkxgnbw8kl8dw4p1mc77cv78fwfa4yb0274s96w0a5";
   };
 
-  propagatedBuildInputs = [ python-Levenshtein ];
+  propagatedBuildInputs = [ levenshtein ];
   checkInputs = [ pycodestyle hypothesis pytest ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/thefuzz/default.nix
+++ b/pkgs/development/python-modules/thefuzz/default.nix
@@ -4,7 +4,7 @@
 , pythonOlder
 , pytestCheckHook
 , hypothesis
-, python-Levenshtein
+, levenshtein
 }:
 
 buildPythonPackage rec {
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     hash = "sha256-b3Em2y8silQhKwXjp0DkX0KRxJfXXSB1Fyj2Nbt0qj0=";
   };
 
-  propagatedBuildInputs = [ python-Levenshtein ];
+  propagatedBuildInputs = [ levenshtein ];
 
   # Skip linting
   postPatch = ''

--- a/pkgs/development/python-modules/trytond/default.nix
+++ b/pkgs/development/python-modules/trytond/default.nix
@@ -13,7 +13,7 @@
 , wrapt
 , passlib
 , pydot
-, python-Levenshtein
+, levenshtein
 , html2text
 , weasyprint
 , gevent
@@ -49,7 +49,7 @@ buildPythonPackage rec {
 
     # extra dependencies
     pydot
-    python-Levenshtein
+    levenshtein
     html2text
     weasyprint
     gevent

--- a/pkgs/development/python-modules/videocr/default.nix
+++ b/pkgs/development/python-modules/videocr/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, python-Levenshtein
+, levenshtein
 , pytesseract
 , opencv4
 , fuzzywuzzy
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    python-Levenshtein
+    levenshtein
     pytesseract
     opencv4
     fuzzywuzzy

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-uniemoji/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-uniemoji/default.nix
@@ -11,7 +11,7 @@ let
     pygobject3
     (toPythonModule ibus)
     pyxdg
-    python-Levenshtein
+    levenshtein
   ]);
 in stdenv.mkDerivation rec {
   pname = "ibus-uniemoji";


### PR DESCRIPTION
###### Description of changes
`python-Levenshtein` was turned into an alias in 1b1a48f4b2af but continued to be used. That breaks setups with `allowAliases = false`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
