### PR TITLE
python310Packages.aiopvpc: 3.0.0 -> 4.0.1 

### DIFF
--- a/pkgs/development/python-modules/aiopvpc/default.nix
+++ b/pkgs/development/python-modules/aiopvpc/default.nix
@@ -4,18 +4,17 @@
 , backports-zoneinfo
 , buildPythonPackage
 , fetchFromGitHub
-, holidays
 , poetry-core
 , pytest-asyncio
 , pytest-timeout
 , pytestCheckHook
 , pythonOlder
-, tzdata
+, python-dotenv
 }:
 
 buildPythonPackage rec {
   pname = "aiopvpc";
-  version = "3.0.0";
+  version = "4.0.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -24,8 +23,13 @@ buildPythonPackage rec {
     owner = "azogue";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-eTCQddoZIaCs7iKGNBC8aSq6ek4vwYXgIXx35UlME/k=";
+    hash = "sha256-E5z74/5VuFuOyAfeT4PQlHUNOiVT4sPgOdxoAIIymxU=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace \
+      " --cov --cov-report term --cov-report html" ""
+  '';
 
   nativeBuildInputs = [
     poetry-core
@@ -33,8 +37,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     aiohttp
-    holidays
-    tzdata
     async-timeout
   ] ++ lib.optionals (pythonOlder "3.9") [
     backports-zoneinfo
@@ -44,17 +46,8 @@ buildPythonPackage rec {
     pytest-asyncio
     pytest-timeout
     pytestCheckHook
+    python-dotenv
   ];
-
-  disabledTests = [
-    # Failures seem related to changes in holidays-0.13, https://github.com/azogue/aiopvpc/issues/44
-    "test_number_of_national_holidays"
-  ];
-
-  postPatch = ''
-    substituteInPlace pyproject.toml --replace \
-      " --cov --cov-report term --cov-report html" ""
-  '';
 
   pythonImportsCheck = [
     "aiopvpc"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
