### PR TITLE
autoPatchelfHook: fix symlink handling

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.py
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.py
@@ -131,7 +131,14 @@ def populate_cache(initial: List[Path], recursive: bool =False) -> None:
             if not path.is_file():
                 continue
 
+            # As an optimisation, resolve the symlinks here, as the target is unique
+            # XXX: (layus, 2022-07-25) is this really an optimisation in all cases ?
+            # It could make the rpath bigger or break the fragile precedence of $out.
             resolved = path.resolve()
+            # Do not use resolved paths when names do not match
+            if resolved.name != path.name:
+                resolved = path
+
             try:
                 with open_elf(path) as elf:
                     osabi = get_osabi(elf)

--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -159,16 +159,6 @@ let
         ln --symbolic --force --no-target-directory "$out/$(cut -b 7- <<< "$target")" "$link"
       done
     '';
-
-    # since 7b9fd5d1c9802131ca0a01ff08a3ff64379d2df4
-    # autopatchelf misses to add $out/lib to rpath;
-    # we have to call autopatchelf manually as it would
-    # run too late and overwrite our rpath otherwise
-    dontAutoPatchelf = true;
-    postFixup = ''
-      autoPatchelf $out
-      patchelf --add-rpath $out/lib $out/lib/*
-    '';
   };
 
   binPath = lib.makeBinPath ([ acl gnugrep procps ]


### PR DESCRIPTION
###### Description of changes

The [new](https://github.com/NixOS/nixpkgs/pull/149731) `autoPatchelfHook` builds a list of library files/paths to speed up library discovery when patching elf files.  However, under certain circumstances, this list gets faulty entries, leading to broken RPATHs.

In https://github.com/NixOS/nixpkgs/pull/172372 a workaround for `tsm-client` was implemented as its build process triggered the bug.  In https://github.com/NixOS/nixpkgs/pull/172372#issuecomment-1194687183 `autoPatchelfHook` author @layus uncovered and analysed the underlying bug, and drafted a patch to fix `auto-patchelf`.  Please see there or in the commit message for more details on the bug and the fix.

The pull-request at hand implements that patch, and removes the workaround from `tsm-client`.

`autoPatchelfHook` does not have a maintainer. Notifying its author and CODEOWNER:

Dear @layus , I took the liberty to wrap your patch in the pull request at hand.  Please have a look to verify if this is according to your intentions and could be merged.


###### Things done

I tested the fixed `autoPatchelfHook` with `tsm-client` and `zoom-us`:

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
