### PR TITLE
gitops: init at 0.14.1

### DIFF
--- a/pkgs/applications/networking/cluster/gitops/default.nix
+++ b/pkgs/applications/networking/cluster/gitops/default.nix
@@ -1,0 +1,64 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, testers, gitops }:
+
+buildGoModule rec {
+  pname = "gitops";
+  version = "0.14.1";
+
+  src = fetchFromGitHub {
+    owner = "weaveworks";
+    repo = "weave-gitops";
+    rev = "727513969553bfcc603e1c0ae1a75d79e4132b58";
+    sha256 = "sha256-OiNSo17S2KSnuLrPPSPjMUCinPbYmEZoT/bZlS3isWQ=";
+  };
+
+  vendorSha256 = "sha256-p+ikGLqYwdC+/IAE9wbcq3w0xoTf5xlqrYmXx3f40+U=";
+
+  subPackages = [ "cmd/gitops" ];
+
+  ldflags =
+    let
+      package_url = "github.com/weaveworks/weave-gitops";
+      # these are likely not necessary
+      flux_version = "0.37.0";
+      dev_bucket_container_image = "ghcr.io/weaveworks/gitops-bucket-server@sha256:9fa2a68032b9d67197a3d41a46b5029ffdf9a7bc415e4e7e9794faec8bc3b8e4";
+      tier = "oss";
+      helm_chart_version = "4.0.11";
+    in
+    [
+      "-X ${package_url}/cmd/gitops/version.Branch=releases/v${version}"
+      "-X ${package_url}/cmd/gitops/version.BuildTime=1970-01-01_00:00:00"
+      "-X ${package_url}/cmd/gitops/version.GitCommit=${src.rev}"
+      "-X ${package_url}/cmd/gitops/version.Version=v${version}"
+      # these are likely not necessary
+      "-X ${package_url}/pkg/version.FluxVersion=${flux_version}"
+      "-X ${package_url}/pkg/run/watch.DevBucketContainerImage=${dev_bucket_container_image}"
+      "-X ${package_url}/pkg/analytics.Tier=${tier}"
+      "-X ${package_url}/core/server.Branch=releases/v${version}"
+      "-X ${package_url}/core/server.Buildtime=1970-01-01_00:00:00"
+      "-X ${package_url}/core/server.GitCommit=${src.rev}"
+      "-X ${package_url}/core/server.Version=v${version}"
+      "-X ${package_url}/cmd/gitops/beta/run.HelmChartVersion=${helm_chart_version}"
+    ];
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = ''
+    installShellCompletion --cmd gitops \
+      --bash <($out/bin/gitops completion bash --no-analytics) \
+      --zsh <($out/bin/gitops completion zsh --no-analytics) \
+      --fish <($out/bin/gitops completion fish --no-analytics)
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = gitops;
+    command = "gitops version --no-analytics";
+    version = "v${version}";
+  };
+
+  meta = with lib; {
+    description = "Weave GitOps OSS";
+    homepage = "https://docs.gitops.weave.works/docs/intro";
+    changelog = "https://github.com/weaveworks/weave-gitops/releases/tag/v${version}";
+    license = licenses.mpl20;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28696,6 +28696,8 @@ with pkgs;
 
   gigalixir = callPackage ../tools/misc/gigalixir { };
 
+  gitops = callPackage ../applications/networking/cluster/gitops { };
+
   go-libp2p-daemon = callPackage ../servers/go-libp2p-daemon { };
 
   go-motion = callPackage ../development/tools/go-motion { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- New package: `gitops`
- URL: https://docs.gitops.weave.works
- Github: https://github.com/weaveworks/weave-gitops

Extra notes:

Makefile for gitops package included a bunch of ldflags. I've included them, but it is unclear if they are actually necessary for this bin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
