### PR TITLE
cudaPackages_12: init at 12.0.0

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/redist/extension.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/extension.nix
@@ -13,6 +13,7 @@ final: prev: let
     "11.6" = ./manifests/redistrib_11.6.2.json;
     "11.7" = ./manifests/redistrib_11.7.0.json;
     "11.8" = ./manifests/redistrib_11.8.0.json;
+    "12.0" = ./manifests/redistrib_12.0.0.json;
   };
 
   # Function to build a single cudatoolkit redist package

--- a/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_12.0.0.json
+++ b/pkgs/development/compilers/cudatoolkit/redist/manifests/redistrib_12.0.0.json
@@ -1,0 +1,1127 @@
+{
+    "release_date": "2022-12-08",
+    "cuda_cccl": {
+        "name": "CXX Core Compute Libraries",
+        "license": "CUDA Toolkit",
+        "version": "12.0.90",
+        "linux-x86_64": {
+            "relative_path": "cuda_cccl/linux-x86_64/cuda_cccl-linux-x86_64-12.0.90-archive.tar.xz",
+            "sha256": "37f6e03b6f95579d8e2e96b9ba15eeb1224dcd18b21ad50c3ac249e408152a24",
+            "md5": "ced6a2998ad8c3a5f421a60e708bf2c1",
+            "size": "1029064"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cccl/linux-ppc64le/cuda_cccl-linux-ppc64le-12.0.90-archive.tar.xz",
+            "sha256": "c6de67acd6a65b24db0383f6330b842ed19b6c27a27a37f828e9f3e96cc96f72",
+            "md5": "3b533c00dfe103773f60e706d2e6a3c7",
+            "size": "1029080"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cccl/linux-sbsa/cuda_cccl-linux-sbsa-12.0.90-archive.tar.xz",
+            "sha256": "f2a19927c558a9c872fa87eda4c0dc0446e5c4c744df4f846d01f4d4e08c8cd7",
+            "md5": "66b520f391ae130c31198daf58e61d32",
+            "size": "1028684"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cccl/windows-x86_64/cuda_cccl-windows-x86_64-12.0.90-archive.zip",
+            "sha256": "dd422d4cc8462d112411659a56cc78cb6010d704f83db3e48c55a3f66eed5ec2",
+            "md5": "efd7fc187d6f1b57d7fa2ca7c6ffe7ad",
+            "size": "2608382"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cccl/linux-aarch64/cuda_cccl-linux-aarch64-12.0.90-archive.tar.xz",
+            "sha256": "1f606217f6477afaa3e8226d0629ce84eb3b35790c2a832fb46baf7912722cb9",
+            "md5": "244bb1fb614395058ae08f7e436d783b",
+            "size": "1029128"
+        }
+    },
+    "cuda_compat": {
+        "name": "CUDA compat L4T",
+        "license": "CUDA Toolkit",
+        "version": "12.0.31752801",
+        "linux-aarch64": {
+            "relative_path": "cuda_compat/linux-aarch64/cuda_compat-linux-aarch64-12.0.31752801-archive.tar.xz",
+            "sha256": "dcb1fa133eb89eb10b049271e6be8861deaefd612133ceec0e13baf38fe43e93",
+            "md5": "c046dad28e75b3765625757ba006f845",
+            "size": "16051812"
+        }
+    },
+    "cuda_cudart": {
+        "name": "CUDA Runtime (cudart)",
+        "license": "CUDA Toolkit",
+        "version": "12.0.107",
+        "linux-x86_64": {
+            "relative_path": "cuda_cudart/linux-x86_64/cuda_cudart-linux-x86_64-12.0.107-archive.tar.xz",
+            "sha256": "c0e16e9593a69afe4997ae96a8b024e751ebce0254523fd969b08bb028582d23",
+            "md5": "70f9998315314b2e2c4d311a5d70da74",
+            "size": "977884"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cudart/linux-ppc64le/cuda_cudart-linux-ppc64le-12.0.107-archive.tar.xz",
+            "sha256": "d785fd613e35e3761fdb0016a31a56417f570605cbfb9a93ca9dc68be6789188",
+            "md5": "983548770e312f604f818be087609c6d",
+            "size": "967996"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cudart/linux-sbsa/cuda_cudart-linux-sbsa-12.0.107-archive.tar.xz",
+            "sha256": "5de248c6c203f6c91ce34256bbfc028bc87c1b0c552f9f51edb65e60ad665f63",
+            "md5": "e723920f9c598c87db718022005e0961",
+            "size": "969628"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cudart/windows-x86_64/cuda_cudart-windows-x86_64-12.0.107-archive.zip",
+            "sha256": "1cd8516feee068c6d718453e76b0dfcbee27844a35d4f3aa608a3d316190309c",
+            "md5": "8c8b57dc2f0e5ea52d1f5b0dfe032676",
+            "size": "2267147"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cudart/linux-aarch64/cuda_cudart-linux-aarch64-12.0.107-archive.tar.xz",
+            "sha256": "a9c29e8fceb877eeeb252a10030074e5a5fa31afb418df42e1261aebd8bf7d8c",
+            "md5": "3971437445a966ab1a37d7b8041e98b0",
+            "size": "975680"
+        }
+    },
+    "cuda_cuobjdump": {
+        "name": "cuobjdump",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-x86_64": {
+            "relative_path": "cuda_cuobjdump/linux-x86_64/cuda_cuobjdump-linux-x86_64-12.0.76-archive.tar.xz",
+            "sha256": "c2b627534d8eedff86b50bbf13c043a3c9a01a048fa6aa40678be5548c96d2a9",
+            "md5": "baa64f45529bc50de813bf0d6ea91295",
+            "size": "164564"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cuobjdump/linux-ppc64le/cuda_cuobjdump-linux-ppc64le-12.0.76-archive.tar.xz",
+            "sha256": "6b57dcc8a448068f0bd6a3c109f7dfbf96725f60c260a122a2c818f9cbe5b81c",
+            "md5": "5e6dea10146a48e4ffbd1eb90d5f0a91",
+            "size": "209288"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cuobjdump/linux-sbsa/cuda_cuobjdump-linux-sbsa-12.0.76-archive.tar.xz",
+            "sha256": "30744ab5f7ae24d2265bd5167d750907abb2d2f6f62922aeab1fac5aa4030eca",
+            "md5": "285c7a3a8a16e735d625af0bd6038eb7",
+            "size": "173012"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cuobjdump/windows-x86_64/cuda_cuobjdump-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "00688ad84b04df7e6a39e6d4d5fb29fda42d36bdf7e3a432c332ebafbed6fb90",
+            "md5": "5d28cdc57561d98c0e647f9174cdeb6c",
+            "size": "3786191"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cuobjdump/linux-aarch64/cuda_cuobjdump-linux-aarch64-12.0.76-archive.tar.xz",
+            "sha256": "e75adc4b9c6ebc00d1de652a3a243f362ae654b82fc5653a890819c433e8abac",
+            "md5": "936385ead6e6c764187f350d4e475939",
+            "size": "172952"
+        }
+    },
+    "cuda_cupti": {
+        "name": "CUPTI",
+        "license": "CUDA Toolkit",
+        "version": "12.0.90",
+        "linux-x86_64": {
+            "relative_path": "cuda_cupti/linux-x86_64/cuda_cupti-linux-x86_64-12.0.90-archive.tar.xz",
+            "sha256": "3c93a6a8c5eab3a56c1a0a514c0ac7d374807c70a9551155f089588b6c5e1d10",
+            "md5": "fb7af580f717fee8ed666b1b4a73eea5",
+            "size": "18932212"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cupti/linux-ppc64le/cuda_cupti-linux-ppc64le-12.0.90-archive.tar.xz",
+            "sha256": "bbabb508eb4fb0f9d98ac3ab4a40d0278de41cef95139c1bfe6436b716dd6cfc",
+            "md5": "e75692d08f0b6a1755e66471a1f93c47",
+            "size": "9856220"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cupti/linux-sbsa/cuda_cupti-linux-sbsa-12.0.90-archive.tar.xz",
+            "sha256": "33b3b06cf9838fa3289c7e40f143a8f58b941ccad93f9d0640a29bb83aa2152e",
+            "md5": "d95ed64afd78865d16b8e6021d26cb5a",
+            "size": "9825196"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cupti/windows-x86_64/cuda_cupti-windows-x86_64-12.0.90-archive.zip",
+            "sha256": "b65a34a3715e3ef2b835bdd36c43b21c20800325be1eda1e84ad4d80ee837c92",
+            "md5": "4ebbcd9fae699bc6a224148a2a132f36",
+            "size": "13242979"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cupti/linux-aarch64/cuda_cupti-linux-aarch64-12.0.90-archive.tar.xz",
+            "sha256": "9ae58aa13c33a9d6ec053ec18ff87970ce51a8de77a0371ee1e8133d9733e2bb",
+            "md5": "8b7ebc65a1e34fe9eb3cb0d9cf7ffd3a",
+            "size": "7742504"
+        }
+    },
+    "cuda_cuxxfilt": {
+        "name": "CUDA cuxxfilt (demangler)",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-x86_64": {
+            "relative_path": "cuda_cuxxfilt/linux-x86_64/cuda_cuxxfilt-linux-x86_64-12.0.76-archive.tar.xz",
+            "sha256": "363502e0743a21f487bac7ebd63ef8dba6cf11a2b16cd82149e0cecc83c24c34",
+            "md5": "9f066a6547b751765bca4cdaf8e25f09",
+            "size": "186832"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_cuxxfilt/linux-ppc64le/cuda_cuxxfilt-linux-ppc64le-12.0.76-archive.tar.xz",
+            "sha256": "bfd38cadc3066cf28366722e15bd85c298cd7f4ebe4c7852a4149ba2a6b84d2d",
+            "md5": "aac148c78969134bc889dd86e2f78895",
+            "size": "179528"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_cuxxfilt/linux-sbsa/cuda_cuxxfilt-linux-sbsa-12.0.76-archive.tar.xz",
+            "sha256": "2f992cc3dabce111cb93caabb599caa868797fee6b37ff53676fadce36701e6f",
+            "md5": "5221152f2f132150f67985cb7c731fca",
+            "size": "171236"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_cuxxfilt/windows-x86_64/cuda_cuxxfilt-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "0d6276d4a49e7e394b7f8ee150bb6d538297334c7d6b3d1266fa29311ba933f4",
+            "md5": "f9920e0f1c1c6a2cf3ad9882c6fb043f",
+            "size": "168494"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_cuxxfilt/linux-aarch64/cuda_cuxxfilt-linux-aarch64-12.0.76-archive.tar.xz",
+            "sha256": "04337e54fe12dad4fe9aae44dbc952bccaeeb438be11c3730326b5def18ba3bc",
+            "md5": "9fbadd8c487f309d743bc2494c80ff4a",
+            "size": "172044"
+        }
+    },
+    "cuda_demo_suite": {
+        "name": "CUDA Demo Suite",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-x86_64": {
+            "relative_path": "cuda_demo_suite/linux-x86_64/cuda_demo_suite-linux-x86_64-12.0.76-archive.tar.xz",
+            "sha256": "b8c16b37d6e83e1cd6013a9d296a1244c8e88c6dbaa3111dbbe2bb5119ddd439",
+            "md5": "2b3940445ffdba7965f75bdbdf88e486",
+            "size": "4005452"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_demo_suite/windows-x86_64/cuda_demo_suite-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "2bc2d30189f41b0f3150d0629089a1b1c695f12b61ac0dc14877a8e93437761a",
+            "md5": "4b78b701a76537166ac1d41d84558a7b",
+            "size": "5048289"
+        }
+    },
+    "cuda_documentation": {
+        "name": "CUDA Documentation",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-x86_64": {
+            "relative_path": "cuda_documentation/linux-x86_64/cuda_documentation-linux-x86_64-12.0.76-archive.tar.xz",
+            "sha256": "63226377fa39bcd93619d799b688a15d0cb9d0b3ebe8adb3cb2b2537f5839d5a",
+            "md5": "f64f43fc17ee19cf9307ca3386be8de8",
+            "size": "67016"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_documentation/linux-ppc64le/cuda_documentation-linux-ppc64le-12.0.76-archive.tar.xz",
+            "sha256": "699ca03fcec35d4f7e454b97cac8e59b08085f155708ff522aba1910b61a8698",
+            "md5": "fb2c805291ac7a1ab34e2415e1c6bd11",
+            "size": "67188"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_documentation/linux-sbsa/cuda_documentation-linux-sbsa-12.0.76-archive.tar.xz",
+            "sha256": "771425dbb376e6a9b0caa9a7e31ae598c667b4031d4ca902ea47c9f4ddce05a0",
+            "md5": "140d34578251899104de09ab5bd3eedb",
+            "size": "66988"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_documentation/windows-x86_64/cuda_documentation-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "a980c971deb1ad8fd76c514d63a5df7e2fcec3ddcf4bd9f07a4430aa6ad2f2de",
+            "md5": "7deb38b0b3b41e96b3f84d3b31b71e49",
+            "size": "105364"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_documentation/linux-aarch64/cuda_documentation-linux-aarch64-12.0.76-archive.tar.xz",
+            "sha256": "7808f0eb7f37e22d0cad9bfb67b49cee6843ecb6a0f81dde66647720797f186d",
+            "md5": "a81c23575e2eb4a4225be0a056d0b0bd",
+            "size": "67004"
+        }
+    },
+    "cuda_gdb": {
+        "name": "CUDA GDB",
+        "license": "CUDA Toolkit",
+        "version": "12.0.90",
+        "linux-x86_64": {
+            "relative_path": "cuda_gdb/linux-x86_64/cuda_gdb-linux-x86_64-12.0.90-archive.tar.xz",
+            "sha256": "99fe034f035e426314c138902c6ff972697d8691a2291372fe3fbc8ea6542e05",
+            "md5": "1a780fa6dc71636dc9d6400cb1df21f0",
+            "size": "65690768"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_gdb/linux-ppc64le/cuda_gdb-linux-ppc64le-12.0.90-archive.tar.xz",
+            "sha256": "e981b441520fa734451f54ee6fb0c3747d844242d1ca6588e23978c0f4d18be2",
+            "md5": "7aaa44c15862b6b27bb832d592cebf45",
+            "size": "65468312"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_gdb/linux-sbsa/cuda_gdb-linux-sbsa-12.0.90-archive.tar.xz",
+            "sha256": "df48dc586b500db4e7c35e313116bcd760885340e6a554ceca020f640b4896b8",
+            "md5": "1f0c317de2e264c3981bde9d710e15e5",
+            "size": "65372192"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_gdb/linux-aarch64/cuda_gdb-linux-aarch64-12.0.90-archive.tar.xz",
+            "sha256": "93d45774b85b6826d7a0d930b518bb3682c3ae3eb539c49737894a21d574ce21",
+            "md5": "606b2c05e2feaad2a4d2fe89587cac66",
+            "size": "65271068"
+        }
+    },
+    "cuda_nsight": {
+        "name": "Nsight Eclipse Edition Plugin",
+        "license": "CUDA Toolkit",
+        "version": "12.0.78",
+        "linux-x86_64": {
+            "relative_path": "cuda_nsight/linux-x86_64/cuda_nsight-linux-x86_64-12.0.78-archive.tar.xz",
+            "sha256": "d7d151829fa516041174366f1460371e598f0b5b1665fb4a369b539bfc4b60e0",
+            "md5": "af78990a65dd616cae8632660d459e63",
+            "size": "118608488"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nsight/linux-ppc64le/cuda_nsight-linux-ppc64le-12.0.78-archive.tar.xz",
+            "sha256": "00af4bff3ac54bdb0b9c16eba80aa3c95814845805559691d504b8837d620b32",
+            "md5": "686772a1d5532ce104ac83c3957efa0d",
+            "size": "118608480"
+        }
+    },
+    "cuda_nvcc": {
+        "name": "CUDA NVCC",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvcc/linux-x86_64/cuda_nvcc-linux-x86_64-12.0.76-archive.tar.xz",
+            "sha256": "160ca9f8828f53daa4b2066c5361aacb45fa2575885f70c223cda1d11df53d6f",
+            "md5": "2014f06172f634e592dc73557b128866",
+            "size": "44030620"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvcc/linux-ppc64le/cuda_nvcc-linux-ppc64le-12.0.76-archive.tar.xz",
+            "sha256": "dc5bd7eac57b32a9645c0c23c6a1ba8a9533e846eeec31414e1aa4230afee2f8",
+            "md5": "98f2c6d8a280c577b49f2f1181a1fde2",
+            "size": "40973728"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvcc/linux-sbsa/cuda_nvcc-linux-sbsa-12.0.76-archive.tar.xz",
+            "sha256": "85c8c643ea2cfa398e1b5ffcd597f5bb3b738526c9e3fb8e39dd909c55345f36",
+            "md5": "8adcc46ee0d47b96f96536cd7ef0711b",
+            "size": "39603744"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvcc/windows-x86_64/cuda_nvcc-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "f67406f44263f0e4a110a8cf0200bff1d3d0e32917db8a7c9e417a87eb7ca372",
+            "md5": "659567fef2b820773e8a3f3d74036f85",
+            "size": "58899378"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvcc/linux-aarch64/cuda_nvcc-linux-aarch64-12.0.76-archive.tar.xz",
+            "sha256": "5623df048157f29e825df6c219a308d9988671c4ba2068353f5590f5d5cacb85",
+            "md5": "5a29cb52cfa3a106cdef626ed023e01d",
+            "size": "39724216"
+        }
+    },
+    "cuda_nvdisasm": {
+        "name": "CUDA nvdisasm",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvdisasm/linux-x86_64/cuda_nvdisasm-linux-x86_64-12.0.76-archive.tar.xz",
+            "sha256": "0e0660100b052248529ee07353479a7d703258ef3200ac52e9676298511d10c3",
+            "md5": "8f7eac1f3cbe384c4169d6294190cf8a",
+            "size": "49863368"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvdisasm/linux-ppc64le/cuda_nvdisasm-linux-ppc64le-12.0.76-archive.tar.xz",
+            "sha256": "aca86a9b2b7678884aa58e7a29881044e6d12dbf790b46266f08f6855a10ac79",
+            "md5": "ad3cb34c8c7cb150c0fdc800e7069a8b",
+            "size": "49865020"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvdisasm/linux-sbsa/cuda_nvdisasm-linux-sbsa-12.0.76-archive.tar.xz",
+            "sha256": "4991a102fd8d7d3aa632cf5a28df6368f4074a4ced952e7665c382c6dbdec1fd",
+            "md5": "bef0429bc003c9f90905320df0444c3c",
+            "size": "49807864"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvdisasm/windows-x86_64/cuda_nvdisasm-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "7d716f14dc1342d62c9c67d4636cc1dbd496d7648b6097a53d05e1d6864a487c",
+            "md5": "4e394432bee60b914cd6b729364e45c6",
+            "size": "50113509"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvdisasm/linux-aarch64/cuda_nvdisasm-linux-aarch64-12.0.76-archive.tar.xz",
+            "sha256": "110567ea874f7fa15f35fc3a9ad6d79dc8dd472e86702dc87d47b9de5aa666bb",
+            "md5": "dbccdbae44abdc3dc80ade192496da47",
+            "size": "49807504"
+        }
+    },
+    "cuda_nvml_dev": {
+        "name": "CUDA NVML Headers",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvml_dev/linux-x86_64/cuda_nvml_dev-linux-x86_64-12.0.76-archive.tar.xz",
+            "sha256": "6780e554784bef73050144afe39668e26923d2533c268460c348e0e380d5d048",
+            "md5": "965db81d17011596c89428a0a5f86480",
+            "size": "81844"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvml_dev/linux-ppc64le/cuda_nvml_dev-linux-ppc64le-12.0.76-archive.tar.xz",
+            "sha256": "319b96999d144192094d254f0607debb14118ce206ef7dfeba3d13da1cc805ec",
+            "md5": "b30ba5deacce533f6027c614a8e75f82",
+            "size": "81312"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvml_dev/linux-sbsa/cuda_nvml_dev-linux-sbsa-12.0.76-archive.tar.xz",
+            "sha256": "4aee09e48ecd30b2dcaa9de4eb8af2fcdf36ed040eac50c14f3345a12410b6ec",
+            "md5": "94fe6aa2748a5cae080fe451e7039a0c",
+            "size": "82068"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvml_dev/windows-x86_64/cuda_nvml_dev-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "abc366280d0aa1ca047323a3e316270b80ffabb649021184647cd16b44c60a71",
+            "md5": "6f064c5fa6b96a478986593f345e7dd6",
+            "size": "114128"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvml_dev/linux-aarch64/cuda_nvml_dev-linux-aarch64-12.0.76-archive.tar.xz",
+            "sha256": "62b1d7bedb9b928b28d903b87855fc2f4b9db7d6ce38e27a196340ef828bf4e1",
+            "md5": "135c74bf4517a5e27cfa9f969311737a",
+            "size": "81992"
+        }
+    },
+    "cuda_nvprof": {
+        "name": "CUDA nvprof",
+        "license": "CUDA Toolkit",
+        "version": "12.0.90",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvprof/linux-x86_64/cuda_nvprof-linux-x86_64-12.0.90-archive.tar.xz",
+            "sha256": "e3313459ff03f17836fc43e53fa7bc1d3ba4079e6089c48ac9d91009c762f196",
+            "md5": "a2f267cd8a511191e3690a22ac95299a",
+            "size": "1964632"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvprof/linux-ppc64le/cuda_nvprof-linux-ppc64le-12.0.90-archive.tar.xz",
+            "sha256": "b1067e82bbf4ce592fd94c8b654d91a72e5b70c2ec407348ce7f7cf462acd6a4",
+            "md5": "8e52f284df19ed42c8593608ee9daa9a",
+            "size": "1613276"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvprof/windows-x86_64/cuda_nvprof-windows-x86_64-12.0.90-archive.zip",
+            "sha256": "d509046b6670105bc11a6a31e412a07c7ceb2f76f5248d1d5699be1544dc6221",
+            "md5": "e1795d1a90cfe134abbc47c8f79556f1",
+            "size": "1601545"
+        }
+    },
+    "cuda_nvprune": {
+        "name": "CUDA nvprune",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvprune/linux-x86_64/cuda_nvprune-linux-x86_64-12.0.76-archive.tar.xz",
+            "sha256": "51888da85f2a77b09d8e430c764cc5ef06d178dc6acec129e88130e6cb232978",
+            "md5": "01f2900c204b78d691ec842e1c8d2fd5",
+            "size": "56264"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvprune/linux-ppc64le/cuda_nvprune-linux-ppc64le-12.0.76-archive.tar.xz",
+            "sha256": "b1f7f8eeccaa9c0bf98fd4b31f182b7677ab692da3e9010d43a9157d18898e50",
+            "md5": "3afe2dbdab0a9fc2e8786819650929fa",
+            "size": "57240"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvprune/linux-sbsa/cuda_nvprune-linux-sbsa-12.0.76-archive.tar.xz",
+            "sha256": "39eff5df71d45112b606f0f2d03b6be7981c147b941ce7b3f530d24e07c7bc77",
+            "md5": "b09ae0655fbb40707f4a4336b3265893",
+            "size": "48476"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvprune/windows-x86_64/cuda_nvprune-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "38860f15bda7bceaf6aff5d088b6cc50260d16036c4c30ec7f3a9d0c3edc3cba",
+            "md5": "ad56d80358749c16e9638a0bf3248758",
+            "size": "145929"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvprune/linux-aarch64/cuda_nvprune-linux-aarch64-12.0.76-archive.tar.xz",
+            "sha256": "38f5ad012d0f8c1e47af42020d9d9282d5681f9a3eeba7b4787222c9c27e0480",
+            "md5": "8f6cdacb6cea72b52ebb179a54e04f62",
+            "size": "48468"
+        }
+    },
+    "cuda_nvrtc": {
+        "name": "CUDA NVRTC",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvrtc/linux-x86_64/cuda_nvrtc-linux-x86_64-12.0.76-archive.tar.xz",
+            "sha256": "0a4ebc9a1516a5e00f14c69365ba782dcfab545d2abb15740569970f89855bff",
+            "md5": "84efcdbcdfdc7307aaa2b46e946305cc",
+            "size": "30070440"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvrtc/linux-ppc64le/cuda_nvrtc-linux-ppc64le-12.0.76-archive.tar.xz",
+            "sha256": "a8a5ad2c6823435762acb209fbfb032d22fc3d09c4bfc0cade8d3734f4a26c60",
+            "md5": "ee1165e9fcccdab9112df312160f6679",
+            "size": "27776652"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvrtc/linux-sbsa/cuda_nvrtc-linux-sbsa-12.0.76-archive.tar.xz",
+            "sha256": "40d88b96fd41b28f2c5a14fa14a2c16559b0abb77689d1f85525789b23e21cad",
+            "md5": "a52760480e6c82b3db71a8e4480009de",
+            "size": "27613176"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvrtc/windows-x86_64/cuda_nvrtc-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "2e97727ea5c943d0757e564fe87818a5c8c3d27bc78d60a7aaab8874e3ec5960",
+            "md5": "87c314e4e9e3b60e926f5d766795fa13",
+            "size": "96571437"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvrtc/linux-aarch64/cuda_nvrtc-linux-aarch64-12.0.76-archive.tar.xz",
+            "sha256": "6a5bc6281cc778281a0f23402d05ca8265d83b8591d1d3ba661039ad56968c23",
+            "md5": "d7996ee250f4623f86893df8c0705062",
+            "size": "27620372"
+        }
+    },
+    "cuda_nvtx": {
+        "name": "CUDA NVTX",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvtx/linux-x86_64/cuda_nvtx-linux-x86_64-12.0.76-archive.tar.xz",
+            "sha256": "1d2cbcb05a2e8a04b51a866b6997cb73ed90e61ffa183669d3f9ff7a0c7fd654",
+            "md5": "8514350a4a5e4d4b968612ac5aafd3c6",
+            "size": "48396"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvtx/linux-ppc64le/cuda_nvtx-linux-ppc64le-12.0.76-archive.tar.xz",
+            "sha256": "2a8aef88030147cd0a394d6fe1ceb2d26aa9694aa751e10d58e39623f27cf7e2",
+            "md5": "c6c975272145ffe63126d0fd39263773",
+            "size": "48424"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_nvtx/linux-sbsa/cuda_nvtx-linux-sbsa-12.0.76-archive.tar.xz",
+            "sha256": "2cb31f10cf0e58d296611bac2bb6e2f9ccb498753bb148b487defbd95e11f3e8",
+            "md5": "7eee00ed46808fb2421a167568ca7063",
+            "size": "48964"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvtx/windows-x86_64/cuda_nvtx-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "e16c1214fb7ae1bb60a9224e07b70aa5fd03310226140672ab3b409ddf4ae2a7",
+            "md5": "f49f414b982391c1b7848afe5fa29e78",
+            "size": "65690"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_nvtx/linux-aarch64/cuda_nvtx-linux-aarch64-12.0.76-archive.tar.xz",
+            "sha256": "a698427df9910c96deb6fb77870360b2d723c57a23383ab4c8d84040ce04a468",
+            "md5": "94fe72e188fdbad8492a9c0751831079",
+            "size": "48848"
+        }
+    },
+    "cuda_nvvp": {
+        "name": "CUDA NVVP",
+        "license": "CUDA Toolkit",
+        "version": "12.0.90",
+        "linux-x86_64": {
+            "relative_path": "cuda_nvvp/linux-x86_64/cuda_nvvp-linux-x86_64-12.0.90-archive.tar.xz",
+            "sha256": "3139235d52d0a41c56cb5caead9481154895754205b7ded7f96137fae3a9e9b1",
+            "md5": "8b5dd4767cd6028e7bbad5c1b53b74b4",
+            "size": "117594056"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_nvvp/linux-ppc64le/cuda_nvvp-linux-ppc64le-12.0.90-archive.tar.xz",
+            "sha256": "48928f3b3103c2fe47e557b4bd9966049b637c563af7a171358700cecf84d609",
+            "md5": "410f75915e32d61ad76cd1b1d3b5535e",
+            "size": "111727748"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_nvvp/windows-x86_64/cuda_nvvp-windows-x86_64-12.0.90-archive.zip",
+            "sha256": "edc4302461ba6f9b716e146d6bb5f10f7dc776ae1268bfd383cfd74ee94fdf19",
+            "md5": "4176efce368b865763327d97803202cb",
+            "size": "120357419"
+        }
+    },
+    "cuda_opencl": {
+        "name": "CUDA OpenCL",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-x86_64": {
+            "relative_path": "cuda_opencl/linux-x86_64/cuda_opencl-linux-x86_64-12.0.76-archive.tar.xz",
+            "sha256": "285b646a231d1101d7ffb7b37ca081f2c170114102ebfd0439fe189dbdc07b37",
+            "md5": "9b248633d7fd920442af53dd0906c999",
+            "size": "69168"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_opencl/windows-x86_64/cuda_opencl-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "9a8688abf527dd1105e2f366e5aa84f901975a3ba94d977088764c45586370d3",
+            "md5": "598fdccab3e88205c17ff06c4e0be022",
+            "size": "103553"
+        }
+    },
+    "cuda_profiler_api": {
+        "name": "CUDA Profiler API",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-x86_64": {
+            "relative_path": "cuda_profiler_api/linux-x86_64/cuda_profiler_api-linux-x86_64-12.0.76-archive.tar.xz",
+            "sha256": "0fb470a3065ad39666dd231c12f8c8a9a94f34c4ac8494e5a399ea8e6ad69346",
+            "md5": "4748d343c6cdbce71f08e4241c877025",
+            "size": "16056"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_profiler_api/linux-ppc64le/cuda_profiler_api-linux-ppc64le-12.0.76-archive.tar.xz",
+            "sha256": "211513a8a194557a2b838a46700a820af6f38932fac5a82fa229c162779d9a25",
+            "md5": "e58b3254395a92b8918b415fd6d0e8d6",
+            "size": "16056"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_profiler_api/linux-sbsa/cuda_profiler_api-linux-sbsa-12.0.76-archive.tar.xz",
+            "sha256": "b93d4e99077c31e7034eeaea09068b43abc0dd2868a01d489ebcd1e51ceab816",
+            "md5": "5f843fb1aad1b6ee1c19f64e8bb02085",
+            "size": "16052"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_profiler_api/windows-x86_64/cuda_profiler_api-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "e8bccbfda35abc7076ba6623578d11d05966a9c7fed817cbfe7d4dea9627057e",
+            "md5": "100f5883eb8242d3fec645616e4fa8fe",
+            "size": "20075"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_profiler_api/linux-aarch64/cuda_profiler_api-linux-aarch64-12.0.76-archive.tar.xz",
+            "sha256": "31d6e843ce65c6e02cf7e4d8ed71566b6a243714750e6742b36c1a705db247ed",
+            "md5": "514992a5be0c84f33cea052f3137dbab",
+            "size": "16048"
+        }
+    },
+    "cuda_sanitizer_api": {
+        "name": "CUDA Compute Sanitizer API",
+        "license": "CUDA Toolkit",
+        "version": "12.0.90",
+        "linux-x86_64": {
+            "relative_path": "cuda_sanitizer_api/linux-x86_64/cuda_sanitizer_api-linux-x86_64-12.0.90-archive.tar.xz",
+            "sha256": "80e23d82bf4a0bb79c564104121467bd0d15f0142e1dc4fff36bb491bc4b3d4f",
+            "md5": "b050c5f1139eff774f00d15eadbbb581",
+            "size": "8124684"
+        },
+        "linux-ppc64le": {
+            "relative_path": "cuda_sanitizer_api/linux-ppc64le/cuda_sanitizer_api-linux-ppc64le-12.0.90-archive.tar.xz",
+            "sha256": "50d66cab58c7b8aa8473b36844669ee2ea7fc85ad92d49473b30214de22c2d25",
+            "md5": "b737683145211694fcfe45b5f57b7732",
+            "size": "7453156"
+        },
+        "linux-sbsa": {
+            "relative_path": "cuda_sanitizer_api/linux-sbsa/cuda_sanitizer_api-linux-sbsa-12.0.90-archive.tar.xz",
+            "sha256": "c872f56fa4a0ce50f8acf5f154d73d0c7a3290e9fa7ffa0b368fbdae3d1435b9",
+            "md5": "d231a77f1a21aaf9e3397d70eaea1236",
+            "size": "6020964"
+        },
+        "windows-x86_64": {
+            "relative_path": "cuda_sanitizer_api/windows-x86_64/cuda_sanitizer_api-windows-x86_64-12.0.90-archive.zip",
+            "sha256": "cdb48694de35aed5576aaf81f2443d12791a346d7a186e2c37e7606e252ef4e4",
+            "md5": "053582e559296ad422eb85f0a6df6ee6",
+            "size": "13689020"
+        },
+        "linux-aarch64": {
+            "relative_path": "cuda_sanitizer_api/linux-aarch64/cuda_sanitizer_api-linux-aarch64-12.0.90-archive.tar.xz",
+            "sha256": "33d777ba9460c0b1cdb99c41a5c2f6d8506c0036b29770819cbf9b0669c81e05",
+            "md5": "696634de97f6d9486a1122c0bcd53384",
+            "size": "3442072"
+        }
+    },
+    "fabricmanager": {
+        "name": "NVIDIA Fabric Manager",
+        "license": "NVIDIA Driver",
+        "version": "525.60.13",
+        "linux-x86_64": {
+            "relative_path": "fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-525.60.13-archive.tar.xz",
+            "sha256": "1adfbb12817f213e39d389442505f75dd7cc085ce4afa98ecdc2ea26dcb321da",
+            "md5": "1a1773bd6ae9cdbe9cf08c623f50bb4b",
+            "size": "1630476"
+        },
+        "linux-sbsa": {
+            "relative_path": "fabricmanager/linux-sbsa/fabricmanager-linux-sbsa-525.60.13-archive.tar.xz",
+            "sha256": "6c74abdb3f5bb54742a71e0c610d9e550c2754a10f12581dc058324799416a44",
+            "md5": "bab165a4ba0c2bdaf55de62129b8309b",
+            "size": "1506948"
+        }
+    },
+    "libcublas": {
+        "name": "CUDA cuBLAS",
+        "license": "CUDA Toolkit",
+        "version": "12.0.1.189",
+        "linux-x86_64": {
+            "relative_path": "libcublas/linux-x86_64/libcublas-linux-x86_64-12.0.1.189-archive.tar.xz",
+            "sha256": "38272cc9184b4a57a6250fc2cd914ffc827f9f8cd5a3e1356bc3c31f843caf8f",
+            "md5": "135f10725f9b02eaa0056511b700aff4",
+            "size": "448944412"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcublas/linux-ppc64le/libcublas-linux-ppc64le-12.0.1.189-archive.tar.xz",
+            "sha256": "2d46e735f8e76e2eb7df1b4f41d56aa8d5d2683f99988bac82d6ae33fb6d344b",
+            "md5": "2f3ccd6dbd1cfa7b747e1066852e8643",
+            "size": "371489968"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcublas/linux-sbsa/libcublas-linux-sbsa-12.0.1.189-archive.tar.xz",
+            "sha256": "96b68f6821684f39f338862639ce74a74c75830bf44dcd17ef372a1cb8c2304d",
+            "md5": "2f9ad67392e1cd1ebbb4553a9429a0b0",
+            "size": "446508656"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcublas/windows-x86_64/libcublas-windows-x86_64-12.0.1.189-archive.zip",
+            "sha256": "88f29bec81880844da2eee13f1cdc51e1ccd8b4c60af6df633577810b30f80d0",
+            "md5": "4c66759a793bd0f350a2bdc621186dfe",
+            "size": "375183725"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcublas/linux-aarch64/libcublas-linux-aarch64-12.0.1.189-archive.tar.xz",
+            "sha256": "5c07b5c50ec784a90ede8ce3b5f4a8ea088489a171d27d8e84609fa905c1866f",
+            "md5": "403c178317cb52013c05f11ed09917ae",
+            "size": "318378464"
+        }
+    },
+    "libcudla": {
+        "name": "cuDLA",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-aarch64": {
+            "relative_path": "libcudla/linux-aarch64/libcudla-linux-aarch64-12.0.76-archive.tar.xz",
+            "sha256": "d85f38c47bceeac61eedff54157e5f9ac424b7a199bfd6299f2b99090faa879e",
+            "md5": "561d85906e7d09f9aafa3de801107f68",
+            "size": "38416"
+        }
+    },
+    "libcufft": {
+        "name": "CUDA cuFFT",
+        "license": "CUDA Toolkit",
+        "version": "11.0.0.21",
+        "linux-x86_64": {
+            "relative_path": "libcufft/linux-x86_64/libcufft-linux-x86_64-11.0.0.21-archive.tar.xz",
+            "sha256": "4650f79fcf377af410afedb56445f1332e8f213ec3c94d660f9a91328c3ecb4a",
+            "md5": "54369abfc2de7a9704d4a6abfdf57de8",
+            "size": "121895016"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcufft/linux-ppc64le/libcufft-linux-ppc64le-11.0.0.21-archive.tar.xz",
+            "sha256": "e711671995e9d92d16015a4cd3751ec30710a49fa22f2b88a4a42905c248d861",
+            "md5": "39efd61abb12157378ddac5f597acb14",
+            "size": "122075552"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcufft/linux-sbsa/libcufft-linux-sbsa-11.0.0.21-archive.tar.xz",
+            "sha256": "91aa1ba5e68ca65778222c9a427a9214c4550d2f45e978e51779a207bafc17a3",
+            "md5": "947fe2aeff52e2448cf8b6c85b75d151",
+            "size": "121276340"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcufft/windows-x86_64/libcufft-windows-x86_64-11.0.0.21-archive.zip",
+            "sha256": "a33f577d48ef432d5cfa8d0ebfa789cc5261af5dd84fd9c608235edc3f769e43",
+            "md5": "150394e3997e99dd5bfda601ae51f8ce",
+            "size": "87877603"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcufft/linux-aarch64/libcufft-linux-aarch64-11.0.0.21-archive.tar.xz",
+            "sha256": "ddc525a7c92816115c8bc39a440f4bad71c29b04bfdb7ce9a58be6167e855a3f",
+            "md5": "d7ba56c1ca4c0cbab93e0787c042d58e",
+            "size": "121615432"
+        }
+    },
+    "libcufile": {
+        "name": "CUDA cuFile",
+        "license": "CUDA Toolkit",
+        "version": "1.5.0.59",
+        "linux-x86_64": {
+            "relative_path": "libcufile/linux-x86_64/libcufile-linux-x86_64-1.5.0.59-archive.tar.xz",
+            "sha256": "222c49b29afb544c69542c4e658b0a1bd01fd2306f2136ad6990ccfff482a097",
+            "md5": "eb688d2305ed503bd4b43accf09d7ce1",
+            "size": "40919608"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcufile/linux-aarch64/libcufile-linux-aarch64-1.5.0.59-archive.tar.xz",
+            "sha256": "4e8d2b525322be9ab6ae574bd1d0325a4bf9c6c3bbdaa1611b5b969b7b34b0c4",
+            "md5": "1c79281002eb45d238f5ec14ff836977",
+            "size": "40583436"
+        }
+    },
+    "libcurand": {
+        "name": "CUDA cuRAND",
+        "license": "CUDA Toolkit",
+        "version": "10.3.1.50",
+        "linux-x86_64": {
+            "relative_path": "libcurand/linux-x86_64/libcurand-linux-x86_64-10.3.1.50-archive.tar.xz",
+            "sha256": "7c25712016fdde96011c3370673d9007eddd7231261a9b47f36b213ceb964191",
+            "md5": "4144e77f5ca16ad596fc3d76b206c865",
+            "size": "81944120"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcurand/linux-ppc64le/libcurand-linux-ppc64le-10.3.1.50-archive.tar.xz",
+            "sha256": "ac020f6e88105927f96f58ca331d3cddba35b37376f4716e866155c4f56681dd",
+            "md5": "7d367772ea86af8199ce315c96a57dae",
+            "size": "81985844"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcurand/linux-sbsa/libcurand-linux-sbsa-10.3.1.50-archive.tar.xz",
+            "sha256": "c7ae331dd6c9936a4e9746abdc222514bbda47a1e495e396b8244b918de377e2",
+            "md5": "6a3139862df5eb789a55b6d8d5f587f4",
+            "size": "81931640"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcurand/windows-x86_64/libcurand-windows-x86_64-10.3.1.50-archive.zip",
+            "sha256": "5fb95fbbd1c652e1e2a8c12c41d225117cab3f718c739f0d49d580c11b4a44f1",
+            "md5": "32dc14283d64989131c88af5b6910e5f",
+            "size": "55271970"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcurand/linux-aarch64/libcurand-linux-aarch64-10.3.1.50-archive.tar.xz",
+            "sha256": "bb1ffdb88d4177c6608f3aceb5c2d2ef0314387e3b17c2cd66d571be0ea37e55",
+            "md5": "80866689104d7742bb1725d982605804",
+            "size": "82230320"
+        }
+    },
+    "libcusolver": {
+        "name": "CUDA cuSOLVER",
+        "license": "CUDA Toolkit",
+        "version": "11.4.2.57",
+        "linux-x86_64": {
+            "relative_path": "libcusolver/linux-x86_64/libcusolver-linux-x86_64-11.4.2.57-archive.tar.xz",
+            "sha256": "c9460db500d0c7d14debb2c8e0d88fc26a39197363f1b000ccf760866f636f12",
+            "md5": "800886ff264202d172b89df3dadbcd25",
+            "size": "83059560"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcusolver/linux-ppc64le/libcusolver-linux-ppc64le-11.4.2.57-archive.tar.xz",
+            "sha256": "bf3c9a090652d011aafe2190c6f26fe108194cf8512d3c571e406054740168bb",
+            "md5": "cc8287aac0117581f8a017569e819de2",
+            "size": "83070796"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcusolver/linux-sbsa/libcusolver-linux-sbsa-11.4.2.57-archive.tar.xz",
+            "sha256": "0ca46b73520657f96f921711c05af7053bd398328d510aecddfff2521c000e91",
+            "md5": "9d361eeb7894e0ea97ab0072dec8b76c",
+            "size": "82258964"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcusolver/windows-x86_64/libcusolver-windows-x86_64-11.4.2.57-archive.zip",
+            "sha256": "c09836df1f43a3496f2b61ad8827af662ace298508869564a40c30d909ba550f",
+            "md5": "d06f19ad2f63f84707f8a8f68d320814",
+            "size": "122669822"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcusolver/linux-aarch64/libcusolver-linux-aarch64-11.4.2.57-archive.tar.xz",
+            "sha256": "64b68e5d145fcc883e132df090fa931e3fb34fb9ed802584bb38f5202264c50b",
+            "md5": "eb07c50be715202d76338ad7110d1aec",
+            "size": "76026940"
+        }
+    },
+    "libcusparse": {
+        "name": "CUDA cuSPARSE",
+        "license": "CUDA Toolkit",
+        "version": "12.0.0.76",
+        "linux-x86_64": {
+            "relative_path": "libcusparse/linux-x86_64/libcusparse-linux-x86_64-12.0.0.76-archive.tar.xz",
+            "sha256": "66bd1962f4905b6fc49446d5b2570bcd6171a96833b93f44ad4fc5650f47a496",
+            "md5": "9d1f8dd5d9085ec5b0f70a2e0f429ade",
+            "size": "186834824"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libcusparse/linux-ppc64le/libcusparse-linux-ppc64le-12.0.0.76-archive.tar.xz",
+            "sha256": "36b5f682ebe21089d1bbc8250eabd18c9c9a8bf498b5f878ea4944fda16d8203",
+            "md5": "802d9b51bb957c9f7cf01cd077a929b9",
+            "size": "186984664"
+        },
+        "linux-sbsa": {
+            "relative_path": "libcusparse/linux-sbsa/libcusparse-linux-sbsa-12.0.0.76-archive.tar.xz",
+            "sha256": "ee3a2ff7becc449aeda6b2cec11ad7f0606cef4b54eb6511d5f0c1166c79cc80",
+            "md5": "42b015133b9395cf7c5cd059ac4c8ba8",
+            "size": "186428912"
+        },
+        "windows-x86_64": {
+            "relative_path": "libcusparse/windows-x86_64/libcusparse-windows-x86_64-12.0.0.76-archive.zip",
+            "sha256": "a475bc85cfc204aff825e3e5d97d7c1993d3f2cfec22a87e76b8d596fc496a02",
+            "md5": "7c5144483b1b050cbb91c4bffa5a1e94",
+            "size": "151652787"
+        },
+        "linux-aarch64": {
+            "relative_path": "libcusparse/linux-aarch64/libcusparse-linux-aarch64-12.0.0.76-archive.tar.xz",
+            "sha256": "72a882a92d0ae9a9d62dd1ed0409ddee241da04923bfc0c4b9639a4d13fed4d8",
+            "md5": "1ce21b4b799209c90cc55e4c42f5f7ad",
+            "size": "191797084"
+        }
+    },
+    "libnpp": {
+        "name": "CUDA NPP",
+        "license": "CUDA Toolkit",
+        "version": "12.0.0.30",
+        "linux-x86_64": {
+            "relative_path": "libnpp/linux-x86_64/libnpp-linux-x86_64-12.0.0.30-archive.tar.xz",
+            "sha256": "003365261d69caa6219ba698b649a961ad41ae386772fe673f3b8166c1b42775",
+            "md5": "a2721015edbd6ae8a63da0c2fcfb3c73",
+            "size": "183973264"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libnpp/linux-ppc64le/libnpp-linux-ppc64le-12.0.0.30-archive.tar.xz",
+            "sha256": "4e2b56928cfef99725931f98b5840ca35a56505d927871ce53accba6f38005e5",
+            "md5": "0bc29dcf667156062c719a0e84b863ff",
+            "size": "184254800"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnpp/linux-sbsa/libnpp-linux-sbsa-12.0.0.30-archive.tar.xz",
+            "sha256": "6239013db1d4badf1cc1af8acebe3fc1bc0ef167092b314721078742a2916976",
+            "md5": "eda65a21bb0a0d762b082508620eb299",
+            "size": "183254792"
+        },
+        "windows-x86_64": {
+            "relative_path": "libnpp/windows-x86_64/libnpp-windows-x86_64-12.0.0.30-archive.zip",
+            "sha256": "a7abd59e05b326d6adfca16840071d2ed02d0cc6df092d921ed96d489a2e864e",
+            "md5": "dcfac50bad2ee907c0d4cbb272f5a06c",
+            "size": "152918791"
+        },
+        "linux-aarch64": {
+            "relative_path": "libnpp/linux-aarch64/libnpp-linux-aarch64-12.0.0.30-archive.tar.xz",
+            "sha256": "248fde03fb06d6dbdf080b05016baec5ed15bdd202374599de6165110b48e4b0",
+            "md5": "ee08825c03495d38f12350816952fc08",
+            "size": "179283116"
+        }
+    },
+    "libnvidia_nscq": {
+        "name": "NVIDIA NSCQ API",
+        "license": "NVIDIA Driver",
+        "version": "525.60.13",
+        "linux-x86_64": {
+            "relative_path": "libnvidia_nscq/linux-x86_64/libnvidia_nscq-linux-x86_64-525.60.13-archive.tar.xz",
+            "sha256": "1335573917e02a0fdb032d2d959d3a82598498680a7aa3a32eb1059db75bbb54",
+            "md5": "3fc1b5ba901c38176f9f9be503c2f7bf",
+            "size": "439128"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnvidia_nscq/linux-sbsa/libnvidia_nscq-linux-sbsa-525.60.13-archive.tar.xz",
+            "sha256": "8a5c56cf99df931b2f7088e3ad0fd962437b0dd5e5b66a8af3ce692c86be44f2",
+            "md5": "dd005f018eae69ecf91160535e4f077f",
+            "size": "395800"
+        }
+    },
+    "libnvjitlink": {
+        "name": "NVIDIA compiler library for JIT LTO functionality",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "linux-x86_64": {
+            "relative_path": "libnvjitlink/linux-x86_64/libnvjitlink-linux-x86_64-12.0.76-archive.tar.xz",
+            "sha256": "92a70db1ee90f1816a40d4d2019e0a59c43eebb9f3eb1208abedcc00a13e48be",
+            "md5": "629eb972949909a441346ba7aa0b7aea",
+            "size": "25644284"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libnvjitlink/linux-ppc64le/libnvjitlink-linux-ppc64le-12.0.76-archive.tar.xz",
+            "sha256": "dd317e1d052b4231ab95d1b472105640f617f7d250aacc5bc1c952aab93d7483",
+            "md5": "bb08ab81b8df623356c1edd3ff692a92",
+            "size": "23614740"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnvjitlink/linux-sbsa/libnvjitlink-linux-sbsa-12.0.76-archive.tar.xz",
+            "sha256": "9f18090f6587e95be0ee424f07358eeb0e15c5ab3f8636870f68dd84a92ed2e6",
+            "md5": "1847112c9f0c35b9d12a2be3fdf36e72",
+            "size": "23443868"
+        },
+        "windows-x86_64": {
+            "relative_path": "libnvjitlink/windows-x86_64/libnvjitlink-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "cae74b6790174b283d892bb20e1ff91bff13c8a2a8486de4f417e09675469372",
+            "md5": "6637e29e523a18f3c1fc7a3e8e1750ca",
+            "size": "86232010"
+        },
+        "linux-aarch64": {
+            "relative_path": "libnvjitlink/linux-aarch64/libnvjitlink-linux-aarch64-12.0.76-archive.tar.xz",
+            "sha256": "e01c074fe008aa81496d65779068d8443b19b1a1d3b6e36d20e2a4018d59888d",
+            "md5": "81d94bf755b2406d15a986813ef21306",
+            "size": "23442512"
+        }
+    },
+    "libnvjpeg": {
+        "name": "CUDA nvJPEG",
+        "license": "CUDA Toolkit",
+        "version": "12.0.0.28",
+        "linux-x86_64": {
+            "relative_path": "libnvjpeg/linux-x86_64/libnvjpeg-linux-x86_64-12.0.0.28-archive.tar.xz",
+            "sha256": "ad3380591a4d5b97ab57d10e9bf05e23dee6429ff91ea939423a3b35ee0e35de",
+            "md5": "043df4a379a5ce4947909e7a0d3383ea",
+            "size": "1972024"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libnvjpeg/linux-ppc64le/libnvjpeg-linux-ppc64le-12.0.0.28-archive.tar.xz",
+            "sha256": "f7136bb691d794c680d77376b306bedb80eeebf687bfa4dc74355fdae5adcebb",
+            "md5": "c7269e3c1bf6b5000fceebf64fbd83f8",
+            "size": "1980748"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnvjpeg/linux-sbsa/libnvjpeg-linux-sbsa-12.0.0.28-archive.tar.xz",
+            "sha256": "31fd6ee0dccc72f0d583e25b849543551eb4bc49d3285628bf3b17929e09bac1",
+            "md5": "184b017c65856b4f0299a02fc9ec6a5b",
+            "size": "1786868"
+        },
+        "windows-x86_64": {
+            "relative_path": "libnvjpeg/windows-x86_64/libnvjpeg-windows-x86_64-12.0.0.28-archive.zip",
+            "sha256": "b7cb56ab2c69e055a4b1ea41653df917153a568ab23fb0d8121e0739011989a8",
+            "md5": "18d62f0d142f7e8ce6de806190876a18",
+            "size": "1943533"
+        }
+    },
+    "libnvvm_samples": {
+        "name": "NVVM library samples",
+        "license": "CUDA Toolkit",
+        "version": "12.0.94",
+        "linux-x86_64": {
+            "relative_path": "libnvvm_samples/linux-x86_64/libnvvm_samples-linux-x86_64-12.0.94-archive.tar.xz",
+            "sha256": "0f6bcdd9b883cdd8aa706adf1a7b6ffba89ce58ef0ba986ba6dc9d3301d14987",
+            "md5": "9c07aca7a08caa69da3fd6d8e46aaed0",
+            "size": "28988"
+        },
+        "linux-ppc64le": {
+            "relative_path": "libnvvm_samples/linux-ppc64le/libnvvm_samples-linux-ppc64le-12.0.94-archive.tar.xz",
+            "sha256": "38abed8bc9bf7d103e5d73db587a157dfbf9ef91b8c2d79d8d51c0c085d7d6f7",
+            "md5": "5d080ed2bd81e0e3c2c497203f76f189",
+            "size": "28992"
+        },
+        "linux-sbsa": {
+            "relative_path": "libnvvm_samples/linux-sbsa/libnvvm_samples-linux-sbsa-12.0.94-archive.tar.xz",
+            "sha256": "892d1e14eefe5d5ba4863575c767e016ac022002014acf87a2ec62e3e562ae09",
+            "md5": "3fd0884d42bd2c380e4c086f372d172c",
+            "size": "28900"
+        },
+        "windows-x86_64": {
+            "relative_path": "libnvvm_samples/windows-x86_64/libnvvm_samples-windows-x86_64-12.0.94-archive.zip",
+            "sha256": "e801c44c296f93e6c0a1fbb1815fac4e1d58be248bc5c3321ead5b02b825261d",
+            "md5": "ce6670a8312bc878f9dc1ad3c2680f28",
+            "size": "44383"
+        },
+        "linux-aarch64": {
+            "relative_path": "libnvvm_samples/linux-aarch64/libnvvm_samples-linux-aarch64-12.0.94-archive.tar.xz",
+            "sha256": "069111f6c03835e56795f3306c9a7406f036f734a4b92c4a6007d532e64be5df",
+            "md5": "a2ca1ffa02c9583ebe455c6481813cdb",
+            "size": "29000"
+        }
+    },
+    "nsight_compute": {
+        "name": "Nsight Compute",
+        "license": "NVIDIA SLA",
+        "version": "2022.4.0.15",
+        "linux-x86_64": {
+            "relative_path": "nsight_compute/linux-x86_64/nsight_compute-linux-x86_64-2022.4.0.15-archive.tar.xz",
+            "sha256": "f084e05eb4d2ba32aceb25e1dcfe03f2a50127630973722b65219cf9e986a139",
+            "md5": "5728a6b6f74c6fa7399c343f1c727f71",
+            "size": "704648508"
+        },
+        "linux-ppc64le": {
+            "relative_path": "nsight_compute/linux-ppc64le/nsight_compute-linux-ppc64le-2022.4.0.15-archive.tar.xz",
+            "sha256": "20e58ce79681bc8fd39394cfb8f8316c177fe4175af3ae95c025996f45904732",
+            "md5": "9e49ee03465ac3c0ba0df9063d664433",
+            "size": "181691528"
+        },
+        "linux-sbsa": {
+            "relative_path": "nsight_compute/linux-sbsa/nsight_compute-linux-sbsa-2022.4.0.15-archive.tar.xz",
+            "sha256": "7d0b3d4d01ce36657fa739496c7b0a9c627f5fa42021c1696ddd15e119bb05a4",
+            "md5": "50dbf4765e7faad5f5c3d4e0adde0d30",
+            "size": "341158648"
+        },
+        "windows-x86_64": {
+            "relative_path": "nsight_compute/windows-x86_64/nsight_compute-windows-x86_64-2022.4.0.15-archive.zip",
+            "sha256": "958da9986841c49cb5a2885d1e14e4c673ba94e4b404ef9389d083b7a0095d84",
+            "md5": "4aef8035c676ba89c4d27656c4a4f01e",
+            "size": "634477385"
+        },
+        "linux-aarch64": {
+            "relative_path": "nsight_compute/linux-aarch64/nsight_compute-linux-aarch64-2022.4.0.15-archive.tar.xz",
+            "sha256": "cdcf9b4cefdafbaacbcc2d3266537458fd3924d8a6fb67592605030d18954604",
+            "md5": "0b5b0f866f9331df8e59316719aaa2d1",
+            "size": "704209708"
+        }
+    },
+    "nsight_systems": {
+        "name": "Nsight Systems",
+        "license": "NVIDIA SLA",
+        "version": "2022.4.2.18",
+        "linux-x86_64": {
+            "relative_path": "nsight_systems/linux-x86_64/nsight_systems-linux-x86_64-2022.4.2.18-archive.tar.xz",
+            "sha256": "9f472990098a719bb8cc3136512e37eb99843c80c95560f9f8edfb2e50d9fa67",
+            "md5": "b490dfb944a6b8d4e0d12ca4b07b7492",
+            "size": "197472896"
+        },
+        "linux-ppc64le": {
+            "relative_path": "nsight_systems/linux-ppc64le/nsight_systems-linux-ppc64le-2022.4.2.18-archive.tar.xz",
+            "sha256": "6a45a64052c80db3ac99dff56bd415cc1c767d5bfb6fa97acf8081a9e793e94b",
+            "md5": "ad6bfa7fa72adf5324d0e2e75a3cec90",
+            "size": "53600240"
+        },
+        "linux-sbsa": {
+            "relative_path": "nsight_systems/linux-sbsa/nsight_systems-linux-sbsa-2022.4.2.18-archive.tar.xz",
+            "sha256": "7e1598d5a8eec9bd84c9276d36c5efe7eebf44e5cc308b08c8a6f985ca41e0e2",
+            "md5": "28be2fa20b9e90b9cf207d60cec75c4b",
+            "size": "187083996"
+        },
+        "windows-x86_64": {
+            "relative_path": "nsight_systems/windows-x86_64/nsight_systems-windows-x86_64-2022.4.2.18-archive.zip",
+            "sha256": "5984fd60fd80f6cb0073ab7bc5edc754bfa8412c77b1068dbd82da3abe73137e",
+            "md5": "78b945d4735790cecfe163031b39c16e",
+            "size": "729028336"
+        }
+    },
+    "nsight_vse": {
+        "name": "Nsight Visual Studio Edition (VSE)",
+        "license": "NVIDIA SLA",
+        "version": "2022.4.0.22322",
+        "windows-x86_64": {
+            "relative_path": "nsight_vse/windows-x86_64/nsight_vse-windows-x86_64-2022.4.0.22322-archive.zip",
+            "sha256": "d0452c1bb063482920040d1e1b4f3239bff2de238762c91176a101fb9c748bf8",
+            "md5": "9a6d042c20eef6349e2e621c2a218086",
+            "size": "536307565"
+        }
+    },
+    "nvidia_driver": {
+        "name": "NVIDIA Linux Driver",
+        "license": "NVIDIA Driver",
+        "version": "525.60.13",
+        "linux-x86_64": {
+            "relative_path": "nvidia_driver/linux-x86_64/nvidia_driver-linux-x86_64-525.60.13-archive.tar.xz",
+            "sha256": "a42691822f6e87060da5682a8e0662c86d1b20fbf31d12cb2969b819995e4138",
+            "md5": "ad2972799f4ebf292e8642c28c83127d",
+            "size": "417069508"
+        },
+        "linux-ppc64le": {
+            "relative_path": "nvidia_driver/linux-ppc64le/nvidia_driver-linux-ppc64le-525.60.13-archive.tar.xz",
+            "sha256": "4ad08f8431195580349f4984fae2d93697d2f5572837c1e7ae59c37feab291c8",
+            "md5": "b38a21c5dd06e56a6dcf840cfeb5b82a",
+            "size": "97903116"
+        },
+        "linux-sbsa": {
+            "relative_path": "nvidia_driver/linux-sbsa/nvidia_driver-linux-sbsa-525.60.13-archive.tar.xz",
+            "sha256": "1708ae3ba857559cbfc4e6c06267ed6126eff2c68fa5321a95906f50e984148c",
+            "md5": "78379197e219d8172a3e9e1cc0de81e3",
+            "size": "268660720"
+        }
+    },
+    "nvidia_fs": {
+        "name": "NVIDIA filesystem",
+        "license": "CUDA Toolkit",
+        "version": "2.14.12",
+        "linux-x86_64": {
+            "relative_path": "nvidia_fs/linux-x86_64/nvidia_fs-linux-x86_64-2.14.12-archive.tar.xz",
+            "sha256": "12a2a04b4cd0b6f9d502556694594e122e22cc1effc7fa359308dbe405732bc2",
+            "md5": "f47d9f5415c50ddb41d87b58b218c277",
+            "size": "57124"
+        },
+        "linux-aarch64": {
+            "relative_path": "nvidia_fs/linux-aarch64/nvidia_fs-linux-aarch64-2.14.12-archive.tar.xz",
+            "sha256": "c90434ff603a74a4966bce28b0152b383b0c6f48b2e935c4194db5d3ceaa2f77",
+            "md5": "1bb76127d950212d9450f259f2012825",
+            "size": "57112"
+        }
+    },
+    "visual_studio_integration": {
+        "name": "CUDA Visual Studio Integration",
+        "license": "CUDA Toolkit",
+        "version": "12.0.76",
+        "windows-x86_64": {
+            "relative_path": "visual_studio_integration/windows-x86_64/visual_studio_integration-windows-x86_64-12.0.76-archive.zip",
+            "sha256": "ef81457b08ef6b03899cb08433b1be4043cdf2c69386fc0d45ba55f9c3b36db2",
+            "md5": "1f048a3cb028e3c50b91823d7211fc63",
+            "size": "544915"
+        }
+    }
+}

--- a/pkgs/development/compilers/cudatoolkit/versions.toml
+++ b/pkgs/development/compilers/cudatoolkit/versions.toml
@@ -71,3 +71,13 @@ version = "11.8.0"
 url = "https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run"
 sha256 = "sha256-kiPErzrr5Ke77Zq9mxY7A6GzS4VfvCtKDRtwasCaWhY="
 gcc = "gcc11"
+
+["12.0"]
+version = "12.0.0"
+url = "https://developer.download.nvidia.com/compute/cuda/12.0.0/local_installers/cuda_12.0.0_525.60.13_linux.run"
+sha256 = "sha256-kF6blRaQCDn7dgZHGdt1JDnzi4y3MLSTNdi9U93605I="
+# CUDA 12 is compatible with gcc12, but nixpkgs default gcc is still on gcc11 as
+# of 2023-01-08. See https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements.
+# This should be upgraded to gcc12 once nixpkgs default gcc is upgraded. Other
+# CUDA versions should likely have their gcc versions upgraded as well.
+gcc = "gcc11"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6185,6 +6185,12 @@ with pkgs;
   cudaPackages_11_7 = callPackage ./cuda-packages.nix { cudaVersion = "11.7"; };
   cudaPackages_11_8 = callPackage ./cuda-packages.nix { cudaVersion = "11.8"; };
   cudaPackages_11 = cudaPackages_11_7;
+
+  cudaPackages_12_0 = callPackage ./cuda-packages.nix { cudaVersion = "12.0"; };
+  cudaPackages_12 = cudaPackages_12_0;
+
+  # TODO: try upgrading once there is a cuDNN release supporting CUDA 12. No
+  # such cuDNN release as of 2023-01-10.
   cudaPackages = recurseIntoAttrs cudaPackages_11;
 
   # TODO: move to alias


### PR DESCRIPTION
###### Description of changes

Add the recently released CUDA 12. Unfortunately, there is not a compatible cuDNN version released at the moment. I attempted to get it build with cuDNN 8.6.0, the latest upstream and in nixpkgs, but that failed since those cuDNN libraries look for `*.so.11` CUDA libraries, so our RUNPATH patching step fails (as it should). Still, handy to have this packaged, and will be useful in the future once compatible cuDNN versions are released.

cc @NixOS/cuda-maintainers 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
