### PR TITLE
dracut: init at 059

### DIFF
--- a/pkgs/os-specific/linux/dracut/default.nix
+++ b/pkgs/os-specific/linux/dracut/default.nix
@@ -1,0 +1,128 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gitUpdater
+, makeBinaryWrapper
+, pkg-config
+, asciidoc
+, libxslt
+, docbook_xsl
+, bash
+, kmod
+, binutils
+, busybox
+, bzip2
+, coreutils
+, cpio
+, findutils
+, glibc
+, gnugrep
+, gnused
+, gnutar
+, gzip
+, kbd
+, lvm2
+, lz4
+, lzop
+, procps
+, rng-tools
+, squashfsTools
+, systemd
+, util-linux
+, xz
+, zstd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dracut";
+  version = "059";
+
+  src = fetchFromGitHub {
+    owner = "dracutdevs";
+    repo = "dracut";
+    rev = version;
+    hash = "sha256-zSyC2SnSQkmS/mDpBXG2DtVVanRRI9COKQJqYZZCPJM=";
+  };
+
+  strictDeps = true;
+
+  buildInputs = [
+    bash
+    kmod
+  ];
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    pkg-config
+    asciidoc
+    libxslt
+    docbook_xsl
+  ];
+
+  postPatch = ''
+    substituteInPlace dracut.sh \
+      --replace 'dracutbasedir="$dracutsysrootdir"/usr/lib/dracut' 'dracutbasedir="$dracutsysrootdir"'"$out/lib/dracut"
+    substituteInPlace lsinitrd.sh \
+      --replace 'dracutbasedir=/usr/lib/dracut' "dracutbasedir=$out/lib/dracut"
+
+    echo 'DRACUT_VERSION=${version}' >dracut-version.sh
+  '';
+
+  preConfigure = ''
+    patchShebangs ./configure
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/dracut --prefix PATH : ${lib.makeBinPath [
+      coreutils
+      util-linux
+    ]} --prefix DRACUT_PATH : ${lib.makeBinPath [
+      bash
+      binutils
+      coreutils
+      findutils
+      glibc
+      gnugrep
+      gnused
+      gnutar
+      kbd
+      lvm2
+      procps
+      rng-tools
+      squashfsTools
+      systemd
+      util-linux
+      busybox
+    ]}
+    wrapProgram $out/bin/dracut-catimages --set PATH ${lib.makeBinPath [
+      coreutils
+      cpio
+      findutils
+      gzip
+    ]}
+    wrapProgram $out/bin/lsinitrd --set PATH ${lib.makeBinPath [
+      binutils
+      bzip2
+      coreutils
+      cpio
+      gnused
+      gzip
+      lz4
+      lzop
+      squashfsTools
+      util-linux
+      xz
+      zstd
+    ]}
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    homepage = "https://dracut.wiki.kernel.org";
+    description = "An event driven initramfs infrastructure";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ lilyinstarlight ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28399,6 +28399,8 @@ with pkgs;
 
   dr14_tmeter = callPackage ../applications/audio/dr14_tmeter { };
 
+  dracut = callPackage ../os-specific/linux/dracut { };
+
   dragonflydb = callPackage ../servers/nosql/dragonflydb { };
 
   dragonfly-reverb = callPackage ../applications/audio/dragonfly-reverb { };


### PR DESCRIPTION
###### Description of changes

This PR adds a functioning dracut package. To actually generate an initrd with it, though, you'll want to make a dracut.conf specifying where you want to pull everything (e.g. systemd units, kernel modules, etc.) and set `DRACUT_PATH` to include any necessarily tools not already in the wrapper

I personally just want this for the `lsinitrd` and `skipcpio` commands though, and I do not plan on generating initrd images with it (but generating them did seem to theoretically work in my tests, when I started putting some paths in a dracut.conf)

Supersedes and closes #77868
Closes #77858

@CMCDragonkai Since you had yourself listed as maintainer on #77868, do you want for me to still add you as maintainer on the package in this PR?

cc: @ketzacoatl

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).