### PR TITLE
stuntrally: 2.6.2 -> 2.7

### DIFF
--- a/pkgs/games/stuntrally/default.nix
+++ b/pkgs/games/stuntrally/default.nix
@@ -14,34 +14,50 @@
 , libXcursor
 , bullet
 , openal
+, tinyxml
+, tinyxml-2
 }:
 
+let
+  stuntrally_ogre = ogre.overrideAttrs (old: {
+    cmakeFlags = old.cmakeFlags ++ [
+      "-DOGRE_NODELESS_POSITIONING=ON"
+      "-DOGRE_RESOURCEMANAGER_STRICT=0"
+    ];
+  });
+  stuntrally_mygui = mygui.override {
+    withOgre = true;
+    inherit ogre;
+  };
+in
+
 stdenv.mkDerivation rec {
-  pname = "stunt-rally";
-  version = "2.6.2";
+  pname = "stuntrally";
+  version = "2.7";
 
   src = fetchFromGitHub {
     owner = "stuntrally";
     repo = "stuntrally";
     rev = version;
-    hash = "sha256-9I6hXsosqx+yYiEOEnPXQJHZkGtSU+JqThorwjemlc0=";
+    hash = "sha256-0Eh9ilIHSh/Uz8TuPnXxLQfy7KF7qqNXUgBXQUCz9ys=";
   };
   tracks = fetchFromGitHub {
     owner = "stuntrally";
     repo = "tracks";
     rev = version;
-    hash = "sha256-eZJAvkKe3PrXDzxTa5WFBHfltB3jhQh8puzOFDO9lso=";
+    hash = "sha256-fglm1FetFGHM/qGTtpxDb8+k2iAREn5DQR5GPujuLms=";
   };
 
   preConfigure = ''
-    ln -s ${tracks} data/tracks
+    rmdir data/tracks
+    ln -s ${tracks}/ data/tracks
   '';
 
   nativeBuildInputs = [ cmake pkg-config makeWrapper ];
   buildInputs = [
     boost
-    ogre
-    mygui
+    stuntrally_ogre
+    stuntrally_mygui
     ois
     SDL2
     libvorbis
@@ -49,6 +65,8 @@ stdenv.mkDerivation rec {
     libXcursor
     bullet
     openal
+    tinyxml
+    tinyxml-2
   ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35269,7 +35269,7 @@ with pkgs;
   stt = callPackage ../tools/audio/stt { };
 
   stuntrally = callPackage ../games/stuntrally
-    { ogre = ogre1_9; mygui = mygui.override { withOgre = true; }; };
+    { };
 
   superTux = callPackage ../games/supertux { };
 


### PR DESCRIPTION
###### Description of changes

[StuntRally 2.7 Changelog](https://stuntrally.tuxfamily.org/wiki/doku.php?id=changelog)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
