### PR TITLE
ssm-session-manager: Build from source; 1.2.331.0 -> 1.2.398.0 

### DIFF
--- a/pkgs/applications/networking/cluster/ssm-session-manager-plugin/default.nix
+++ b/pkgs/applications/networking/cluster/ssm-session-manager-plugin/default.nix
@@ -1,51 +1,55 @@
-{ stdenv, lib, fetchurl, autoPatchelfHook, dpkg, awscli, unzip }:
-let
-  ver = "1.2.331.0";
-  source = {
-    url = rec {
-      "x86_64-linux" = "https://s3.amazonaws.com/session-manager-downloads/plugin/${ver}/ubuntu_64bit/session-manager-plugin.deb";
-      "aarch64-linux" = "https://s3.amazonaws.com/session-manager-downloads/plugin/${ver}/ubuntu_arm64/session-manager-plugin.deb";
-      "x86_64-darwin" = "https://s3.amazonaws.com/session-manager-downloads/plugin/${ver}/mac/sessionmanager-bundle.zip";
-      "aarch64-darwin" = x86_64-darwin;
-    }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
-    sha256 = rec {
-      "x86_64-linux" = "sha256-xWnY89dslkGhRTh9llRFkuUqYIjHQNt+TLnkPQr3u1Q=";
-      "aarch64-linux" = "sha256-QE6+EjLoydTPuLitG6fALXAtvIkfyoFuWij8Z2HT6+Q=";
-      "x86_64-darwin" = "0gr6frdn9jvxnkymkcpvgkqw4z2sac9jdf5qj4hzakq1zkfviazf";
-      "aarch64-darwin" = x86_64-darwin;
-    }."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
-  };
-  archivePath = if stdenv.isDarwin then "sessionmanager-bundle" else "usr/local/sessionmanagerplugin";
-in
-stdenv.mkDerivation rec {
+{ stdenv
+, lib
+, fetchFromGitHub
+, buildGo120Package
+}:
+
+buildGo120Package rec {
   pname = "ssm-session-manager-plugin";
-  version = ver;
+  version = "1.2.331.0";
 
-  src = fetchurl source;
+  goPackagePath = "github.com/aws/SSMCLI";
 
-  nativeBuildInputs = lib.optionals stdenv.isLinux [
-    autoPatchelfHook
-    dpkg
-  ] ++ lib.optionals stdenv.isDarwin [
-    unzip
-  ];
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "session-manager-plugin";
+    rev = version;
+    sha256 = "MnTiczFdiP9Xn9fkElVp6tPl7K7PWNyOGjsyLnQHreY=";
+  };
 
-  unpackPhase = if stdenv.isDarwin then "unzip $src" else "dpkg-deb -x $src .";
+  postPatch = ''
+    mv vendor{,-old}
+    mv vendor-old/src vendor
+    rm -r vendor-old
+  '';
+
+  preBuild = ''
+    pushd go/src/${lib.escapeShellArg goPackagePath}
+    echo -n ${lib.escapeShellArg version} > VERSION
+    go run src/version/versiongenerator/version-gen.go
+    popd
+  '';
+
+  doCheck = true;
+  checkFlags = "-skip TestSetSessionHandlers";
+
+  preCheck = ''
+    if ! [[ $(go/bin/sessionmanagerplugin-main --version) = ${lib.escapeShellArg version} ]]; then
+      echo 'wrong version'
+      exit 1
+    fi
+  '';
 
   installPhase = ''
     runHook preInstall
-
-    install -m755 -D ${archivePath}/bin/session-manager-plugin $out/bin/session-manager-plugin
-
+    install -Dm555 go/bin/sessionmanagerplugin-main "$out/bin/session-manager-plugin"
     runHook postInstall
   '';
 
   meta = with lib; {
     homepage = "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html";
     description = "Amazon SSM Session Manager Plugin";
-    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.unfree;
-    maintainers = with maintainers; [ mbaillie ];
+    license = licenses.asl20;
+    maintainers = with maintainers; [ amarshall mbaillie ];
   };
 }

--- a/pkgs/applications/networking/cluster/ssm-session-manager-plugin/default.nix
+++ b/pkgs/applications/networking/cluster/ssm-session-manager-plugin/default.nix
@@ -6,15 +6,15 @@
 
 buildGo120Package rec {
   pname = "ssm-session-manager-plugin";
-  version = "1.2.331.0";
+  version = "1.2.398.0";
 
-  goPackagePath = "github.com/aws/SSMCLI";
+  goPackagePath = "github.com/aws/session-manager-plugin";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "session-manager-plugin";
     rev = version;
-    sha256 = "MnTiczFdiP9Xn9fkElVp6tPl7K7PWNyOGjsyLnQHreY=";
+    sha256 = "ufNnr/sxOHUDUsGXwxp1yloVAI6DMtuEdjcQZ2XaHRg=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

Previously this package was marked unfree binary, now it is a free-licensed source build. Additionally, update to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
