### PR TITLE
linuxPackages: Add HP-Vendor kernel module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2599,6 +2599,12 @@
     githubId = 42220376;
     name = "Charlotte Van Petegem";
   };
+  cidkidnix = {
+    name = "Dylan Green";
+    email = "cidkidnix@protonmail.com";
+    github = "cidkidnix";
+    githubId = 67574902;
+  };
   ciferkey = {
     name = "Matthew Brunelle";
     email = "ciferkey@gmail.com";

--- a/pkgs/os-specific/linux/hp-vendor/default.nix
+++ b/pkgs/os-specific/linux/hp-vendor/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchFromGitHub, kernel }:
+stdenv.mkDerivation rec {
+  name = "hp-vendor-${version}-${kernel.version}";
+  version = "master_jammy";
+
+  passthru.moduleName = "hp-vendor";
+
+  src = (fetchFromGitHub {
+    owner = "pop-os";
+    repo = "hp-vendor";
+    rev = "eeb8e7432224902587089593083ec018fb7edbd8";
+    sha256 = "sha256-y+naNa4jURzdh8N2uqeIgs9MGEP3J/0MG+AcTD6k2KY=";
+  }) + "/dkms";
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  buildFlags = [
+    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    install -D hp_vendor.ko $out/lib/modules/${kernel.modDirVersion}/misc/hp_vendor.ko
+  '';
+
+  meta = with lib; {
+    maintainers = [ maintainers.cidkidnix ];
+    license = [ licenses.gpl2Plus ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    broken = versionOlder kernel.version "4.14";
+    description = "System76 HP-Vendor DKMS driver";
+    homepage = "https://github.com/pop-os/hp-vendor";
+    longDescription = ''
+      The System76 HP vendor DKMS driver
+    '';
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -453,6 +453,8 @@ in {
 
     systemtap = callPackage ../development/tools/profiling/systemtap { };
 
+    hp-vendor = callPackage ../os-specific/linux/hp-vendor { };
+
     system76 = callPackage ../os-specific/linux/system76 { };
 
     system76-acpi = callPackage ../os-specific/linux/system76-acpi { };


### PR DESCRIPTION
###### Description of changes
HP-Vendor kernel module used on HP Dev One laptops, provides some hwmon interfaces along with (proper) battery reporting
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
