### PR TITLE
pam_rssh: init at unstable-2023-01-09

### DIFF
--- a/pkgs/os-specific/linux/pam_rssh/default.nix
+++ b/pkgs/os-specific/linux/pam_rssh/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  openssl,
+  pam,
+  pkg-config,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "pam_rssh";
+  version = "unstable-2023-01-12";
+
+  src = fetchFromGitHub {
+    owner = "z4yx";
+    repo = pname;
+    rev = "773823b9a8605436e5bcfabd1c3ff8deb8503f43";
+    hash = "sha512-rAr4ugo+IaxOKXtfEq9stK4edodork2uz10trHDv9MN4Oc296uDQjLh8Sle04Z4mbW56rWlT8eHrW6YpqGHFpw==";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha512-gSZ2EAhFJ1XqYmrVqJm3QP0l433XQxvkstkvyDAFZXB6KXiGzN0EoFxYoTdD0q2fE3tr5EBlmm4iC/Jo3wi4sg==";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    pam
+  ];
+
+  doCheck = false;
+  # How do disable specific tests?
+  # checkFlags = [
+  #   # Expects $USER and $SSH_AUTH_SOCK
+  #   "--skip=lib::tests::sshagent_list_identities"
+  #   "--skip=lib::tests::sshagent_auth"
+  #   "--skip=lib::tests::sshagent_more_auth"
+  #   "--skip=lib::tests::parse_user_authorized_keys"
+  # ];
+
+  meta = with lib; {
+    description = "Remote sudo authenticated via ssh-agent";
+    homepage = "https://github.com/z4yx/pam_rssh";
+    license = licenses.mit;
+    maintainers = with maintainers; [jamiemagee];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27019,6 +27019,8 @@ with pkgs;
 
   pam_pgsql = callPackage ../os-specific/linux/pam_pgsql { };
 
+  pam_rssh = callPackage ../os-specific/linux/pam_rssh { };
+
   pam_ssh_agent_auth = callPackage ../os-specific/linux/pam_ssh_agent_auth { };
 
   pam_tmpdir = callPackage ../os-specific/linux/pam_tmpdir { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
An alternative to `pam_ssh_agent_auth` that offers support for FIDO2/U2F keys (ECDSA-SK + ED25519-SK). Support in `pam_ssh_agent_auth` has stalled https://github.com/jbeverly/pam_ssh_agent_auth/issues/23

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
