### PR TITLE
[Backport release-22.11] kernel updates

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -52,11 +52,11 @@
     "6.0": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-6.0.15-hardened1.patch",
-            "sha256": "0v7aqxa6ba2jkx1dd9axr9vsnn3pbq30vwfd0akc72zc8c5zll1r",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/6.0.15-hardened1/linux-hardened-6.0.15-hardened1.patch"
+            "name": "linux-hardened-6.0.16-hardened1.patch",
+            "sha256": "19rakmfdkkbvvzphsksccgad3wc2khlcynzdqx10d7spldj8nkp1",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/6.0.16-hardened1/linux-hardened-6.0.16-hardened1.patch"
         },
-        "sha256": "08389890gq4b9vkvrb22lzkr4blkn3a5ma074ns19gl89wyyp16l",
-        "version": "6.0.15"
+        "sha256": "1r2wf3hf7yxl7lxma7plyi8pk3dmlsrpm763rf0g1h8ilsy72844",
+        "version": "6.0.16"
     }
 }

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -32,12 +32,12 @@
     "5.15": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-5.15.85-hardened1.patch",
-            "sha256": "03zjcjyiklhxhq958hx1mlhhjcz0isdrij217q8ji78bz3y40m0q",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.15.85-hardened1/linux-hardened-5.15.85-hardened1.patch"
+            "name": "linux-hardened-5.15.86-hardened1.patch",
+            "sha256": "04yp2qqn9axvkaqgihb1vxnkwnjs5s2q9106y5x4r1q4bf42nz2v",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/5.15.86-hardened1/linux-hardened-5.15.86-hardened1.patch"
         },
-        "sha256": "024qhjh9mgfnanr1qd8002n6a4wpn98lajli12a0m3n9z8lsw2rc",
-        "version": "5.15.85"
+        "sha256": "1vpjnmwqsx6akph2nvbsv2jl7pp8b7xns3vmwbljsl23lkpxkz40",
+        "version": "5.15.86"
     },
     "5.4": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/linux-5.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.10.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "5.10.161";
+  version = "5.10.162";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";
-    sha256 = "0ya04njrxr4d37zkxvivmn5f0bdvcb504pyp9ahwz8nqpk8gdaks";
+    sha256 = "05yjgp1la5flwqji9b6j7nbdgg5fwzv2ph536v4f9pzza3y01i1f";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-6.0.nix
+++ b/pkgs/os-specific/linux/kernel/linux-6.0.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "6.0.16";
+  version = "6.0.17";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
-    sha256 = "1r2wf3hf7yxl7lxma7plyi8pk3dmlsrpm763rf0g1h8ilsy72844";
+    sha256 = "020xrv9449gd0jnfgi0sb69bgs2p9sd49dghmd3bnnal584r5vm7";
   };
 } // (args.argsOverride or { }))

--- a/pkgs/os-specific/linux/kernel/linux-6.1.nix
+++ b/pkgs/os-specific/linux/kernel/linux-6.1.nix
@@ -3,7 +3,7 @@
 with lib;
 
 buildLinux (args // rec {
-  version = "6.1.2";
+  version = "6.1.3";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStringsSep "." (take 3 (splitVersion "${version}.0")) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
-    sha256 = "1bni72q0jjg39vqckcif57kh7d1x4k4jir5a11pz9clryp2g6hgf";
+    sha256 = "05q3b32kinvbgbibb8s3x8ax3gzlgznlcwvwb4y46gjilzkrmj3d";
   };
 } // (args.argsOverride or { }))


### PR DESCRIPTION
###### Description of changes
Picked https://github.com/NixOS/nixpkgs/pull/209050 except for `linux_testing`, as our config can't handle 6.2 even on nixpkgs master yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
