### PR TITLE
nixos/starship: Allow using presets

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, stdenvNoCC, lndir, runtimeShell, shellcheck }:
+{ lib, stdenv, stdenvNoCC, lndir, runtimeShell, shellcheck, python3 }:
 
 let
   inherit (lib)
@@ -826,4 +826,26 @@ rec {
     outputHash = "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
     preferLocalBuild = true;
   } "mkdir $out";
+
+  runPythonScript = name: runPythonScriptWith { inherit name; };
+
+  runPythonScriptWith =
+    {
+      # name of the resulting derivation
+      name,
+      python ? python3,
+    }:
+    pythonScript:
+
+    runCommand name {
+      nativeBuildInputs = [
+        python
+      ];
+      passAsFile = [
+        "pythonScript"
+      ];
+      inherit pythonScript;
+    } ''
+      exec python3 "$pythonScriptPath"
+    '';
 }

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -45,7 +45,7 @@
 , tpm2-tools
 , fwupd-efi
 , nixosTests
-, runCommand
+, runPythonScript
 , unstableGitUpdater
 , modemmanager
 , libqmi
@@ -75,13 +75,6 @@ let
   # haveFlashrom = isx86;
   # Experimental
   haveFlashrom = false;
-
-  runPythonCommand = name: buildCommandPython: runCommand name {
-    nativeBuildInputs = [ python3 ];
-      inherit buildCommandPython;
-  } ''
-    exec python3 -c "$buildCommandPython"
-  '';
 
   test-firmware =
     let
@@ -360,7 +353,7 @@ let
       in {
         installedTests = nixosTests.installed-tests.fwupd;
 
-        passthruMatches = runPythonCommand "fwupd-test-passthru-matches" ''
+        passthruMatches = runPythonScript "fwupd-test-passthru-matches" ''
           import itertools
           import configparser
           import os

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -104,6 +104,7 @@ let
     import ../build-support/trivial-builders.nix {
       inherit lib;
       inherit (self) runtimeShell stdenv stdenvNoCC;
+      inherit (self) python3;
       inherit (self.pkgsBuildHost) shellcheck;
       inherit (self.pkgsBuildHost.xorg) lndir;
     };


### PR DESCRIPTION
###### Description of changes

Until there is a [native method](https://github.com/starship/starship/issues/3039), we need to merge it manually.

Also introduce `runPythonScript` trivial builder.

cc @lilyball @danth 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
