### PR TITLE
python3Packages.graphite-web: add patches for CVEs, enable tests

### DIFF
--- a/pkgs/development/python-modules/graphite-web/default.nix
+++ b/pkgs/development/python-modules/graphite-web/default.nix
@@ -97,7 +97,6 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
     description = "Enterprise scalable realtime graphing";
     homepage = "http://graphiteapp.org/";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/graphite-web/default.nix
+++ b/pkgs/development/python-modules/graphite-web/default.nix
@@ -4,7 +4,7 @@
 , cairocffi
 , django
 , django_tagging
-, fetchPypi
+, fetchFromGitHub
 , gunicorn
 , pyparsing
 , python-memcached
@@ -24,9 +24,11 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-Pxho1QWo2jJZYAMJx999bbELDVMr7Wp7wsssYPkc01o=";
+  src = fetchFromGitHub {
+    owner = "graphite-project";
+    repo = pname;
+    rev = version;
+    hash = "sha256-2HgCBKwLfxJLKMopoIdsEW5k/j3kNAiifWDnJ98a7Qo=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/graphite-web/default.nix
+++ b/pkgs/development/python-modules/graphite-web/default.nix
@@ -5,6 +5,7 @@
 , django
 , django_tagging
 , fetchFromGitHub
+, fetchpatch
 , gunicorn
 , pyparsing
 , python-memcached
@@ -30,6 +31,19 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-2HgCBKwLfxJLKMopoIdsEW5k/j3kNAiifWDnJ98a7Qo=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-4730.CVE-2022-4729.CVE-2022-4728.part-1.patch";
+      url = "https://github.com/graphite-project/graphite-web/commit/9c626006eea36a9fd785e8f811359aebc9774970.patch";
+      sha256 = "sha256-JMmdhLqsaRhUG2FsH+yPNl+cR7O2YLfKFliL2GU0aAk=";
+    })
+    (fetchpatch {
+      name = "CVE-2022-4730.CVE-2022-4729.CVE-2022-4728.part-2.patch";
+      url = "https://github.com/graphite-project/graphite-web/commit/2f178f490e10efc03cd1d27c72f64ecab224eb23.patch";
+      sha256 = "sha256-NL7K5uekf3NlLa58aFFRPJT9ktjqBeNlWC4Htd0fRQ0=";
+    })
+  ];
 
   propagatedBuildInputs = [
     cairocffi

--- a/pkgs/development/python-modules/graphite-web/default.nix
+++ b/pkgs/development/python-modules/graphite-web/default.nix
@@ -15,7 +15,6 @@
 , txamqp
 , urllib3
 , whisper
-, whitenoise
 }:
 
 buildPythonPackage rec {
@@ -57,7 +56,6 @@ buildPythonPackage rec {
     txamqp
     urllib3
     whisper
-    whitenoise
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2022-4730
https://nvd.nist.gov/vuln/detail/CVE-2022-4729
https://nvd.nist.gov/vuln/detail/CVE-2022-4728

All actually fixed by the same patch(es).

As a proof of this fix being sound, I enabled the tests (new tests are included with the patches, which pass). This led me to realize that the `whitenoise` support was broken with our modern version of `whitenoise` (see https://github.com/graphite-project/graphite-web/issues/2735), so I had to remove that.

While I was at it I noticed that the tests pass fine for me on macos 10.15 and aarch64-linux, so removed the `broken` marker for those.

Will backport the changes up to the patch additions but won't include the test enablement in stable in case it breaks some peoples systems (and it would also require removal of the `whitenoise` dependency).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
