### PR TITLE
Fix issue 16182  `Error: _assignFirst found no valid variant!`

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -253,7 +253,7 @@ The propagated equivalent of `depsTargetTarget`. This is prefixed for the same r
 
 #### `NIX_DEBUG` {#var-stdenv-NIX_DEBUG}
 
-A natural number indicating how much information to log. If set to 1 or higher, `stdenv` will print moderate debugging information during the build. In particular, the `gcc` and `ld` wrapper scripts will print out the complete command line passed to the wrapped tools. If set to 6 or higher, the `stdenv` setup script will be run with `set -x` tracing. If set to 7 or higher, the `gcc` and `ld` wrapper scripts will also be run with `set -x` tracing.
+A number between 0 and 7 indicating how much information to log. If set to 1 or higher, `stdenv` will print moderate debugging information during the build. In particular, the `gcc` and `ld` wrapper scripts will print out the complete command line passed to the wrapped tools. If set to 6 or higher, the `stdenv` setup script will be run with `set -x` tracing. If set to 7 or higher, the `gcc` and `ld` wrapper scripts will also be run with `set -x` tracing.
 
 ### Attributes affecting build properties {#attributes-affecting-build-properties}
 

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -19,13 +19,15 @@ _assignFirst() {
         if [ -n "${!var-}" ]; then eval "${varName}"="${var}"; return; fi
     done
     echo
-    echo "error: _assignFirst: could not find a non-empty variable to assign to ${varName}. The following variables were all unset or empty: $*."
+    echo "error: _assignFirst: could not find a non-empty variable to assign to ${varName}."
+    echo "       The following variables were all unset or empty:"
+    echo "           $*"
     if [ -z "${out:-}" ]; then
         echo '       If you do not want an "out" output in your derivation, make sure to define'
         echo '       the other specific required outputs. This can be achieved by picking one'
-        echo "       of $* to add as an output."
+        echo "       of the above as an output."
         echo '       You do not have to remove "out" if you want to have a different default'
-        echo '        output, as it is the first output in `outputs` that is the default output.'
+        echo '       output, because the first output is taken as a default.'
         echo
     fi
     return 1 # none found

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -4,16 +4,30 @@ preFixupHooks+=(_multioutDocs)
 preFixupHooks+=(_multioutDevs)
 postFixupHooks+=(_multioutPropagateDev)
 
-# Assign the first string containing nonempty variable to the variable named $1
+# _assignFirst varName otherVarNames*
+#
+# Set the value of the variable named $varName to the first of otherVarNames
+# that refers to a non-empty variable name.
+#
+# If none of otherVarNames refers to a non-empty variable, the error message is
+# specific to this function's use case, which is setting up the output variables.
 _assignFirst() {
     local varName="$1"
     local REMOVE=REMOVE # slightly hacky - we allow REMOVE (i.e. not a variable name)
     shift
-    while (( $# )); do
-        if [ -n "${!1-}" ]; then eval "${varName}"="$1"; return; fi
-        shift
+    for var in "$@"; do
+        if [ -n "${!var-}" ]; then eval "${varName}"="${var}"; return; fi
     done
-    echo "Error: _assignFirst found no valid variant!"
+    echo
+    echo "error: _assignFirst: could not find a non-empty variable to assign to ${varName}. The following variables were all unset or empty: $*."
+    if [ -z "${out:-}" ]; then
+        echo '       If you do not want an "out" output in your derivation, make sure to define'
+        echo '       the other specific required outputs. This can be achieved by picking one'
+        echo "       of $* to add as an output."
+        echo '       You do not have to remove "out" if you want to have a different default'
+        echo '        output, as it is the first output in `outputs` that is the default output.'
+        echo
+    fi
     return 1 # none found
 }
 

--- a/pkgs/build-support/testers/expect-failure.sh
+++ b/pkgs/build-support/testers/expect-failure.sh
@@ -35,6 +35,14 @@ echo "testBuildFailure: Original builder produced exit code: $r"
 # -----------------------------------------
 # Write the build log to the default output
 
+getAllOutputNames() {
+    if [ -n "$__structuredAttrs" ]; then
+        echo "${!outputs[*]}"
+    else
+        echo "$outputs"
+    fi
+}
+
 outs=( $(getAllOutputNames) )
 defOut=${outs[0]}
 defOutPath=${!defOut}


### PR DESCRIPTION
###### Description of changes

Work towards #16182 by improving the error message:

```
error: _assignFirst: could not find a non-empty variable to assign to outputDev. The following variables were all unset or empty: dev out.
       If you do not want an "out" output in your derivation, make sure to define
       the other specific required outputs. This can be achieved by picking one
       of dev out to add as an output.
       You do not have to remove "out" if you want to have a different default
       output, as it is the first output in `outputs` that is the default output.
```

This used to be `Error: _assignFirst found no valid variant!`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
