### PR TITLE
dapr-cli: adds version information with build flags

### DIFF
--- a/pkgs/development/tools/dapr/cli/default.nix
+++ b/pkgs/development/tools/dapr/cli/default.nix
@@ -19,6 +19,13 @@ buildGoModule rec {
     export HOME=$(mktemp -d)
   '';
 
+  ldflags = [
+    "-X main.version=${version}"
+    "-X main.apiVersion=1.0"
+    "-X github.com/dapr/cli/pkg/standalone.gitcommit=${src.rev}"
+    "-X github.com/dapr/cli/pkg/standalone.gitversion=${version}"
+  ];
+
   postInstall = ''
     mv $out/bin/cli $out/bin/dapr
 
@@ -31,7 +38,7 @@ buildGoModule rec {
     description = "A CLI for managing Dapr, the distributed application runtime";
     homepage = "https://dapr.io";
     license = licenses.mit;
-    maintainers = with maintainers; [ lucperkins ];
+    maintainers = with maintainers; [ joshvanl lucperkins ];
     mainProgram = "dapr";
   };
 }


### PR DESCRIPTION
Adds version information to build flags so that `dapr version ` outputs the current version:

```bash
[nix-shell:~/.cache/nixpkgs-review/rev-95abc8a503a008088ab2f5d218a479b66681fae6]$ ./results/dapr-cli/bin/dapr version
CLI version: 1.8.1
Runtime version: n/a
```

See [here](https://github.com/dapr/cli/blob/c1f9627ed66f0c1da05a8f875d8ba79409223b86/Makefile#L99) how dapr is doing this upstream.

Also adds myself as a maintainer.

@lucperkins 
