### PR TITLE
hred: init at 1.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13863,6 +13863,14 @@
     github = "tejasag";
     githubId = 67542663;
   };
+  tejing = {
+    name = "Jeff Huffman";
+    email = "tejing@tejing.com";
+    matrix = "@tejing:matrix.org";
+    github = "tejing1";
+    githubId = 5663576;
+    keys = [{ fingerprint = "6F0F D43B 80E5 583E 60FC  51DC 4936 D067 EB12 AB32"; }];
+  };
   telotortium = {
     email = "rirelan@gmail.com";
     github = "telotortium";

--- a/pkgs/development/tools/hred/default.nix
+++ b/pkgs/development/tools/hred/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildNpmPackage, fetchFromGitHub, runCommand, hred, jq }:
+
+buildNpmPackage rec {
+  pname = "hred";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "danburzo";
+    repo = "hred";
+    rev = "v${version}";
+    hash = "sha256-rnobJG9Z1lXEeFm+c0f9OsbiTzxeP3+zut5LYpGzWfc=";
+  };
+
+  npmDepsHash = "sha256-POxlGWK0TJMwNWDpiK5+OXLGtAx4lFJO3imoe/h+7Sc=";
+
+  dontNpmBuild = true;
+
+  passthru.tests = {
+    simple = runCommand "${pname}-test" {} ''
+      set -e -o pipefail
+      echo '<i id="foo">bar</i>' | ${hred}/bin/hred 'i#foo { @id => id, @.textContent => text }' -c | ${jq}/bin/jq -c > $out
+      [ "$(cat $out)" = '{"id":"foo","text":"bar"}' ]
+    '';
+  };
+
+  meta = {
+    description = "A command-line tool to extract data from HTML";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/danburzo/hred";
+    maintainers = with lib.maintainers; [ tejing ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1879,6 +1879,8 @@ with pkgs;
 
   gst = callPackage ../applications/version-management/gst { };
 
+  hred = callPackage ../development/tools/hred { };
+
   hub = callPackage ../applications/version-management/hub { };
 
   hut = callPackage ../applications/version-management/hut { };


### PR DESCRIPTION
###### Description of changes

Packaged [hred](https://github.com/danburzo/hred), a command-line tool to extract data from HTML.

~~Given that this is a node package, of course the generate script has made changes affecting other packages, which I did not test.~~

Also added myself to the maintainers list. I went with a handle different from my github username, but if you really want me to change it, I will. Github is essentially the only place my name gets a `1` at the end, though. I'm `tejing` everywhere else.

Closes #165720

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
