### PR TITLE
JXplorer: init at 3.3.1.2

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -190,6 +190,11 @@ in mkLicense lset) ({
     free = false;
   };
 
+  caossl = {
+    fullName = "Computer Associates Open Source Licence Version 1.0";
+    url = "http://jxplorer.org/licence.html";
+  };
+
   cal10 = {
     fullName = "Cryptographic Autonomy License version 1.0 (CAL-1.0)";
     url = "https://opensource.org/licenses/CAL-1.0";

--- a/pkgs/applications/networking/jxplorer/default.nix
+++ b/pkgs/applications/networking/jxplorer/default.nix
@@ -1,0 +1,50 @@
+{ lib, stdenv, fetchurl, makeDesktopItem, ant, jdk8, copyDesktopItems, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "jxplorer";
+  version = "3.3.1.2";
+
+  src = fetchurl {
+    url = "https://github.com/pegacat/jxplorer/releases/download/v${version}/jxplorer-${version}-project.tar.bz2";
+    hash = "sha256-/lWkavH51OqNFSLpgT+4WcQcfW3WvnnOkB03jB7bE/s=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "JXplorer";
+      exec = "jxplorer";
+      comment = "A Java Ldap Browser";
+      desktopName = "JXplorer";
+      genericName = "Java Ldap Browser";
+      icon = "jxplorer";
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -d "$out/opt/jxplorer" "$out/bin" "$out/share/pixmaps"
+    cp -r ./. "$out/opt/jxplorer"
+    install -Dm644 images/JX128.png "$out/share/pixmaps/jxplorer.png"
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    chmod +x $out/opt/jxplorer/jxplorer.sh
+    makeWrapper $out/opt/jxplorer/jxplorer.sh $out/bin/jxplorer \
+      --chdir $out/opt/jxplorer \
+      --set JAVA_HOME ${jdk8}
+  '';
+
+  meta = with lib; {
+    description = "A Java Ldap Browser";
+    homepage    = "https://sourceforge.net/projects/jxplorer/";
+    license     = lib.licenses.caossl;
+    maintainers = with maintainers; [ benwbooth ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27800,6 +27800,8 @@ with pkgs;
 
   jnetmap = callPackage ../applications/networking/jnetmap {};
 
+  jxplorer  = callPackage ../applications/networking/jxplorer {};
+
   join-desktop = callPackage ../applications/misc/join-desktop { };
 
   json-plot = callPackage ../applications/graphics/json-plot {};


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
