### PR TITLE
python3.pkgs.opencensus-context: init at 0.1.3

### DIFF
--- a/pkgs/development/python-modules/opencensus-context/default.nix
+++ b/pkgs/development/python-modules/opencensus-context/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, unittestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "opencensus-context";
+  version = "0.1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-oDEIw8ENjIC7Xd9cih8DMWH6YZcqmRf5ubOhhRfwCIw=";
+  };
+
+  pythonNamespaces = [
+    "opencensus.common"
+  ];
+
+  doCheck = false; # No tests in archive
+
+  meta = with lib; {
+    description = "OpenCensus Runtime Context";
+    homepage = "https://github.com/census-instrumentation/opencensus-python/tree/master/context/opencensus-context";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ billhuang ];
+  };
+}

--- a/pkgs/development/python-modules/opencensus/default.nix
+++ b/pkgs/development/python-modules/opencensus/default.nix
@@ -1,24 +1,11 @@
 { buildPythonPackage
 , fetchPypi
 , lib
-, python
 , unittestCheckHook
 , google-api-core
+, opencensus-context
 }:
 
-let
-  opencensus-context = buildPythonPackage rec {
-    pname = "opencensus-context";
-    version = "0.1.3";
-
-    checkInputs = [ unittestCheckHook ];
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "sha256-oDEIw8ENjIC7Xd9cih8DMWH6YZcqmRf5ubOhhRfwCIw=";
-    };
-  };
-in
 buildPythonPackage rec {
   pname = "opencensus";
   version = "0.11.0";
@@ -28,23 +15,20 @@ buildPythonPackage rec {
     sha256 = "sha256-AmIWq6uJ2U2FBJLz3GWVAFXsT4QRX6bHvq/7pEo0bkI=";
   };
 
-  buildInputs = [
-    # opencensus-context is embedded in opencensus
+  propagatedBuildInputs = [
+    google-api-core
     opencensus-context
   ];
 
-  propagatedBuildInputs = [
-    google-api-core
+  pythonNamespaces = [
+    "opencensus.common"
   ];
 
-  postInstall = ''
-    ln -sf ${opencensus-context}/${python.sitePackages}/opencensus/common/runtime_context \
-      $out/${python.sitePackages}/opencensus/common/
-  '';
+  doCheck = false; # No tests in sdist
 
-  checkInputs = [ unittestCheckHook ];
-
-  pythonImportsCheck = [ "opencensus" ];
+  pythonImportsCheck = [
+    "opencensus.common"
+  ];
 
   meta = with lib; {
     description = "A stats collection and distributed tracing framework";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6527,6 +6527,8 @@ self: super: with self; {
 
   opencensus = callPackage ../development/python-modules/opencensus { };
 
+  opencensus-context = callPackage ../development/python-modules/opencensus-context { };
+
   opencv3 = toPythonModule (pkgs.opencv3.override {
     enablePython = true;
     pythonPackages = self;


### PR DESCRIPTION
Split package into top-level Python library.

We need to propagate it just like any other package, otherwise dependents cannot detect it during installation.

The `__init__.py` collide since it uses old-style namespaces so we get rid of those. In the future we may need to extend the namespaces. This was enough for my dependency `opencensus-ext-azure`.

Having it as a top-level Python is just common practice; there is no good reason not to.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
