### PR TITLE
ocamlPackages.mirage-nat: 2.2.5 → 3.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/arp/default.nix
+++ b/pkgs/development/ocaml-modules/arp/default.nix
@@ -15,8 +15,8 @@ buildDunePackage rec {
     sha256 = "1x3l8v96ywc3wrcwbf0j04b8agap4fif0fz6ki2ndzx57yqcjszn";
   };
 
-  minimumOCamlVersion = "4.06";
-  useDune2 = true;
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   nativeBuildInputs = [
     bisect_ppx

--- a/pkgs/development/ocaml-modules/mirage-nat/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-nat/default.nix
@@ -1,38 +1,29 @@
 { lib, buildDunePackage, fetchurl
-, ipaddr, cstruct, lwt, logs, lru
-, tcpip, ethernet, stdlib-shims
+, ipaddr, cstruct, logs, lru
+, tcpip, ethernet
 , alcotest, mirage-clock-unix
-, ppxlib, ppx_deriving
 }:
 
 buildDunePackage rec {
   pname = "mirage-nat";
-  version = "2.2.5";
+  version = "3.0.1";
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
-  # due to cstruct
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
-    url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "01xp0z4mywhawz7rxizi9ph342mqqwyfa5hqgvs8lhqzcym5d104";
+    url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-${version}.tbz";
+    hash = "sha256-wReySOMulGkrPD60XxpgMrUoHzY9hQ7TZzYQyJ3eiik=";
   };
-
-  buildInputs = [
-    ppxlib
-  ];
 
   propagatedBuildInputs = [
     ipaddr
     cstruct
-    lwt
     logs
     lru
     tcpip
     ethernet
-    stdlib-shims
-    ppx_deriving
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/tcpip/default.nix
+++ b/pkgs/development/ocaml-modules/tcpip/default.nix
@@ -15,7 +15,7 @@ buildDunePackage rec {
   pname = "tcpip";
   version = "7.1.2";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-${pname}/releases/download/v${version}/${pname}-${version}.tbz";


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/mirage-nat/blob/v3.0.1/CHANGES.md#v301-2022-11-08

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
