### PR TITLE
photocollage: init at 1.4.5

### DIFF
--- a/pkgs/applications/graphics/photocollage/default.nix
+++ b/pkgs/applications/graphics/photocollage/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, pkgs
+, python
+, wrapGAppsHook
+}:
+
+with python.pkgs;
+
+buildPythonApplication rec {
+  pname = "photocollage";
+  version = "1.4.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-1YbPQJ63Ko0I8EPE3RPmV84q0D0S21vmZ0u7h1QFX5A=";
+  };
+
+  nativeBuildInputs = [
+    pkgs.gobject-introspection
+    wrapGAppsHook
+  ];
+
+  propagatedBuildInputs = [
+    pkgs.gdk-pixbuf
+    pkgs.gettext
+    pkgs.gtk3
+
+    pillow
+    pycairo
+    pygobject3
+  ];
+
+  patches = [
+    ./import_gi.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "\"msgfmt\"" "\"${pkgs.gettext}/bin/msgfmt\""
+  '';
+
+  meta = with lib; {
+    description = "Create photo collage posters";
+    homepage = "https://github.com/adrienverge/PhotoCollage";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ pamplemousse ];
+  };
+}

--- a/pkgs/applications/graphics/photocollage/import_gi.patch
+++ b/pkgs/applications/graphics/photocollage/import_gi.patch
@@ -1,0 +1,14 @@
+diff --git a/photocollage/artwork.py b/photocollage/artwork.py
+index 493f179..cf8f69b 100644
+--- a/photocollage/artwork.py
++++ b/photocollage/artwork.py
+@@ -18,6 +18,9 @@ import base64
+ from io import BytesIO
+ 
+ import cairo
++
++import gi
++gi.require_version('GdkPixbuf', '2.0')
+ from gi.repository import GdkPixbuf
+ 
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16140,6 +16140,9 @@ with pkgs;
 
   pachyderm = callPackage ../applications/networking/cluster/pachyderm { };
 
+  photocollage = callPackage ../applications/graphics/photocollage {
+    python = python3;
+  };
 
   # PHP interpreters, packages and extensions.
   #


### PR DESCRIPTION
###### Description of changes

A Python application to build photo collage posters - https://github.com/adrienverge/PhotoCollage .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
