### PR TITLE
volantes-cursors: init at 2022-08-27

### DIFF
--- a/pkgs/data/icons/volantes-cursors/default.nix
+++ b/pkgs/data/icons/volantes-cursors/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, inkscape
+, xcursorgen
+}:
+stdenv.mkDerivation {
+  pname = "volantes-cursors";
+  version = "2022-08-27";
+
+  src = fetchFromGitHub {
+    owner = "varlesh";
+    repo = "volantes-cursors";
+    rev = "b13a4bbf6bd1d7e85fadf7f2ecc44acc198f8d01";
+    hash = "sha256-vJe1S+YHrUBwJSwt2+InTu5ho2FOtz7FjDxu0BIA1Js=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ inkscape xcursorgen ];
+
+  makeTargets = [ "build" ];
+
+  makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+
+  meta = with lib; {
+    homepage = "https://www.pling.com/p/1356095/";
+    description = "Classic cursor theme with a flying style";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ jordanisaacs ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38707,4 +38707,6 @@ with pkgs;
   resgate = callPackage ../servers/resgate { };
 
   oversteer = callPackage ../applications/misc/oversteer { };
+
+  volantes-cursors = callPackage ../data/icons/volantes-cursors { };
 }


### PR DESCRIPTION
###### Description of changes

Init [volantes-cursors](https://www.pling.com/p/1356095/). It is a cursor theme.

###### Things done

Been running the theme built with nix for a few months now.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


