### PR TITLE
wordpressPackages: add builtins and update

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/languages.json
+++ b/pkgs/servers/web-apps/wordpress/packages/languages.json
@@ -1,8 +1,8 @@
 {
   "de_DE": {
     "path": "de_DE",
-    "rev": "1010364",
-    "sha256": "0viir2hyfvf8vbnfz8hzijsbdqqqigd887risvdsy8w8ysd71f8r",
+    "rev": "1036537",
+    "sha256": "001jh83kv86av8yvkdwfcvpwik1yz8qxkyybmqkgx13hpaxhbf80",
     "version": "6.0"
   },
   "fr_FR": {

--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -1,9 +1,15 @@
 {
   "add-widget-after-content": {
-    "path": "add-widget-after-content/tags/2.4.4",
-    "rev": "2671853",
-    "sha256": "0snrkd783f1qxry01858l3r0ll9381xhsig7wlmrvi1zm5jf2drc",
-    "version": "2.4.4"
+    "path": "add-widget-after-content/tags/2.4.5",
+    "rev": "2844985",
+    "sha256": "17h55fzmssaqv5k2s2a2n5rz49flhzg9gflnps1qpr62apki5156",
+    "version": "2.4.5"
+  },
+  "akismet": {
+    "path": "akismet/tags/5.0.2",
+    "rev": "2827210",
+    "sha256": "0qxpivk7s0q23bf64bwq8k81l593jyc178kqlgnvfkkvgs51kjk7",
+    "version": "5.0.2"
   },
   "antispam-bee": {
     "path": "antispam-bee/tags/2.11.1",
@@ -24,10 +30,10 @@
     "version": "2.0.14"
   },
   "co-authors-plus": {
-    "path": "co-authors-plus/tags/3.5.6",
-    "rev": "2819241",
-    "sha256": "02na4smh9mba8bpksmcbj6k8q2k0024ax40p1k7zs8s22s70nkc1",
-    "version": "3.5.6"
+    "path": "co-authors-plus/tags/3.5.7",
+    "rev": "2844205",
+    "sha256": "0d6ji1410fg0mp8926y8c5nmnkp2m76wrbaia7ppb0c9h1pbki65",
+    "version": "3.5.7"
   },
   "code-syntax-block": {
     "path": "code-syntax-block/tags/3.1.1",
@@ -48,10 +54,16 @@
     "version": "1.0.1"
   },
   "gutenberg": {
-    "path": "gutenberg/tags/14.9.0",
-    "rev": "2843613",
-    "sha256": "1aa27nmks0b411n13qsgk0xhh82n8cjpqxj6r4v55lfr835rr4av",
-    "version": "14.9.0"
+    "path": "gutenberg/tags/14.9.1",
+    "rev": "2845697",
+    "sha256": "0wkwbka78nj6dqrjrm9qpbzfk848v38myrzvdwk40qz8ab6mhrqb",
+    "version": "14.9.1"
+  },
+  "hello-dolly": {
+    "path": "hello-dolly/tags/1.7.2",
+    "rev": "2807593",
+    "sha256": "0zzbzdkzpgc65djn3694li82zc2q25q3zzv0kqjr7zwqmnrli0jp",
+    "version": "1.7.2"
   },
   "hkdev-maintenance-mode": {
     "path": "hkdev-maintenance-mode/trunk",
@@ -60,10 +72,10 @@
     "version": "2.2.6"
   },
   "jetpack": {
-    "path": "jetpack/tags/11.6",
-    "rev": "2829451",
-    "sha256": "0hfsjcfd10mplsh4k78mmag9nh2zl0m42vrgrykdaw58zwjis2fj",
-    "version": "11.6"
+    "path": "jetpack/tags/11.7",
+    "rev": "2846103",
+    "sha256": "0nsq0m3ir3dygivljwg05nl8m2bsb47r8nq9r83jj930a996x5cj",
+    "version": "11.7"
   },
   "jetpack-lite": {
     "path": "jetpack-lite/tags/3.0.3",
@@ -72,16 +84,16 @@
     "version": "3.0.3"
   },
   "lightbox-photoswipe": {
-    "path": "lightbox-photoswipe/tags/5.0.18",
-    "rev": "2796750",
-    "sha256": "1c6wnxq70rxqj95w0ygnhkl8kxnvcpy4sxj2nniim0wsilpr3w8g",
-    "version": "5.0.18"
+    "path": "lightbox-photoswipe/tags/5.0.19",
+    "rev": "2845708",
+    "sha256": "00nll7i5h71bq9h3f4fnkf4zg1z8vrmrmzq7a5f71ysymsw104g1",
+    "version": "5.0.19"
   },
   "mailpoet": {
-    "path": "mailpoet/tags/4.3.1",
-    "rev": "2843001",
-    "sha256": "0nnmfk1rxhf31makfc0v7mlh30799saxpf8agqdlavrmqpvypvzb",
-    "version": "4.3.1"
+    "path": "mailpoet/tags/4.4.0",
+    "rev": "2846160",
+    "sha256": "0p99634i5k11m06lbh3cx92iacbgv4qc9cix9p8w8349v0wp66a8",
+    "version": "4.4.0"
   },
   "merge-minify-refresh": {
     "path": "merge-minify-refresh/trunk",
@@ -108,10 +120,10 @@
     "version": "0.9.3"
   },
   "webp-converter-for-media": {
-    "path": "webp-converter-for-media/tags/5.6.2",
-    "rev": "2843800",
-    "sha256": "0yki15slmvvnc9511gsg7kkvmnic3cb0p7iz2lm90j4pdchz0api",
-    "version": "5.6.2"
+    "path": "webp-converter-for-media/tags/5.6.3",
+    "rev": "2846410",
+    "sha256": "17h4dbd77qfb6djlw87s2cswhpb63d78jj4f629q81hfasm87rdw",
+    "version": "5.6.3"
   },
   "webp-express": {
     "path": "webp-express/tags/0.25.5",
@@ -120,10 +132,10 @@
     "version": "0.25.5"
   },
   "wordpress-seo": {
-    "path": "wordpress-seo/tags/19.13",
-    "rev": "2836498",
-    "sha256": "1ajfxw0fhx0lispcmlcm6wlgfml6kq2315gfdnlf41ai8rl3lpkh",
-    "version": "19.13"
+    "path": "wordpress-seo/tags/19.14",
+    "rev": "2845973",
+    "sha256": "03z416vj5xw4pq58g5jr5ai7hkjswi94xjldcah22iy0q6031v2n",
+    "version": "19.14"
   },
   "worker": {
     "path": "worker/tags/4.9.16",
@@ -138,16 +150,16 @@
     "version": "1.0"
   },
   "wp-fastest-cache": {
-    "path": "wp-fastest-cache/tags/1.0.9",
-    "rev": "2833576",
-    "sha256": "00jajz49lqgcl83hkiis9qf3h4zh7xzpnwi17hrmnarrqss9z7q2",
-    "version": "1.0.9"
+    "path": "wp-fastest-cache/tags/1.1.0",
+    "rev": "2846969",
+    "sha256": "0vzmsvifzizm3cdp3g3zrr02d6f35mi35dhbmng7xkz5lfvi78i9",
+    "version": "1.1.0"
   },
   "wp-gdpr-compliance": {
-    "path": "wp-gdpr-compliance/tags/2.0.20",
-    "rev": "2793947",
-    "sha256": "1vvwmi03hjyqw566m75m8lxbhnl3y4h461531a26xwsbmjgbmf9a",
-    "version": "2.0.20"
+    "path": "wp-gdpr-compliance/tags/2.0.21",
+    "rev": "2845379",
+    "sha256": "1bdwvvrrr1rm64lfdfyzmgbcs2f89mbs3jbzpkcapcl81ad9wjki",
+    "version": "2.0.21"
   },
   "wp-mail-smtp": {
     "path": "wp-mail-smtp/tags/3.7.0",
@@ -156,10 +168,10 @@
     "version": "3.7.0"
   },
   "wp-statistics": {
-    "path": "wp-statistics/tags/13.2.11",
-    "rev": "2841966",
-    "sha256": "0bdg63q9wq82rpj7lxiwsvbpxa03r2v1pngs2pxifd4632b7ikni",
-    "version": "13.2.11"
+    "path": "wp-statistics/tags/13.2.15",
+    "rev": "2847850",
+    "sha256": "1x205kffqzqm2156vxb67i12a2k4figzbdhahilnbl1qihskgcsy",
+    "version": "13.2.15"
   },
   "wp-user-avatars": {
     "path": "wp-user-avatars/trunk",
@@ -168,9 +180,9 @@
     "version": "1.4.1"
   },
   "wpforms-lite": {
-    "path": "wpforms-lite/tags/1.7.9",
-    "rev": "2844054",
-    "sha256": "1hhcl75cb7njgch0app9kifl9fjznan1m4gqa3yc6kdhicjb5sz6",
-    "version": "1.7.9"
+    "path": "wpforms-lite/tags/1.7.9.1",
+    "rev": "2846820",
+    "sha256": "0a7qzxvzzg5c2m623ghfvza4xpzagzhm28iy93j4557j6b5118fg",
+    "version": "1.7.9.1"
   }
 }

--- a/pkgs/servers/web-apps/wordpress/packages/themes.json
+++ b/pkgs/servers/web-apps/wordpress/packages/themes.json
@@ -1,9 +1,27 @@
 {
+  "twentynineteen": {
+    "path": "twentynineteen/2.4",
+    "rev": "178730",
+    "sha256": "1yi6pfndykgd1igd4fd6rqqg5mqa6hnszi3nwv3h1pmjz5yx7vs1",
+    "version": "2.4"
+  },
+  "twentytwenty": {
+    "path": "twentytwenty/2.1",
+    "rev": "178731",
+    "sha256": "1nqd286jkivaqylz9nfsa8naz2xwpyclhk7b8x8wvb4yn4cgrnc5",
+    "version": "2.1"
+  },
   "twentytwentyone": {
     "path": "twentytwentyone/1.7",
     "rev": "178738",
     "sha256": "090j6xb2hpq4qjis4yismgzip893ihdqs5r58a13nngl17xilmxw",
     "version": "1.7"
+  },
+  "twentytwentythree": {
+    "path": "twentytwentythree/1.0",
+    "rev": "178734",
+    "sha256": "1avrdg1fnv524xb921rgh2hrj87avbb3hhq1szs1mh9g1gv83i0x",
+    "version": "1.0"
   },
   "twentytwentytwo": {
     "path": "twentytwentytwo/1.3",

--- a/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/wordpress-plugins.json
@@ -1,5 +1,6 @@
 [
   "add-widget-after-content"
+, "akismet"
 , "antispam-bee"
 , "async-javascript"
 , "breeze"
@@ -8,6 +9,7 @@
 , "co-authors-plus"
 , "disable-xml-rpc"
 , "gutenberg"
+, "hello-dolly"
 , "hkdev-maintenance-mode"
 , "jetpack"
 , "jetpack-lite"

--- a/pkgs/servers/web-apps/wordpress/packages/wordpress-themes.json
+++ b/pkgs/servers/web-apps/wordpress/packages/wordpress-themes.json
@@ -1,4 +1,7 @@
 [
-  "twentytwentytwo"
+  "twentynineteen"
+, "twentytwenty"
+, "twentytwentytwo"
 , "twentytwentyone"
+, "twentytwentythree"
 ]


### PR DESCRIPTION
###### Description of changes

As a companion to #210873, this change adds some of the builtin plugins and themes, that generally ship with wordpress, so that consumers can explicitly opt into including them in their wordpress derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
