### PR TITLE
selene: 0.23.1 -> 0.24.0

### DIFF
--- a/pkgs/development/tools/selene/default.nix
+++ b/pkgs/development/tools/selene/default.nix
@@ -1,7 +1,6 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
-, fetchpatch
 , robloxSupport ? true
 , pkg-config
 , openssl
@@ -11,26 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "selene";
-  version = "0.23.1";
+  version = "0.24.0";
 
   src = fetchFromGitHub {
     owner = "kampfkarren";
     repo = pname;
     rev = version;
-    sha256 = "sha256-gD49OzhpO059wawA+PJc8SIYQ23965LF21zqIfj62Y4=";
+    sha256 = "sha256-tw9OLdXhqxgqROub0P/+nd4LQGNw3QDxlCyyf8ogRQM=";
   };
 
-  cargoSha256 = "sha256-oekqM/Jvh0z6O6iJhSi7Ph5gsF5Fssr5ItKpmyozhPk=";
-
-  patches = [
-    # fix broken test
-    # https://github.com/kampfkarren/selene/pull/471
-    (fetchpatch {
-      name = "fix-test-roblox-incorrect-roact-usage.patch";
-      url = "https://github.com/kampfkarren/selene/commit/f4abf9f3fb639b372fe4ac47449f8a1e455c28a5.patch";
-      sha256 = "sha256-nk7HGygXXu91cqiRZBA/sLBlaJLkNg90C2NX8Kr1WGA=";
-    })
-  ];
+  cargoSha256 = "sha256-5/xAX8BhB81cB7x2Pe/MKCV0Fi76ZcO6XHFQxTVIuLA=";
 
   nativeBuildInputs = lib.optionals robloxSupport [
     pkg-config
@@ -38,7 +27,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals robloxSupport [
     openssl
-  ] ++ lib.optional (robloxSupport && stdenv.isDarwin) [
+  ] ++ lib.optionals (robloxSupport && stdenv.isDarwin) [
     darwin.apple_sdk.frameworks.Security
   ];
 


### PR DESCRIPTION
Diff: https://github.com/kampfkarren/selene/compare/0.23.1...0.24.0

Changelog: https://github.com/kampfkarren/selene/blob/0.24.0/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
