### PR TITLE
vdirsyncer: fix Google integration

### DIFF
--- a/pkgs/development/python-modules/aiohttp-oauthlib/default.nix
+++ b/pkgs/development/python-modules/aiohttp-oauthlib/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, oauthlib
+, aiohttp
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "aiohttp-oauthlib";
+  version = "0.1.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-iTzRpZ3dDC5OmA46VE+XELfE/7nie0zQOLUf4dcDk7c=";
+  };
+
+  propagatedBuildInputs = [
+    oauthlib
+    aiohttp
+  ];
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  # Package has no tests.
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://git.sr.ht/~whynothugo/aiohttp-oauthlib";
+    description = "oauthlib integration for aiohttp clients";
+    license = licenses.isc;
+    maintainers = with maintainers; [ sumnerevans ];
+  };
+}

--- a/pkgs/development/python-modules/vdirsyncer/default.nix
+++ b/pkgs/development/python-modules/vdirsyncer/default.nix
@@ -13,6 +13,7 @@
 , pytest-subtesthack
 , setuptools-scm
 , aiostream
+, aiohttp-oauthlib
 , aiohttp
 , pytest-asyncio
 , trustme
@@ -49,6 +50,7 @@ buildPythonPackage rec {
     requests-toolbelt
     aiostream
     aiohttp
+    aiohttp-oauthlib
   ];
 
   nativeBuildInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -198,6 +198,8 @@ self: super: with self; {
 
   aiohttp-jinja2 = callPackage ../development/python-modules/aiohttp-jinja2 { };
 
+  aiohttp-oauthlib = callPackage ../development/python-modules/aiohttp-oauthlib { };
+
   aiohttp-openmetrics = callPackage ../development/python-modules/aiohttp-openmetrics { };
 
   aiohttp-remotes = callPackage ../development/python-modules/aiohttp-remotes { };


### PR DESCRIPTION
###### Description of changes

Packages https://pypi.org/project/aiohttp-oauthlib/ which is now a dependency of [vdirsyncer](https://github.com/pimutils/vdirsyncer) if you want the Google integration to work. Without this, if you try to use the Google integration, vdirsyncer crashes and doesn't sync any events.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

I tested that it actually syncs the Google events now.

-----

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>khal</li>
    <li>python310Packages.aiohttp-oauthlib</li>
    <li>vdirsyncer (python310Packages.vdirsyncer)</li>
    <li>python39Packages.aiohttp-oauthlib</li>
    <li>python39Packages.vdirsyncer</li>
  </ul>
</details>

-----

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
