### PR TITLE
polybar: Remove i3-gaps support

### DIFF
--- a/pkgs/applications/misc/polybar/default.nix
+++ b/pkgs/applications/misc/polybar/default.nix
@@ -28,7 +28,6 @@
 , wirelesstools
 , libnl
 , i3
-, i3-gaps
 , jsoncpp
 
   # override the variables ending in 'Support' to enable or disable modules
@@ -39,7 +38,6 @@
 , iwSupport ? false
 , nlSupport ? true
 , i3Support ? false
-, i3GapsSupport ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -59,7 +57,7 @@ stdenv.mkDerivation rec {
     pkg-config
     python3Packages.sphinx
     removeReferencesTo
-  ] ++ lib.optional (i3Support || i3GapsSupport) makeWrapper;
+  ] ++ lib.optional i3Support makeWrapper;
 
   buildInputs = [
     cairo
@@ -82,9 +80,7 @@ stdenv.mkDerivation rec {
   ++ lib.optional pulseSupport libpulseaudio
   ++ lib.optional iwSupport wirelesstools
   ++ lib.optional nlSupport libnl
-  ++ lib.optional (i3Support || i3GapsSupport) jsoncpp
-  ++ lib.optional i3Support i3
-  ++ lib.optional i3GapsSupport i3-gaps;
+  ++ lib.optionals i3Support [ jsoncpp i3 ];
 
   patches = [ ./remove-hardcoded-etc.diff ];
 
@@ -95,16 +91,10 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall =
-    if i3Support then ''
+    lib.optionalString i3Support ''
       wrapProgram $out/bin/polybar \
         --prefix PATH : "${i3}/bin"
-    ''
-    else if i3GapsSupport
-    then ''
-      wrapProgram $out/bin/polybar \
-        --prefix PATH : "${i3-gaps}/bin"
-    ''
-    else "";
+    '';
 
   postFixup = ''
     remove-references-to -t ${stdenv.cc} $out/bin/polybar

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31159,7 +31159,6 @@ with pkgs;
     iwSupport = false;
     nlSupport = true;
     i3Support = true;
-    i3GapsSupport = false;
   };
 
   yambar = callPackage ../applications/misc/yambar { };


### PR DESCRIPTION
Breaks when no aliases are enabled since #208861.
Does not appear to result in rebuilds.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
