### PR TITLE
octoprint: fix build by relaxing constraint

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -172,6 +172,7 @@ let
                     "Flask-Login"
                     "werkzeug"
                     "flask"
+                    "Flask-Limiter"
                   ];
                 in
                 ''


### PR DESCRIPTION
###### Description of changes

`octoprint` fails to build currently with
```
Processing ./OctoPrint-1.8.6-py2.py3-none-any.whl
Requirement already satisfied: colorlog in /nix/store/hhm87vi4mr2xjv3c3zl4yfa7xlg830i4-python3.10-colorlog-6.7.0/lib/python3.10/site-packages (from OctoPrint==1.8.6) (6.7.0)
Requirement already satisfied: OctoPrint-FirmwareCheck>=2021.10.11 in /nix/store/f170fb6p8y436j9l9jvci59gnxybnpg7-python3.10-OctoPrint-FirmwareCheck-2021.10.11/lib/python3.10/site-packages (from OctoPrint==1.8.6) (2021.10.11)
Requirement already satisfied: netifaces<1,>=0.11 in /nix/store/pl16slln0xb9582d4db7h17s163wvmk3-python3.10-netifaces-0.11.0/lib/python3.10/site-packages (from OctoPrint==1.8.6) (0.11.0)
Requirement already satisfied: pyserial<4,>=3.4 in /nix/store/jxzz20a7i2byxh0zqfk0vhh3cx8yafcz-python3.10-pyserial-3.5/lib/python3.10/site-packages (from OctoPrint==1.8.6) (3.5)
ERROR: Could not find a version that satisfies the requirement Flask-Limiter<3,>=2.6 (from octoprint) (from versions: none)
ERROR: No matching distribution found for Flask-Limiter<3,>=2.6
```

This is easily fixed by adding `Flask-Limiter` to `ignoreVersionConstraints`. All tests still pass.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
