### PR TITLE
[22.11] openimageio2: 2.2.17.0 -> 2.4.6.1

### DIFF
--- a/pkgs/applications/graphics/openimageio/2.x.nix
+++ b/pkgs/applications/graphics/openimageio/2.x.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchFromGitHub
+, fetchpatch
 , boost
 , cmake
 , giflib
@@ -16,14 +17,22 @@
 
 stdenv.mkDerivation rec {
   pname = "openimageio";
-  version = "2.2.17.0";
+  version = "2.4.6.1";
 
   src = fetchFromGitHub {
     owner = "OpenImageIO";
     repo = "oiio";
-    rev = "Release-${version}";
-    sha256 = "0jqpb1zci911wdm928addsljxx8zsh0gzbhv9vbw6man4wi93h6h";
+    rev = "v${version}";
+    sha256 = "sha256-oBICukkborxXFHXyM2rIn5qSbCWECjwDQI9MUg13IRU=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "arm-fix-signed-unsigned-simd-mismatch.patch";
+      url = "https://github.com/OpenImageIO/oiio/commit/726c51181a2888b0bd1edbef5ac8451e9cc3f893.patch";
+      hash = "sha256-G4vexf0OHZ/sbcRob5X92tajkmAv72ok8rcVQtIE9XE=";
+    })
+  ];
 
   outputs = [ "bin" "out" "dev" "doc" ];
 
@@ -58,7 +67,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://www.openimageio.org";
+    homepage = "https://openimageio.org";
     description = "A library and tools for reading and writing images";
     license = licenses.bsd3;
     maintainers = with maintainers; [ goibhniu ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31052,7 +31052,7 @@ with pkgs;
     boost = boost175;
   };
 
-  openimageio2 = callPackage ../applications/graphics/openimageio/2.x.nix { };
+  openimageio2 = darwin.apple_sdk_11_0.callPackage ../applications/graphics/openimageio/2.x.nix { };
 
   openjump = callPackage ../applications/misc/openjump { };
 


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-36354
https://nvd.nist.gov/vuln/detail/CVE-2022-38143
https://nvd.nist.gov/vuln/detail/CVE-2022-41639
https://nvd.nist.gov/vuln/detail/CVE-2022-41649
https://nvd.nist.gov/vuln/detail/CVE-2022-41684
https://nvd.nist.gov/vuln/detail/CVE-2022-41794
https://nvd.nist.gov/vuln/detail/CVE-2022-41837
https://nvd.nist.gov/vuln/detail/CVE-2022-41838
https://nvd.nist.gov/vuln/detail/CVE-2022-41977
https://nvd.nist.gov/vuln/detail/CVE-2022-41981
https://nvd.nist.gov/vuln/detail/CVE-2022-41988
https://nvd.nist.gov/vuln/detail/CVE-2022-41999
https://nvd.nist.gov/vuln/detail/CVE-2022-43592
https://nvd.nist.gov/vuln/detail/CVE-2022-43593
https://nvd.nist.gov/vuln/detail/CVE-2022-43594
https://nvd.nist.gov/vuln/detail/CVE-2022-43595
https://nvd.nist.gov/vuln/detail/CVE-2022-43596
https://nvd.nist.gov/vuln/detail/CVE-2022-43597
https://nvd.nist.gov/vuln/detail/CVE-2022-43598
https://nvd.nist.gov/vuln/detail/CVE-2022-43599
https://nvd.nist.gov/vuln/detail/CVE-2022-43600
https://nvd.nist.gov/vuln/detail/CVE-2022-43601
https://nvd.nist.gov/vuln/detail/CVE-2022-43602
https://nvd.nist.gov/vuln/detail/CVE-2022-43603

Partial backport of #208013, leaving it `opencolorio_1`-based to reduce unnecessary change.

I did look at patching openimageio 2.2 but the changes were just too extensive.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
