### PR TITLE
kernel: add deterministic-uname to moduleBuildDependencies

### DIFF
--- a/pkgs/os-specific/linux/bbswitch/default.nix
+++ b/pkgs/os-specific/linux/bbswitch/default.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation {
 
   preBuild = ''
     substituteInPlace Makefile \
-      --replace "\$(shell uname -r)" "${kernel.modDirVersion}" \
       --replace "/lib/modules" "${kernel.dev}/lib/modules"
   '';
 

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -57,8 +57,12 @@ let
     hasAttr getAttr optional optionals optionalString optionalAttrs maintainers platforms;
 
   # Dependencies that are required to build kernel modules
-  moduleBuildDependencies = [ perl libelf ]
-    ++ optional (lib.versionAtLeast version "5.13") zstd;
+  moduleBuildDependencies = [
+    perl
+    libelf
+    # module makefiles often run uname commands to find out the kernel version
+    (buildPackages.deterministic-uname.override { inherit modDirVersion; })
+  ] ++ optional (lib.versionAtLeast version "5.13") zstd;
 
   drvAttrs = config_: kernelConf: kernelPatches: configfile:
     let

--- a/pkgs/os-specific/linux/mxu11x0/default.nix
+++ b/pkgs/os-specific/linux/mxu11x0/default.nix
@@ -11,9 +11,9 @@ stdenv.mkDerivation rec {
 
   version = mxu_version + "-${kernel.version}";
 
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
   preBuild = ''
-    sed -i -e "s/\$(uname -r).*/${kernel.modDirVersion}/g" driver/mxconf
-    sed -i -e "s/\$(shell uname -r).*/${kernel.modDirVersion}/g" driver/Makefile
     sed -i -e 's|/lib/modules|${kernel.dev}/lib/modules|' driver/mxconf
     sed -i -e 's|/lib/modules|${kernel.dev}/lib/modules|' driver/Makefile
   '';

--- a/pkgs/os-specific/linux/rtl8188eus-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl8188eus-aircrack/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation {
   prePatch = ''
     substituteInPlace ./Makefile \
       --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
-      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
       --replace /sbin/depmod \# \
       --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';
@@ -30,9 +29,7 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ bc ];
-
-  buildInputs = kernel.moduleBuildDependencies;
+  nativeBuildInputs = [ bc ] ++ kernel.moduleBuildDependencies;
 
   preInstall = ''
     mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"

--- a/pkgs/os-specific/linux/rtl8189es/default.nix
+++ b/pkgs/os-specific/linux/rtl8189es/default.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
 
   prePatch = ''
     substituteInPlace ./Makefile --replace /lib/modules/ "${kernel.dev}/lib/modules/"
-    substituteInPlace ./Makefile --replace '$(shell uname -r)' "${kernel.modDirVersion}"
     substituteInPlace ./Makefile --replace /sbin/depmod \#
     substituteInPlace ./Makefile --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';

--- a/pkgs/os-specific/linux/rtl8723ds/default.nix
+++ b/pkgs/os-specific/linux/rtl8723ds/default.nix
@@ -13,8 +13,7 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "pic" ];
 
-  nativeBuildInputs = [ bc ];
-  buildInputs = kernel.moduleBuildDependencies;
+  nativeBuildInputs = [ bc ] ++ kernel.moduleBuildDependencies;
 
   makeFlags = [
     "ARCH=${stdenv.hostPlatform.linuxArch}"
@@ -25,7 +24,6 @@ stdenv.mkDerivation {
   postPatch = ''
     substituteInPlace ./Makefile \
       --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
-      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
       --replace "/sbin/depmod" "#" \
       --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';

--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -11,21 +11,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-BHC1DpWHv/1UvSfj6S5fo/ODZ1VDgLQO2A9EC+BR1JE=";
   };
 
-  nativeBuildInputs = [ bc nukeReferences ];
-  buildInputs = kernel.moduleBuildDependencies;
+  nativeBuildInputs = [ bc nukeReferences ] ++ kernel.moduleBuildDependencies;
   hardeningDisable = [ "pic" "format" ];
 
   prePatch = ''
     substituteInPlace ./Makefile \
       --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
-      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
       --replace /sbin/depmod \# \
       --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';
 
   makeFlags = [
     "ARCH=${stdenv.hostPlatform.linuxArch}"
-    "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     ("CONFIG_PLATFORM_I386_PC=" + (if stdenv.hostPlatform.isx86 then "y" else "n"))
     ("CONFIG_PLATFORM_ARM_RPI=" + (if stdenv.hostPlatform.isAarch then "y" else "n"))
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [

--- a/pkgs/os-specific/linux/rtl8814au/default.nix
+++ b/pkgs/os-specific/linux/rtl8814au/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation {
   prePatch = ''
     substituteInPlace ./Makefile \
       --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
-      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
       --replace /sbin/depmod \# \
       --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';

--- a/pkgs/os-specific/linux/rtl8821au/default.nix
+++ b/pkgs/os-specific/linux/rtl8821au/default.nix
@@ -11,8 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-wx7xQBCfLu3UWB7ghp8dZ7OB2MFd5i8X0/ygyvW2K50=";
   };
 
-  nativeBuildInputs = [ bc nukeReferences ];
-  buildInputs = kernel.moduleBuildDependencies;
+  nativeBuildInputs = [ bc nukeReferences ] ++ kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" "format" ];
 
@@ -20,7 +19,6 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "ARCH=${stdenv.hostPlatform.linuxArch}"
-    "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     ("CONFIG_PLATFORM_I386_PC=" + (if stdenv.hostPlatform.isx86 then "y" else "n"))
     ("CONFIG_PLATFORM_ARM_RPI=" + (if (stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64) then "y" else "n"))
   ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
@@ -30,7 +28,6 @@ stdenv.mkDerivation rec {
   prePatch = ''
     substituteInPlace ./Makefile \
       --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
-      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
       --replace /sbin/depmod \# \
       --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';

--- a/pkgs/os-specific/linux/rtl8821ce/default.nix
+++ b/pkgs/os-specific/linux/rtl8821ce/default.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation rec {
   prePatch = ''
     substituteInPlace ./Makefile \
       --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
-      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
       --replace /sbin/depmod \# \
       --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';

--- a/pkgs/os-specific/linux/rtl8821cu/default.nix
+++ b/pkgs/os-specific/linux/rtl8821cu/default.nix
@@ -19,7 +19,6 @@ stdenv.mkDerivation rec {
   prePatch = ''
     substituteInPlace ./Makefile \
       --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
-      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
       --replace /sbin/depmod \# \
       --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';

--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -19,7 +19,6 @@ stdenv.mkDerivation rec {
   prePatch = ''
     substituteInPlace ./Makefile \
       --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
-      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
       --replace /sbin/depmod \# \
       --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';

--- a/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
+++ b/pkgs/os-specific/linux/rtl88xxau-aircrack/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-TpmpueKAaCe7Nlmv8pMvgMXGVmXVa/1mBwtEoy4JyCY=";
   };
 
-  buildInputs = kernel.moduleBuildDependencies;
+  nativeBuildInputs = kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
 
@@ -23,7 +23,6 @@ stdenv.mkDerivation rec {
   prePatch = ''
     substituteInPlace ./Makefile \
       --replace /lib/modules/ "${kernel.dev}/lib/modules/" \
-      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
       --replace /sbin/depmod \# \
       --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';

--- a/pkgs/os-specific/linux/vmware/default.nix
+++ b/pkgs/os-specific/linux/vmware/default.nix
@@ -20,14 +20,12 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace Makefile \
       --replace '/lib/modules/$(VM_UNAME)/misc' "$out/lib/modules/${kernel.modDirVersion}/misc" \
-      --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
       --replace /sbin/modinfo "${kmod}/bin/modinfo" \
       --replace 'test -z "$(DESTDIR)"' "0"
 
     for module in "vmmon-only" "vmnet-only"; do
       substituteInPlace "./$module/Makefile" \
         --replace '/lib/modules/' "${kernel.dev}/lib/modules/" \
-        --replace '$(shell uname -r)' "${kernel.modDirVersion}" \
         --replace /bin/grep "${gnugrep}/bin/grep"
     done
   '';


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
