### PR TITLE
lib/path/tests: Fix property tests when "-n" is generated

### DIFF
--- a/lib/path/tests/prop.sh
+++ b/lib/path/tests/prop.sh
@@ -55,7 +55,7 @@ fi
 declare -a strings=()
 mkdir -p "$tmp/strings"
 while IFS= read -r -d $'\0' str; do
-    echo -n "$str" > "$tmp/strings/${#strings[@]}"
+    printf "%s" "$str" > "$tmp/strings/${#strings[@]}"
     strings+=("$str")
 done < <(awk \
     -f "$SCRIPT_DIR"/generate.awk \


### PR DESCRIPTION
###### Description of changes

When "-n" is generated by the property tests, it causes `echo` to not output the string since it's interpreted as an option. Apparently [there's no good way to print "-n" with `echo`][1], so switching to `printf` instead

[1]: https://unix.stackexchange.com/questions/85846/how-can-i-print-n-with-echo

Thanks to @vcunat for reporting [the original failure](https://hydra.nixos.org/build/204720675) in [the PR that introduced it](https://github.com/NixOS/nixpkgs/pull/205190)

I love this, while the property tests didn't detect a mistake in the code implementation, they did detect a mistake in the test implementation!

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles: 

###### Things done

- [x] Successfully ran `lib/path/tests/prop.sh 13110`