### PR TITLE
coqPackages_8_13.smtcoq: fix build by using older make

### DIFF
--- a/pkgs/development/coq-modules/smtcoq/cvc4.nix
+++ b/pkgs/development/coq-modules/smtcoq/cvc4.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, cln, fetchurl, gmp, swig, pkg-config
+{ lib, stdenv, cln, fetchurl, gmp, gnumake42, swig, pkg-config
 , libantlr3c, boost, autoreconfHook
 , python3
 }:
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "1iw793zsi48q91lxpf8xl8lnvv0jsj4whdad79rakywkm1gbs62w";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  # Build fails with GNUmake 4.4
+  nativeBuildInputs = [ autoreconfHook gnumake42 pkg-config ];
   buildInputs = [ gmp swig libantlr3c boost python3 ]
     ++ lib.optionals stdenv.isLinux [ cln ];
 

--- a/pkgs/development/coq-modules/smtcoq/default.nix
+++ b/pkgs/development/coq-modules/smtcoq/default.nix
@@ -29,7 +29,7 @@ mkCoqDerivation {
 
   propagatedBuildInputs = [ trakt cvc4 veriT' zchaff ] ++ (with coq.ocamlPackages; [ num zarith ]);
   mlPlugin = true;
-  nativeBuildInputs = with coq.ocamlPackages; [ ocamlbuild ];
+  nativeBuildInputs = (with pkgs; [ gnumake42 ]) ++ (with coq.ocamlPackages; [ ocamlbuild ]);
 
   # This is meant to ease future troubleshooting of cvc4 build failures
   passthru = { inherit cvc4; };

--- a/pkgs/development/coq-modules/smtcoq/default.nix
+++ b/pkgs/development/coq-modules/smtcoq/default.nix
@@ -31,6 +31,9 @@ mkCoqDerivation {
   mlPlugin = true;
   nativeBuildInputs = with coq.ocamlPackages; [ ocamlbuild ];
 
+  # This is meant to ease future troubleshooting of cvc4 build failures
+  passthru = { inherit cvc4; };
+
   meta = {
     description = "Communication between Coq and SAT/SMT solvers ";
     maintainers = with maintainers; [ siraben ];


### PR DESCRIPTION
###### Description of changes

It seems that CVC4-1.6 and smtcoq won’t build with GNUmake 4.4.
This fixes the build failure reported by Pierre there: https://github.com/coq-community/coq-nix-toolbox/pull/129
cc @proux01

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
