### PR TITLE
openai: 0.25.0 -> 0.26.1

### DIFF
--- a/pkgs/development/python-modules/openai/default.nix
+++ b/pkgs/development/python-modules/openai/default.nix
@@ -1,12 +1,14 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, aiohttp
 , matplotlib
 , numpy
 , openpyxl
 , pandas
 , pandas-stubs
 , plotly
+, pytest-asyncio
 , pytest-mock
 , pytestCheckHook
 , pythonOlder
@@ -20,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "openai";
-  version = "0.25.0";
+  version = "0.26.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7.1";
@@ -29,29 +31,33 @@ buildPythonPackage rec {
     owner = "openai";
     repo = "openai-python";
     rev = "v${version}";
-    hash = "sha256-bwv7lpdDYlk+y3KBjv7cSvaGr3v02riNCUfPFh6yv1I=";
+    hash = "sha256-M6ZaYTOBAwLogWPafSnBYw3rUry+sS9VwQWAM9tDfr8=";
   };
 
   propagatedBuildInputs = [
-    numpy
-    openpyxl
-    pandas
-    pandas-stubs
+    aiohttp
     requests
     tqdm
+  ] ++ lib.optionals (pythonOlder "3.8") [
     typing-extensions
   ];
 
   passthru.optional-dependencies = {
-    wandb = [
-      wandb
+    datalib = [
+      numpy
+      openpyxl
+      pandas
+      pandas-stubs
     ];
     embeddings = [
       matplotlib
       plotly
       scikit-learn
       tenacity
-    ];
+    ] ++ passthru.optional-dependencies.datalib;
+    wandb = [
+      wandb
+    ] ++ passthru.optional-dependencies.datalib;
   };
 
   pythonImportsCheck = [
@@ -60,6 +66,7 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
+    pytest-asyncio
     pytest-mock
   ];
 
@@ -72,6 +79,7 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # Requires a real API key
     "openai/tests/test_endpoints.py"
+    "openai/tests/asyncio/test_endpoints.py"
     # openai: command not found
     "openai/tests/test_file_cli.py"
     "openai/tests/test_long_examples_validator.py"

--- a/pkgs/development/python-modules/openai/default.nix
+++ b/pkgs/development/python-modules/openai/default.nix
@@ -18,6 +18,7 @@
 , tqdm
 , typing-extensions
 , wandb
+, withOptionalDependencies ? false
 }:
 
 buildPythonPackage rec {
@@ -40,7 +41,9 @@ buildPythonPackage rec {
     tqdm
   ] ++ lib.optionals (pythonOlder "3.8") [
     typing-extensions
-  ];
+  ] ++ lib.optionals withOptionalDependencies (builtins.attrValues {
+    inherit (passthru.optional-dependencies) embeddings wandb;
+  });
 
   passthru.optional-dependencies = {
     datalib = [


### PR DESCRIPTION
###### Description of changes

* Updated to latest version (changes: https://github.com/openai/openai-python/compare/v0.25.0...v0.26.1)
* Updated `propagatedBuildInputs` and `passthru.optional-dependencies` to match changes made to package.
* Added `withOptionalDependencies` option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
