### PR TITLE
flutter: add darwin support

### DIFF
--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -5,7 +5,7 @@ let
   getPatches = dir:
     let files = builtins.attrNames (builtins.readDir dir);
     in map (f: dir + ("/" + f)) files;
-  mkFlutter = { version, engineVersion, dartVersion, hash, dartHash, patches }:
+  mkFlutter = { version, engineVersion, dartVersion, flutterHash, dartHash, patches }:
     let
       args = {
         inherit version engineVersion patches;
@@ -21,12 +21,34 @@ let
               url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${dartVersion}/sdk/dartsdk-linux-arm64-release.zip";
               sha256 = dartHash.aarch64-linux;
             };
+            "${dartVersion}-x86_64-darwin" = fetchzip {
+              url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${dartVersion}/sdk/dartsdk-macos-x64-release.zip";
+              sha256 = dartHash.x86_64-darwin;
+            };
+            "${dartVersion}-aarch64-darwin" = fetchzip {
+              url = "https://storage.googleapis.com/dart-archive/channels/stable/release/${dartVersion}/sdk/dartsdk-macos-arm64-release.zip";
+              sha256 = dartHash.aarch64-darwin;
+            };
           };
         };
-        src = fetchzip {
-          url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${version}-stable.tar.xz";
-          sha256 = hash;
-        };
+        src = {
+          x86_64-linux = fetchzip {
+            url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${version}-stable.tar.xz";
+            sha256 = flutterHash.x86_64-linux;
+          };
+          aarch64-linux = fetchzip {
+            url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${version}-stable.tar.xz";
+            sha256 = flutterHash.aarch64-linux;
+          };
+          x86_64-darwin = fetchzip {
+            url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_${version}-stable.zip";
+            sha256 = flutterHash.x86_64-darwin;
+          };
+          aarch64-darwin = fetchzip {
+            url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_arm64_${version}-stable.zip";
+            sha256 = flutterHash.aarch64-darwin;
+          };
+        }.${stdenv.hostPlatform.system};
       };
     in
     (mkCustomFlutter args).overrideAttrs (prev: next: {
@@ -55,10 +77,17 @@ in
     version = "3.10.5";
     engineVersion = "45f6e009110df4f34ec2cf99f63cf73b71b7a420";
     dartVersion = "3.0.5";
-    hash = "sha256-lLppUQzu+fl81TMYSPD+HA83BqeIg7bXpURyo49NPwI=";
     dartHash = {
       x86_64-linux = "sha256-UVVwPFk0qsKNR4JZMOGSGh1T482MN/8Xp4MZ3SA3C28=";
       aarch64-linux = "sha256-phzaFfrv7qbZOOhPq92q39R6mr5vFeBqEmYDU7e7lZQ=";
+      x86_64-darwin = "sha256-4gJ659bNzs2lfI1LRwFACgu/ttkj+3xIrqLijju+CaI=";
+      aarch64-darwin = "sha256-RJt+muq5IrcAhVLYEgdbVygcY1oB7tnVCN+iqktC+6c=";
+    };
+    flutterHash = rec {
+      x86_64-linux = "sha256-lLppUQzu+fl81TMYSPD+HA83BqeIg7bXpURyo49NPwI=";
+      aarch64-linux = x86_64-linux;
+      x86_64-darwin = "sha256-1ZC5aCoGVBCeTSsu/ZEl1v53lLnzulx8Ya6YXvo4yIY=";
+      aarch64-darwin = "sha256-TCMempLjO47IbP5MAZVHlXXvNaURGo+EbaL0K8e27wU=";
     };
     patches = flutter3Patches;
   };
@@ -67,10 +96,17 @@ in
     version = "3.7.12";
     engineVersion = "1a65d409c7a1438a34d21b60bf30a6fd5db59314";
     dartVersion = "2.19.6";
-    hash = "sha256-5ExDBQXIpoZ5NwS66seY3m9/V8xDiyq/RdzldAyHdEE=";
     dartHash = {
       x86_64-linux = "sha256-4ezRuwhQHVCxZg5WbzU/tBUDvZVpfCo6coDE4K0UzXo=";
       aarch64-linux = "sha256-pYmClIqOo0sRPOkrcF4xQbo0mHlrr1TkhT1fnNyYNck=";
+      x86_64-darwin = "sha256-tuIQhIOX2ub0u99CW/l7nCya9YVNokCZNgbVFqO4ils=";
+      aarch64-darwin = "sha256-Oe8/0ygDN3xf5/2I3N/OBzF0bps7Mg0K2zJKj+E9Nak=";
+    };
+    flutterHash = rec {
+      x86_64-linux = "sha256-5ExDBQXIpoZ5NwS66seY3m9/V8xDiyq/RdzldAyHdEE=";
+      aarch64-linux = x86_64-linux;
+      x86_64-darwin = "sha256-cJF8KB9fNb3hTZShDAPsMmr1neRdIMLvIl/m2tpzwQs=";
+      aarch64-darwin = "sha256-yetEE65UP2Wh9ocx7nClQjYLHO6lIbZPay1+I2tDSM4=";
     };
     patches = flutter3Patches;
   };

--- a/pkgs/development/compilers/flutter/engine-artifacts/default.nix
+++ b/pkgs/development/compilers/flutter/engine-artifacts/default.nix
@@ -135,8 +135,7 @@ let
   mkArtifactDerivation = { platform ? null, variant ? null, subdirectory ? null, archive, ... }@args:
     let
       artifactDirectory = if platform == null then null else "${platform}${lib.optionalString (variant != null) "-${variant}"}";
-      archiveExtension = ".${(lib.last (lib.splitString "." archive))}";
-      archiveBasename = lib.removeSuffix archiveExtension archive;
+      archiveBasename = lib.removeSuffix ".${(lib.last (lib.splitString "." archive))}" archive;
       overrideUnpackCmd = builtins.elem archive [ "FlutterEmbedder.framework.zip" "FlutterMacOS.framework.zip" ];
     in
     stdenv.mkDerivation ({

--- a/pkgs/development/compilers/flutter/engine-artifacts/default.nix
+++ b/pkgs/development/compilers/flutter/engine-artifacts/default.nix
@@ -2,10 +2,11 @@
 , stdenv
 , hostPlatform
 , engineVersion
+, fetchurl
 , fetchzip
 , autoPatchelfHook
-
 , gtk3
+, unzip
 }:
 
 let
@@ -43,6 +44,56 @@ let
               ];
             };
           };
+
+        darwin = {
+          "arm64" = {
+            base = [
+              { archive = "artifacts.zip"; }
+              { archive = "font-subset.zip"; }
+            ];
+            variants = lib.genAttrs [ "profile" "release" ]
+              (variant: [
+                { archive = "artifacts.zip"; }
+              ]);
+          };
+          "x64" = {
+            base = [
+              { archive = "FlutterEmbedder.framework.zip"; }
+              { archive = "FlutterMacOS.framework.zip"; }
+              { archive = "artifacts.zip"; }
+              { archive = "font-subset.zip"; }
+              { archive = "gen_snapshot.zip"; }
+            ];
+            variants.profile = [
+              { archive = "FlutterMacOS.framework.zip"; }
+              { archive = "artifacts.zip"; }
+              { archive = "gen_snapshot.zip"; }
+            ];
+            variants.release = [
+              { archive = "FlutterMacOS.dSYM.zip"; }
+              { archive = "FlutterMacOS.framework.zip"; }
+              { archive = "artifacts.zip"; }
+              { archive = "gen_snapshot.zip"; }
+            ];
+          };
+        };
+
+        ios =
+          (lib.genAttrs
+            [ "" ]
+            (arch:
+              {
+                base = [
+                  { archive = "artifacts.zip"; }
+                ];
+                variants.profile = [
+                  { archive = "artifacts.zip"; }
+                ];
+                variants.release = [
+                  { archive = "artifacts.zip"; }
+                  { archive = "Flutter.dSYM.zip"; }
+                ];
+              }));
 
         linux = lib.genAttrs
           [ "arm64" "x64" ]
@@ -84,19 +135,31 @@ let
   mkArtifactDerivation = { platform ? null, variant ? null, subdirectory ? null, archive, ... }@args:
     let
       artifactDirectory = if platform == null then null else "${platform}${lib.optionalString (variant != null) "-${variant}"}";
-      archiveBasename = lib.removeSuffix ".${(lib.last (lib.splitString "." archive))}" archive;
+      archiveExtension = ".${(lib.last (lib.splitString "." archive))}";
+      archiveBasename = lib.removeSuffix archiveExtension archive;
+      overrideUnpackCmd = builtins.elem archive [ "FlutterEmbedder.framework.zip" "FlutterMacOS.framework.zip" ];
     in
     stdenv.mkDerivation ({
       pname = "flutter-artifact${lib.optionalString (platform != null) "-${artifactDirectory}"}-${archiveBasename}";
       version = engineVersion;
 
-      src = fetchzip {
-        url = "https://storage.googleapis.com/flutter_infra_release/flutter/${engineVersion}${lib.optionalString (platform != null) "/${artifactDirectory}"}/${archive}";
-        stripRoot = false;
-        hash = (if artifactDirectory == null then hashes else hashes.${artifactDirectory}).${archive};
-      };
+      nativeBuildInputs = [ unzip ]
+        ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
-      nativeBuildInputs = [ autoPatchelfHook ];
+      src =
+        if overrideUnpackCmd then
+          (fetchurl {
+            url = "https://storage.googleapis.com/flutter_infra_release/flutter/${engineVersion}${lib.optionalString (platform != null) "/${artifactDirectory}"}/${archive}";
+            hash = (if artifactDirectory == null then hashes else hashes.${artifactDirectory}).${archive};
+          }) else
+          (fetchzip {
+            url = "https://storage.googleapis.com/flutter_infra_release/flutter/${engineVersion}${lib.optionalString (platform != null) "/${artifactDirectory}"}/${archive}";
+            stripRoot = false;
+            hash = (if artifactDirectory == null then hashes else hashes.${artifactDirectory}).${archive};
+          });
+
+      setSourceRoot = if overrideUnpackCmd then "sourceRoot=`pwd`" else null;
+      unpackCmd = if overrideUnpackCmd then "unzip -o $src -d $out" else null;
 
       installPhase =
         let
@@ -117,13 +180,13 @@ let
             (architecture: variants: {
               base = map
                 (args: mkArtifactDerivation ({
-                  platform = "${os}-${architecture}";
+                  platform = "${os}${lib.optionalString (architecture != "") "-${architecture}"}";
                 } // args))
                 variants.base;
               variants = builtins.mapAttrs
                 (variant: variantArtifacts: map
                   (args: mkArtifactDerivation ({
-                    platform = "${os}-${architecture}";
+                    platform = "${os}${lib.optionalString (architecture != "") "-${architecture}"}";
                     inherit variant;
                   } // args))
                   variantArtifacts)

--- a/pkgs/development/compilers/flutter/engine-artifacts/hashes.nix
+++ b/pkgs/development/compilers/flutter/engine-artifacts/hashes.nix
@@ -56,20 +56,20 @@
       "artifacts.zip" = "sha256-gG/OcCJE3XPO6T8bltMtPxdlYX5HQ/4qYsdHe0OdDaE=";
     };
     darwin-x64 = {
-      "FlutterEmbedder.framework.zip" = "sha256-tU/Y1ZJD5j03KaH2Qm/ltc/royX3yikqkHVfxcokV48=";
-      "FlutterMacOS.framework.zip" = "sha256-yjr3xCrJ/HUWD90R2Hk4JC91sDiQYD9I92c7/0KwW1Q=";
+      "FlutterEmbedder.framework.zip" = "sha256-G84GGK6gtR+CYu9S/GhdNTL4KWqgFBp8QdvWOq+IZlk=";
+      "FlutterMacOS.framework.zip" = "sha256-1/txBoXDIs7Gn5zsZ4jYQXK73+iaZV4sRdYKqEBUTxU=";
       "artifacts.zip" = "sha256-H7Moy6E1eRrOXYYAIgiJHOmstyy3YaCnu8O3IPr9BK8=";
       "font-subset.zip" = "sha256-VSkG3zZw/4DDInwxPaMXT2B1LXIb0Ejkb2xf5SVrwW4=";
       "gen_snapshot.zip" = "sha256-Pknv1fUcXGbWzt6So0DgWnvL4b43k51KMWiX1YXd2As=";
     };
     darwin-x64-profile = {
-      "FlutterMacOS.framework.zip" = "sha256-YxskgIfeBn/OqR3O9TRUc4UEnfGVb0WihwSSi3lZrsY=";
+      "FlutterMacOS.framework.zip" = "sha256-3umN1HNX4UA00EFsBnWS0X04QRKlcCnChDYd9L6x1L4=";
       "artifacts.zip" = "sha256-8Aj2+nTKKeVLEYN+swVlVqRB/3fVSwrb3i1g1JUDsNY=";
       "gen_snapshot.zip" = "sha256-bi3RqSdOQODpPmY+eBUQPiNeZ/bECoOUx/pOADpTZiA=";
     };
     darwin-x64-release = {
       "FlutterMacOS.dSYM.zip" = "sha256-LfDQuCcBXEV3Jao/sbfIvjn1d2ZfZrWgzNzFE1zE3Rw=";
-      "FlutterMacOS.framework.zip" = "sha256-R6B2fBKfbvfsD7YNWNbuS4qRknOaZ9kfiN4S7z9sLC0=";
+      "FlutterMacOS.framework.zip" = "sha256-2xuPPJifdu/kvvtR0viMvbTOXfv8ndtNAhTmef8863o=";
       "artifacts.zip" = "sha256-3p41zRjvWYCl/Kk/7/0MjV2FS10XEtyX1hYmxTHT8lU=";
       "gen_snapshot.zip" = "sha256-ExXwj1QO1XQznZ49rW08tibA5BaURShE6pUYDokZfpE=";
     };

--- a/pkgs/development/compilers/flutter/engine-artifacts/hashes.nix
+++ b/pkgs/development/compilers/flutter/engine-artifacts/hashes.nix
@@ -6,10 +6,12 @@
     android-arm-profile = {
       "artifacts.zip" = "sha256-MErLoGJWXg4yJ6b6c5bqP8Nat6O7eYSfM71mMNAAQf4=";
       "linux-x64.zip" = "sha256-0TZQ05HR7NRqHzeoHZ/sOrjKiSvCpMUH85YXXzV4URg=";
+      "darwin-x64.zip" = "sha256-gOmxGurYyuuGxPnzK+2O1s7d7x514R9MfincibxVTCI=";
     };
     android-arm-release = {
       "artifacts.zip" = "sha256-hU4S4FOqUGokByZ47nzOqQ4A9QFshruqrpJvJUBHUho=";
       "linux-x64.zip" = "sha256-AqNlqjOht+c2sdW5ReoF66ZJWJl1W4vGKbQ3YyderRY=";
+      "darwin-x64.zip" = "sha256-UiJNbIvjYvIX2oFNCz+TurUdhHS8vcl9X6WEkEs5hvU=";
     };
     android-arm64 = {
       "artifacts.zip" = "sha256-ApNg3Uu9gyGNsx7sdpTCz1yADVAI5ZuNHgvgiuH9IpQ=";
@@ -17,10 +19,12 @@
     android-arm64-profile = {
       "artifacts.zip" = "sha256-D/8+WKPIkOaV3PwkCHiJROFlokm4lWWmtPQb93Yqwr0=";
       "linux-x64.zip" = "sha256-S0RHLov6/C22VvGdvZV87Ybaxun8YBrw1gTgNklRcM0=";
+      "darwin-x64.zip" = "sha256-AWivGn0TCVEW+N8g9bpEP1JuKWhrccb+ANQgyLjBjfw=";
     };
     android-arm64-release = {
       "artifacts.zip" = "sha256-OoYqHtwmT+VWJ+G+sMXM5+ux3h1Fnyo9Vj2za9cm5eE=";
       "linux-x64.zip" = "sha256-NuXclg1a+Ofw5AWJ1tajpn2jYEZw6DluWxrFVL8rPfg=";
+      "darwin-x64.zip" = "sha256-/j5sVfyllkhsc9mpdbOqlT7VT1H6nD3Y+mYnWXDh0yI=";
     };
     android-x64 = {
       "artifacts.zip" = "sha256-hrBvnzCj/24h5kat96avlgXi6WhMsos5aPlkgxOYo8Q=";
@@ -28,10 +32,12 @@
     android-x64-profile = {
       "artifacts.zip" = "sha256-xzSj/2ah9aQoosaNGkSWFP3bMNJqRSFc0+78XEBHwzM=";
       "linux-x64.zip" = "sha256-HfBiz1JWlBQ8KEfmf8uDlVzFlDt3+VF2VeY82tsMjHs=";
+      "darwin-x64.zip" = "sha256-J5JJH9GAQaQKahimb09fLC59VchPP15iMHY9bDMfdf8=";
     };
     android-x64-release = {
       "artifacts.zip" = "sha256-TcfMeA+8Uf9yRrYdEIsjip0cKmSUm2Ow1tkoE9803XY=";
       "linux-x64.zip" = "sha256-D6efb6pj9+xjPnJu3O+ZCmwfatBzasuFZEFRntAiU9U=";
+      "darwin-x64.zip" = "sha256-hDftGgKqW6tzH/+jFOYfzxssbS01XtiWEeycJr3QSoc=";
     };
     android-x86 = {
       "artifacts.zip" = "sha256-nN66nIrcbJHq2S4oIT5e2NCv7mS5Kw+HBv3ReHs+d3Y=";
@@ -39,8 +45,46 @@
     android-x86-jit-release = {
       "artifacts.zip" = "sha256-A8F6K78Ykp1rMsUmjD7B9nFFPAubZnqAqgWSzbNCRwk=";
     };
+    darwin-arm64 = {
+      "artifacts.zip" = "sha256-lfkEToKFBBOee7KgOl1z/ZeMQwEBWkmAYb2Hbfk8dfg=";
+      "font-subset.zip" = "sha256-W7GnLvCobED7uyhpURF4T4SL4yZIQmE2JFQVQIxl0NI=";
+    };
+    darwin-arm64-profile = {
+      "artifacts.zip" = "sha256-DfYS+FEqjtq02jFRBqVR3SVWe4LAoPa5MMKWCbvF7mI=";
+    };
+    darwin-arm64-release = {
+      "artifacts.zip" = "sha256-gG/OcCJE3XPO6T8bltMtPxdlYX5HQ/4qYsdHe0OdDaE=";
+    };
+    darwin-x64 = {
+      "FlutterEmbedder.framework.zip" = "sha256-tU/Y1ZJD5j03KaH2Qm/ltc/royX3yikqkHVfxcokV48=";
+      "FlutterMacOS.framework.zip" = "sha256-yjr3xCrJ/HUWD90R2Hk4JC91sDiQYD9I92c7/0KwW1Q=";
+      "artifacts.zip" = "sha256-H7Moy6E1eRrOXYYAIgiJHOmstyy3YaCnu8O3IPr9BK8=";
+      "font-subset.zip" = "sha256-VSkG3zZw/4DDInwxPaMXT2B1LXIb0Ejkb2xf5SVrwW4=";
+      "gen_snapshot.zip" = "sha256-Pknv1fUcXGbWzt6So0DgWnvL4b43k51KMWiX1YXd2As=";
+    };
+    darwin-x64-profile = {
+      "FlutterMacOS.framework.zip" = "sha256-YxskgIfeBn/OqR3O9TRUc4UEnfGVb0WihwSSi3lZrsY=";
+      "artifacts.zip" = "sha256-8Aj2+nTKKeVLEYN+swVlVqRB/3fVSwrb3i1g1JUDsNY=";
+      "gen_snapshot.zip" = "sha256-bi3RqSdOQODpPmY+eBUQPiNeZ/bECoOUx/pOADpTZiA=";
+    };
+    darwin-x64-release = {
+      "FlutterMacOS.dSYM.zip" = "sha256-LfDQuCcBXEV3Jao/sbfIvjn1d2ZfZrWgzNzFE1zE3Rw=";
+      "FlutterMacOS.framework.zip" = "sha256-R6B2fBKfbvfsD7YNWNbuS4qRknOaZ9kfiN4S7z9sLC0=";
+      "artifacts.zip" = "sha256-3p41zRjvWYCl/Kk/7/0MjV2FS10XEtyX1hYmxTHT8lU=";
+      "gen_snapshot.zip" = "sha256-ExXwj1QO1XQznZ49rW08tibA5BaURShE6pUYDokZfpE=";
+    };
     "flutter_patched_sdk.zip" = "sha256-Pvsjttm5OwpJ/pW4UQXvvEiJYCM5CoZZfVXz5jef37k=";
     "flutter_patched_sdk_product.zip" = "sha256-fhj2uUOrLwrzHrM6RNVpPNize5Qu6mLQDcSzLT2TbRA=";
+    ios = {
+      "artifacts.zip" = "sha256-yqJ4+lNsedRFbe11dBK4KGMX5+Nilj1V0i2E94n7q+0=";
+    };
+    ios-profile = {
+      "artifacts.zip" = "sha256-ZguLM1QoYyg5dXPw3Fl1zSLdbirShV3xZuxl1CfEf50=";
+    };
+    ios-release = {
+      "Flutter.dSYM.zip" = "sha256-Y57wt1y4NIdbRMM1r/d1Dv8bekwO9/9gpLkTEcw7Hfs=";
+      "artifacts.zip" = "sha256-Sm4Pkm1mWu3k5S+aws+kRpth+o3yTBYITg23LhnSViE=";
+    };
     linux-arm64 = {
       "artifacts.zip" = "sha256-xyKVaEFb5gVkVrPzDrOql5BmXGO0FnCSeXOoQ10ZFrw=";
       "font-subset.zip" = "sha256-Ulwb6q2SzB4suMJhAM3zAwWOzlEImlu9Ha+w5u4QqIU=";
@@ -75,10 +119,12 @@
     android-arm-profile = {
       "artifacts.zip" = "sha256-MZK1zaSv9yuZaVDR1dReCM7WRDxKql0yxsPa8WFc1yw=";
       "linux-x64.zip" = "sha256-9OlBv2C6Msj73g624TixbstudCTbdIJ6PzPMsbQENy4=";
+      "darwin-x64.zip" = "sha256-lVJ31F7UMaXQym3touJQ2cN8svKBaWJurDTVZPeMzCo=";
     };
     android-arm-release = {
       "artifacts.zip" = "sha256-tjHckwoxQkkKoyTl6+wBKK40mFDmSDvCPNhBHVA+xxw=";
       "linux-x64.zip" = "sha256-zE9oYkv4WBcbgEdYfYIcdDXX3tnYfCg+3KA3oA03nYA=";
+      "darwin-x64.zip" = "sha256-mCr29gIn808NF4k8kdC7oLTSU6AXq7I/bJF3BBdJlAo=";
     };
     android-arm64 = {
       "artifacts.zip" = "sha256-8W/JrOGhAzHWpM2Jh9vjdkaB6ODmCItqcmF47GqbNQk=";
@@ -86,10 +132,12 @@
     android-arm64-profile = {
       "artifacts.zip" = "sha256-9SGBWp05lxLQTpLuzq8FYSQQOpjo8UL93Pv4YYFD4QE=";
       "linux-x64.zip" = "sha256-5nH2AAxupRIhn8gNH+1V+vSP+qqfx5MS97EC4s3QHe8=";
+      "darwin-x64.zip" = "sha256-kkutEwKcj1wKJREbxbx8+DW53WVbizg6zKIFFVujgAM=";
     };
     android-arm64-release = {
       "artifacts.zip" = "sha256-7O7RBfEo6enZtVNsnt4HH0bex8Xpz9mqCvb2LNLbg3Q=";
       "linux-x64.zip" = "sha256-loucmX4+0R11L1nzewiMTeRZoB6wLK0WasW5W3rIvYU=";
+      "darwin-x64.zip" = "sha256-0bpNQDfIzQqwQpzThLfOXEEEpH/uCJCRF331d0/pzfs=";
     };
     android-x64 = {
       "artifacts.zip" = "sha256-j7AezbyzH07yOR0/W1ttfCjMHMdOlXLQjAsu/ExqmqA=";
@@ -97,10 +145,12 @@
     android-x64-profile = {
       "artifacts.zip" = "sha256-J8cqdcHoj1hpo6zY5R6S9lvkVXp7wvzQlurM7TEUe+k=";
       "linux-x64.zip" = "sha256-YuRHctkDjLZVGQr+m5uM+AxYNLkfqycV4UNcAp7JavE=";
+      "darwin-x64.zip" = "sha256-Mw8C279cVbQHTdIsHhIT5HWe52X8XXbkIDpVcEz1tWc=";
     };
     android-x64-release = {
       "artifacts.zip" = "sha256-uhq3fXcxXjF4/YHSkf6V4wToL9jOUKBm3978j/7xI/s=";
       "linux-x64.zip" = "sha256-iJfatLW7jVcrfNdVx/QOPiyON5ce0tSNGOBx0TILrKE=";
+      "darwin-x64.zip" = "sha256-3P3QZ+jW3Jl6PJvRY9pBHQdhj8UcsHFAjln8q6UlL+A=";
     };
     android-x86 = {
       "artifacts.zip" = "sha256-/xLacCi65hg1gEahty0btrc+NR/jfebSAIt31qwIlZY=";
@@ -108,8 +158,46 @@
     android-x86-jit-release = {
       "artifacts.zip" = "sha256-Ntq0i+sFruDhlyp9VBxBnsNqqGoQeXMeIwfi+BNlr0Q=";
     };
+    darwin-arm64 = {
+      "artifacts.zip" = "sha256-A21Tnn4jC5IzdL3c7n6/q9H6uJ/ofvJ+K9W8PPpAoYM=";
+      "font-subset.zip" = "sha256-NhnUOK1Gn4ekKOf5rDoy4HodzhlS8ylf/MN/6l4Dk18=";
+    };
+    darwin-arm64-profile = {
+      "artifacts.zip" = "sha256-aDWrz3bebC6kZRe2LgunsmFhbxJhmP1bsZv5A/SGF2Y=";
+    };
+    darwin-arm64-release = {
+      "artifacts.zip" = "sha256-F44e39KSX8juojFBV/CSvFES+RQW+gHKDWtfnydqiNo=";
+    };
+    darwin-x64 = {
+      "FlutterEmbedder.framework.zip" = "sha256-+S2unNH8cpfqUiPLTwGUUW00DdNYFDN8KM/O1pMdxQs=";
+      "FlutterMacOS.framework.zip" = "sha256-iCGXzxBhJGR6rWcECRg0W5Qv4I6ePo7UrWIqjQK1bWI=";
+      "artifacts.zip" = "sha256-2Ng0rxVDeMCH3kFHS7rhVd6R8oiJqvfsNDp+rzgtA50=";
+      "font-subset.zip" = "sha256-5IyNNLUT27WUCr61LjnMjmAZEv63ZaF+rl/p2XHFlVU=";
+      "gen_snapshot.zip" = "sha256-zPJaXPdvbQGx79c41XdRrBW/+3aV/INaPtO47+hHdxM=";
+    };
+    darwin-x64-profile = {
+      "FlutterMacOS.framework.zip" = "sha256-PV4sTACDGeLLPz+AchxngWrQypmmUVQ48bQlAfH323w=";
+      "artifacts.zip" = "sha256-LBosuXu9mPh5WT0Mmgu9rX5Nuy+iIGN8Xvi7uVAyFhc=";
+      "gen_snapshot.zip" = "sha256-douXVnavzSGBuld3WhwHagBNK6FEU679puM8/fNGz2I=";
+    };
+    darwin-x64-release = {
+      "FlutterMacOS.dSYM.zip" = "sha256-A8kyc1fmsGemgUVhI46yTC6XNkrXdoPYvwXomHoW6kM=";
+      "FlutterMacOS.framework.zip" = "sha256-dZ/MO9J+zanoGfvPaAinnANte92bQOlh697fd/LvGqA=";
+      "artifacts.zip" = "sha256-T/wxPd1LmstfGHr2Fx6cfhRifaGm6CUlig6cBMcOO5g=";
+      "gen_snapshot.zip" = "sha256-qeZxVp6btr/fUQRf7nOhlnSC03+QTcRaggiVOmPxVuo=";
+    };
     "flutter_patched_sdk.zip" = "sha256-kRRFCqQGBDimqwMiSn4yRMNRfZHt03YJqsKW47IBIvQ=";
     "flutter_patched_sdk_product.zip" = "sha256-BowamIQHPZgfcZbWG7OFrB5GeEwdcA7AdUrF2Y+KIds=";
+    ios = {
+      "artifacts.zip" = "sha256-VoofDPEBUW2jBrXg3Z556uC2UdrD9JCpioZNhX1p/P0=";
+    };
+    ios-profile = {
+      "artifacts.zip" = "sha256-5jDIqk7tWuRxXsAzrjBq9xzQrt/eREmmoEF3zc2xQ5M=";
+    };
+    ios-release = {
+      "Flutter.dSYM.zip" = "sha256-TuDld2LcHshl1mXcuIwfZgWLm1My4RpXUwI2B/QbLRk=";
+      "artifacts.zip" = "sha256-bGuUCKVqNNWWGVccVVKIBmCxTqgu4Q2Kj/Znnl9ZR2Q=";
+    };
     linux-arm64 = {
       "artifacts.zip" = "sha256-jME3ivE+M+ceAt3aGPSeVwPaW8UhwGQOoL5lmRUqrOU=";
       "font-subset.zip" = "sha256-MqavBMXOlx5JX94Oe/8GGuuDNh7A2UkjiOrEhCDW5cc=";

--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -5,6 +5,7 @@
 , src
 , lib
 , stdenv
+, darwin
 , git
 , which
 }:
@@ -18,6 +19,8 @@ let
       outputs = [ "out" "cache" ];
 
       buildInputs = [ git ];
+      nativeBuildInputs = [ ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.DarwinTools ];
 
       preConfigure = ''
         if [ "$(< bin/internal/engine.version)" != '${engineVersion}' ]; then
@@ -69,8 +72,8 @@ let
 
         # Certain prebuilts should be replaced with Nix-built (or at least Nix-patched) equivalents.
         rm -r \
-          bin/cache/dart-sdk \
-          bin/cache/artifacts/engine
+          $FLUTTER_ROOT/bin/cache/dart-sdk \
+          $FLUTTER_ROOT/bin/cache/artifacts/engine
       '';
 
       installPhase = ''
@@ -84,7 +87,8 @@ let
       '';
 
       doInstallCheck = true;
-      nativeInstallCheckInputs = [ which ];
+      nativeInstallCheckInputs = [ which ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.DarwinTools ];
       installCheckPhase = ''
         runHook preInstallCheck
 
@@ -112,7 +116,7 @@ let
         '';
         homepage = "https://flutter.dev";
         license = licenses.bsd3;
-        platforms = [ "x86_64-linux" "aarch64-linux" ];
+        platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
         maintainers = with maintainers; [ babariviere ericdallo FlafyDev gilice hacker1024 ];
       };
     };

--- a/pkgs/development/compilers/flutter/patches/flutter3/move-cache.patch
+++ b/pkgs/development/compilers/flutter/patches/flutter3/move-cache.patch
@@ -7,7 +7,7 @@ index dd80b1e46e..8e54517765 100644
  import 'convert.dart';
  import 'features.dart';
 +import 'globals.dart' as globals;
- 
+
  const String kFlutterRootEnvironmentVariableName = 'FLUTTER_ROOT'; // should point to //flutter/ (root of flutter/flutter repo)
  const String kFlutterEngineEnvironmentVariableName = 'FLUTTER_ENGINE'; // should point to //engine/src/ (root of flutter/engine repo)
 @@ -318,8 +319,13 @@ class Cache {
@@ -26,7 +26,7 @@ index dd80b1e46e..8e54517765 100644
        _lock = lockFile.openSync(mode: FileMode.write);
      } on FileSystemException catch (e) {
 @@ -378,8 +384,7 @@ class Cache {
- 
+
    String get devToolsVersion {
      if (_devToolsVersion == null) {
 -      const String devToolsDirPath = 'dart-sdk/bin/resources/devtools';
@@ -40,7 +40,7 @@ index 1c31c1b5db..76c7210d3b 100644
 --- a/packages/flutter_tools/lib/src/cache.dart
 +++ b/packages/flutter_tools/lib/src/cache.dart
 @@ -529,6 +529,11 @@ class Cache {
- 
+
    /// Return the top-level directory in the cache; this is `bin/cache`.
    Directory getRoot() {
 +    const Platform platform = LocalPlatform();

--- a/pkgs/development/compilers/flutter/patches/flutter3/move-cache.patch
+++ b/pkgs/development/compilers/flutter/patches/flutter3/move-cache.patch
@@ -7,7 +7,7 @@ index dd80b1e46e..8e54517765 100644
  import 'convert.dart';
  import 'features.dart';
 +import 'globals.dart' as globals;
-
+ 
  const String kFlutterRootEnvironmentVariableName = 'FLUTTER_ROOT'; // should point to //flutter/ (root of flutter/flutter repo)
  const String kFlutterEngineEnvironmentVariableName = 'FLUTTER_ENGINE'; // should point to //engine/src/ (root of flutter/engine repo)
 @@ -318,8 +319,13 @@ class Cache {
@@ -26,7 +26,7 @@ index dd80b1e46e..8e54517765 100644
        _lock = lockFile.openSync(mode: FileMode.write);
      } on FileSystemException catch (e) {
 @@ -378,8 +384,7 @@ class Cache {
-
+ 
    String get devToolsVersion {
      if (_devToolsVersion == null) {
 -      const String devToolsDirPath = 'dart-sdk/bin/resources/devtools';
@@ -40,7 +40,7 @@ index 1c31c1b5db..76c7210d3b 100644
 --- a/packages/flutter_tools/lib/src/cache.dart
 +++ b/packages/flutter_tools/lib/src/cache.dart
 @@ -529,6 +529,11 @@ class Cache {
-
+ 
    /// Return the top-level directory in the cache; this is `bin/cache`.
    Directory getRoot() {
 +    const Platform platform = LocalPlatform();


### PR DESCRIPTION
###### Description of changes

> Based on https://github.com/NixOS/nixpkgs/pull/196133

Adds `x86_64`/`aarch64`-darwin support for flutter

---

EDIT: Closes #145701

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
