### PR TITLE
sooperlooper: 1.7.4 -> 1.7.8

### DIFF
--- a/pkgs/applications/audio/sooperlooper/default.nix
+++ b/pkgs/applications/audio/sooperlooper/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , autoreconfHook
 , pkg-config
 , which
@@ -9,7 +10,7 @@
 , libxml2
 , libjack2
 , libsndfile
-, wxGTK30
+, wxGTK32
 , libsigcxx
 , libsamplerate
 , rubberband
@@ -21,14 +22,22 @@
 
 stdenv.mkDerivation rec {
   pname = "sooperlooper";
-  version = "1.7.4";
+  version = "1.7.8";
 
   src = fetchFromGitHub {
     owner = "essej";
     repo = "sooperlooper";
-    rev = "v${builtins.replaceStrings [ "." ] [ "_" ] version}";
-    sha256 = "1jng9bkb7iikad0dy1fkiq9wjjdhh1xi1p0cp2lvnz1dsc4yk6iw";
+    rev = "v${version}";
+    sha256 = "sha256-Lrsz/UDCgoac63FJ3CaPVaYwvBtzkGQQRLhUi6lUusE=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "10-build_with_wx_32.patch";
+      url = "https://sources.debian.org/data/main/s/sooperlooper/1.7.8~dfsg0-2/debian/patches/10-build_with_wx_32.patch";
+      sha256 = "sha256-NF/w+zgRBNkSTqUJhfH9kQogXSYEF70pCN+loR0hjpg=";
+    })
+  ];
 
   autoreconfPhase = ''
     patchShebangs ./autogen.sh
@@ -47,7 +56,7 @@ stdenv.mkDerivation rec {
     libxml2
     libjack2
     libsndfile
-    wxGTK30
+    wxGTK32
     libsigcxx
     libsamplerate
     rubberband
@@ -68,7 +77,7 @@ stdenv.mkDerivation rec {
       However, this kind of live performance looping tool is most effectively used via hardware (midi footpedals, etc)
       and the engine can be run standalone on a computer without a monitor.
     '';
-    homepage = "http://essej.net/sooperlooper/"; # https is broken
+    homepage = "https://sonosaurus.com/sooperlooper/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ magnetophon ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
