### PR TITLE
gawk: unconditionally apply the patch to fix PIE linkage on musl

### DIFF
--- a/pkgs/tools/text/gawk/default.nix
+++ b/pkgs/tools/text/gawk/default.nix
@@ -16,7 +16,7 @@
 
 assert (doCheck && stdenv.isLinux) -> glibcLocales != null;
 
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation rec {
   pname = "gawk" + lib.optionalString interactive "-interactive";
   version = "5.2.1";
 
@@ -31,13 +31,19 @@ stdenv.mkDerivation (rec {
     ./darwin-no-pma.patch
   ];
 
+  # PIE is incompatible with the "persistent malloc" ("pma") feature.
+  # While build system attempts to pass -no-pie to gcc. nixpkgs' `ld`
+  # wrapped still passes `-pie` flag to linker and breaks linkage.
+  # Let's disable "pie" until `ld` is fixed to do the right thing.
+  hardeningDisable = [ "pie" ];
+
   # When we do build separate interactive version, it makes sense to always include man.
   outputs = [ "out" "info" ]
     ++ lib.optional (!interactive) "man";
 
-  nativeBuildInputs = lib.optional (doCheck && stdenv.isLinux) glibcLocales
-    # no-pma fix
-    ++ [ autoreconfHook ];
+  # no-pma fix
+  nativeBuildInputs = [ autoreconfHook ]
+    ++ lib.optional (doCheck && stdenv.isLinux) glibcLocales;
 
   buildInputs = lib.optional withSigsegv libsigsegv
     ++ lib.optional interactive readline
@@ -83,8 +89,4 @@ stdenv.mkDerivation (rec {
     platforms = platforms.unix ++ platforms.windows;
     maintainers = [ ];
   };
-} // lib.optionalAttrs stdenv.hostPlatform.isMusl {
-  # PIE is incompatible with the "persistent malloc" ("pma") feature.
-  # FIXME: make unconditional in staging (added to avoid rebuilds in staging-next)
-  hardeningDisable = [ "pie" ];
-})
+}


### PR DESCRIPTION
Related: https://github.com/NixOS/nixpkgs/pull/210124

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
