### PR TITLE
capitaine-cursors-themed: init at r5

### DIFF
--- a/pkgs/data/icons/capitaine-cursors-themed/default.nix
+++ b/pkgs/data/icons/capitaine-cursors-themed/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchzip }:
+fetchzip rec {
+  pname = "capitaine-cursors-themed";
+  version = "5";
+  stripRoot = false;
+  url = "https://github.com/sainnhe/capitaine-cursors/releases/download/r${version}/Linux.zip";
+  sha256 = "jQNAXuR/OtvohWziGYgb5Ni2/tEIGaY9HIyUUW793EY=";
+
+  postFetch = ''
+    mkdir -p $out/share/icons
+    cp -r ./ $out/share/icons
+  '';
+
+  meta = with lib; {
+    description = "A fork of the capitaine cursor theme, with some additional variants (Gruvbox, Nord, Palenight) and support for HiDPI";
+    homepage = "https://github.com/sainnhe/capitaine-cursors";
+    license = licenses.lgpl3Only;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.math-42 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26505,6 +26505,8 @@ with pkgs;
 
   capitaine-cursors = callPackage ../data/icons/capitaine-cursors { };
 
+  capitaine-cursors-themed = callPackage ../data/icons/capitaine-cursors-themed { };
+
   carlito = callPackage ../data/fonts/carlito {};
 
   cascadia-code = callPackage ../data/fonts/cascadia-code { };


### PR DESCRIPTION
###### Description of changes
closes #210414 

Add a fork of the capitainer cursosrs icon theme for the cursorl: 
Home page: https://github.com/sainnhe/capitaine-cursors
See also: https://www.pling.com/p/1818760/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
