### PR TITLE
ocamlPackages.tls: 0.15.3 → 0.15.4

### DIFF
--- a/pkgs/development/ocaml-modules/tls/async.nix
+++ b/pkgs/development/ocaml-modules/tls/async.nix
@@ -6,6 +6,7 @@ buildDunePackage rec {
   inherit (tls) src meta version;
 
   minimalOCamlVersion = "4.11";
+  duneVersion = "3";
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -6,15 +6,15 @@
 
 buildDunePackage rec {
   pname = "tls";
-  version = "0.15.3";
+  version = "0.15.4";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-tls/releases/download/v${version}/tls-${version}.tbz";
-    sha256 = "0nj6fhgrirn8ky4hb24m3ilhr41ynzgk6bqmjs17g8rdibwmdd2x";
+    sha256 = "sha256-X40dVrBvYGnv0dCj3gxFy0iNPRPrfxMshOx7o/DRw4I=";
   };
 
-  minimumOCamlVersion = "4.08";
-  useDune2 = true;
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     cstruct

--- a/pkgs/development/ocaml-modules/tls/mirage.nix
+++ b/pkgs/development/ocaml-modules/tls/mirage.nix
@@ -4,7 +4,8 @@
 
 buildDunePackage {
   pname = "tls-mirage";
-  inherit (tls) src version minimumOCamlVersion useDune2;
+  inherit (tls) src version;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     fmt


### PR DESCRIPTION
###### Description of changes

Use dune 3.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
