### PR TITLE
nixos/systemd/initrd: follow init param symlinks

### DIFF
--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -497,7 +497,7 @@ in {
               case $o in
                   init=*)
                       IFS== read -r -a initParam <<< "$o"
-                      closure="$(dirname "''${initParam[1]}")"
+                      closure="''${initParam[1]}"
                       ;;
               esac
           done
@@ -507,6 +507,13 @@ in {
             echo 'No init= parameter on the kernel command line' >&2
             exit 1
           fi
+
+          # Resolve symlinks in the init parameter. We need this for some boot loaders
+          # (e.g. boot.loader.generationsDir).
+          closure="$(chroot /sysroot ${pkgs.coreutils}/bin/realpath "$closure")"
+
+          # Assume the directory containing the init script is the closure.
+          closure="$(dirname "$closure")"
 
           # If we are not booting a NixOS closure (e.g. init=/bin/sh),
           # we don't know what root to prepare so we don't do anything


### PR DESCRIPTION
###### Description of changes

Fixes an incompatibility between `boot.initrd.systemd` and `boot.loader.generationsDir`. Fixes https://github.com/NixOS/nixpkgs/issues/219767.

The `initrd-nixos-activation` service determines which system closure to activate by inspecting the `init` kernel parameter. It assumes that the `init` parameter is a full path to the system closure, such that taking `dirname` and appending `/prepare-root` will point to the right script.

However, some boot loaders pass an `init` path which includes symlinks. For example, on a system using `boot.loader.generationsDir`, `init=/boot/default/init` where `/boot/default` is a symlink to a folder like `/boot/system-38`, which in turn contains `init`, a symlink to the `init` script in the system closure in the Nix store. This setup breaks with `boot.initrd.systemd` because the `initrd-nixos-activation` script fails to find and activate the system.

This change resolves symlinks in the `init` parameter. ~It does this by repeatedly calling `readlink -m` because the filesystem is mounted at `/sysroot`, so absolute symlinks will terminate symlink resolution.~ It now uses `chroot`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Testing

Tested booting with these configurations:

- [x] systemd-boot (`init` = absolute path)
- [x] generationsDir with https://github.com/NixOS/nixpkgs/pull/198728 (`init` = relative link -> absolute link -> absolute path)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] armv7l-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - [x] `systemd-initrd-simple`
    - [x] `systemd-initrd-btrfs-raid`
    - [x] `systemd-initrd-networkd`
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
