### PR TITLE
deepin(library): init at 20.8

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -168,6 +168,15 @@ with lib.maintainers; {
     shortName = "Cosmopolitan";
   };
 
+  deepin = {
+    members = [
+      rewine
+    ];
+    scope = "Maintain deepin desktop environment and related packages.";
+    shortName = "DDE";
+    enableFeatureFreezePing = true;
+  };
+
   deshaw = {
     # Verify additions to this team with at least one already existing member of the team.
     members = [

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -49,7 +49,6 @@ with lib;
     (mkRemovedOptionModule [ "services" "chronos" ] "The corresponding package was removed from nixpkgs.")
     (mkRemovedOptionModule [ "services" "couchpotato" ] "The corresponding package was removed from nixpkgs.")
     (mkRemovedOptionModule [ "services" "dd-agent" ] "dd-agent was removed from nixpkgs in favor of the newer datadog-agent.")
-    (mkRemovedOptionModule [ "services" "deepin" ] "The corresponding packages were removed from nixpkgs.")
     (mkRemovedOptionModule [ "services" "dnscrypt-proxy" ] "Use services.dnscrypt-proxy2 instead")
     (mkRemovedOptionModule [ "services" "firefox" "syncserver" ] "The corresponding package was removed from nixpkgs.")
     (mkRemovedOptionModule [ "services" "flashpolicyd" ] "The flashpolicyd module has been removed. Adobe Flash Player is deprecated.")

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -12,6 +12,7 @@ let
     qt5platform-plugins = callPackage ./library/qt5platform-plugins { };
     qt5integration = callPackage ./library/qt5integration { };
     disomaster = callPackage ./library/disomaster { };
+    docparser = callPackage ./library/docparser { };
   };
 in
 lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -14,6 +14,7 @@ let
     dde-qt-dbus-factory = callPackage ./library/dde-qt-dbus-factory { };
     disomaster = callPackage ./library/disomaster { };
     docparser = callPackage ./library/docparser { };
+    gio-qt = callPackage ./library/gio-qt { };
   };
 in
 lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -8,6 +8,7 @@ let
     dtkcommon = callPackage ./library/dtkcommon { };
     dtkcore = callPackage ./library/dtkcore { };
     dtkgui = callPackage ./library/dtkgui { };
+    dtkwidget = callPackage ./library/dtkwidget { };
 
   };
 in

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -11,6 +11,7 @@ let
     dtkwidget = callPackage ./library/dtkwidget { };
     qt5platform-plugins = callPackage ./library/qt5platform-plugins { };
     qt5integration = callPackage ./library/qt5integration { };
+    dde-qt-dbus-factory = callPackage ./library/dde-qt-dbus-factory { };
     disomaster = callPackage ./library/disomaster { };
     docparser = callPackage ./library/docparser { };
   };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -7,6 +7,8 @@ let
     #### LIBRARIES
     dtkcommon = callPackage ./library/dtkcommon { };
     dtkcore = callPackage ./library/dtkcore { };
+    dtkgui = callPackage ./library/dtkgui { };
+
   };
 in
 lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -16,6 +16,7 @@ let
     docparser = callPackage ./library/docparser { };
     gio-qt = callPackage ./library/gio-qt { };
     image-editor = callPackage ./library/image-editor { };
+    udisks2-qt5 = callPackage ./library/udisks2-qt5 { };
   };
 in
 lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -11,7 +11,7 @@ let
     dtkwidget = callPackage ./library/dtkwidget { };
     qt5platform-plugins = callPackage ./library/qt5platform-plugins { };
     qt5integration = callPackage ./library/qt5integration { };
-    
+    disomaster = callPackage ./library/disomaster { };
   };
 in
 lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -12,6 +12,7 @@ let
     qt5platform-plugins = callPackage ./library/qt5platform-plugins { };
     qt5integration = callPackage ./library/qt5integration { };
     deepin-wayland-protocols = callPackage ./library/deepin-wayland-protocols { };
+    dwayland = callPackage ./library/dwayland { };
     dde-qt-dbus-factory = callPackage ./library/dde-qt-dbus-factory { };
     disomaster = callPackage ./library/disomaster { };
     docparser = callPackage ./library/docparser { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -4,7 +4,8 @@ let
   let
     inherit (self) callPackage;
   in {
-
+    #### LIBRARIES
+    dtkcommon = callPackage ./library/dtkcommon { };
   };
 in
 lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -10,7 +10,8 @@ let
     dtkgui = callPackage ./library/dtkgui { };
     dtkwidget = callPackage ./library/dtkwidget { };
     qt5platform-plugins = callPackage ./library/qt5platform-plugins { };
-
+    qt5integration = callPackage ./library/qt5integration { };
+    
   };
 in
 lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -9,6 +9,7 @@ let
     dtkcore = callPackage ./library/dtkcore { };
     dtkgui = callPackage ./library/dtkgui { };
     dtkwidget = callPackage ./library/dtkwidget { };
+    qt5platform-plugins = callPackage ./library/qt5platform-plugins { };
 
   };
 in

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -6,6 +6,7 @@ let
   in {
     #### LIBRARIES
     dtkcommon = callPackage ./library/dtkcommon { };
+    dtkcore = callPackage ./library/dtkcore { };
   };
 in
 lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -1,0 +1,10 @@
+{ lib, pkgs, libsForQt5 }:
+let
+  packages = self:
+  let
+    inherit (self) callPackage;
+  in {
+
+  };
+in
+lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -11,6 +11,7 @@ let
     dtkwidget = callPackage ./library/dtkwidget { };
     qt5platform-plugins = callPackage ./library/qt5platform-plugins { };
     qt5integration = callPackage ./library/qt5integration { };
+    deepin-wayland-protocols = callPackage ./library/deepin-wayland-protocols { };
     dde-qt-dbus-factory = callPackage ./library/dde-qt-dbus-factory { };
     disomaster = callPackage ./library/disomaster { };
     docparser = callPackage ./library/docparser { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -15,6 +15,7 @@ let
     disomaster = callPackage ./library/disomaster { };
     docparser = callPackage ./library/docparser { };
     gio-qt = callPackage ./library/gio-qt { };
+    image-editor = callPackage ./library/image-editor { };
   };
 in
 lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/deepin/library/dde-qt-dbus-factory/default.nix
+++ b/pkgs/desktops/deepin/library/dde-qt-dbus-factory/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, qmake
+, qtbase
+, wrapQtAppsHook
+, python3
+, dtkcore
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dde-qt-dbus-factory";
+  version = "5.5.22";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-jqk04S+i3py3rVJcHmkPKHsU+eNEN1yoUBBlfXBbcwM=";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+    python3
+  ];
+
+  buildInputs = [
+    qtbase
+    dtkcore
+  ];
+
+  qmakeFlags = [
+    "INSTALL_ROOT=${placeholder "out"}"
+    "LIB_INSTALL_DIR=${placeholder "out"}/lib"
+  ];
+
+  postPatch = ''
+    substituteInPlace libdframeworkdbus/libdframeworkdbus.pro \
+     --replace "/usr" ""
+
+    substituteInPlace libdframeworkdbus/DFrameworkdbusConfig.in \
+      --replace "/usr/include" "$out/include"
+  '';
+
+  meta = with lib; {
+    description = "Repo of auto-generated D-Bus source code which DDE used";
+    homepage = "https://github.com/linuxdeepin/dde-qt-dbus-factory";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/deepin-wayland-protocols/default.nix
+++ b/pkgs/desktops/deepin/library/deepin-wayland-protocols/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+}:
+
+stdenv.mkDerivation rec {
+  pname = "deepin-wayland-protocols";
+  version = "1.6.0-deepin.1.2";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-8Im3CueC8sYA5mwRU/Z7z8HA4mPQvVSqcTD813QCYxo=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  meta = with lib; {
+    description = "XML files of the non-standard wayland protocols use in deepin";
+    homepage = "https://github.com/linuxdeepin/deepin-wayland-protocols";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/disomaster/default.nix
+++ b/pkgs/desktops/deepin/library/disomaster/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, qmake
+, qttools
+, wrapQtAppsHook
+, libisoburn
+}:
+
+stdenv.mkDerivation rec {
+  pname = "disomaster";
+  version = "5.0.8";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-wN8mhddqqzYXkT6rRWsHVCWzaG2uRcF2iiFHlZx2LfY=";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    qttools
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [ libisoburn ];
+
+  qmakeFlags = [ "VERSION=${version}" ];
+
+  meta = with lib; {
+    description = "A libisoburn wrapper class for Qt";
+    homepage = "https://github.com/linuxdeepin/disomaster";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/docparser/default.nix
+++ b/pkgs/desktops/deepin/library/docparser/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, qmake
+, qttools
+, wrapQtAppsHook
+, poppler
+}:
+
+stdenv.mkDerivation rec {
+  pname = "docparser";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-iWRWSu8fALTTLLWdQGbpunN/1tpvKxuN/ZWJg34x0mU=";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    qttools
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [ poppler ];
+
+  qmakeFlags = [ "VERSION=${version}" ];
+
+  meta = with lib; {
+    description = "A document parser library ported from document2html";
+    homepage = "https://github.com/linuxdeepin/docparser";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/dtkcommon/default.nix
+++ b/pkgs/desktops/deepin/library/dtkcommon/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, cmake
+, qtbase
+, qttools
+, wrapQtAppsHook
+, glib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dtkcommon";
+  version = "5.6.3";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-9gFJ0Uun0q/XVaegxTUu4Kkc+/GE09eAV68VZgWurrM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qttools
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [ qtbase ];
+
+  qmakeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  preFixup = ''
+    glib-compile-schemas ${glib.makeSchemaPath "$out" "${pname}-${version}"}
+  '';
+
+  meta = with lib; {
+    description = "A public project for building DTK Library";
+    homepage = "https://github.com/linuxdeepin/dtkcommon";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/dtkcore/default.nix
+++ b/pkgs/desktops/deepin/library/dtkcore/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, cmake
+, gsettings-qt
+, wrapQtAppsHook
+, lshw
+, dtkcommon
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dtkcore";
+  version = "5.6.3";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-DEpo/eKMjtTVGEkq5JofkRNSHtTOZ1t2QNjrdulUtPQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/dsysinfo.cpp \
+      --replace "/usr/share/deepin/distribution.info" "/etc/distribution.info" \
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    gsettings-qt
+    lshw
+  ];
+
+  propagatedBuildInputs = [ dtkcommon ];
+
+  cmakeFlags = [
+    "-DDVERSION=${version}"
+    "-DBUILD_DOCS=OFF"
+    "-DDSG_PREFIX_PATH='/run/current-system/sw'"
+    "-DMKSPECS_INSTALL_DIR=${placeholder "out"}/mkspecs/modules"
+  ];
+
+  meta = with lib; {
+    description = "Deepin tool kit core library";
+    homepage = "https://github.com/linuxdeepin/dtkcore";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/dtkgui/default.nix
+++ b/pkgs/desktops/deepin/library/dtkgui/default.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, cmake
+, qttools
+, wrapQtAppsHook
+, librsvg
+, lxqt
+, dtkcore
+, qtimageformats
+, freeimage
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dtkgui";
+  version = "5.6.3";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-r6ZwGPiK6CcKEg8RoHV07wJbQI3idJFV3WFtuKim8n4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    qttools
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    lxqt.libqtxdg
+  ];
+
+  propagatedBuildInputs = [
+    dtkcore
+    librsvg
+    qtimageformats
+    freeimage
+  ];
+
+  cmakeFlags = [
+    "-DDVERSION=${version}"
+    "-DBUILD_DOCS=OFF"
+    "-DMKSPECS_INSTALL_DIR=${placeholder "out"}/mkspecs/modules"
+  ];
+
+  meta = with lib; {
+    description = "Deepin Toolkit, gui module for DDE look and feel";
+    homepage = "https://github.com/linuxdeepin/dtkgui";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/dtkwidget/default.nix
+++ b/pkgs/desktops/deepin/library/dtkwidget/default.nix
@@ -1,0 +1,67 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, dtkgui
+, pkg-config
+, cmake
+, qttools
+, qtmultimedia
+, qtsvg
+, qtx11extras
+, wrapQtAppsHook
+, cups
+, gsettings-qt
+, libstartup_notification
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dtkwidget";
+  version = "5.6.3";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-APk2p8pdLsaKvPp95HtEI1F1LM4ySUL+fhGsC5vHasU=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/widgets/dapplication.cpp \
+      --replace "auto dataDirs = DStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);" \
+                "auto dataDirs = DStandardPaths::standardLocations(QStandardPaths::GenericDataLocation) << \"$out/share\";"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    qttools
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtmultimedia
+    qtsvg
+    qtx11extras
+    cups
+    gsettings-qt
+    libstartup_notification
+    xorg.libXdmcp
+  ];
+
+  propagatedBuildInputs = [ dtkgui ];
+
+  cmakeFlags = [
+    "-DDVERSION=${version}"
+    "-DBUILD_DOCS=OFF"
+    "-DMKSPECS_INSTALL_DIR=${placeholder "out"}/mkspecs/modules"
+  ];
+
+  meta = with lib; {
+    description = "Deepin graphical user interface library";
+    homepage = "https://github.com/linuxdeepin/dtkwidget";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/dwayland/default.nix
+++ b/pkgs/desktops/deepin/library/dwayland/default.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, qtbase
+, qtwayland
+, wayland
+, wayland-protocols
+, extra-cmake-modules
+, deepin-wayland-protocols
+, qttools
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dwayland";
+  version = "5.24.3-deepin.1.4";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-/aWS4uvhxi9azxJWjRE+Bw+veURFO+mC8l9yypseclU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    qttools
+  ];
+
+  buildInputs = [
+    qtbase
+    qtwayland
+    wayland
+    wayland-protocols
+    deepin-wayland-protocols
+  ];
+
+  dontWrapQtApps = true;
+
+  meta = with lib; {
+    description = "Qt-style API to interact with the wayland-client and wayland-server";
+    homepage = "https://github.com/linuxdeepin/dwayland";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/gio-qt/default.nix
+++ b/pkgs/desktops/deepin/library/gio-qt/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, wrapQtAppsHook
+, glibmm
+, doxygen
+, buildDocs ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gio-qt";
+  version = "0.0.11";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-dlY1CTlXywgGZUonBBe3cDwx8h2xXrPY6Ft/D59nlug=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DPROJECT_VERSION=${version}"
+  ]
+  ++ lib.optional (!buildDocs) [ "-DBUILD_DOCS=OFF" ];
+
+  buildInputs = lib.optional buildDocs doxygen;
+
+  propagatedBuildInputs = [ glibmm ];
+
+  meta = with lib; {
+    description = "Gio wrapper for Qt applications";
+    homepage = "https://github.com/linuxdeepin/gio-qt";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/image-editor/default.nix
+++ b/pkgs/desktops/deepin/library/image-editor/default.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, dtkwidget
+, cmake
+, qttools
+, pkg-config
+, wrapQtAppsHook
+, opencv
+, freeimage
+, libmediainfo
+, ffmpegthumbnailer
+, pcre
+}:
+
+stdenv.mkDerivation rec {
+  pname = "image-editor";
+  version = "1.0.24";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-0p/aicuBfaEyvfZomnz49IJLospWIdl23ZreDe+Bzqc=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "feat_check_PREFIX_value_before_set";
+      url = "https://github.com/linuxdeepin/image-editor/commit/dae86e848cf53ba0ece879d81e8d5335d61a7473.patch";
+      sha256 = "sha256-lxmR+nIrMWVyhl1jpA17x2yqJ40h5vnpqKKcjd8j9RY=";
+    })
+    (fetchpatch {
+      name = "feat_use_FULL_install_path";
+      url = "https://github.com/linuxdeepin/image-editor/commit/855ae53a0444ac628aa0fe893932df6263b82e2e.patch";
+      sha256 = "sha256-3Dynlwl/l/b6k6hOHjTdoDQ/VGBDfyRz9b8QY8FEsCc=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace libimageviewer/service/ffmpegvideothumbnailer.cpp \
+        --replace 'libPath("libffmpegthumbnailer.so")'  'QString("${ffmpegthumbnailer.out}/lib/libffmpegthumbnailer.so")'
+
+    substituteInPlace libimageviewer/CMakeLists.txt --replace '/usr' '$out'
+    substituteInPlace libimagevisualresult/CMakeLists.txt --replace '/usr' '$out'
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config qttools wrapQtAppsHook ];
+
+  buildInputs = [
+    dtkwidget
+    opencv
+    freeimage
+    libmediainfo
+    ffmpegthumbnailer
+    pcre
+  ];
+
+  cmakeFlags = [ "-DVERSION=${version}" ];
+
+  meta = with lib; {
+    description = "Image editor lib for dtk";
+    homepage = "https://github.com/linuxdeepin/image-editor";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/qt5integration/default.nix
+++ b/pkgs/desktops/deepin/library/qt5integration/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, dtkwidget
+, qmake
+, qtbase
+, qtsvg
+, pkg-config
+, wrapQtAppsHook
+, qtx11extras
+, qt5platform-plugins
+, lxqt
+, mtdev
+, xorg
+, gtest
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qt5integration";
+  version = "5.6.3";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-GXxPoBM4tlWezTfv/f+/IJezzcAsuMbr/OOGaSOpn2g=";
+  };
+
+  nativeBuildInputs = [ qmake pkg-config wrapQtAppsHook ];
+
+  buildInputs = [
+    dtkwidget
+    qtx11extras
+    qt5platform-plugins
+    mtdev
+    lxqt.libqtxdg
+    xorg.xcbutilrenderutil
+    gtest
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/${qtbase.qtPluginPrefix}
+    cp -r bin/plugins/* $out/${qtbase.qtPluginPrefix}/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Qt platform theme integration plugins for DDE";
+    homepage = "https://github.com/linuxdeepin/qt5integration";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/qt5platform-plugins/default.nix
+++ b/pkgs/desktops/deepin/library/qt5platform-plugins/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, qmake
+, pkg-config
+, qtbase
+, qtx11extras
+, wrapQtAppsHook
+, mtdev
+, cairo
+, xorg
+, waylandSupport ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qt5platform-plugins";
+  version = "5.6.3";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-AySltMI9x5mfquy532h1QfGpfwSfI9+h6BtIHPyNWGk=";
+  };
+
+  ## https://github.com/linuxdeepin/qt5platform-plugins/pull/119
+  postPatch = ''
+    rm -r xcb/libqt5xcbqpa-dev/
+    mkdir -p xcb/libqt5xcbqpa-dev/${qtbase.version}
+    cp -r ${qtbase.src}/src/plugins/platforms/xcb/*.h xcb/libqt5xcbqpa-dev/${qtbase.version}/
+  '';
+
+  nativeBuildInputs = [ qmake pkg-config wrapQtAppsHook ];
+
+  buildInputs = [
+    mtdev
+    cairo
+    qtbase
+    qtx11extras
+    xorg.libSM
+  ];
+
+  qmakeFlags = [
+    "INSTALL_PATH=${placeholder "out"}/${qtbase.qtPluginPrefix}/platforms"
+  ]
+  ++ lib.optional (!waylandSupport) [ "CONFIG+=DISABLE_WAYLAND" ];
+
+  meta = with lib; {
+    description = "Qt platform plugins for DDE";
+    homepage = "https://github.com/linuxdeepin/qt5platform-plugins";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/library/udisks2-qt5/default.nix
+++ b/pkgs/desktops/deepin/library/udisks2-qt5/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, qmake
+, pkg-config
+, wrapQtAppsHook
+, udisks
+}:
+
+stdenv.mkDerivation rec {
+  pname = "udisks2-qt5";
+  version = "5.0.6";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-WS4fmqEYXi5dkn8RvyJBzy3+r+UgFcGDFFpQlbblLu4=";
+  };
+
+  nativeBuildInputs = [ qmake pkg-config wrapQtAppsHook ];
+
+  buildInputs = [ udisks ];
+
+  qmakeFlags = [ "VERSION=${version}" ];
+
+  meta = with lib; {
+    description = "UDisks2 D-Bus interfaces binding for Qt5";
+    homepage = "https://github.com/linuxdeepin/udisks2-qt5";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -341,7 +341,6 @@ mapAliases ({
 
   debian_devscripts = throw "'debian_devscripts' has been renamed to/replaced by 'debian-devscripts'"; # Converted to throw 2022-02-22
   debugedit-unstable = debugedit; # Added 2021-11-22
-  deepin = throw "deepin was a work in progress and it has been canceled and removed https://github.com/NixOS/nixpkgs/issues/94870"; # added 2020-08-31
   deepspeech = throw "deepspeech was removed in favor of stt. https://github.com/NixOS/nixpkgs/issues/119496"; # added 2021-05-05
   deisctl = throw "deisctl was removed ; the service does not exist anymore"; # added 2022-02-06
   deis = throw "deis was removed ; the service does not exist anymore"; # added 2022-02-06

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35393,6 +35393,8 @@ with pkgs;
   cinnamon = recurseIntoAttrs (callPackage ../desktops/cinnamon { });
   inherit (cinnamon) mint-x-icons mint-y-icons;
 
+  deepin = recurseIntoAttrs (callPackage ../desktops/deepin { });
+
   enlightenment = recurseIntoAttrs (callPackage ../desktops/enlightenment { });
 
   gnome2 = recurseIntoAttrs (callPackage ../desktops/gnome-2 { });


### PR DESCRIPTION
###### Description of changes
I'm trying to port  [Deepin Desktop Environment](https://www.deepin.org/en/dde/) to NixOS. Resume work of @romildo and (at)worldofpeace on https://github.com/NixOS/nixpkgs/issues/94870

I created a [flake repository](https://github.com/linuxdeepin/dde-nixos) for this work. Porting work nearing completion，I think it's time to request a review. 

It will need 70+ commits to add DDE for NixOS, Here is the first part, add all libraries needed for DDE.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
