### PR TITLE
haskell.compiler.ghc961: init at 9.6.1

### DIFF
--- a/pkgs/development/compilers/ghc/9.6.1.nix
+++ b/pkgs/development/compilers/ghc/9.6.1.nix
@@ -1,0 +1,4 @@
+import ./common-hadrian.nix rec {
+  version = "9.6.1";
+  sha256 = "fe5ac909cb8bb087e235de97fa63aff47a8ae650efaa37a2140f4780e21f34cb";
+}

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -395,9 +395,11 @@ stdenv.mkDerivation ({
 
   nativeBuildInputs = [
     perl ghc hadrian bootPkgs.alex bootPkgs.happy bootPkgs.hscolour
+    # autoconf and friends are necessary for hadrian to create the bindist
+    autoconf automake m4
   ] ++ lib.optionals (rev != null) [
     # We need to execute the boot script
-    autoconf automake m4 python3
+    python3
   ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
     autoSignDarwinBinariesHook
   ] ++ lib.optionals enableDocs [

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -1,0 +1,50 @@
+{ pkgs, haskellLib }:
+
+let
+  inherit (pkgs) lib;
+in
+
+with haskellLib;
+
+self: super: {
+  llvmPackages = lib.dontRecurseIntoAttrs self.ghc.llvmPackages;
+
+  # Disable GHC core libraries
+  array = null;
+  base = null;
+  binary = null;
+  bytestring = null;
+  Cabal = null;
+  Cabal-syntax = null;
+  containers = null;
+  deepseq = null;
+  directory = null;
+  exceptions = null;
+  filepath = null;
+  ghc-bignum = null;
+  ghc-boot = null;
+  ghc-boot-th = null;
+  ghc-compact = null;
+  ghc-heap = null;
+  ghc-prim = null;
+  ghci = null;
+  haskeline = null;
+  hpc = null;
+  integer-gmp = null;
+  libiserv = null;
+  mtl = null;
+  parsec = null;
+  pretty = null;
+  process = null;
+  rts = null;
+  stm = null;
+  system-cxx-std-lib = null;
+  template-haskell = null;
+  # terminfo is not built if GHC is a cross compiler
+  terminfo = if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then null else self.terminfo_0_4_1_5;
+  text = null;
+  time = null;
+  transformers = null;
+  unix = null;
+  xhtml = null;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15002,7 +15002,7 @@ with pkgs;
   haskellPackages = dontRecurseIntoAttrs
     # JS backend is only available for GHC >= 9.6
     (if stdenv.hostPlatform.isGhcjs
-     then haskell.packages.native-bignum.ghcHEAD
+     then haskell.packages.native-bignum.ghc96
      # Prefer native-bignum to avoid linking issues with gmp
      else if stdenv.hostPlatform.isStatic
      then haskell.packages.native-bignum.ghc92

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -25,6 +25,8 @@ let
     "ghc943"
     "ghc944"
     "ghc94"
+    "ghc96"
+    "ghc961"
     "ghcHEAD"
   ];
 
@@ -40,6 +42,8 @@ let
     "ghc942"
     "ghc943"
     "ghc944"
+    "ghc96"
+    "ghc961"
     "ghcHEAD"
   ];
 
@@ -299,6 +303,27 @@ in {
       llvmPackages = pkgs.llvmPackages_12;
     };
     ghc94 = ghc944;
+    ghc961 = callPackage ../development/compilers/ghc/9.6.1.nix {
+      bootPkgs =
+        # For GHC 9.2 no armv7l bindists are available.
+        if stdenv.hostPlatform.isAarch32 then
+          packages.ghc924
+        else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
+          packages.ghc924
+        else if stdenv.isAarch64 then
+          packages.ghc924BinaryMinimal
+        else
+          packages.ghc924Binary;
+      inherit (buildPackages.python3Packages) sphinx;
+      # Need to use apple's patched xattr until
+      # https://github.com/xattr/xattr/issues/44 and
+      # https://github.com/xattr/xattr/issues/55 are solved.
+      inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
+      # Support range >= 10 && < 15
+      buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_14;
+      llvmPackages = pkgs.llvmPackages_14;
+    };
+    ghc96 = ghc961;
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
       bootPkgs =
         # For GHC 9.2 no armv7l bindists are available.
@@ -315,7 +340,7 @@ in {
       # https://github.com/xattr/xattr/issues/44 and
       # https://github.com/xattr/xattr/issues/55 are solved.
       inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
-      # 2022-08-04: Support range >= 10 && < 15
+      # 2023-01-15: Support range >= 10 && < 15
       buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_14;
       llvmPackages = pkgs.llvmPackages_14;
     };
@@ -451,6 +476,12 @@ in {
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.4.x.nix { };
     };
     ghc94 = ghc942;
+    ghc961 = callPackage ../development/haskell-modules {
+      buildHaskellPackages = bh.packages.ghc961;
+      ghc = bh.compiler.ghc961;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.6.x.nix { };
+    };
+    ghc96 = ghc961;
     ghcHEAD = callPackage ../development/haskell-modules {
       buildHaskellPackages = bh.packages.ghcHEAD;
       ghc = bh.compiler.ghcHEAD;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -346,19 +346,26 @@ let
             };
           };
 
-      # TODO(@sternenseemann): when GHC 9.6 comes out we need separate jobs for
-      # default GHC and ghcHEAD.
-      pkgsCross.ghcjs.haskellPackages =
+      pkgsCross.ghcjs =
         removePlatforms
           [
             # Hydra output size of 3GB is exceeded
             "aarch64-linux"
           ]
           {
-            inherit (packagePlatforms pkgs.pkgsCross.ghcjs.haskellPackages)
-              ghc
-              hello
-            ;
+            haskellPackages = {
+              inherit (packagePlatforms pkgs.pkgsCross.ghcjs.haskellPackages)
+                ghc
+                hello
+              ;
+            };
+
+            haskell.packages.ghcHEAD = {
+              inherit (packagePlatforms pkgs.pkgsCross.ghcjs.haskell.packages.ghcHEAD)
+                ghc
+                hello
+              ;
+            };
           };
     })
     (versionedCompilerJobs {


### PR DESCRIPTION
xhtml seems to be built unconditionally now which is at least one thing improved by hadrian.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
