### PR TITLE
python: improve ABI name detection

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -171,11 +171,22 @@ let
       else if isx86_32 then "i386"
       else parsed.cpu.name;
     pythonAbiName =
-      # python's build doesn't differentiate between musl and glibc in its
-      # abi detection, our wrapper should match.
-      if stdenv.hostPlatform.isMusl then
-        replaceStrings [ "musl" ] [ "gnu" ] parsed.abi.name
-        else parsed.abi.name;
+      # python's build doesn't support every gnu<extension>, and doesn't
+      # differentiate between musl and glibc, so we list those supported in
+      # here:
+      # https://github.com/python/cpython/blob/e488e300f5c01289c10906c2e53a8e43d6de32d8/configure.ac#L724
+      # Note: this is an approximation, as it doesn't take into account the CPU
+      # family, or the nixpkgs abi naming conventions.
+      if elem parsed.abi.name [
+        "gnux32"
+        "gnueabihf"
+        "gnueabi"
+        "gnuabin32"
+        "gnuabi64"
+        "gnuspe"
+      ]
+      then parsed.abi.name
+      else "gnu";
     multiarch =
       if isDarwin then "darwin"
       else "${multiarchCpu}-${parsed.kernel.name}-${pythonAbiName}";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This makes `pkgsCross.ppc64.python3Packages.pip` work again.

We somewhat recently changed the PPC64 arch to be `powerpc64-unknown-linux-gnuabielfv2` with this ABI name as a way to differentiate between the ELFv1 and ELFv1 variant of PowerPC64. Python doesn't support this ABI name (which is expected), so I went and changed the mapping between nixpkgs' ABI names and Python's ABI names.

This basically use the ABI name as-is, if it is supported by Python, and will fallback to the "gnu" ABI if it is not supported.

This targets `master` as this shouldn't cause rebuilds for Tier 1, Tier 2, or Tier 3 architectures.

Pinging @NixOS/exotic-platform-maintainers and @FRidh

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested platforms (by building `python3Packages.pip`:
  - [x] x86_64-linux (cache hit)
  - [x] `pkgsCross.ppc64`
  - [x] `pkgsCross.ppc64-musl`
  - [x] `pkgsCross.raspberryPi`
  - [x] `pkgsCross.aarch64-multiplatform`
  - [x] `pkgsCross.gnu32`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - Nothing to be built.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - `pip --version` works for `gnu32` cross
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
