### PR TITLE
tinygo: 0.25.0 -> 0.26.0

### DIFF
--- a/pkgs/development/compilers/tinygo/0002-Add-clang-header-path.patch
+++ b/pkgs/development/compilers/tinygo/0002-Add-clang-header-path.patch
@@ -18,18 +18,18 @@ index 121398fa..a589988b 100644
  	sourceDir: func() string {
  		llvmDir := filepath.Join(goenv.Get("TINYGOROOT"), "llvm-project/compiler-rt/lib/builtins")
 diff --git a/builder/picolibc.go b/builder/picolibc.go
-index f1b061ae..159f90cf 100644
+index d0786ee3..9a5cf9b0 100644
 --- a/builder/picolibc.go
 +++ b/builder/picolibc.go
-@@ -27,7 +27,7 @@ var Picolibc = Library{
- 			"-D_COMPILING_NEWLIB",
- 			"-DHAVE_ALIAS_ATTRIBUTE",
- 			"-DTINY_STDIO",
+@@ -30,7 +30,7 @@ var Picolibc = Library{
+ 			"-D_IEEE_LIBM",
+ 			"-D__OBSOLETE_MATH_FLOAT=1", // use old math code that doesn't expect a FPU
+ 			"-D__OBSOLETE_MATH_DOUBLE=0",
 -			"-nostdlibinc",
 +			"-isystem", "@clang_include@",
- 			"-isystem", picolibcDir + "/include",
- 			"-I" + picolibcDir + "/tinystdio",
- 			"-I" + headerPath,
+ 			"-isystem", newlibDir + "/libc/include",
+ 			"-I" + newlibDir + "/libc/tinystdio",
+ 			"-I" + newlibDir + "/libm/common",
 diff --git a/compileopts/config.go b/compileopts/config.go
 index a006b673..3a105b49 100644
 --- a/compileopts/config.go

--- a/pkgs/development/compilers/tinygo/default.nix
+++ b/pkgs/development/compilers/tinygo/default.nix
@@ -28,17 +28,17 @@ in
 
 buildGoModule rec {
   pname = "tinygo";
-  version = "0.25.0";
+  version = "0.26.0";
 
   src = fetchFromGitHub {
     owner = "tinygo-org";
     repo = "tinygo";
     rev = "v${version}";
-    sha256 = "sha256-Rxdxum1UIaz8tpEAGqpLvKd25nHdj4Se+IoN29EJEHg=";
+    sha256 = "rI8CADPWKdNvfknEsrpp2pCeZobf9fAp0GDIWjupzZA=";
     fetchSubmodules = true;
   };
 
-  vendorSha256 = "sha256-QxLY4KT05PtA/W7d1vKxsq5w35YZ6MJL3Lh726b+E9w=";
+  vendorSha256 = "sha256-ihQd/RAjAQhgQZHbNiWmAD0eOo1MvqAR/OwIOUWtdAM=";
 
   patches = [
     ./0001-Makefile.patch


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Version bumped. Build appears to succeed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
