### PR TITLE
lib.types: Add flake type

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -94,6 +94,23 @@ checkConfigOutput '^42$' config.value ./declare-oneOf.nix ./define-value-int-pos
 checkConfigOutput '^\[ \]$' config.value ./declare-oneOf.nix ./define-value-list.nix
 checkConfigOutput '^"24"$' config.value ./declare-oneOf.nix ./define-value-string.nix
 
+test_flake_type() {
+    # A flake must be returned without any pre or post-processing.
+    checkConfigOutput "^true$" config.result ./declare-flake.nix ./define-flake.nix
+
+    # Even an identical flake can not be merged. In the "best" case it's the same flake,
+    # but we'd have to check that is. Perhaps some attributes could be merged, but
+    # many can't, so this would effectively create two _usage_ types:
+    #  - full access, allowing access to `sourceInfo` and `packages.default`
+    #  - only access to attributes that can be expected to be merged, such as
+    #    `packages.foo`
+    # However, the latter would still break the rule that an addition somewhere "unrelated"
+    # doesn't break anything. So merging would be a bad idea.
+    checkConfigError "The option .flake. is defined multiple times" config.result ./declare-flake.nix ./define-flake.nix ./define-flake-again.nix
+    checkConfigError "However, flakes can not be merged" config.result ./declare-flake.nix ./define-flake.nix ./define-flake-again.nix
+}
+test_flake_type
+
 # Check mkForce without submodules.
 set -- config.enable ./declare-enable.nix ./define-enable.nix
 checkConfigOutput '^true$' "$@"

--- a/lib/tests/modules/declare-flake.nix
+++ b/lib/tests/modules/declare-flake.nix
@@ -1,0 +1,3 @@
+{ lib, ... }: {
+  options.flake = lib.mkOption { type = lib.types.flake; };
+}

--- a/lib/tests/modules/define-flake-again.nix
+++ b/lib/tests/modules/define-flake-again.nix
@@ -1,0 +1,15 @@
+{ config, lib, ... }:
+let example = {
+      _type = "flake";
+      sourceInfo = {};
+      inputs = {};
+      outputs = {};
+      foo = lib.mkForce {}; # must be copied verbatim
+      packages = throw "Validating the flake is not the responsibility of this type, and evaluating any significant part of it would be too costly.";
+    };
+in
+{
+  config = {
+    flake = example;
+  };
+}

--- a/lib/tests/modules/define-flake.nix
+++ b/lib/tests/modules/define-flake.nix
@@ -1,0 +1,17 @@
+{ config, lib, ... }:
+let example = {
+      _type = "flake";
+      sourceInfo = {};
+      inputs = {};
+      outputs = {};
+      foo = lib.mkForce {}; # must be copied verbatim
+      packages = throw "Validating the flake is not the responsibility of this type, and evaluating any significant part of it would be too costly.";
+    };
+in
+{
+  options.result = lib.mkOption {};
+  config = {
+    flake = example;
+    result = config.flake // { packages = null; } == example // { packages = null; };
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -483,6 +483,18 @@ rec {
       merge = mergeEqualOption;
     };
 
+    flake = mkOptionType {
+      name = "flake";
+      descriptionClass = "noun";
+      check =
+        if builtins.compareVersions builtins.nixVersion "2.12.0" >= 0
+        then
+          x: x._type or null == "flake"
+        else
+          x: x?inputs && x?sourceInfo && x?outputs;
+      merge = mergeUniqueOption { message = "However, flakes can not be merged."; };
+    };
+
     listOf = elemType: mkOptionType rec {
       name = "listOf";
       description = "list of ${optionDescriptionPhrase (class: class == "noun" || class == "composite") elemType}";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cc @Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
