### PR TITLE
locate-dominating-file: init 0.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12235,6 +12235,12 @@
     githubId = 710906;
     name = "Roel van Dijk";
   };
+  roman = {
+    email = "open-source@roman-gonzalez.info";
+    github = "roman";
+    githubId = 7335;
+    name = "Roman Gonzalez";
+  };
   romildo = {
     email = "malaquias@gmail.com";
     github = "romildo";

--- a/pkgs/tools/misc/locate-dominating-file/default.nix
+++ b/pkgs/tools/misc/locate-dominating-file/default.nix
@@ -1,0 +1,56 @@
+{ bats
+, bash
+, fetchFromGitHub
+, lib
+, stdenvNoCC
+, getopt
+}:
+let
+  version = "0.0.1";
+in
+stdenvNoCC.mkDerivation {
+  pname = "locate-dominating-file";
+  inherit version;
+  src = fetchFromGitHub {
+    owner = "roman";
+    repo = "locate-dominating-file";
+    rev = "v${version}";
+    sha256 = "sha256-gwh6fAw7BV7VFIkQN02QIhK47uxpYheMk64UeLyp2IY=";
+  };
+
+  doCheck = true;
+
+  postPatch = ''
+    for file in $(find src tests -type f); do
+      patchShebangs "$file"
+    done
+  '';
+
+  buildInputs = [ getopt ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp src/locate-dominating-file.sh $out/bin/locate-dominating-file
+
+    runHook postInstall
+  '';
+
+  checkInputs = [ (bats.withLibraries (p: [ p.bats-support p.bats-assert ])) ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    bats -t tests
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "Program that looks up in a directory hierarchy for a given filename";
+    license = licenses.mit;
+    maintainers = [ maintainers.roman ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38682,6 +38682,8 @@ with pkgs;
 
   tuner = callPackage ../applications/audio/tuner { };
 
+  locate-dominating-file = callPackage ../tools/misc/locate-dominating-file { };
+
   jfrog-cli = callPackage ../tools/misc/jfrog-cli { };
 
   ov = callPackage ../tools/text/ov { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This simple bash script utility allows bash developers to look up a specific file in the directory hierarchy. This tool becomes handy when searching for specific files like `.envrc` or `.git,` etc.

The name is inspired by the [`locate-dominating-file` elisp function](https://www.gnu.org/software/emacs/manual/html_node/elisp/Contents-of-Directories.html#index-locate_002ddominating_002dfile).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
