### PR TITLE
keepassrpc: use dontUnpack instead of placeholder unpackCmd/sourceRoot

### DIFF
--- a/pkgs/applications/misc/keepass-plugins/keepassrpc/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/keepassrpc/default.nix
@@ -18,17 +18,10 @@ let
       maintainers = with maintainers; [ mjanczyk svsdep mgregoire ];
     };
 
-    pluginFilename = "KeePassRPC.plgx";
-
-    unpackCmd = ''
-      mkdir deps/
-      cp -p $src deps/$pluginFilename
-    '';
-    sourceRoot = "deps";
-
+    dontUnpack = true;
     installPhase = ''
       mkdir -p $out/lib/dotnet/keepass/
-      cp $pluginFilename $out/lib/dotnet/keepass/$pluginFilename
+      cp $src $out/lib/dotnet/keepass/
     '';
   };
 in


### PR DESCRIPTION
###### Description of changes
Minor simplification to make this more like most of the other keepass plugins.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).