### PR TITLE
mc: 4.8.28 -> 4.8.29

### DIFF
--- a/pkgs/applications/file-managers/mc/default.nix
+++ b/pkgs/applications/file-managers/mc/default.nix
@@ -16,7 +16,6 @@
 , libssh2
 , openssl
 , coreutils
-, autoreconfHook
 , autoSignDarwinBinariesHook
 
 # updater only
@@ -25,23 +24,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mc";
-  version = "4.8.28";
+  version = "4.8.29";
 
   src = fetchurl {
     url = "https://www.midnight-commander.org/downloads/${pname}-${version}.tar.xz";
-    sha256 = "sha256-6ZTZvppxcumsSkrWIQeSH2qjEuZosFbf5bi867r1OAM=";
+    sha256 = "sha256-dzpFMRL7bRdaMi8EL1g69K1FZtdCT63PsPW2GxjGMco=";
   };
 
-  patches = [
-    # Add support for PERL_FOR_BUILD to fix cross-compilation:
-    #   https://midnight-commander.org/ticket/4399
-    (fetchurl {
-      url = "https://midnight-commander.org/raw-attachment/ticket/4399/0001-configure.ac-introduce-PERL_FOR_BUILD.patch";
-      hash = "sha256-i4cbg/pner+yPfgmP04DEIvpNDlM9YDca1TNBdhWhwI=";
-    })
-  ];
-
-  nativeBuildInputs = [ pkg-config autoreconfHook unzip ]
+  nativeBuildInputs = [ pkg-config unzip ]
     # The preFixup hook rewrites the binary, which invaliates the code
     # signature. Add the fixup hook to sign the output.
     ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [


### PR DESCRIPTION
While at it dropped upstreamed patch for PERL_FOR_BUILD support.

Changes: https://midnight-commander.org/wiki/NEWS-4.8.29

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
