### PR TITLE
keeweb: use debian package instead appimage

### DIFF
--- a/pkgs/applications/misc/keeweb/default.nix
+++ b/pkgs/applications/misc/keeweb/default.nix
@@ -1,13 +1,34 @@
-{ lib, stdenv, fetchurl, appimageTools, undmg, libsecret, libxshmfence }:
+{ lib
+, stdenv
+, fetchurl
+, undmg
+, dpkg
+, autoPatchelfHook
+, wrapGAppsHook
+, makeWrapper
+, alsa-lib
+, at-spi2-atk
+, gdk-pixbuf
+, glibc
+, nss
+, udev
+, xorg
+, gnome
+, mesa
+, gtk3
+, libusb1
+, libsecret
+, libappindicator
+, xdotool
+}:
 let
   pname = "keeweb";
   version = "1.18.7";
-  name = "${pname}-${version}";
 
   srcs = {
     x86_64-linux = fetchurl {
-      url = "https://github.com/keeweb/keeweb/releases/download/v${version}/KeeWeb-${version}.linux.AppImage";
-      hash = "sha256-W3Dfo7YZfLObodAS7ZN3jqnYzLNAnjJIfJC6il5THwY=";
+      url = "https://github.com/keeweb/keeweb/releases/download/v${version}/KeeWeb-${version}.linux.x64.deb";
+      hash = "sha256-/U+vn5TLIU9/J6cRFjuAdyGzlwC04mp4L2X2ETp+ZSE=";
     };
     x86_64-darwin = fetchurl {
       url = "https://github.com/keeweb/keeweb/releases/download/v${version}/KeeWeb-${version}.mac.x64.dmg";
@@ -18,11 +39,29 @@ let
       hash = "sha256-bkhwsWYLkec16vMOfXUce7jfrmI9W2xHiZvU1asebK4=";
     };
   };
-  src = srcs.${stdenv.hostPlatform.system};
+  src = srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
-  appimageContents = appimageTools.extract {
-    inherit name src;
-  };
+  libraries = [
+    alsa-lib
+    at-spi2-atk
+    gdk-pixbuf
+    nss
+    udev
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXext
+    xorg.libXrandr
+    xorg.libXScrnSaver
+    xorg.libXtst
+    xorg.libxshmfence
+    gnome.gnome-keyring
+    mesa
+    gtk3
+    libusb1
+    libsecret
+    libappindicator
+    xdotool
+  ];
 
   meta = with lib; {
     description = "Free cross-platform password manager compatible with KeePass";
@@ -33,35 +72,46 @@ let
     maintainers = with maintainers; [ sikmir ];
     platforms = builtins.attrNames srcs;
   };
-
-  linux = appimageTools.wrapType2 rec {
-    inherit name src meta;
-
-    extraPkgs = pkgs: with pkgs; [ libsecret libxshmfence ];
-
-    extraInstallCommands = ''
-      mv $out/bin/{${name},${pname}}
-      install -Dm644 ${appimageContents}/keeweb.desktop -t $out/share/applications
-      install -Dm644 ${appimageContents}/keeweb.png -t $out/share/icons/hicolor/256x256/apps
-      install -Dm644 ${appimageContents}/usr/share/mime/keeweb.xml -t $out/share/mime
-      substituteInPlace $out/share/applications/keeweb.desktop \
-        --replace "Exec=AppRun" "Exec=$out/bin/${pname}"
-    '';
-  };
-
-  darwin = stdenv.mkDerivation {
-    inherit pname version src meta;
-
-    nativeBuildInputs = [ undmg ];
-
-    sourceRoot = ".";
-
-    installPhase = ''
-      mkdir -p $out/Applications
-      cp -r *.app $out/Applications
-    '';
-  };
 in
 if stdenv.isDarwin
-then darwin
-else linux
+then stdenv.mkDerivation {
+  inherit pname version src meta;
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+  '';
+}
+else stdenv.mkDerivation {
+  inherit pname version src meta;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    wrapGAppsHook
+    makeWrapper
+  ];
+
+  buildInputs = libraries;
+
+  unpackPhase = ''
+    ${dpkg}/bin/dpkg-deb --fsys-tarfile $src | tar --extract
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r usr/share $out/share
+
+    makeWrapper $out/share/keeweb-desktop/keeweb $out/bin/keeweb \
+      --argv0 "keeweb" \
+      --add-flags "$out/share/keeweb-desktop/resources/app.asar" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath libraries}"
+
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
###### Description of changes
use debian package instead appimage
The dependency is separated, and in this way, nss can be independently specified as nss_latest

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
