### PR TITLE
smlfmt: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9740,6 +9740,16 @@
     githubId = 5047140;
     name = "Victor Collod";
   };
+  munksgaard = {
+    name = "Philip Munksgaard";
+    email = "philip@munksgaard.me";
+    github = "munksgaard";
+    githubId = 230613;
+    matrix = "@philip:matrix.munksgaard.me";
+    keys = [{
+      fingerprint = "5658 4D09 71AF E45F CC29 6BD7 4CE6 2A90 EFC0 B9B2";
+    }];
+  };
   muscaln = {
     email = "muscaln@protonmail.com";
     github = "muscaln";

--- a/pkgs/development/tools/smlfmt/default.nix
+++ b/pkgs/development/tools/smlfmt/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, mlton }:
+
+stdenv.mkDerivation rec {
+  pname = "smlfmt";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "shwestrick";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-7CTfMiEvuOena5SOE0qKpFPq6ARxmkE6d+loznZNbC0=";
+  };
+
+  nativeBuildInputs = [ mlton ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 -t $out/bin smlfmt
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A custom parser/auto-formatter for Standard ML";
+    longDescription = ''
+      A custom parser and code formatter for Standard ML, with helpful error messages.
+
+      Supports SML source files (.sml, .sig, .fun, etc.) as well as MLBasis
+      compilation files (.mlb) using MLton conventions, including MLBasis path
+      maps.
+    '';
+
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ munksgaard ];
+    platforms = mlton.meta.platforms;
+    homepage = "https://github.com/shwestrick/smlfmt";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15591,6 +15591,8 @@ with pkgs;
 
   shmig = callPackage ../development/tools/database/shmig { };
 
+  smlfmt = callPackage ../development/tools/smlfmt { };
+
   # smlnjBootstrap should be redundant, now that smlnj works on Darwin natively
   smlnjBootstrap = callPackage ../development/compilers/smlnj/bootstrap.nix { };
   smlnj = callPackage ../development/compilers/smlnj {


### PR DESCRIPTION
###### Description of changes

Add smlfmt, a source code formatter for Standard ML source files.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
