### PR TITLE
tvbrowser: fix, update, build from source, add small test

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -838,6 +838,12 @@
       </listitem>
       <listitem>
         <para>
+          <literal>tvbrowser-bin</literal> was removed, and now
+          <literal>tvbrowser</literal> is built from source.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>nixos-version</literal> now accepts
           <literal>--configuration-revision</literal> to display more
           information about the current generation revision

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -209,6 +209,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [Xastir](https://xastir.org/index.php/Main_Page) can now access AX.25 interfaces via the `libax25` package.
 
+- `tvbrowser-bin` was removed, and now `tvbrowser` is built from source.
+
 - `nixos-version` now accepts `--configuration-revision` to display more information about the current generation revision
 
 - The option `services.nomad.extraSettingsPlugins` has been fixed to allow more than one plugin in the path.

--- a/pkgs/applications/misc/tvbrowser/bin.nix
+++ b/pkgs/applications/misc/tvbrowser/bin.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/java/${pname}
     cp -R * $out/share/java/${pname}
     rm $out/share/java/${pname}/${pname}.{sh,desktop}
@@ -46,6 +48,8 @@ stdenv.mkDerivation rec {
     makeWrapper ${jre}/bin/java $out/bin/${pname} \
       --add-flags "--module-path=lib:${pname}.jar -m ${pname}/tvbrowser.TVBrowser"  \
       --chdir "$out/share/java/${pname}"
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/tvbrowser/bin.nix
+++ b/pkgs/applications/misc/tvbrowser/bin.nix
@@ -50,6 +50,6 @@ in stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ jfrankenau ];
+    maintainers = with maintainers; [ jfrankenau yarny ];
   };
 }

--- a/pkgs/applications/misc/tvbrowser/bin.nix
+++ b/pkgs/applications/misc/tvbrowser/bin.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, makeWrapper, jre, makeDesktopItem }:
 
 let
-  minimalJavaVersion = "8";
+  minimalJavaVersion = "11";
 
   desktopItem = makeDesktopItem {
     name = "tvbrowser";
@@ -19,12 +19,12 @@ in
 assert lib.versionAtLeast jre.version minimalJavaVersion;
 stdenv.mkDerivation rec {
   pname = "tvbrowser";
-  version = "4.0.1";
+  version = "4.2.7";
   name = "${pname}-bin-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/${pname}/TV-Browser%20Releases%20%28Java%20${minimalJavaVersion}%20and%20higher%29/${version}/${pname}_${version}_bin.tar.gz";
-    sha256 = "0ahsirf6cazs5wykgbwsc6n35w6jprxyphzqmm7d370n37sb07pm";
+    hash = "sha256-A1ZLGHA1sSSafwWy6MlPikQMk+6CechftzFTLDaBfrs=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     makeWrapper ${jre}/bin/java $out/bin/${pname} \
-      --add-flags "-jar $out/share/java/${pname}/${pname}.jar" \
+      --add-flags "--module-path=lib:${pname}.jar -m ${pname}/tvbrowser.TVBrowser"  \
       --chdir "$out/share/java/${pname}"
   '';
 

--- a/pkgs/applications/misc/tvbrowser/bin.nix
+++ b/pkgs/applications/misc/tvbrowser/bin.nix
@@ -1,6 +1,8 @@
 { lib, stdenv, fetchurl, makeWrapper, jre, makeDesktopItem }:
 
 let
+  minimalJavaVersion = "8";
+
   desktopItem = makeDesktopItem {
     name = "tvbrowser";
     exec = "tvbrowser";
@@ -13,13 +15,15 @@ let
     startupWMClass = "tvbrowser-TVBrowser";
   };
 
-in stdenv.mkDerivation rec {
+in
+assert lib.versionAtLeast jre.version minimalJavaVersion;
+stdenv.mkDerivation rec {
   pname = "tvbrowser";
   version = "4.0.1";
   name = "${pname}-bin-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${pname}/TV-Browser%20Releases%20%28Java%208%20and%20higher%29/${version}/${pname}_${version}_bin.tar.gz";
+    url = "mirror://sourceforge/${pname}/TV-Browser%20Releases%20%28Java%20${minimalJavaVersion}%20and%20higher%29/${version}/${pname}_${version}_bin.tar.gz";
     sha256 = "0ahsirf6cazs5wykgbwsc6n35w6jprxyphzqmm7d370n37sb07pm";
   };
 

--- a/pkgs/applications/misc/tvbrowser/default.nix
+++ b/pkgs/applications/misc/tvbrowser/default.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/share/${pname}
     cp -R runtime/tvbrowser_linux/* $out/share/${pname}
-    rm $out/share/${pname}/${pname}.sh
 
     mkdir -p $out/share/applications
     mv -t $out/share/applications $out/share/${pname}/${pname}.desktop
@@ -56,9 +55,12 @@ stdenv.mkDerivation rec {
     done
 
     mkdir -p $out/bin
-    makeWrapper ${jdk}/bin/java $out/bin/${pname}  \
-      --add-flags "--module-path=lib:${pname}.jar -m ${pname}/tvbrowser.TVBrowser"  \
-      --chdir "$out/share/${pname}"
+    makeWrapper  \
+        $out/share/${pname}/${pname}.sh  \
+        $out/bin/${pname}  \
+        --prefix PATH : ${jdk}/bin  \
+        --prefix XDG_DATA_DIRS : $out/share  \
+        --set PROGRAM_DIR $out/share/${pname}
 
     runHook postInstall
   '';

--- a/pkgs/applications/misc/tvbrowser/default.nix
+++ b/pkgs/applications/misc/tvbrowser/default.nix
@@ -53,22 +53,22 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/java/${pname}
-    cp -R runtime/tvbrowser_linux/* $out/share/java/${pname}
-    rm $out/share/java/${pname}/${pname}.sh
+    mkdir -p $out/share/${pname}
+    cp -R runtime/tvbrowser_linux/* $out/share/${pname}
+    rm $out/share/${pname}/${pname}.sh
 
     mkdir -p $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications/
 
     for i in 16 32 48 128; do
       mkdir -p $out/share/icons/hicolor/''${i}x''${i}/apps
-      ln -s $out/share/java/${pname}/imgs/${pname}$i.png $out/share/icons/hicolor/''${i}x''${i}/apps/${pname}.png
+      ln -s $out/share/${pname}/imgs/${pname}$i.png $out/share/icons/hicolor/''${i}x''${i}/apps/${pname}.png
     done
 
     mkdir -p $out/bin
     makeWrapper ${jdk}/bin/java $out/bin/${pname}  \
       --add-flags "--module-path=lib:${pname}.jar -m ${pname}/tvbrowser.TVBrowser"  \
-      --chdir "$out/share/java/${pname}"
+      --chdir "$out/share/${pname}"
 
     runHook postInstall
   '';

--- a/pkgs/applications/misc/tvbrowser/default.nix
+++ b/pkgs/applications/misc/tvbrowser/default.nix
@@ -6,6 +6,7 @@
 , ant
 , jdk
 , makeWrapper
+, callPackage
 }:
 
 let
@@ -71,6 +72,8 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.tests.startwindow = callPackage ./test.nix {};
 
   meta = with lib; {
     description = "Electronic TV Program Guide";

--- a/pkgs/applications/misc/tvbrowser/default.nix
+++ b/pkgs/applications/misc/tvbrowser/default.nix
@@ -69,10 +69,19 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Electronic TV Program Guide";
+    downloadPage = "https://www.tvbrowser.org/index.php?id=tv-browser";
     homepage = "https://www.tvbrowser.org/";
+    changelog = "https://www.tvbrowser.org/index.php?id=news";
     sourceProvenance = with sourceTypes; [ binaryBytecode fromSource ];
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
+    mainProgram = pname;
     platforms = platforms.linux;
     maintainers = with maintainers; [ jfrankenau yarny ];
+    longDescription = ''
+      TV-Browser shows TV program data arranged like in printed
+      TV programs after downloading it from the internet.
+      Plugins are used to download program data
+      and to provide additional functionality.
+    '';
   };
 }

--- a/pkgs/applications/misc/tvbrowser/default.nix
+++ b/pkgs/applications/misc/tvbrowser/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchurl
-, makeDesktopItem
 , stdenv
 , fetchzip
 , ant
@@ -16,19 +15,6 @@ let
     url = "https://www.tvbrowser.org/data/uploads/1372016422809_543/NewsPlugin.jar";
     hash = "sha256-5XoypuMd2AFBE2SJ6EdECuvq6D81HLLuu9UoA9kcKAM=";
   };
-
-  desktopItem = makeDesktopItem {
-    name = "tvbrowser";
-    exec = "tvbrowser";
-    icon = "tvbrowser";
-    comment = "Themeable and easy to use TV Guide";
-    desktopName = "TV-Browser";
-    genericName = "Electronic TV Program Guide";
-    categories = [ "AudioVideo" "TV" "Java" ];
-    startupNotify = true;
-    startupWMClass = "tvbrowser-TVBrowser";
-  };
-
 in
 assert lib.versionAtLeast jdk.version minimalJavaVersion;
 stdenv.mkDerivation rec {
@@ -46,6 +32,7 @@ stdenv.mkDerivation rec {
     runHook preBuild
 
     ant runtime-linux -Dnewsplugin.url=file://${newsPlugin}
+    ant tvbrowser-desktop-entry
 
     runHook postBuild
   '';
@@ -58,7 +45,10 @@ stdenv.mkDerivation rec {
     rm $out/share/${pname}/${pname}.sh
 
     mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+    mv -t $out/share/applications $out/share/${pname}/${pname}.desktop
+    sed -e 's|=imgs/|='$out'/share/${pname}/imgs/|'  \
+        -e 's|=${pname}.sh|='$out'/bin/${pname}|'  \
+        -i $out/share/applications/${pname}.desktop
 
     for i in 16 32 48 128; do
       mkdir -p $out/share/icons/hicolor/''${i}x''${i}/apps

--- a/pkgs/applications/misc/tvbrowser/test.nix
+++ b/pkgs/applications/misc/tvbrowser/test.nix
@@ -1,0 +1,40 @@
+{ lib
+, xvfb-run
+, tvbrowser
+, runCommand
+, writeShellApplication
+, xorg
+}:
+
+let
+  testScript = writeShellApplication {
+    name = "tvbrowser-test-script";
+    runtimeInputs = [ xorg.xwininfo tvbrowser ];
+    text = ''
+      function find_tvbrowser_windows {
+          for window_name in java tvbrowser-TVBrowser 'Setup assistant' ; do
+              grep -q "$window_name" "$1"  ||  return 1
+          done
+      }
+      tvbrowser &
+      for _ in {0..900} ; do
+          xwininfo -root -tree  \
+              | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d'  \
+              | tee window-names
+          echo
+          if find_tvbrowser_windows window-names ; then
+              break
+          fi
+          sleep 1
+      done
+      find_tvbrowser_windows window-names
+    '';
+  };
+in
+runCommand
+"tvbrowser-test"
+{ buildInputs = [ xvfb-run ]; }
+''
+  HOME=$PWD xvfb-run ${lib.getExe testScript}
+  touch ${placeholder "out"}
+''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1543,6 +1543,7 @@ mapAliases ({
   truecrypt = throw "'truecrypt' has been renamed to/replaced by 'veracrypt'"; # Converted to throw 2022-02-22
   tuijam = throw "tuijam has been removed because Google Play Music was discontinued"; # Added 2021-03-07
   turbo-geth = throw "turbo-geth has been renamed to erigon"; # Added 2021-08-08
+  tvbrowser-bin = throw "tvbrowser-bin was removed because it is now built from sources; use 'tvbrowser' instead"; # Added 2023-02-04
   twister = throw "twister has been removed: abandoned by upstream and python2-only"; # Added 2022-04-26
   tychus = throw "tychus has been dropped due to the lack of maintenance from upstream since 2018"; # Added 2022-06-03
   typora = throw "Newer versions of typora use anti-user encryption and refuse to start. As such it has been removed"; # Added 2021-09-11

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38261,7 +38261,7 @@ with pkgs;
 
   trufflehog = callPackage ../tools/security/trufflehog { };
 
-  tvbrowser-bin = callPackage ../applications/misc/tvbrowser/bin.nix { };
+  tvbrowser = callPackage ../applications/misc/tvbrowser { };
 
   tvheadend = callPackage ../servers/tvheadend {
     dtv-scan-tables = dtv-scan-tables_tvheadend;


### PR DESCRIPTION
###### Description of changes

Updates and fixes `tvbrowser` (previously `tvbrowser-bin`), and add a simple test derivation to verify basic functionality.

`tvbrowser-bin` was broken since https://github.com/NixOS/nixpkgs/commit/48978fb8d0696d10e7bba6b3226358a682a2cb91 .  The pull request at hand fixes the package and introduces the following improvements:

* Update to current version 4.2.7.  This version is compatible with current `jre` and thereby fixes the package.
* Switch to a build from source instead of using pre-build jar files.  This is the reason for renaming the package to `tvbrowser`.  This is mentioned in the release notes; an alias is added.
* Use the `.desktop` file that is created by the build process instead of creating our own.
* Use the wrapper script that is created by the build process.
* Move output files from `/share/java/tvbrowser` to `/share/tvbrowser`.
* Update/Extend `meta` attributes.
* Add a simple test derivation that verifies the main program opens its windows.

To facilitate bisections, the changes are divided into separate commits.  More details on the rationale behind these changes are given in the commit messages.


###### Notifying maintainer

Dear @jfrankenau, maybe you can have a look and provide a review.  Given this package was broken for several years and this pull request introduces significant changes, I took the liberty of adding myself as co-maintainer.  I hope you don't mind.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


###### Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>tvbrowser-bin</li>
  </ul>
</details>
<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>tvbrowser</li>
  </ul>
</details>
