### PR TITLE
katago: 1.11.0 -> 1.12.3

### DIFF
--- a/pkgs/development/libraries/science/math/tensorrt/extension.nix
+++ b/pkgs/development/libraries/science/math/tensorrt/extension.nix
@@ -29,22 +29,60 @@ final: prev: let
       else throw "tensorrt-${tensorRTDefaultVersion} does not support your cuda version ${cudaVersion}"; };
   in allBuilds // defaultBuild;
 
+  tarballURL = {fullVersion, fileVersionCuda, fileVersionCudnn} : "TensorRT-${fullVersion}.Linux.x86_64-gnu.cuda-${fileVersionCuda}.cudnn${fileVersionCudnn}.tar.gz";
+
   tensorRTVersions = {
+    "8.5.2" = [
+      rec {
+        fileVersionCuda = "11.8";
+        fileVersionCudnn = "8.6";
+        fullVersion = "8.5.2.2";
+        sha256 = "sha256-Ov5irNS/JETpEz01FIFNMs9YVmjGHL7lSXmDpgCdgao=";
+        tarball = tarballURL {inherit fileVersionCuda fileVersionCudnn fullVersion;};
+        supportedCudaVersions = [ "11.0" "11.1" "11.2" "11.3" "11.4" "11.5" "11.6" "11.7" "11.8" ];
+      }
+      rec {
+        fileVersionCuda = "10.2";
+        fileVersionCudnn = "8.6";
+        fullVersion = "8.5.2.2";
+        sha256 = "sha256-UruwQShYcHLY5d81lKNG7XaoUsZr245c+PUpUN6pC5E=";
+        tarball = tarballURL {inherit fileVersionCuda fileVersionCudnn fullVersion;};
+        supportedCudaVersions = [ "10.2" ];
+      }
+    ];
+    "8.5.1" = [
+      rec {
+        fileVersionCuda = "11.8";
+        fileVersionCudnn = "8.6";
+        fullVersion = "8.5.1.7";
+        sha256 = "sha256-Ocx/B3BX0TY3lOj/UcTPIaXb7M8RFrACC6Da4PMGMHY=";
+        tarball = tarballURL {inherit fileVersionCuda fileVersionCudnn fullVersion;};
+        supportedCudaVersions = [ "11.0" "11.1" "11.2" "11.3" "11.4" "11.5" "11.6" "11.7" "11.8" ];
+      }
+      rec {
+        fileVersionCuda = "10.2";
+        fileVersionCudnn = "8.6";
+        fullVersion = "8.5.1.7";
+        sha256 = "sha256-CcFGJhw7nFdPnSYYSxcto2MHK3F84nLQlJYjdIw8dPM=";
+        tarball = tarballURL {inherit fileVersionCuda fileVersionCudnn fullVersion;};
+        supportedCudaVersions = [ "10.2" ];
+      }
+    ];
     "8.4.0" = [
       rec {
         fileVersionCuda = "11.6";
         fileVersionCudnn = "8.3";
         fullVersion = "8.4.0.6";
         sha256 = "sha256-DNgHHXF/G4cK2nnOWImrPXAkOcNW6Wy+8j0LRpAH/LQ=";
-        tarball = "TensorRT-${fullVersion}.Linux.x86_64-gnu.cuda-${fileVersionCuda}.cudnn${fileVersionCudnn}.tar.gz";
-        supportedCudaVersions = [ "11.0" "11.1" "11.2" "11.3" "11.4" "11.5" "11.6" "11.7" ];
+        tarball = tarballURL {inherit fileVersionCuda fileVersionCudnn fullVersion;};
+        supportedCudaVersions = [ "11.0" "11.1" "11.2" "11.3" "11.4" "11.5" "11.6" ];
       }
       rec {
         fileVersionCuda = "10.2";
         fileVersionCudnn = "8.3";
         fullVersion = "8.4.0.6";
         sha256 = "sha256-aCzH0ZI6BrJ0v+e5Bnm7b8mNltA7NNuIa8qRKzAQv+I=";
-        tarball = "TensorRT-${fullVersion}.Linux.x86_64-gnu.cuda-${fileVersionCuda}.cudnn${fileVersionCudnn}.tar.gz";
+        tarball = tarballURL {inherit fileVersionCuda fileVersionCudnn fullVersion;};
         supportedCudaVersions = [ "10.2" ];
       }
     ];
@@ -60,7 +98,8 @@ final: prev: let
     "11.4" = "8.4.0";
     "11.5" = "8.4.0";
     "11.6" = "8.4.0";
-    "11.7" = "8.4.0";
+    "11.7" = "8.5.2";
+    "11.8" = "8.5.2";
   }.${cudaVersion} or "8.4.0";
 
 in tensorRTPackages

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34668,11 +34668,15 @@ with pkgs;
   katago = callPackage ../games/katago { };
 
   katagoWithCuda = katago.override {
-    enableCuda = true;
+    backend = "cuda";
   };
 
   katagoCPU = katago.override {
-    enableGPU = false;
+    backend = "eigen";
+  };
+
+  katagoTensorRT = katago.override {
+    backend = "tensorrt";
   };
 
   klavaro = callPackage ../games/klavaro { };


### PR DESCRIPTION
###### Description of changes

Added TensorRT backend, refactored backend selection, **IMPORTANT** also bumps TensorRT version to 8.5.2 for CUDA 11.7 and 11.8.  (Per Nvidia's documentation, 8.4.0.6 does not officially support 11.7, but we're using it for it.  Additionally, KataGo requires 8.5 or better for the new TensorRT backend.  8.4.0.6 remains the default for 11.6 and lower, in interest of not messing things up as much as possible.)

New version also adds support for nested residual block networks, such as the b18 network that was used in the UEC.

I anticipate the changes to TensorRT being somewhat controversial and/or wrong.  Please let me know how to make it better.  While I have verified the sha256 sums for each of the four versions I added, I've only attempted building against 8.5.2 for Cuda 11.

Also updated the wiki page: https://nixos.wiki/wiki/Katago

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
