### PR TITLE
proxysql: fix build again

### DIFF
--- a/pkgs/servers/sql/proxysql/default.nix
+++ b/pkgs/servers/sql/proxysql/default.nix
@@ -68,10 +68,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # otherwise, it looks for …-1.15
-  ACLOCAL = "aclocal";
-  AUTOMAKE = "automake";
-
   GIT_VERSION = version;
 
   dontConfigure = true;
@@ -139,6 +135,18 @@ stdenv.mkDerivation rec {
     popd
 
     sed -i s_/usr/bin/env_${coreutils}/bin/env_g libssl/openssl/config
+
+    pushd libmicrohttpd/libmicrohttpd
+    autoreconf
+    popd
+
+    pushd libconfig/libconfig
+    autoreconf
+    popd
+
+    pushd libdaemon/libdaemon
+    autoreconf
+    popd
 
     popd
     patchShebangs .

--- a/pkgs/servers/sql/proxysql/default.nix
+++ b/pkgs/servers/sql/proxysql/default.nix
@@ -32,13 +32,13 @@
 
 stdenv.mkDerivation rec {
   pname = "proxysql";
-  version = "2.4.5";
+  version = "2.4.6";
 
   src = fetchFromGitHub {
     owner = "sysown";
     repo = pname;
     rev = version;
-    hash = "sha256-JWrll6VF0Ss1DlPNrh+xd3sGMclMeb6dlVgHd/UaNs0=";
+    hash = "sha256-EquQCmXXspCpbyi1apoCcrICZAYq9BXlZsvy3KfHPJc=";
   };
 
   patches = [

--- a/pkgs/servers/sql/proxysql/default.nix
+++ b/pkgs/servers/sql/proxysql/default.nix
@@ -32,13 +32,13 @@
 
 stdenv.mkDerivation rec {
   pname = "proxysql";
-  version = "2.4.6";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "sysown";
     repo = pname;
     rev = version;
-    hash = "sha256-EquQCmXXspCpbyi1apoCcrICZAYq9BXlZsvy3KfHPJc=";
+    hash = "sha256-psQzKycavS9xr24wGiRkr255IXW79AoG9fUEBkvPMZk=";
   };
 
   patches = [

--- a/pkgs/servers/sql/proxysql/makefiles.patch
+++ b/pkgs/servers/sql/proxysql/makefiles.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index fba4e6a1..ceff4f3d 100644
+index ecbe04a9..4b5031a3 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -57,11 +57,7 @@ endif
@@ -15,7 +15,7 @@ index fba4e6a1..ceff4f3d 100644
  USERCHECK := $(shell getent passwd proxysql)
  GROUPCHECK := $(shell getent group proxysql)
  
-@@ -724,16 +720,10 @@ cleanbuild:
+@@ -754,16 +750,10 @@ cleanbuild:
  
  .PHONY: install
  install: src/proxysql
@@ -36,10 +36,10 @@ index fba4e6a1..ceff4f3d 100644
  	install -m 0755 etc/init.d/proxysql /etc/init.d
  ifeq ($(DISTRO),"CentOS Linux")
 diff --git a/deps/Makefile b/deps/Makefile
-index 13eed9c5..9abb2262 100644
+index b25e31b7..7196e493 100644
 --- a/deps/Makefile
 +++ b/deps/Makefile
-@@ -65,18 +65,11 @@ endif
+@@ -65,11 +65,6 @@ endif
  
  
  libinjection/libinjection/src/libinjection.a:
@@ -48,8 +48,10 @@ index 13eed9c5..9abb2262 100644
 -ifneq ($(CENTOSVER),6)
 -	cd libinjection/libinjection && patch -p1 < ../update-build-py3.diff
 -endif
- 	sed -i 's/CC=/CC?=/' libinjection/libinjection/src/Makefile
- 	cd libinjection/libinjection && CC=${CC} CXX=${CXX} ${MAKE}
+ ifeq ($(UNAME_S),Darwin)
+ 	sed -i '' 's/CC=/CC?=/' libinjection/libinjection/src/Makefile
+ else
+@@ -79,8 +74,6 @@ endif
  libinjection: libinjection/libinjection/src/libinjection.a
  
  libssl/openssl/libssl.a:
@@ -58,7 +60,7 @@ index 13eed9c5..9abb2262 100644
  	cd libssl/openssl && patch crypto/ec/curve448/curve448.c < ../curve448.c-multiplication-overflow.patch
  	cd libssl/openssl && patch crypto/asn1/a_time.c < ../a_time.c-multiplication-overflow.patch
  	cd libssl/openssl && ./config no-ssl3 no-tests
-@@ -93,8 +86,6 @@ ifeq ($(MIN_VERSION),$(lastword $(sort $(GCC_VERSION) $(MIN_VERSION))))
+@@ -97,8 +90,6 @@ ifeq ($(MIN_VERSION),$(lastword $(sort $(GCC_VERSION) $(MIN_VERSION))))
  endif
  
  libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a re2/re2/obj/libre2.a
@@ -67,7 +69,7 @@ index 13eed9c5..9abb2262 100644
  ifeq ($(REQUIRE_PATCH), true)
  	cd libhttpserver/libhttpserver && patch src/httpserver/basic_auth_fail_response.hpp < ../basic_auth_fail_response.hpp.patch
  	cd libhttpserver/libhttpserver && patch src/httpserver/create_webserver.hpp < ../create_webserver.hpp.patch
-@@ -117,34 +108,16 @@ endif
+@@ -121,35 +112,17 @@ endif
  libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a
  
  libev/libev/.libs/libev.a:
@@ -82,6 +84,7 @@ index 13eed9c5..9abb2262 100644
 -	cd curl && rm -rf curl-*/ || true
 -	cd curl && tar -zxf curl-*.tar.gz
 -	#cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --with-ssl=$(shell pwd)/../../libssl/openssl/ && CC=${CC} CXX=${CXX} ${MAKE}
+ 	cd curl/curl && patch configure < ../configure.patch
  	cd curl/curl && CFLAGS=-fPIC ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --without-librtmp --without-libpsl --without-zstd --with-ssl=$(shell pwd)/libssl/openssl/ --enable-shared=no && CC=${CC} CXX=${CXX} ${MAKE}
  curl: curl/curl/lib/.libs/libcurl.a
  
@@ -96,13 +99,13 @@ index 13eed9c5..9abb2262 100644
 -	cd libmicrohttpd && tar -zxf libmicrohttpd-0.9.68.tar.gz
 -	cd libmicrohttpd/libmicrohttpd && patch src/microhttpd/connection.c < ../connection.c-snprintf-overflow.patch
 -endif
--ifeq ($(OS),Darwin)
+-ifeq ($(UNAME_S),Darwin)
 -	cd libmicrohttpd/libmicrohttpd && patch src/microhttpd/mhd_sockets.c < ../mhd_sockets.c-issue-5977.patch
 -endif
  	cd libmicrohttpd/libmicrohttpd && ./configure --enable-https && CC=${CC} CXX=${CXX} ${MAKE}
  microhttpd: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a
  
-@@ -155,8 +128,6 @@ cityhash/cityhash/src/.libs/libcityhash.a:
+@@ -160,8 +133,6 @@ cityhash/cityhash/src/.libs/libcityhash.a:
  cityhash: cityhash/cityhash/src/.libs/libcityhash.a
  
  lz4/lz4/liblz4.a:
@@ -111,16 +114,16 @@ index 13eed9c5..9abb2262 100644
  	cd lz4/lz4 && CC=${CC} CXX=${CXX} ${MAKE}
  lz4: lz4/lz4/liblz4.a
  
-@@ -181,8 +152,6 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-s
+@@ -186,8 +157,6 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-s
  
  
  libdaemon/libdaemon/libdaemon/.libs/libdaemon.a:
 -	cd libdaemon && rm -rf libdaemon-*/ || true
 -	cd libdaemon && tar -zxf libdaemon-0.14.tar.gz
- 	cd libdaemon/libdaemon && cp ../config.guess . && chmod +x config.guess && ./configure --disable-examples
+ 	cd libdaemon/libdaemon && cp ../config.guess . && chmod +x config.guess && cp ../config.sub . && chmod +x config.sub && ./configure --disable-examples
  	cd libdaemon/libdaemon && CC=${CC} CXX=${CXX} ${MAKE}
  
-@@ -253,17 +222,12 @@ sqlite3/sqlite3/sqlite3.o:
+@@ -261,17 +230,12 @@ sqlite3/sqlite3/sqlite3.o:
  sqlite3: sqlite3/sqlite3/sqlite3.o
  
  libconfig/libconfig/lib/.libs/libconfig++.a:
@@ -138,7 +141,7 @@ index 13eed9c5..9abb2262 100644
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../serial_exposer.patch
  	cd prometheus-cpp/prometheus-cpp && patch -p0 < ../registry_counters_reset.patch
  	cd prometheus-cpp/prometheus-cpp && patch -p0 < ../include_limits.patch
-@@ -273,10 +237,6 @@ prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a:
+@@ -281,10 +245,6 @@ prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a:
  prometheus-cpp: prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a
  
  re2/re2/obj/libre2.a:
@@ -147,9 +150,9 @@ index 13eed9c5..9abb2262 100644
 -#	cd re2/re2 && sed -i -e 's/-O3 -g /-O3 -fPIC /' Makefile
 -#	cd re2/re2 && patch util/mutex.h < ../mutex.h.patch
  	cd re2/re2 && patch re2/onepass.cc < ../onepass.cc-multiplication-overflow.patch
- 	cd re2/re2 && sed -i -e 's/-O3 /-O3 -fPIC -DMEMORY_SANITIZER -DRE2_ON_VALGRIND /' Makefile
- 	cd re2/re2 && sed -i -e 's/RE2_CXXFLAGS?=-std=c++11 /RE2_CXXFLAGS?=-std=c++11 -fPIC /' Makefile
-@@ -285,8 +245,6 @@ re2/re2/obj/libre2.a:
+ ifeq ($(UNAME_S),Darwin)
+ 	cd re2/re2 && sed -i '' -e 's/-O3 /-O3 -fPIC -DMEMORY_SANITIZER -DRE2_ON_VALGRIND /' Makefile
+@@ -298,8 +258,6 @@ endif
  re2: re2/re2/obj/libre2.a
  
  pcre/pcre/.libs/libpcre.a:

--- a/pkgs/servers/sql/proxysql/makefiles.patch
+++ b/pkgs/servers/sql/proxysql/makefiles.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index ecbe04a9..4b5031a3 100644
+index e7dae058..09c28859 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -57,11 +57,7 @@ endif
@@ -15,7 +15,7 @@ index ecbe04a9..4b5031a3 100644
  USERCHECK := $(shell getent passwd proxysql)
  GROUPCHECK := $(shell getent group proxysql)
  
-@@ -754,16 +750,10 @@ cleanbuild:
+@@ -784,16 +780,10 @@ cleanbuild:
  
  .PHONY: install
  install: src/proxysql
@@ -36,22 +36,21 @@ index ecbe04a9..4b5031a3 100644
  	install -m 0755 etc/init.d/proxysql /etc/init.d
  ifeq ($(DISTRO),"CentOS Linux")
 diff --git a/deps/Makefile b/deps/Makefile
-index b25e31b7..7196e493 100644
+index 23ef204c..3fbcc4a7 100644
 --- a/deps/Makefile
 +++ b/deps/Makefile
-@@ -65,11 +65,6 @@ endif
+@@ -65,10 +65,7 @@ endif
  
  
  libinjection/libinjection/src/libinjection.a:
 -	cd libinjection && rm -rf libinjection-*/ || true
 -	cd libinjection && tar -zxf libinjection-3.10.0.tar.gz
--ifneq ($(CENTOSVER),6)
+ ifneq ($(CENTOSVER),6)
 -	cd libinjection/libinjection && patch -p1 < ../update-build-py3.diff
--endif
+ 	cd libinjection/libinjection && patch -p1 < ../libinjection_sqli.c.patch
+ endif
  ifeq ($(UNAME_S),Darwin)
- 	sed -i '' 's/CC=/CC?=/' libinjection/libinjection/src/Makefile
- else
-@@ -79,8 +74,6 @@ endif
+@@ -80,8 +77,6 @@ endif
  libinjection: libinjection/libinjection/src/libinjection.a
  
  libssl/openssl/libssl.a:
@@ -60,16 +59,25 @@ index b25e31b7..7196e493 100644
  	cd libssl/openssl && patch crypto/ec/curve448/curve448.c < ../curve448.c-multiplication-overflow.patch
  	cd libssl/openssl && patch crypto/asn1/a_time.c < ../a_time.c-multiplication-overflow.patch
  	cd libssl/openssl && ./config no-ssl3 no-tests
-@@ -97,8 +90,6 @@ ifeq ($(MIN_VERSION),$(lastword $(sort $(GCC_VERSION) $(MIN_VERSION))))
+@@ -99,9 +94,6 @@ ifeq ($(MIN_VERSION),$(lastword $(SORTED_VERSIONS)))
  endif
  
  libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a re2/re2/obj/libre2.a
 -	cd libhttpserver && rm -rf libhttpserver-*/ || true
 -	cd libhttpserver && tar -zxf libhttpserver-0.18.1.tar.gz
- ifeq ($(REQUIRE_PATCH), true)
+-#ifeq ($(REQUIRE_PATCH), true)
  	cd libhttpserver/libhttpserver && patch src/httpserver/basic_auth_fail_response.hpp < ../basic_auth_fail_response.hpp.patch
  	cd libhttpserver/libhttpserver && patch src/httpserver/create_webserver.hpp < ../create_webserver.hpp.patch
-@@ -121,35 +112,17 @@ endif
+ 	cd libhttpserver/libhttpserver && patch src/httpserver/deferred_response.hpp < ../deferred_response.hpp.patch
+@@ -112,7 +104,6 @@ libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmi
+ 	cd libhttpserver/libhttpserver && patch src/httpserver/http_response.hpp < ../http_response.hpp.patch
+ 	cd libhttpserver/libhttpserver && patch src/httpserver/string_response.hpp < ../string_response.hpp.patch
+ 	cd libhttpserver/libhttpserver && patch -p0 < ../re2_regex.patch
+-#endif
+ 	cd libhttpserver/libhttpserver && patch -p0 < ../final_val_post_process.patch
+ 	cd libhttpserver/libhttpserver && patch -p0 < ../empty_uri_log_crash.patch
+ ifeq ($(UNAME_S),FreeBSD)
+@@ -124,35 +115,17 @@ endif
  libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a
  
  libev/libev/.libs/libev.a:
@@ -105,7 +113,7 @@ index b25e31b7..7196e493 100644
  	cd libmicrohttpd/libmicrohttpd && ./configure --enable-https && CC=${CC} CXX=${CXX} ${MAKE}
  microhttpd: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a
  
-@@ -160,8 +133,6 @@ cityhash/cityhash/src/.libs/libcityhash.a:
+@@ -163,8 +136,6 @@ cityhash/cityhash/src/.libs/libcityhash.a:
  cityhash: cityhash/cityhash/src/.libs/libcityhash.a
  
  lz4/lz4/liblz4.a:
@@ -114,7 +122,7 @@ index b25e31b7..7196e493 100644
  	cd lz4/lz4 && CC=${CC} CXX=${CXX} ${MAKE}
  lz4: lz4/lz4/liblz4.a
  
-@@ -186,8 +157,6 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-s
+@@ -189,8 +160,6 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-s
  
  
  libdaemon/libdaemon/libdaemon/.libs/libdaemon.a:
@@ -123,7 +131,7 @@ index b25e31b7..7196e493 100644
  	cd libdaemon/libdaemon && cp ../config.guess . && chmod +x config.guess && cp ../config.sub . && chmod +x config.sub && ./configure --disable-examples
  	cd libdaemon/libdaemon && CC=${CC} CXX=${CXX} ${MAKE}
  
-@@ -261,17 +230,12 @@ sqlite3/sqlite3/sqlite3.o:
+@@ -264,17 +233,12 @@ sqlite3/sqlite3/sqlite3.o:
  sqlite3: sqlite3/sqlite3/sqlite3.o
  
  libconfig/libconfig/lib/.libs/libconfig++.a:
@@ -141,7 +149,7 @@ index b25e31b7..7196e493 100644
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../serial_exposer.patch
  	cd prometheus-cpp/prometheus-cpp && patch -p0 < ../registry_counters_reset.patch
  	cd prometheus-cpp/prometheus-cpp && patch -p0 < ../include_limits.patch
-@@ -281,10 +245,6 @@ prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a:
+@@ -284,10 +248,6 @@ prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a:
  prometheus-cpp: prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a
  
  re2/re2/obj/libre2.a:
@@ -152,7 +160,7 @@ index b25e31b7..7196e493 100644
  	cd re2/re2 && patch re2/onepass.cc < ../onepass.cc-multiplication-overflow.patch
  ifeq ($(UNAME_S),Darwin)
  	cd re2/re2 && sed -i '' -e 's/-O3 /-O3 -fPIC -DMEMORY_SANITIZER -DRE2_ON_VALGRIND /' Makefile
-@@ -298,8 +258,6 @@ endif
+@@ -301,8 +261,6 @@ endif
  re2: re2/re2/obj/libre2.a
  
  pcre/pcre/.libs/libpcre.a:


### PR DESCRIPTION
###### Description of changes
#209876 did build for me, but… now it doesn't?

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).