### PR TITLE
teyjus: 2.1 -> unstable-2019-07-26

### DIFF
--- a/pkgs/development/compilers/teyjus/default.nix
+++ b/pkgs/development/compilers/teyjus/default.nix
@@ -2,20 +2,31 @@
 
 stdenv.mkDerivation rec {
   pname = "teyjus";
-  version = "2.1";
+  version = "unstable-2019-07-26";
 
   src = fetchFromGitHub {
     owner = "teyjus";
     repo = "teyjus";
-    rev = "v${version}";
-    sha256 = "sha256-nz7jZ+GdF6mZQPzBrVD9K/RtoeuVRuhfs7vej4zDkhg=";
+    rev = "e63f40aa9f1d0ea5e7bac41aae5e479c3616545c";
+    sha256 = "sha256-gaAWKd5/DZrIPaaQzx9l0KtCMW9LPw17vvNPsnopZA0=";
   };
 
-  patches = [ ./fix-lex-to-flex.patch ];
+  patches = [
+    ./fix-lex-to-flex.patch
+  ];
 
-  buildInputs = [ omake ocaml flex bison ];
+  postPatch = ''
+    sed -i "/TST/d" source/OMakefile
+    rm -rf source/front/caml
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ omake ocaml flex bison ];
 
   hardeningDisable = [ "format" ];
+
+  NIX_CFLAGS_COMPILE = "-I${ocaml}/include";
 
   buildPhase = "omake all";
 
@@ -28,6 +39,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/teyjus/teyjus";
     license = lib.licenses.gpl3;
     maintainers = [ maintainers.bcdarwin ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15687,11 +15687,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa Foundation;
   };
 
-  teyjus = callPackage ../development/compilers/teyjus (
-    with ocaml-ng.ocamlPackages_4_02; {
-      inherit ocaml;
-      omake = omake_rc1;
-  });
+  teyjus = callPackage ../development/compilers/teyjus { };
 
   thrust = callPackage ../development/tools/thrust {
     gconf = gnome2.GConf;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
