### PR TITLE
octoprint: fix overlay composition

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -83,7 +83,7 @@ let
                 hash = "sha256-DCUesPy4/g7DYN/9CDRvwAWHcv4dFsF+gsysg5UWThQ=";
               };
 
-              propagatedBuildInputs = with super; [
+              propagatedBuildInputs = with self; [
                 argon2-cffi
                 blinker
                 cachelib
@@ -136,7 +136,7 @@ let
                 py.pkgs.appdirs
               ];
 
-              checkInputs = with super; [
+              checkInputs = with self; [
                 ddt
                 mock
                 pytestCheckHook
@@ -146,7 +146,7 @@ let
                 # substitute pip and let it find out, that it can't write anywhere
                 (substituteAll {
                   src = ./pip-path.patch;
-                  pip = "${super.pip}/bin/pip";
+                  pip = "${self.pip}/bin/pip";
                 })
 
                 # hardcore path to ffmpeg and hide related settings


### PR DESCRIPTION
###### Description of changes

Fixes a `self`/`super` mix-up that prevents users from overriding built-in `octoprint` plugins.

While working on https://github.com/NixOS/nixpkgs/issues/210629, I tried patching `octoprint-pisupport` like this:

```nix
{
  nixpkgs.overlays = [
    (self: super: {
      octoprint = super.octoprint.override {
        packageOverrides = (pself: psuper: {
          octoprint-pisupport = psuper.octoprint-pisupport.overrideAttrs (prev: {
            patches = (prev.patches or []) ++ [
              (pkgs.substituteAll {
                src = ./octoprint-vcgencmd-fix.patch;
                vcgencmd = "${self.libraspberrypi}/bin/vcgencmd";
              })
            ];
          });
        });
      };
    })
  ];
}
```

It didn't work. The issue is that the `octoprint` derivation pulls in `super.octoprint-pisupport`, meaning the derivation _before_ any overlays are applied. This PR switches `super` to `self` where appropriate so that all dependencies of `octoprint` can have overlays applied.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
