### PR TITLE
binutils: avoid texinfo dependency during bootstrap

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -15,7 +15,6 @@ in
 , noSysDirs
 , perl
 , substitute
-, texinfo
 , zlib
 
 , enableGold ? withGold stdenv.targetPlatform
@@ -52,7 +51,7 @@ let
   targetPrefix = lib.optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-";
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = targetPrefix + "binutils";
   inherit version;
 
@@ -110,10 +109,12 @@ stdenv.mkDerivation {
 
   strictDeps = true;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
+  # texinfo was removed here in https://github.com/NixOS/nixpkgs/pull/210132
+  # to reduce rebuilds during stdenv bootstrap.  Please don't add it back without
+  # checking the impact there first.
   nativeBuildInputs = [
     bison
     perl
-    texinfo
   ]
   ++ lib.optionals targetPlatform.isiOS [ autoreconfHook ]
   ++ lib.optionals buildPlatform.isDarwin [ autoconf269 automake gettext libtool ]
@@ -144,6 +145,20 @@ stdenv.mkDerivation {
     for i in binutils/Makefile.in gas/Makefile.in ld/Makefile.in gold/Makefile.in; do
         sed -i "$i" -e 's|ln |ln -s |'
     done
+
+    # autoreconfHook is not included for all targets.
+    # Call it here explicitly as well.
+    ${finalAttrs.postAutoreconf}
+  '';
+
+  postAutoreconf = ''
+    # As we regenerated configure build system tries hard to use
+    # texinfo to regenerate manuals. Let's avoid the dependency
+    # on texinfo in bootstrap path and keep manuals unmodified.
+    touch gas/doc/.dirstamp
+    touch gas/doc/asconfig.texi
+    touch gas/doc/as.1
+    touch gas/doc/as.info
   '';
 
   # As binutils takes part in the stdenv building, we don't want references
@@ -226,4 +241,4 @@ stdenv.mkDerivation {
     # collision due to the ld/as wrappers/symlinks in the latter.
     priority = 10;
   };
-}
+})


### PR DESCRIPTION
Normally binutils provides pregenerated manuals along with release tarball. Manuals regeneration is needed every time we change `configure.ac`. But usually there are no material changes in it.

This change instead inhibits manuals regeenration by keeping man and info files up to date.

The diff of bootstrap tree before and after the change:

    $ nix-store --query --graph $(nix-instantiate -A stdenv) |
        fgrep ' -> ' | awk '{print $3}' | sort -u |
        sed 's/"[0-9a-z]\{32\}-/"/g' | sort > before

    $ nix-store --query --graph $(nix-instantiate -A stdenv) |
        fgrep ' -> ' | awk '{print $3}' | sort -u |
        sed 's/"[0-9a-z]\{32\}-/"/g' | sort > after

    $ diff -U0 before after
    --- before
    +++ after
    @@ -100 +99,0 @@
    -"texinfo-6.8.drv"

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
