### PR TITLE
checkov: 2.1.20 -> 2.2.258

### DIFF
--- a/pkgs/development/python-modules/bc-detect-secrets/default.nix
+++ b/pkgs/development/python-modules/bc-detect-secrets/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pyyaml
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "bc-detect-secrets";
+  version = "1.4.8";
+
+  propagatedBuildInputs = [
+    pyyaml
+    requests
+  ];
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-T26g5Om6X0SeTJeVblhtWO0/iI3YnTUg4kZPDZIaLJ4=";
+  };
+
+  meta = with lib; {
+    description = "Tool for detecting secrets in the codebase";
+    homepage = "https://github.com/bridgecrewio/detect-secrets";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/development/python-modules/bc-jsonpath-ng/default.nix
+++ b/pkgs/development/python-modules/bc-jsonpath-ng/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, ply
+, decorator
+, pytestCheckHook
+, oslotest
+}:
+
+buildPythonPackage rec {
+  pname = "bc-jsonpath-ng";
+  version = "1.5.8";
+
+  src = fetchFromGitHub {
+    owner = "bridgecrewio";
+    repo = "jsonpath-ng";
+    rev = "refs/tags/${version}";
+    hash = "sha256-sS7Y46sMX+imemNdoZUkVPp1llZTQrOkNjMdCxW0wiI=";
+  };
+
+  propagatedBuildInputs = [
+    decorator
+    ply
+  ];
+
+  checkInputs = [
+    oslotest
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Implementation of JSONPath for Python";
+    homepage = "https://github.com/bridgecrewio/jsonpath-ng";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/development/python-modules/pyston-autoload/default.nix
+++ b/pkgs/development/python-modules/pyston-autoload/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchPypi, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "pyston-autoload";
+  version = "2.3.5";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit version format;
+    pname = "pyton_autoload";
+    sha256 = "0n1k83ww0pr4q6z0h7p8hvy21hcgb96jvgllfbwhvvyf37h3wlll";
+    dist = "cp310";
+    python = "cp310";
+    platform = "manylinux2014_x86_64";
+  };
+
+  meta = with lib; {
+    description = "Automatically loads and enables pyston";
+    homepage = "https://www.github.com/pyston/pyston";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/development/tools/analysis/checkov/default.nix
+++ b/pkgs/development/tools/analysis/checkov/default.nix
@@ -15,16 +15,6 @@ let
         doCheck = false;
       });
 
-      jsonschema = super.jsonschema.overridePythonAttrs (oldAttrs: rec {
-        version = "3.2.0";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "sha256-yKhbKNN3zHc35G4tnytPRO48Dh3qxr9G3e/HGH0weXo=";
-        };
-        SETUPTOOLS_SCM_PRETEND_VERSION = version;
-        doCheck = false;
-      });
-
     };
   };
 in
@@ -57,6 +47,7 @@ buildPythonApplication rec {
     aiomultiprocess
     argcomplete
     bc-detect-secrets
+    bc-jsonpath-ng
     bc-python-hcl2
     boto3
     cachetools
@@ -81,6 +72,7 @@ buildPythonApplication rec {
     policyuniverse
     prettytable
     pycep-parser
+    pyston-autoload
     pyyaml
     semantic-version
     tabulate

--- a/pkgs/development/tools/analysis/checkov/default.nix
+++ b/pkgs/development/tools/analysis/checkov/default.nix
@@ -32,14 +32,14 @@ with py.pkgs;
 
 buildPythonApplication rec {
   pname = "checkov";
-  version = "2.1.20";
+  version = "2.2.258";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "bridgecrewio";
     repo = pname;
     rev = version;
-    hash = "sha256-dXpgm9S++jtBhuzX9db8Pm5LF6Qb4isXx5uyOGdWGUc=";
+    hash = "sha256-yggai2U6PFqct9s26qU53UK0Vxl9ZJD9FW4VTbSZd6I=";
   };
 
   patches = [
@@ -56,6 +56,7 @@ buildPythonApplication rec {
     aiohttp
     aiomultiprocess
     argcomplete
+    bc-detect-secrets
     bc-python-hcl2
     boto3
     cachetools

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1175,6 +1175,8 @@ self: super: with self; {
 
   bc-detect-secrets = callPackage ../development/python-modules/bc-detect-secrets { };
 
+  bc-jsonpath-ng = callPackage ../development/python-modules/bc-jsonpath-ng { };
+
   bc-python-hcl2 = callPackage ../development/python-modules/bc-python-hcl2 { };
 
   bcdoc = callPackage ../development/python-modules/bcdoc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8797,6 +8797,8 @@ self: super: with self; {
     inherit (pkgs) systemd;
   };
 
+  pyston-autoload = callPackage ../development/python-modules/pyston-autoload { };
+
   PyStemmer = callPackage ../development/python-modules/pystemmer { };
 
   pystray = callPackage ../development/python-modules/pystray { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1173,6 +1173,8 @@ self: super: with self; {
 
   bbox = callPackage ../development/python-modules/bbox { };
 
+  bc-detect-secrets = callPackage ../development/python-modules/bc-detect-secrets { };
+
   bc-python-hcl2 = callPackage ../development/python-modules/bc-python-hcl2 { };
 
   bcdoc = callPackage ../development/python-modules/bcdoc { };


### PR DESCRIPTION
###### Description of changes

Continuation of https://github.com/NixOS/nixpkgs/pull/180094

Currently trying to package new dependency `pyston-autoloader` which isa wheel format but won't download yet via fetchPypi

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
