### PR TITLE
borgbackup: cherry-pick patch to fix tests

### DIFF
--- a/pkgs/tools/backup/borgbackup/default.nix
+++ b/pkgs/tools/backup/borgbackup/default.nix
@@ -28,8 +28,8 @@ python3.pkgs.buildPythonApplication rec {
     (fetchpatch {
       # Fix HashIndexSizeTestCase.test_size_on_disk_accurate problems on ZFS,
       # see https://github.com/borgbackup/borg/issues/7250
-      url = "https://github.com/borgbackup/borg/pull/7252/commits/537a814e53e20013a041faa7192da005f137cf5b.patch";
-      hash = "sha256-dnF/FW8pS4Ub9aAL4b7zf6ZNjMZaiMqdtl5R+DlAZTM=";
+      url = "https://github.com/borgbackup/borg/pull/7252/commits/fe3775cf8078c18d8fe39a7f42e52e96d3ecd054.patch";
+      hash = "sha256-gdssHfhdkmRfSAOeXsq9Afg7xqGM3NLIq4QnzmPBhw4=";
     })
   ];
 


### PR DESCRIPTION
borgbackup/borg#7250 is now fixed in 1.2-maint (pending for borg 1.2.4)
but borgbackup/borg#7252 was amended to a different approach before 
being approved. Replace the original workaround with upstream's fix.

###### Description of changes

Replaced a patch adding `flush()` with one changing to `unopened_tempfile`: see #207631 for the original issue and https://github.com/borgbackup/borg/pull/7252#discussion_r1067602899 for the reasons behind using a different fix.

```diff
@@ src/borg/testsuite/hashindex.py: def test_size_on_disk_accurate(self):
              idx[H(i)] = i, i**2, i**3
-         with tempfile.NamedTemporaryFile() as file:
-             idx.write(file)
-+            file.flush()
-             size = os.path.getsize(file.fileno())
+-        with tempfile.NamedTemporaryFile() as file:
+-            idx.write(file)
+-            size = os.path.getsize(file.fileno())
++        with unopened_tempfile() as filepath:
++            idx.write(filepath)
++            size = os.path.getsize(filepath)
              assert idx.size() == size
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
