### PR TITLE
Stash-bin: Init at 0.18.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16265,4 +16265,10 @@
     github = "Detegr";
     githubId = 724433;
   };
+  airradda = {
+    name = "Airradda";
+    email = "nix@airradda.com";
+    github = "Airradda";
+    githubId = 3744856;
+  };
 }

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -671,6 +671,7 @@
   ./services/misc/spice-webdavd.nix
   ./services/misc/ssm-agent.nix
   ./services/misc/sssd.nix
+  ./services/misc/stash-bin.nix
   ./services/misc/subsonic.nix
   ./services/misc/sundtek.nix
   ./services/misc/svnserve.nix

--- a/nixos/modules/services/misc/stash-bin.nix
+++ b/nixos/modules/services/misc/stash-bin.nix
@@ -1,0 +1,117 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.stash;
+  opt = options.services.stash;
+
+in
+{
+
+  options.services.stash = {
+    enable = mkEnableOption (mdDoc "Stash");
+
+    user = mkOption {
+      type = types.str;
+      default = "stash";
+      description = mdDoc "User account under which Stash runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "stash";
+      description = mdDoc "Group under which Stash runs.";
+    };
+
+    host = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = mdDoc "The ip address for the host that stash is listening to.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 9999;
+      description = mdDoc "The port that stash serves to.";
+    };
+
+    externalHost = mkOption {
+      type = types.str;
+      default = "";
+      description = mdDoc "Needed in some cases when you use a reverse proxy.";
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/stash";
+      description = mdDoc "Path where to store data files.";
+    };
+
+    package = mkPackageOptionMD pkgs "stash" {};
+};
+
+  config = mkIf cfg.enable (
+    let
+      stashPython = pkgs.python3.withPackages (ps: with ps; [
+        cloudscraper
+        configparser
+        progressbar
+        requests
+      ]);
+      stashPackages = with pkgs; [
+        stashPython
+        bashInteractive
+        openssl
+        sqlite
+        ffmpeg
+      ];
+    in
+    {
+      systemd.services.stash = {
+        description = mdDoc "Stash daemon";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        environment = {
+          HOME = "%S/stash";
+          STASH_HOST = cfg.host;
+          STASH_PORT = toString cfg.port;
+          STASH_EXTERNAL_HOST = toString cfg.externalHost;
+        };
+
+        path = stashPackages;
+
+        preStart = ''
+          mkdir -p ~/.stash && chmod 0700 ~/.stash;
+          rm -f ~/.stash/ffmpeg && ln -s ${cfg.ffmpegPkg}/bin/ffmpeg ~/.stash/ffmpeg;
+          rm -f ~/.stash/ffprobe && ln -s ${cfg.ffmpegPkg}/bin/ffprobe ~/.stash/ffprobe;
+        '';
+
+        serviceConfig = {
+          Type = "simple";
+          Restart = "on-failure";
+          DynamicUser = true;
+          StateDirectory = "stash";
+          ExecStart = "${cfg.package}/bin/stash --nowbrowser";
+        };
+      };
+
+      users.users = mkMerge [
+        (mkIf (cfg.user == "stash") {
+          stash = {
+            isSystemUser = true;
+            group = cfg.group;
+            home = cfg.dataDir;
+            createHome = true;
+          };
+        })
+        (attrsets.setAttrByPath [ cfg.user "packages" ] ([ cfg.package ] ++ stashPackages))
+      ];
+
+      users.groups = optionalAttrs (cfg.group == "stash") {
+        stash = { };
+      };
+    }
+  );
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -609,6 +609,7 @@ in {
   sslh = handleTest ./sslh.nix {};
   sssd = handleTestOn ["x86_64-linux"] ./sssd.nix {};
   sssd-ldap = handleTestOn ["x86_64-linux"] ./sssd-ldap.nix {};
+  stash-bin = handleTest ./stash-bin.nix {};
   starship = handleTest ./starship.nix {};
   step-ca = handleTestOn ["x86_64-linux"] ./step-ca.nix {};
   stratis = handleTest ./stratis {};

--- a/nixos/tests/stash-bin.nix
+++ b/nixos/tests/stash-bin.nix
@@ -1,0 +1,19 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "stash";
+  meta = with pkgs.lib; {
+    maintainers = with maintainers; [ airradda ];
+  };
+
+  nodes.machine = { pkgs, ... }: {
+    services.stash = {
+      enable = true;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("stash.service")
+    machine.wait_until_succeeds(
+        "curl --fail -L http://localhost:9999/"
+    )
+  '';
+})

--- a/pkgs/servers/stash-bin/default.nix
+++ b/pkgs/servers/stash-bin/default.nix
@@ -1,0 +1,85 @@
+{ pkgs
+, lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, openssl
+, ffmpeg
+, sqlite
+, makeWrapper
+}:
+
+let
+  version = "0.18.0";
+
+  platforms = {
+    aarch64-darwin = {
+      name = "macos-applesilicon";
+      sha256 = "sha256-UehAXV6aUNTkoymDmh7qSY+uuqLhkgzjL2TPYsZrNUs=";
+    };
+    aarch64-linux = {
+      name = "linux-arm64v8";
+      sha256 = "sha256-us5TJ0fajhi81HRQ7hI8bvh/KRKcXlNoXLQRxGqpbt8=";
+    };
+    armv6l-linux = {
+      name = "linux-arm32v6";
+      sha256 = "sha256-97EQHNFAzCfBA1uI593M+eyIomU1BUgRWiXpKTEWckw=";
+    };
+    armv7l-linux = {
+      name = "linux-arm32v7";
+      sha256 = "sha256-y/yhgzids6TJ4CxqJa3OtDjbeWUB0jaXqS9skLb9oYg=";
+    };
+    x86_64-darwin = {
+      name = "macos-intel";
+      sha256 = "sha256-iR4s+aI8rwLjDtEHEgsiB3tgAxTMMEcUNcF4bwUv1yI=";
+    };
+    x86_64-linux = {
+      name = "linux";
+      sha256 = "sha256-05upB7EaqIWGFd24QQOTLxzL8OC+HAvH9P5dZyjDZ3U=";
+    };
+  };
+
+  plat =
+    if (lib.hasAttrByPath [ stdenv.hostPlatform.system ] platforms)
+    then platforms.${stdenv.hostPlatform.system}
+    else throw "Unsupported architecture: ${stdenv.hostPlatform.system}";
+in
+stdenv.mkDerivation rec {
+  inherit version;
+
+  name = "stash-bin";
+
+  executable = fetchurl {
+    inherit (plat) sha256;
+    url = "https://github.com/stashapp/stash/releases/download/v${version}/stash-${plat.name}";
+    executable = true;
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    ffmpeg
+    openssl
+    sqlite
+    makeWrapper
+    (pkgs.python3.withPackages (p: with p; [ requests configparser progressbar cloudscraper ]))
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper "${executable}" "$out/bin/stash" \
+      --prefix PATH ":" "${lib.makeBinPath [ ffmpeg ]}"
+  '';
+
+  meta = with lib; {
+    description = "An organizer for your porn, written in Go";
+    license = licenses.agpl3Plus;
+    homepage = "https://stashapp.cc";
+    maintainers = with lib.maintainers; [ airradda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38495,4 +38495,6 @@ with pkgs;
   tuner = callPackage ../applications/audio/tuner { };
 
   jfrog-cli = callPackage ../tools/misc/jfrog-cli { };
+
+  stash-bin = callPackage ../servers/stash-bin { };
 }


### PR DESCRIPTION
Stash is "An organizer for your porn, written in Go."

This is simply a slightly modified version of nocoolnametom's PR (#173799) updated to version 0.18.0 and with most of the suggestions made by @oxzi and @mweinelt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
