### PR TITLE
lib.path.hasPrefix, lib.path.removePrefix: init

### DIFF
--- a/lib/path/default.nix
+++ b/lib/path/default.nix
@@ -108,6 +108,12 @@ in /* No rec! Add dependencies on this file at the top. */ {
     More specifically, it checks that the first argument is a [path value type](https://nixos.org/manual/nix/stable/language/values.html#type-path"),
     and that the second argument is a valid subpath string (see `lib.path.subpath.isValid`).
 
+    Laws:
+
+    - Not influenced by subpath normalisation
+
+        append p s == append p (subpath.normalise s)
+
     Type:
       append :: Path -> String -> Path
 

--- a/lib/path/tests/unit.nix
+++ b/lib/path/tests/unit.nix
@@ -3,7 +3,7 @@
 { libpath }:
 let
   lib = import libpath;
-  inherit (lib.path) append subpath;
+  inherit (lib.path) hasPrefix append subpath;
 
   cases = lib.runTests {
     # Test examples from the lib.path.append documentation
@@ -38,6 +38,23 @@ let
     testAppendExample8 = {
       expr = (builtins.tryEval (append /foo "../bar")).success;
       expected = false;
+    };
+
+    testHasPrefixExample1 = {
+      expr = hasPrefix /foo /foo/bar;
+      expected = true;
+    };
+    testHasPrefixExample2 = {
+      expr = hasPrefix /foo /foo;
+      expected = true;
+    };
+    testHasPrefixExample3 = {
+      expr = hasPrefix /foo/bar /foo;
+      expected = false;
+    };
+    testHasPrefixExample4 = {
+      expr = hasPrefix /. /foo;
+      expected = true;
     };
 
     # Test examples from the lib.path.subpath.isValid documentation

--- a/lib/path/tests/unit.nix
+++ b/lib/path/tests/unit.nix
@@ -3,7 +3,7 @@
 { libpath }:
 let
   lib = import libpath;
-  inherit (lib.path) hasPrefix append subpath;
+  inherit (lib.path) hasPrefix removePrefix append subpath;
 
   cases = lib.runTests {
     # Test examples from the lib.path.append documentation
@@ -55,6 +55,23 @@ let
     testHasPrefixExample4 = {
       expr = hasPrefix /. /foo;
       expected = true;
+    };
+
+    testRemovePrefixExample1 = {
+      expr = removePrefix /foo /foo/bar;
+      expected = "./bar";
+    };
+    testRemovePrefixExample2 = {
+      expr = removePrefix /foo /foo;
+      expected = "./.";
+    };
+    testRemovePrefixExample3 = {
+      expr = (builtins.tryEval (removePrefix /foo/bar /foo)).success;
+      expected = false;
+    };
+    testRemovePrefixExample4 = {
+      expr = removePrefix /. /foo;
+      expected = "./foo";
     };
 
     # Test examples from the lib.path.subpath.isValid documentation

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -264,7 +264,8 @@ rec {
         lib.strings.hasPrefix: The first argument (${toString pref}) is a path value, but only strings are supported.
             There is almost certainly a bug in the calling code, since this function always returns `false` in such a case.
             This function also copies the path to the Nix store, which may not be what you want.
-            This behavior is deprecated and will throw an error in the future.''
+            This behavior is deprecated and will throw an error in the future.
+            You might want to use `lib.path.hasPrefix` instead, which correctly supports paths.''
       (substring 0 (stringLength pref) str == pref);
 
   /* Determine whether a string has given suffix.

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -625,7 +625,8 @@ rec {
         lib.strings.removePrefix: The first argument (${toString prefix}) is a path value, but only strings are supported.
             There is almost certainly a bug in the calling code, since this function never removes any prefix in such a case.
             This function also copies the path to the Nix store, which may not be what you want.
-            This behavior is deprecated and will throw an error in the future.''
+            This behavior is deprecated and will throw an error in the future.
+            You might want to use `lib.path.removePrefix` instead, which correctly supports paths.''
     (let
       preLen = stringLength prefix;
       sLen = stringLength str;


### PR DESCRIPTION
###### Description of changes

Adds two new path library functions:
- `lib.path.hasPrefix :: Path -> Path -> Bool`: Whether the second path is a prefix of the first path, or equal to it:
  ```nix
  lib.path.hasPrefix ./. ./lib
  -> true
  ```
- `lib.path.removePrefix :: Path -> Path -> String`: Remove a first prefix path from a second path, the result is a normalised subpath string, see [`lib.path.subpath.normalise`](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.path.subpath.normalise):
  ```nix
  lib.path.removePrefix ./. ./lib
  -> "./lib"
  ```

This relates to other work in [the path library effort](https://github.com/NixOS/nixpkgs/issues/210426).
This PR depended on https://github.com/NixOS/nixpkgs/pull/221204, which is now merged.

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles: 

###### Things done
- [x] Wrote docs
- [x] Wrote tests