### PR TITLE
errbot: using slixmpp

### DIFF
--- a/pkgs/applications/networking/errbot/default.nix
+++ b/pkgs/applications/networking/errbot/default.nix
@@ -39,7 +39,7 @@ in python3.pkgs.buildPythonApplication rec {
     pyopenssl
     requests
     slackclient
-    sleekxmpp
+    slixmpp
     telegram
     webtest
   ];


### PR DESCRIPTION
errbot is using slixmpp instead of sleekxmpp since v6.1.5

###### Description of changes

[](https://errbot.readthedocs.io/en/latest/changes.html#v6-1-5-2020-10-10)
