### PR TITLE
nss_esr: 3.79.2 -> 3.79.3

### DIFF
--- a/pkgs/development/libraries/nss/esr.nix
+++ b/pkgs/development/libraries/nss/esr.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "3.79.2";
-  hash = "sha256-hwcHDI74CgYp2vhQyKspKQ6T/O55f6g/cZvb9z1np4E=";
+  version = "3.79.3";
+  hash = "sha256-8fhrlMe832xWYTYVMnZE7MV20W8sMX+5hHDcAcWYSA4=";
 }

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -103,11 +103,14 @@ stdenv.mkDerivation rec {
       runHook postBuild
     '';
 
-  NIX_CFLAGS_COMPILE =
-    "-Wno-error -DNIX_NSS_LIBDIR=\"${placeholder "out"}/lib/\" "
-    + lib.optionalString stdenv.hostPlatform.is64bit "-DNSS_USE_64=1"
-    + lib.optionalString stdenv.hostPlatform.isILP32 " -DNS_PTR_LE_32=1" # See RNG_RandomUpdate() in drdbg.c
-  ;
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error"
+    "-DNIX_NSS_LIBDIR=\"${placeholder "out"}/lib/\""
+  ] ++ lib.optionals stdenv.hostPlatform.is64bit [
+    "-DNSS_USE_64=1"
+  ] ++ lib.optionals stdenv.hostPlatform.isILP32 [
+    "-DNS_PTR_LE_32=1" # See RNG_RandomUpdate() in drdbg.c
+  ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
###### Description of changes
Contains  #208704

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).