### PR TITLE
maple-font: 5.5 -> 6.1

### DIFF
--- a/pkgs/data/fonts/maple-font/default.nix
+++ b/pkgs/data/fonts/maple-font/default.nix
@@ -35,17 +35,25 @@ let
     };
 in
 {
-  Mono-v5 = maple-font {
+  Mono = maple-font {
     pname = "MapleMono";
-    version = "5.5";
-    sha256 = "sha256-xkZ9NefjWHPjWNW8LGM8CgT2Zrg4j1evvx1K56sUzR8=";
+    version = "6.1";
+    sha256 = "sha256-JWyZH2F9lwWt9ROhuOtVf8HIjUAWkhCbXium0iNQry8=";
     desc = "monospace";
   };
-  Mono-NF-v5 = maple-font {
+
+  NF = maple-font {
     pname = "MapleMono-NF";
-    version = "5.5";
-    sha256 = "sha256-cPVGuH1CSfnRvQ4ehBvOVno7CT6Popc1Nnpcn5uJoQY=";
+    version = "6.1";
+    sha256 = "sha256-z0qoPMvowasHRK1IUMnx+lufUXqZkT3WBLtpEkP4V4I=";
     desc = "Nerd Font";
+  };
+
+  SC-NF = maple-font {
+    pname = "MapleMono-SC-NF";
+    version = "6.1";
+    sha256 = "sha256-cp7pASXEiP8Td8yR+5hKpZyTST0o0pxgck4llHps4go=";
+    desc = "Nerd Font SC";
   };
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5000,8 +5000,9 @@ with pkgs;
 
   mapcidr = callPackage ../tools/misc/mapcidr { };
 
-  maple-mono = (callPackage ../data/fonts/maple-font { }).Mono-v5;
-  maple-mono-NF = (callPackage ../data/fonts/maple-font { }).Mono-NF-v5;
+  maple-mono = (callPackage ../data/fonts/maple-font { }).Mono;
+  maple-mono-NF = (callPackage ../data/fonts/maple-font { }).NF;
+  maple-mono-SC-NF = (callPackage ../data/fonts/maple-font { }).SC-NF;
 
   marl = callPackage ../development/libraries/marl {};
 


### PR DESCRIPTION
###### Description of changes
Update maple-font, ~~but waiting for https://github.com/subframe7536/Maple-font/issues/78 to be closed.~~ closed.  

Add new package `maple-mono-SC-NF`  

[Release Note](https://github.com/subframe7536/Maple-font/releases/tag/v6.1)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
