### PR TITLE
python310Packages.pycaption: 1.0.1 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/pycaption/default.nix
+++ b/pkgs/development/python-modules/pycaption/default.nix
@@ -1,41 +1,43 @@
-{ lib, fetchpatch
-, buildPythonPackage, fetchPypi, isPy3k
-, beautifulsoup4, lxml, cssutils, future, enum34, six
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, beautifulsoup4
+, lxml
+, cssutils
+, pytest-lazy-fixture
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pycaption";
-  version = "1.0.1";
+  version = "2.1.0";
+
+  disabled = pythonOlder "3.6";
+
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0f2hx9ky65c4niws3x5yx59yi8mqqrw9b2cghd220g4hj9yl800h";
+    hash = "sha256-mV//EYdP7wKYD3Vc49z6LQVQeOuhzNKFZLf28RYdABk=";
   };
 
-  disabled = !isPy3k;
-
-  prePatch = ''
-    substituteInPlace setup.py \
-      --replace 'beautifulsoup4>=4.2.1,<4.5.0' \
-                'beautifulsoup4>=4.2.1,<5'
-  '';
-
-  # don't require enum34 on python >= 3.4
-  patches = [
-    (fetchpatch {
-        url = "https://github.com/pbs/pycaption/pull/161.patch";
-        sha256 = "0p58awpsqx1qc3x9zfl1gd85h1nk7204lzn4kglsgh1bka0j237j";
-    })
+  propagatedBuildInputs = [
+    beautifulsoup4
+    lxml
+    cssutils
   ];
 
-  propagatedBuildInputs = [ beautifulsoup4 lxml cssutils future enum34 six ];
-
-  # Tests not included in pypi (?)
-  doCheck = false;
+  checkInputs = [
+    pytest-lazy-fixture
+    pytestCheckHook
+  ];
 
   meta = with lib; {
+    changelog = "https://github.com/pbs/pycaption/blob/${version}/docs/changelog.rst";
     description = "Closed caption converter";
     homepage = "https://github.com/pbs/pycaption";
-    license = with licenses; [ asl20 ];
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dotlambda ];
   };
 }


### PR DESCRIPTION

###### Description of changes
https://github.com/pbs/pycaption/blob/2.1.0/docs/changelog.rst

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
