### PR TITLE
pomsky: 0.8 -> 0.9

### DIFF
--- a/pkgs/tools/text/pomsky/default.nix
+++ b/pkgs/tools/text/pomsky/default.nix
@@ -2,16 +2,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "pomsky";
-  version = "0.8";
+  version = "0.9";
 
   src = fetchFromGitHub {
     owner = "rulex-rs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1bb28f80wxjpy23mp9zamkprl8xbnx99rmmn8nxcaapq360zv9yi";
+    sha256 = "sha256-SR+cXCPcEejX3AauN3mS6zWU46m4nomMs1UVk+si1NY=";
   };
 
-  cargoSha256 = "sha256-Io8Ar7eNgULBIzI0rlitMI+9hLLWzI8pFwmH38hVVYU=";
+  cargoSha256 = "sha256-5ASB2zPL+0DAPWoB/Ez+DUbEjhDvVk00yyN75w6jzYk=";
+
+  # thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: invalid option '--test-threads''
+  doCheck = false;
 
   meta = with lib; {
     description = "A portable, modern regular expression language";


### PR DESCRIPTION
Diff: https://github.com/rulex-rs/pomsky/compare/v0.8...v0.9

Changelog: https://github.com/rulex-rs/pomsky/blob/v0.9/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
