### PR TITLE
jaeger-*: init at 1.41.0

### DIFF
--- a/pkgs/tools/misc/jaeger/default.nix
+++ b/pkgs/tools/misc/jaeger/default.nix
@@ -1,0 +1,178 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildGoModule
+, git
+, gzip
+, nodejs-16_x
+, yarn
+}:
+
+let
+  version = "1.41.0";
+  src = fetchFromGitHub {
+    owner = "jaegertracing";
+    repo = "jaeger";
+    rev = "v${version}";
+    sha256 = "aa0RdEMRuKrGkXlxkMpouB/c924xRc4m6XTqISX2vkQ=";
+    fetchSubmodules = true;
+    leaveDotGit = true;
+  };
+
+  nodejs = nodejs-16_x;
+  yarn' = yarn.override { inherit nodejs; };
+
+  buildJaeger = { name, description, linkUI ? false }:
+    buildGoModule rec {
+      pname = "jaeger-${name}";
+      inherit version src;
+
+      vendorHash = "sha256-4vja9pI+t8mIF3+f8u5m+gTgC48/HdhEB7sJMTCYz0A=";
+      subPackages = [ "cmd/${name}" ];
+
+      ldflags = [
+        "-s"
+        "-w"
+        "-X github.com/jaegertracing/jaeger/pkg/version.latestVersion=v${version}"
+      ];
+
+      tags = lib.optional linkUI "ui";
+
+      nativeBuildInputs = [ git ];
+
+      preBuild = ''
+        GIT_SHA=$(git rev-parse HEAD)
+        DATE=$(TZ=UTC0 git show --quiet --date='format-local:%Y-%m-%dT%H:%M:%SZ' --format="%cd")
+        ldflags+=" -X github.com/jaegertracing/jaeger/pkg/version.commitSHA=$GIT_SHA"
+        ldflags+=" -X github.com/jaegertracing/jaeger/pkg/version.date=$DATE"
+      '' + lib.optionalString linkUI ''
+        cp --no-preserve=mode -r ${jaeger-ui}/* cmd/query/app/ui/actual/
+        find cmd/query/app/ui/actual -type f | grep -v .gitignore | xargs gzip --no-name
+      '';
+
+      postInstall = ''
+        mv $out/bin/${name} $out/bin/${pname}
+      '';
+
+      meta = with lib; {
+        inherit description;
+        homepage = "https://www.jaegertracing.io";
+        license = licenses.asl20;
+        maintainers = with maintainers; [ emilytrau ];
+      };
+    };
+
+  yarnCache = stdenv.mkDerivation {
+    pname = "jaeger-ui-yarn-cache";
+    inherit version;
+
+    src = "${src}/jaeger-ui";
+
+    nativeBuildInputs = [ yarn' ];
+    buildPhase = ''
+      export HOME=$(mktemp -d)
+      yarn config set yarn-offline-mirror $out
+      yarn install --frozen-lockfile --ignore-scripts --ignore-platform --ignore-engines
+    '';
+
+    installPhase = ''
+      echo yarnCache
+    '';
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-LfYTiVK0AYvp4RxBcL9+kmG52A6ZgAB9OU2d87VIW0Y=";
+  };
+
+  jaeger-ui = stdenv.mkDerivation {
+    pname = "jaeger-ui";
+    inherit version;
+
+    src = "${src}/jaeger-ui";
+
+    nativeBuildInputs = [
+      git
+      gzip
+      nodejs
+      yarn'
+    ];
+
+    configurePhase = ''
+      export HOME=$(mktemp -d)
+
+      # with the update of openssl3, some key ciphers are not supported anymore
+      # this flag will allow those codecs again as a workaround
+      # see https://medium.com/the-node-js-collection/node-js-17-is-here-8dba1e14e382#5f07
+      # and https://github.com/vector-im/element-web/issues/21043
+      export NODE_OPTIONS=--openssl-legacy-provider
+
+      yarn --offline config set yarn-offline-mirror "${yarnCache}"
+      yarn install --offline --ignore-scripts --ignore-platform --ignore-engines
+
+      patchShebangs node_modules/ packages/ scripts/
+    '';
+
+    buildPhase = ''
+      cd packages/plexus
+      yarn --offline build
+      yarn --offline link
+      cd ../..
+
+      cd packages/jaeger-ui
+      yarn --offline link @jaegertracing/plexus
+      yarn --offline build
+    '';
+
+    installPhase = ''
+      cp -r build $out
+    '';
+  };
+in
+{
+  jaeger-agent = buildJaeger {
+    name = "agent";
+    description = "Local daemon program which collects tracing data";
+  };
+
+  jaeger-all-in-one = buildJaeger {
+    name = "all-in-one";
+    description = "Jaeger all-in-one distribution with agent, collector and query in one process";
+    linkUI = true;
+  };
+
+  jaeger-anonymizer = buildJaeger {
+    name = "anonymizer";
+    description = "Hashes fields of a trace for easy sharing";
+  };
+
+  jaeger-collector = buildJaeger {
+    name = "collector";
+    description = "Receives and processes traces from Jaeger agents and clients";
+  };
+
+  jaeger-es-index-cleaner = buildJaeger {
+    name = "es-index-cleaner";
+    description = "Purge old Jaeger indices from Elasticsearch";
+  };
+
+  jaeger-ingester = buildJaeger {
+    name = "ingester";
+    description = "Consumes spans from a particular Kafka topic and writes them to a configured storage";
+  };
+
+  jaeger-query = buildJaeger {
+    name = "query";
+    description = "Provides a Web UI and an API for accessing trace data";
+    linkUI = true;
+  };
+
+  jaeger-remote-storage = buildJaeger {
+    name = "remote-storage";
+    description = "Allows sharing single-node storage implementations like memstore or Badger";
+  };
+
+  jaeger-tracegen = buildJaeger {
+    name = "tracegen";
+    description = "Generate a steady flow of simple traces useful for performance tuning";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8383,6 +8383,18 @@ with pkgs;
 
   jadx = callPackage ../tools/security/jadx { };
 
+  inherit (callPackage ../tools/misc/jaeger { })
+    jaeger-agent
+    jaeger-all-in-one
+    jaeger-anonymizer
+    jaeger-collector
+    jaeger-es-index-cleaner
+    jaeger-ingester
+    jaeger-tracegen
+    jaeger-remote-storage
+    jaeger-query
+    ;
+
   jamesdsp = libsForQt5.callPackage ../applications/audio/jamesdsp { };
   jamesdsp-pulse = libsForQt5.callPackage ../applications/audio/jamesdsp {
     usePipewire = false;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Jaeger: open source, end-to-end distributed tracing. Monitor and troubleshoot transactions in complex distributed systems

https://www.jaegertracing.io/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
