### PR TITLE
lib: make extender available on self-references

### DIFF
--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -107,7 +107,7 @@ rec {
   # Same as `makeExtensible` but the name of the extending attribute is
   # customized.
   makeExtensibleWithCustomName = extenderName: rattrs:
-    fix' rattrs // {
+    fix' (self: (rattrs self) // {
       ${extenderName} = f: makeExtensibleWithCustomName extenderName (extends f rattrs);
-   };
+    });
 }


### PR DESCRIPTION
###### Description of changes

# Existing Behavior

At present, recursive self-references to extensible sets do not themselves have a reference to the extender function:
```
Welcome to Nix 2.12.0. Type :? for help.

nix-repl> masterLib = (builtins.getFlake "github:NixOS/nixpkgs").lib

nix-repl> r1 = masterLib.makeExtensible (self: { inherit self; })

nix-repl> r1
{ __unfix__ = «lambda @ (string):1:28»; extend = «lambda @ /nix/store/al18j0766bggz6hf2da2hrsmbyg8inij-source/lib/fixed-points.nix:111:25»; self = { ... }; }

nix-repl> r1.self
{ __unfix__ = «lambda @ (string):1:28»; self = { ... }; }

nix-repl> r2 = r1.extend (final: prev: { inherit final; })

nix-repl> r2
{ __unfix__ = «lambda @ /nix/store/al18j0766bggz6hf2da2hrsmbyg8inij-source/lib/fixed-points.nix:69:24»; extend = «lambda @ /nix/store/al18j0766bggz6hf2da2hrsmbyg8inij-source/lib/fixed-points.nix:111:25»; final = { ... }; self = «repeated»; }

nix-repl> r2.self
{ __unfix__ = «lambda @ /nix/store/al18j0766bggz6hf2da2hrsmbyg8inij-source/lib/fixed-points.nix:69:24»; final = { ... }; self = «repeated»; }

nix-repl> r2.final
{ __unfix__ = «lambda @ /nix/store/al18j0766bggz6hf2da2hrsmbyg8inij-source/lib/fixed-points.nix:69:24»; final = { ... }; self = «repeated»; }
```

Note: What you should be noticing is that `r1` and `r2` contain a function, `extend`, but none of the captured self-references have access to it.

# Behavior With Change

With this change, the extender function becomes available:

```
nix-repl> ourLib = (builtins.getFlake "github:clhodapp/nixpkgs/fix/extensible-sets").lib

nix-repl> r3 = ourLib.makeExtensible (self: { inherit self; })    

nix-repl> r3
{ __unfix__ = «lambda @ /nix/store/n6pm7h50pvva9kpbval5ifb1rhc33gvi-source/lib/fixed-points.nix:110:11»; extend = «lambda @ /nix/store/n6pm7h50pvva9kpbval5ifb1rhc33gvi-source/lib/fixed-points.nix:111:25»; self = { ... }; }

nix-repl> r3.self
{ __unfix__ = «lambda @ /nix/store/n6pm7h50pvva9kpbval5ifb1rhc33gvi-source/lib/fixed-points.nix:110:11»; extend = «lambda @ /nix/store/n6pm7h50pvva9kpbval5ifb1rhc33gvi-source/lib/fixed-points.nix:111:25»; self = { ... }; }

nix-repl> r4 = r3.extend (final: prev: { inherit final; }) 

nix-repl> r4
{ __unfix__ = «lambda @ /nix/store/n6pm7h50pvva9kpbval5ifb1rhc33gvi-source/lib/fixed-points.nix:110:11»; extend = «lambda @ /nix/store/n6pm7h50pvva9kpbval5ifb1rhc33gvi-source/lib/fixed-points.nix:111:25»; final = { ... }; self = «repeated»; }

nix-repl> r4.self
{ __unfix__ = «lambda @ /nix/store/n6pm7h50pvva9kpbval5ifb1rhc33gvi-source/lib/fixed-points.nix:110:11»; extend = «lambda @ /nix/store/n6pm7h50pvva9kpbval5ifb1rhc33gvi-source/lib/fixed-points.nix:111:25»; final = { ... }; self = «repeated»; }

nix-repl> r4.final
{ __unfix__ = «lambda @ /nix/store/n6pm7h50pvva9kpbval5ifb1rhc33gvi-source/lib/fixed-points.nix:110:11»; extend = «lambda @ /nix/store/n6pm7h50pvva9kpbval5ifb1rhc33gvi-source/lib/fixed-points.nix:111:25»; final = { ... }; self = «repeated»; }
``` 

It behaves just as you would expect it would; Any extension made on the parent set shows up in captured child extensions:
```
nix-repl> r5 = ourLib.makeExtensible (self: { a = self.extend (self': prev: { b = self'.x;});})

nix-repl> r6 = r5.extend (self: prev: { x = 1; })

nix-repl> r6.a.b
1
```

# Why?

This obviously makes the self-references "higher-fidelity" in the sense that they more closely match the final composed set. However, one might ask "Why do you actually need this?", given that the examples given so far seem somewhat abstract and arcane. The answer is: (NixOS, etc.) module composition!

The `lib` arg passed to modules happens to be an extensible set self-reference. Here's a manual traceback of code showing how that happens:
  * https://github.com/NixOS/nixpkgs/blob/a21493d40d8e121bd3053e445e8c8e44ab66887f/lib/modules.nix#L261
  * https://github.com/NixOS/nixpkgs/blob/a21493d40d8e121bd3053e445e8c8e44ab66887f/lib/modules.nix#L1
  * https://github.com/NixOS/nixpkgs/blob/a21493d40d8e121bd3053e445e8c8e44ab66887f/lib/default.nix#L33
  * https://github.com/NixOS/nixpkgs/blob/a21493d40d8e121bd3053e445e8c8e44ab66887f/lib/default.nix#L10-L11

The effect of this is that the `lib` received by modules is not a full-featured nixpkgs `lib`. The impact of this is that you can't do the thing I'm trying to do: compose an extended nixpkgs `lib` in a module.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
