### PR TITLE
commitizen: 2.38.0 -> 2.39.1

### DIFF
--- a/pkgs/applications/version-management/commitizen/default.nix
+++ b/pkgs/applications/version-management/commitizen/default.nix
@@ -1,5 +1,6 @@
 { buildPythonApplication
 , colorama
+, commitizen
 , decli
 , fetchFromGitHub
 , git
@@ -8,13 +9,14 @@
 , packaging
 , poetry-core
 , py
-, pytest-freezegun
+, pytest-freezer
 , pytest-mock
 , pytest-regressions
 , pytestCheckHook
 , pyyaml
 , questionary
 , termcolor
+, testers
 , tomlkit
 , typing-extensions
 , argcomplete
@@ -24,13 +26,13 @@
 
 buildPythonApplication rec {
   pname = "commitizen";
-  version = "2.38.0";
+  version = "2.39.1";
 
   src = fetchFromGitHub {
     owner = "commitizen-tools";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-W+k+hqH0TKQAXf1Em6A1/VdqzJkhYp99I3lbqH6iDDc=";
+    hash = "sha256-QQIYyg2zwV7cfFxGHVsLiTRBgTGs3O7OJcmURvfY3LQ=";
     deepClone = true;
   };
 
@@ -62,7 +64,7 @@ buildPythonApplication rec {
     pre-commit
     py
     pytestCheckHook
-    pytest-freezegun
+    pytest-freezer
     pytest-mock
     pytest-regressions
     argcomplete
@@ -92,7 +94,13 @@ buildPythonApplication rec {
     "test_commitizen_debug_excepthook"
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests.version = testers.testVersion {
+      package = commitizen;
+      command = "cz version";
+    };
+    updateScript = nix-update-script { };
+  };
 
   meta = with lib; {
     description = "Tool to create committing rules for projects, auto bump versions, and generate changelogs";


### PR DESCRIPTION
###### Description of changes

https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md#v2391-2022-12-31

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
