### PR TITLE
home-assistant.intents: init at 2023.1.25

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -297,8 +297,9 @@ let
         };
       });
 
-      # home-assistant-frontend does not exist in python3.pkgs
+      # internal python packages only consumed by home-assistant itself
       home-assistant-frontend = self.callPackage ./frontend.nix { };
+      home-assistant-intents = self.callPackage ./intents.nix { };
     })
   ];
 
@@ -496,6 +497,7 @@ in python.pkgs.buildPythonApplication rec {
       getPackages
       python
       supportedComponentsWithTests;
+    intents = python.pkgs.home-assistant-intents;
     tests = {
       nixos = nixosTests.home-assistant;
       components = callPackage ./tests.nix { };

--- a/pkgs/servers/home-assistant/intents.nix
+++ b/pkgs/servers/home-assistant/intents.nix
@@ -1,0 +1,67 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, setuptools
+
+# build
+, hassil
+, jinja2
+, pyyaml
+, regex
+, voluptuous
+, python
+
+# tests
+, pytest-xdist
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "home-assistant-intents";
+  version = "2023.1.25";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "home-assistant";
+    repo = "intents";
+    rev = "refs/tags/${version}";
+    hash = "sha256-nMEcN2b0XHF4yRRsHKMplxqcMLl+gJcPAdvwnySN+ug=";
+  };
+
+  sourceRoot = "source/package";
+
+  nativeBuildInputs = [
+    hassil
+    jinja2
+    pyyaml
+    regex
+    setuptools
+    voluptuous
+  ];
+
+  postInstall = ''
+    pushd ..
+    # https://github.com/home-assistant/intents/blob/main/script/package#L18
+    ${python.interpreter} -m script.intentfest merged_output $out/${python.sitePackages}/home-assistant-intents/home_assistant_intents/data
+    popd
+  '';
+
+  checkInputs = [
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "../tests"
+  ];
+
+  meta = with lib; {
+    description = "Intents to be used with Home Assistant";
+    homepage = "https://github.com/home-assistant/intents";
+    license = licenses.cc-by-40;
+    maintainers = teams.home-assistant.members;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Intents for home-assistants conversation component.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
