### PR TITLE
slowcgi-portable: init at 6.5+git20210716.0fce043

### DIFF
--- a/pkgs/servers/slowcgi-portable/default.nix
+++ b/pkgs/servers/slowcgi-portable/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, libevent, libbsd, pkg-config }:
+stdenv.mkDerivation rec {
+  pname = "slowcgi-portable";
+  version = "6.5+git20210716.0fce043";
+
+  src = fetchFromGitHub {
+    owner = "adaugherity";
+    repo = "slowcgi-portable";
+    rev = "0fce04362f807473870a6f700ede6bcaf15818ea";
+    hash = "sha256-JYWY+J28NgEMtrobM0sSn83BpxCXFXW+UpuBK+5dSIw=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libevent
+    libbsd
+  ];
+
+  makeFlags = "prefix=$(out) sbindir=$(out)/bin";
+
+  meta = with lib; {
+    description = "A FastCGI to CGI wrapper, ported from OpenBSD";
+    homepage = "https://github.com/adaugherity/slowcgi-portable";
+    license = licenses.isc;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ piperswe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11744,6 +11744,8 @@ with pkgs;
 
   slirp4netns = callPackage ../tools/networking/slirp4netns { };
 
+  slowcgi-portable = callPackage ../servers/slowcgi-portable { };
+
   slowlorust = callPackage ../tools/networking/slowlorust { };
 
   slsnif = callPackage ../tools/misc/slsnif { };


### PR DESCRIPTION
###### Description of changes

This can be useful for running CGI scripts through Nginx. It's a port of the `slowcgi` utility from OpenBSD.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
