### PR TITLE
python310Packages.dipy: 1.4.1 -> 1.5.0

### DIFF
--- a/pkgs/development/python-modules/dipy/default.nix
+++ b/pkgs/development/python-modules/dipy/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, isPy27
+, pythonOlder
 , packaging
 , pytest
 , cython
@@ -14,15 +14,15 @@
 
 buildPythonPackage rec {
   pname = "dipy";
-  version = "1.4.1";
+  version = "1.5.0";
 
-  disabled = isPy27;
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
-    owner  = "dipy";
-    repo   = pname;
-    rev    = version;
-    sha256 = "0zaqsiq73vprbqbzvzswjfmqgappl5vhpl2fwjrrda33c27klpzj";
+    owner = "dipy";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-kJ8JbnNpjTqGJXwwMTqZdgeN8fOEuxarycunDCRLB74=";
   };
 
   nativeBuildInputs = [ cython packaging ];

--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -11,13 +11,13 @@
 
 let
   pname = "pydicom";
-  version = "2.3.0";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "pydicom";
     repo = "pydicom";
-    rev = "v${version}";
-    hash = "sha256-CAQWaBkzecJ1VXQ5BnAUjmBMjh0I8y+gT7I4P4o2gqI=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-xt0aK908lLgNlpcI86OSxy96Z/PZnQh7+GXzJ0VMQGA=";
   };
 
   # Pydicom needs pydicom-data to run some tests. If these files aren't downloaded


### PR DESCRIPTION
python310Packages.pydicom: 2.3.0 -> 2.3.1

###### Description of changes

Routine update; unbreaks in python311Packages package set.

Results of `nixpkgs-review`:

```
6 packages marked as broken and skipped:
intensity-normalization python310Packages.intensity-normalization python310Packages.nipype python310Packages.pybids python311Packages.nipype python311Packages.pybids

6 packages failed to build:
expliot python310Packages.nitime python311Packages.nilearn python311Packages.nipy python311Packages.nitime python311Packages.pynetdicom

13 packages built:
python310Packages.dicom2nifti python310Packages.dipy python310Packages.nibabel python310Packages.nilearn python310Packages.nipy python310Packages.nitransforms python310Packages.pydicom python310Packages.pynetdicom python311Packages.dicom2nifti python311Packages.dipy python311Packages.nibabel python311Packages.nitransforms python311Packages.pydicom
```

`nitime` and `expliot` are broken for unrelated reasons (resp. test error and dependency issue) and most of the 3.11-related failures appear to be due to `twisted` failing to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
