### PR TITLE
dub: 1.23.0 -> 1.30.0

### DIFF
--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -4,7 +4,7 @@ assert dcompiler != null;
 
 stdenv.mkDerivation rec {
   pname = "dub";
-  version = "1.23.0";
+  version = "1.30.0";
 
   enableParallelBuilding = true;
 
@@ -12,18 +12,17 @@ stdenv.mkDerivation rec {
     owner = "dlang";
     repo = "dub";
     rev = "v${version}";
-    sha256 = "06a4whsl1m600k096nwif83n7za3vr7pj1xwapncy5fcad1gmady";
+    sha256 = "sha256-iVl7bjblvIxvrUX7Phq6h4AIAmZjNVkGYYFA1hhsE7c=";
   };
 
-  postUnpack = ''
-      patchShebangs .
-  '';
-
-  # Can be removed with https://github.com/dlang/dub/pull/1368
   dubvar = "\\$DUB";
   postPatch = ''
-      substituteInPlace test/fetchzip.sh \
-          --replace "dub remove" "\"${dubvar}\" remove"
+    patchShebangs test
+
+
+    # Can be removed with https://github.com/dlang/dub/pull/1368
+    substituteInPlace test/fetchzip.sh \
+        --replace "dub remove" "\"${dubvar}\" remove"
   '';
 
   nativeBuildInputs = [ dcompiler libevent rsync ];
@@ -50,7 +49,7 @@ stdenv.mkDerivation rec {
   checkPhase = ''
     export DUB=$NIX_BUILD_TOP/source/bin/dub
     export PATH=$PATH:$NIX_BUILD_TOP/source/bin/
-    export DC=${dcompiler.out}/bin/${dcompiler.pname}
+    export DC=${dcompiler.out}/bin/${if dcompiler.pname=="ldc" then "ldc2" else dcompiler.pname}
     echo "DC out --> $DC"
     export HOME=$TMP
 
@@ -103,6 +102,7 @@ stdenv.mkDerivation rec {
     rm test/single-file-sdl-default-name.sh
     rm test/subpackage-common-with-sourcefile-globbing.sh
     rm test/issue934-path-dep.sh
+    rm -r test/issue2258-dynLib-exe-dep # requires files below
     rm -r test/1-dynLib-simple
     rm -r test/1-exec-simple-package-json
     rm -r test/1-exec-simple
@@ -136,6 +136,7 @@ stdenv.mkDerivation rec {
     rm -r test/issue97-targettype-none-onerecipe
     rm -r test/path-subpackage-ref
     rm -r test/sdl-package-simple
+    rm -r test/dpath-variable # requires execution of dpath-variable.sh
 
     ./test/run-unittest.sh
   '';


### PR DESCRIPTION
Bump dub to latest version

https://github.com/dlang/dub/releases/tag/v1.30.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


#### Note

dub 1.31.1 is also out, but using it breaks Literate (pkgs/development/tools/literate-programming/Literate/default.nix)

<details><summary>Build log of literate with dub 1.31.1</summary>

```
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/8r9ch4bl2p3dkgc50ykid9mxszizw3d5-source
source root is source
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
no configure script, doing nothing
@nix { "action": "setPhase", "phase": "buildPhase" }
building
build flags: SHELL=/nix/store/561wgc73s0x1250hrgp7jm22hhv7yfln-bash-5.2-p15/bin/bash
dub --root=lit/tangle build
    Starting Performing "debug" build using ldc2 for x86_64.
Error  /homeless-shelter: Permission denied
make: *** [Makefile:11: bin/tangle] Error 2

```

</details>
