### PR TITLE
ruby: 2.7.6 -> 2.7.7, 3.0.4 -> 3.0.5, 3.1.2 -> 3.1.3

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -261,8 +261,8 @@ in {
   mkRuby = generic;
 
   ruby_2_7 = generic {
-    version = rubyVersion "2" "7" "6" "";
-    sha256 = "042xrdk7hsv4072bayz3f8ffqh61i8zlhvck10nfshllq063n877";
+    version = rubyVersion "2" "7" "7" "";
+    sha256 = "sha256-4QEn22kdf/NkAs/oj0GMjQJaPx7qkgRLFi3XLwuMe5A=";
   };
 
   ruby_3_0 = generic {

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -266,8 +266,8 @@ in {
   };
 
   ruby_3_0 = generic {
-    version = rubyVersion "3" "0" "4" "";
-    sha256 = "0avj4g3s2839b2y4m6pk8kid74r8nj7k0qm2rsdcwjzhg8h7rd3h";
+    version = rubyVersion "3" "0" "5" "";
+    sha256 = "sha256-mvxjgKAnpP4a4aPi7MtrSXucWsBjHBLKVvm3vrSEh3Y=";
   };
 
   ruby_3_1 = generic {

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -271,7 +271,7 @@ in {
   };
 
   ruby_3_1 = generic {
-    version = rubyVersion "3" "1" "2" "";
-    sha256 = "0gm84ipk6mrfw94852w5h7xxk2lqrxjbnlwb88svf0lz70933131";
+    version = rubyVersion "3" "1" "3" "";
+    sha256 = "sha256-XqSYo19M0Vh1IApS3eQrbrF54SZOF9eHMsOlfNHGq54=";
   };
 }

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -1,12 +1,11 @@
 { patchSet, useRailsExpress, ops, patchLevel, fetchpatch }:
 
 {
-  "2.7.6" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/01-fix-with-openssl-dir-option.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/02-fix-broken-tests-caused-by-ad.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/03-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/04-more-detailed-stacktrace.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/05-malloc-trim.patch"
+  "2.7.7" = ops useRailsExpress [
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch"
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/02-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/03-more-detailed-stacktrace.patch"
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/04-malloc-trim.patch"
   ];
   "3.0.4" = ops useRailsExpress [
     "${patchSet}/patches/ruby/3.0/head/railsexpress/01-fix-with-openssl-dir-option.patch"

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -11,7 +11,7 @@
     "${patchSet}/patches/ruby/3.0/head/railsexpress/01-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/3.0/head/railsexpress/02-malloc-trim.patch"
   ];
-  "3.1.2" = ops useRailsExpress [
+  "3.1.3" = ops useRailsExpress [
     "${patchSet}/patches/ruby/3.1/head/railsexpress/01-improve-gc-stats.patch"
     "${patchSet}/patches/ruby/3.1/head/railsexpress/02-malloc-trim.patch"
   ];

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -7,10 +7,9 @@
     "${patchSet}/patches/ruby/2.7/head/railsexpress/03-more-detailed-stacktrace.patch"
     "${patchSet}/patches/ruby/2.7/head/railsexpress/04-malloc-trim.patch"
   ];
-  "3.0.4" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/01-fix-with-openssl-dir-option.patch"
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/03-malloc-trim.patch"
+  "3.0.5" = ops useRailsExpress [
+    "${patchSet}/patches/ruby/3.0/head/railsexpress/01-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/3.0/head/railsexpress/02-malloc-trim.patch"
   ];
   "3.1.2" = ops useRailsExpress [
     "${patchSet}/patches/ruby/3.1/head/railsexpress/01-improve-gc-stats.patch"


### PR DESCRIPTION
###### Description of changes

https://www.ruby-lang.org/en/news/2022/11/24/ruby-2-7-7-released/
https://www.ruby-lang.org/en/news/2022/11/24/ruby-3-0-5-released/
https://www.ruby-lang.org/en/news/2022/11/24/ruby-3-1-3-released/

This is an update to https://github.com/NixOS/nixpkgs/pull/202772, which @marsam closed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
