### PR TITLE
xl2tpd: update homepage

### DIFF
--- a/pkgs/tools/networking/xl2tpd/default.nix
+++ b/pkgs/tools/networking/xl2tpd/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {
-    homepage = "http://www.xelerance.com/software/xl2tpd/";
+    homepage = src.meta.homepage;
     description = "Layer 2 Tunnelling Protocol Daemon (RFC 2661)";
     platforms = platforms.linux;
     license = licenses.gpl2;


### PR DESCRIPTION
The current one is a 404, see https://github.com/NixOS/nixos-search/issues/598