### PR TITLE
journaldriver: 1.1.0 -> 5656.0.0; new upstream

### DIFF
--- a/pkgs/tools/misc/journaldriver/default.nix
+++ b/pkgs/tools/misc/journaldriver/default.nix
@@ -1,25 +1,27 @@
-{ lib, fetchFromGitHub, rustPlatform, pkg-config, openssl, systemd }:
+{ lib, fetchgit, rustPlatform, pkg-config, openssl, systemd }:
 
 rustPlatform.buildRustPackage rec {
   pname = "journaldriver";
-  version     = "1.1.0";
-  cargoSha256 = "1gzfwkcm63fn41jls16c5sqxz28b0hrfpjhwsvvbwcfv40qxjhsg";
+  version = "5656.0.0";
+  cargoSha256 = "0jxv7skqgkk2j28jzs0gqnic0pqbdpgy8ryhz613pn0cslgy1p5q";
 
-  src = fetchFromGitHub {
-    owner  = "tazjin";
-    repo   = "journaldriver";
-    rev    = "v${version}";
-    sha256 = "0672iq6s9klb1p37hciyl7snbjgjw98kwrbfkypv07lplc5qcnrf";
+  src = fetchgit {
+    url = "https://code.tvl.fyi/depot.git:/ops/journaldriver.git";
+    sha256 = "0bnf67k6pkw4rngn58b5zm19danr4sh2g6rfd4k5w2sa1lzqai04";
+
+    # TVL revision r/5656; as of 2023-01-13 the revision tag is
+    # unavailable through git, hence the pinned hash.
+    rev = "4e191353228197ce548d63cb9955e53661244f9c";
   };
 
-  buildInputs       = [ openssl systemd ];
+  buildInputs = [ openssl systemd ];
   nativeBuildInputs = [ pkg-config ];
 
   meta = with lib; {
     description = "Log forwarder from journald to Stackdriver Logging";
-    homepage    = "https://github.com/tazjin/journaldriver";
-    license     = licenses.gpl3;
+    homepage = "https://code.tvl.fyi/about/ops/journaldriver";
+    license = licenses.gpl3;
     maintainers = [ maintainers.tazjin ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
This includes the following upstream changes:

* [tvl/cl/7818](https://cl.tvl.fyi/c/depot/+/7818): bump of all Rust dependency versions
* [tvl/cl/7819](https://cl.tvl.fyi/c/depot/+/7819): bump of version number to current revision

Prompted by #210452

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
