### PR TITLE
wlgreet: 2022-01-25 -> 0.4.1

### DIFF
--- a/pkgs/applications/display-managers/greetd/wlgreet.nix
+++ b/pkgs/applications/display-managers/greetd/wlgreet.nix
@@ -4,17 +4,17 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "wlgreet-unstable";
-  version = "2022-01-25";
+  pname = "wlgreet";
+  version = "0.4.1";
 
   src = fetchFromSourcehut {
     owner = "~kennylevinsen";
-    repo = "wlgreet";
-    rev = "8517e578cb64a8fb3bd8f8a438cdbe46f208b87c";
-    sha256 = "0la4xlikw61cxvbkil1d22dgvazi7rs17n5i2z02090fvnfxxzxh";
+    repo = pname;
+    rev = version;
+    hash = "sha256-qfEzr8tAE1+PK7xs1NQ1q6d/GlFA7/kSWXbJDOCrEsw=";
   };
 
-  cargoSha256 = "651d2bf01612534f1c4b0472c812095a86eb064d16879380c87f684c04fe0d8d";
+  cargoHash = "sha256-1ugExUtrzqyd9dTlBHcc44UrtEfYrfUryuG79IkTv2Y=";
 
   meta = with lib; {
     description = "Raw wayland greeter for greetd, to be run under sway or similar";


### PR DESCRIPTION
Fixes a crash when using wlgreet and sway on unstable.

###### Description of changes
Upgrade wlgreet from an unstable version to 0.4.1 to resolve crashing on unstable.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
