### PR TITLE
qq: fix input-method not work

### DIFF
--- a/pkgs/applications/networking/instant-messengers/qq/default.nix
+++ b/pkgs/applications/networking/instant-messengers/qq/default.nix
@@ -17,6 +17,7 @@
 , at-spi2-core
 , autoPatchelfHook
 , wrapGAppsHook
+, makeWrapper
 }:
 
 let
@@ -42,6 +43,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     autoPatchelfHook
     wrapGAppsHook
+    makeWrapper
     dpkg
   ];
 
@@ -71,7 +73,9 @@ stdenv.mkDerivation {
     substituteInPlace $out/share/applications/qq.desktop \
       --replace "/opt/QQ/qq" "$out/bin/qq" \
       --replace "/usr/share" "$out/share"
-    ln -s $out/opt/QQ/qq $out/bin/qq
+    makeWrapper $out/opt/QQ/qq $out/bin/qq \
+      --argv0 "qq" \
+      --prefix GTK_IM_MODULE_FILE : "/run/current-system/sw/etc/gtk-3.0/immodules.cache"
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Description of changes

It seems that although QQ uses gtk3, it will not try to get immodules.cache from /run/current-system/sw/etc/gtk-3.0/immodules.cache
QQ will only visit GTK3's GTK_PATH to find immodules.cache (/run/current-system/sw/lib/gtk-3.0/3.0.0/immodules.cache)
This causes QQ to be unable to use the input-method (like ibus, fcitx seems to work)
This may be caused by qq using an old version of gtk3 (idk)
As for why nixos uses /etc/immodules.cache instead of overriding /lib/gtk-3.0/3.0.0/immodules.cache, please refer to the implementation of input-method module
It seems that nix cannot allow multiple packages to modify the same file at the same time in $out (FHS environment)
Fortunately, gtk allows us to use the GTK_IM_MODULE_FILE environment variable to force immodules.cache to be specified, so I try to temporarily solve this problem

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
