### PR TITLE
python3Packages.pscript: 0.7.6 -> 0.7.7

### DIFF
--- a/pkgs/development/python-modules/pscript/default.nix
+++ b/pkgs/development/python-modules/pscript/default.nix
@@ -3,18 +3,21 @@
 , fetchFromGitHub
 , pytestCheckHook
 , nodejs
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pscript";
   version = "0.7.7";
+  format = "setuptools";
 
-  # PyPI tarball doesn't include tests directory
+  disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "flexxui";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-AhVI+7FiWyH+DfAXnau4aAHJAJtsWEpmnU90ey2z35o=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-AhVI+7FiWyH+DfAXnau4aAHJAJtsWEpmnU90ey2z35o=";
   };
 
   checkInputs = [
@@ -27,13 +30,15 @@ buildPythonPackage rec {
     rm -rf pscript_legacy
   '';
 
+  pythonImportsCheck = [
+    "pscript"
+  ];
+
   meta = with lib; {
     description = "Python to JavaScript compiler";
-    license = licenses.bsd2;
     homepage = "https://pscript.readthedocs.io";
-    maintainers = [ maintainers.matthiasbeyer ];
+    changelog = "https://github.com/flexxui/pscript/blob/v${version}/docs/releasenotes.rst";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ matthiasbeyer ];
   };
 }
-
-
-

--- a/pkgs/development/python-modules/pscript/default.nix
+++ b/pkgs/development/python-modules/pscript/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "pscript";
-  version = "0.7.6";
+  version = "0.7.7";
 
   # PyPI tarball doesn't include tests directory
   src = fetchFromGitHub {
     owner = "flexxui";
     repo = pname;
     rev = "v${version}";
-    sha256 = "169px5n4jjnpdn9y86f28qwd95bwf1q1rz0a1h3lb5nn5c6ym8c4";
+    sha256 = "sha256-AhVI+7FiWyH+DfAXnau4aAHJAJtsWEpmnU90ey2z35o=";
   };
 
   checkInputs = [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
