### PR TITLE
larynx: init at 0.0.2

### DIFF
--- a/pkgs/development/python-modules/espeak-phonemizer/cdll.patch
+++ b/pkgs/development/python-modules/espeak-phonemizer/cdll.patch
@@ -1,0 +1,21 @@
+diff --git a/espeak_phonemizer/__init__.py b/espeak_phonemizer/__init__.py
+index a09472e..730a7f9 100644
+--- a/espeak_phonemizer/__init__.py
++++ b/espeak_phonemizer/__init__.py
+@@ -163,14 +163,10 @@ class Phonemizer:
+             # Already initialized
+             return
+ 
+-        self.libc = ctypes.cdll.LoadLibrary("libc.so.6")
++        self.libc = ctypes.cdll.LoadLibrary("@libc@")
+         self.libc.open_memstream.restype = ctypes.POINTER(ctypes.c_char)
+ 
+-        try:
+-            self.lib_espeak = ctypes.cdll.LoadLibrary("libespeak-ng.so")
+-        except OSError:
+-            # Try .so.1
+-            self.lib_espeak = ctypes.cdll.LoadLibrary("libespeak-ng.so.1")
++        self.lib_espeak = ctypes.cdll.LoadLibrary("@libespeak_ng@")
+ 
+         sample_rate = self.lib_espeak.espeak_Initialize(
+             Phonemizer.AUDIO_OUTPUT_SYNCHRONOUS, 0, None, 0

--- a/pkgs/development/python-modules/espeak-phonemizer/default.nix
+++ b/pkgs/development/python-modules/espeak-phonemizer/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, substituteAll
+, glibc
+, espeak-ng
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "espeak-phonemizer";
+  version = "1.1.0";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "rhasspy";
+    repo = "espeak-phonemizer";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-qnJtS5iIARdg+umolzLHT3/nLon9syjxfTnMWHOmYPU=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./cdll.patch;
+      libc = "${lib.getLib glibc}/lib/libc.so.6";
+      libespeak_ng = "${lib.getLib espeak-ng}/lib/libespeak-ng.so";
+    })
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/rhasspy/espeak-phonemizer/releases/tag/v${version}";
+    description = "Uses ctypes and libespeak-ng to transform test into IPA phonemes";
+    homepage = "https://github.com/rhasspy/espeak-phonemizer";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -13,6 +13,20 @@
 , requests
 , smbprotocol
 , tqdm
+
+# optionals
+, adlfs
+, dask
+, distributed
+, dropbox
+, fusepy
+, gcsfs
+, libarchive-c
+, ocifs
+, panel
+, pyarrow
+, pygit2
+, s3fs
 }:
 
 buildPythonPackage rec {
@@ -36,6 +50,75 @@ buildPythonPackage rec {
     smbprotocol
     tqdm
   ];
+
+  passthru.optional-dependencies = {
+    entrypoints = [
+    ];
+    abfs = [
+      adlfs
+    ];
+    adl = [
+      adlfs
+    ];
+    dask = [
+      dask
+      distributed
+    ];
+    dropbox = [
+      # missing dropboxdrivefs
+      requests
+      dropbox
+    ];
+    gcs = [
+      gcsfs
+    ];
+    git = [
+      pygit2
+    ];
+    github = [
+      requests
+    ];
+    gs = [
+      gcsfs
+    ];
+    hdfs = [
+      pyarrow
+    ];
+    arrow = [
+      pyarrow
+    ];
+    http = [
+      aiohttp
+      requests
+    ];
+    sftp = [
+      paramiko
+    ];
+    s3 = [
+      s3fs
+    ];
+    oci = [
+      ocifs
+    ];
+    smb = [
+      smbprotocol
+    ];
+    ssh = [
+      paramiko
+    ];
+    fuse = [
+      fusepy
+    ];
+    libarchive = [
+      libarchive-c
+    ];
+    gui = [
+      panel
+    ];
+    tqdm = [
+      tqdm
+    ];
+  };
 
   checkInputs = [
     numpy

--- a/pkgs/development/python-modules/larynx-train/default.nix
+++ b/pkgs/development/python-modules/larynx-train/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, buildPythonPackage
+, larynx
+
+# build
+, cython
+, python
+
+# propagates
+, espeak-phonemizer
+, librosa
+, numpy
+, onnxruntime
+, pytorch-lightning
+, torch
+}:
+
+buildPythonPackage rec {
+  inherit (larynx) version src meta;
+
+  pname = "larynx-train";
+  format = "setuptools";
+
+  sourceRoot = "source/src/python";
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "onnxruntime~=1.11.0" "onnxruntime" \
+      --replace "pytorch-lightning~=1.7.0" "pytorch-lightning" \
+      --replace "torch~=1.11.0" "torch"
+  '';
+
+  postBuild = ''
+    make -C larynx_train/vits/monotonic_align
+  '';
+
+  postInstall = ''
+    export MONOTONIC_ALIGN=$out/${python.sitePackages}/larynx_train/vits/monotonic_align/monotonic_align
+    mkdir -p $MONOTONIC_ALIGN
+    cp -v ./larynx_train/vits/monotonic_align/larynx_train/vits/monotonic_align/core.*.so $MONOTONIC_ALIGN/
+  '';
+
+  propagatedBuildInputs = [
+    espeak-phonemizer
+    librosa
+    numpy
+    onnxruntime
+    pytorch-lightning
+    torch
+  ];
+
+  pythonImportsCheck = [
+    "larynx_train"
+  ];
+
+  doCheck = false; # no tests
+}

--- a/pkgs/development/python-modules/lightning-utilities/default.nix
+++ b/pkgs/development/python-modules/lightning-utilities/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# build
+, setuptools
+
+# runtime
+, packaging
+, typing-extensions
+
+# tests
+, pytest-timeout
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "lightning-utilities";
+  version = "0.5.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "Lightning-AI";
+    repo = "utilities";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-J73sUmX1a7ww+rt1vwBt9P0Xbeoxag6jR0W63xEySCI=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    packaging
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "lightning_utilities"
+  ];
+
+  checkInputs = [
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    "lightning_utilities.core.enums.StrEnum"
+    "lightning_utilities.core.imports.RequirementCache"
+    "lightning_utilities.core.imports.compare_version"
+    "lightning_utilities.core.imports.get_dependency_min_version_spec"
+  ];
+
+  disabledTestPaths = [
+    "docs"
+
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/Lightning-AI/utilities/releases/tag/v${version}";
+    description = "Common Python utilities and GitHub Actions in Lightning Ecosystem";
+    homepage = "https://github.com/Lightning-AI/utilities";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/pytorch-lightning/default.nix
+++ b/pkgs/development/python-modules/pytorch-lightning/default.nix
@@ -1,47 +1,65 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, isPy27
-, future
+, pythonOlder
 , fsspec
+, lightning-utilities
+, numpy
 , packaging
-, pytestCheckHook
-, torch
 , pyyaml
-, tensorboard
+, tensorboardx
+, torch
 , torchmetrics
-, tqdm }:
+, tqdm
+, traitlets
+
+# tests
+, psutil
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "pytorch-lightning";
   version = "1.8.6";
-
-  disabled = isPy27;
+  format = "pyproject";
 
   src = fetchFromGitHub {
-    owner = "PyTorchLightning";
-    repo = pname;
+    owner = "Lightning-AI";
+    repo = "pytorch-lightning";
     rev = "refs/tags/${version}";
     hash = "sha256-5AyOCeRFiV7rdmoBPx03Xju6eTR/3jiE+HQBiEmdzmo=";
   };
 
+  preConfigure = ''
+    export PACKAGE_NAME=pytorch
+ '';
+
   propagatedBuildInputs = [
-    packaging
-    future
     fsspec
-    torch
+    numpy
+    packaging
     pyyaml
-    tensorboard
+    tensorboardx
+    torch
+    lightning-utilities
     torchmetrics
     tqdm
+    traitlets
+  ]
+  ++ fsspec.optional-dependencies.http;
+
+  checkInputs = [
+    psutil
+    pytestCheckHook
   ];
 
-  checkInputs = [ pytestCheckHook ];
   # Some packages are not in NixPkgs; other tests try to build distributed
   # models, which doesn't work in the sandbox.
   doCheck = false;
 
-  pythonImportsCheck = [ "pytorch_lightning" ];
+  pythonImportsCheck = [
+    "pytorch_lightning"
+  ];
 
   meta = with lib; {
     description = "Lightweight PyTorch wrapper for machine learning researchers";

--- a/pkgs/tools/audio/larynx/default.nix
+++ b/pkgs/tools/audio/larynx/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkgconfig
+, espeak-ng
+, onnxruntime
+, pcaudiolib
+, larynx-train
+}:
+
+let
+  pname = "larynx";
+  version = "0.0.2";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "rhasspy";
+    repo = "larynx2";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-6SZ1T2A1DyVmBH2pJBHJdsnniRuLrI/dthRTRRyVSQQ=";
+  };
+
+  sourceRoot = "source/src/cpp";
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "/usr/local/include/onnxruntime" "${onnxruntime}"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+  ];
+
+  buildInputs = [
+    espeak-ng
+    onnxruntime
+    pcaudiolib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -m 0755 larynx $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    changelog = "https://github.com/rhasspy/larynx2/releases/tag/v${version}";
+    description = "A fast, local neural text to speech system";
+    homepage = "https://github.com/rhasspy/larynx2";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/tools/audio/larynx/default.nix
+++ b/pkgs/tools/audio/larynx/default.nix
@@ -50,6 +50,10 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  passthru.tests = {
+    inherit larynx-train;
+  };
+
   meta = with lib; {
     changelog = "https://github.com/rhasspy/larynx2/releases/tag/v${version}";
     description = "A fast, local neural text to speech system";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9102,6 +9102,8 @@ with pkgs;
 
   larynx = callPackage ../tools/audio/larynx { };
 
+  larynx-train = with python3Packages; toPythonApplication larynx-train;
+
   latex2html = callPackage ../tools/misc/latex2html { };
 
   lazycli = callPackage ../tools/misc/lazycli { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9100,6 +9100,8 @@ with pkgs;
 
   jump = callPackage ../tools/system/jump {};
 
+  larynx = callPackage ../tools/audio/larynx { };
+
   latex2html = callPackage ../tools/misc/latex2html { };
 
   lazycli = callPackage ../tools/misc/lazycli { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5156,6 +5156,8 @@ self: super: with self; {
 
   lark = callPackage ../development/python-modules/lark { };
 
+  larynx-train = callPackage ../development/python-modules/larynx-train { };
+
   latexcodec = callPackage ../development/python-modules/latexcodec { };
 
   latexify-py = callPackage ../development/python-modules/latexify-py { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3045,6 +3045,8 @@ self: super: with self; {
 
   eradicate = callPackage ../development/python-modules/eradicate { };
 
+  espeak-phonemizer = callPackage ../development/python-modules/espeak-phonemizer { };
+
   esprima = callPackage ../development/python-modules/esprima { };
 
   escapism = callPackage ../development/python-modules/escapism { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5392,6 +5392,8 @@ self: super: with self; {
 
   lightning = callPackage ../development/python-modules/lightning { };
 
+  lightning-utilities  = callPackage ../development/python-modules/lightning-utilities { };
+
   lightparam = callPackage ../development/python-modules/lightparam { };
 
   lightwave = callPackage ../development/python-modules/lightwave { };


### PR DESCRIPTION
###### Description of changes

Trying to play with larynx2, something that is apparently being worked on for the year of the voice of home-assistant.

- [x] cpp
  - Waiting for upstream to be compatible with the latest onnxruntime release
  - <del>Might have to override onnxruntime for compatibility with upstream released models./del>
  - https://github.com/rhasspy/larynx2/issues/1
- [x] python (`larnyx_train`)

##### Example
```
❯ echo "This is Larynx, a fast, local neural text to speech system." |./result/bin/larynx --model /tmp/voice-english/en-us-blizzard_lessac-medium.onnx --output_file /tmp/larynx.wav
Load time: 0.238411 sec
Real-time factor: 0.0336467 (infer=0.113591 sec, audio=3.376 sec)
```

https://shells.darmstadt.ccc.de/~hexa/larynx.wav

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
