### PR TITLE
fstar: use proper z3 version and build .checked files

### DIFF
--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -18,14 +18,14 @@ assert ocamlBindings -> ocaml != null && findlib != null && zarith != null;
 
 with lib;
 
-let common = { version, sha256, patches ? [ ] }:
+let common = { version, sha256, patches ? [ ], tag ? "z3" }:
   stdenv.mkDerivation rec {
     pname = "z3";
     inherit version sha256 patches;
     src = fetchFromGitHub {
       owner = "Z3Prover";
       repo = pname;
-      rev = "z3-${version}";
+      rev = "${tag}-${version}";
       sha256 = sha256;
     };
 
@@ -94,5 +94,10 @@ in
   z3_4_8 = common {
     version = "4.8.15";
     sha256 = "0xkwqz0y5d1lfb6kfqy8wn8n2dqalzf4c8ghmjsajc1bpdl70yc5";
+  };
+  z3_4_8_5 = common {
+    tag = "Z3";
+    version = "4.8.5";
+    sha256 = "sha256-ytG5O9HczbIVJAiIGZfUXC/MuYH7d7yLApaeTRlKXoc=";
   };
 }

--- a/pkgs/development/compilers/fstar/default.nix
+++ b/pkgs/development/compilers/fstar/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   nativeBuildInputs = [
+    z3
     makeWrapper
     installShellFiles
     removeReferencesTo
@@ -24,9 +25,7 @@ stdenv.mkDerivation rec {
     menhir
   ]);
 
-  buildInputs = [
-    z3
-  ] ++ (with ocamlPackages; [
+  buildInputs = with ocamlPackages; [
     batteries
     zarith
     stdint
@@ -39,11 +38,9 @@ stdenv.mkDerivation rec {
     ppx_deriving
     ppx_deriving_yojson
     process
-  ]);
+  ];
 
   makeFlags = [ "PREFIX=$(out)" ];
-
-  buildFlags = [ "libs" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14861,7 +14861,9 @@ with pkgs;
 
   fsharp = callPackage ../development/compilers/fsharp { };
 
-  fstar = callPackage ../development/compilers/fstar { };
+  fstar = callPackage ../development/compilers/fstar {
+    z3 = z3_4_8_5;
+  };
 
   dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix {});
 
@@ -36876,7 +36878,8 @@ with pkgs;
 
   inherit (callPackages ../applications/science/logic/z3 { python = python3; })
     z3_4_11
-    z3_4_8;
+    z3_4_8
+    z3_4_8_5;
   z3 = z3_4_8;
   z3-tptp = callPackage ../applications/science/logic/z3/tptp.nix {};
 


### PR DESCRIPTION
###### Description of changes

This gets rid of warnings 241 and 282 and also speeds up fstar.exe.

Previously, I would get the following output from `fstar.exe` when building a tutorial file:

```bash
$ fstar.exe Part1.GettingOffTheGround.fst
/nix/store/f8nas9mfl1acnb3l43f4afd84d1vsv7q-fstar-2022.01.15/lib/fstar/prims.fst(0,0-0,0): (Warning 241) Unable to load /nix/store/f8nas9mfl1acnb3l43f4afd84d1vsv7q-fstar-2022.01.15/lib/fstar/prims.fst.checked since checked file /nix
/store/f8nas9mfl1acnb3l43f4afd84d1vsv7q-fstar-2022.01.15/lib/fstar/prims.fst.checked does not exist; will recheck /nix/store/f8nas9mfl1acnb3l43f4afd84d1vsv7q-fstar-2022.01.15/lib/fstar/prims.fst (suppressing this warning for further
 modules)
(Warning 282) Expected Z3 version "Z3 version 4.8.5", got "Z3 version 4.8.15 - 64 bit
"
Please download the version of Z3 corresponding to your platform from:
https://github.com/FStarLang/binaries/tree/master/z3-tested
and add the bin/ subdirectory into your PATH

Verified module: Part1.GettingOffTheGround
All verification conditions discharged successfully
```

Now I get this instead:
```bash
$ fstar.exe Part1.GettingOffTheGround.fst
Verified module: Part1.GettingOffTheGround
All verification conditions discharged successfully
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @gebner @pnmadelaine @W95Psp 