### PR TITLE
python3Packages.pydantic Disable docs build for python<3.10

### DIFF
--- a/pkgs/development/python-modules/pydantic/default.nix
+++ b/pkgs/development/python-modules/pydantic/default.nix
@@ -9,12 +9,13 @@
 , pytest-mock
 , pytestCheckHook
 , python-dotenv
+, pythonAtLeast
 , pythonOlder
 , pyupgrade
 , typing-extensions
 # dependencies for building documentation.
 # docs fail to build in Darwin sandbox: https://github.com/samuelcolvin/pydantic/issues/4245
-, withDocs ? (stdenv.hostPlatform == stdenv.buildPlatform && !stdenv.isDarwin)
+, withDocs ? (stdenv.hostPlatform == stdenv.buildPlatform && !stdenv.isDarwin && pythonAtLeast "3.10")
 , ansi2html
 , markdown-include
 , mkdocs


### PR DESCRIPTION
It fails, because the examples require python3.10 to be executed.

```
WARNING: examples for 3.10+ requires python 3.10. They won't be executed
Traceback (most recent call last):
  File "/build/source/docs/build/main.py", line 31, in <module>
    sys.exit(main())
  File "/build/source/docs/build/main.py", line 27, in main
    return exec_examples()
  File "/build/source/docs/build/exec_examples.py", line 354, in exec_examples
    versions.extend(populate_upgraded_versions(file, file_text, lowest_version))
  File "/build/source/docs/build/exec_examples.py", line 294, in populate_upgraded_versions
    new_file.write_text(upgraded_file_text)
  File "/nix/store/9pilxd2znfsj64ybyg8lmgql9vy3fq4g-python3-3.9.16/lib/python3.9/pathlib.py", line 1285, in write_text
    with self.open(mode='w', encoding=encoding, errors=errors) as f:
  File "/nix/store/9pilxd2znfsj64ybyg8lmgql9vy3fq4g-python3-3.9.16/lib/python3.9/pathlib.py", line 1252, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "/nix/store/9pilxd2znfsj64ybyg8lmgql9vy3fq4g-python3-3.9.16/lib/python3.9/pathlib.py", line 1120, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/build/source/docs/.tmp_examples/upgraded/dataclasses_default_schema_3_9.py'
make: *** [Makefile:118: docs] Error 1
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
