### PR TITLE
stdenv: drop remove unnecessary env var

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -524,7 +524,7 @@ buildStdenv.mkDerivation ({
             fi
 
             # Extract the debug info.
-            header "separating debug info from $i (build ID $id)"
+            echo "separating debug info from $i (build ID $id)"
             mkdir -p "$dst/''${id:0:2}"
             $OBJCOPY --only-keep-debug "$i" "$dst/''${id:0:2}/''${id:2}.debug"
 

--- a/pkgs/build-support/fetchbzr/builder.sh
+++ b/pkgs/build-support/fetchbzr/builder.sh
@@ -1,10 +1,8 @@
 if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source "$stdenv/setup"
 
-header "exporting \`$url' (revision $rev) into \`$out'"
+echo "exporting \`$url' (revision $rev) into \`$out'"
 
 # Perform a lightweight checkout so that we don't end up importing
 # all the repository's history.
 BZR_LOG=/dev/null bzr -Ossl.cert_reqs=none export -r "$rev" --format=dir "$out" "$url"
-
-stopNest

--- a/pkgs/build-support/fetchcvs/builder.sh
+++ b/pkgs/build-support/fetchcvs/builder.sh
@@ -24,5 +24,3 @@ else
 fi
 (cd export && cvs -f -z0 -d "$cvsRoot" export $tag "$module")
 mv export/* $out
-
-stopNest

--- a/pkgs/build-support/fetchdarcs/builder.sh
+++ b/pkgs/build-support/fetchdarcs/builder.sh
@@ -11,10 +11,8 @@ elif test -n "$context"; then
     tagflags="--context=$context"
 fi
 
-header "getting $url $partial ${tagtext} into $out"
+echo "getting $url $partial ${tagtext} into $out"
 
 darcs get --lazy $tagflags "$url" "$out"
 # remove metadata, because it can change
 rm -rf "$out/_darcs"
-
-stopNest

--- a/pkgs/build-support/fetchdocker/fetchdocker-builder.sh
+++ b/pkgs/build-support/fetchdocker/fetchdocker-builder.sh
@@ -1,6 +1,6 @@
 if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source "${stdenv}/setup"
-header "exporting ${repository}/${imageName} (tag: ${tag}) into ${out}"
+echo "exporting ${repository}/${imageName} (tag: ${tag}) into ${out}"
 mkdir -p "${out}"
 
 cat <<EOF > "${out}/compositeImage.sh"
@@ -26,4 +26,3 @@ ${gnutar}/bin/tar \
   -c "${manifest}" "${repositories}" -T "${imageFileStorePaths}"
 EOF
 chmod +x "${out}/compositeImage.sh"
-stopNest

--- a/pkgs/build-support/fetchdocker/generic-fetcher.nix
+++ b/pkgs/build-support/fetchdocker/generic-fetcher.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   inherit name;
   builder = writeText "${fetcher}-builder.sh" ''
     source "$stdenv/setup"
-    header "${fetcher} exporting to $out"
+    echo "${fetcher} exporting to $out"
 
     declare -A creds
 
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
     fi
 
     if [ -f "$dockerCredentialsFile" ]; then
-      header "using credentials from $dockerCredentialsFile"
+      echo "using credentials from $dockerCredentialsFile"
 
       CREDSFILE=$(cat "$dockerCredentialsFile")
       creds[token]=$(${awk} -F'=' '/DOCKER_TOKEN/ {print $2}' <<< "$CREDSFILE" | head -n1)
@@ -77,8 +77,6 @@ stdenv.mkDerivation {
       ${layerDigestFlag} \
       "${repository}/${imageName}" \
       "${tag}"
-
-    stopNest
   '';
 
   buildInputs = [ haskellPackages.hocker ];

--- a/pkgs/build-support/fetchfirefoxaddon/default.nix
+++ b/pkgs/build-support/fetchfirefoxaddon/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
   builder = writeScript "xpibuilder" ''
     source $stdenv/setup
 
-    header "firefox addon $name into $out"
+    echo "firefox addon $name into $out"
 
     UUID="${extid}"
     mkdir -p "$out/$UUID"

--- a/pkgs/build-support/fetchfossil/builder.sh
+++ b/pkgs/build-support/fetchfossil/builder.sh
@@ -1,6 +1,6 @@
 if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
-header "Cloning Fossil $url [$rev] into $out"
+echo "Cloning Fossil $url [$rev] into $out"
 
 # Fossil, bless its adorable little heart, wants to write global configuration
 # to $HOME/.fossil. AFAICT, there is no way to disable this functionality.
@@ -19,5 +19,3 @@ popd
 
 # Just nuke the checkout file.
 rm $out/.fslckout
-
-stopNest

--- a/pkgs/build-support/fetchgit/builder.sh
+++ b/pkgs/build-support/fetchgit/builder.sh
@@ -6,7 +6,7 @@
 if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
-header "exporting $url (rev $rev) into $out"
+echo "exporting $url (rev $rev) into $out"
 
 $SHELL $fetcher --builder --url "$url" --out "$out" --rev "$rev" \
   ${leaveDotGit:+--leave-dotGit} \
@@ -18,4 +18,3 @@ $SHELL $fetcher --builder --url "$url" --out "$out" --rev "$rev" \
   ${branchName:+--branch-name "$branchName"}
 
 runHook postFetch
-stopNest

--- a/pkgs/build-support/fetchhg/builder.sh
+++ b/pkgs/build-support/fetchhg/builder.sh
@@ -1,10 +1,8 @@
 if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
-header "getting $url${rev:+ ($rev)} into $out"
+echo "getting $url${rev:+ ($rev)} into $out"
 
 hg clone --insecure "$url" hg-clone
 
 hg archive -q$subrepoClause -y ${rev:+-r "$rev"} --cwd hg-clone $out
 rm -f $out/.hg_archival.txt
-
-stopNest

--- a/pkgs/build-support/fetchmtn/builder.sh
+++ b/pkgs/build-support/fetchmtn/builder.sh
@@ -8,7 +8,7 @@ if ! [ -f "$cacheDB" ]; then
     mtn --db "$cacheDB" db init
 fi
 
-header "getting revision $selector";
+echo "getting revision $selector";
 
 done=;
 for source in $dbs; do
@@ -32,9 +32,7 @@ for source in $dbs; do
     fi;
 done;
 
-stopNest;
-
-header "checking out the revision $revision";
+echo "checking out the revision $revision";
 
 if test -n "$done"; then
     mtn checkout --db "$cacheDB" -r "$revision" "$out" -b "${branch}"
@@ -43,10 +41,6 @@ else
     exit 1;
 fi;
 
-stopNest
-
-header "clearing _MTN in the output"
+echo "clearing _MTN in the output"
 
 rm -rf "$out/_MTN"
-
-stopNest

--- a/pkgs/build-support/fetchsvn/builder.sh
+++ b/pkgs/build-support/fetchsvn/builder.sh
@@ -1,7 +1,7 @@
 if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
-header "exporting $url (r$rev) into $out"
+echo "exporting $url (r$rev) into $out"
 
 if test -n "$http_proxy"; then
     # Configure proxy
@@ -22,5 +22,3 @@ fi;
 svn export --trust-server-cert --non-interactive \
     ${ignoreExternals:+--ignore-externals} ${ignoreKeywords:+--ignore-keywords} \
     -r "$rev" "$url" "$out"
-
-stopNest

--- a/pkgs/build-support/fetchsvnssh/builder.sh
+++ b/pkgs/build-support/fetchsvnssh/builder.sh
@@ -1,7 +1,7 @@
 if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
-header "exporting $url (r$rev) into $out"
+echo "exporting $url (r$rev) into $out"
 
 if test "$sshSupport"; then
     export SVN_SSH="$openssh/bin/ssh"
@@ -12,5 +12,3 @@ fi
 # whether the server is being spoofed --- only the cryptographic
 # hash of the output matters.
 expect -f $sshSubversion "$username" "$password" "$rev" "$url" $out
-
-stopNest

--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -37,7 +37,7 @@ if [ -n "$downloadToTemp" ]; then downloadedFile="$TMPDIR/file"; fi
 tryDownload() {
     local url="$1"
     echo
-    header "trying $url"
+    echo "trying $url"
     local curlexit=18;
 
     success=

--- a/pkgs/build-support/release/debian-build.nix
+++ b/pkgs/build-support/release/debian-build.nix
@@ -43,9 +43,8 @@ vmTools.runInLinuxImage (stdenv.mkDerivation (
       [ ! -f /etc/lsb-release ] || (source /etc/lsb-release; echo "OS release: $DISTRIB_DESCRIPTION")
       echo "System/kernel: $(uname -a)"
       if test -e /etc/debian_version; then echo "Debian release: $(cat /etc/debian_version)"; fi
-      header "installed Debian packages"
+      echo "installed Debian packages"
       dpkg-query --list
-      stopNest
     '';
 
     installPhase = ''
@@ -73,11 +72,10 @@ vmTools.runInLinuxImage (stdenv.mkDerivation (
       [ "$(echo $out/debs/*.deb)" != "" ]
 
       for i in $out/debs/*.deb; do
-        header "Generated DEB package: $i"
+        echo "Generated DEB package: $i"
         dpkg-deb --info "$i"
         pkgName=$(dpkg-deb -W "$i" | awk '{print $1}')
         echo "file deb $i" >> $out/nix-support/hydra-build-products
-        stopNest
       done
       dpkg -i $out/debs/*.deb
 

--- a/pkgs/build-support/release/nix-build.nix
+++ b/pkgs/build-support/release/nix-build.nix
@@ -74,10 +74,9 @@ stdenv.mkDerivation (
       if test -n "$succeedOnFailure"; then
           if test -n "$keepBuildDirectory"; then
               KEEPBUILDDIR="$out/`basename $TMPDIR`"
-              header "Copying build directory to $KEEPBUILDDIR"
+              echo "Copying build directory to $KEEPBUILDDIR"
               mkdir -p $KEEPBUILDDIR
               cp -R "$TMPDIR/"* $KEEPBUILDDIR
-              stopNest
           fi
       fi
     '';

--- a/pkgs/build-support/release/source-tarball.nix
+++ b/pkgs/build-support/release/source-tarball.nix
@@ -64,10 +64,9 @@ stdenv.mkDerivation (
       if test -n "$succeedOnFailure"; then
           if test -n "$keepBuildDirectory"; then
               KEEPBUILDDIR="$out/`basename $TMPDIR`"
-              header "Copying build directory to $KEEPBUILDDIR"
+              echo "Copying build directory to $KEEPBUILDDIR"
               mkdir -p $KEEPBUILDDIR
               cp -R "$TMPDIR/"* $KEEPBUILDDIR
-              stopNest
           fi
       fi
     '';

--- a/pkgs/build-support/setup-hooks/audit-tmpdir.sh
+++ b/pkgs/build-support/setup-hooks/audit-tmpdir.sh
@@ -13,7 +13,7 @@ auditTmpdir() {
     local dir="$1"
     [ -e "$dir" ] || return 0
 
-    header "checking for references to $TMPDIR/ in $dir..."
+    echo "checking for references to $TMPDIR/ in $dir..."
 
     local i
     find "$dir" -type f -print0 | while IFS= read -r -d $'\0' i; do
@@ -36,6 +36,4 @@ auditTmpdir() {
         fi
 
     done
-
-    stopNest
 }

--- a/pkgs/build-support/setup-hooks/canonicalize-jars.sh
+++ b/pkgs/build-support/setup-hooks/canonicalize-jars.sh
@@ -6,12 +6,11 @@ fixupOutputHooks+=('if [ -z "$dontCanonicalizeJars" -a -e "$prefix" ]; then cano
 
 canonicalizeJarsIn() {
   local dir="$1"
-  header "canonicalizing jars in $dir"
+  echo "canonicalizing jars in $dir"
   dir="$(realpath -sm -- "$dir")"
   while IFS= read -rd '' f; do
     canonicalizeJar "$f"
   done < <(find -- "$dir" -type f -name '*.jar' -print0)
-  stopNest
 }
 
 source @canonicalize_jar@

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -100,8 +100,6 @@ patchShebangs() {
             fi
         fi
     done < <(find "$@" -type f -perm -0100 -print0)
-
-    stopNest
 }
 
 patchShebangsAuto () {

--- a/pkgs/build-support/setup-hooks/postgresql-test-hook/postgresql-test-hook.sh
+++ b/pkgs/build-support/setup-hooks/postgresql-test-hook/postgresql-test-hook.sh
@@ -53,7 +53,7 @@ EOF
     echo >&2 'initdb not found. Did you add postgresql to the checkInputs?'
     false
   fi
-  header 'initializing postgresql'
+  echo 'initializing postgresql'
   initdb -U postgres
 
   # Move the socket
@@ -65,15 +65,15 @@ EOF
     echo "listen_addresses = ''" >>"$PGDATA/postgresql.conf"
   fi
 
-  header 'starting postgresql'
+  echo 'starting postgresql'
   eval "${postgresqlStartCommands:-pg_ctl start}"
 
-  header 'setting up postgresql'
+  echo 'setting up postgresql'
   eval "$postgresqlTestSetupCommands"
 
 }
 
 postgresqlStop() {
-  header 'stopping postgresql'
+  echo 'stopping postgresql'
   pg_ctl stop
 }

--- a/pkgs/build-support/setup-hooks/separate-debug-info.sh
+++ b/pkgs/build-support/setup-hooks/separate-debug-info.sh
@@ -26,7 +26,7 @@ _separateDebugInfo() {
         fi
 
         # Extract the debug info.
-        header "separating debug info from $i (build ID $id)"
+        echo "separating debug info from $i (build ID $id)"
         mkdir -p "$dst/${id:0:2}"
 
         # This may fail, e.g. if the binary is for a different

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -527,9 +527,8 @@ rec {
       echo "System/kernel: $(uname -a)"
       if test -e /etc/fedora-release; then echo "Fedora release: $(cat /etc/fedora-release)"; fi
       if test -e /etc/SuSE-release; then echo "SUSE release: $(cat /etc/SuSE-release)"; fi
-      header "installed RPM packages"
+      echo "installed RPM packages"
       rpm -qa --qf "%{Name}-%{Version}-%{Release} (%{Arch}; %{Distribution}; %{Vendor})\n"
-      stopNest
     '';
 
     buildPhase = ''
@@ -559,9 +558,8 @@ rec {
       find $rpmout -name "*.rpm" -exec cp {} $out/$outDir \;
 
       for i in $out/$outDir/*.rpm; do
-        header "Generated RPM/SRPM: $i"
+        echo "Generated RPM/SRPM: $i"
         rpm -qip $i
-        stopNest
       done
 
       eval "$postInstall"

--- a/pkgs/development/compilers/chicken/4/fetchegg/builder.sh
+++ b/pkgs/development/compilers/chicken/4/fetchegg/builder.sh
@@ -1,10 +1,8 @@
 if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
-header "exporting egg ${eggName} (version $version) into $out"
+echo "exporting egg ${eggName} (version $version) into $out"
 
 mkdir -p $out
 chicken-install -r "${eggName}:${version}"
 cp -r ${eggName}/* $out/
-
-stopNest

--- a/pkgs/development/compilers/chicken/5/fetchegg/builder.sh
+++ b/pkgs/development/compilers/chicken/5/fetchegg/builder.sh
@@ -1,11 +1,9 @@
 if [ -e .attrs.sh ]; then source .attrs.sh; fi
 source $stdenv/setup
 
-header "exporting egg ${eggName} (version $version) into $out"
+echo "exporting egg ${eggName} (version $version) into $out"
 
 mkdir -p $out
 CHICKEN_EGG_CACHE=. chicken-install -r "${eggName}:${version}"
 rm ${eggName}/{STATUS,TIMESTAMP}
 cp -r ${eggName}/* $out/
-
-stopNest

--- a/pkgs/development/tools/misc/automake/automake-1.11.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.11.x.nix
@@ -22,9 +22,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ perl autoconf ];
   buildInputs = [ autoconf ];
 
-  # Disable indented log output from Make, otherwise "make.test" will
-  # fail.
-  preCheck = "unset NIX_INDENT_MAKE";
   doCheck = false; # takes _a lot_ of time, fails 11 of 782 tests
 
   # Don't fixup "#! /bin/sh" in Libtool, otherwise it will use the

--- a/pkgs/development/tools/misc/automake/automake-1.15.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.15.x.nix
@@ -16,9 +16,6 @@ stdenv.mkDerivation rec {
 
   patches = [ ./help2man-SOURCE_DATE_EPOCH-support.patch ];
 
-  # Disable indented log output from Make, otherwise "make.test" will
-  # fail.
-  preCheck = "unset NIX_INDENT_MAKE";
   doCheck = false; # takes _a lot_ of time, fails 3 out of 2698 tests, all seem to be related to paths
   doInstallCheck = false; # runs the same thing, fails the same tests
 

--- a/pkgs/development/tools/misc/automake/automake-1.16.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.16.x.nix
@@ -15,9 +15,6 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
-  # Disable indented log output from Make, otherwise "make.test" will
-  # fail.
-  preCheck = "unset NIX_INDENT_MAKE";
   doCheck = false; # takes _a lot_ of time, fails 3 out of 2698 tests, all seem to be related to paths
   doInstallCheck = false; # runs the same thing, fails the same tests
 

--- a/pkgs/development/tools/misc/patchelf/setup-hook.sh
+++ b/pkgs/development/tools/misc/patchelf/setup-hook.sh
@@ -8,7 +8,7 @@ patchELF() {
     local dir="$1"
     [ -e "$dir" ] || return 0
 
-    header "shrinking RPATHs of ELF executables and libraries in $dir"
+    echo "shrinking RPATHs of ELF executables and libraries in $dir"
 
     local i
     while IFS= read -r -d $'\0' i; do
@@ -17,6 +17,4 @@ patchELF() {
         echo "shrinking $i"
         patchelf --shrink-rpath "$i" || true
     done < <(find "$dir" -type f -print0)
-
-    stopNest
 }

--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -132,7 +132,7 @@ stdenv.mkDerivation rec {
   # NixOS module which is based on those files without relying on them. Still, it
   # is helpful to have properly patched versions for non-NixOS distributions.
   postFixup = ''
-    header "Fixing aesmd.service"
+    echo "Fixing aesmd.service"
     substituteInPlace $out/lib/systemd/system/aesmd.service \
       --replace '@aesm_folder@' \
                 "$out/aesm" \
@@ -149,7 +149,7 @@ stdenv.mkDerivation rec {
       --replace "/bin/kill" \
                 "${coreutils}/bin/kill"
 
-    header "Fixing remount-dev-exec.service"
+    echo "Fixing remount-dev-exec.service"
     substituteInPlace $out/lib/systemd/system/remount-dev-exec.service \
       --replace '/bin/mount' \
                 "${util-linux}/bin/mount"

--- a/pkgs/os-specific/linux/sgx/sdk/default.nix
+++ b/pkgs/os-specific/linux/sgx/sdk/default.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation rec {
       };
     in
     ''
-      header "Setting up IPP crypto build artifacts"
+      echo "Setting up IPP crypto build artifacts"
 
       pushd 'external/ippcp_internal'
 
@@ -149,7 +149,7 @@ stdenv.mkDerivation rec {
     ./linux/installer/bin/sgx_linux_x64_sdk_${version}.bin -prefix $installDir
     installDir=$installDir/sgxsdk
 
-    header "Move files created by installer"
+    echo "Move files created by installer"
 
     mkdir -p $out/bin
     pushd $out
@@ -206,15 +206,15 @@ stdenv.mkDerivation rec {
 
 
   preFixup = ''
-    header "Strip sgxsdk prefix"
+    echo "Strip sgxsdk prefix"
     for path in "$out/share/bin/environment" "$out/bin/sgx-gdb"; do
       substituteInPlace $path --replace "$TMPDIR/sgxsdk" "$out"
     done
 
-    header "Fixing pkg-config files"
+    echo "Fixing pkg-config files"
     sed -i "s|prefix=.*|prefix=$out|g" $out/lib/pkgconfig/*.pc
 
-    header "Fixing SGX_SDK default in samples"
+    echo "Fixing SGX_SDK default in samples"
     substituteInPlace $out/share/SampleCode/LocalAttestation/buildenv.mk \
       --replace '/opt/intel/sgxsdk' "$out"
     for file in $out/share/SampleCode/*/Makefile; do
@@ -222,12 +222,12 @@ stdenv.mkDerivation rec {
         --replace '/opt/intel/sgxsdk' "$out"
     done
 
-    header "Fixing BINUTILS_DIR in buildenv.mk"
+    echo "Fixing BINUTILS_DIR in buildenv.mk"
     substituteInPlace $out/share/bin/buildenv.mk \
       --replace 'BINUTILS_DIR ?= /usr/local/bin' \
                 'BINUTILS_DIR ?= ${BINUTILS_DIR}'
 
-    header "Fixing GDB path in bin/sgx-gdb"
+    echo "Fixing GDB path in bin/sgx-gdb"
     substituteInPlace $out/bin/sgx-gdb --replace '/usr/local/bin/gdb' '${gdb}/bin/gdb'
   '';
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -125,11 +125,6 @@ _eval() {
 ######################################################################
 # Logging.
 
-# Obsolete.
-stopNest() { true; }
-header() { echo "$1"; }
-closeNest() { true; }
-
 # Prints a command such that all word splits are unambiguous. We need
 # to split the command in three parts because the middle format string
 # will be, and must be, repeated for each argument. The first argument
@@ -798,10 +793,6 @@ unset _HOST_PATH
 unset _XDG_DATA_DIRS
 
 
-# Make GNU Make produce nested output.
-export NIX_INDENT_MAKE=1
-
-
 # Normalize the NIX_BUILD_CORES variable. The value might be 0, which
 # means that we're supposed to try and auto-detect the number of
 # available CPU cores at run-time.
@@ -1033,7 +1024,7 @@ _defaultUnpack() {
 
 unpackFile() {
     curSrc="$1"
-    header "unpacking source archive $curSrc" 3
+    echo "unpacking source archive $curSrc"
     if ! runOneHook unpackCmd "$curSrc"; then
         echo "do not know how to unpack source archive $curSrc"
         exit 1
@@ -1130,7 +1121,7 @@ patchPhase() {
     fi
 
     for i in "${patchesArray[@]}"; do
-        header "applying patch $i" 3
+        echo "applying patch $i"
         local uncompress=cat
         case "$i" in
             *.gz)
@@ -1494,15 +1485,15 @@ distPhase() {
 showPhaseHeader() {
     local phase="$1"
     case "$phase" in
-        unpackPhase) header "unpacking sources";;
-        patchPhase) header "patching sources";;
-        configurePhase) header "configuring";;
-        buildPhase) header "building";;
-        checkPhase) header "running tests";;
-        installPhase) header "installing";;
-        fixupPhase) header "post-installation fixup";;
-        installCheckPhase) header "running install tests";;
-        *) header "$phase";;
+        unpackPhase) echo "unpacking sources";;
+        patchPhase) echo "patching sources";;
+        configurePhase) echo "configuring";;
+        buildPhase) echo "building";;
+        checkPhase) echo "running tests";;
+        installPhase) echo "installing";;
+        fixupPhase) echo "post-installation fixup";;
+        installCheckPhase) echo "running install tests";;
+        *) echo "$phase";;
     esac
 }
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -32,7 +32,7 @@ if [ -n "$__structuredAttrs" ]; then
     export NIX_ATTRS_JSON_FILE="$NIX_BUILD_TOP/.attrs.json"
     export NIX_ATTRS_SH_FILE="$NIX_BUILD_TOP/.attrs.sh"
 else
-    : ${outputs:=out}
+    : "${outputs:=out}"
 fi
 
 getAllOutputNames() {
@@ -393,7 +393,7 @@ fi
 # implementation uses zip archive and zip does not support dates going back to
 # 1970.
 export SOURCE_DATE_EPOCH
-: ${SOURCE_DATE_EPOCH:=315532800}
+: "${SOURCE_DATE_EPOCH:=315532800}"
 
 
 # Wildcard expansions that don't match should expand to an empty list.
@@ -605,12 +605,12 @@ findInputs() {
 # in each list must be store paths, and therefore space-free.
 
 # Make sure all are at least defined as empty
-: ${depsBuildBuild=} ${depsBuildBuildPropagated=}
-: ${nativeBuildInputs=} ${propagatedNativeBuildInputs=} ${defaultNativeBuildInputs=}
-: ${depsBuildTarget=} ${depsBuildTargetPropagated=}
-: ${depsHostHost=} ${depsHostHostPropagated=}
-: ${buildInputs=} ${propagatedBuildInputs=} ${defaultBuildInputs=}
-: ${depsTargetTarget=} ${depsTargetTargetPropagated=}
+: "${depsBuildBuild=}" "${depsBuildBuildPropagated=}"
+: "${nativeBuildInputs=}" "${propagatedNativeBuildInputs=}" "${defaultNativeBuildInputs=}"
+: "${depsBuildTarget=}" "${depsBuildTargetPropagated=}"
+: "${depsHostHost=}" "${depsHostHostPropagated=}"
+: "${buildInputs=}" "${propagatedBuildInputs=}" "${defaultBuildInputs=}"
+: "${depsTargetTarget=}" "${depsTargetTargetPropagated=}"
 
 for pkg in ${depsBuildBuild[@]} ${depsBuildBuildPropagated[@]}; do
     findInputs "$pkg" -1 -1
@@ -1070,7 +1070,7 @@ unpackPhase() {
     # Find the source directory.
 
     # set to empty if unset
-    : ${sourceRoot=}
+    : "${sourceRoot=}"
 
     if [ -n "${setSourceRoot:-}" ]; then
         runOneHook setSourceRoot
@@ -1174,7 +1174,7 @@ configurePhase() {
     runHook preConfigure
 
     # set to empty if unset
-    : ${configureScript=}
+    : "${configureScript=}"
 
     if [[ -z "$configureScript" && -x ./configure ]]; then
         configureScript=./configure

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1,4 +1,5 @@
 # shellcheck shell=bash
+# shellcheck disable=1090,2154,2123,2034,2178
 __nixpkgs_setup_set_original=$-
 set -eu
 set -o pipefail
@@ -443,7 +444,6 @@ runHook addInputsHook
 
 # Package accumulators
 
-# shellcheck disable=SC2034
 declare -a pkgsBuildBuild pkgsBuildHost pkgsBuildTarget
 declare -a pkgsHostHost pkgsHostTarget
 declare -a pkgsTargetTarget
@@ -468,7 +468,6 @@ declare -a pkgTargetHookVars=(envTargetTargetHook)
 declare -a pkgHookVarVars=(pkgBuildHookVars pkgHostHookVars pkgTargetHookVars)
 
 # those variables are declared here, since where and if they are used varies
-# shellcheck disable=SC2034
 declare -a preFixupHooks fixupOutputHooks preConfigureHooks postFixupHooks postUnpackHooks unpackCmdHooks
 
 # Add env hooks for all sorts of deps with the specified host offset.

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -879,7 +879,7 @@ substituteStream() {
 # fail loudly if provided with a binary (containing null bytes)
 consumeEntire() {
     # read returns non-0 on EOF, so we want read to fail
-    if IFS='' read -r -d '' $1 ; then
+    if IFS='' read -r -d '' "$1" ; then
         echo "consumeEntire(): ERROR: Input null bytes, won't process" >&2
         return 1
     fi
@@ -1436,7 +1436,7 @@ installCheckPhase() {
         echo "no Makefile or custom installCheckPhase, doing nothing"
     #TODO(@oxij): should flagsArray influence make -n?
     elif [[ -z "${installCheckTarget:-}" ]] \
-       && ! make -n ${makefile:+-f $makefile} ${installCheckTarget:-installcheck} >/dev/null 2>&1; then
+       && ! make -n ${makefile:+-f $makefile} "${installCheckTarget:-installcheck}" >/dev/null 2>&1; then
         echo "no installcheck target in ${makefile:-Makefile}, doing nothing"
     else
         # Old bash empty array hack
@@ -1503,14 +1503,14 @@ showPhaseFooter() {
     local startTime="$2"
     local endTime="$3"
     local delta=$(( endTime - startTime ))
-    (( $delta < 30 )) && return
+    (( delta < 30 )) && return
 
     local H=$((delta/3600))
     local M=$((delta%3600/60))
     local S=$((delta%60))
     echo -n "$phase completed in "
-    (( $H > 0 )) && echo -n "$H hours "
-    (( $M > 0 )) && echo -n "$M minutes "
+    (( H > 0 )) && echo -n "$H hours "
+    (( M > 0 )) && echo -n "$M minutes "
     echo "$S seconds"
 }
 
@@ -1552,7 +1552,7 @@ genericBuild() {
         if [[ "$curPhase" = distPhase && -z "${doDist:-}" ]]; then continue; fi
 
         if [[ -n $NIX_LOG_FD ]]; then
-            echo "@nix { \"action\": \"setPhase\", \"phase\": \"$curPhase\" }" >&$NIX_LOG_FD
+            echo "@nix { \"action\": \"setPhase\", \"phase\": \"$curPhase\" }" >&"$NIX_LOG_FD"
         fi
 
         showPhaseHeader "$curPhase"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-# shellcheck disable=1090,2154,2123,2034,2178
+# shellcheck disable=1090,2154,2123,2034,2178,2048
 __nixpkgs_setup_set_original=$-
 set -eu
 set -o pipefail

--- a/pkgs/tools/package-management/nix/nix-perl.nix
+++ b/pkgs/tools/package-management/nix/nix-perl.nix
@@ -40,6 +40,4 @@ stdenv.mkDerivation {
   ];
 
   preConfigure = "export NIX_STATE_DIR=$TMPDIR";
-
-  preBuild = "unset NIX_INDENT_MAKE";
 }

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -47,10 +47,10 @@ pkgs.releaseTools.sourceTarball {
     opts=(--option build-users-group "")
     nix-store --init
 
-    header "checking eval-release.nix"
+    echo "checking eval-release.nix"
     nix-instantiate --eval --strict --show-trace ./maintainers/scripts/eval-release.nix > /dev/null
 
-    header "checking find-tarballs.nix"
+    echo "checking find-tarballs.nix"
     nix-instantiate --readonly-mode --eval --strict --show-trace --json \
        ./maintainers/scripts/find-tarballs.nix \
       --arg expr 'import ./maintainers/scripts/all-tarballs.nix' > $TMPDIR/tarballs.json
@@ -61,7 +61,7 @@ pkgs.releaseTools.sourceTarball {
       exit 1
     fi
 
-    header "generating packages.json"
+    echo "generating packages.json"
     mkdir -p $out/nix-support
     echo -n '{"version":2,"packages":' > tmp
     nix-env -f . -I nixpkgs=$src -qa --meta --json --arg config 'import ${./packages-config.nix}' "''${opts[@]}" >> tmp

--- a/pkgs/top-level/nixpkgs-basic-release-checks.nix
+++ b/pkgs/top-level/nixpkgs-basic-release-checks.nix
@@ -32,7 +32,7 @@ pkgs.runCommand "nixpkgs-release-checks" { src = nixpkgs; buildInputs = [nix]; }
 
     # Check that all-packages.nix evaluates on a number of platforms without any warnings.
     for platform in ${pkgs.lib.concatStringsSep " " supportedSystems}; do
-        header "checking Nixpkgs on $platform"
+        echo "checking Nixpkgs on $platform"
 
         # To get a call trace; see https://nixos.org/manual/nixpkgs/stable/#function-library-lib.trivial.warn
         # Relies on impure eval


### PR DESCRIPTION
and the associated obsolete functions

support for log nesting was removed in 2017 6669a3b

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
