### PR TITLE
dictd.wordnet: replace python2 in build script with python3

### DIFF
--- a/pkgs/servers/dict/dictd-wordnet.nix
+++ b/pkgs/servers/dict/dictd-wordnet.nix
@@ -1,10 +1,10 @@
-{lib, stdenv, python2, wordnet, writeScript}:
+{lib, stdenv, python3, wordnet, writeScript}:
 
 stdenv.mkDerivation rec {
   version = "542";
   pname = "dict-db-wordnet";
 
-  buildInputs = [python2 wordnet];
+  buildInputs = [python3 wordnet];
   convert = ./wordnet_structures.py;
 
   builder = writeScript "builder.sh" ''

--- a/pkgs/servers/dict/wordnet_structures.py
+++ b/pkgs/servers/dict/wordnet_structures.py
@@ -307,13 +307,13 @@ if (__name__ == '__main__'):
 
    for i in range(0,len(args),2):
       print('Opening index file %r...' % args[i])
-      file_index = file(args[i])
+      file_index = open(args[i])
       print('Opening data file %r...' % args[i+1])
-      file_data = file(args[i+1])
+      file_data = open(args[i+1])
       print('Parsing index file and data file...')
       wnd.wn_dict_add(file_index, file_data)
 
    print('All input files parsed. Writing output to index file %r and data file %r.' % (options.oi, options.od))
 
-   wnd.dict_generate(file(options.oi, 'w'),file(options.od, 'w'))
+   wnd.dict_generate(open(options.oi, 'w'),open(options.od, 'w'))
    print('All done.')

--- a/pkgs/servers/dict/wordnet_structures.py
+++ b/pkgs/servers/dict/wordnet_structures.py
@@ -262,7 +262,7 @@ original version.\n\n
       self.dict_entry_write(file_index, file_data, '00-database-url', '00-database-url\n%s\n' % self.wn_url)
 
      
-      words = self.word_data.keys()
+      words = list(self.word_data.keys())
       words.sort()
       for word in words:
          for wi in self.word_data[word]:
@@ -306,14 +306,14 @@ if (__name__ == '__main__'):
    wnd = WordnetDict(wn_url=options.wn_url, desc_short=options.desc_short, desc_long=options.desc_long)
    
    for i in range(0,len(args),2):
-      print 'Opening index file %r...' % args[i]
+      print('Opening index file %r...' % args[i])
       file_index = file(args[i])
-      print 'Opening data file %r...' % args[i+1]
+      print('Opening data file %r...' % args[i+1])
       file_data = file(args[i+1])
-      print 'Parsing index file and data file...'
+      print('Parsing index file and data file...')
       wnd.wn_dict_add(file_index, file_data)
 
-   print 'All input files parsed. Writing output to index file %r and data file %r.' % (options.oi, options.od)
+   print('All input files parsed. Writing output to index file %r and data file %r.' % (options.oi, options.od))
    
    wnd.dict_generate(file(options.oi, 'w'),file(options.od, 'w'))
-   print 'All done.' 
+   print('All done.') 

--- a/pkgs/servers/dict/wordnet_structures.py
+++ b/pkgs/servers/dict/wordnet_structures.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #Copyright 2007 Sebastian Hagen
 # This file is part of wordnet_tools.
 
@@ -49,7 +49,7 @@ class WordIndex:
       self.ptrs = ptrs
       self.synsets = synsets
       self.tagsense_count = tagsense_count
-   
+
    @classmethod
    def build_from_line(cls, line_data, synset_map):
       line_split = line_data.split()
@@ -61,14 +61,14 @@ class WordIndex:
       tagsense_count = int(line_split[5 + ptr_count],10)
       synsets = [synset_map[int(line_split[i],10)] for i in range(6 + ptr_count, 6 + ptr_count + synset_count)]
       return cls(lemma, category, ptrs, synsets, tagsense_count)
-   
+
    @classmethod
    def build_from_file(cls, f, synset_map, rv_base=None):
       if (rv_base is None):
          rv = {}
       else:
          rv = rv_base
-         
+
       for line in f:
          if (line.startswith('  ')):
             continue
@@ -81,8 +81,8 @@ class WordIndex:
 
    def __repr__(self):
       return '%s%s' % (self.__class__.__name__, (self.lemma, self.category, self.ptrs, self.synsets, self.tagsense_count))
-   
-   
+
+
 class WordIndexDictFormatter(WordIndex):
    category_map_rev = {
       CAT_NOUN: 'n',
@@ -96,12 +96,12 @@ class WordIndexDictFormatter(WordIndex):
    prefix_fmtn_line_first = '         '
    prefix_fmtf_line_nonfirst = '%5d: '
    prefix_fmtn_line_nonfirst = '       '
-   
+
    def dict_str(self):
       tw = TextWrapper(width=self.LINE_WIDTH_MAX,
          initial_indent=(self.prefix_fmtf_line_first % self.category_map_rev[self.category]),
          subsequent_indent=self.prefix_fmtn_line_first)
-         
+
       lines = (tw.wrap(self.synsets[0].dict_str()))
       i = 2
       for synset in self.synsets[1:]:
@@ -122,7 +122,7 @@ class Synset:
       self.gloss = gloss
       self.frames = frames
       self.comments = []
-   
+
    @classmethod
    def build_from_line(cls, line_data):
       line_split = line_data.split()
@@ -132,7 +132,7 @@ class Synset:
       words = [line_split[i] for i in range(4, 4 + word_count*2,2)]
       ptr_count = int(line_split[4 + word_count*2],10)
       ptrs = [(line_split[i], line_split[i+1], line_split[i+2], line_split[i+3]) for i in range(5 + word_count*2,4 + word_count*2 + ptr_count*4,4)]
-     
+
       tok = line_split[5 + word_count*2 + ptr_count*4]
       base = 6 + word_count*2 + ptr_count*4
       if (tok != '|'):
@@ -141,20 +141,20 @@ class Synset:
          base += frame_count*3 + 1
       else:
          frames = []
-     
+
       line_split2 = line_data.split(None, base)
       if (len(line_split2) < base):
          gloss = None
       else:
          gloss = line_split2[-1]
-     
+
       return cls(synset_offset, ss_type, words, ptrs, gloss, frames)
-   
+
    @classmethod
    def build_from_file(cls, f):
       rv = {}
       comments = []
-     
+
       for line in f:
          if (line.startswith('  ')):
             line_s = line.lstrip().rstrip('\n')
@@ -197,14 +197,14 @@ original version.\n\n
 
    datetime_fmt = '%Y-%m-%dT%H:%M:%S'
    base64_map = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
-   
+
    def __init__(self, wn_url, desc_short, desc_long):
       self.word_data = {}
       self.wn_url = wn_url
       self.desc_short = desc_short
       self.desc_long = desc_long
       self.wn_license = None
-   
+
    def wn_dict_add(self, file_index, file_data):
       file_data.seek(0)
       file_index.seek(0)
@@ -212,7 +212,7 @@ original version.\n\n
       WordIndexDictFormatter.build_from_file(file_index, synsets, self.word_data)
       if (license_lines):
          self.wn_license = '\n'.join(license_lines) + '\n'
-   
+
    @classmethod
    def base64_encode(cls, i):
       """Encode a non-negative integer into a dictd compatible base64 string"""
@@ -223,7 +223,7 @@ original version.\n\n
       while (r < i):
          e += 1
          r = 64**e - 1
-     
+
       rv = ''
       while (e > 0):
          e -= 1
@@ -231,7 +231,7 @@ original version.\n\n
          rv += cls.base64_map[d]
          i = i % (64**e)
       return rv
-     
+
    @classmethod
    def dict_entry_write(cls, file_index, file_data, key, entry, linesep='\n'):
       """Write a single dict entry for <key> to index and data files"""
@@ -240,7 +240,7 @@ original version.\n\n
       entry_len = len(entry)
       file_index.write('%s\t%s\t%s%s' % (key, cls.base64_encode(entry_start),
             cls.base64_encode(entry_len), linesep))
-     
+
    def dict_generate(self, file_index, file_data):
       file_index.seek(0)
       file_data.seek(0)
@@ -261,7 +261,7 @@ original version.\n\n
       self.dict_entry_write(file_index, file_data, '00-database-short', '00-database-short\n%s\n' % self.desc_short)
       self.dict_entry_write(file_index, file_data, '00-database-url', '00-database-url\n%s\n' % self.wn_url)
 
-     
+
       words = list(self.word_data.keys())
       words.sort()
       for word in words:
@@ -280,14 +280,14 @@ original version.\n\n
             else:
                continue
             break
-           
+
          outstr = ''
          for wi in self.word_data[word]:
             outstr += wi.dict_str() + '\n'
-         
+
          outstr = '%s%s%s' % (word_cs, wi.linesep, outstr)
          self.dict_entry_write(file_index, file_data, word_cs, outstr, wi.linesep)
-     
+
       file_index.truncate()
       file_data.truncate()
 
@@ -300,11 +300,11 @@ if (__name__ == '__main__'):
    op.add_option('--wn_url', dest='wn_url', default='ftp://ftp.cogsci.princeton.edu/pub/wordnet/2.0', help='URL for wordnet sources')
    op.add_option('--db_desc_short', dest='desc_short', default='     WordNet (r) 2.1 (2005)', help='short dict DB description')
    op.add_option('--db_desc_long', dest='desc_long', default='    WordNet (r): A Lexical Database for English from the\n     Cognitive Science Laboratory at Princeton University', help='long dict DB description')
-   
+
    (options, args) = op.parse_args()
-   
+
    wnd = WordnetDict(wn_url=options.wn_url, desc_short=options.desc_short, desc_long=options.desc_long)
-   
+
    for i in range(0,len(args),2):
       print('Opening index file %r...' % args[i])
       file_index = file(args[i])
@@ -314,6 +314,6 @@ if (__name__ == '__main__'):
       wnd.wn_dict_add(file_index, file_data)
 
    print('All input files parsed. Writing output to index file %r and data file %r.' % (options.oi, options.od))
-   
+
    wnd.dict_generate(file(options.oi, 'w'),file(options.od, 'w'))
-   print('All done.') 
+   print('All done.')

--- a/pkgs/servers/dict/wordnet_structures.py
+++ b/pkgs/servers/dict/wordnet_structures.py
@@ -26,6 +26,7 @@
 # written.
 
 import datetime
+import math
 from textwrap import TextWrapper
 
 CAT_ADJECTIVE = 0
@@ -227,7 +228,7 @@ original version.\n\n
       rv = ''
       while (e > 0):
          e -= 1
-         d = (i / 64**e)
+         d = math.floor(i / 64**e)
          rv += cls.base64_map[d]
          i = i % (64**e)
       return rv


### PR DESCRIPTION
###### Description of changes

The database was converted with a python2 script but python2 does not evaluate any longer on master. The script is converted to python3 with the minimal changes possible.

If it is desirable to refactor or modernize the script further I can add commits for that. 

Originally the script seems to stem from the [wordnet tools](https://wordnet.princeton.edu/download) but I was not able to find it in the download directory (and archives therein).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
