### PR TITLE
cargo: fix cross-compilation by adding missing zlib dependency

### DIFF
--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -26,6 +26,7 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     pkg-config cmake installShellFiles makeWrapper
     (lib.getDev pkgsHostHost.curl)
+    zlib
   ];
   buildInputs = [ cacert file curl python3 openssl zlib ]
     ++ lib.optionals stdenv.isDarwin [ CoreFoundation Security ];


### PR DESCRIPTION
Previously it was failing with:

   Compiling cargo v0.67.1 (/build/rustc-1.66.1-src/src/tools/cargo)
error: linking with `/nix/store/gcc-wrapper-11.3.0/bin/cc` failed: exit status: 1
  |
  = note: /nix/store/binutils-2.39/bin/ld: skipping incompatible /nix/store/zlib-aarch64-unknown-linux-gnu-1.2.13/lib/libz.so when searching for -lz
          /nix/store/binutils-2.39/bin/ld: cannot find -lz: No such file or directory
          /nix/store/binutils-2.39/bin/ld: skipping incompatible /nix/store/zlib-aarch64-unknown-linux-gnu-1.2.13/lib/libz.so when searching for -lz
          collect2: error: ld returned 1 exit status

###### Description of changes

Add zlib dependency as nativeBuildInput for cargo, since it appears it's needed.

No idea if this should still go in the cycle (https://github.com/NixOS/nixpkgs/pull/209180), let's discuss.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux (cross-compiled from aarch64-multiplatform)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

