### PR TITLE
grandperspective: init at 3.0.1

### DIFF
--- a/pkgs/os-specific/darwin/grandperspective/default.nix
+++ b/pkgs/os-specific/darwin/grandperspective/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchurl, undmg, ... }:
+
+stdenv.mkDerivation rec {
+  version = "3.0.1";
+  pname = "grandperspective";
+
+  src = fetchurl {
+    inherit version;
+    url = "mirror://sourceforge/grandperspectiv/GrandPerspective-${builtins.replaceStrings [ "." ] [ "_" ] version}.dmg";
+    sha256 = "sha256-ZPqrlN9aw5q7656GmmxCnTRBw3lu9n952rIyun8MsiI=";
+  };
+
+  sourceRoot = "GrandPerspective.app";
+  buildInputs = [ undmg ];
+  installPhase = ''
+    mkdir -p "$out/Applications/GrandPerspective.app";
+    cp -R . "$out/Applications/GrandPerspective.app";
+  '';
+
+  meta = with lib; {
+    description = "Open-source macOS application to analyze disk usage";
+    longDescription = ''
+      GrandPerspective is a small utility application for macOS that graphically shows the disk usage within a file
+      system. It can help you to manage your disk, as you can easily spot which files and folders take up the most
+      space. It uses a so called tree map for visualisation. Each file is shown as a rectangle with an area proportional to
+      the file's size. Files in the same folder appear together, but their placement is otherwise arbitrary.
+    '';
+    homepage = "https://grandperspectiv.sourceforge.net";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ eliandoran ];
+    platforms = [ "x86_64-darwin" ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3437,6 +3437,8 @@ with pkgs;
 
   goku = callPackage ../os-specific/darwin/goku { };
 
+  grandperspective = callPackage ../os-specific/darwin/grandperspective { };
+
   grb = callPackage ../applications/misc/grb { };
 
   kerf   = kerf_1; /* kerf2 is WIP */


### PR DESCRIPTION
###### Description of changes

Official description:
> GrandPerspective is a small utility application for macOS that graphically shows the disk usage within a file system. It can help you to manage your disk, as you can easily spot which files and folders take up the most space. It uses a so called tree map for visualisation. Each file is shown as a rectangle with an area proportional to the file's size. Files in the same folder appear together, but their placement is otherwise arbitrary.

Project home page: https://grandperspectiv.sourceforge.net/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
