### PR TITLE
androidenv: generate package.xml in packages' directory

### DIFF
--- a/pkgs/development/mobile/androidenv/mkrepo.rb
+++ b/pkgs/development/mobile/androidenv/mkrepo.rb
@@ -29,6 +29,49 @@ def image_url value, dir
   end
 end
 
+# Returns a JSON with the data and structure of the input XML
+def to_json_collector doc
+  json = {}
+  index = 0
+  doc.element_children.each { |node|
+    if node.children.length == 1 and node.children.first.text?
+      json["#{node.name}:#{index}"] ||= node.content
+      index += 1
+      next
+    end
+    json["#{node.name}:#{index}"] ||= to_json_collector node
+    index += 1
+  }
+  element_attributes = {}
+  doc.attribute_nodes.each do |attr|
+    if attr.name == "type"
+      type = attr.value.split(':', 2).last
+      case attr.value
+      when 'generic:genericDetailsType'
+        element_attributes["xsi:type"] ||= "ns5:#{type}"
+      when 'addon:extraDetailsType'
+        element_attributes["xsi:type"] ||= "ns8:#{type}"
+      when 'addon:mavenType'
+        element_attributes["xsi:type"] ||= "ns8:#{type}"
+      when 'sdk:platformDetailsType'
+        element_attributes["xsi:type"] ||= "ns11:#{type}"
+      when 'sdk:sourceDetailsType'
+        element_attributes["xsi:type"] ||= "ns11:#{type}"
+      when 'sys-img:sysImgDetailsType'
+        element_attributes["xsi:type"] ||= "ns12:#{type}"
+      when 'addon:addonDetailsType' then
+        element_attributes["xsi:type"] ||= "ns8:#{type}"
+      end
+    else
+      element_attributes[attr.name] ||= attr.value
+    end
+  end
+  if !element_attributes.empty?
+    json['element-attributes'] ||= element_attributes
+  end
+  json
+end
+
 # Returns a tuple of [type, revision, revision components] for a package node.
 def package_revision package
   type_details = package.at_css('> type-details')
@@ -148,7 +191,7 @@ def fixup value
     else
       [k, v]
     end
-  end.sort {|(k1, v1), (k2, v2)| k1 <=> k2}]
+  end.sort {|(k1, v1), (k2, v2)| k1 <=> k2 }]
 end
 
 # Normalize the specified license text.
@@ -189,7 +232,12 @@ def parse_package_xml doc
     display_name = text package.at_css('> display-name')
     uses_license = package.at_css('> uses-license')
     uses_license &&= uses_license['ref']
+    obsolete ||= package['obsolete']
+    type_details = to_json_collector package.at_css('> type-details')
+    revision_details = to_json_collector package.at_css('> revision')
     archives = package_archives(package) {|url| repo_url url}
+    dependencies_xml = package.at_css('> dependencies')
+    dependencies = to_json_collector dependencies_xml if dependencies_xml
 
     target = (packages[name] ||= {})
     target = (target[revision] ||= {})
@@ -199,6 +247,10 @@ def parse_package_xml doc
     target['revision'] ||= revision
     target['displayName'] ||= display_name
     target['license'] ||= uses_license if uses_license
+    target['obsolete'] ||= obsolete if obsolete == 'true'
+    target['type-details'] ||= type_details
+    target['revision-details'] ||= revision_details
+    target['dependencies'] ||= dependencies if dependencies
     target['archives'] ||= {}
     merge target['archives'], archives
   end
@@ -218,11 +270,17 @@ def parse_image_xml doc
     display_name = text package.at_css('> display-name')
     uses_license = package.at_css('> uses-license')
     uses_license &&= uses_license['ref']
+    obsolete &&= package['obsolete']
+    type_details = to_json_collector package.at_css('> type-details')
+    revision_details = to_json_collector package.at_css('> revision')
     archives = package_archives(package) {|url| image_url url, components[-2]}
+    dependencies_xml = package.at_css('> dependencies')
+    dependencies = to_json_collector dependencies_xml if dependencies_xml
 
     target = images
     components.each do |component|
-      target = (target[component] ||= {})
+      target[component] ||= {}
+      target = target[component]
     end
 
     target['name'] ||= "system-image-#{revision}"
@@ -230,6 +288,10 @@ def parse_image_xml doc
     target['revision'] ||= revision
     target['displayName'] ||= display_name
     target['license'] ||= uses_license if uses_license
+    target['obsolete'] ||= obsolete if obsolete
+    target['type-details'] ||= type_details
+    target['revision-details'] ||= revision_details
+    target['dependencies'] ||= dependencies if dependencies
     target['archives'] ||= {}
     merge target['archives'], archives
   end
@@ -249,7 +311,12 @@ def parse_addon_xml doc
     display_name = text package.at_css('> display-name')
     uses_license = package.at_css('> uses-license')
     uses_license &&= uses_license['ref']
+    obsolete &&= package['obsolete']
+    type_details = to_json_collector package.at_css('> type-details')
+    revision_details = to_json_collector package.at_css('> revision')
     archives = package_archives(package) {|url| repo_url url}
+    dependencies_xml = package.at_css('> dependencies')
+    dependencies = to_json_collector dependencies_xml if dependencies_xml
 
     case type
     when 'addon:addonDetailsType'
@@ -278,6 +345,10 @@ def parse_addon_xml doc
     target['revision'] ||= revision
     target['displayName'] ||= display_name
     target['license'] ||= uses_license if uses_license
+    target['obsolete'] ||= obsolete if obsolete
+    target['type-details'] ||= type_details
+    target['revision-details'] ||= revision_details
+    target['dependencies'] ||= dependencies if dependencies
     target['archives'] ||= {}
     merge target['archives'], archives
   end

--- a/pkgs/development/mobile/androidenv/repo.json
+++ b/pkgs/development/mobile/androidenv/repo.json
@@ -14,7 +14,42 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-10",
-        "revision": "10"
+        "revision": "10",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "10",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "11": {
@@ -31,7 +66,35 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-11",
-        "revision": "11"
+        "revision": "11",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "11",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "12": {
@@ -48,7 +111,42 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-12",
-        "revision": "12"
+        "revision": "12",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "12",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       },
       "google_tv_addon": {
         "archives": [
@@ -63,7 +161,26 @@
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-12",
-        "revision": "12"
+        "revision": "12",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "12",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "tag:3": {
+            "display:1": "Google TV Addon",
+            "id:0": "google_tv_addon"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "13": {
@@ -80,7 +197,42 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-13",
-        "revision": "13"
+        "revision": "13",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "13",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       },
       "google_tv_addon": {
         "archives": [
@@ -95,7 +247,26 @@
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-13",
-        "revision": "13"
+        "revision": "13",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "13",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "tag:3": {
+            "display:1": "Google TV Addon",
+            "id:0": "google_tv_addon"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "14": {
@@ -112,7 +283,42 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-14",
-        "revision": "14"
+        "revision": "14",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "14",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "15": {
@@ -129,7 +335,49 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-15",
-        "revision": "15"
+        "revision": "15",
+        "revision-details": {
+          "major:0": "3"
+        },
+        "type-details": {
+          "api-level:0": "15",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            },
+            "library:2": {
+              "description:0": "Collection of video effects",
+              "element-attributes": {
+                "localJarPath": "effects.jar",
+                "name": "com.google.android.media.effects"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "16": {
@@ -146,7 +394,49 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-16",
-        "revision": "16"
+        "revision": "16",
+        "revision-details": {
+          "major:0": "4"
+        },
+        "type-details": {
+          "api-level:0": "16",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            },
+            "library:2": {
+              "description:0": "Collection of video effects",
+              "element-attributes": {
+                "localJarPath": "effects.jar",
+                "name": "com.google.android.media.effects"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "17": {
@@ -163,7 +453,49 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-17",
-        "revision": "17"
+        "revision": "17",
+        "revision-details": {
+          "major:0": "4"
+        },
+        "type-details": {
+          "api-level:0": "17",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            },
+            "library:2": {
+              "description:0": "Collection of video effects",
+              "element-attributes": {
+                "localJarPath": "effects.jar",
+                "name": "com.google.android.media.effects"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "18": {
@@ -180,7 +512,49 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-18",
-        "revision": "18"
+        "revision": "18",
+        "revision-details": {
+          "major:0": "4"
+        },
+        "type-details": {
+          "api-level:0": "18",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            },
+            "library:2": {
+              "description:0": "Collection of video effects",
+              "element-attributes": {
+                "localJarPath": "effects.jar",
+                "name": "com.google.android.media.effects"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "19": {
@@ -197,7 +571,49 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-19",
-        "revision": "19"
+        "revision": "19",
+        "revision-details": {
+          "major:0": "20"
+        },
+        "type-details": {
+          "api-level:0": "19",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            },
+            "library:2": {
+              "description:0": "Collection of video effects",
+              "element-attributes": {
+                "localJarPath": "effects.jar",
+                "name": "com.google.android.media.effects"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "21": {
@@ -214,7 +630,49 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-21",
-        "revision": "21"
+        "revision": "21",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "21",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            },
+            "library:2": {
+              "description:0": "Collection of video effects",
+              "element-attributes": {
+                "localJarPath": "effects.jar",
+                "name": "com.google.android.media.effects"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "22": {
@@ -231,7 +689,49 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-22",
-        "revision": "22"
+        "revision": "22",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "22",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            },
+            "library:2": {
+              "description:0": "Collection of video effects",
+              "element-attributes": {
+                "localJarPath": "effects.jar",
+                "name": "com.google.android.media.effects"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "23": {
@@ -248,7 +748,49 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-23",
-        "revision": "23"
+        "revision": "23",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "23",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            },
+            "library:2": {
+              "description:0": "Collection of video effects",
+              "element-attributes": {
+                "localJarPath": "effects.jar",
+                "name": "com.google.android.media.effects"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "24": {
@@ -265,7 +807,49 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-24",
-        "revision": "24"
+        "revision": "24",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "24",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            },
+            "library:2": {
+              "description:0": "Collection of video effects",
+              "element-attributes": {
+                "localJarPath": "effects.jar",
+                "name": "com.google.android.media.effects"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "25": {
@@ -282,7 +866,49 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-25",
-        "revision": "25"
+        "revision": "25",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "23",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            },
+            "library:1": {
+              "description:0": "API for USB Accessories",
+              "element-attributes": {
+                "localJarPath": "usb.jar",
+                "name": "com.android.future.usb.accessory"
+              }
+            },
+            "library:2": {
+              "description:0": "Collection of video effects",
+              "element-attributes": {
+                "localJarPath": "effects.jar",
+                "name": "com.google.android.media.effects"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "3": {
@@ -299,7 +925,35 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-3",
-        "revision": "3"
+        "revision": "3",
+        "revision-details": {
+          "major:0": "3"
+        },
+        "type-details": {
+          "api-level:0": "3",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "4": {
@@ -316,7 +970,35 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-4",
-        "revision": "4"
+        "revision": "4",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "4",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "5": {
@@ -333,7 +1015,35 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-5",
-        "revision": "5"
+        "revision": "5",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "5",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "6": {
@@ -350,7 +1060,35 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-6",
-        "revision": "6"
+        "revision": "6",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "6",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "7": {
@@ -367,7 +1105,35 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-7",
-        "revision": "7"
+        "revision": "7",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "7",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "8": {
@@ -384,7 +1150,35 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-8",
-        "revision": "8"
+        "revision": "8",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "8",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     },
     "9": {
@@ -401,7 +1195,35 @@
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-9",
-        "revision": "9"
+        "revision": "9",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "9",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns8:addonDetailsType"
+          },
+          "libraries:4": {
+            "library:0": {
+              "description:0": "API for Google Maps",
+              "element-attributes": {
+                "localJarPath": "maps.jar",
+                "name": "com.google.android.maps"
+              }
+            }
+          },
+          "tag:3": {
+            "display:1": "Google APIs",
+            "id:0": "google_apis"
+          },
+          "vendor:2": {
+            "display:1": "Google Inc.",
+            "id:0": "google"
+          }
+        }
       }
     }
   },
@@ -419,7 +1241,21 @@
       "license": "android-sdk-license",
       "name": "extras-android-m2repository",
       "path": "extras/android/m2repository",
-      "revision": "47.0.0"
+      "revision": "47.0.0",
+      "revision-details": {
+        "major:0": "47",
+        "micro:2": "0",
+        "minor:1": "0"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;google;Android_Emulator_Hypervisor_Driver": {
       "archives": [
@@ -434,7 +1270,21 @@
       "license": "android-sdk-license",
       "name": "extras-google-Android_Emulator_Hypervisor_Driver",
       "path": "extras/google/Android_Emulator_Hypervisor_Driver",
-      "revision": "1.8.0"
+      "revision": "1.8.0",
+      "revision-details": {
+        "major:0": "1",
+        "micro:2": "0",
+        "minor:1": "8"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": "Google LLC.",
+          "id:0": "google"
+        }
+      }
     },
     "extras;google;admob_ads_sdk": {
       "archives": [
@@ -449,7 +1299,19 @@
       "license": "android-sdk-license",
       "name": "extras-google-admob_ads_sdk",
       "path": "extras/google/admob_ads_sdk",
-      "revision": "11"
+      "revision": "11",
+      "revision-details": {
+        "major:0": "11"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": "Google Inc.",
+          "id:0": "google"
+        }
+      }
     },
     "extras;google;analytics_sdk_v2": {
       "archives": [
@@ -464,7 +1326,19 @@
       "license": "android-sdk-license",
       "name": "extras-google-analytics_sdk_v2",
       "path": "extras/google/analytics_sdk_v2",
-      "revision": "3"
+      "revision": "3",
+      "revision-details": {
+        "major:0": "3"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": "Google Inc.",
+          "id:0": "google"
+        }
+      }
     },
     "extras;google;gcm": {
       "archives": [
@@ -479,7 +1353,19 @@
       "license": "android-sdk-license",
       "name": "extras-google-gcm",
       "path": "extras/google/gcm",
-      "revision": "3"
+      "revision": "3",
+      "revision-details": {
+        "major:0": "3"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": "Google Inc.",
+          "id:0": "google"
+        }
+      }
     },
     "extras;google;google_play_services": {
       "archives": [
@@ -490,11 +1376,30 @@
           "url": "https://dl.google.com/android/repository/google_play_services_v16_1_rc09.zip"
         }
       ],
+      "dependencies": {
+        "dependency:0": {
+          "element-attributes": {
+            "path": "patcher;v4"
+          }
+        }
+      },
       "displayName": "Google Play services",
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services",
       "path": "extras/google/google_play_services",
-      "revision": "49"
+      "revision": "49",
+      "revision-details": {
+        "major:0": "49"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": "Google Inc.",
+          "id:0": "google"
+        }
+      }
     },
     "extras;google;google_play_services_froyo": {
       "archives": [
@@ -509,7 +1414,19 @@
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services_froyo",
       "path": "extras/google/google_play_services_froyo",
-      "revision": "12"
+      "revision": "12",
+      "revision-details": {
+        "major:0": "12"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": "Google Inc.",
+          "id:0": "google"
+        }
+      }
     },
     "extras;google;instantapps": {
       "archives": [
@@ -524,7 +1441,21 @@
       "license": "android-sdk-license",
       "name": "extras-google-instantapps",
       "path": "extras/google/instantapps",
-      "revision": "1.9.0"
+      "revision": "1.9.0",
+      "revision-details": {
+        "major:0": "1",
+        "micro:2": "0",
+        "minor:1": "9"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": "Google Inc.",
+          "id:0": "google"
+        }
+      }
     },
     "extras;google;m2repository": {
       "archives": [
@@ -535,11 +1466,30 @@
           "url": "https://dl.google.com/android/repository/google_m2repository_gms_v11_3_rc05_wear_2_0_5.zip"
         }
       ],
+      "dependencies": {
+        "dependency:0": {
+          "element-attributes": {
+            "path": "patcher;v4"
+          }
+        }
+      },
       "displayName": "Google Repository",
       "license": "android-sdk-license",
       "name": "extras-google-m2repository",
       "path": "extras/google/m2repository",
-      "revision": "58"
+      "revision": "58",
+      "revision-details": {
+        "major:0": "58"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": "Google Inc.",
+          "id:0": "google"
+        }
+      }
     },
     "extras;google;market_apk_expansion": {
       "archives": [
@@ -554,7 +1504,19 @@
       "license": "android-sdk-license",
       "name": "extras-google-market_apk_expansion",
       "path": "extras/google/market_apk_expansion",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": "Google Inc.",
+          "id:0": "google"
+        }
+      }
     },
     "extras;google;market_licensing": {
       "archives": [
@@ -569,7 +1531,20 @@
       "license": "android-sdk-license",
       "name": "extras-google-market_licensing",
       "path": "extras/google/market_licensing",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": {
+          },
+          "id:0": "google"
+        }
+      }
     },
     "extras;google;simulators": {
       "archives": [
@@ -584,7 +1559,19 @@
       "license": "android-sdk-license",
       "name": "extras-google-simulators",
       "path": "extras/google/simulators",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": "Google Inc.",
+          "id:0": "google"
+        }
+      }
     },
     "extras;google;usb_driver": {
       "archives": [
@@ -599,7 +1586,19 @@
       "license": "android-sdk-license",
       "name": "extras-google-usb_driver",
       "path": "extras/google/usb_driver",
-      "revision": "13"
+      "revision": "13",
+      "revision-details": {
+        "major:0": "13"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": "Google Inc.",
+          "id:0": "google"
+        }
+      }
     },
     "extras;google;webdriver": {
       "archives": [
@@ -614,7 +1613,19 @@
       "license": "android-sdk-license",
       "name": "extras-google-webdriver",
       "path": "extras/google/webdriver",
-      "revision": "2"
+      "revision": "2",
+      "revision-details": {
+        "major:0": "2"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:extraDetailsType"
+        },
+        "vendor:0": {
+          "display:1": "Google Inc.",
+          "id:0": "google"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0": {
       "archives": [
@@ -629,7 +1640,19 @@
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha4": {
       "archives": [
@@ -644,7 +1667,19 @@
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-alpha4",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-alpha4",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha8": {
       "archives": [
@@ -659,7 +1694,19 @@
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-alpha8",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-alpha8",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta1": {
       "archives": [
@@ -674,7 +1721,19 @@
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta1",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta1",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta2": {
       "archives": [
@@ -689,7 +1748,19 @@
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta2",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta2",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta3": {
       "archives": [
@@ -704,7 +1775,19 @@
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta3",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta3",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta4": {
       "archives": [
@@ -719,7 +1802,19 @@
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta4",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta4",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta5": {
       "archives": [
@@ -734,7 +1829,19 @@
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta5",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta5",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.1": {
       "archives": [
@@ -749,7 +1856,19 @@
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.1",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.1",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2": {
       "archives": [
@@ -764,7 +1883,19 @@
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.2",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.2",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0": {
       "archives": [
@@ -775,11 +1906,30 @@
           "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0.zip"
         }
       ],
+      "dependencies": {
+        "dependency:0": {
+          "element-attributes": {
+            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0"
+          }
+        }
+      },
       "displayName": "ConstraintLayout for Android 1.0.0",
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-alpha4": {
       "archives": [
@@ -790,11 +1940,30 @@
           "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-alpha4.zip"
         }
       ],
+      "dependencies": {
+        "dependency:0": {
+          "element-attributes": {
+            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha4"
+          }
+        }
+      },
       "displayName": "com.android.support.constraint:constraint-layout:1.0.0-alpha4",
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-alpha4",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-alpha4",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-alpha8": {
       "archives": [
@@ -805,11 +1974,30 @@
           "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-alpha8.zip"
         }
       ],
+      "dependencies": {
+        "dependency:0": {
+          "element-attributes": {
+            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha8"
+          }
+        }
+      },
       "displayName": "ConstraintLayout for Android 1.0.0-alpha8",
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-alpha8",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-alpha8",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta1": {
       "archives": [
@@ -820,11 +2008,30 @@
           "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-beta1.zip"
         }
       ],
+      "dependencies": {
+        "dependency:0": {
+          "element-attributes": {
+            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta1"
+          }
+        }
+      },
       "displayName": "ConstraintLayout for Android 1.0.0-beta1",
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta1",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta1",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta2": {
       "archives": [
@@ -835,11 +2042,30 @@
           "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-beta2.zip"
         }
       ],
+      "dependencies": {
+        "dependency:0": {
+          "element-attributes": {
+            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta2"
+          }
+        }
+      },
       "displayName": "ConstraintLayout for Android 1.0.0-beta2",
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta2",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta2",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta3": {
       "archives": [
@@ -850,11 +2076,30 @@
           "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-beta3.zip"
         }
       ],
+      "dependencies": {
+        "dependency:0": {
+          "element-attributes": {
+            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta3"
+          }
+        }
+      },
       "displayName": "ConstraintLayout for Android 1.0.0-beta3",
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta3",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta3",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta4": {
       "archives": [
@@ -865,11 +2110,30 @@
           "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-beta4.zip"
         }
       ],
+      "dependencies": {
+        "dependency:0": {
+          "element-attributes": {
+            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta4"
+          }
+        }
+      },
       "displayName": "ConstraintLayout for Android 1.0.0-beta4",
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta4",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta4",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta5": {
       "archives": [
@@ -880,11 +2144,30 @@
           "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-beta5.zip"
         }
       ],
+      "dependencies": {
+        "dependency:0": {
+          "element-attributes": {
+            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta5"
+          }
+        }
+      },
       "displayName": "ConstraintLayout for Android 1.0.0-beta5",
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta5",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta5",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.1": {
       "archives": [
@@ -895,11 +2178,30 @@
           "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.1.zip"
         }
       ],
+      "dependencies": {
+        "dependency:0": {
+          "element-attributes": {
+            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.1"
+          }
+        }
+      },
       "displayName": "ConstraintLayout for Android 1.0.1",
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.1",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.1",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     },
     "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2": {
       "archives": [
@@ -910,11 +2212,30 @@
           "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.2.zip"
         }
       ],
+      "dependencies": {
+        "dependency:0": {
+          "element-attributes": {
+            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
+          }
+        }
+      },
       "displayName": "ConstraintLayout for Android 1.0.2",
       "license": "android-sdk-license",
       "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.2",
       "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.2",
-      "revision": "1"
+      "revision": "1",
+      "revision-details": {
+        "major:0": "1"
+      },
+      "type-details": {
+        "element-attributes": {
+          "xsi:type": "ns8:mavenType"
+        },
+        "vendor:0": {
+          "display:1": "Android",
+          "id:0": "android"
+        }
+      }
     }
   },
   "images": {
@@ -926,14 +2247,36 @@
               "os": "all",
               "sha1": "8537616a7add47cce24c60f18bc2429e3dc90ae3",
               "size": 67927049,
-              "url": "https://dl.google.com/android/repository/sys-img/default/armeabi-v7a-10_r05.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-10_r05.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-10-default-armeabi-v7a",
           "path": "system-images/android-10/default/armeabi-v7a",
-          "revision": "10-default-armeabi-v7a"
+          "revision": "10-default-armeabi-v7a",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "10",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -941,14 +2284,36 @@
               "os": "all",
               "sha1": "a166d5ccbb165e1dd5464fbfeec30a61f77790d8",
               "size": 75386095,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-10_r05.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-10_r05.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-10-default-x86",
           "path": "system-images/android-10/default/x86",
-          "revision": "10-default-x86"
+          "revision": "10-default-x86",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "10",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -961,11 +2326,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-10_r06.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-armeabi-v7a",
           "path": "system-images/android-10/google_apis/armeabi-v7a",
-          "revision": "10-google_apis-armeabi-v7a"
+          "revision": "10-google_apis-armeabi-v7a",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:3": "armeabi-v7a",
+            "api-level:0": "10",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -976,11 +2366,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-10_r06.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-x86",
           "path": "system-images/android-10/google_apis/x86",
-          "revision": "10-google_apis-x86"
+          "revision": "10-google_apis-x86",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "10",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -992,14 +2407,29 @@
               "os": "all",
               "sha1": "d8991b0c06b18d7d6ed4169d67460ee1add6661b",
               "size": 99621822,
-              "url": "https://dl.google.com/android/repository/sys-img/default/sysimg_armv7a-14_r02.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-14_r02.zip"
             }
           ],
           "displayName": "ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-14-default-armeabi-v7a",
           "path": "system-images/android-14/default/armeabi-v7a",
-          "revision": "14-default-armeabi-v7a"
+          "revision": "14-default-armeabi-v7a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "14",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         }
       }
     },
@@ -1011,14 +2441,36 @@
               "os": "all",
               "sha1": "03d7ed95a9d3b107e3f2e5b166d017ea12529e70",
               "size": 102452069,
-              "url": "https://dl.google.com/android/repository/sys-img/default/armeabi-v7a-15_r05.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-15_r05.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-15-default-armeabi-v7a",
           "path": "system-images/android-15/default/armeabi-v7a",
-          "revision": "15-default-armeabi-v7a"
+          "revision": "15-default-armeabi-v7a",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "15",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1026,14 +2478,36 @@
               "os": "all",
               "sha1": "61381aef3fd0cdc8255cb3298072a920c80186ca",
               "size": 116030933,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-15_r07.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-15_r07.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-15-default-x86",
           "path": "system-images/android-15/default/x86",
-          "revision": "15-default-x86"
+          "revision": "15-default-x86",
+          "revision-details": {
+            "major:0": "7"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "15",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -1046,11 +2520,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-15_r06.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-armeabi-v7a",
           "path": "system-images/android-15/google_apis/armeabi-v7a",
-          "revision": "15-google_apis-armeabi-v7a"
+          "revision": "15-google_apis-armeabi-v7a",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:3": "armeabi-v7a",
+            "api-level:0": "15",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1061,11 +2560,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-15_r07.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-x86",
           "path": "system-images/android-15/google_apis/x86",
-          "revision": "15-google_apis-x86"
+          "revision": "15-google_apis-x86",
+          "revision-details": {
+            "major:0": "7"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "15",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -1077,14 +2601,36 @@
               "os": "all",
               "sha1": "69b944b0d5a18c8563fa80d7d229af64890f724e",
               "size": 118646340,
-              "url": "https://dl.google.com/android/repository/sys-img/default/armeabi-v7a-16_r06.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-16_r06.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-16-default-armeabi-v7a",
           "path": "system-images/android-16/default/armeabi-v7a",
-          "revision": "16-default-armeabi-v7a"
+          "revision": "16-default-armeabi-v7a",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "16",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "mips": {
           "archives": [
@@ -1092,14 +2638,29 @@
               "os": "all",
               "sha1": "67943c54fb3943943ffeb05fdd39c0b753681f6e",
               "size": 122482530,
-              "url": "https://dl.google.com/android/repository/sys-img/default/sysimg_mips-16_r04.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/sysimg_mips-16_r04.zip"
             }
           ],
           "displayName": "MIPS System Image",
           "license": "mips-android-sysimage-license",
           "name": "system-image-16-default-mips",
           "path": "system-images/android-16/default/mips",
-          "revision": "16-default-mips"
+          "revision": "16-default-mips",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:2": "mips",
+            "api-level:0": "16",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1107,14 +2668,36 @@
               "os": "all",
               "sha1": "ee6718e7556c8f8bd8d3f470b34f2c5dbf9bcff4",
               "size": 135305313,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-16_r07.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-16_r07.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-16-default-x86",
           "path": "system-images/android-16/default/x86",
-          "revision": "16-default-x86"
+          "revision": "16-default-x86",
+          "revision-details": {
+            "major:0": "7"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "16",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -1127,11 +2710,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-16_r06.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-armeabi-v7a",
           "path": "system-images/android-16/google_apis/armeabi-v7a",
-          "revision": "16-google_apis-armeabi-v7a"
+          "revision": "16-google_apis-armeabi-v7a",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:3": "armeabi-v7a",
+            "api-level:0": "16",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1142,11 +2750,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-16_r07.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-x86",
           "path": "system-images/android-16/google_apis/x86",
-          "revision": "16-google_apis-x86"
+          "revision": "16-google_apis-x86",
+          "revision-details": {
+            "major:0": "7"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "16",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -1158,14 +2791,36 @@
               "os": "all",
               "sha1": "a18a3fd0958ec4ef52507f58e414fc5c7dfd59d6",
               "size": 124437041,
-              "url": "https://dl.google.com/android/repository/sys-img/default/armeabi-v7a-17_r06.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-17_r06.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-17-default-armeabi-v7a",
           "path": "system-images/android-17/default/armeabi-v7a",
-          "revision": "17-default-armeabi-v7a"
+          "revision": "17-default-armeabi-v7a",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "17",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "mips": {
           "archives": [
@@ -1173,14 +2828,29 @@
               "os": "all",
               "sha1": "f0c6e153bd584c29e51b5c9723cfbf30f996a05d",
               "size": 131781761,
-              "url": "https://dl.google.com/android/repository/sys-img/default/sysimg_mips-17_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/sysimg_mips-17_r01.zip"
             }
           ],
           "displayName": "MIPS System Image",
           "license": "mips-android-sysimage-license",
           "name": "system-image-17-default-mips",
           "path": "system-images/android-17/default/mips",
-          "revision": "17-default-mips"
+          "revision": "17-default-mips",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:2": "mips",
+            "api-level:0": "17",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1188,14 +2858,39 @@
               "os": "all",
               "sha1": "1ad5ffb51e31f5fe9fa47411fed2c2ade9a33865",
               "size": 194811128,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-17_r07.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-17_r07.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-17-default-x86",
           "path": "system-images/android-17/default/x86",
-          "revision": "17-default-x86"
+          "revision": "17-default-x86",
+          "revision-details": {
+            "major:0": "7"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "17",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "default"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       },
       "google_apis": {
@@ -1208,11 +2903,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-17_r06.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-armeabi-v7a",
           "path": "system-images/android-17/google_apis/armeabi-v7a",
-          "revision": "17-google_apis-armeabi-v7a"
+          "revision": "17-google_apis-armeabi-v7a",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:3": "armeabi-v7a",
+            "api-level:0": "17",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1223,11 +2943,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-17_r07.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-x86",
           "path": "system-images/android-17/google_apis/x86",
-          "revision": "17-google_apis-x86"
+          "revision": "17-google_apis-x86",
+          "revision-details": {
+            "major:0": "7"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "17",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -1239,14 +2984,36 @@
               "os": "all",
               "sha1": "580b583720f7de671040d5917c8c9db0c7aa03fd",
               "size": 130590545,
-              "url": "https://dl.google.com/android/repository/sys-img/default/armeabi-v7a-18_r05.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-18_r05.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-18-default-armeabi-v7a",
           "path": "system-images/android-18/default/armeabi-v7a",
-          "revision": "18-default-armeabi-v7a"
+          "revision": "18-default-armeabi-v7a",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "18",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1254,14 +3021,36 @@
               "os": "all",
               "sha1": "7a4ced4d9b0ab48047825491b4072dc2eb9b610e",
               "size": 150097655,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-18_r04.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-18_r04.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-18-default-x86",
           "path": "system-images/android-18/default/x86",
-          "revision": "18-default-x86"
+          "revision": "18-default-x86",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "18",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -1274,11 +3063,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-18_r06.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-armeabi-v7a",
           "path": "system-images/android-18/google_apis/armeabi-v7a",
-          "revision": "18-google_apis-armeabi-v7a"
+          "revision": "18-google_apis-armeabi-v7a",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:3": "armeabi-v7a",
+            "api-level:0": "18",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1289,11 +3103,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-18_r06.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-x86",
           "path": "system-images/android-18/google_apis/x86",
-          "revision": "18-google_apis-x86"
+          "revision": "18-google_apis-x86",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "18",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -1305,14 +3144,36 @@
               "os": "all",
               "sha1": "d1a5fd4f2e1c013c3d3d9bfe7e9db908c3ed56fa",
               "size": 159871567,
-              "url": "https://dl.google.com/android/repository/sys-img/default/armeabi-v7a-19_r05.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-19_r05.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-19-default-armeabi-v7a",
           "path": "system-images/android-19/default/armeabi-v7a",
-          "revision": "19-default-armeabi-v7a"
+          "revision": "19-default-armeabi-v7a",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "19",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1320,14 +3181,36 @@
               "os": "all",
               "sha1": "2ac82153aae97f7eae4c5a0761224fe04321d03d",
               "size": 185886274,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-19_r06.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-19_r06.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-19-default-x86",
           "path": "system-images/android-19/default/x86",
-          "revision": "19-default-x86"
+          "revision": "19-default-x86",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "19",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -1340,11 +3223,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-19_r40.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-armeabi-v7a",
           "path": "system-images/android-19/google_apis/armeabi-v7a",
-          "revision": "19-google_apis-armeabi-v7a"
+          "revision": "19-google_apis-armeabi-v7a",
+          "revision-details": {
+            "major:0": "40"
+          },
+          "type-details": {
+            "abi:3": "armeabi-v7a",
+            "api-level:0": "19",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1355,11 +3263,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-19_r40.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-x86",
           "path": "system-images/android-19/google_apis/x86",
-          "revision": "19-google_apis-x86"
+          "revision": "19-google_apis-x86",
+          "revision-details": {
+            "major:0": "40"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "19",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -1378,7 +3311,21 @@
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-armeabi-v7a",
           "path": "system-images/android-21/android-tv/armeabi-v7a",
-          "revision": "21-android-tv-armeabi-v7a"
+          "revision": "21-android-tv-armeabi-v7a",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "21",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1393,7 +3340,21 @@
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-x86",
           "path": "system-images/android-21/android-tv/x86",
-          "revision": "21-android-tv-x86"
+          "revision": "21-android-tv-x86",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "21",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         }
       },
       "default": {
@@ -1403,14 +3364,29 @@
               "os": "all",
               "sha1": "c4375f1b4b4cd21a8617660e25f621cedcbd8332",
               "size": 211426314,
-              "url": "https://dl.google.com/android/repository/sys-img/default/arm64-v8a-21_r04.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-21_r04.zip"
             }
           ],
           "displayName": "ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-21-default-arm64-v8a",
           "path": "system-images/android-21/default/arm64-v8a",
-          "revision": "21-default-arm64-v8a"
+          "revision": "21-default-arm64-v8a",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "21",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "armeabi-v7a": {
           "archives": [
@@ -1418,14 +3394,36 @@
               "os": "all",
               "sha1": "8c606f81306564b65e41303d2603e4c42ded0d10",
               "size": 187163871,
-              "url": "https://dl.google.com/android/repository/sys-img/default/armeabi-v7a-21_r04.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-21_r04.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-21-default-armeabi-v7a",
           "path": "system-images/android-21/default/armeabi-v7a",
-          "revision": "21-default-armeabi-v7a"
+          "revision": "21-default-armeabi-v7a",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "21",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1433,14 +3431,36 @@
               "os": "all",
               "sha1": "00f0eb0a1003efe3316347f762e20a85d8749cff",
               "size": 208212529,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-21_r05.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-21_r05.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86",
           "path": "system-images/android-21/default/x86",
-          "revision": "21-default-x86"
+          "revision": "21-default-x86",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "21",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -1448,14 +3468,36 @@
               "os": "all",
               "sha1": "9078a095825a69e5e215713f0866c83cef65a342",
               "size": 292623982,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86_64-21_r05.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-21_r05.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86_64",
           "path": "system-images/android-21/default/x86_64",
-          "revision": "21-default-x86_64"
+          "revision": "21-default-x86_64",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:2": "x86_64",
+            "api-level:0": "21",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -1472,7 +3514,25 @@
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-arm64-v8a",
           "path": "system-images/android-21/google_apis/arm64-v8a",
-          "revision": "21-google_apis-arm64-v8a"
+          "revision": "21-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "32"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "21",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "armeabi-v7a": {
           "archives": [
@@ -1483,11 +3543,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-21_r32.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-armeabi-v7a",
           "path": "system-images/android-21/google_apis/armeabi-v7a",
-          "revision": "21-google_apis-armeabi-v7a"
+          "revision": "21-google_apis-armeabi-v7a",
+          "revision-details": {
+            "major:0": "32"
+          },
+          "type-details": {
+            "abi:3": "armeabi-v7a",
+            "api-level:0": "21",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1498,11 +3583,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-21_r32.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86",
           "path": "system-images/android-21/google_apis/x86",
-          "revision": "21-google_apis-x86"
+          "revision": "21-google_apis-x86",
+          "revision-details": {
+            "major:0": "32"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "21",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -1513,11 +3623,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-21_r32.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86_64",
           "path": "system-images/android-21/google_apis/x86_64",
-          "revision": "21-google_apis-x86_64"
+          "revision": "21-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "32"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "21",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -1536,7 +3671,21 @@
           "license": "android-sdk-license",
           "name": "system-image-22-android-tv-x86",
           "path": "system-images/android-22/android-tv/x86",
-          "revision": "22-android-tv-x86"
+          "revision": "22-android-tv-x86",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "22",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         }
       },
       "default": {
@@ -1546,14 +3695,29 @@
               "os": "all",
               "sha1": "703e27a9a4fb7a6e763cb7d713b89e5249a8fc99",
               "size": 219124634,
-              "url": "https://dl.google.com/android/repository/sys-img/default/arm64-v8a-22_r02.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-22_r02.zip"
             }
           ],
           "displayName": "ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-22-default-arm64-v8a",
           "path": "system-images/android-22/default/arm64-v8a",
-          "revision": "22-default-arm64-v8a"
+          "revision": "22-default-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "22",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "armeabi-v7a": {
           "archives": [
@@ -1561,14 +3725,36 @@
               "os": "all",
               "sha1": "2114ec015dbf3a16cbcb4f63e8a84a1b206a07a1",
               "size": 194596267,
-              "url": "https://dl.google.com/android/repository/sys-img/default/armeabi-v7a-22_r02.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-22_r02.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-22-default-armeabi-v7a",
           "path": "system-images/android-22/default/armeabi-v7a",
-          "revision": "22-default-armeabi-v7a"
+          "revision": "22-default-armeabi-v7a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "22",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1576,14 +3762,36 @@
               "os": "all",
               "sha1": "e33e2a6cc3f1cc56b2019dbef3917d2eeb26f54e",
               "size": 214268954,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-22_r06.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-22_r06.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86",
           "path": "system-images/android-22/default/x86",
-          "revision": "22-default-x86"
+          "revision": "22-default-x86",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "22",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -1591,14 +3799,36 @@
               "os": "all",
               "sha1": "5db3b27f78cd9c4c5092b1cad5a5dd479fb5b2e4",
               "size": 299976630,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86_64-22_r06.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-22_r06.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86_64",
           "path": "system-images/android-22/default/x86_64",
-          "revision": "22-default-x86_64"
+          "revision": "22-default-x86_64",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:2": "x86_64",
+            "api-level:0": "22",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -1615,7 +3845,25 @@
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-arm64-v8a",
           "path": "system-images/android-22/google_apis/arm64-v8a",
-          "revision": "22-google_apis-arm64-v8a"
+          "revision": "22-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "26"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "22",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "armeabi-v7a": {
           "archives": [
@@ -1626,11 +3874,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-22_r26.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-armeabi-v7a",
           "path": "system-images/android-22/google_apis/armeabi-v7a",
-          "revision": "22-google_apis-armeabi-v7a"
+          "revision": "22-google_apis-armeabi-v7a",
+          "revision-details": {
+            "major:0": "26"
+          },
+          "type-details": {
+            "abi:3": "armeabi-v7a",
+            "api-level:0": "22",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1641,11 +3914,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-22_r26.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86",
           "path": "system-images/android-22/google_apis/x86",
-          "revision": "22-google_apis-x86"
+          "revision": "22-google_apis-x86",
+          "revision-details": {
+            "major:0": "26"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "22",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -1656,11 +3954,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-22_r26.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86_64",
           "path": "system-images/android-22/google_apis/x86_64",
-          "revision": "22-google_apis-x86_64"
+          "revision": "22-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "26"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "22",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -1679,7 +4002,21 @@
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-armeabi-v7a",
           "path": "system-images/android-23/android-tv/armeabi-v7a",
-          "revision": "23-android-tv-armeabi-v7a"
+          "revision": "23-android-tv-armeabi-v7a",
+          "revision-details": {
+            "major:0": "12"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "23",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1690,11 +4027,32 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-23_r21.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Android TV Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-x86",
           "path": "system-images/android-23/android-tv/x86",
-          "revision": "23-android-tv-x86"
+          "revision": "23-android-tv-x86",
+          "revision-details": {
+            "major:0": "21"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "23",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         }
       },
       "default": {
@@ -1704,14 +4062,29 @@
               "os": "all",
               "sha1": "ac18f3bd717e02804eee585e029f5dbc1a2616bf",
               "size": 253807785,
-              "url": "https://dl.google.com/android/repository/sys-img/default/arm64-v8a-23_r07.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-23_r07.zip"
             }
           ],
           "displayName": "ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-23-default-arm64-v8a",
           "path": "system-images/android-23/default/arm64-v8a",
-          "revision": "23-default-arm64-v8a"
+          "revision": "23-default-arm64-v8a",
+          "revision-details": {
+            "major:0": "7"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "23",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "armeabi-v7a": {
           "archives": [
@@ -1719,14 +4092,36 @@
               "os": "all",
               "sha1": "7cf2ad756e54a3acfd81064b63cb0cb9dff2798d",
               "size": 238333358,
-              "url": "https://dl.google.com/android/repository/sys-img/default/armeabi-v7a-23_r06.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-23_r06.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-23-default-armeabi-v7a",
           "path": "system-images/android-23/default/armeabi-v7a",
-          "revision": "23-default-armeabi-v7a"
+          "revision": "23-default-armeabi-v7a",
+          "revision-details": {
+            "major:0": "6"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "23",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1734,14 +4129,36 @@
               "os": "all",
               "sha1": "f6c3e3dd7bd951454795aa75c3a145fd05ac25bb",
               "size": 260804863,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-23_r10.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-23_r10.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86",
           "path": "system-images/android-23/default/x86",
-          "revision": "23-default-x86"
+          "revision": "23-default-x86",
+          "revision-details": {
+            "major:0": "10"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "23",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -1749,14 +4166,36 @@
               "os": "all",
               "sha1": "7cbc291483ca07dc67b71268c5f08a5755f50f51",
               "size": 365009313,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86_64-23_r10.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-23_r10.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86_64",
           "path": "system-images/android-23/default/x86_64",
-          "revision": "23-default-x86_64"
+          "revision": "23-default-x86_64",
+          "revision-details": {
+            "major:0": "10"
+          },
+          "type-details": {
+            "abi:2": "x86_64",
+            "api-level:0": "23",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -1773,7 +4212,25 @@
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-arm64-v8a",
           "path": "system-images/android-23/google_apis/arm64-v8a",
-          "revision": "23-google_apis-arm64-v8a"
+          "revision": "23-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "33"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "23",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "armeabi-v7a": {
           "archives": [
@@ -1784,11 +4241,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-23_r33.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-armeabi-v7a",
           "path": "system-images/android-23/google_apis/armeabi-v7a",
-          "revision": "23-google_apis-armeabi-v7a"
+          "revision": "23-google_apis-armeabi-v7a",
+          "revision-details": {
+            "major:0": "33"
+          },
+          "type-details": {
+            "abi:3": "armeabi-v7a",
+            "api-level:0": "23",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1799,11 +4281,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-23_r33.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86",
           "path": "system-images/android-23/google_apis/x86",
-          "revision": "23-google_apis-x86"
+          "revision": "23-google_apis-x86",
+          "revision-details": {
+            "major:0": "33"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "23",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -1814,11 +4321,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-23_r33.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86_64",
           "path": "system-images/android-23/google_apis/x86_64",
-          "revision": "23-google_apis-x86_64"
+          "revision": "23-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "33"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "23",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -1833,11 +4365,32 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-24_r22.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Android TV Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-24-android-tv-x86",
           "path": "system-images/android-24/android-tv/x86",
-          "revision": "24-android-tv-x86"
+          "revision": "24-android-tv-x86",
+          "revision-details": {
+            "major:0": "22"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "24",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         }
       },
       "default": {
@@ -1847,14 +4400,29 @@
               "os": "all",
               "sha1": "e88ebdf4533efa0370603ee4ab0e7834e0cc364f",
               "size": 305854153,
-              "url": "https://dl.google.com/android/repository/sys-img/default/arm64-v8a-24_r09.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-24_r09.zip"
             }
           ],
           "displayName": "ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-24-default-arm64-v8a",
           "path": "system-images/android-24/default/arm64-v8a",
-          "revision": "24-default-arm64-v8a"
+          "revision": "24-default-arm64-v8a",
+          "revision-details": {
+            "major:0": "9"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "24",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "armeabi-v7a": {
           "archives": [
@@ -1862,14 +4430,36 @@
               "os": "all",
               "sha1": "e22c47afd06398b35f2705ca2e7fa85323351568",
               "size": 782997866,
-              "url": "https://dl.google.com/android/repository/sys-img/default/armeabi-v7a-24_r07.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-24_r07.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-24-default-armeabi-v7a",
           "path": "system-images/android-24/default/armeabi-v7a",
-          "revision": "24-default-armeabi-v7a"
+          "revision": "24-default-armeabi-v7a",
+          "revision-details": {
+            "major:0": "7"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "24",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1877,14 +4467,36 @@
               "os": "all",
               "sha1": "c1cae7634b0216c0b5990f2c144eb8ca948e3511",
               "size": 313489224,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-24_r08.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-24_r08.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86",
           "path": "system-images/android-24/default/x86",
-          "revision": "24-default-x86"
+          "revision": "24-default-x86",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "24",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -1892,14 +4504,36 @@
               "os": "all",
               "sha1": "f6559e1949a5879f31a9662f4f0e50ad60181684",
               "size": 419261998,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86_64-24_r08.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-24_r08.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86_64",
           "path": "system-images/android-24/default/x86_64",
-          "revision": "24-default-x86_64"
+          "revision": "24-default-x86_64",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:2": "x86_64",
+            "api-level:0": "24",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -1912,11 +4546,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-24_r29.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-arm64-v8a",
           "path": "system-images/android-24/google_apis/arm64-v8a",
-          "revision": "24-google_apis-arm64-v8a"
+          "revision": "24-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "27"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "24",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -1927,11 +4586,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-24_r27.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86",
           "path": "system-images/android-24/google_apis/x86",
-          "revision": "24-google_apis-x86"
+          "revision": "24-google_apis-x86",
+          "revision-details": {
+            "major:0": "27"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "24",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -1942,11 +4626,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-24_r27.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86_64",
           "path": "system-images/android-24/google_apis/x86_64",
-          "revision": "24-google_apis-x86_64"
+          "revision": "24-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "27"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "24",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       },
       "google_apis_playstore": {
@@ -1959,11 +4668,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-24_r19.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis_playstore-x86",
           "path": "system-images/android-24/google_apis_playstore/x86",
-          "revision": "24-google_apis_playstore-x86"
+          "revision": "24-google_apis_playstore-x86",
+          "revision-details": {
+            "major:0": "19"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "24",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -1978,11 +4712,32 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-25_r16.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Android TV Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-25-android-tv-x86",
           "path": "system-images/android-25/android-tv/x86",
-          "revision": "25-android-tv-x86"
+          "revision": "25-android-tv-x86",
+          "revision-details": {
+            "major:0": "16"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "25",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         }
       },
       "android-wear": {
@@ -1995,11 +4750,32 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/armeabi-v7a-25_r03.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Android Wear ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-armeabi-v7a",
           "path": "system-images/android-25/android-wear/armeabi-v7a",
-          "revision": "25-android-wear-armeabi-v7a"
+          "revision": "25-android-wear-armeabi-v7a",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:2": "armeabi-v7a",
+            "api-level:0": "25",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android Wear",
+              "id:0": "android-wear"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2010,11 +4786,32 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86-25_r03.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Android Wear Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-x86",
           "path": "system-images/android-25/android-wear/x86",
-          "revision": "25-android-wear-x86"
+          "revision": "25-android-wear-x86",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "25",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android Wear",
+              "id:0": "android-wear"
+            }
+          }
         }
       },
       "default": {
@@ -2024,14 +4821,29 @@
               "os": "all",
               "sha1": "b39d359623323a1b4906c071dec396040016ea73",
               "size": 308416103,
-              "url": "https://dl.google.com/android/repository/sys-img/default/arm64-v8a-25_r02.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-25_r02.zip"
             }
           ],
           "displayName": "ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-25-default-arm64-v8a",
           "path": "system-images/android-25/default/arm64-v8a",
-          "revision": "25-default-arm64-v8a"
+          "revision": "25-default-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "25",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2039,14 +4851,36 @@
               "os": "all",
               "sha1": "78ce7eb1387d598685633b9f7cbb300c3d3aeb5f",
               "size": 316695942,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-25_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-25_r01.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86",
           "path": "system-images/android-25/default/x86",
-          "revision": "25-default-x86"
+          "revision": "25-default-x86",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "25",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2054,14 +4888,36 @@
               "os": "all",
               "sha1": "7093d7b39216020226ff430a3b7b81c94d31ad37",
               "size": 422702097,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86_64-25_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-25_r01.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86_64",
           "path": "system-images/android-25/default/x86_64",
-          "revision": "25-default-x86_64"
+          "revision": "25-default-x86_64",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:2": "x86_64",
+            "api-level:0": "25",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": {
+              },
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -2078,7 +4934,25 @@
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-arm64-v8a",
           "path": "system-images/android-25/google_apis/arm64-v8a",
-          "revision": "25-google_apis-arm64-v8a"
+          "revision": "25-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "20"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "25",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "armeabi-v7a": {
           "archives": [
@@ -2089,11 +4963,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-25_r18.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs ARM EABI v7a System Image",
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-armeabi-v7a",
           "path": "system-images/android-25/google_apis/armeabi-v7a",
-          "revision": "25-google_apis-armeabi-v7a"
+          "revision": "25-google_apis-armeabi-v7a",
+          "revision-details": {
+            "major:0": "18"
+          },
+          "type-details": {
+            "abi:3": "armeabi-v7a",
+            "api-level:0": "25",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2104,11 +5003,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-25_r18.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86",
           "path": "system-images/android-25/google_apis/x86",
-          "revision": "25-google_apis-x86"
+          "revision": "25-google_apis-x86",
+          "revision-details": {
+            "major:0": "18"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "25",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2119,11 +5043,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-25_r18.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86_64",
           "path": "system-images/android-25/google_apis/x86_64",
-          "revision": "25-google_apis-x86_64"
+          "revision": "25-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "18"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "25",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       },
       "google_apis_playstore": {
@@ -2136,11 +5085,36 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-25_r09.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis_playstore-x86",
           "path": "system-images/android-25/google_apis_playstore/x86",
-          "revision": "25-google_apis_playstore-x86"
+          "revision": "25-google_apis_playstore-x86",
+          "revision-details": {
+            "major:0": "9"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "25",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -2155,11 +5129,42 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-26_r14.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "26",
+                "micro:2": "3",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Android TV Intel x86 Atom System Image",
           "license": "android-sdk-preview-license",
           "name": "system-image-26-android-tv-x86",
           "path": "system-images/android-26/android-tv/x86",
-          "revision": "26-android-tv-x86"
+          "revision": "26-android-tv-x86",
+          "revision-details": {
+            "major:0": "14"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "26",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         }
       },
       "android-wear": {
@@ -2172,11 +5177,32 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86-26_r04.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Android Wear Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-26-android-wear-x86",
           "path": "system-images/android-26/android-wear/x86",
-          "revision": "26-android-wear-x86"
+          "revision": "26-android-wear-x86",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "26",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android Wear",
+              "id:0": "android-wear"
+            }
+          }
         }
       },
       "default": {
@@ -2186,14 +5212,40 @@
               "os": "all",
               "sha1": "c3199baf49790fc65f90f7ce734435d5778f6a30",
               "size": 328910124,
-              "url": "https://dl.google.com/android/repository/sys-img/default/arm64-v8a-26_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-26_r01.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "31",
+                "micro:2": "1",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-26-default-arm64-v8a",
           "path": "system-images/android-26/default/arm64-v8a",
-          "revision": "26-default-arm64-v8a"
+          "revision": "26-default-arm64-v8a",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "26",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2201,14 +5253,35 @@
               "os": "all",
               "sha1": "e613d6e0da668e30daf547f3c6627a6352846f90",
               "size": 350195807,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-26_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-26_r01.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86",
           "path": "system-images/android-26/default/x86",
-          "revision": "26-default-x86"
+          "revision": "26-default-x86",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "26",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2216,14 +5289,35 @@
               "os": "all",
               "sha1": "432f149c048bffce7f9de526ec65b336daf7a0a3",
               "size": 474178332,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86_64-26_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-26_r01.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86_64",
           "path": "system-images/android-26/default/x86_64",
-          "revision": "26-default-x86_64"
+          "revision": "26-default-x86_64",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:2": "x86_64",
+            "api-level:0": "26",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -2236,11 +5330,41 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-26_r01.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "31",
+                "micro:2": "1",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google APIs ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-arm64-v8a",
           "path": "system-images/android-26/google_apis/arm64-v8a",
-          "revision": "26-google_apis-arm64-v8a"
+          "revision": "26-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "26",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2251,11 +5375,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-26_r16.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "26",
+                "micro:2": "3",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86",
           "path": "system-images/android-26/google_apis/x86",
-          "revision": "26-google_apis-x86"
+          "revision": "26-google_apis-x86",
+          "revision-details": {
+            "major:0": "16"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "26",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2266,11 +5425,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-26_r16.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "26",
+                "micro:2": "3",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86_64",
           "path": "system-images/android-26/google_apis/x86_64",
-          "revision": "26-google_apis-x86_64"
+          "revision": "26-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "16"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "26",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       },
       "google_apis_playstore": {
@@ -2283,11 +5477,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-26_r07.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "26",
+                "micro:2": "3",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom System Image",
           "license": "android-sdk-preview-license",
           "name": "system-image-26-google_apis_playstore-x86",
           "path": "system-images/android-26/google_apis_playstore/x86",
-          "revision": "26-google_apis_playstore-x86"
+          "revision": "26-google_apis_playstore-x86",
+          "revision-details": {
+            "major:0": "7"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "26",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -2302,11 +5531,32 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-27_r09.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Android TV Intel x86 Atom System Image",
           "license": "android-sdk-preview-license",
           "name": "system-image-27-android-tv-x86",
           "path": "system-images/android-27/android-tv/x86",
-          "revision": "27-android-tv-x86"
+          "revision": "27-android-tv-x86",
+          "revision-details": {
+            "major:0": "9"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "27",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         }
       },
       "default": {
@@ -2316,14 +5566,40 @@
               "os": "all",
               "sha1": "cb01199edae33ce375c6d8e08aea08911ff0d583",
               "size": 331796092,
-              "url": "https://dl.google.com/android/repository/sys-img/default/arm64-v8a-27_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-27_r01.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "31",
+                "micro:2": "1",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-27-default-arm64-v8a",
           "path": "system-images/android-27/default/arm64-v8a",
-          "revision": "27-default-arm64-v8a"
+          "revision": "27-default-arm64-v8a",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "27",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2331,14 +5607,35 @@
               "os": "all",
               "sha1": "4ec990fac7b62958decd12e18a4cd389dfe7c582",
               "size": 360984187,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-27_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-27_r01.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86",
           "path": "system-images/android-27/default/x86",
-          "revision": "27-default-x86"
+          "revision": "27-default-x86",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "27",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2346,14 +5643,35 @@
               "os": "all",
               "sha1": "2878261011a59ca3de29dc5b457a495fdb268d60",
               "size": 491675204,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86_64-27_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-27_r01.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86_64",
           "path": "system-images/android-27/default/x86_64",
-          "revision": "27-default-x86_64"
+          "revision": "27-default-x86_64",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:2": "x86_64",
+            "api-level:0": "27",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -2366,11 +5684,41 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-27_r01.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "31",
+                "micro:2": "1",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google APIs ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-arm64-v8a",
           "path": "system-images/android-27/google_apis/arm64-v8a",
-          "revision": "27-google_apis-arm64-v8a"
+          "revision": "27-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "27",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2381,11 +5729,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-27_r11.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "27",
+                "micro:2": "7",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-x86",
           "path": "system-images/android-27/google_apis/x86",
-          "revision": "27-google_apis-x86"
+          "revision": "27-google_apis-x86",
+          "revision-details": {
+            "major:0": "11"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "27",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       },
       "google_apis_playstore": {
@@ -2398,11 +5781,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-27_r03.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "26",
+                "micro:2": "3",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis_playstore-x86",
           "path": "system-images/android-27/google_apis_playstore/x86",
-          "revision": "27-google_apis_playstore-x86"
+          "revision": "27-google_apis_playstore-x86",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "27",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -2417,11 +5835,32 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-28_r10.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Android TV Intel x86 Atom System Image",
           "license": "android-sdk-preview-license",
           "name": "system-image-28-android-tv-x86",
           "path": "system-images/android-28/android-tv/x86",
-          "revision": "28-android-tv-x86"
+          "revision": "28-android-tv-x86",
+          "revision-details": {
+            "major:0": "10"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "28",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         }
       },
       "android-wear": {
@@ -2434,11 +5873,32 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86-28_r09.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Wear OS Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-28-android-wear-x86",
           "path": "system-images/android-28/android-wear/x86",
-          "revision": "28-android-wear-x86"
+          "revision": "28-android-wear-x86",
+          "revision-details": {
+            "major:0": "9"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "28",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Wear OS",
+              "id:0": "android-wear"
+            }
+          }
         }
       },
       "default": {
@@ -2448,14 +5908,40 @@
               "os": "all",
               "sha1": "4de0491612ca12097be7deb76af835ebabadefca",
               "size": 425671679,
-              "url": "https://dl.google.com/android/repository/sys-img/default/arm64-v8a-28_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-28_r01.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "31",
+                "micro:2": "1",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-28-default-arm64-v8a",
           "path": "system-images/android-28/default/arm64-v8a",
-          "revision": "28-default-arm64-v8a"
+          "revision": "28-default-arm64-v8a",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "28",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2463,14 +5949,28 @@
               "os": "all",
               "sha1": "ce03c42d80c0fc6dc47f6455dbee7aa275d02780",
               "size": 437320152,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-28_r04.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-28_r04.zip"
             }
           ],
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86",
           "path": "system-images/android-28/default/x86",
-          "revision": "28-default-x86"
+          "revision": "28-default-x86",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "28",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2478,14 +5978,28 @@
               "os": "all",
               "sha1": "d47a85c8f4e9fd57df97814ad8884eeb0f3a0ef0",
               "size": 564792723,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86_64-28_r04.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-28_r04.zip"
             }
           ],
           "displayName": "Intel x86 Atom_64 System Image",
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86_64",
           "path": "system-images/android-28/default/x86_64",
-          "revision": "28-default-x86_64"
+          "revision": "28-default-x86_64",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:2": "x86_64",
+            "api-level:0": "28",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -2498,11 +6012,41 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-28_r01.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "31",
+                "micro:2": "1",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google APIs ARM 64 v8a System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis-arm64-v8a",
           "path": "system-images/android-28/google_apis/arm64-v8a",
-          "revision": "28-google_apis-arm64-v8a"
+          "revision": "28-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "28",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2513,11 +6057,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-28_r12.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "29",
+                "micro:2": "12",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis-x86",
           "path": "system-images/android-28/google_apis/x86",
-          "revision": "28-google_apis-x86"
+          "revision": "28-google_apis-x86",
+          "revision-details": {
+            "major:0": "12"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "28",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2528,11 +6107,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-28_r11.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "29",
+                "micro:2": "12",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-x86_64",
           "path": "system-images/android-28/google_apis/x86_64",
-          "revision": "28-google_apis-x86_64"
+          "revision": "28-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "11"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "28",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       },
       "google_apis_playstore": {
@@ -2545,11 +6159,41 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-28_r01.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "31",
+                "micro:2": "1",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google ARM64-V8a Play ARM 64 v8a System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-28/google_apis_playstore/arm64-v8a",
-          "revision": "28-google_apis_playstore-arm64-v8a"
+          "revision": "28-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "28",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google ARM64-V8a Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2560,11 +6204,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-28_r09.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "27",
+                "micro:2": "7",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86",
           "path": "system-images/android-28/google_apis_playstore/x86",
-          "revision": "28-google_apis_playstore-x86"
+          "revision": "28-google_apis_playstore-x86",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "28",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2575,11 +6254,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-28_r08.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "27",
+                "micro:2": "7",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86_64",
           "path": "system-images/android-28/google_apis_playstore/x86_64",
-          "revision": "28-google_apis_playstore-x86_64"
+          "revision": "28-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "28",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -2594,11 +6308,42 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-29_r03.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "28",
+                "micro:2": "6",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Android TV Intel x86 Atom System Image",
           "license": "android-sdk-preview-license",
           "name": "system-image-29-android-tv-x86",
           "path": "system-images/android-29/android-tv/x86",
-          "revision": "29-android-tv-x86"
+          "revision": "29-android-tv-x86",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "29",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         }
       },
       "default": {
@@ -2608,14 +6353,28 @@
               "os": "all",
               "sha1": "fa0d67d7430fcc84b2fe2508ea81e92ac644e264",
               "size": 498049256,
-              "url": "https://dl.google.com/android/repository/sys-img/default/arm64-v8a-29_r08.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-29_r08.zip"
             }
           ],
           "displayName": "ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-29-default-arm64-v8a",
           "path": "system-images/android-29/default/arm64-v8a",
-          "revision": "29-default-arm64-v8a"
+          "revision": "29-default-arm64-v8a",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "29",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2623,26 +6382,52 @@
               "os": "windows",
               "sha1": "cc4fa13e49cb2e93770d4f2e90ea1dd2a81e315b",
               "size": 516543600,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-29_r08-windows.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-29_r08-windows.zip"
             },
             {
               "os": "macosx",
               "sha1": "cc4fa13e49cb2e93770d4f2e90ea1dd2a81e315b",
               "size": 516543600,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-29_r08-darwin.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-29_r08-darwin.zip"
             },
             {
               "os": "linux",
               "sha1": "cc4fa13e49cb2e93770d4f2e90ea1dd2a81e315b",
               "size": 516543600,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86-29_r08-linux.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86-29_r08-linux.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "28",
+                "micro:2": "9",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86",
           "path": "system-images/android-29/default/x86",
-          "revision": "29-default-x86"
+          "revision": "29-default-x86",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "29",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2650,26 +6435,52 @@
               "os": "windows",
               "sha1": "e4b798d6fcddff90d528d74ef22ce3dd4a2ca798",
               "size": 689676765,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86_64-29_r08-windows.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-29_r08-windows.zip"
             },
             {
               "os": "macosx",
               "sha1": "e4b798d6fcddff90d528d74ef22ce3dd4a2ca798",
               "size": 689676765,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86_64-29_r08-darwin.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-29_r08-darwin.zip"
             },
             {
               "os": "linux",
               "sha1": "e4b798d6fcddff90d528d74ef22ce3dd4a2ca798",
               "size": 689676765,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86_64-29_r08-linux.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-29_r08-linux.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "28",
+                "micro:2": "9",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86_64",
           "path": "system-images/android-29/default/x86_64",
-          "revision": "29-default-x86_64"
+          "revision": "29-default-x86_64",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:2": "x86_64",
+            "api-level:0": "29",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -2682,11 +6493,41 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-29_r12.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "2",
+                "minor:1": "8"
+              }
+            }
+          },
           "displayName": "Google APIs ARM 64 v8a System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis-arm64-v8a",
           "path": "system-images/android-29/google_apis/arm64-v8a",
-          "revision": "29-google_apis-arm64-v8a"
+          "revision": "29-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "12"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "29",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2697,11 +6538,41 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-29_r12.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "2",
+                "minor:1": "8"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86",
           "path": "system-images/android-29/google_apis/x86",
-          "revision": "29-google_apis-x86"
+          "revision": "29-google_apis-x86",
+          "revision-details": {
+            "major:0": "12"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "29",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2712,11 +6583,41 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-29_r12.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "2",
+                "minor:1": "8"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86_64",
           "path": "system-images/android-29/google_apis/x86_64",
-          "revision": "29-google_apis-x86_64"
+          "revision": "29-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "12"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "29",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       },
       "google_apis_playstore": {
@@ -2735,11 +6636,41 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-29_r09-linux.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "2",
+                "minor:1": "8"
+              }
+            }
+          },
           "displayName": "Google Play ARM 64 v8a System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-29/google_apis_playstore/arm64-v8a",
-          "revision": "29-google_apis_playstore-arm64-v8a"
+          "revision": "29-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "9"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "29",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2762,11 +6693,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-29_r08-linux.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "28",
+                "micro:2": "9",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86",
           "path": "system-images/android-29/google_apis_playstore/x86",
-          "revision": "29-google_apis_playstore-x86"
+          "revision": "29-google_apis_playstore-x86",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "29",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2789,11 +6755,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-29_r08-linux.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "28",
+                "micro:2": "9",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86_64",
           "path": "system-images/android-29/google_apis_playstore/x86_64",
-          "revision": "29-google_apis_playstore-x86_64"
+          "revision": "29-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "29",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -2808,11 +6809,42 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-30_r04.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "28",
+                "micro:2": "6",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Android TV Intel x86 Atom System Image",
           "license": "android-sdk-preview-license",
           "name": "system-image-30-android-tv-x86",
           "path": "system-images/android-30/android-tv/x86",
-          "revision": "30-android-tv-x86"
+          "revision": "30-android-tv-x86",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "30",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         }
       },
       "android-wear": {
@@ -2825,11 +6857,32 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/arm64-v8a-30_r11.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Wear OS 3 ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-arm64-v8a",
           "path": "system-images/android-30/android-wear/arm64-v8a",
-          "revision": "30-android-wear-arm64-v8a"
+          "revision": "30-android-wear-arm64-v8a",
+          "revision-details": {
+            "major:0": "11"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "30",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Wear OS 3",
+              "id:0": "android-wear"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2840,11 +6893,32 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86-30_r11.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            }
+          },
           "displayName": "Wear OS 3 Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-x86",
           "path": "system-images/android-30/android-wear/x86",
-          "revision": "30-android-wear-x86"
+          "revision": "30-android-wear-x86",
+          "revision-details": {
+            "major:0": "11"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "30",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Wear OS 3",
+              "id:0": "android-wear"
+            }
+          }
         }
       },
       "default": {
@@ -2854,14 +6928,28 @@
               "os": "all",
               "sha1": "2462af138023fbbd1114421818890884d4ebceab",
               "size": 548363604,
-              "url": "https://dl.google.com/android/repository/sys-img/default/arm64-v8a-30_r01.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-30_r01.zip"
             }
           ],
           "displayName": "ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-30-default-arm64-v8a",
           "path": "system-images/android-30/default/arm64-v8a",
-          "revision": "30-default-arm64-v8a"
+          "revision": "30-default-arm64-v8a",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "30",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2869,14 +6957,40 @@
               "os": "all",
               "sha1": "e08119b65d2c188ef69f127028eb4c8cc632cd8f",
               "size": 676379913,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86_64-30_r10.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-30_r10.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "29",
+                "micro:2": "11",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-30-default-x86_64",
           "path": "system-images/android-30/default/x86_64",
-          "revision": "30-default-x86_64"
+          "revision": "30-default-x86_64",
+          "revision-details": {
+            "major:0": "10"
+          },
+          "type-details": {
+            "abi:2": "x86_64",
+            "api-level:0": "30",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -2889,11 +7003,41 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-30_r11.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "0",
+                "minor:1": "8"
+              }
+            }
+          },
           "displayName": "Google APIs ARM 64 v8a System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis-arm64-v8a",
           "path": "system-images/android-30/google_apis/arm64-v8a",
-          "revision": "30-google_apis-arm64-v8a"
+          "revision": "30-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "11"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "30",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2904,11 +7048,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-30_r10.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "4",
+                "minor:1": "0"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86",
           "path": "system-images/android-30/google_apis/x86",
-          "revision": "30-google_apis-x86"
+          "revision": "30-google_apis-x86",
+          "revision-details": {
+            "major:0": "10"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "30",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2919,11 +7098,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-30_r11.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "0",
+                "minor:1": "8"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86_64",
           "path": "system-images/android-30/google_apis/x86_64",
-          "revision": "30-google_apis-x86_64"
+          "revision": "30-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "11"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "30",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       },
       "google_apis_playstore": {
@@ -2942,11 +7156,41 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-30_r10-linux.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "0",
+                "minor:1": "8"
+              }
+            }
+          },
           "displayName": "Google Play ARM 64 v8a System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-30/google_apis_playstore/arm64-v8a",
-          "revision": "30-google_apis_playstore-arm64-v8a"
+          "revision": "30-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "10"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "30",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -2969,11 +7213,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-30_r09-linux.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "4",
+                "minor:1": "0"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis_playstore-x86",
           "path": "system-images/android-30/google_apis_playstore/x86",
-          "revision": "30-google_apis_playstore-x86"
+          "revision": "30-google_apis_playstore-x86",
+          "revision-details": {
+            "major:0": "9"
+          },
+          "type-details": {
+            "abi:3": "x86",
+            "api-level:0": "30",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -2996,11 +7275,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-30_r10-linux.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "4",
+                "minor:1": "0"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom_64 System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-x86_64",
           "path": "system-images/android-30/google_apis_playstore/x86_64",
-          "revision": "30-google_apis_playstore-x86_64"
+          "revision": "30-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "10"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "30",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -3015,11 +7329,42 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/arm64-v8a-31_r04.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "28",
+                "micro:2": "6",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Android TV ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-arm64-v8a",
           "path": "system-images/android-31/android-tv/arm64-v8a",
-          "revision": "31-android-tv-arm64-v8a"
+          "revision": "31-android-tv-arm64-v8a",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "31",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -3030,11 +7375,42 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-31_r04.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "28",
+                "micro:2": "6",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Android TV Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-x86",
           "path": "system-images/android-31/android-tv/x86",
-          "revision": "31-android-tv-x86"
+          "revision": "31-android-tv-x86",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "31",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         }
       },
       "default": {
@@ -3044,14 +7420,40 @@
               "os": "all",
               "sha1": "1052df2d0afc8fe57138db19d5ebd82d10c607da",
               "size": 635481190,
-              "url": "https://dl.google.com/android/repository/sys-img/default/arm64-v8a-31_r03.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-31_r03.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "31",
+                "micro:2": "7",
+                "minor:1": "2"
+              }
+            }
+          },
           "displayName": "ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-31-default-arm64-v8a",
           "path": "system-images/android-31/default/arm64-v8a",
-          "revision": "31-default-arm64-v8a"
+          "revision": "31-default-arm64-v8a",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "31",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -3059,14 +7461,40 @@
               "os": "all",
               "sha1": "1200d6983af477fd6439f11cc5cabf9866bc4a16",
               "size": 657244568,
-              "url": "https://dl.google.com/android/repository/sys-img/default/x86_64-31_r03.zip"
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-31_r03.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "31",
+                "micro:2": "7",
+                "minor:1": "2"
+              }
+            }
+          },
           "displayName": "Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-31-default-x86_64",
           "path": "system-images/android-31/default/x86_64",
-          "revision": "31-default-x86_64"
+          "revision": "31-default-x86_64",
+          "revision-details": {
+            "major:0": "4"
+          },
+          "type-details": {
+            "abi:2": "x86_64",
+            "api-level:0": "31",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
         }
       },
       "google_apis": {
@@ -3079,11 +7507,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-31_r10.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "31",
+                "micro:2": "7",
+                "minor:1": "2"
+              }
+            }
+          },
           "displayName": "Google APIs ARM 64 v8a System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis-arm64-v8a",
           "path": "system-images/android-31/google_apis/arm64-v8a",
-          "revision": "31-google_apis-arm64-v8a"
+          "revision": "31-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "9"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "31",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -3094,11 +7557,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-31_r11.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "31",
+                "micro:2": "7",
+                "minor:1": "2"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom_64 System Image",
           "license": "android-sdk-preview-license",
           "name": "system-image-31-google_apis-x86_64",
           "path": "system-images/android-31/google_apis/x86_64",
-          "revision": "31-google_apis-x86_64"
+          "revision": "31-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "11"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "31",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       },
       "google_apis_playstore": {
@@ -3117,11 +7615,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-31_r09-linux.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "31",
+                "micro:2": "7",
+                "minor:1": "2"
+              }
+            }
+          },
           "displayName": "Google Play ARM 64 v8a System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-31/google_apis_playstore/arm64-v8a",
-          "revision": "31-google_apis_playstore-arm64-v8a"
+          "revision": "31-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "9"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "31",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -3132,11 +7665,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-31_r09.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "3",
+                "minor:1": "7"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom_64 System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-x86_64",
           "path": "system-images/android-31/google_apis_playstore/x86_64",
-          "revision": "31-google_apis_playstore-x86_64"
+          "revision": "31-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "9"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "31",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -3151,11 +7719,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-32_r03.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "3",
+                "minor:1": "7"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom_64 System Image",
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis-x86_64",
           "path": "system-images/android-32/google_apis/x86_64",
-          "revision": "32-google_apis-x86_64"
+          "revision": "32-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "32",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       },
       "google_apis_playstore": {
@@ -3174,11 +7777,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-32_r03-linux.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "3",
+                "minor:1": "7"
+              }
+            }
+          },
           "displayName": "Google Play ARM 64 v8a System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-32/google_apis_playstore/arm64-v8a",
-          "revision": "32-google_apis_playstore-arm64-v8a"
+          "revision": "32-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "32",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -3201,11 +7839,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-32_r03-linux.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "3",
+                "minor:1": "7"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom_64 System Image",
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis_playstore-x86_64",
           "path": "system-images/android-32/google_apis_playstore/x86_64",
-          "revision": "32-google_apis_playstore-x86_64"
+          "revision": "32-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "32",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -3220,11 +7893,42 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/arm64-v8a-33_r05.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "28",
+                "micro:2": "6",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Android TV ARM 64 v8a System Image",
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-arm64-v8a",
           "path": "system-images/android-33/android-tv/arm64-v8a",
-          "revision": "33-android-tv-arm64-v8a"
+          "revision": "33-android-tv-arm64-v8a",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:2": "arm64-v8a",
+            "api-level:0": "33",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         },
         "x86": {
           "archives": [
@@ -3235,11 +7939,42 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-33_r05.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "28",
+                "micro:2": "6",
+                "minor:1": "1"
+              }
+            }
+          },
           "displayName": "Android TV Intel x86 Atom System Image",
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-x86",
           "path": "system-images/android-33/android-tv/x86",
-          "revision": "33-android-tv-x86"
+          "revision": "33-android-tv-x86",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:2": "x86",
+            "api-level:0": "33",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Android TV",
+              "id:0": "android-tv"
+            }
+          }
         }
       },
       "google_apis": {
@@ -3252,11 +7987,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-33_r08.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "3",
+                "minor:1": "7"
+              }
+            }
+          },
           "displayName": "Google APIs ARM 64 v8a System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis-arm64-v8a",
           "path": "system-images/android-33/google_apis/arm64-v8a",
-          "revision": "33-google_apis-arm64-v8a"
+          "revision": "33-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "33",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -3267,11 +8037,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-33_r08.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "3",
+                "minor:1": "7"
+              }
+            }
+          },
           "displayName": "Google APIs Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis-x86_64",
           "path": "system-images/android-33/google_apis/x86_64",
-          "revision": "33-google_apis-x86_64"
+          "revision": "33-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "33",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       },
       "google_apis_playstore": {
@@ -3290,11 +8095,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-33_r07-linux.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "3",
+                "minor:1": "7"
+              }
+            }
+          },
           "displayName": "Google Play ARM 64 v8a System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33/google_apis_playstore/arm64-v8a",
-          "revision": "33-google_apis_playstore-arm64-v8a"
+          "revision": "33-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "7"
+          },
+          "type-details": {
+            "abi:3": "arm64-v8a",
+            "api-level:0": "33",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -3305,11 +8145,46 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-33_r07.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "3",
+                "minor:1": "7"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom_64 System Image",
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis_playstore-x86_64",
           "path": "system-images/android-33/google_apis_playstore/x86_64",
-          "revision": "33-google_apis_playstore-x86_64"
+          "revision": "33-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "7"
+          },
+          "type-details": {
+            "abi:3": "x86_64",
+            "api-level:0": "33",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:1": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:2": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     },
@@ -3330,11 +8205,47 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-TiramisuPrivacySandbox_r08-linux.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "3",
+                "minor:1": "7"
+              }
+            }
+          },
           "displayName": "Google Play ARM 64 v8a System Image",
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-TiramisuPrivacySandbox-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-TiramisuPrivacySandbox/google_apis_playstore/arm64-v8a",
-          "revision": "TiramisuPrivacySandbox-google_apis_playstore-arm64-v8a"
+          "revision": "TiramisuPrivacySandbox-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:4": "arm64-v8a",
+            "api-level:0": "33",
+            "codename:1": "TiramisuPrivacySandbox",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:2": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:3": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         },
         "x86_64": {
           "archives": [
@@ -3345,11 +8256,47 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-TiramisuPrivacySandbox_r08.zip"
             }
           ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "patcher;v4"
+              }
+            },
+            "dependency:1": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "30",
+                "micro:2": "3",
+                "minor:1": "7"
+              }
+            }
+          },
           "displayName": "Google Play Intel x86 Atom_64 System Image",
           "license": "android-sdk-preview-license",
           "name": "system-image-TiramisuPrivacySandbox-google_apis_playstore-x86_64",
           "path": "system-images/android-TiramisuPrivacySandbox/google_apis_playstore/x86_64",
-          "revision": "TiramisuPrivacySandbox-google_apis_playstore-x86_64"
+          "revision": "TiramisuPrivacySandbox-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "8"
+          },
+          "type-details": {
+            "abi:4": "x86_64",
+            "api-level:0": "33",
+            "codename:1": "TiramisuPrivacySandbox",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "tag:2": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:3": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
         }
       }
     }
@@ -3403,11 +8350,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r17-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 17",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/17.0.0",
-        "revision": "17.0.0"
+        "revision": "17.0.0",
+        "revision-details": {
+          "major:0": "17",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "18.0.1": {
         "archives": [
@@ -3430,11 +8395,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r18.0.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 18.0.1",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/18.0.1",
-        "revision": "18.0.1"
+        "revision": "18.0.1",
+        "revision-details": {
+          "major:0": "18",
+          "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "18.1.0": {
         "archives": [
@@ -3457,11 +8440,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r18.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 18.1",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/18.1.0",
-        "revision": "18.1.0"
+        "revision": "18.1.0",
+        "revision-details": {
+          "major:0": "18",
+          "micro:2": "0",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "18.1.1": {
         "archives": [
@@ -3484,11 +8485,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r18.1.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 18.1.1",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/18.1.1",
-        "revision": "18.1.1"
+        "revision": "18.1.1",
+        "revision-details": {
+          "major:0": "18",
+          "micro:2": "1",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "19.0.0": {
         "archives": [
@@ -3511,11 +8530,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 19",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/19.0.0",
-        "revision": "19.0.0"
+        "revision": "19.0.0",
+        "revision-details": {
+          "major:0": "19",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "19.0.1": {
         "archives": [
@@ -3538,11 +8575,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19.0.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 19.0.1",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/19.0.1",
-        "revision": "19.0.1"
+        "revision": "19.0.1",
+        "revision-details": {
+          "major:0": "19",
+          "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "19.0.2": {
         "archives": [
@@ -3565,11 +8620,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19.0.2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 19.0.2",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/19.0.2",
-        "revision": "19.0.2"
+        "revision": "19.0.2",
+        "revision-details": {
+          "major:0": "19",
+          "micro:2": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "19.0.3": {
         "archives": [
@@ -3592,11 +8665,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19.0.3-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 19.0.3",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/19.0.3",
-        "revision": "19.0.3"
+        "revision": "19.0.3",
+        "revision-details": {
+          "major:0": "19",
+          "micro:2": "3",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "19.1.0": {
         "archives": [
@@ -3619,11 +8710,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 19.1",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/19.1.0",
-        "revision": "19.1.0"
+        "revision": "19.1.0",
+        "revision-details": {
+          "major:0": "19",
+          "micro:2": "0",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "20.0.0": {
         "archives": [
@@ -3646,11 +8754,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r20-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 20",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/20.0.0",
-        "revision": "20.0.0"
+        "revision": "20.0.0",
+        "revision-details": {
+          "major:0": "20",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.0.0": {
         "archives": [
@@ -3673,11 +8798,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 21",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/21.0.0",
-        "revision": "21.0.0"
+        "revision": "21.0.0",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.0.1": {
         "archives": [
@@ -3700,11 +8843,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.0.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 21.0.1",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/21.0.1",
-        "revision": "21.0.1"
+        "revision": "21.0.1",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.0.2": {
         "archives": [
@@ -3727,11 +8888,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.0.2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 21.0.2",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/21.0.2",
-        "revision": "21.0.2"
+        "revision": "21.0.2",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.1.0": {
         "archives": [
@@ -3754,11 +8933,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 21.1",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/21.1.0",
-        "revision": "21.1.0"
+        "revision": "21.1.0",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "0",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.1.1": {
         "archives": [
@@ -3781,11 +8978,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.1.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 21.1.1",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/21.1.1",
-        "revision": "21.1.1"
+        "revision": "21.1.1",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "1",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.1.2": {
         "archives": [
@@ -3808,11 +9023,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.1.2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 21.1.2",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/21.1.2",
-        "revision": "21.1.2"
+        "revision": "21.1.2",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "2",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "22.0.0": {
         "archives": [
@@ -3835,11 +9067,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r22-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 22",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/22.0.0",
-        "revision": "22.0.0"
+        "revision": "22.0.0",
+        "revision-details": {
+          "major:0": "22",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "22.0.1": {
         "archives": [
@@ -3862,11 +9112,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r22.0.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 22.0.1",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/22.0.1",
-        "revision": "22.0.1"
+        "revision": "22.0.1",
+        "revision-details": {
+          "major:0": "22",
+          "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.0": {
         "archives": [
@@ -3889,11 +9156,29 @@
             "url": "https://dl.google.com/android/repository/build-tools_r23-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 23",
         "license": "android-sdk-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/23.0.0",
-        "revision": "23.0.0"
+        "revision": "23.0.0",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.1": {
         "archives": [
@@ -3916,11 +9201,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r23.0.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 23.0.1",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.1",
-        "revision": "23.0.1"
+        "revision": "23.0.1",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.2": {
         "archives": [
@@ -3943,11 +9245,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r23.0.2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 23.0.2",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.2",
-        "revision": "23.0.2"
+        "revision": "23.0.2",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.3": {
         "archives": [
@@ -3970,11 +9289,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r23.0.3-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 23.0.3",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.3",
-        "revision": "23.0.3"
+        "revision": "23.0.3",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "3",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "24.0.0": {
         "archives": [
@@ -3997,11 +9333,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r24-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 24",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.0",
-        "revision": "24.0.0"
+        "revision": "24.0.0",
+        "revision-details": {
+          "major:0": "24",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "24.0.1": {
         "archives": [
@@ -4024,11 +9377,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r24.0.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 24.0.1",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.1",
-        "revision": "24.0.1"
+        "revision": "24.0.1",
+        "revision-details": {
+          "major:0": "24",
+          "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "24.0.2": {
         "archives": [
@@ -4051,11 +9421,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r24.0.2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 24.0.2",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.2",
-        "revision": "24.0.2"
+        "revision": "24.0.2",
+        "revision-details": {
+          "major:0": "24",
+          "micro:2": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "24.0.3": {
         "archives": [
@@ -4078,11 +9465,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r24.0.3-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 24.0.3",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.3",
-        "revision": "24.0.3"
+        "revision": "24.0.3",
+        "revision-details": {
+          "major:0": "24",
+          "micro:2": "3",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "25.0.0": {
         "archives": [
@@ -4105,11 +9509,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r25-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 25",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.0",
-        "revision": "25.0.0"
+        "revision": "25.0.0",
+        "revision-details": {
+          "major:0": "25",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "25.0.1": {
         "archives": [
@@ -4132,11 +9553,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r25.0.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 25.0.1",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.1",
-        "revision": "25.0.1"
+        "revision": "25.0.1",
+        "revision-details": {
+          "major:0": "25",
+          "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "25.0.2": {
         "archives": [
@@ -4159,11 +9597,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r25.0.2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 25.0.2",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.2",
-        "revision": "25.0.2"
+        "revision": "25.0.2",
+        "revision-details": {
+          "major:0": "25",
+          "micro:2": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "25.0.3": {
         "archives": [
@@ -4186,11 +9641,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r25.0.3-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 25.0.3",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.3",
-        "revision": "25.0.3"
+        "revision": "25.0.3",
+        "revision-details": {
+          "major:0": "25",
+          "micro:2": "3",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "26.0.0": {
         "archives": [
@@ -4213,11 +9685,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r26-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 26",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.0",
-        "revision": "26.0.0"
+        "revision": "26.0.0",
+        "revision-details": {
+          "major:0": "26",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "26.0.1": {
         "archives": [
@@ -4240,11 +9729,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r26.0.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 26.0.1",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.1",
-        "revision": "26.0.1"
+        "revision": "26.0.1",
+        "revision-details": {
+          "major:0": "26",
+          "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "26.0.2": {
         "archives": [
@@ -4267,11 +9773,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r26.0.2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 26.0.2",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.2",
-        "revision": "26.0.2"
+        "revision": "26.0.2",
+        "revision-details": {
+          "major:0": "26",
+          "micro:2": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "26.0.3": {
         "archives": [
@@ -4294,11 +9817,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r26.0.3-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 26.0.3",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.3",
-        "revision": "26.0.3"
+        "revision": "26.0.3",
+        "revision-details": {
+          "major:0": "26",
+          "micro:2": "3",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "27.0.0": {
         "archives": [
@@ -4321,11 +9861,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r27-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 27",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.0",
-        "revision": "27.0.0"
+        "revision": "27.0.0",
+        "revision-details": {
+          "major:0": "27",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "27.0.1": {
         "archives": [
@@ -4348,11 +9905,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r27.0.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 27.0.1",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.1",
-        "revision": "27.0.1"
+        "revision": "27.0.1",
+        "revision-details": {
+          "major:0": "27",
+          "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "27.0.2": {
         "archives": [
@@ -4375,11 +9949,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r27.0.2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 27.0.2",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.2",
-        "revision": "27.0.2"
+        "revision": "27.0.2",
+        "revision-details": {
+          "major:0": "27",
+          "micro:2": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "27.0.3": {
         "archives": [
@@ -4402,11 +9993,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r27.0.3-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 27.0.3",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.3",
-        "revision": "27.0.3"
+        "revision": "27.0.3",
+        "revision-details": {
+          "major:0": "27",
+          "micro:2": "3",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "28.0.0": {
         "archives": [
@@ -4429,11 +10037,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 28",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.0",
-        "revision": "28.0.0"
+        "revision": "28.0.0",
+        "revision-details": {
+          "major:0": "28",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "28.0.0-rc1": {
         "archives": [
@@ -4456,11 +10081,30 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28-rc1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 28-rc1",
         "license": "android-sdk-preview-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/28.0.0-rc1",
-        "revision": "28.0.0-rc1"
+        "revision": "28.0.0-rc1",
+        "revision-details": {
+          "major:0": "28",
+          "micro:2": "0",
+          "minor:1": "0",
+          "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "28.0.0-rc2": {
         "archives": [
@@ -4483,11 +10127,30 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28-rc2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 28-rc2",
         "license": "android-sdk-preview-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/28.0.0-rc2",
-        "revision": "28.0.0-rc2"
+        "revision": "28.0.0-rc2",
+        "revision-details": {
+          "major:0": "28",
+          "micro:2": "0",
+          "minor:1": "0",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "28.0.1": {
         "archives": [
@@ -4510,11 +10173,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28.0.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 28.0.1",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.1",
-        "revision": "28.0.1"
+        "revision": "28.0.1",
+        "revision-details": {
+          "major:0": "28",
+          "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "28.0.2": {
         "archives": [
@@ -4537,11 +10217,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28.0.2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 28.0.2",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.2",
-        "revision": "28.0.2"
+        "revision": "28.0.2",
+        "revision-details": {
+          "major:0": "28",
+          "micro:2": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "28.0.3": {
         "archives": [
@@ -4564,11 +10261,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28.0.3-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 28.0.3",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.3",
-        "revision": "28.0.3"
+        "revision": "28.0.3",
+        "revision-details": {
+          "major:0": "28",
+          "micro:2": "3",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "29.0.0": {
         "archives": [
@@ -4591,11 +10305,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 29",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.0",
-        "revision": "29.0.0"
+        "revision": "29.0.0",
+        "revision-details": {
+          "major:0": "29",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "29.0.0-rc1": {
         "archives": [
@@ -4618,11 +10349,30 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29-rc1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 29-rc1",
         "license": "android-sdk-preview-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/29.0.0-rc1",
-        "revision": "29.0.0-rc1"
+        "revision": "29.0.0-rc1",
+        "revision-details": {
+          "major:0": "29",
+          "micro:2": "0",
+          "minor:1": "0",
+          "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "29.0.0-rc2": {
         "archives": [
@@ -4645,11 +10395,30 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29-rc2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 29-rc2",
         "license": "android-sdk-preview-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/29.0.0-rc2",
-        "revision": "29.0.0-rc2"
+        "revision": "29.0.0-rc2",
+        "revision-details": {
+          "major:0": "29",
+          "micro:2": "0",
+          "minor:1": "0",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "29.0.0-rc3": {
         "archives": [
@@ -4672,11 +10441,30 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29-rc3-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 29-rc3",
         "license": "android-sdk-preview-license",
         "name": "build-tools",
+        "obsolete": "true",
         "path": "build-tools/29.0.0-rc3",
-        "revision": "29.0.0-rc3"
+        "revision": "29.0.0-rc3",
+        "revision-details": {
+          "major:0": "29",
+          "micro:2": "0",
+          "minor:1": "0",
+          "preview:3": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "29.0.1": {
         "archives": [
@@ -4699,11 +10487,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29.0.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 29.0.1",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.1",
-        "revision": "29.0.1"
+        "revision": "29.0.1",
+        "revision-details": {
+          "major:0": "29",
+          "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "29.0.2": {
         "archives": [
@@ -4726,11 +10531,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29.0.2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 29.0.2",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.2",
-        "revision": "29.0.2"
+        "revision": "29.0.2",
+        "revision-details": {
+          "major:0": "29",
+          "micro:2": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "29.0.3": {
         "archives": [
@@ -4753,11 +10575,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29.0.3-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 29.0.3",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.3",
-        "revision": "29.0.3"
+        "revision": "29.0.3",
+        "revision-details": {
+          "major:0": "29",
+          "micro:2": "3",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "30.0.0": {
         "archives": [
@@ -4780,11 +10619,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r30-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 30",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.0",
-        "revision": "30.0.0"
+        "revision": "30.0.0",
+        "revision-details": {
+          "major:0": "30",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "30.0.1": {
         "archives": [
@@ -4807,11 +10663,28 @@
             "url": "https://dl.google.com/android/repository/build-tools_r30.0.1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 30.0.1",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.1",
-        "revision": "30.0.1"
+        "revision": "30.0.1",
+        "revision-details": {
+          "major:0": "30",
+          "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "30.0.2": {
         "archives": [
@@ -4834,11 +10707,28 @@
             "url": "https://dl.google.com/android/repository/efbaa277338195608aa4e3dbd43927e97f60218c.build-tools_r30.0.2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 30.0.2",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.2",
-        "revision": "30.0.2"
+        "revision": "30.0.2",
+        "revision-details": {
+          "major:0": "30",
+          "micro:2": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "30.0.3": {
         "archives": [
@@ -4861,11 +10751,28 @@
             "url": "https://dl.google.com/android/repository/f6d24b187cc6bd534c6c37604205171784ac5621.build-tools_r30.0.3-macosx.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "tools"
+            }
+          }
+        },
         "displayName": "Android SDK Build-Tools 30.0.3",
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.3",
-        "revision": "30.0.3"
+        "revision": "30.0.3",
+        "revision-details": {
+          "major:0": "30",
+          "micro:2": "3",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "31.0.0": {
         "archives": [
@@ -4892,7 +10799,17 @@
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/31.0.0",
-        "revision": "31.0.0"
+        "revision": "31.0.0",
+        "revision-details": {
+          "major:0": "31",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "32.0.0": {
         "archives": [
@@ -4919,7 +10836,17 @@
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/32.0.0",
-        "revision": "32.0.0"
+        "revision": "32.0.0",
+        "revision-details": {
+          "major:0": "32",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "32.1.0-rc1": {
         "archives": [
@@ -4946,7 +10873,18 @@
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/32.1.0-rc1",
-        "revision": "32.1.0-rc1"
+        "revision": "32.1.0-rc1",
+        "revision-details": {
+          "major:0": "32",
+          "micro:2": "0",
+          "minor:1": "1",
+          "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "33.0.0": {
         "archives": [
@@ -4973,7 +10911,17 @@
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.0",
-        "revision": "33.0.0"
+        "revision": "33.0.0",
+        "revision-details": {
+          "major:0": "33",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "33.0.1": {
         "archives": [
@@ -5000,7 +10948,17 @@
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.1",
-        "revision": "33.0.1"
+        "revision": "33.0.1",
+        "revision-details": {
+          "major:0": "33",
+          "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "cmake": {
@@ -5029,7 +10987,17 @@
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.10.2.4988404",
-        "revision": "3.10.2"
+        "revision": "3.10.2",
+        "revision-details": {
+          "major:0": "3",
+          "micro:2": "2",
+          "minor:1": "10"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "3.18.1": {
         "archives": [
@@ -5056,7 +11024,17 @@
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.18.1",
-        "revision": "3.18.1"
+        "revision": "3.18.1",
+        "revision-details": {
+          "major:0": "3",
+          "micro:2": "1",
+          "minor:1": "18"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "3.22.1": {
         "archives": [
@@ -5083,7 +11061,17 @@
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.22.1",
-        "revision": "3.22.1"
+        "revision": "3.22.1",
+        "revision-details": {
+          "major:0": "3",
+          "micro:2": "1",
+          "minor:1": "22"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "3.6.4111459": {
         "archives": [
@@ -5110,7 +11098,17 @@
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.6.4111459",
-        "revision": "3.6.4111459"
+        "revision": "3.6.4111459",
+        "revision-details": {
+          "major:0": "3",
+          "micro:2": "4111459",
+          "minor:1": "6"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "cmdline-tools": {
@@ -5139,7 +11137,16 @@
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/1.0",
-        "revision": "1.0"
+        "revision": "1.0",
+        "revision-details": {
+          "major:0": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "2.0": {
         "archives": [
@@ -5165,8 +11172,18 @@
         "displayName": "Android SDK Command-line Tools",
         "license": "android-sdk-license",
         "name": "cmdline-tools",
+        "obsolete": "true",
         "path": "cmdline-tools/2.0",
-        "revision": "2.0"
+        "revision": "2.0",
+        "revision-details": {
+          "major:0": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "2.1": {
         "archives": [
@@ -5193,7 +11210,16 @@
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/2.1",
-        "revision": "2.1"
+        "revision": "2.1",
+        "revision-details": {
+          "major:0": "2",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "3.0": {
         "archives": [
@@ -5220,7 +11246,16 @@
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/3.0",
-        "revision": "3.0"
+        "revision": "3.0",
+        "revision-details": {
+          "major:0": "3",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "4.0": {
         "archives": [
@@ -5247,7 +11282,16 @@
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/4.0",
-        "revision": "4.0"
+        "revision": "4.0",
+        "revision-details": {
+          "major:0": "4",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "5.0": {
         "archives": [
@@ -5274,7 +11318,16 @@
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/5.0",
-        "revision": "5.0"
+        "revision": "5.0",
+        "revision-details": {
+          "major:0": "5",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "6.0": {
         "archives": [
@@ -5301,7 +11354,16 @@
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/6.0",
-        "revision": "6.0"
+        "revision": "6.0",
+        "revision-details": {
+          "major:0": "6",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "7.0": {
         "archives": [
@@ -5328,7 +11390,16 @@
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/7.0",
-        "revision": "7.0"
+        "revision": "7.0",
+        "revision-details": {
+          "major:0": "7",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "8.0": {
         "archives": [
@@ -5355,7 +11426,16 @@
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/8.0",
-        "revision": "8.0"
+        "revision": "8.0",
+        "revision-details": {
+          "major:0": "8",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "emulator": {
@@ -5380,11 +11460,28 @@
             "url": "https://dl.google.com/android/repository/emulator-windows_x64-8807927.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "Android Emulator",
         "license": "android-sdk-license",
         "name": "emulator",
         "path": "emulator",
-        "revision": "31.3.10"
+        "revision": "31.3.10",
+        "revision-details": {
+          "major:0": "31",
+          "micro:2": "10",
+          "minor:1": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "31.3.14": {
         "archives": [
@@ -5407,11 +11504,28 @@
             "url": "https://dl.google.com/android/repository/emulator-darwin_x64-9322596.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "Android Emulator",
         "license": "android-sdk-license",
         "name": "emulator",
         "path": "emulator",
-        "revision": "31.3.14"
+        "revision": "31.3.14",
+        "revision-details": {
+          "major:0": "31",
+          "micro:2": "14",
+          "minor:1": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "32.1.8": {
         "archives": [
@@ -5434,11 +11548,28 @@
             "url": "https://dl.google.com/android/repository/emulator-windows_x64-9310560.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "Android Emulator",
         "license": "android-sdk-preview-license",
         "name": "emulator",
         "path": "emulator",
-        "revision": "32.1.8"
+        "revision": "32.1.8",
+        "revision-details": {
+          "major:0": "32",
+          "micro:2": "8",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "extras": {
@@ -5467,7 +11598,16 @@
         "license": "android-sdk-license",
         "name": "extras",
         "path": "extras/google/auto",
-        "revision": "2.0"
+        "revision": "2.0",
+        "revision-details": {
+          "major:0": "2",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "2.1": {
         "archives": [
@@ -5494,7 +11634,16 @@
         "license": "android-sdk-license",
         "name": "extras",
         "path": "extras/google/auto",
-        "revision": "2.1"
+        "revision": "2.1",
+        "revision-details": {
+          "major:0": "2",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "ndk": {
@@ -5519,11 +11668,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r16b-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 16.1.4479499",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/16.1.4479499",
-        "revision": "16.1.4479499"
+        "revision": "16.1.4479499",
+        "revision-details": {
+          "major:0": "16",
+          "micro:2": "4479499",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "17.2.4988734": {
         "archives": [
@@ -5546,11 +11712,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r17c-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 17.2.4988734",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/17.2.4988734",
-        "revision": "17.2.4988734"
+        "revision": "17.2.4988734",
+        "revision-details": {
+          "major:0": "17",
+          "micro:2": "4988734",
+          "minor:1": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "18.1.5063045": {
         "archives": [
@@ -5573,11 +11756,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r18b-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 18.1.5063045",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/18.1.5063045",
-        "revision": "18.1.5063045"
+        "revision": "18.1.5063045",
+        "revision-details": {
+          "major:0": "18",
+          "micro:2": "5063045",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "19.0.5232133": {
         "archives": [
@@ -5600,11 +11800,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r19-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 19.0.5232133",
         "license": "android-sdk-license",
         "name": "ndk",
+        "obsolete": "true",
         "path": "ndk/19.0.5232133",
-        "revision": "19.0.5232133"
+        "revision": "19.0.5232133",
+        "revision-details": {
+          "major:0": "19",
+          "micro:2": "5232133",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "19.2.5345600": {
         "archives": [
@@ -5627,11 +11845,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r19c-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 19.2.5345600",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/19.2.5345600",
-        "revision": "19.2.5345600"
+        "revision": "19.2.5345600",
+        "revision-details": {
+          "major:0": "19",
+          "micro:2": "5345600",
+          "minor:1": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "20.0.5392854-rc2": {
         "archives": [
@@ -5654,11 +11889,30 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-beta2-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 20.0.5392854",
         "license": "android-sdk-preview-license",
         "name": "ndk",
+        "obsolete": "true",
         "path": "ndk/20.0.5392854",
-        "revision": "20.0.5392854-rc2"
+        "revision": "20.0.5392854-rc2",
+        "revision-details": {
+          "major:0": "20",
+          "micro:2": "5392854",
+          "minor:1": "0",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "20.0.5471264-rc3": {
         "archives": [
@@ -5681,11 +11935,30 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-beta3-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 20.0.5471264",
         "license": "android-sdk-preview-license",
         "name": "ndk",
+        "obsolete": "true",
         "path": "ndk/20.0.5471264",
-        "revision": "20.0.5471264-rc3"
+        "revision": "20.0.5471264-rc3",
+        "revision-details": {
+          "major:0": "20",
+          "micro:2": "5471264",
+          "minor:1": "0",
+          "preview:3": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "20.0.5594570": {
         "archives": [
@@ -5708,11 +11981,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 20.0.5594570",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.0.5594570",
-        "revision": "20.0.5594570"
+        "revision": "20.0.5594570",
+        "revision-details": {
+          "major:0": "20",
+          "micro:2": "5594570",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "20.1.5948944": {
         "archives": [
@@ -5735,11 +12025,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20b-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 20.1.5948944",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.1.5948944",
-        "revision": "20.1.5948944"
+        "revision": "20.1.5948944",
+        "revision-details": {
+          "major:0": "20",
+          "micro:2": "5948944",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.0.6011959-rc2": {
         "archives": [
@@ -5762,11 +12069,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21-beta2-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 21.0.6011959",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.0.6011959",
-        "revision": "21.0.6011959-rc2"
+        "revision": "21.0.6011959-rc2",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6011959",
+          "minor:1": "0",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.0.6113669": {
         "archives": [
@@ -5789,11 +12114,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 21.0.6113669",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.0.6113669",
-        "revision": "21.0.6113669"
+        "revision": "21.0.6113669",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6113669",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.1.6210238-rc1": {
         "archives": [
@@ -5816,11 +12158,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta1-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 21.1.6210238",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6210238",
-        "revision": "21.1.6210238-rc1"
+        "revision": "21.1.6210238-rc1",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6210238",
+          "minor:1": "1",
+          "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.1.6273396-rc2": {
         "archives": [
@@ -5843,11 +12203,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta2-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 21.1.6273396",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6273396",
-        "revision": "21.1.6273396-rc2"
+        "revision": "21.1.6273396-rc2",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6273396",
+          "minor:1": "1",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.1.6352462": {
         "archives": [
@@ -5870,11 +12248,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 21.1.6352462",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.1.6352462",
-        "revision": "21.1.6352462"
+        "revision": "21.1.6352462",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6352462",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.1.6363665-rc3": {
         "archives": [
@@ -5897,11 +12292,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta3-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 21.1.6363665",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6363665",
-        "revision": "21.1.6363665-rc3"
+        "revision": "21.1.6363665-rc3",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6363665",
+          "minor:1": "1",
+          "preview:3": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.2.6472646": {
         "archives": [
@@ -5924,11 +12337,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21c-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 21.2.6472646",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.2.6472646",
-        "revision": "21.2.6472646"
+        "revision": "21.2.6472646",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6472646",
+          "minor:1": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.3.6528147": {
         "archives": [
@@ -5951,11 +12381,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21d-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 21.3.6528147",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.3.6528147",
-        "revision": "21.3.6528147"
+        "revision": "21.3.6528147",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6528147",
+          "minor:1": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.4.7075529": {
         "archives": [
@@ -5978,11 +12425,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21e-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 21.4.7075529",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.4.7075529",
-        "revision": "21.4.7075529"
+        "revision": "21.4.7075529",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "7075529",
+          "minor:1": "4"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "22.0.6917172-rc1": {
         "archives": [
@@ -6005,11 +12469,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22-beta1-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 22.0.6917172",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/22.0.6917172",
-        "revision": "22.0.6917172-rc1"
+        "revision": "22.0.6917172-rc1",
+        "revision-details": {
+          "major:0": "22",
+          "micro:2": "6917172",
+          "minor:1": "0",
+          "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "22.0.7026061": {
         "archives": [
@@ -6032,11 +12514,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 22.0.7026061",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.0.7026061",
-        "revision": "22.0.7026061"
+        "revision": "22.0.7026061",
+        "revision-details": {
+          "major:0": "22",
+          "micro:2": "7026061",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "22.1.7171670": {
         "archives": [
@@ -6059,11 +12558,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22b-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 22.1.7171670",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.1.7171670",
-        "revision": "22.1.7171670"
+        "revision": "22.1.7171670",
+        "revision-details": {
+          "major:0": "22",
+          "micro:2": "7171670",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.7123448-rc1": {
         "archives": [
@@ -6086,11 +12602,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta1-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 23.0.7123448",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7123448",
-        "revision": "23.0.7123448-rc1"
+        "revision": "23.0.7123448-rc1",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "7123448",
+          "minor:1": "0",
+          "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.7196353-rc2": {
         "archives": [
@@ -6113,11 +12647,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta2-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 23.0.7196353",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7196353",
-        "revision": "23.0.7196353-rc2"
+        "revision": "23.0.7196353-rc2",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "7196353",
+          "minor:1": "0",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.7272597-rc3": {
         "archives": [
@@ -6140,11 +12692,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta3-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 23.0.7272597",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7272597",
-        "revision": "23.0.7272597-rc3"
+        "revision": "23.0.7272597-rc3",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "7272597",
+          "minor:1": "0",
+          "preview:3": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.7344513-rc4": {
         "archives": [
@@ -6167,11 +12737,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta4-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 23.0.7344513",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7344513",
-        "revision": "23.0.7344513-rc4"
+        "revision": "23.0.7344513-rc4",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "7344513",
+          "minor:1": "0",
+          "preview:3": "4"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.7421159-rc5": {
         "archives": [
@@ -6194,11 +12782,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta5-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 23.0.7421159",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7421159",
-        "revision": "23.0.7421159-rc5"
+        "revision": "23.0.7421159-rc5",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "7421159",
+          "minor:1": "0",
+          "preview:3": "5"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.7530507-rc6": {
         "archives": [
@@ -6221,11 +12827,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta6-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 23.0.7530507",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7530507",
-        "revision": "23.0.7530507-rc6"
+        "revision": "23.0.7530507-rc6",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "7530507",
+          "minor:1": "0",
+          "preview:3": "6"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.7599858": {
         "archives": [
@@ -6248,11 +12872,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 23.0.7599858",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.0.7599858",
-        "revision": "23.0.7599858"
+        "revision": "23.0.7599858",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "7599858",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.1.7779620": {
         "archives": [
@@ -6275,11 +12916,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23b-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 23.1.7779620",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.1.7779620",
-        "revision": "23.1.7779620"
+        "revision": "23.1.7779620",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "7779620",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.2.8568313": {
         "archives": [
@@ -6302,11 +12960,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23c-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 23.2.8568313",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.2.8568313",
-        "revision": "23.2.8568313"
+        "revision": "23.2.8568313",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "8568313",
+          "minor:1": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "24.0.7856742-rc1": {
         "archives": [
@@ -6329,11 +13004,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r24-beta1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 24.0.7856742",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7856742",
-        "revision": "24.0.7856742-rc1"
+        "revision": "24.0.7856742-rc1",
+        "revision-details": {
+          "major:0": "24",
+          "micro:2": "7856742",
+          "minor:1": "0",
+          "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "24.0.7956693-rc2": {
         "archives": [
@@ -6356,11 +13049,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r24-beta2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 24.0.7956693",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7956693",
-        "revision": "24.0.7956693-rc2"
+        "revision": "24.0.7956693-rc2",
+        "revision-details": {
+          "major:0": "24",
+          "micro:2": "7956693",
+          "minor:1": "0",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "24.0.8079956-rc3": {
         "archives": [
@@ -6383,11 +13094,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r24-rc1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 24.0.8079956",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.8079956",
-        "revision": "24.0.8079956-rc3"
+        "revision": "24.0.8079956-rc3",
+        "revision-details": {
+          "major:0": "24",
+          "micro:2": "8079956",
+          "minor:1": "0",
+          "preview:3": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "24.0.8215888": {
         "archives": [
@@ -6410,11 +13139,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r24-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 24.0.8215888",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/24.0.8215888",
-        "revision": "24.0.8215888"
+        "revision": "24.0.8215888",
+        "revision-details": {
+          "major:0": "24",
+          "micro:2": "8215888",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "25.0.8151533-rc1": {
         "archives": [
@@ -6437,11 +13183,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-beta1-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 25.0.8151533",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8151533",
-        "revision": "25.0.8151533-rc1"
+        "revision": "25.0.8151533-rc1",
+        "revision-details": {
+          "major:0": "25",
+          "micro:2": "8151533",
+          "minor:1": "0",
+          "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "25.0.8221429-rc2": {
         "archives": [
@@ -6464,11 +13228,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-beta2-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 25.0.8221429",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8221429",
-        "revision": "25.0.8221429-rc2"
+        "revision": "25.0.8221429-rc2",
+        "revision-details": {
+          "major:0": "25",
+          "micro:2": "8221429",
+          "minor:1": "0",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "25.0.8355429-rc3": {
         "archives": [
@@ -6491,11 +13273,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-beta3-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 25.0.8355429",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8355429",
-        "revision": "25.0.8355429-rc3"
+        "revision": "25.0.8355429-rc3",
+        "revision-details": {
+          "major:0": "25",
+          "micro:2": "8355429",
+          "minor:1": "0",
+          "preview:3": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "25.0.8528842-rc4": {
         "archives": [
@@ -6518,11 +13318,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-beta4-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 25.0.8528842",
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8528842",
-        "revision": "25.0.8528842-rc4"
+        "revision": "25.0.8528842-rc4",
+        "revision-details": {
+          "major:0": "25",
+          "micro:2": "8528842",
+          "minor:1": "0",
+          "preview:3": "4"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "25.0.8775105": {
         "archives": [
@@ -6545,11 +13363,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 25.0.8775105",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.0.8775105",
-        "revision": "25.0.8775105"
+        "revision": "25.0.8775105",
+        "revision-details": {
+          "major:0": "25",
+          "micro:2": "8775105",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "25.1.8937393": {
         "archives": [
@@ -6572,11 +13407,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25b-windows.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK (Side by side) 25.1.8937393",
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.1.8937393",
-        "revision": "25.1.8937393"
+        "revision": "25.1.8937393",
+        "revision-details": {
+          "major:0": "25",
+          "micro:2": "8937393",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "ndk-bundle": {
@@ -6601,11 +13453,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r16b-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "16.1.4479499"
+        "revision": "16.1.4479499",
+        "revision-details": {
+          "major:0": "16",
+          "micro:2": "4479499",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "17.2.4988734": {
         "archives": [
@@ -6628,11 +13497,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r17c-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "17.2.4988734"
+        "revision": "17.2.4988734",
+        "revision-details": {
+          "major:0": "17",
+          "micro:2": "4988734",
+          "minor:1": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "18.1.5063045": {
         "archives": [
@@ -6655,11 +13541,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r18b-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "18.1.5063045"
+        "revision": "18.1.5063045",
+        "revision-details": {
+          "major:0": "18",
+          "micro:2": "5063045",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "19.0.5232133": {
         "archives": [
@@ -6682,11 +13585,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r19-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
+        "obsolete": "true",
         "path": "ndk-bundle",
-        "revision": "19.0.5232133"
+        "revision": "19.0.5232133",
+        "revision-details": {
+          "major:0": "19",
+          "micro:2": "5232133",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "19.2.5345600": {
         "archives": [
@@ -6709,11 +13630,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r19c-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "19.2.5345600"
+        "revision": "19.2.5345600",
+        "revision-details": {
+          "major:0": "19",
+          "micro:2": "5345600",
+          "minor:1": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "20.0.5392854-rc2": {
         "archives": [
@@ -6736,11 +13674,30 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-beta2-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
+        "obsolete": "true",
         "path": "ndk-bundle",
-        "revision": "20.0.5392854-rc2"
+        "revision": "20.0.5392854-rc2",
+        "revision-details": {
+          "major:0": "20",
+          "micro:2": "5392854",
+          "minor:1": "0",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "20.0.5471264-rc3": {
         "archives": [
@@ -6763,11 +13720,30 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-beta3-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
+        "obsolete": "true",
         "path": "ndk-bundle",
-        "revision": "20.0.5471264-rc3"
+        "revision": "20.0.5471264-rc3",
+        "revision-details": {
+          "major:0": "20",
+          "micro:2": "5471264",
+          "minor:1": "0",
+          "preview:3": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "20.0.5594570": {
         "archives": [
@@ -6790,11 +13766,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "20.0.5594570"
+        "revision": "20.0.5594570",
+        "revision-details": {
+          "major:0": "20",
+          "micro:2": "5594570",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "20.1.5948944": {
         "archives": [
@@ -6817,11 +13810,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20b-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "20.1.5948944"
+        "revision": "20.1.5948944",
+        "revision-details": {
+          "major:0": "20",
+          "micro:2": "5948944",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.0.6011959-rc2": {
         "archives": [
@@ -6844,11 +13854,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21-beta2-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "21.0.6011959-rc2"
+        "revision": "21.0.6011959-rc2",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6011959",
+          "minor:1": "0",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.0.6113669": {
         "archives": [
@@ -6871,11 +13899,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "21.0.6113669"
+        "revision": "21.0.6113669",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6113669",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.1.6210238-rc1": {
         "archives": [
@@ -6898,11 +13943,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta1-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "21.1.6210238-rc1"
+        "revision": "21.1.6210238-rc1",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6210238",
+          "minor:1": "1",
+          "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.1.6273396-rc2": {
         "archives": [
@@ -6925,11 +13988,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta2-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "21.1.6273396-rc2"
+        "revision": "21.1.6273396-rc2",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6273396",
+          "minor:1": "1",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.1.6352462": {
         "archives": [
@@ -6952,11 +14033,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "21.1.6352462"
+        "revision": "21.1.6352462",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6352462",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.1.6363665-rc3": {
         "archives": [
@@ -6979,11 +14077,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta3-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "21.1.6363665-rc3"
+        "revision": "21.1.6363665-rc3",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6363665",
+          "minor:1": "1",
+          "preview:3": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.2.6472646": {
         "archives": [
@@ -7006,11 +14122,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21c-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "21.2.6472646"
+        "revision": "21.2.6472646",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6472646",
+          "minor:1": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.3.6528147": {
         "archives": [
@@ -7033,11 +14166,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21d-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "21.3.6528147"
+        "revision": "21.3.6528147",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "6528147",
+          "minor:1": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "21.4.7075529": {
         "archives": [
@@ -7060,11 +14210,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21e-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "21.4.7075529"
+        "revision": "21.4.7075529",
+        "revision-details": {
+          "major:0": "21",
+          "micro:2": "7075529",
+          "minor:1": "4"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "22.0.6917172-rc1": {
         "archives": [
@@ -7087,11 +14254,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22-beta1-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "22.0.6917172-rc1"
+        "revision": "22.0.6917172-rc1",
+        "revision-details": {
+          "major:0": "22",
+          "micro:2": "6917172",
+          "minor:1": "0",
+          "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "22.0.7026061": {
         "archives": [
@@ -7114,11 +14299,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "22.0.7026061"
+        "revision": "22.0.7026061",
+        "revision-details": {
+          "major:0": "22",
+          "micro:2": "7026061",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "22.1.7171670": {
         "archives": [
@@ -7141,11 +14343,28 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22b-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "22.1.7171670"
+        "revision": "22.1.7171670",
+        "revision-details": {
+          "major:0": "22",
+          "micro:2": "7171670",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.7123448-rc1": {
         "archives": [
@@ -7168,11 +14387,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta1-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "23.0.7123448-rc1"
+        "revision": "23.0.7123448-rc1",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "7123448",
+          "minor:1": "0",
+          "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.7196353-rc2": {
         "archives": [
@@ -7195,11 +14432,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta2-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "23.0.7196353-rc2"
+        "revision": "23.0.7196353-rc2",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "7196353",
+          "minor:1": "0",
+          "preview:3": "2"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.7272597-rc3": {
         "archives": [
@@ -7222,11 +14477,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta3-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "23.0.7272597-rc3"
+        "revision": "23.0.7272597-rc3",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "7272597",
+          "minor:1": "0",
+          "preview:3": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "23.0.7344513-rc4": {
         "archives": [
@@ -7249,11 +14522,29 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta4-windows-x86_64.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          }
+        },
         "displayName": "NDK",
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
-        "revision": "23.0.7344513-rc4"
+        "revision": "23.0.7344513-rc4",
+        "revision-details": {
+          "major:0": "23",
+          "micro:2": "7344513",
+          "minor:1": "0",
+          "preview:3": "4"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "patcher": {
@@ -7270,7 +14561,15 @@
         "license": "android-sdk-license",
         "name": "patcher",
         "path": "patcher/v4",
-        "revision": "1"
+        "revision": "1",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "platform-tools": {
@@ -7299,7 +14598,17 @@
         "license": "android-sdk-license",
         "name": "platform-tools",
         "path": "platform-tools",
-        "revision": "33.0.3"
+        "revision": "33.0.3",
+        "revision-details": {
+          "major:0": "33",
+          "micro:2": "3",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "platforms": {
@@ -7316,7 +14625,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-10",
-        "revision": "10"
+        "revision": "10",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "10",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "4"
+            }
+          }
+        }
       },
       "11": {
         "archives": [
@@ -7331,7 +14656,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-11",
-        "revision": "11"
+        "revision": "11",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "11",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "4"
+            }
+          }
+        }
       },
       "12": {
         "archives": [
@@ -7346,7 +14687,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-12",
-        "revision": "12"
+        "revision": "12",
+        "revision-details": {
+          "major:0": "3"
+        },
+        "type-details": {
+          "api-level:0": "12",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "4"
+            }
+          }
+        }
       },
       "13": {
         "archives": [
@@ -7361,7 +14718,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-13",
-        "revision": "13"
+        "revision": "13",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "13",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "4"
+            }
+          }
+        }
       },
       "14": {
         "archives": [
@@ -7376,7 +14749,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-14",
-        "revision": "14"
+        "revision": "14",
+        "revision-details": {
+          "major:0": "4"
+        },
+        "type-details": {
+          "api-level:0": "14",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "12"
+            }
+          }
+        }
       },
       "15": {
         "archives": [
@@ -7391,7 +14780,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-15",
-        "revision": "15"
+        "revision": "15",
+        "revision-details": {
+          "major:0": "5"
+        },
+        "type-details": {
+          "api-level:0": "15",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "12"
+            }
+          }
+        }
       },
       "16": {
         "archives": [
@@ -7406,7 +14811,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-16",
-        "revision": "16"
+        "revision": "16",
+        "revision-details": {
+          "major:0": "5"
+        },
+        "type-details": {
+          "api-level:0": "16",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "12"
+            }
+          }
+        }
       },
       "17": {
         "archives": [
@@ -7421,7 +14842,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-17",
-        "revision": "17"
+        "revision": "17",
+        "revision-details": {
+          "major:0": "3"
+        },
+        "type-details": {
+          "api-level:0": "17",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "12"
+            }
+          }
+        }
       },
       "18": {
         "archives": [
@@ -7436,7 +14873,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-18",
-        "revision": "18"
+        "revision": "18",
+        "revision-details": {
+          "major:0": "3"
+        },
+        "type-details": {
+          "api-level:0": "18",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "12"
+            }
+          }
+        }
       },
       "19": {
         "archives": [
@@ -7451,7 +14904,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-19",
-        "revision": "19"
+        "revision": "19",
+        "revision-details": {
+          "major:0": "4"
+        },
+        "type-details": {
+          "api-level:0": "19",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "12"
+            }
+          }
+        }
       },
       "2": {
         "archives": [
@@ -7477,8 +14946,25 @@
         "displayName": "Android SDK Platform 2",
         "license": "android-sdk-license",
         "name": "platforms",
+        "obsolete": "true",
         "path": "platforms/android-2",
-        "revision": "2"
+        "revision": "2",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "2",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "4"
+            }
+          }
+        }
       },
       "20": {
         "archives": [
@@ -7493,7 +14979,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-20",
-        "revision": "20"
+        "revision": "20",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "20",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "12"
+            }
+          }
+        }
       },
       "21": {
         "archives": [
@@ -7508,7 +15010,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-21",
-        "revision": "21"
+        "revision": "21",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "21",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "12"
+            }
+          }
+        }
       },
       "22": {
         "archives": [
@@ -7523,7 +15041,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-22",
-        "revision": "22"
+        "revision": "22",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "22",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "14"
+            }
+          }
+        }
       },
       "23": {
         "archives": [
@@ -7538,7 +15072,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-23",
-        "revision": "23"
+        "revision": "23",
+        "revision-details": {
+          "major:0": "3"
+        },
+        "type-details": {
+          "api-level:0": "23",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "16"
+            }
+          }
+        }
       },
       "24": {
         "archives": [
@@ -7553,7 +15103,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-24",
-        "revision": "24"
+        "revision": "24",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "24",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "16"
+            }
+          }
+        }
       },
       "25": {
         "archives": [
@@ -7568,7 +15134,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-25",
-        "revision": "25"
+        "revision": "25",
+        "revision-details": {
+          "major:0": "3"
+        },
+        "type-details": {
+          "api-level:0": "25",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "16"
+            }
+          }
+        }
       },
       "26": {
         "archives": [
@@ -7583,7 +15165,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-26",
-        "revision": "26"
+        "revision": "26",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "26",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
       },
       "27": {
         "archives": [
@@ -7598,7 +15196,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-27",
-        "revision": "27"
+        "revision": "27",
+        "revision-details": {
+          "major:0": "3"
+        },
+        "type-details": {
+          "api-level:0": "27",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
       },
       "28": {
         "archives": [
@@ -7613,7 +15227,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-28",
-        "revision": "28"
+        "revision": "28",
+        "revision-details": {
+          "major:0": "6"
+        },
+        "type-details": {
+          "api-level:0": "28",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
       },
       "29": {
         "archives": [
@@ -7628,7 +15258,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-29",
-        "revision": "29"
+        "revision": "29",
+        "revision-details": {
+          "major:0": "5"
+        },
+        "type-details": {
+          "api-level:0": "29",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
       },
       "3": {
         "archives": [
@@ -7654,8 +15300,25 @@
         "displayName": "Android SDK Platform 3",
         "license": "android-sdk-license",
         "name": "platforms",
+        "obsolete": "true",
         "path": "platforms/android-3",
-        "revision": "3"
+        "revision": "3",
+        "revision-details": {
+          "major:0": "4"
+        },
+        "type-details": {
+          "api-level:0": "3",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "4"
+            }
+          }
+        }
       },
       "30": {
         "archives": [
@@ -7670,7 +15333,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-30",
-        "revision": "30"
+        "revision": "30",
+        "revision-details": {
+          "major:0": "3"
+        },
+        "type-details": {
+          "api-level:0": "30",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
       },
       "31": {
         "archives": [
@@ -7685,7 +15364,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-31",
-        "revision": "31"
+        "revision": "31",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "31",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
       },
       "32": {
         "archives": [
@@ -7700,7 +15395,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-32",
-        "revision": "32"
+        "revision": "32",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "32",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
       },
       "33": {
         "archives": [
@@ -7715,7 +15426,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33",
-        "revision": "33"
+        "revision": "33",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "33",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
       },
       "4": {
         "archives": [
@@ -7741,8 +15468,25 @@
         "displayName": "Android SDK Platform 4",
         "license": "android-sdk-license",
         "name": "platforms",
+        "obsolete": "true",
         "path": "platforms/android-4",
-        "revision": "4"
+        "revision": "4",
+        "revision-details": {
+          "major:0": "3"
+        },
+        "type-details": {
+          "api-level:0": "4",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "4"
+            }
+          }
+        }
       },
       "5": {
         "archives": [
@@ -7768,8 +15512,25 @@
         "displayName": "Android SDK Platform 5",
         "license": "android-sdk-license",
         "name": "platforms",
+        "obsolete": "true",
         "path": "platforms/android-5",
-        "revision": "5"
+        "revision": "5",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "5",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "4"
+            }
+          }
+        }
       },
       "6": {
         "archives": [
@@ -7795,8 +15556,25 @@
         "displayName": "Android SDK Platform 6",
         "license": "android-sdk-license",
         "name": "platforms",
+        "obsolete": "true",
         "path": "platforms/android-6",
-        "revision": "6"
+        "revision": "6",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "6",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "4"
+            }
+          }
+        }
       },
       "7": {
         "archives": [
@@ -7811,7 +15589,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-7",
-        "revision": "7"
+        "revision": "7",
+        "revision-details": {
+          "major:0": "3"
+        },
+        "type-details": {
+          "api-level:0": "7",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "4"
+            }
+          }
+        }
       },
       "8": {
         "archives": [
@@ -7826,7 +15620,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-8",
-        "revision": "8"
+        "revision": "8",
+        "revision-details": {
+          "major:0": "3"
+        },
+        "type-details": {
+          "api-level:0": "8",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "4"
+            }
+          }
+        }
       },
       "9": {
         "archives": [
@@ -7841,7 +15651,23 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-9",
-        "revision": "9"
+        "revision": "9",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "9",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "4"
+            }
+          }
+        }
       },
       "TiramisuPrivacySandbox": {
         "archives": [
@@ -7856,7 +15682,22 @@
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-TiramisuPrivacySandbox",
-        "revision": "TiramisuPrivacySandbox"
+        "revision": "TiramisuPrivacySandbox",
+        "revision-details": {
+          "major:0": "8"
+        },
+        "type-details": {
+          "api-level:0": "33",
+          "codename:1": "TiramisuPrivacySandbox",
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "layoutlib:2": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
       }
     },
     "skiaparser": {
@@ -7885,7 +15726,15 @@
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/3",
-        "revision": "1"
+        "revision": "1",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "3": {
         "archives": [
@@ -7912,7 +15761,15 @@
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/2",
-        "revision": "3"
+        "revision": "3",
+        "revision-details": {
+          "major:0": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       },
       "6": {
         "archives": [
@@ -7939,7 +15796,15 @@
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/1",
-        "revision": "6"
+        "revision": "6",
+        "revision-details": {
+          "major:0": "6"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "sources": {
@@ -7955,8 +15820,20 @@
         "displayName": "Sources for Android 14",
         "license": "android-sdk-license",
         "name": "sources",
+        "obsolete": "true",
         "path": "sources/android-14",
-        "revision": "14"
+        "revision": "14",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "14",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "15": {
         "archives": [
@@ -7971,7 +15848,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-15",
-        "revision": "15"
+        "revision": "15",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "15",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "16": {
         "archives": [
@@ -7986,7 +15874,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-16",
-        "revision": "16"
+        "revision": "16",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "16",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "17": {
         "archives": [
@@ -8001,7 +15900,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-17",
-        "revision": "17"
+        "revision": "17",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "17",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "18": {
         "archives": [
@@ -8016,7 +15926,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-18",
-        "revision": "18"
+        "revision": "18",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "18",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "19": {
         "archives": [
@@ -8031,7 +15952,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-19",
-        "revision": "19"
+        "revision": "19",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "19",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "20": {
         "archives": [
@@ -8046,7 +15978,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-20",
-        "revision": "20"
+        "revision": "20",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "20",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "21": {
         "archives": [
@@ -8061,7 +16004,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-21",
-        "revision": "21"
+        "revision": "21",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "21",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "22": {
         "archives": [
@@ -8076,7 +16030,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-22",
-        "revision": "22"
+        "revision": "22",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "22",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "23": {
         "archives": [
@@ -8091,7 +16056,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-23",
-        "revision": "23"
+        "revision": "23",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "23",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "24": {
         "archives": [
@@ -8106,7 +16082,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-24",
-        "revision": "24"
+        "revision": "24",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "24",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "25": {
         "archives": [
@@ -8121,7 +16108,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-25",
-        "revision": "25"
+        "revision": "25",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "25",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "26": {
         "archives": [
@@ -8136,7 +16134,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-26",
-        "revision": "26"
+        "revision": "26",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "26",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "27": {
         "archives": [
@@ -8151,7 +16160,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-27",
-        "revision": "27"
+        "revision": "27",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "27",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "28": {
         "archives": [
@@ -8166,7 +16186,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-28",
-        "revision": "28"
+        "revision": "28",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "28",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "29": {
         "archives": [
@@ -8181,7 +16212,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-29",
-        "revision": "29"
+        "revision": "29",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "29",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "30": {
         "archives": [
@@ -8196,7 +16238,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-30",
-        "revision": "30"
+        "revision": "30",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "30",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "31": {
         "archives": [
@@ -8211,7 +16264,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-31",
-        "revision": "31"
+        "revision": "31",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "31",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "32": {
         "archives": [
@@ -8226,7 +16290,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-32",
-        "revision": "32"
+        "revision": "32",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "32",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       },
       "33": {
         "archives": [
@@ -8241,7 +16316,18 @@
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-33",
-        "revision": "33"
+        "revision": "33",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "33",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          }
+        }
       }
     },
     "tools": {
@@ -8266,11 +16352,42 @@
             "url": "https://dl.google.com/android/repository/sdk-tools-windows-4333796.zip"
           }
         ],
+        "dependencies": {
+          "dependency:0": {
+            "element-attributes": {
+              "path": "patcher;v4"
+            }
+          },
+          "dependency:1": {
+            "element-attributes": {
+              "path": "emulator"
+            }
+          },
+          "dependency:2": {
+            "element-attributes": {
+              "path": "platform-tools"
+            },
+            "min-revision:0": {
+              "major:0": "20"
+            }
+          }
+        },
         "displayName": "Android SDK Tools",
         "license": "android-sdk-license",
         "name": "tools",
+        "obsolete": "true",
         "path": "tools",
-        "revision": "26.1.1"
+        "revision": "26.1.1",
+        "revision-details": {
+          "major:0": "26",
+          "micro:2": "1",
+          "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
###### Description of changes
This PR solves the warning of `sdkmanager` and `avdmanager`, after merging https://github.com/NixOS/nixpkgs/pull/208793 of course! That PR is reviewed and hopefully will be merged before this one!

Also this is a part of https://github.com/NixOS/nixpkgs/issues/208047

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
