### PR TITLE
ceph: add missing python library

### DIFF
--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -181,6 +181,17 @@ let
     monA.wait_until_succeeds("ceph osd stat | grep -e '3 osds: 3 up[^,]*, 3 in'")
     monA.wait_until_succeeds("ceph -s | grep 'mgr: ${cfg.monA.name}(active,'")
     monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
+
+    # Enable the dashboard and recheck health
+    monA.succeed(
+        "ceph mgr module enable dashboard",
+        "ceph config set mgr mgr/dashboard/ssl false",
+        # default is 8080 but it's better to be explicit
+        "ceph config set mgr mgr/dashboard/server_port 8080",
+    )
+    monA.wait_for_open_port(8080)
+    monA.wait_until_succeeds("curl -q --fail http://localhost:8080")
+    monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
   '';
 in {
   name = "basic-single-node-ceph-cluster";

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -113,6 +113,7 @@ let
   };
 
   ceph-python-env = python.withPackages (ps: [
+    # Check .requires files below https://github.com/ceph/ceph/tree/main/debian for dependencies
     ps.sphinx
     ps.flask
     ps.routes

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -115,6 +115,7 @@ let
   ceph-python-env = python.withPackages (ps: [
     ps.sphinx
     ps.flask
+    ps.routes
     ps.cython
     ps.setuptools
     ps.virtualenv


### PR DESCRIPTION
This is a regression in 22.11. After updating from 22.05 the dashboard no longer works and `ceph status` reports a health check error.

The `routes` python library required by the mgr dashboard module is missing.

`ceph -s` reports:

```
  cluster:
    id:     …
    health: HEALTH_ERR
            Module 'dashboard' has failed: No module named 'routes'
```

`ceph -w` reports:

```
mgr.b [ERR] Unhandled exception from module 'dashboard' while running on mgr.b: No module named 'routes'
mon.b [ERR] Health check failed: Module 'dashboard' has failed: No module named 'routes' (MGR_MODULE_ERROR)
```

###### Description of changes

This simply adds the `routes` library to the python environment.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - ~~and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)~~
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - ~~made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages~~
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- ~~[23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)~~
  - [ ] ~~(Package updates) Added a release notes entry if the change is major or breaking~~
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
  - [ ] ~~(Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).