### PR TITLE
gaiad package to support cosmos network transactions

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7034,6 +7034,12 @@
     githubId = 15893072;
     name = "Josh van Leeuwen";
   };
+  jovalie = {
+    email = "jovalie@proton.me";
+    github = "jovalie";
+    githubId = 18274535;
+    name = "Joan Puteri Zheng";
+  };
   jpas = {
     name = "Jarrod Pas";
     email = "jarrod@jarrodpas.com";

--- a/pkgs/applications/blockchains/gaiad/default.nix
+++ b/pkgs/applications/blockchains/gaiad/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, buildGoModule, fetchzip, nixosTests }:
+
+let
+  bins = [
+    "gaiad"
+  ];
+
+in
+buildGoModule rec {
+  pname = "gaia";
+  version = "7.1.0";
+
+  src = fetchzip {
+    url = "https://github.com/cosmos/${pname}/archive/refs/tags/v${version}.zip";
+    sha256 = "sha256-hsDqDASwTPIb1BGOqa9nu4C5Y5q3hBoXYhkAFY7B9Cs=";
+  };
+
+  vendorSha256 = "sha256-bNeSSZ1n1fEvO9ITGGJzsc+S2QE7EoB703mPHzrEqAg=";
+
+  doCheck = false;
+
+  enableParallelBuilding = true;
+
+  outputs = [ "out" ];
+
+  meta = with lib; {
+    description = "Stargate Cosmos Hub App";
+    longDescription = "The Gaia Daemon (`sgaiad`) enables you to interact with the Cosmos Hub, the first of an exploding number of interconnected blockchains that comprise the Cosmos Network.";
+    homepage    = "https://hub.cosmos.network";
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ jovalie ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19396,7 +19396,7 @@ with pkgs;
 
   funambol = callPackage ../development/libraries/funambol { };
 
-  gaiad = callPackage ../applications/blockchains/gaiad { } ; 
+  gaiad = callPackage ../applications/blockchains/gaiad { } ;
 
   galer = callPackage ../tools/security/galer { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19396,6 +19396,8 @@ with pkgs;
 
   funambol = callPackage ../development/libraries/funambol { };
 
+  gaiad = callPackage ../applications/blockchains/gaiad { } ; 
+
   galer = callPackage ../tools/security/galer { };
 
   gallia = callPackage ../tools/security/gallia { };


### PR DESCRIPTION
###### Description of changes

I added support for the package `gaiad`, the latest stable binary of Cosmos Hub SDK. Cosmos Network aims to create a network of crypto networks united by open-source tools for streamlining transactions between them. The Cosmos Hub was the first blockchain to be launched on the Cosmos network. It was built to act as an intermediary between all the independent blockchains created within the Cosmos network. `gaiad` binary allows users to interact with the Cosmos Hub as delegator, validator or node operators. This is my first contribution, please do let me know if anything should be changed. 
Related Issue:  #210488 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
