### PR TITLE
Bisq: 1.9.8 -> 1.9.9

### DIFF
--- a/pkgs/applications/blockchains/bisq-desktop/default.nix
+++ b/pkgs/applications/blockchains/bisq-desktop/default.nix
@@ -34,11 +34,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bisq-desktop";
-  version = "1.9.8";
+  version = "1.9.9";
 
   src = fetchurl {
     url = "https://github.com/bisq-network/bisq/releases/download/v${version}/Bisq-64bit-${version}.deb";
-    sha256 = "1hwfchwqvflfzpv8n9wvj567a68fa4bch0hi8vk4pzmwxsx4z7g1";
+    sha256 = "0jisxzajsc4wfvxabvfzd0x9y1fxzg39fkhap1781q7wyi4ry9kd";
   };
 
   nativeBuildInputs = [ makeWrapper copyDesktopItems imagemagick dpkg zip xz ];

--- a/pkgs/applications/blockchains/bisq-desktop/update.sh
+++ b/pkgs/applications/blockchains/bisq-desktop/update.sh
@@ -7,14 +7,13 @@ version="$(curl -s https://api.github.com/repos/bisq-network/bisq/releases| jq '
 depname="Bisq-64bit-$version.deb"
 src="https://github.com/bisq-network/bisq/releases/download/v$version/$depname"
 signature="$src.asc"
-key="CB36 D7D2 EBB2 E35D 9B75 500B CD5D C1C5 29CD FD3B"
 
 pushd $(mktemp -d --suffix=-bisq-updater)
 export GNUPGHOME=$PWD/gnupg
 mkdir -m 700 -p "$GNUPGHOME"
 curl -L -o "$depname" -- "$src"
 curl -L -o signature.asc -- "$signature"
-gpg --batch --recv-keys "$key"
+curl https://bisq.network/pubkey/E222AA02.asc | gpg --import
 gpg --batch --verify signature.asc "$depname"
 sha256=$(nix-prefetch-url --type sha256 "file://$PWD/$depname")
 popd


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Update bisq-desktop from 1.9.8 to 1.9.9. See https://github.com/bisq-network/bisq/releases/tag/v1.9.9
- Update the updater script because the upstream dep package is now signed by a different party.

> Url of the signing key (Alejandro García): https://bisq.network/pubkey/E222AA02.asc
> Full fingerprint: B493 3191 06CC 3D1F 252E  19CB F806 F422 E222 AA02

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking!
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
