### PR TITLE
python3Packages.poetry-dynamic-versioning: fix build after last version bump

### DIFF
--- a/pkgs/development/python-modules/poetry-dynamic-versioning/default.nix
+++ b/pkgs/development/python-modules/poetry-dynamic-versioning/default.nix
@@ -54,6 +54,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Plugin for Poetry to enable dynamic versioning based on VCS tags";
     homepage = "https://github.com/mtkennerly/poetry-dynamic-versioning";
+    changelog = "https://github.com/mtkennerly/poetry-dynamic-versioning/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ cpcloud ];
   };

--- a/pkgs/development/python-modules/poetry-dynamic-versioning/default.nix
+++ b/pkgs/development/python-modules/poetry-dynamic-versioning/default.nix
@@ -43,6 +43,8 @@ buildPythonPackage rec {
     # these require .git, but leaveDotGit = true doesn't help
     "test__get_version__defaults"
     "test__get_version__format_jinja"
+    # these expect to be able to run the poetry cli which fails in test hook
+    "test_integration"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
###### Description of changes

This was broken by the bump in f3bf226a9 (see Hydra failure: https://hydra.nixos.org/build/205374995)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>python310Packages.ibis-framework</li>
    <li>python310Packages.poetry-dynamic-versioning</li>
    <li>python39Packages.ibis-framework</li>
    <li>python39Packages.poetry-dynamic-versioning</li>
  </ul>
</details>