### PR TITLE
oauth2l: init at 1.3.0

### DIFF
--- a/pkgs/tools/networking/oauth2l/default.nix
+++ b/pkgs/tools/networking/oauth2l/default.nix
@@ -1,0 +1,24 @@
+{ lib , buildGoModule , fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "oauth2l";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "oauth2l";
+    rev = "v${version}";
+    hash = "sha256-bL1bys/CBo/P9VfWc/FB8JHW/aBwC521V8DB1sFBIAA=";
+  };
+
+  subPackages = [ "." ];
+  ldflags = [ "-s" "-w" ];
+  vendorHash = null;
+
+  meta = with lib; {
+    description = "A simple CLI for interacting with Google API authentication";
+    homepage = "https://github.com/google/oauth2l";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ zombiezen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9070,6 +9070,8 @@ with pkgs;
 
   node2nix = nodePackages.node2nix;
 
+  oauth2l = callPackage ../tools/networking/oauth2l { };
+
   openipmi = callPackage ../tools/system/openipmi { };
 
   ox = callPackage ../applications/editors/ox { };


### PR DESCRIPTION
###### Description of changes

A simple CLI for interacting with Google API authentication: https://github.com/google/oauth2l

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).