### PR TITLE
python310Packages.pymc: 4.4.0 -> 5.0.1

### DIFF
--- a/pkgs/development/python-modules/pymc/default.nix
+++ b/pkgs/development/python-modules/pymc/default.nix
@@ -1,6 +1,4 @@
 { lib
-, aeppl
-, aesara
 , arviz
 , buildPythonPackage
 , cachetools
@@ -8,6 +6,7 @@
 , fastprogress
 , fetchFromGitHub
 , numpy
+, pytensor
 , pythonOlder
 , pythonRelaxDepsHook
 , scipy
@@ -16,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "pymc";
-  version = "4.4.0";
+  version = "5.0.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -25,7 +24,7 @@ buildPythonPackage rec {
     owner = "pymc-devs";
     repo = "pymc";
     rev = "refs/tags/v${version}";
-    hash = "sha256-ZBltvvKXfqHYLeYOEYFK8kQc0wHM9+UHLRJFMSYX4Ow=";
+    hash = "sha256-uWvzWbZyRRE8L9X9+azmN+1JYahwwNSYCk2fQ/C8Yi0=";
   };
 
   nativeBuildInputs = [
@@ -33,13 +32,12 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    aeppl
-    aesara
     arviz
     cachetools
     cloudpickle
     fastprogress
     numpy
+    pytensor
     scipy
     typing-extensions
   ];

--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -1,0 +1,88 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, cons
+, cython
+, etuples
+, fetchFromGitHub
+, filelock
+, jax
+, jaxlib
+, logical-unification
+, minikanren
+, numba
+, numba-scipy
+, numpy
+, pytestCheckHook
+, pythonOlder
+, scipy
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "pytensor";
+  version = "2.8.11";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "pymc-devs";
+    repo = pname;
+    rev = "refs/tags/rel-${version}";
+    hash = "sha256-rewo2uh4sw9rIaWQPqSuk1DHcdyR293tuZIGOS79PII=";
+  };
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    cons
+    etuples
+    filelock
+    logical-unification
+    minikanren
+    numpy
+    scipy
+    typing-extensions
+  ];
+
+  checkInputs = [
+    jax
+    jaxlib
+    numba
+    numba-scipy
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--durations=50" ""
+  '';
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  pythonImportsCheck = [
+    "pytensor"
+  ];
+
+  disabledTestPaths = [
+    # Don't run the most compute-intense tests
+    "tests/scan/"
+    "tests/tensor/"
+    "tests/sandbox/"
+    "tests/sparse/sandbox/"
+  ];
+
+  meta = with lib; {
+    description = "Python library to define, optimize, and efficiently evaluate mathematical expressions involving multi-dimensional arrays";
+    homepage = "https://github.com/pymc-devs/pytensor";
+    changelog = "https://github.com/pymc-devs/pytensor/releases";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bcdarwin ];
+    broken = (stdenv.isLinux && stdenv.isAarch64);
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8817,6 +8817,8 @@ self: super: with self; {
 
   pytenable = callPackage ../development/python-modules/pytenable { };
 
+  pytensor = callPackage ../development/python-modules/pytensor { };
+
   pytelegrambotapi = callPackage ../development/python-modules/pyTelegramBotAPI { };
 
   pytesseract = callPackage ../development/python-modules/pytesseract { };


### PR DESCRIPTION
python310Packages.pytensor: init at 2.8.11

###### Description of changes

Update `pymc` package.  `pymc` has forked `aesara` as `pytensor` so also add that.  (I've copied the Nix expression rather than inheriting from it but either way could be done since the differences are currently minimal.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
