### PR TITLE
python310Packages.wheel: 0.37.1 -> 0.38.4

### DIFF
--- a/pkgs/development/python-modules/wheel/0001-tests-Rename-a-a-o-_-.py-_-.py.patch
+++ b/pkgs/development/python-modules/wheel/0001-tests-Rename-a-a-o-_-.py-_-.py.patch
@@ -20,18 +20,15 @@ name that has the same encoding in each normal form.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/tests/test_bdist_wheel.py b/tests/test_bdist_wheel.py
-index 651c034..9b94ac8 100644
+index 5a6db16..42cf121 100644
 --- a/tests/test_bdist_wheel.py
 +++ b/tests/test_bdist_wheel.py
-@@ -58,7 +58,7 @@ def test_unicode_record(wheel_paths):
+@@ -69,7 +69,7 @@ def test_unicode_record(wheel_paths):
      with ZipFile(path) as zf:
-         record = zf.read('unicode.dist-0.1.dist-info/RECORD')
+         record = zf.read("unicode.dist-0.1.dist-info/RECORD")
  
--    assert u'åäö_日本語.py'.encode('utf-8') in record
-+    assert u'æɐø_日本價.py'.encode('utf-8') in record
+-    assert "åäö_日本語.py".encode() in record
++    assert "æɐø_日本價.py".encode() in record
  
  
- def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
--- 
-2.17.2 (Apple Git-113)
-
+ UTF8_PKG_INFO = """\

--- a/pkgs/development/python-modules/wheel/default.nix
+++ b/pkgs/development/python-modules/wheel/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "wheel";
-  version = "0.37.1";
+  version = "0.38.4";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = pname;
     rev = version;
-    sha256 = "sha256-JlTmUPY3yo/uROyd3nW1dJa23zbLhgQTwcmqZkPOrHs=";
+    hash = "sha256-yZLU0t/nz6kfnnoLL15bybOxN4+SJUaTJsCpGffl1QU=";
     name = "${pname}-${version}-source";
     postFetch = ''
       cd $out


### PR DESCRIPTION
https://github.com/pypa/wheel/blob/main/docs/news.rst

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
