### PR TITLE
nix-info: fix error when no channel installed

### DIFF
--- a/pkgs/tools/nix/info/info.sh
+++ b/pkgs/tools/nix/info/info.sh
@@ -69,8 +69,14 @@ nixev() {
     nix-instantiate --eval --strict -E "$1"
 }
 
+# use `nix eval` command
+nixev2() {
+    nix eval --raw "$1"
+}
+
 desc_system() {
-    nixev '(import <nixpkgs> {}).stdenv.hostPlatform.system'
+    nixev '(import <nixpkgs> {}).stdenv.hostPlatform.system' 2>/dev/null ||
+        nixev2 'nixpkgs#stdenv.hostPlatform.system'
 }
 
 desc_host_os() {
@@ -98,7 +104,7 @@ desc_multi_user() {
 }
 
 desc_nixpkgs_path() {
-    nixev '<nixpkgs>'
+    nixev '<nixpkgs>' 2>/dev/null || echo "not found"
 }
 
 channel_facts() {

--- a/pkgs/tools/nix/info/info.sh
+++ b/pkgs/tools/nix/info/info.sh
@@ -69,14 +69,8 @@ nixev() {
     nix-instantiate --eval --strict -E "$1"
 }
 
-# use `nix eval` command
-nixev2() {
-    nix eval --raw "$1"
-}
-
 desc_system() {
-    nixev '(import <nixpkgs> {}).stdenv.hostPlatform.system' 2>/dev/null ||
-        nixev2 'nixpkgs#stdenv.hostPlatform.system'
+    nixev 'builtins.currentSystem'
 }
 
 desc_host_os() {


### PR DESCRIPTION

###### Description of changes

Modify the nix-info script so that it doesn't fails when user only use flakes and never installed any channels. This could happen when user installed nix using non-standard ways, e.g. [using archlinux's package manager](https://archlinux.org/packages/community/x86_64/nix/).

###### Things done

This patch use the new nix CLI when old fails.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
