### PR TITLE
build-dotnet-module: fix mktemp

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -196,7 +196,7 @@ stdenvNoCC.mkDerivation (args // {
            TMPDIR=
         fi
 
-        export tmp=$(mktemp -d "deps-${pname}-XXXXXX")
+        export tmp=$(mktemp -td "deps-${pname}-XXXXXX")
         HOME=$tmp/home
 
         exitTrap() {


### PR DESCRIPTION
#### Copy of commit msg
Re-add missing `-t` arg which I erroneously removed in a98e52085584d806bd80ab203c7b75c4e361f522.

Without it, the tmpdir is created in $PWD.