### PR TITLE
crazydiskinfo: init at version 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16325,4 +16325,10 @@
     github = "franzmondlichtmann";
     githubId = 105480088;
   };
+  asimpson = {
+    email = "adam@adamsimpson.net";
+    name = "Adam Simpson";
+    github = "asimpson";
+    githubId = 1048831;
+  };
 }

--- a/pkgs/applications/misc/crazydiskinfo/default.nix
+++ b/pkgs/applications/misc/crazydiskinfo/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, cmake, ncurses, libatasmart, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "crazydiskinfo";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "pabs3";
+    repo = pname;
+    rev = "8563aa8636c37f0b889f3b4b27338691efdeac2b";
+    hash = "sha256-pfkJqVtrjoauUQRXLJGvnGWx+TpkbdN62h5raVdqb1g=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ ncurses libatasmart ];
+
+  configurePhase = ''
+    mkdir build
+    cd build
+    cmake ..
+  '';
+
+  installPhase = "install -D crazy $out/bin/crazy";
+
+  meta = with lib; {
+    description = "crazydiskinfo provides a TUI that surfaces smart data and uses Crystal Disk Info's algorithm for disk health and temperatures.";
+    homepage = "https://github.com/otakuto/crazydiskinfo";
+    license = licenses.mit;
+    maintainers = with maintainers; [ asimpson ];
+    platforms = platforms.linux;
+    mainProgram = "crazy";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38585,4 +38585,6 @@ with pkgs;
   jfrog-cli = callPackage ../tools/misc/jfrog-cli { };
 
   ov = callPackage ../tools/text/ov { };
+
+  crazydiskinfo = callPackage ../applications/misc/crazydiskinfo { };
 }


### PR DESCRIPTION
###### Description of changes
[crazydiskinfo](https://github.com/otakuto/crazydiskinfo) provides a TUI that surfaces `smart` data and uses [Crystal Disk Info's](https://crystalmark.info/en/software/crystaldiskinfo/) algorithm for disk health and temperatures.

This currently builds against a [PR][1] that fixes some cmake errors. I will submit a PR to build against the main branch once that PR is merged.

[1]: https://github.com/otakuto/crazydiskinfo/pull/33

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
