### PR TITLE
qt5.qtbase, qt6.qtbase: hardcode QT_QPA_PLATFORM_PLUGIN_PATH too avoid omitting

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -98,6 +98,10 @@ stdenv.mkDerivation {
   '';
 
   postPatch = ''
+    substituteInPlace src/gui/kernel/qguiapplication.cpp \
+        --replace 'qgetenv("QT_QPA_PLATFORM_PLUGIN_PATH")' 'QByteArrayLiteral("@bin@/@qtPluginPrefix@/platforms")' \
+        --subst-var qtPluginPrefix \
+        --subst-var bin
     for prf in qml_plugin.prf qt_plugin.prf qt_docs.prf qml_module.prf create_cmake.prf; do
         substituteInPlace "mkspecs/features/$prf" \
             --subst-var qtPluginPrefix \

--- a/pkgs/development/libraries/qt-6/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase.nix
@@ -197,6 +197,10 @@ stdenv.mkDerivation rec {
 
   # https://bugreports.qt.io/browse/QTBUG-97568
   postPatch = ''
+    substituteInPlace src/gui/kernel/qguiapplication.cpp \
+        --replace 'qgetenv("QT_QPA_PLATFORM_PLUGIN_PATH")' 'QByteArrayLiteral("@bin@/@qtPluginPrefix@/platforms")' \
+        --subst-var qtPluginPrefix \
+        --subst-var bin
     substituteInPlace src/corelib/CMakeLists.txt --replace /bin/ls ${coreutils}/bin/ls
   '' + lib.optionalString stdenv.isDarwin ''
     substituteInPlace cmake/QtAutoDetect.cmake --replace "/usr/bin/xcrun" "${xcbuild}/bin/xcrun"


### PR DESCRIPTION
###### Description of changes

When debugging #157862

I got:
```
Application path not initialized
qt.qpa.plugin: Could not find the Qt platform plugin "cocoa" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

From this [post](https://forum.qt.io/topic/133532/how-to-solve-could-not-load-the-qt-platform-plugin-cocoa-in-even-though-it-was-found) and
https://github.com/NixOS/nixpkgs/blob/f2f2a140ad9ac94ecaad1203e50bfab13f46e8e0/pkgs/applications/networking/p2p/tribler/default.nix#L89

the patch seems correct. I can't build this version but I can't build the non-patched version either. It is still present in binary cache so I guess my machine is at fault. I checked I see a `qguiapplication.o` so compilation did succeed. I also checked the patched file and the path it contains is similar to what is found for tribler. Since I can't build I can't test that the line showed become useless in tribler (so maybe it has cleanup to be done).

META: No one in code owner of qt6 ?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
