### PR TITLE
Pass lib throughout NixOS and pkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,17 +5,7 @@
 
   outputs = { self }:
     let
-      jobs = import ./pkgs/top-level/release.nix {
-        nixpkgs = self;
-      };
-
-      lib = import ./lib;
-
-      forAllSystems = lib.genAttrs lib.systems.flakeExposed;
-    in
-    {
-      lib = lib.extend (final: prev: {
-
+      lib = (import ./lib).extend (final: prev: {
         nixos = import ./nixos/lib { lib = final; };
 
         nixosSystem = args:
@@ -34,6 +24,16 @@
             }
           );
       });
+
+      jobs = import ./pkgs/top-level/release.nix {
+        inherit lib;
+        nixpkgs = self;
+      };
+
+      forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+    in
+    {
+      inherit lib;
 
       checks.x86_64-linux.tarball = jobs.tarball;
 

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
         nixosSystem = args:
           import ./nixos/lib/eval-config.nix (
             args // {
+              lib = args.lib or final;
               modules = args.modules ++ [{
                 system.nixos.versionSuffix =
                   ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";

--- a/nixos/lib/testing-python.nix
+++ b/nixos/lib/testing-python.nix
@@ -1,6 +1,7 @@
 args@
 { system
-, pkgs ? import ../.. { inherit system config; }
+, lib ? import ../../lib
+, pkgs ? import ../.. { inherit system config lib; }
   # Use a minimal kernel?
 , minimal ? false
   # Ignored

--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -2,7 +2,8 @@
 # and nixos-14.04). The channel is updated every time the ‘tested’ job
 # succeeds, and all other jobs have finished (they may fail).
 
-{ nixpkgs ? { outPath = (import ../lib).cleanSource ./..; revCount = 56789; shortRev = "gfedcba"; }
+{ lib ? import ../lib
+, nixpkgs ? { outPath = lib.cleanSource ./..; revCount = 56789; shortRev = "gfedcba"; }
 , stableBranch ? false
 , supportedSystems ? [ "aarch64-linux" "x86_64-linux" ]
 , limitedSupportedSystems ? [ "i686-linux" ]
@@ -12,7 +13,9 @@ let
 
   nixpkgsSrc = nixpkgs; # urgh
 
-  pkgs = import ./.. {};
+  pkgs = import ./.. {
+    inherit lib;
+  };
 
   removeMaintainers = set: if builtins.isAttrs set
     then if (set.type or "") == "derivation"
@@ -23,13 +26,13 @@ let
 in rec {
 
   nixos = removeMaintainers (import ./release.nix {
-    inherit stableBranch;
+    inherit stableBranch lib;
     supportedSystems = supportedSystems ++ limitedSupportedSystems;
     nixpkgs = nixpkgsSrc;
   });
 
   nixpkgs = builtins.removeAttrs (removeMaintainers (import ../pkgs/top-level/release.nix {
-    inherit supportedSystems;
+    inherit supportedSystems lib;
     nixpkgs = nixpkgsSrc;
   })) [ "unstable" ];
 

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -21,7 +21,7 @@ let
   };
 
   nixpkgs' = builtins.removeAttrs (import ../pkgs/top-level/release.nix {
-    inherit supportedSystems;
+    inherit supportedSystems lib;
     nixpkgs = nixpkgsSrc;
   }) [ "unstable" ];
 

--- a/nixos/release-small.nix
+++ b/nixos/release-small.nix
@@ -2,7 +2,8 @@
 # small subset of Nixpkgs, mostly useful for servers that need fast
 # security updates.
 
-{ nixpkgs ? { outPath = (import ../lib).cleanSource ./..; revCount = 56789; shortRev = "gfedcba"; }
+{ lib ? import ../lib
+, nixpkgs ? { outPath = lib.cleanSource ./..; revCount = 56789; shortRev = "gfedcba"; }
 , stableBranch ? false
 , supportedSystems ? [ "aarch64-linux" "x86_64-linux" ] # no i686-linux
 }:
@@ -11,12 +12,13 @@ let
 
   nixpkgsSrc = nixpkgs; # urgh
 
-  pkgs = import ./.. { system = "x86_64-linux"; };
-
-  lib = pkgs.lib;
+  pkgs = import ./.. {
+    inherit lib;
+    system = "x86_64-linux";
+  };
 
   nixos' = import ./release.nix {
-    inherit stableBranch supportedSystems;
+    inherit stableBranch supportedSystems lib;
     nixpkgs = nixpkgsSrc;
   };
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -1,12 +1,12 @@
-with import ../lib;
-
-{ nixpkgs ? { outPath = cleanSource ./..; revCount = 130979; shortRev = "gfedcba"; }
+{ lib ? import ../lib
+, nixpkgs ? { outPath = lib.cleanSource ./..; revCount = 130979; shortRev = "gfedcba"; }
 , stableBranch ? false
 , supportedSystems ? [ "x86_64-linux" "aarch64-linux" ]
 , configuration ? {}
 }:
 
-with import ../pkgs/top-level/release-lib.nix { inherit supportedSystems; };
+with lib;
+with import ../pkgs/top-level/release-lib.nix { inherit supportedSystems lib; };
 
 let
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -21,7 +21,7 @@ let
   allTestsForSystem = system:
     import ./tests/all-tests.nix {
       inherit system;
-      pkgs = import ./.. { inherit system; };
+      pkgs = import ./.. { inherit system lib; };
       callTest = config: {
         ${system} = hydraJob config.test;
       };
@@ -31,7 +31,7 @@ let
       allDrivers =
         import ./tests/all-tests.nix {
         inherit system;
-        pkgs = import ./.. { inherit system; };
+        pkgs = import ./.. { inherit system lib; };
         callTest = config: {
           ${system} = hydraJob config.driver;
         };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -36,6 +36,7 @@ let
     if elem system systems then handleTest path args
     else {};
 
+  # TODO: make this overridable?
   nixosLib = import ../lib {
     # Experimental features need testing too, but there's no point in warning
     # about it, so we enable the feature flag.

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -38,6 +38,9 @@
   # list it returns.
   stdenvStages ? import ../stdenv
 
+, # Library functions for Nixpkgs
+  lib ? import ../../lib
+
 , # Ignore unexpected args.
   ...
 } @ args:
@@ -47,8 +50,6 @@ let # Rename the function arguments
   crossSystem0 = crossSystem;
 
 in let
-  lib = import ../../lib;
-
   inherit (lib) throwIfNot;
 
   checked =

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -75,6 +75,7 @@ in
       else []
 
 , crossOverlays ? []
+, lib ? import ../../lib
 
 , ...
 } @ args:

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -1,14 +1,11 @@
 { supportedSystems
+, lib ? import ../../lib
 , packageSet ? (import ../..)
 , scrubJobs ? true
 , # Attributes passed to nixpkgs. Don't build packages marked as unfree.
   nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
 }:
-
-let
-  lib = import ../../lib;
-in with lib;
-
+with lib;
 rec {
 
   pkgs = packageSet (lib.recursiveUpdate { system = "x86_64-linux"; config.allowUnsupportedSystem = true; } nixpkgsArgs);

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -1,13 +1,14 @@
 /* A small release file, with few packages to be built.  The aim is to reduce
    the load on Hydra when testing the `stdenv-updates' branch. */
 
-{ nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
+{ lib ? import ../../lib
+, nixpkgs ? { outPath = lib.cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
 , supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 , # Attributes passed to nixpkgs. Don't build packages marked as unfree.
   nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
 }:
 
-with import ./release-lib.nix { inherit supportedSystems nixpkgsArgs; };
+with import ./release-lib.nix { inherit supportedSystems nixpkgsArgs lib; };
 
 {
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -8,7 +8,8 @@
 
    $ nix-build pkgs/top-level/release.nix -A coreutils.x86_64-linux
 */
-{ nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; revision = "0000000000000000000000000000000000000000"; }
+{ lib ? import ../../lib
+, nixpkgs ? { outPath = lib.cleanSource ../..; revCount = 1234; shortRev = "abcdef"; revision = "0000000000000000000000000000000000000000"; }
 , officialRelease ? false
   # The platforms for which we build Nixpkgs.
 , supportedSystems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ]
@@ -19,7 +20,7 @@
 , nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
 }:
 
-with import ./release-lib.nix { inherit supportedSystems scrubJobs nixpkgsArgs; };
+with import ./release-lib.nix { inherit supportedSystems scrubJobs nixpkgsArgs lib; };
 
 let
 


### PR DESCRIPTION
###### Description of changes

The idea for this PR is to allow people to override `lib`, this is great for people who wish to hack onto `nixpkgs` and helps ensure they don't have to copy files from `nixpkgs` into their own code to pass their replacement `lib`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
