### PR TITLE
mtdev: add FreeBSD support

### DIFF
--- a/pkgs/development/libraries/mtdev/default.nix
+++ b/pkgs/development/libraries/mtdev/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, evdev-proto }:
 
 stdenv.mkDerivation rec {
   pname = "mtdev";
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     url = "https://bitmath.org/code/mtdev/${pname}-${version}.tar.bz2";
     sha256 = "1q700h9dqcm3zl6c3gj0qxxjcx6ibw2c51wjijydhwdcm26v5mqm";
   };
+
+  buildInputs = lib.optional stdenv.hostPlatform.isFreeBSD evdev-proto;
 
   meta = with lib; {
     homepage = "https://bitmath.org/code/mtdev/";
@@ -20,6 +22,6 @@ stdenv.mkDerivation rec {
       See the kernel documentation for further details.
     '';
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = with platforms; freebsd ++ linux;
   };
 }

--- a/pkgs/development/libraries/mtdev/default.nix
+++ b/pkgs/development/libraries/mtdev/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "http://bitmath.org/code/mtdev/";
+    homepage = "https://bitmath.org/code/mtdev/";
     description = "Multitouch Protocol Translation Library";
     longDescription = ''
       The mtdev is a stand-alone library which transforms all variants of

--- a/pkgs/os-specific/bsd/freebsd/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/default.nix
@@ -2,7 +2,7 @@
 , makeScopeWithSplicing, generateSplicesForMkScope
 , buildPackages
 , bsdSetupHook, makeSetupHook
-, fetchgit, fetchurl, coreutils, groff, mandoc, byacc, flex, which, m4, gawk, substituteAll, runtimeShell
+, fetchgit, fetchzip, coreutils, groff, mandoc, byacc, flex, which, m4, gawk, substituteAll, runtimeShell
 , zlib, expat, libmd
 , runCommand, writeShellScript, writeText, symlinkJoin
 }:
@@ -74,6 +74,11 @@ in makeScopeWithSplicing
     inherit (self) mkDerivation;
   in {
   inherit freebsdSrc;
+
+  ports = fetchzip {
+    url = "https://cgit.freebsd.org/ports/snapshot/ports-dde3b2b456c3a4bdd217d0bf3684231cc3724a0a.tar.gz";
+    sha256 = "BpHqJfnGOeTE7tkFJBx0Wk8ryalmf4KNTit/Coh026E=";
+  };
 
   # Why do we have splicing and yet do `nativeBuildInputs = with self; ...`?
   # See note in ../netbsd/default.nix.

--- a/pkgs/os-specific/bsd/freebsd/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/default.nix
@@ -388,6 +388,12 @@ in makeScopeWithSplicing
     outputs = [ "out" "man" "test" ];
   };
 
+  sed = mkDerivation {
+    path = "usr.bin/sed";
+    TESTSRC = "${freebsdSrc}/contrib/netbsd-tests";
+    MK_TESTS = "no";
+  };
+
   # Don't add this to nativeBuildInputs directly.  Use statHook instead.
   stat = mkDerivation {
     path = "usr.bin/stat";

--- a/pkgs/os-specific/bsd/freebsd/evdev-proto/default.nix
+++ b/pkgs/os-specific/bsd/freebsd/evdev-proto/default.nix
@@ -1,0 +1,64 @@
+{ lib, stdenv, linuxHeaders, freebsd, runCommandCC, buildPackages }:
+
+stdenv.mkDerivation {
+  pname = "evdev-proto";
+  inherit (linuxHeaders) version;
+
+  src = freebsd.ports;
+
+  sourceRoot = "source/devel/evdev-proto";
+
+  useTempPrefix = true;
+
+  nativeBuildInputs = [ freebsd.makeMinimal ];
+
+  ARCH = freebsd.makeMinimal.MACHINE_ARCH;
+  OPSYS = "FreeBSD";
+  _OSRELEASE = "${lib.versions.majorMinor freebsd.makeMinimal.version}-RELEASE";
+
+  AWK = "awk";
+  CHMOD = "chmod";
+  FIND = "find";
+  MKDIR = "mkdir -p";
+  PKG_BIN = "${buildPackages.pkg}/bin/pkg";
+  RM = "rm -f";
+  SED = "${buildPackages.freebsd.sed}/bin/sed";
+  SETENV = "env";
+  SH = "sh";
+  TOUCH = "touch";
+  XARGS = "xargs";
+
+  ABI_FILE = runCommandCC "abifile" {} "$CC -shared -o $out";
+  CLEAN_FETCH_ENV = true;
+  INSTALL_AS_USER = true;
+  NO_CHECKSUM = true;
+  NO_MTREE = true;
+  SRC_BASE = freebsd.freebsdSrc;
+
+  preUnpack = ''
+    export MAKE_JOBS_NUMBER="$NIX_BUILD_CORES"
+
+    export DISTDIR="$PWD/distfiles"
+    export PKG_DBDIR="$PWD/pkg"
+    export PREFIX="$prefix"
+
+    mkdir -p "$DISTDIR/evdev-proto"
+    tar -C "$DISTDIR/evdev-proto" \
+        -xf ${linuxHeaders.src} \
+        --strip-components 4 \
+        linux-${linuxHeaders.version}/include/uapi/linux
+  '';
+
+  makeFlags = [ "DIST_SUBDIR=evdev-proto" ];
+
+  postInstall = ''
+    mv $prefix $out
+  '';
+
+  meta = with lib; {
+    description = "Input event device header files for FreeBSD";
+    maintainers = with maintainers; [ qyliss ];
+    platforms = platforms.freebsd;
+    license = licenses.gpl2Only;
+  };
+}

--- a/pkgs/tools/package-management/pkg/default.nix
+++ b/pkgs/tools/package-management/pkg/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchFromGitHub, m4, pkg-config, tcl
+, bzip2, libarchive, libbsd, lzma, openssl, zlib
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pkg";
+  version = "1.19.0";
+
+  src = fetchFromGitHub {
+    owner = "freebsd";
+    repo = "pkg";
+    rev = finalAttrs.version;
+    sha256 = "W66g8kVvaPJSyOZcgyDcUBrWQQ5YDkRqofSWfIsjd+k=";
+  };
+
+  setOutputFlags = false;
+  separateDebugInfo = true;
+
+  nativeBuildInputs = [ m4 pkg-config tcl ];
+  buildInputs = [ bzip2 libarchive lzma openssl zlib ]
+    ++ lib.optional stdenv.isLinux libbsd;
+
+  enableParallelBuilding = true;
+
+  preInstall = ''
+    mkdir -p $out/etc
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/freebsd/pkg";
+    description = "Package management tool for FreeBSD";
+    maintainers = with maintainers; [ qyliss ];
+    platforms = with platforms; darwin ++ freebsd ++ linux ++ netbsd ++ openbsd;
+    license = licenses.bsd2;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25422,6 +25422,8 @@ with pkgs;
 
   erofs-utils = callPackage ../os-specific/linux/erofs-utils { };
 
+  evdev-proto = callPackage ../os-specific/bsd/freebsd/evdev-proto { };
+
   fscryptctl = callPackage ../os-specific/linux/fscryptctl { };
   # unstable until the first 1.x release
   fscrypt-experimental = callPackage ../os-specific/linux/fscrypt { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5249,6 +5249,8 @@ with pkgs;
 
   pika = callPackage ../applications/graphics/pika { };
 
+  pkg = callPackage ../tools/package-management/pkg { };
+
   playerctl = callPackage ../tools/audio/playerctl { };
 
   pn = callPackage ../tools/text/pn { };


### PR DESCRIPTION
###### Description of changes

The interesting part of this is evdev-proto. FreeBSD implements Linux's evdev API, but doesn't come with headers
for it.  Instead, the Linux headers are just modified to be suitable for FreeBSD, via a port called evdev-proto.  I don't want to copy the complicated sed expressions from the port into Nixpkgs, so instead we just build and install the port inside a Nix derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
