### PR TITLE
[22.11] pjsip: add patches for CVE-2022-23537 & CVE-2022-23547

### DIFF
--- a/pkgs/applications/networking/pjsip/1.12.1-CVE-2022-23537.patch
+++ b/pkgs/applications/networking/pjsip/1.12.1-CVE-2022-23537.patch
@@ -1,0 +1,87 @@
+Based on upstream d8440f4d711a654b511f50f79c0445b26f9dd1e1 with
+whitespace changes to allow it to apply to 1.12.1
+
+diff --git a/pjnath/include/pjnath/stun_msg.h b/pjnath/include/pjnath/stun_msg.h
+index 6b5fc0f21..e8f52db3c 100644
+--- a/pjnath/include/pjnath/stun_msg.h
++++ b/pjnath/include/pjnath/stun_msg.h
+@@ -443,6 +443,7 @@ typedef enum pj_stun_status
+ 
+    \endverbatim
+  */
++#pragma pack(1)
+ typedef struct pj_stun_msg_hdr
+ {
+     /**
+@@ -474,6 +475,7 @@ typedef struct pj_stun_msg_hdr
+     pj_uint8_t		tsx_id[12];
+ 
+ } pj_stun_msg_hdr;
++#pragma pack()
+ 
+ 
+ /**
+@@ -491,6 +493,7 @@ typedef struct pj_stun_msg_hdr
+ 
+    \endverbatim
+  */
++#pragma pack(1)
+ typedef struct pj_stun_attr_hdr
+ {
+     /**
+@@ -507,6 +510,7 @@ typedef struct pj_stun_attr_hdr
+     pj_uint16_t		length;
+ 
+ } pj_stun_attr_hdr;
++#pragma pack()
+ 
+ 
+ /**
+diff --git a/pjnath/src/pjnath/stun_msg.c b/pjnath/src/pjnath/stun_msg.c
+index bd83351e6..18b70cc22 100644
+--- a/pjnath/src/pjnath/stun_msg.c
++++ b/pjnath/src/pjnath/stun_msg.c
+@@ -746,8 +746,8 @@ PJ_DEF(int) pj_stun_set_padding_char(int chr)
+ 
+ 
+ #define INIT_ATTR(a,t,l)    (a)->hdr.type=(pj_uint16_t)(t), \
+-			    (a)->hdr.length=(pj_uint16_t)(l)
+-#define ATTR_HDR_LEN	    4
++                            (a)->hdr.length=(pj_uint16_t)(l)
++#define ATTR_HDR_LEN        sizeof(pj_stun_attr_hdr)
+ 
+ static pj_uint16_t GETVAL16H(const pj_uint8_t *buf, unsigned pos)
+ {
+@@ -2328,6 +2328,14 @@ PJ_DEF(pj_status_t) pj_stun_msg_decode(pj_pool_t *pool,
+ 	status = pj_stun_msg_check(pdu, pdu_len, options);
+ 	if (status != PJ_SUCCESS)
+ 	    return status;
++    } else {
++        /* For safety, verify packet length at least */
++        pj_uint32_t msg_len = GETVAL16H(pdu, 2) + 20;
++        if (msg_len > pdu_len ||
++            ((options & PJ_STUN_IS_DATAGRAM) && msg_len != pdu_len))
++        {
++            return PJNATH_EINSTUNMSGLEN;
++        }
+     }
+ 
+     /* Create the message, copy the header, and convert to host byte order */
+@@ -2346,7 +2354,7 @@ PJ_DEF(pj_status_t) pj_stun_msg_decode(pj_pool_t *pool,
+ 	p_response = NULL;
+ 
+     /* Parse attributes */
+-    while (pdu_len >= 4) {
++    while (pdu_len >= ATTR_HDR_LEN) {
+ 	unsigned attr_type, attr_val_len;
+ 	const struct attr_desc *adesc;
+ 
+@@ -2358,7 +2366,7 @@ PJ_DEF(pj_status_t) pj_stun_msg_decode(pj_pool_t *pool,
+ 	attr_val_len = (attr_val_len + 3) & (~3);
+ 
+ 	/* Check length */
+-	if (pdu_len < attr_val_len) {
++	if (pdu_len < attr_val_len + ATTR_HDR_LEN) {
+ 	    pj_str_t err_msg;
+ 	    char err_msg_buf[80];
+ 

--- a/pkgs/applications/networking/pjsip/1.12.1-CVE-2022-23547.patch
+++ b/pkgs/applications/networking/pjsip/1.12.1-CVE-2022-23547.patch
@@ -1,0 +1,41 @@
+Based on upstream bc4812d31a67d5e2f973fbfaf950d6118226cf36 with
+whitespace changes to allow it to apply to 1.12.1
+
+diff --git a/pjnath/src/pjnath/stun_msg.c b/pjnath/src/pjnath/stun_msg.c
+index 18b70cc22..b6a6b3528 100644
+--- a/pjnath/src/pjnath/stun_msg.c
++++ b/pjnath/src/pjnath/stun_msg.c
+@@ -1439,12 +1439,12 @@ static pj_status_t decode_uint_attr(pj_pool_t *pool,
+     attr = PJ_POOL_ZALLOC_T(pool, pj_stun_uint_attr);
+     GETATTRHDR(buf, &attr->hdr);
+ 
+-    attr->value = GETVAL32H(buf, 4);
+-
+     /* Check that the attribute length is valid */
+     if (attr->hdr.length != 4)
+ 	return PJNATH_ESTUNINATTRLEN;
+ 
++    attr->value = GETVAL32H(buf, 4);
++
+     /* Done */
+     *p_attr = attr;
+ 
+@@ -1758,14 +1758,15 @@ static pj_status_t decode_errcode_attr(pj_pool_t *pool,
+     attr = PJ_POOL_ZALLOC_T(pool, pj_stun_errcode_attr);
+     GETATTRHDR(buf, &attr->hdr);
+ 
++    /* Check that the attribute length is valid */
++    if (attr->hdr.length < 4)
++        return PJNATH_ESTUNINATTRLEN;
++
+     attr->err_code = buf[6] * 100 + buf[7];
+ 
+     /* Get pointer to the string in the message */
+     value.ptr = ((char*)buf + ATTR_HDR_LEN + 4);
+     value.slen = attr->hdr.length - 4;
+-    /* Make sure the length is never negative */
+-    if (value.slen < 0)
+-    	value.slen = 0;
+ 
+     /* Copy the string to the attribute */
+     pj_strdup(pool, &attr->reason, &value);

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
       url = "https://github.com/pjsip/pjproject/commit/450baca94f475345542c6953832650c390889202.patch";
       sha256 = "sha256-30kHrmB51UIw4x/J6/CD+vPKf/gBYDCcFoUpwEWkDMY=";
     })
+    ./1.12.1-CVE-2022-23537.patch
+    ./1.12.1-CVE-2022-23547.patch
   ];
 
   buildInputs = [ openssl libsamplerate ]


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-23537
https://nvd.nist.gov/vuln/detail/CVE-2022-23547

See #209500 for unstable.

Needed to adjust the patches because upstream have been playing with autoformatters.

Have tested successfully on aarch64-linux with the tests from #169498 enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
