### PR TITLE
cargo-{guppy,hakari}: update

### DIFF
--- a/pkgs/development/tools/rust/cargo-guppy/default.nix
+++ b/pkgs/development/tools/rust/cargo-guppy/default.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-guppy";
-  version = "unstable-2023-01-08";
+  version = "unstable-2023-01-14";
 
   src = fetchFromGitHub {
     owner = "guppy-rs";
     repo = "guppy";
-    rev = "81753212702ca2b11b65ac8b98db6c9e4f4d278f";
-    sha256 = "sha256-fCZlnE+/U+Z+X9n6x6qWHxODH5ESV0cM+hwxeyUZs6c=";
+    rev = "d593660fbcbfe50569de5a8aad5bd1ac19885733";
+    sha256 = "sha256-5kJTkVAklaSWqGIRjVJX56e8cjxyKAx/2E54OF0mIuw=";
   };
 
-  cargoSha256 = "sha256-H2voc37Ywmi8oy15UY9J3hW6sbqc3RZuelxWJxrwZKg=";
+  cargoSha256 = "sha256-H2ta/eH2VzEzHbYs0ugzFseLh0S5lxhB7/wvJEFGj0M=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-hakari/default.nix
+++ b/pkgs/development/tools/rust/cargo-hakari/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-hakari";
-  version = "0.9.19";
+  version = "0.9.20";
 
   src = fetchFromGitHub {
     owner = "guppy-rs";
     repo = "guppy";
     rev = "cargo-hakari-${version}";
-    sha256 = "sha256-w2qRln8TGHuduQCsA7dklymVORdsC+aZoK80o+0+KVc=";
+    sha256 = "sha256-4baQYtT5/RosRh/XVo13vfRg35+3rSJ5t9Q0JwwrRSk=";
   };
 
-  cargoHash = "sha256-HYkzqkTZDn/ibl03s3Y0GjINYrn1eBNiT6SjljecgmM=";
+  cargoHash = "sha256-AmuXMocsN82r4D+73rtFjd7YY6u2oxy9VZZpH6Ml0HI=";
 
   cargoBuildFlags = [ "-p" "cargo-hakari" ];
   cargoTestFlags = [ "-p" "cargo-hakari" ];

--- a/pkgs/development/tools/rust/cargo-hakari/default.nix
+++ b/pkgs/development/tools/rust/cargo-hakari/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-hakari";
-  version = "0.9.18";
+  version = "0.9.19";
 
   src = fetchFromGitHub {
     owner = "guppy-rs";
     repo = "guppy";
     rev = "cargo-hakari-${version}";
-    sha256 = "sha256-ZjU+0e0GmLCC9cha1RcTV0vEbuRi/SmU9qaNONIB7nI=";
+    sha256 = "sha256-w2qRln8TGHuduQCsA7dklymVORdsC+aZoK80o+0+KVc=";
   };
 
-  cargoHash = "sha256-/KH+h+4xfU2fitWv+IrLkwgiQ8tVjm41DiZtbrerRZ4=";
+  cargoHash = "sha256-HYkzqkTZDn/ibl03s3Y0GjINYrn1eBNiT6SjljecgmM=";
 
   cargoBuildFlags = [ "-p" "cargo-hakari" ];
   cargoTestFlags = [ "-p" "cargo-hakari" ];

--- a/pkgs/development/tools/rust/cargo-hakari/default.nix
+++ b/pkgs/development/tools/rust/cargo-hakari/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-hakari";
-  version = "0.9.20";
+  version = "0.9.21";
 
   src = fetchFromGitHub {
     owner = "guppy-rs";
     repo = "guppy";
     rev = "cargo-hakari-${version}";
-    sha256 = "sha256-4baQYtT5/RosRh/XVo13vfRg35+3rSJ5t9Q0JwwrRSk=";
+    sha256 = "sha256-wra3p3WAcGpsvW0DMMqWKFbAsrDTDnrYWQd6HS3sEls=";
   };
 
-  cargoHash = "sha256-AmuXMocsN82r4D+73rtFjd7YY6u2oxy9VZZpH6Ml0HI=";
+  cargoHash = "sha256-aNsG3ZmTMc5myOVs4h7uI5I5jjnjPd8AC2H7sSGmtHk=";
 
   cargoBuildFlags = [ "-p" "cargo-hakari" ];
   cargoTestFlags = [ "-p" "cargo-hakari" ];


### PR DESCRIPTION
###### Description of changes

cargo-hakari:
Diff: https://github.com/guppy-rs/guppy/compare/cargo-hakari-0.9.18...cargo-hakari-0.9.19
Changelog: https://github.com/guppy-rs/guppy/blob/cargo-hakari-0.9.19/tools/cargo-hakari/CHANGELOG.md

cargo-guppy:
Diff: https://github.com/guppy-rs/guppy/compare/81753212702ca2b11b65ac8b98db6c9e4f4d278f...d593660fbcbfe50569de5a8aad5bd1ac19885733

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
