### PR TITLE
win-virtio: 0.1.196-1 -> 0.1.229-1

### DIFF
--- a/pkgs/applications/virtualization/driver/win-virtio/default.nix
+++ b/pkgs/applications/virtualization/driver/win-virtio/default.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchurl, p7zip }:
 stdenv.mkDerivation rec {
   pname = "win-virtio";
-  version = "0.1.196-1";
+  version = "0.1.229-1";
 
   dontUnpack = true;
 
   src = fetchurl {
     url = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-${version}/virtio-win.iso";
-    sha256 = "1zj53xybygps66m3v5kzi61vqy987zp6bfgk0qin9pja68qq75vx";
+    hash = "sha256-yIoN3jRgXq7mz4ifPioMKvPK65G130WhJcpPcBrLu+A=";
   };
 
   buildPhase = ''

--- a/pkgs/applications/virtualization/driver/win-virtio/default.nix
+++ b/pkgs/applications/virtualization/driver/win-virtio/default.nix
@@ -1,40 +1,31 @@
-{ lib, stdenv, fetchurl, p7zip }:
+{ lib, stdenv, fetchurl, libarchive }:
 stdenv.mkDerivation rec {
   pname = "win-virtio";
   version = "0.1.229-1";
-
-  dontUnpack = true;
 
   src = fetchurl {
     url = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-${version}/virtio-win.iso";
     hash = "sha256-yIoN3jRgXq7mz4ifPioMKvPK65G130WhJcpPcBrLu+A=";
   };
 
-  buildPhase = ''
-    runHook preBuild
-    ${p7zip}/bin/7z x $src
-    runHook postBuild
-  '';
+  nativeBuildInputs = [
+    libarchive
+  ];
 
-  installPhase =
-    let
-      copy = arch: version: {input, output}: "mkdir -p $out/${arch}/${output}; cp ${input}/${version}/${arch}/* $out/${arch}/${output}/.";
-      virtio = [{input="Balloon"; output="vioballoon";}
-                {input="NetKVM"; output="vionet";}
-                {input="vioscsi"; output="vioscsi";}
-                {input="vioserial"; output="vioserial";}
-                {input="viostor"; output="viostor";}
-                {input="viorng"; output="viorng";}
-               ];
-    in ''
-      runHook preInstall
-      ${lib.concatStringsSep "\n" ((map (copy "amd64" "w10") virtio) ++ (map (copy "x86" "w10") virtio))}
-      runHook postInstall
-    '';
+  unpackCmd = "mkdir source; bsdtar -xf $curSrc -C source";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -R ./. $out/
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Windows VirtIO Drivers";
-    homepage = "https://fedoraproject.org/wiki/Windows_Virtio_Drivers";
+    homepage = "https://docs.fedoraproject.org/en-US/quick-docs/creating-windows-virtual-machines-using-virtio-drivers/index.html";
     license = [ licenses.bsd3 ];
     maintainers = [ ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Description of changes
Also just copy everything instead of just some things very elaborately.
There is no clear motivation given for why this was done in 91b85236d0651983b2d2162623309f497cc0f225.

Closes #187710 cc @samuel-f 

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).