### PR TITLE
asterisk: 16.29.0 -> 16.30.0, 18.15.0 -> 18.16.0, 19.7.0 -> 19.8.0, 20.0.0 -> 20.1.0

### DIFF
--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -9,22 +9,22 @@
 }:
 
 let
-  # remove when upgrading to pjsip >2.12.1
+  # remove when upgrading to pjsip >2.13
   pjsip_patches = [
-    (fetchpatch {
-      name = "0150-CVE-2022-31031.patch";
-      url = "https://github.com/pjsip/pjproject/commit/450baca94f475345542c6953832650c390889202.patch";
-      sha256 = "sha256-30kHrmB51UIw4x/J6/CD+vPKf/gBYDCcFoUpwEWkDMY=";
-    })
-    (fetchpatch {
-      name = "0151-CVE-2022-39244.patch";
-      url = "https://github.com/pjsip/pjproject/commit/c4d34984ec92b3d5252a7d5cddd85a1d3a8001ae.patch";
-      sha256 = "sha256-hTUMh6bYAizn6GF+sRV1vjKVxSf9pnI+eQdPOqsdJI4=";
-    })
     (fetchpatch {
       name = "0152-CVE-2022-39269.patch";
       url = "https://github.com/pjsip/pjproject/commit/d2acb9af4e27b5ba75d658690406cec9c274c5cc.patch";
       sha256 = "sha256-bKE/MrRAqN1FqD2ubhxIOOf5MgvZluHHeVXPjbR12iQ=";
+    })
+    (fetchpatch {
+      name = "pjsip-2.12.1-CVE-2022-23537.patch";
+      url = "https://raw.githubusercontent.com/NixOS/nixpkgs/ca2b44568eb0ffbd0b5a22eb70feb6dbdcda8e9c/pkgs/applications/networking/pjsip/1.12.1-CVE-2022-23537.patch";
+      sha256 = "sha256-KNSnHt0/o1qJk4r2z5bxbYxKAa7WBtzGOhRXkru3VK4=";
+    })
+    (fetchpatch {
+      name = "pjsip-2.12.1-CVE-2022-23547.patch";
+      url = "https://raw.githubusercontent.com/NixOS/nixpkgs/ca2b44568eb0ffbd0b5a22eb70feb6dbdcda8e9c/pkgs/applications/networking/pjsip/1.12.1-CVE-2022-23547.patch";
+      sha256 = "sha256-0iEr/Z4UQpWsTXYWVYzWWk7MQDOFnTQ1BBYpynGLTVQ=";
     })
   ];
   common = {version, sha256, externals}: stdenv.mkDerivation {

--- a/pkgs/servers/asterisk/versions.json
+++ b/pkgs/servers/asterisk/versions.json
@@ -1,18 +1,18 @@
 {
   "asterisk_16": {
-    "sha256": "406a91290e18d25a6fc23ae6b9c56b1fb2bd70216e336c74cf9c26b908c89c3d",
-    "version": "16.29.0"
+    "sha256": "f8448e8784df7fac019e459bf7c82529d80afe64ae97d73d40e6aa0e4fb39724",
+    "version": "16.30.0"
   },
   "asterisk_18": {
-    "sha256": "a963dafeba0e7e1051a1ac56964999c111dbcdb25a47010bc1f772bf8edbed75",
-    "version": "18.15.0"
+    "sha256": "2d280794ae7505ed3dfc58b3190774cb491aa74c339fbde1a11740e6be79b466",
+    "version": "18.16.0"
   },
   "asterisk_19": {
-    "sha256": "832a967c5a040b0768c0e8df1646762f7304019fcf7f2e065a8b4828fa4092b7",
-    "version": "19.7.0"
+    "sha256": "f0c56d1f8e39e0427455edfe25d24ff088c756bdc32dd1278c9f7a320815cbaa",
+    "version": "19.8.0"
   },
   "asterisk_20": {
-    "sha256": "949022c20dc6da65b456e1b1b5b42a7901bb41fc9ce20920891739e7220d72eb",
-    "version": "20.0.0"
+    "sha256": "4364dc762652e2fd4d3e7dc8428c83550ebae090b8a0e9d4820583e081778883",
+    "version": "20.1.0"
   }
 }


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2022-37325, CVE-2022-42705 and CVE-2022-42706.

https://downloads.asterisk.org/pub/security/AST-2022-007.html
https://downloads.asterisk.org/pub/security/AST-2022-008.html
https://downloads.asterisk.org/pub/security/AST-2022-009.html

Changelogs:
https://downloads.asterisk.org/pub/telephony/asterisk/ChangeLog-20.1.0
https://downloads.asterisk.org/pub/telephony/asterisk/ChangeLog-19.8.0
https://downloads.asterisk.org/pub/telephony/asterisk/ChangeLog-18.16.0
https://downloads.asterisk.org/pub/telephony/asterisk/ChangeLog-16.30.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>asterisk (asterisk-stable ,asterisk_19)</li>
    <li>asterisk_18 (asterisk-lts)</li>
    <li>asterisk-module-sccp</li>
    <li>asterisk_16</li>
    <li>asterisk_20</li>
  </ul>
</details>