### PR TITLE
GNOME updates

### DIFF
--- a/pkgs/desktops/gnome/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-boxes/default.nix
@@ -51,11 +51,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-boxes";
-  version = "43.1";
+  version = "43.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "NB5qXO1RrVAPwd00ZZ1YhsP3YEViS1POZBv/Y8WwimE=";
+    sha256 = "nD4OlDPBhTqZ7VLt7BMmP0Q/hW28o7IWXC46cLhjKzA=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/apps/gnome-maps/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-maps/default.nix
@@ -28,11 +28,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-maps";
-  version = "43.2";
+  version = "43.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-wCIdJQvkXqNulxrmO/3pcaRhRclnscZZ6WxbBypxVR0=";
+    sha256 = "sha256-iVUelLEnEwXP/yBLRMGDZyZ3gaV9LMt7b3u6Yo4JxRE=";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome/apps/gnome-text-editor/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-text-editor/default.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-text-editor";
-  version = "43.1";
+  version = "43.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-text-editor/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-lzpLDeto+fkaVKTdQVtq/em1rj7mhLx2FHH5QpD59ss=";
+    sha256 = "sha256-MwRcehI/qife5+ubqabybxsXGMWg52M30Hmg1MkA4UY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/eog/default.nix
+++ b/pkgs/desktops/gnome/core/eog/default.nix
@@ -30,13 +30,13 @@
 
 stdenv.mkDerivation rec {
   pname = "eog";
-  version = "43.1";
+  version = "43.2";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-/tef88oZusYvJxVcm91p7vh1hwuXHm3LCqOMCT0TGXE=";
+    sha256 = "sha256-nc/c5VhakOK7HPV+N3yx6xLUG9m8ubus31BrwbE1Tvk=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/core/gnome-remote-desktop/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-remote-desktop/default.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-remote-desktop";
-  version = "43.2";
+  version = "43.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-hKn9Zam62M73NIL9otIKzRIvC4Uhsd6GyUE4ibn6l3E=";
+    hash = "sha256-EdRR0f3kTxgJ6/Ya/0vqX570/cAjWaiWR/bp59RUKaw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-software/default.nix
@@ -45,11 +45,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gnome-software";
-  version = "43.2";
+  version = "43.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-software/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "Iqp/CjF8dw9ouJfp5RKyy+2xgbaV/9sLZY2Zu9ZPNo0=";
+    sha256 = "k+6AdHl4rSzALlrnPQo9Psgu6hNPx3niqpFpAbu1gJA=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/games/gnome-chess/default.nix
+++ b/pkgs/desktops/gnome/games/gnome-chess/default.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-chess";
-  version = "43.0";
+  version = "43.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-chess/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "ZDP+3y9C+yK/IC2fE47C7gcjetXXQ4CQULXICbVs28s=";
+    sha256 = "c08JLZX8YECe6so0J7WkjLm1mdoRmVEZ2FuqmWU+ApI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/games/tali/default.nix
+++ b/pkgs/desktops/gnome/games/tali/default.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation rec {
   pname = "tali";
-  version = "40.8";
+  version = "40.9";
 
   src = fetchurl {
     url = "mirror://gnome/sources/tali/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "bBeMFg/LtNEb49FWnVOODngUDVC721KnWDGI95XAF+4=";
+    sha256 = "+p7eNm8KcuTKpSGJw6sLEMG1aoDHiFsBZgJVjETc59M=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Highlights:

- https://gitlab.gnome.org/GNOME/gnome-maps/-/commit/bec3d2f2 is not backported to gnome-43
- Vala is [starting to check](https://gitlab.gnome.org/GNOME/gnome-chess/-/merge_requests/44) the size of a given integer constants and uses the appropriate type for it


 | Bump | | | | |
|---|---|---|---|---|
| gnome-boxes: 43.1 -> 43.2 | [Diff](https://gitlab.gnome.org/GNOME/gnome-boxes/-/compare/43.1...43.2) | [NEWS](https://gitlab.gnome.org/GNOME/gnome-boxes/-/blob/43.2/NEWS) | [Fedora](https://src.fedoraproject.org/rpms/gnome-boxes/commits/f37) | [Arch](https://github.com/archlinux/svntogit-community/commits/packages/gnome-boxes) |
| gnome-chess: 43.0 -> 43.1 | [Diff](https://gitlab.gnome.org/GNOME/gnome-chess/-/compare/43.0...43.1) | [NEWS](https://gitlab.gnome.org/GNOME/gnome-chess/-/blob/43.1/NEWS) | [Fedora](https://src.fedoraproject.org/rpms/gnome-chess/commits/f37) | [Arch](https://github.com/archlinux/svntogit-packages/commits/packages/gnome-chess) |
| gnome-remote-desktop: 43.2 -> 43.3 | [Diff](https://gitlab.gnome.org/GNOME/gnome-remote-desktop/-/compare/43.2...43.3) |  | [Fedora](https://src.fedoraproject.org/rpms/gnome-remote-desktop/commits/f37) | [Arch](https://github.com/archlinux/svntogit-packages/commits/packages/gnome-remote-desktop) |
 | gnome-software: 43.2 -> 43.3 | [Diff](https://gitlab.gnome.org/GNOME/gnome-software/-/compare/43.2...43.3) | [NEWS](https://gitlab.gnome.org/GNOME/gnome-software/-/blob/43.3/NEWS) | [Fedora](https://src.fedoraproject.org/rpms/gnome-software/commits/f37) | [Arch](https://github.com/archlinux/svntogit-packages/commits/packages/gnome-software) |
 | eog: 43.1 -> 43.2 | [Diff](https://gitlab.gnome.org/GNOME/eog/-/compare/43.1...43.2) | [NEWS](https://gitlab.gnome.org/GNOME/eog/-/blob/43.2/NEWS) | [Fedora](https://src.fedoraproject.org/rpms/eog/commits/f37) | [Arch](https://github.com/archlinux/svntogit-packages/commits/packages/eog) |
| gnome-maps: 43.2 -> 43.3 | [Diff](https://gitlab.gnome.org/GNOME/gnome-maps/-/compare/v43.2...v43.3) | [NEWS](https://gitlab.gnome.org/GNOME/gnome-maps/-/blob/v43.3/NEWS) | [Fedora](https://src.fedoraproject.org/rpms/gnome-maps/commits/f37) | [Arch](https://github.com/archlinux/svntogit-packages/commits/packages/gnome-maps) |
| tali: 40.8 -> 40.9 | [Diff](https://gitlab.gnome.org/GNOME/tali/-/compare/40.8...40.9) | [NEWS](https://gitlab.gnome.org/GNOME/tali/-/blob/40.9/NEWS) | [Fedora](https://src.fedoraproject.org/rpms/tali/commits/f37) | [Arch](https://github.com/archlinux/svntogit-packages/commits/packages/tali) |
| gnome-text-editor: 43.1 -> 43.2 | [Diff](https://gitlab.gnome.org/GNOME/gnome-text-editor/-/compare/43.1...43.2) | [NEWS](https://gitlab.gnome.org/GNOME/gnome-text-editor/-/blob/43.2/NEWS) | [Fedora](https://src.fedoraproject.org/rpms/gnome-text-editor/commits/f37) | [Arch](https://github.com/archlinux/svntogit-packages/commits/packages/gnome-text-editor) |


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Result of `nixpkgs-review pr 210357` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>11 packages built:</summary>
  <ul>
    <li>gnome-text-editor</li>
    <li>gnome.eog</li>
    <li>gnome.gnome-boxes</li>
    <li>gnome.gnome-chess</li>
    <li>gnome.gnome-control-center</li>
    <li>gnome.gnome-maps</li>
    <li>gnome.gnome-remote-desktop</li>
    <li>gnome.gnome-software</li>
    <li>gnome.tali</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
  </ul>
</details>
