### PR TITLE
Nheko: 0.10.2 ->  0.11.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/nheko/default.nix
+++ b/pkgs/applications/networking/instant-messengers/nheko/default.nix
@@ -23,6 +23,7 @@
 , pkg-config
 , nlohmann_json
 , coeurl
+, re2
 , libevent
 , curl
 , voipSupport ? true
@@ -32,13 +33,13 @@
 
 mkDerivation rec {
   pname = "nheko";
-  version = "0.10.2";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "Nheko-Reborn";
     repo = "nheko";
     rev = "v${version}";
-    sha256 = "sha256-gid8XOZ1/hMDGNbse4GYfcAdqHiySWyy4isBgcpekIQ=";
+    sha256 = "sha256-4Xe3eRnDkgyYB+hUP8TBWTt+m29HVtgcqVEQUUsIpCY=";
   };
 
   nativeBuildInputs = [
@@ -64,6 +65,7 @@ mkDerivation rec {
     qtquickcontrols2
     qtgraphicaleffects
     qtkeychain
+    re2
     coeurl
     libevent
     curl

--- a/pkgs/development/libraries/coeurl/default.nix
+++ b/pkgs/development/libraries/coeurl/default.nix
@@ -11,14 +11,14 @@
 
 stdenv.mkDerivation rec {
   pname = "coeurl";
-  version = "0.2.1";
+  version = "0.3.0";
 
   src = fetchFromGitLab {
     domain = "nheko.im";
     owner = "nheko-reborn";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-+FIxi019+jnjpo4NhBQ4tb3ObLrEStMN5YD+MrTLa2E=";
+    sha256 = "sha256-sN+YSddUOdnJLcnHyWdjNm1PpxCwnkwiqSvyrwUrg6w=";
   };
 
   nativeBuildInputs = [ ninja pkg-config meson ];

--- a/pkgs/development/libraries/mtxclient/default.nix
+++ b/pkgs/development/libraries/mtxclient/default.nix
@@ -5,6 +5,7 @@
 , pkg-config
 , openssl
 , olm
+, re2
 , spdlog
 , nlohmann_json
 , coeurl
@@ -14,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mtxclient";
-  version = "0.8.2";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "Nheko-Reborn";
     repo = "mtxclient";
     rev = "v${version}";
-    sha256 = "sha256-x2c+wZWAWYoKxSqEezoInw3SwcGo9dQNDvuq7racLBA=";
+    sha256 = "sha256-39tdTY2emN3/FxZxwl6dcQn1bOgybws166wqFPJl68M=";
   };
 
   postPatch = ''
@@ -44,6 +45,7 @@ stdenv.mkDerivation rec {
     nlohmann_json
     openssl
     olm
+    re2
     coeurl
     libevent
     curl


### PR DESCRIPTION
https://github.com/Nheko-Reborn/nheko/releases/tag/v0.11.0
###### Description of changes
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
Bumped nheko and it's libraries that are only used by nheko so far.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
```
3 packages updated:
coeurl (0.2.1 → 0.3.0) mtxclient (0.8.2 → 0.9.0) nheko (0.10.2 → 0.11.0)
```
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
