### PR TITLE
sapling: use latest Python

### DIFF
--- a/pkgs/applications/version-management/sapling/default.nix
+++ b/pkgs/applications/version-management/sapling/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, python38Packages
+, python3Packages
 , fetchFromGitHub
 , fetchurl
 , sd
@@ -90,11 +90,7 @@ let
   };
 
   # Builds the main `sl` binary and its Python extensions
-  #
-  # FIXME(lf-): when next updating this package, delete the python 3.8 override
-  # here, since the fix for https://github.com/facebook/sapling/issues/279 that
-  # required it will be in the next release.
-  sapling = python38Packages.buildPythonPackage {
+  sapling = python3Packages.buildPythonPackage {
     pname = "sapling-main";
     inherit src version;
 
@@ -135,7 +131,7 @@ let
     #    so that 'sl web' always works
     # 4) 'sl web' will still work if 'nodejs' is in $PATH, just not OOTB
     preFixup = ''
-      sitepackages=$out/lib/${python38Packages.python.libPrefix}/site-packages
+      sitepackages=$out/lib/${python3Packages.python.libPrefix}/site-packages
       chmod +w $sitepackages
       cp -r ${isl} $sitepackages/edenscm-isl
     '' + lib.optionalString (!enableMinimal) ''


### PR DESCRIPTION
###### Description of changes

After upgrading to Sapling 0.2.20221222-152408-ha6a66d09, we no longer need a specific version of Python. Use the Nixpkgs default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
