### PR TITLE
libtar: apply patches for CVE-2021-33640, CVE-2021-33643, CVE-2021-33644, CVE-2021-33645 and CVE-2021-33646

### DIFF
--- a/pkgs/development/libraries/libtar/default.nix
+++ b/pkgs/development/libraries/libtar/default.nix
@@ -18,10 +18,24 @@ stdenv.mkDerivation rec {
         inherit sha256;
       };
     in [
-      (fp "no_static_buffers"         "0yv90bhvqjj0v650gzn8fbzhdhzx5z0r1lh5h9nv39wnww435bd0")
+      (fetchpatch {
+        name = "no_static_buffers.patch";
+        url = "https://src.fedoraproject.org/rpms/libtar/raw/e25b692fc7ceaa387dafb865b472510754f51bd2/f/libtar-1.2.20-no-static-buffer.patch";
+        sha256 = "sha256-QcWOgdkNlALb+YDVneT1zCNAMf4d8IUm2kUUUy2VvJs=";
+      })
       (fp "no_maxpathlen"             "11riv231wpbdb1cm4nbdwdsik97wny5sxcwdgknqbp61ibk572b7")
       (fp "CVE-2013-4420"             "0d010190bqgr2ggy02qwxvjaymy9a22jmyfwdfh4086v876cbxpq")
       (fp "th_get_size-unsigned-int"  "1ravbs5yrfac98mnkrzciw9hd2fxq4dc07xl3wx8y2pv1bzkwm41")
+      (fetchpatch {
+        name = "CVE-2021-33643_CVE-2021-33644.patch";
+        url = "https://src.fedoraproject.org/rpms/libtar/raw/e25b692fc7ceaa387dafb865b472510754f51bd2/f/libtar-1.2.20-CVE-2021-33643-CVE-2021-33644.patch";
+        sha256 = "sha256-HdjotTvKJNntkdcV+kR08Ht/MyNeB6qUT0qo67BBOVA=";
+      })
+      (fetchpatch {
+        name = "CVE-2021-33645_CVE-2021-33646_CVE-2021-33640.patch";
+        url = "https://src.fedoraproject.org/rpms/libtar/raw/e25b692fc7ceaa387dafb865b472510754f51bd2/f/libtar-1.2.20-CVE-2021-33645-CVE-2021-33646.patch";
+        sha256 = "sha256-p9DEFAL5Y+Ldy5c9Wj9h/BSg4TDxIxCjCQJD+wGQ7oI=";
+      })
     ];
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2021-33640
https://nvd.nist.gov/vuln/detail/CVE-2021-33643
https://nvd.nist.gov/vuln/detail/CVE-2021-33644
https://nvd.nist.gov/vuln/detail/CVE-2021-33645
https://nvd.nist.gov/vuln/detail/CVE-2021-33646

One of the existing patch that was pulled from Debian has been replaced by the Fedora version to be able to apply the
CVE-2021-33645/CVE-2021-33646/CVE-2021-33640 patch without changes.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>10 packages built:</summary>
  <ul>
    <li>frog</li>
    <li>languageMachines.libfolia</li>
    <li>languageMachines.mbt</li>
    <li>languageMachines.test</li>
    <li>languageMachines.ticcutils</li>
    <li>languageMachines.timbl</li>
    <li>languageMachines.timblserver</li>
    <li>languageMachines.ucto</li>
    <li>libtar</li>
    <li>linuxstopmotion</li>
  </ul>
</details>