### PR TITLE
dtv-scan-tables: use version from linuxtv.org

### DIFF
--- a/pkgs/data/misc/dtv-scan-tables/default.nix
+++ b/pkgs/data/misc/dtv-scan-tables/default.nix
@@ -26,9 +26,20 @@ stdenv.mkDerivation rec {
   allowedReferences = [ ];
 
   meta = with lib; {
-    description = "Digital TV scan tables";
+    description = "Digital TV (DVB) channel/transponder scan tables";
     homepage = "https://github.com/tvheadend/dtv-scan-tables";
     license = with licenses; [ gpl2Only lgpl21Only ];
+    longDescription = ''
+      When scanning for dvb channels,
+      most applications require an initial set of
+      transponder coordinates (frequencies etc.).
+      These coordinates differ, depending of the
+      receiver's location or on the satellite.
+      The package delivers a collection of transponder
+      tables ready to be used by software like "dvbv5-scan".
+      The package at hand is maintained and used by tvheadend,
+      it is a fork of the original one hosted by linuxtv.org.
+    '';
     maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/data/misc/dtv-scan-tables/default.nix
+++ b/pkgs/data/misc/dtv-scan-tables/default.nix
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
     v4l-utils
   ];
 
-  installFlags = [
-    "DATADIR=$(out)"
+  makeFlags = [
+    "PREFIX=$(out)"
   ];
 
   meta = with lib; {

--- a/pkgs/data/misc/dtv-scan-tables/default.nix
+++ b/pkgs/data/misc/dtv-scan-tables/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     "PREFIX=$(out)"
   ];
 
+  allowedReferences = [ ];
+
   meta = with lib; {
     description = "Digital TV scan tables";
     homepage = "https://github.com/tvheadend/dtv-scan-tables";

--- a/pkgs/data/misc/dtv-scan-tables/linuxtv.nix
+++ b/pkgs/data/misc/dtv-scan-tables/linuxtv.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchurl
+, v4l-utils
+}:
+
+let
+
+  version_ = "2022-04-30-57ed29822750";
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "dtv-scan-tables";
+  version = "${version_}-linuxtv";
+
+  src = fetchurl {
+    url = "https://linuxtv.org/downloads/${pname}/${pname}-${version_}.tar.bz2";
+    hash = "sha256-amJoqjkkWTePo6E5IvwBWj+mP/gi9LDWTTPXE1Cm7J4=";
+  };
+
+  nativeBuildInputs = [
+    v4l-utils
+  ];
+
+  sourceRoot = "usr/share/dvb";
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  allowedReferences = [ ];
+
+  meta = with lib; {
+    # git repo with current revision is here:
+    #downloadPage = "https://git.linuxtv.org/dtv-scan-tables.git";
+    # Weekly releases are supposed to be here
+    downloadPage = "https://linuxtv.org/downloads/dtv-scan-tables/";
+    # but sometimes they lag behind several weeks or even months.
+    description = "Digital TV (DVB) channel/transponder scan tables";
+    homepage = "https://www.linuxtv.org/wiki/index.php/Dtv-scan-tables";
+    license = with licenses; [ gpl2Only lgpl21Only ];
+    longDescription = ''
+      When scanning for dvb channels,
+      most applications require an initial set of
+      transponder coordinates (frequencies etc.).
+      These coordinates differ, depending of the
+      receiver's location or on the satellite.
+      The package delivers a collection of transponder
+      tables ready to be used by software like "dvbv5-scan".
+    '';
+    maintainers = with maintainers; [ yarny ];
+  };
+}

--- a/pkgs/data/misc/dtv-scan-tables/tvheadend.nix
+++ b/pkgs/data/misc/dtv-scan-tables/tvheadend.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
   pname = "dtv-scan-tables";
-  version = "20221027";
+  version = "20221027-tvheadend";
 
   src = fetchFromGitHub {
     owner = "tvheadend";

--- a/pkgs/servers/tvheadend/default.nix
+++ b/pkgs/servers/tvheadend/default.nix
@@ -105,7 +105,7 @@ in stdenv.mkDerivation {
       --replace /usr/bin/tar ${gnutar}/bin/tar
 
     substituteInPlace src/input/mpegts/scanfile.c \
-      --replace /usr/share/dvb ${dtv-scan-tables}/dvbv5
+      --replace /usr/share/dvb ${dtv-scan-tables}/share/dvbv5
 
     # the version detection script `support/version` reads this file if it
     # exists, so let's just use that

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -455,7 +455,9 @@ with pkgs;
 
   dsq = callPackage ../tools/misc/dsq { };
 
+  dtv-scan-tables_linuxtv = callPackage ../data/misc/dtv-scan-tables/linuxtv.nix { };
   dtv-scan-tables_tvheadend = callPackage ../data/misc/dtv-scan-tables/tvheadend.nix { };
+  dtv-scan-tables = dtv-scan-tables_linuxtv;
 
   dufs = callPackage ../servers/http/dufs {
     inherit (darwin.apple_sdk.frameworks) Security;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -455,7 +455,7 @@ with pkgs;
 
   dsq = callPackage ../tools/misc/dsq { };
 
-  dtv-scan-tables = callPackage ../data/misc/dtv-scan-tables { };
+  dtv-scan-tables_tvheadend = callPackage ../data/misc/dtv-scan-tables/tvheadend.nix { };
 
   dufs = callPackage ../servers/http/dufs {
     inherit (darwin.apple_sdk.frameworks) Security;
@@ -37818,7 +37818,9 @@ with pkgs;
 
   tvbrowser-bin = callPackage ../applications/misc/tvbrowser/bin.nix { };
 
-  tvheadend = callPackage ../servers/tvheadend { };
+  tvheadend = callPackage ../servers/tvheadend {
+    dtv-scan-tables = dtv-scan-tables_tvheadend;
+  };
 
   twiggy = callPackage ../development/tools/twiggy { };
 


### PR DESCRIPTION
##### Description of changes

This pull request proposes to replace the current `dtv-scan-tables` package with a different one.


###### Some background

* `dtv-scan-tables` contains dvb transponder data (frequency etc.) that is needed by dvb software to perform a channel scan.  This data changes frequently, as tv stations are opened/closed/moved.
* To my knowledge, the "original" `dtv-scan-tables` repository is hosted by [linuxtv](https://www.linuxtv.org/wiki/index.php/Dtv-scan-tables).  [There exist many forks.](https://github.com/crazycat69/dtv-scan-tables/network/members)  [One of them is maintained by the tvheadend project.](https://github.com/tvheadend/dtv-scan-tables)
* The `tvheadend` package in Nixpkgs requires `dtv-scan-tables` to be built.  To this end, the tvheadend fork of `dtv-scan-tables` is build and pulled in as a dependency of the `tvheadend` package.  https://github.com/NixOS/nixpkgs/commit/b948496d975bc5866b0c9b73af547a86ae4307e5 introduced a new Nixpkgs top-level package `dtv-scan-tables` that is used as dependency of the `tvheadend` package;  before that commit, `dtv-scan-tables` hasn't been a Nixpkgs package of its own, instead it has been defined inside a `let .. in`-block in the `tvheadend` build recipe.

I've been using the `dtv-scan-tables` from linuxtv for many years.  I just tried the tvheadend-fork that is now packaged with Nixpkgs and it turned out that a lot of transponders and therefore channels are missing.  So, apparently, the tvheadend-fork is missing some data compared with the linuxtv version; but it is hard to really compare those versions, especially as I cannot move my dvb hardware to every place on earth and aim for all possible satellites :-)


###### Here are my observations

The following tests have been performed with a "Hauppauge WinTV HVR-5525 HD" (`Conexant CX23887/8 PCIe Broadcast Audio and Video Decoder with 3D Comb` according to `hwinfo`), located in southern Germany.  Channels were scanned with `${v4l-utils}/bin/dvbv5-scan --cc DE --get_frontend --nit --timeout-multiply 5`.

* Scanning for dvb-s channels at satellite position 19.2E (Astra) turns up 1130 channels with linuxtv, 597 channels with tvheadend.  Missing channels include many important (in my region) non-HD channels, like "kabel eins", "Das Erste", "ORF2E", "RTLZWEI", "SAT.1", "VOX", "ZDF".
* Scanning for dvb-s channels at satellite position 13.0E (Eutelsat Hotbird) turns up 1239 channels with linuxtv, 223 channels with tvheadend.  Missing channels include "MTV", "STARS.TV", several "BBC .." channels, and some more I don't recognize.
* Scanning for german dvb-t channels (`dvb-t/de-All`) from Munich Olympiaturm turns up 49 channels with linuxtv, nothing with tvheadend.

From this I conclude that the tvheadend scan tables are insufficient to discover all possible channels -- *at least in my region*.  However, I cannot claim that the linuxtv scan tables are superiour in general, as I cannot test that.  There are a lot of transponder entries in the tvheadend scan tables that are missing in the linuxtv scan tables, but e.g. in the case of german dvb-t, they are mostly outdated.

Another observation, after searching around on [Repology](https://repology.org/project/dtv-scan-tables/versions): At least [AUR](https://aur.archlinux.org/packages/dtv-scan-tables-git), [Debian Unstable](http://deb.debian.org/debian/pool/main/d/dtv-scan-tables/dtv-scan-tables_0+git20190925.6d01903-0.1.dsc), [Fedora Rawhide](https://src.fedoraproject.org/rpms/dtv-scan-tables/blob/rawhide/f/dtv-scan-tables.spec), [Gentoo](https://packages.gentoo.org/packages/media-tv/dtv-scan-tables) and [openSUSE Tumbleweed](https://build.opensuse.org/package/view_file/openSUSE:Factory/dtv-scan-tables/dtv-scan-tables.spec?expand=1) all use the linuxtv version for their `dtv-scan-tables` packages.


###### Proposed changes by this pull request

* Introduce the linuxtv-based `dtv-scan-tables` package as `pkgs.dtv-scan-tables_linuxtv`.
* Keep the previous tvheadend-based package, but rename it to `pkgs.dtv-scan-tables_tvheadend`.
* Use `{ dtv-scan-tables = dtv-scan-tables_tvheadend; }` for the `tvheadend` package.  So the `tvheadend` package may still use "its own" scan tables.
* Set `dtv-scan-tables = dtv-scan-tables_linuxtv;` in `all-packages.nix`, so that users independent of `tvheadend` use the linuxtv-based version.
* To make both packages compatible and get them in line with most other packages, the scan tables are moved from `/dvbv5` to `/share/dvbv5` (relative to the respective `$out`).  This permits to add those packages to `systemPackages` or to merge them with `buildEnv`.

Package attribute names are inspired by the rules for packages with multiple versions in https://nixos.org/manual/nixpkgs/stable/#sec-package-naming and https://nixos.org/manual/nixpkgs/stable/#sec-versioning .  Besides these changes, the pull request also polishes the existing `dtv-scan-tables` package: The build now ensures there are no stray references in the output, and `meta` descriptions are expanded a bit.


##### Informing maintainers

* Current (tvheadend-based) `dtv-scan-tables` has no maintainer, but @mweinelt introduced it with the commit mentioned above.
* `tvheadend` maintainer @simonvandel .

I'm retaining the tvheadend-based scan table package because I don't want to break `tvheadend` in any way.
Also, I can't tell if their scan tables have any advantage over the linuxtv-based ones.  If there isn't any advantage, and if `tvheadend` also works fine with linuxtv-based scan tables (i.e. finds all channels it's supposed to find), it might be better to completely replace tvheadend-based scan tables by linuxtv-based ones.

If you have the time, it would be nice if you could test `tvheadend`, especially with linuxtv-based scan tables.  If you conclude that linuxtv-based scan tables are sufficient for Nixpkgs, I can modify this pull request to completely remove the tvheadend-based package.


##### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


##### Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>dtv-scan-tables</li>
    <li>dtv-scan-tables_tvheadend</li>
    <li>tvheadend</li>
  </ul>
</details>
