### PR TITLE
ringing-lib: init at 0-unstable-2024-05-31

### DIFF
--- a/pkgs/by-name/ri/ringing-lib/package.nix
+++ b/pkgs/by-name/ri/ringing-lib/package.nix
@@ -1,0 +1,45 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  autoreconfHook,
+  pkg-config,
+  readline,
+  xercesc,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ringing-lib";
+  version = "0-unstable-2024-05-31";
+
+  src = fetchFromGitHub {
+    owner = "ringing-lib";
+    repo = "ringing-lib";
+    rev = "4f791c559743499589d66dc44266cd681f6901de";
+    hash = "sha256-+P2x2ywk7Ev7GacfUONusVHjlE6bIVBeJasjlcw5kTU=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+  buildInputs = [
+    readline
+    xercesc
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+  meta = {
+    description = "Library of C++ classes and utilities for change ringing";
+    homepage = "https://ringing-lib.github.io/";
+    license = with lib.licenses; [
+      gpl2Plus
+      lgpl2Plus
+    ];
+    maintainers = with lib.maintainers; [ jshholland ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tools and C++ class library for English change ringing: http://ringing-lib.github.io/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
