### PR TITLE
eduvpn-client: init at 3.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7707,6 +7707,12 @@
     githubId = 845652;
     name = "Kier Davis";
   };
+  kilianar = {
+    email = "nix@kilianar.de";
+    github = "kilianar";
+    githubId = 105428155;
+    name = "kilianar";
+  };
   kilimnik = {
     email = "mail@kilimnik.de";
     github = "kilimnik";

--- a/pkgs/development/python-modules/eduvpn-client/0001-remove-pytest-runner.patch
+++ b/pkgs/development/python-modules/eduvpn-client/0001-remove-pytest-runner.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index f35017d..60bd4d5 100644
+--- a/setup.py
++++ b/setup.py
+@@ -73,7 +73,6 @@ setup(
+     long_description=long_description,
+     long_description_content_type="text/markdown",
+     license="GPL3",
+-    setup_requires=['pytest-runner'],
+     tests_require=tests_require,
+     test_suite="tests",
+     keywords="vpn openvpn networking security",

--- a/pkgs/development/python-modules/eduvpn-client/default.nix
+++ b/pkgs/development/python-modules/eduvpn-client/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, buildPythonPackage
+, dbus-python
+, fetchFromGitHub
+, gdk-pixbuf
+, gobject-introspection
+, gtk3
+, libnotify
+, networkmanager
+, pygobject3
+, pytest-runner
+, pynacl
+, pytestCheckHook
+, requests_oauthlib
+, setuptools
+, wrapGAppsHook
+}:
+
+buildPythonPackage rec {
+  pname = "eduvpn-client";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "eduvpn";
+    repo = "python-${pname}";
+    rev = version;
+    hash = "sha256-dCVCXCPw0PCE0d6KPmuhv/V4WVQS+ucQbWoR0Lx5TDk=";
+  };
+
+  dontWrapGApps = true;
+
+  nativeBuildInputs = [
+    gdk-pixbuf
+    gobject-introspection
+    wrapGAppsHook
+  ];
+
+  patches = [
+    ./0001-remove-pytest-runner.patch
+  ];
+
+  buildInputs = [
+    gtk3
+    libnotify
+    networkmanager
+  ];
+
+  propagatedBuildInputs = [
+    dbus-python
+    pygobject3
+    pynacl
+    requests_oauthlib
+    setuptools
+  ];
+
+  postPatch = ''
+    substituteInPlace eduvpn/utils.py \
+      --replace "/usr/local" "$out"
+  '';
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}");
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    changelog = "https://raw.githubusercontent.com/eduvpn/python-eduvpn-client/${version}/CHANGES.md";
+    description = "Linux client and Python client API for eduVPN";
+    homepage = "https://eduvpn.org";
+    license = licenses.gpl3;
+    mainProgram = "eduvpn-gui";
+    maintainers = with maintainers; [ kilianar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1409,6 +1409,8 @@ with pkgs;
 
   copier = callPackage ../tools/misc/copier { };
 
+  eduvpn-client = with python3Packages; toPythonApplication eduvpn-client;
+
   gamemode = callPackage ../tools/games/gamemode {
     libgamemode32 = pkgsi686Linux.gamemode.lib;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2943,6 +2943,8 @@ self: super: with self; {
     inherit (pkgs) edlib;
   };
 
+  eduvpn-client = callPackage ../development/python-modules/eduvpn-client { };
+
   edward = callPackage ../development/python-modules/edward { };
 
   effect = callPackage ../development/python-modules/effect { };


### PR DESCRIPTION
###### Description of changes
Add eduvpn, a Linux client and Python client API for [eduVPN](https://www.eduvpn.org/).

- [GitHub project](https://github.com/eduvpn/python-eduvpn-client)
- [3.1.0 Release on GitHub](https://github.com/eduvpn/python-eduvpn-client/releases/tag/3.1.0)

I tested the application with the vpn of my university and everything worked fine.



There was a previous attempt to get this into nixpkgs with #36122, but the pr was closed by the author (@leenaars).


###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).