### PR TITLE
python3.pkgs.sphinxcontrib-openapi: switch back to upstream

### DIFF
--- a/pkgs/development/python-modules/sphinxcontrib-openapi/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-openapi/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , deepmerge
-, fetchFromGitHub
+, fetchPypi
 , fetchpatch
 , isPy27
 , setuptools-scm
@@ -14,23 +14,12 @@
 
 buildPythonPackage rec {
   pname = "sphinxcontrib-openapi";
-  version = "unstable-2022-08-26";
+  version = "0.8.0";
   disabled = isPy27;
 
-  # Switch to Cilums' fork of openapi, which uses m2r instead of mdinclude,
-  # as m2r is unmaintained and incompatible with the version of mistune.
-  # See
-  # https://github.com/cilium/cilium/commit/b9862461568dd41d4dc8924711d4cc363907270b and
-  # https://github.com/cilium/openapi/commit/cd829a05caebd90b31e325d4c9c2714b459d135f
-  # for details.
-  # PR to switch upstream sphinx-contrib/openapi from m2r to sphinx-mdinclude:
-  # https://github.com/sphinx-contrib/openapi/pull/127
-  # (once merged, we should switch away from that fork again)
-  src = fetchFromGitHub {
-    owner = "cilium";
-    repo = "openapi";
-    rev = "0ea3332fa6482114f1a8248a32a1eacb61aebb69";
-    hash = "sha256-a/oVMg9gGTD+NClfpC2SpjbY/mIcZEVLLOR0muAg5zY=";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-rO1qloTOgU5qVHURMyA6Ug7rC3UOjICqPUiFJ9RsLzA=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];


### PR DESCRIPTION
Upstream incorporated the changes present in the cilium fork into their repository, and tagged a new release (0.8.0). We can switch back to the upstream version, rather than the temporary fork.

See https://github.com/NixOS/nixpkgs/pull/188280#issuecomment-1384088517

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
