### PR TITLE
systemd: fix tpm2 driver init

### DIFF
--- a/pkgs/os-specific/linux/systemd/0019-tpm2_context_init-fix-driver-name-checking.patch
+++ b/pkgs/os-specific/linux/systemd/0019-tpm2_context_init-fix-driver-name-checking.patch
@@ -1,0 +1,44 @@
+From 236e9281cb158be3191c500524fbc5f397a25e03 Mon Sep 17 00:00:00 2001
+From: Nick Cao <nickcao@nichi.co>
+Date: Sun, 15 Jan 2023 20:15:55 +0800
+Subject: [PATCH] tpm2_context_init: fix driver name checking
+
+https://github.com/systemd/systemd/commit/542dbc623e introduced
+additional checks for tpm2 driver names, namely ensuring the driver
+name, when concated with "libtss2-tcti-" and ".so.0", generates a valid
+filename (with no '/' inside).
+
+For example, if the driver is name "device", the line
+  fn = strjoina("libtss2-tcti-", driver, ".so.0")
+would yield "libtss2-tcti-device.so.0", passing the check. And the
+filename is then passed to dlopen for loading the driver.
+
+Our current approach for systemd to correctly locate these dynamically
+loaded libraries is to patch the filenames to include their absolute
+path. Thus the line mentioned above is patched into
+  fn = strjoina("/nix/store/xxxxxxx-tpm2-tss-3.2.0/lib/libtss2-tcti-", driver, ".so.0")
+yielding "/nix/store/xxxxxxx-tpm2-tss-3.2.0/lib/libtss2-tcti-device.so.0",
+tripping the check.
+
+This patch relaxes the check to also accept absolute paths, by replacing
+filename_is_valid with path_is_valid.
+---
+ src/shared/tpm2-util.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/shared/tpm2-util.c b/src/shared/tpm2-util.c
+index ba8dfb041d..7de5d5fc77 100644
+--- a/src/shared/tpm2-util.c
++++ b/src/shared/tpm2-util.c
+@@ -192,7 +192,7 @@ int tpm2_context_init(const char *device, struct tpm2_context *ret) {
+                 fn = strjoina("libtss2-tcti-", driver, ".so.0");
+ 
+                 /* Better safe than sorry, let's refuse strings that cannot possibly be valid driver early, before going to disk. */
+-                if (!filename_is_valid(fn))
++                if (!path_is_valid(fn))
+                         return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "TPM2 driver name '%s' not valid, refusing.", driver);
+ 
+                 dl = dlopen(fn, RTLD_NOW);
+-- 
+2.39.0
+

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -174,6 +174,7 @@ stdenv.mkDerivation {
     ./0016-pkg-config-derive-prefix-from-prefix.patch
     ./0017-inherit-systemd-environment-when-calling-generators.patch
     ./0018-core-don-t-taint-on-unmerged-usr.patch
+    ./0019-tpm2_context_init-fix-driver-name-checking.patch
   ] ++ lib.optional stdenv.hostPlatform.isMusl (
     let
       oe-core = fetchzip {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
