### PR TITLE
libtool: drop unused auto* dependencies

### DIFF
--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, autoconf, automake, m4, perl, help2man
+{ lib, stdenv, fetchurl, fetchpatch, m4
 , runtimeShell
 , file
 }:
@@ -23,28 +23,22 @@ stdenv.mkDerivation rec {
   #   https://lists.gnu.org/archive/html/autotools-announce/2022-03/msg00000.html
   FILECMD = "${file}/bin/file";
 
-  # Normally we'd use autoreconfHook, but that includes libtoolize.
-  postPatch = ''
-    aclocal -I m4
-    automake
-    autoconf
-
-    pushd libltdl
-    aclocal -I ../m4
-    automake
-    autoconf
-    popd
-  '' +
+  postPatch =
   # libtool commit da2e352735722917bf0786284411262195a6a3f6 changed
   # the shebang from `/bin/sh` (which is a special sandbox exception)
   # to `/usr/bin/env sh`, meaning that we now need to patch shebangs
   # in libtoolize.in:
   ''
     substituteInPlace libtoolize.in       --replace '#! /usr/bin/env sh' '#!${runtimeShell}'
+    # avoid help2man run after 'libtoolize.in' update
+    touch doc/libtoolize.1
   '';
 
   strictDeps = true;
-  nativeBuildInputs = [ autoconf automake help2man m4 perl ];
+  # As libtool is an early bootstrap dependency try hard not to
+  # add autoconf and automake or help2man dependencies here. That way we can
+  # avoid pulling in perl and get away with just an `m4` depend.
+  nativeBuildInputs = [ m4 file ];
   propagatedBuildInputs = [ m4 file ];
 
   # Don't fixup "#! /bin/sh" in Libtool, otherwise it will use the


### PR DESCRIPTION
Autoreconf was initially added in e44dd84664f ("libtool2: macOS 11 support") for configure patches. The patches were removed since 2.4.7 release. Let's drop these dependencies to make boostrap tree leaner.

The diff of bootstrap tree before and after the change:

    $ nix-store --query --graph $(nix-instantiate -A stdenv) |
        fgrep ' -> ' | awk '{print $3}' | sort -u |
        sed 's/"[0-9a-z]\{32\}-/"/g' | sort > before

    $ nix-store --query --graph $(nix-instantiate -A stdenv) |
        fgrep ' -> ' | awk '{print $3}' | sort -u |
        sed 's/"[0-9a-z]\{32\}-/"/g' | sort > after

    $ diff -U0 before after

    --- before
    +++ after
    @@ -64,2 +63,0 @@
    -"help2man-1.49.2.drv"
    -"help2man-1.49.2.drv"
    @@ -77 +74,0 @@
    -"libxcrypt-4.4.33.drv"
    @@ -88,4 +84,0 @@
    -"perl-5.36.0.drv"
    -"perl-5.36.0.drv"
    -"perl5.36.0-gettext-1.07.drv"
    -"perl5.36.0-gettext-1.07.drv"

This removes 2 of 3 builds of `perl` and `help2man` dependencies.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
