### PR TITLE
colorless: init at 109

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13565,6 +13565,12 @@
     githubId = 16734772;
     name = "Sumner Evans";
   };
+  suominen = {
+    email = "kimmo@suominen.com";
+    github = "suominen";
+    githubId = 1939855;
+    name = "Kimmo Suominen";
+  };
   superbo = {
     email = "supernbo@gmail.com";
     github = "SuperBo";

--- a/pkgs/tools/misc/colorless/default.nix
+++ b/pkgs/tools/misc/colorless/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, fetchurl
+, stdenvNoCC
+, coreutils
+, bash
+, binSh ? "${bash}/bin/bash"
+, gnused
+, less
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "colorless";
+  version = "109";
+
+  src = fetchurl {
+    url = "http://software.kimmo.suominen.com/${pname}-${version}.tar.gz";
+    sha256 = "039a140fa11cf153cc4d03e4f753b7ff142cab88ff116b7600ccf9edee81927c";
+  };
+
+  makeFlags = [
+    "TOOLPATH=${lib.makeBinPath [ coreutils gnused less ]}"
+    "PREFIX=$(out)"
+    "SHELL=${binSh}"
+  ];
+
+  preInstall = ''
+    mkdir -p $out/bin $out/share/man/man1
+  '';
+
+  postInstall = ''
+    install -Dm644 -t $out/share/doc/colorless LICENSE README.md
+  '';
+
+  strictDeps = true;
+
+  meta = with lib; {
+    homepage = "https://kimmo.suominen.com/sw/colorless";
+    description = "Enable colorised command output and pipe it to less";
+    longDescription = ''
+      colorless is a wrapper that enables colorised output of commands and
+      pipes the output to less(1).
+    '';
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ suominen ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1341,6 +1341,8 @@ with pkgs;
 
   clematis = callPackage ../tools/misc/clematis { };
 
+  colorless = callPackage ../tools/misc/colorless { };
+
   cope = callPackage ../tools/misc/cope { };
 
   ejson2env = callPackage ../tools/admin/ejson2env { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Colorless is a wrapper to enable colorised command output and pipe it to
[`less(1)`](https://man.netbsd.org/less.1).

Home page: <https://kimmo.suominen.com/sw/colorless>
Source code: <https://github.com/suominen/colorless>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
