### PR TITLE
AWS C library bumps

### DIFF
--- a/pkgs/development/libraries/aws-c-auth/default.nix
+++ b/pkgs/development/libraries/aws-c-auth/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-auth";
-  version = "0.6.21";
+  version = "0.6.22";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-auth";
     rev = "v${version}";
-    sha256 = "sha256-RVwSSr0EgVnZt/uUAldWQdjBw6/L+CHUutWcinysvNw=";
+    sha256 = "sha256-crqoUXPf+2/bhKvvw6fiKNqozVqczbf+aSlK390/w/Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-common";
-  version = "0.8.5";
+  version = "0.8.9";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-kAwcVB39rcS59I2qJhYc7Xr3mXMWtKfN45jo+8BNHwA=";
+    sha256 = "sha256-zaX97qFJ/YcjEq6mQqtT6SHIEeRxGgDkAvN72Vjxe98=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/aws-c-event-stream/default.nix
+++ b/pkgs/development/libraries/aws-c-event-stream/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-event-stream";
-  version = "0.2.15";
+  version = "0.2.18";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-X0ExfVop/YjFmR8TrIejg76MOTMngdUruT7uy0BibrU=";
+    sha256 = "sha256-zsPhZHguOky55fz2m5xu4H42/pWATGJEHyoK0fZLybc=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/aws-c-http/default.nix
+++ b/pkgs/development/libraries/aws-c-http/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-http";
-  version = "0.6.28";
+  version = "0.7.3";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-http";
     rev = "v${version}";
-    sha256 = "sha256-Yl6+66UHUAQweFh/ziftWQKElamN1Mc9mZCdtFhRKXc=";
+    sha256 = "sha256-n4BTiqxFz9eOTgh4o78TN2QgCIUbE2Z4jDq27HNORLo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/aws-c-io/default.nix
+++ b/pkgs/development/libraries/aws-c-io/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-io";
-  version = "0.13.12";
+  version = "0.13.14";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-4HPFTTnrk1Ro934iS2hacBKCTz4e6Thurjl1P621ZLg=";
+    sha256 = "sha256-3ROSBjRvl036dslLZF5WgdBnlRvafrNaRzt65wfnk0s=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/aws-c-mqtt/default.nix
+++ b/pkgs/development/libraries/aws-c-mqtt/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-mqtt";
-  version = "0.8.2";
+  version = "0.8.4";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-mqtt";
     rev = "v${version}";
-    sha256 = "sha256-C8Ge+dSW/n9dh3MyZt/uOya3ONsC6Ji+59yylL7h8kY=";
+    sha256 = "sha256-33D+XcNH5e8ty/rckuJFMMP7xG0IhG5wl8Thvu9b7hM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/aws-c-s3/default.nix
+++ b/pkgs/development/libraries/aws-c-s3/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-s3";
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-c-s3";
     rev = "v${version}";
-    sha256 = "sha256-PT6ivk6WsM27jaULJ5CBAojaO7rGxzs/cxv7aRf2nn8=";
+    sha256 = "sha256-hPb9KTq/+OrUlE5EtmE6PYvtxsEmBb8K9ab7CAaELNo=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Another breaking change requires these packages to be updated together. Built nix on x86_64 NixOS and x86_64-darwin. Closes https://github.com/NixOS/nixpkgs/pull/210638

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).