### PR TITLE
[22.11] openimageio: deprecate 1.x

### DIFF
--- a/pkgs/applications/graphics/openimageio/default.nix
+++ b/pkgs/applications/graphics/openimageio/default.nix
@@ -44,5 +44,34 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     maintainers = [ maintainers.goibhniu ];
     platforms = platforms.unix;
+    knownVulnerabilities = [
+      # all discovered in 2.x but there is no reason to
+      # believe that these or similar vulnerabilties aren't
+      # present in the totally unmaintained 1.x branch
+      "CVE-2022-36354"
+      "CVE-2022-38143"
+      "CVE-2022-41639"
+      "CVE-2022-41649"
+      "CVE-2022-41684"
+      "CVE-2022-41794"
+      "CVE-2022-41837"
+      "CVE-2022-41838"
+      "CVE-2022-41977"
+      "CVE-2022-41981"
+      "CVE-2022-41988"
+      "CVE-2022-41999"
+      "CVE-2022-43592"
+      "CVE-2022-43593"
+      "CVE-2022-43594"
+      "CVE-2022-43595"
+      "CVE-2022-43596"
+      "CVE-2022-43597"
+      "CVE-2022-43598"
+      "CVE-2022-43599"
+      "CVE-2022-43600"
+      "CVE-2022-43601"
+      "CVE-2022-43602"
+      "CVE-2022-43603"
+    ];
   };
 }

--- a/pkgs/development/libraries/embree/2.x.nix
+++ b/pkgs/development/libraries/embree/2.x.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, pkg-config, ispc, tbb, glfw,
-openimageio, libjpeg, libpng, libpthreadstubs, libX11
+openimageio2, libjpeg, libpng, libpthreadstubs, libX11
 }:
 
 stdenv.mkDerivation {
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   cmakeFlags = [ "-DEMBREE_TUTORIALS=OFF" ];
 
   nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ ispc tbb glfw openimageio libjpeg libpng libX11 libpthreadstubs ];
+  buildInputs = [ ispc tbb glfw openimageio2 libjpeg libpng libX11 libpthreadstubs ];
   meta = with lib; {
     description = "High performance ray tracing kernels from Intel";
     homepage = "https://embree.github.io/";

--- a/pkgs/development/libraries/embree/default.nix
+++ b/pkgs/development/libraries/embree/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkg-config, ispc, tbb, glfw,
-  openimageio, libjpeg, libpng, libpthreadstubs, libX11, glib }:
+  openimageio2, libjpeg, libpng, libpthreadstubs, libX11, glib }:
 
 stdenv.mkDerivation rec {
   pname = "embree";
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
 
   nativeBuildInputs = [ ispc pkg-config cmake ];
-  buildInputs = [ tbb glfw openimageio libjpeg libpng libX11 libpthreadstubs ]
+  buildInputs = [ tbb glfw openimageio2 libjpeg libpng libX11 libpthreadstubs ]
                 ++ lib.optionals stdenv.isDarwin [ glib ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -16,7 +16,7 @@
 , imagemagick
 , graphicsmagick
 , gdal
-, openimageio
+, openimageio2
 , freeimage
 , imlib
 }:
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   passthru.tests = {
-    inherit libgeotiff imagemagick graphicsmagick gdal openimageio freeimage imlib;
+    inherit libgeotiff imagemagick graphicsmagick gdal openimageio2 freeimage imlib;
     inherit (python3Packages) pillow imread;
   };
 


### PR DESCRIPTION
###### Description of changes

This is subtly different from unstable's #209104. Here I've done _effectively_ the same thing, only left the `openimageio` attribute pointing at 1.x and switched the consumers which work with 2.x to reference `openimageio2` (whereas in unstable I simply switched the aliases). This was done to reduce surprises for stable users. The `openimageio` attribute will however bring up `knownVulnerabilities` warnings.

Consumers that I haven't switched to `openimageio2` are already broken for some other reason, so I'm unable to test whether they work with 2.x.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
