### PR TITLE
ruby: Fix withPackages on darwin with makeBinaryWrapper

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -3,7 +3,7 @@
 , zlib, gdbm, ncurses, readline, groff, libyaml, libffi, jemalloc, autoreconfHook, bison
 , autoconf, libiconv, libobjc, libunwind, Foundation
 , buildEnv, bundler, bundix
-, makeWrapper, buildRubyGem, defaultGemConfig, removeReferencesTo
+, makeBinaryWrapper, buildRubyGem, defaultGemConfig, removeReferencesTo
 , openssl, openssl_1_1
 } @ args:
 
@@ -47,7 +47,7 @@ let
       , autoreconfHook, bison, autoconf
       , buildEnv, bundler, bundix
       , libiconv, libobjc, libunwind, Foundation
-      , makeWrapper, buildRubyGem, defaultGemConfig
+      , makeBinaryWrapper, buildRubyGem, defaultGemConfig
       , baseRuby ? buildPackages.ruby_3_1.override {
           useRailsExpress = false;
           docSupport = false;
@@ -245,7 +245,7 @@ let
           };
 
           inherit (import ../../ruby-modules/with-packages {
-            inherit lib stdenv makeWrapper buildRubyGem buildEnv;
+            inherit lib stdenv makeBinaryWrapper buildRubyGem buildEnv;
             gemConfig = defaultGemConfig;
             ruby = self;
           }) withPackages buildGems gems;

--- a/pkgs/development/ruby-modules/with-packages/default.nix
+++ b/pkgs/development/ruby-modules/with-packages/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildEnv, buildRubyGem, ruby, gemConfig, makeWrapper }:
+{ stdenv, lib, buildEnv, buildRubyGem, ruby, gemConfig, makeBinaryWrapper }:
 
 /*
 Example usage:
@@ -43,7 +43,7 @@ let
 
       wrappedRuby = stdenv.mkDerivation {
         name = "wrapped-${ruby.name}";
-        nativeBuildInputs = [ makeWrapper ];
+        nativeBuildInputs = [ makeBinaryWrapper ];
         buildCommand = ''
           mkdir -p $out/bin
           for i in ${ruby}/bin/*; do
@@ -54,7 +54,7 @@ let
 
     in stdenv.mkDerivation {
       name = "${ruby.name}-with-packages";
-      nativeBuildInputs = [ makeWrapper ];
+      nativeBuildInputs = [ makeBinaryWrapper ];
       buildInputs = [ selected ruby ];
 
       dontUnpack = true;

--- a/pkgs/development/ruby-modules/with-packages/test.nix
+++ b/pkgs/development/ruby-modules/with-packages/test.nix
@@ -15,6 +15,22 @@ let
       pkgs.ruby.gems) //
     (import ./require_exceptions.nix);
 
+  testWrapper = ruby: stdenv.mkDerivation {
+    name = "test-wrappedRuby-${ruby.name}";
+    buildInputs = [ ((ruby.withPackages (ps: [ ])).wrappedRuby) ];
+    buildCommand = ''
+      cat <<'EOF' > test-ruby
+      #!/usr/bin/env ruby
+      puts RUBY_VERSION
+      EOF
+
+      chmod +x test-ruby
+      patchShebangs test-ruby
+      [[ $(./test-ruby) = $(${ruby}/bin/ruby test-ruby) ]]
+      touch $out
+    '';
+  };
+
   tests = ruby:
     lib.mapAttrs (name: gem:
       let
@@ -39,7 +55,7 @@ let
 in
   stdenv.mkDerivation {
     name = "test-all-ruby-gems";
-    buildInputs = builtins.foldl' (sum: ruby: sum ++ ( builtins.attrValues (tests ruby) )) [] rubyVersions;
+    buildInputs = builtins.foldl' (sum: ruby: sum ++ [ (testWrapper ruby) ] ++ ( builtins.attrValues (tests ruby) )) [] rubyVersions;
     buildCommand = ''
       touch $out
     '';


### PR DESCRIPTION
###### Description of changes

See also https://github.com/NixOS/nixpkgs/pull/161298

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

#### nixpkgs-review result
```
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
From https://github.com/NixOS/nixpkgs
   c07552f6f7d..851558501d2  master     -> refs/nixpkgs-review/0
$ git worktree add /home/user/.cache/nixpkgs-review/rev-baf1f1293b289ce53d9b660465cd68e1a3e00b96/nixpkgs 851558501d28bd3117010f71cd1afc7684394849
Preparing worktree (detached HEAD 851558501d2)
Updating files: 100% (33158/33158), done.
HEAD is now at 851558501d2 Merge pull request #210162 from r-ryantm/auto-update/cargo-geiger
$ nix-env --option system x86_64-linux -f /home/user/.cache/nixpkgs-review/rev-baf1f1293b289ce53d9b660465cd68e1a3e00b96/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit --no-ff baf1f1293b289ce53d9b660465cd68e1a3e00b96
Automatic merge went well; stopped before committing as requested
When finished, apply stashed changes with `git stash pop`
$ nix-env --option system x86_64-linux -f /home/user/.cache/nixpkgs-review/rev-baf1f1293b289ce53d9b660465cd68e1a3e00b96/nixpkgs -qaP --xml --out-path --show-trace --meta
2 packages updated:
snmpcheck taoup

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/user/.cache/nixpkgs-review/rev-baf1f1293b289ce53d9b660465cd68e1a3e00b96/build.nix
2 packages built:
snmpcheck taoup
```