### PR TITLE
nodePackages.nxapi: init at 1.6.0

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -241,6 +241,7 @@
 , "npm-check-updates"
 , "npm-merge-driver"
 , "nrm"
+, "nxapi"
 , "ocaml-language-server"
 , "orval"
 , "parcel-bundler"

--- a/pkgs/development/node-packages/overrides.nix
+++ b/pkgs/development/node-packages/overrides.nix
@@ -354,6 +354,15 @@ final: prev: {
     '';
   };
 
+  nxapi = prev.nxapi.override {
+    nativeBuildInputs = [ pkgs.buildPackages.makeWrapper ];
+
+    # Disable checking for updates at runtime.
+    postInstall = ''
+      wrapProgram "$out/bin/nxapi" --set NXAPI_SKIP_UPDATE_CHECK 1
+    '';
+  };
+
   parcel = prev.parcel.override {
     buildInputs = [ final.node-gyp-build ];
     preRebuild = ''


### PR DESCRIPTION
###### Description of changes

A tool for interacting with the Nintendo Switch Online and Nintendo Switch Parental Controls APIs.
Notably provides Discord Rich Presence for Switch games, Switch friend notifications, etc.

`/pkgs/development/node-packages/generate.sh` keeps failing for me with a seemingly unrelated error while fetching metadata for a lot of of other stuff, after running for nearly 30 minutes each attempt. I had to splice together a `node2nix` run for just this package with the complete generated files in this repository, ultimately...

Still to be done is the Electron app that is included with `nxapi`, which is supposed to be runnable with `nxapi app`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
