### PR TITLE
agda: pass through meta

### DIFF
--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -22,13 +22,14 @@ let
       unwrapped = Agda;
       tests = { inherit (nixosTests) agda; };
     };
+    inherit (Agda) meta;
   } ''
     mkdir -p $out/bin
     makeWrapper ${Agda}/bin/agda $out/bin/agda \
       --add-flags "--with-compiler=${ghc}/bin/ghc" \
       --add-flags "--library-file=${library-file}" \
       --add-flags "--local-interfaces"
-    makeWrapper ${Agda}/bin/agda-mode $out/bin/agda-mode
+    ln -s ${Agda}/bin/agda-mode $out/bin/agda-mode
     ''; # Local interfaces has been added for now: See https://github.com/agda/agda/issues/4526
 
   withPackages = arg: if builtins.isAttrs arg then withPackages' arg else withPackages' { pkgs = arg; };


### PR DESCRIPTION
Also avoid a useless wrapper.