### PR TITLE
python3Packages.spacy-legacy: fix package description string

### DIFF
--- a/pkgs/development/python-modules/spacy/legacy.nix
+++ b/pkgs/development/python-modules/spacy/legacy.nix
@@ -14,11 +14,15 @@ buildPythonPackage rec {
 
   # checkInputs = [ pytestCheckHook spacy ];
   doCheck = false;
-  pythonImportsCheck = [ "spacy_legacy" ];
+
+  pythonImportsCheck = [
+    "spacy_legacy"
+  ];
 
   meta = with lib; {
     description = "Legacy registered functions for spaCy backwards compatibility";
-    homepage = "https://github.com/justindujardin/pathy";
+    homepage = "https://github.com/explosion/spacy-legacy";
+    changelog = "https://github.com/explosion/spacy-legacy/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ melling ];
   };

--- a/pkgs/development/python-modules/spacy/legacy.nix
+++ b/pkgs/development/python-modules/spacy/legacy.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "spacy_legacy" ];
 
   meta = with lib; {
-    description = "A Path interface for local and cloud bucket storage";
+    description = "Legacy registered functions for spaCy backwards compatibility";
     homepage = "https://github.com/justindujardin/pathy";
     license = licenses.asl20;
     maintainers = with maintainers; [ melling ];


### PR DESCRIPTION
###### Description of changes

Noticed while reviewing #187217 that the package description string is incorrect, updated from PyPi page.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
