### PR TITLE
hylafaxplus: fix build with libtiff 4.5

### DIFF
--- a/pkgs/servers/hylafaxplus/default.nix
+++ b/pkgs/servers/hylafaxplus/default.nix
@@ -72,6 +72,16 @@ stdenv.mkDerivation {
   patches = [
     # adjust configure check to work with libtiff > 4.1
     ./libtiff-4.patch
+    # fix missing exports in libtiff 4.5+
+    # https://gitlab.com/libtiff/libtiff/-/issues/504
+    # can probably be dropped with next hylafaxplus release
+    (fetchurl {
+      name = "hylafaxplus-7.0.6-tiff-4.5.0.patch";
+      url = "https://dev.gentoo.org/~sam/distfiles/net-misc/hylafaxplus/hylafaxplus-7.0.6-tiff-4.5.0.patch.xz";
+      downloadToTemp = true;
+      postFetch = ''xz -d < $downloadedFile > $out'';
+      hash = "sha256-koZvvzlgZHcANVaYdewnuLARz2TTeyDZRjm0EYWzsmk=";
+    })
   ];
   # Note that `configure` (and maybe `faxsetup`) are looking
   # for a couple of standard binaries in the `PATH` and


### PR DESCRIPTION
###### Description of changes

New libtiff 4.5 from https://github.com/NixOS/nixpkgs/commit/4d4af86db63955be68118f1507ce51e576b88016 breaks the current version of `hylafaxplus`.  The pull request at hand adds a patch that fixes the issue and will be included in the next release.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

More: tested with asterisk/iaxmodem

- [x] send/receive normal fax from text file
- [x] handling of busy/unresponsive/non-modem/flaky destination


###### Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>1 package built:</summary>
  <ul>
    <li>hylafaxplus</li>
  </ul>
</details>
