### PR TITLE
nixos/github-runner: allow adding custom runner name suffix

### DIFF
--- a/nixos/modules/services/continuous-integration/github-runner.nix
+++ b/nixos/modules/services/continuous-integration/github-runner.nix
@@ -12,9 +12,7 @@ in
 
 {
   options.services.github-runner = import ./github-runner/options.nix (args // {
-    # Users don't need to specify options.services.github-runner.name; it will default
-    # to the hostname.
-    includeNameDefault = true;
+    includeNameDefault = false;
   });
 
   config = mkIf cfg.enable {

--- a/nixos/modules/services/continuous-integration/github-runner/options.nix
+++ b/nixos/modules/services/continuous-integration/github-runner/options.nix
@@ -58,11 +58,13 @@ with lib;
 
   name = let
     # Same pattern as for `networking.hostName`
-    baseType = types.strMatching "^$|^[[:alnum:]]([[:alnum:]_-]{0,61}[[:alnum:]])?$";
+    baseType = types.str;
   in mkOption {
     type = if includeNameDefault then baseType else types.nullOr baseType;
     description = lib.mdDoc ''
-      Name of the runner to configure. Defaults to the hostname.
+      Name of the runner to configure. Defaults to the hostname. This is not
+      shell escaped, so can run shell code or reference environment variables
+      for example, to generate unique names.
 
       Changing this option triggers a new runner registration.
     '';

--- a/nixos/modules/services/continuous-integration/github-runner/service.nix
+++ b/nixos/modules/services/continuous-integration/github-runner/service.nix
@@ -134,7 +134,7 @@ in
                 --work "$WORK_DIRECTORY"
                 --url ${escapeShellArg cfg.url}
                 --labels ${escapeShellArg (concatStringsSep "," cfg.extraLabels)}
-                --name ${escapeShellArg cfg.name}
+                ${optionalString (cfg.name != null) "--name ${cfg.name}"}
                 ${optionalString cfg.replace "--replace"}
                 ${optionalString (cfg.runnerGroup != null) "--runnergroup ${escapeShellArg cfg.runnerGroup}"}
                 ${optionalString cfg.ephemeral "--ephemeral"}


### PR DESCRIPTION
###### Description of changes

This change can be useful in situations where you may want to run more than a single instance of github-runner per nixos host and auto-scale those hosts, such as in an AWS auto scaling group. Also if no name is provided, it lets `github-runner` discover the hostname of the machine, such assigned hostnames from AWS/GCP

Example:

```
  services.github-runners = genAttrs runnerNames (name: {
    enable = true;
    ephemeral = true;
    replace = true;
    rawNameSuffix = ''-''${HOSTNAME%%.*}'';
    ...
  });
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
