### PR TITLE
python310Packages.dash-bootstrap-components: init at version 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9698,6 +9698,10 @@
     githubId = 839693;
     name = "Ingolf Wanger";
   };
+  mschneider = {
+    email = "markus.schneider.sic+nix@gmail.com";
+    name = "Markus Schneider";
+  };
   mschristiansen = {
     email = "mikkel@rheosystems.com";
     github = "mschristiansen";

--- a/pkgs/applications/window-managers/leftwm/default.nix
+++ b/pkgs/applications/window-managers/leftwm/default.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/leftwm/leftwm";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ mschneider ];
     changelog = "https://github.com/leftwm/leftwm/blob/${version}/CHANGELOG";
   };
 }

--- a/pkgs/data/icons/flat-remix-icon-theme/default.nix
+++ b/pkgs/data/icons/flat-remix-icon-theme/default.nix
@@ -39,6 +39,6 @@ stdenvNoCC.mkDerivation rec  {
     license = with licenses; [ gpl3Only ];
     # breeze-icons and pantheon.elementary-icon-theme dependencies are restricted to linux
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ mschneider ];
   };
 }

--- a/pkgs/development/python-modules/dash-bootstrap-components/default.nix
+++ b/pkgs/development/python-modules/dash-bootstrap-components/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, dash
+}:
+
+buildPythonPackage rec {
+  pname = "dash-bootstrap-components";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    pname = "dash-bootstrap-components";
+    inherit version;
+    sha256 = "sha256-8S8pn9yRlDxw15UElJNlpiL9nKWihLU1lC31zEecE1Q=";
+  };
+
+  propagatedBuildInputs = [ dash ];
+
+  # No tests in archive
+  doCheck = false;
+  pythonImportsCheck = [ "dash_bootstrap_components" ];
+
+  meta = with lib; {
+    description = "dash-bootstrap-components is a library of Bootstrap components for use with Plotly Dash";
+    homepage = "https://dash-bootstrap-components.opensource.faculty.ai/";
+    license = licenses.asl20;
+    maintainers = [ maintainers.mschneider ];
+  };
+}

--- a/pkgs/servers/rpiplay/default.nix
+++ b/pkgs/servers/rpiplay/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/FD-/RPiPlay";
     description = "An open-source implementation of an AirPlay mirroring server.";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ mschneider ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/backup/zfs-autobackup/default.nix
+++ b/pkgs/tools/backup/zfs-autobackup/default.nix
@@ -28,6 +28,6 @@ pythonPackages.buildPythonApplication rec {
     homepage = "https://github.com/psy0rz/zfs_autobackup";
     description = "ZFS backup, replicationand snapshot tool";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ mschneider ];
   };
 }

--- a/pkgs/tools/misc/mons/default.nix
+++ b/pkgs/tools/misc/mons/default.nix
@@ -89,7 +89,7 @@ resholve.mkDerivation rec {
     description = "POSIX Shell script to quickly manage 2-monitors display";
     homepage = "https://github.com/Ventto/mons.git";
     license = licenses.mit;
-    maintainers = with maintainers; [ thiagokokada ];
+    maintainers = with maintainers; [ mschneider thiagokokada ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2161,6 +2161,8 @@ self: super: with self; {
 
   dash = callPackage ../development/python-modules/dash { };
 
+  dash-bootstrap-components = callPackage ../development/python-modules/dash-bootstrap-components { };
+
   dash-core-components = callPackage ../development/python-modules/dash-core-components { };
 
   dash-html-components = callPackage ../development/python-modules/dash-html-components { };


### PR DESCRIPTION
###### Description of changes

[dash-bootstrap-components](https://dash-bootstrap-components.opensource.faculty.ai/) is a library of Bootstrap components for Plotly Dash, that makes it easier to build consistently styled apps with complex, responsive layouts. 

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).