### PR TITLE
lens: 5.5.3 -> 6.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16271,4 +16271,10 @@
     github = "Detegr";
     githubId = 724433;
   };
+  RossComputerGuy = {
+    name = "Tristan Ross";
+    email = "tristan.ross@midstall.com";
+    github = "RossComputerGuy";
+    githubId = 19699320;
+  };
 }

--- a/pkgs/applications/networking/cluster/lens/default.nix
+++ b/pkgs/applications/networking/cluster/lens/default.nix
@@ -1,14 +1,14 @@
-{ lib, fetchurl, appimageTools, wrapGAppsHook }:
+{ lib, fetchurl, appimageTools, wrapGAppsHook, makeWrapper }:
 
 let
   pname = "lens";
-  version = "5.5.3";
-  build = "${version}-latest.20220602.2";
+  version = "6.3.0";
+  build = "2022.12.221341-latest";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://api.k8slens.dev/binaries/Lens-${build}.x86_64.AppImage";
-    sha256 = "sha256-lwiwyXoO+7KgDnQ2Ly0QK0oEVHR73nsMZMGOd2j48dg=";
+    sha256 = "sha256-IJkm2Woz362jydFph9ek+5Jh2jtDH8kKvWoLQhTZPvc=";
     name = "${pname}.AppImage";
   };
 
@@ -23,11 +23,12 @@ appimageTools.wrapType2 {
   extraInstallCommands =
     ''
       mv $out/bin/${name} $out/bin/${pname}
-
+      source "${makeWrapper}/nix-support/setup-hook"
+      wrapProgram $out/bin/${pname} \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
       install -m 444 -D ${appimageContents}/lens.desktop $out/share/applications/${pname}.desktop
       install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/lens.png \
          $out/share/icons/hicolor/512x512/apps/${pname}.png
-
       substituteInPlace $out/share/applications/${pname}.desktop \
         --replace 'Icon=lens' 'Icon=${pname}' \
         --replace 'Exec=AppRun' 'Exec=${pname}'
@@ -37,7 +38,7 @@ appimageTools.wrapType2 {
     description = "The Kubernetes IDE";
     homepage = "https://k8slens.dev/";
     license = licenses.mit;
-    maintainers = with maintainers; [ dbirks ];
+    maintainers = with maintainers; [ dbirks RossComputerGuy ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Redo of https://github.com/NixOS/nixpkgs/pull/209958.

https://github.com/NixOS/nixpkgs/pull/209958#issuecomment-1380052325:
Lens requires being launched with `--no-sandbox`. This is because Lens expects itself being ran inside of an AppImage and so Lens does some sort of proxying to ensure it is able to access its own webserver.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
