### PR TITLE
78 fonts: Fix build after #173430 changed postFetch semantics

### DIFF
--- a/pkgs/data/fonts/andagii/default.nix
+++ b/pkgs/data/fonts/andagii/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "1.0.2";
-in fetchzip {
+in (fetchzip {
   name = "andagii-${version}";
 
   url = "http://www.i18nguy.com/unicode/andagii.zip";
   curlOpts = "--user-agent 'Mozilla/5.0'";
-  postFetch = ''
-    unzip $downloadedFile
-    mkdir -p $out/share/fonts/truetype
-    cp -v ANDAGII_.TTF $out/share/fonts/truetype/andagii.ttf
-  '';
   sha256 = "0j5kf2fmyqgnf5ji6h0h79lq9n9d85hkfrr4ya8hqj4gwvc0smb2";
 
   # There are multiple claims that the font is GPL, so I include the
@@ -24,4 +20,10 @@ in fetchzip {
     license = "unknown";
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    unzip $downloadedFile
+    mkdir -p $out/share/fonts/truetype
+    cp -v ANDAGII_.TTF $out/share/fonts/truetype/andagii.ttf
+  '';
+})

--- a/pkgs/data/fonts/andika/default.nix
+++ b/pkgs/data/fonts/andika/default.nix
@@ -1,18 +1,14 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "6.101";
+  name = "andika-${version}";
 in
-  fetchzip rec {
-    name = "andika-${version}";
+  (fetchzip rec {
+    inherit name;
 
     url = "https://software.sil.org/downloads/r/andika/Andika-${version}.zip";
-
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
-    '';
 
     sha256 = "sha256-J/Ad+fmCMOxLoo+691LE6Bgi/l3ovIfWScwwVWtqACI=";
 
@@ -28,4 +24,10 @@ in
       platforms = platforms.all;
       maintainers = [ maintainers.f--t ];
     };
-  }
+  }).overrideAttrs (_: {
+    postFetch = ''
+      mkdir -p $out/share/{doc,fonts}
+      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    '';
+  })

--- a/pkgs/data/fonts/ankacoder/default.nix
+++ b/pkgs/data/fonts/ankacoder/default.nix
@@ -1,15 +1,10 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let version = "1.100"; in
-fetchzip {
+(fetchzip {
   name = "ankacoder-${version}";
   url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/anka-coder-fonts/AnkaCoder.${version}.zip";
-
-  postFetch = ''
-    unzip $downloadedFile
-    mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
-  '';
 
   sha256 = "1jqx9micfmiarqh9xp330gl96v3vxbwzz9cmg2vi845n9md4im85";
 
@@ -20,4 +15,10 @@ fetchzip {
     maintainers = with maintainers; [ dtzWill ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    unzip $downloadedFile
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+  '';
+})

--- a/pkgs/data/fonts/annapurna-sil/default.nix
+++ b/pkgs/data/fonts/annapurna-sil/default.nix
@@ -1,18 +1,14 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "1.204";
+  name = "annapurna-sil-${version}";
 in
-  fetchzip rec {
-    name = "annapurna-sil-${version}";
+  (fetchzip rec {
+    inherit name;
 
     url = "https://software.sil.org/downloads/r/annapurna/AnnapurnaSIL-${version}.zip";
-
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
-    '';
 
     sha256 = "sha256-kVeP9ZX8H+Wn6jzmH1UQvUKY6vJjadMTdEusS7LodFM=";
 
@@ -26,4 +22,10 @@ in
       platforms = platforms.all;
       maintainers = [ maintainers.kmein ];
     };
-  }
+  }).overrideAttrs (_: {
+    postFetch = ''
+      mkdir -p $out/share/{doc,fonts}
+      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    '';
+  })

--- a/pkgs/data/fonts/babelstone-han/default.nix
+++ b/pkgs/data/fonts/babelstone-han/default.nix
@@ -1,16 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "13.0.3";
-in fetchzip {
+in (fetchzip {
   name = "babelstone-han-${version}";
 
   # upstream download links are unversioned, so hash changes
   url = "https://web.archive.org/web/20200210125314/https://www.babelstone.co.uk/Fonts/Download/BabelStoneHan.zip";
-  postFetch = ''
-    mkdir -p $out/share/fonts/truetype
-    unzip $downloadedFile '*.ttf' -d $out/share/fonts/truetype
-  '';
   sha256 = "018isk3hbzsihzrxavgjbn485ngzvlm96npqx9y7zpkxsssslc4w";
 
   meta = with lib; {
@@ -21,4 +18,9 @@ in fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ emily ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/truetype
+    unzip $downloadedFile '*.ttf' -d $out/share/fonts/truetype
+  '';
+})

--- a/pkgs/data/fonts/barlow/default.nix
+++ b/pkgs/data/fonts/barlow/default.nix
@@ -1,22 +1,14 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 let
   version = "1.422";
 in
-fetchzip rec {
+(fetchzip rec {
   name = "barlow-${version}";
 
   url = "https://tribby.com/fonts/barlow/download/barlow-${version}.zip";
 
   sha256 = "08ld4c3zq4d1px07lc64i7l8848zsc61ddy3654w2sh0hx5sm5ld";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.eot -d $out/share/fonts/eot
-    unzip -j $downloadedFile \*.woff -d $out/share/fonts/woff
-    unzip -j $downloadedFile \*.woff2 -d $out/share/fonts/woff2
-  '';
 
   meta = with lib; {
     description = "A grotesk variable font superfamily";
@@ -25,4 +17,13 @@ fetchzip rec {
     maintainers = [ maintainers.marsam ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.eot -d $out/share/fonts/eot
+    unzip -j $downloadedFile \*.woff -d $out/share/fonts/woff
+    unzip -j $downloadedFile \*.woff2 -d $out/share/fonts/woff2
+  '';
+})

--- a/pkgs/data/fonts/borg-sans-mono/default.nix
+++ b/pkgs/data/fonts/borg-sans-mono/default.nix
@@ -1,20 +1,16 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   pname = "borg-sans-mono";
   version = "0.2.0";
 in
-fetchzip {
+(fetchzip {
   name = "${pname}-${version}";
 
   # https://github.com/marnen/borg-sans-mono/issues/19
   url = "https://github.com/marnen/borg-sans-mono/files/107663/BorgSansMono.ttf.zip";
   sha256 = "1gz4ab0smw76ih5cs2l3n92c77nv7ld5zghq42avjsfhxrc2n5ri";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
 
   meta = with lib; {
     description = "Droid Sans Mono Slashed + Hasklig-style ligatures";
@@ -23,4 +19,9 @@ fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ atila ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+  '';
+})

--- a/pkgs/data/fonts/cascadia-code/default.nix
+++ b/pkgs/data/fonts/cascadia-code/default.nix
@@ -1,19 +1,14 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 let
   version = "2111.01";
 in
-fetchzip {
+(fetchzip {
   name = "cascadia-code-${version}";
 
   url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/CascadiaCode-${version}.zip";
 
   sha256 = "sha256-kUVTQ/oMZztNf22sDbQBpQW0luSc5nr5sxWU5etLDec=";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
 
   meta = with lib; {
     description = "Monospaced font that includes programming ligatures and is designed to enhance the modern look and feel of the Windows Terminal";
@@ -23,4 +18,10 @@ fetchzip {
     maintainers = [ maintainers.marsam ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+  '';
+})

--- a/pkgs/data/fonts/charis-sil/default.nix
+++ b/pkgs/data/fonts/charis-sil/default.nix
@@ -1,18 +1,14 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "6.101";
+  name = "charis-sil-${version}";
 in
-  fetchzip rec {
-    name = "charis-sil-${version}";
+  (fetchzip rec {
+    inherit name;
 
     url = "https://software.sil.org/downloads/r/charis/CharisSIL-${version}.zip";
-
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
-    '';
 
     sha256 = "sha256-b1ms9hJ6IPe7W6O9KgzHZvwT4/nAoLOhdydcUrwNfnU=";
 
@@ -28,4 +24,10 @@ in
       platforms = platforms.all;
       maintainers = [ maintainers.f--t ];
     };
-  }
+  }).overrideAttrs (_: {
+    postFetch = ''
+      mkdir -p $out/share/{doc,fonts}
+      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    '';
+  })

--- a/pkgs/data/fonts/comic-relief/default.nix
+++ b/pkgs/data/fonts/comic-relief/default.nix
@@ -1,20 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "1.1";
-in fetchzip rec {
   name = "comic-relief-${version}";
+in (fetchzip rec {
+  inherit name;
 
   url = "https://fontlibrary.org/assets/downloads/comic-relief/45c456b6db2aaf2f7f69ac66b5ac7239/comic-relief.zip";
-
-  postFetch = ''
-    mkdir -p $out/etc/fonts/conf.d
-    mkdir -p $out/share/doc/${name}
-    mkdir -p $out/share/fonts/truetype
-    cp -v ${./comic-sans-ms-alias.conf}     $out/etc/fonts/conf.d/30-comic-sans-ms.conf
-    unzip -j $downloadedFile \*.ttf      -d $out/share/fonts/truetype
-    unzip -j $downloadedFile FONTLOG.txt -d $out/share/doc/${name}
-  '';
 
   sha256 = "0dz0y7w6mq4hcmmxv6fn4mp6jkln9mzr4s96vsg68wrl5b7k9yff";
 
@@ -37,4 +30,13 @@ in fetchzip rec {
     # want to install the font alias of this package.
     priority = 10;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/etc/fonts/conf.d
+    mkdir -p $out/share/doc/${name}
+    mkdir -p $out/share/fonts/truetype
+    cp -v ${./comic-sans-ms-alias.conf}     $out/etc/fonts/conf.d/30-comic-sans-ms.conf
+    unzip -j $downloadedFile \*.ttf      -d $out/share/fonts/truetype
+    unzip -j $downloadedFile FONTLOG.txt -d $out/share/doc/${name}
+  '';
+})

--- a/pkgs/data/fonts/courier-prime/default.nix
+++ b/pkgs/data/fonts/courier-prime/default.nix
@@ -1,18 +1,14 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "unstable-2019-12-05";
   repo = "CourierPrime";
   rev = "7f6d46a766acd9391d899090de467c53fd9c9cb0";
-in fetchzip rec {
+in (fetchzip rec {
   name = "courier-prime-${version}";
   url = "https://github.com/quoteunquoteapps/${repo}/archive/${rev}/${name}.zip";
   sha256 = "1xh4pkksm6zrafhb69q4lq093q6pl245zi9qhqw3x6c1ab718704";
-
-  postFetch = ''
-    unzip $downloadedFile
-    install -m444 -Dt $out/share/fonts/truetype ${repo}-${rev}/fonts/ttf/*.ttf
-  '';
 
   meta = with lib; {
     description = "Monospaced font designed specifically for screenplays";
@@ -21,4 +17,9 @@ in fetchzip rec {
     maintainers = [ maintainers.austinbutler ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    unzip $downloadedFile
+    install -m444 -Dt $out/share/fonts/truetype ${repo}-${rev}/fonts/ttf/*.ttf
+  '';
+})

--- a/pkgs/data/fonts/cozette/default.nix
+++ b/pkgs/data/fonts/cozette/default.nix
@@ -1,22 +1,15 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "1.13.0";
 in
-fetchzip rec {
+(fetchzip rec {
   name = "Cozette-${version}";
 
   url = "https://github.com/slavfox/Cozette/releases/download/v.${version}/CozetteFonts.zip";
 
   sha256 = "sha256-xp3BCYfNUxCNewg4FfzmJnKp0PARvvnViMVwT25nWdM=";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.bdf -d $out/share/fonts/misc
-    unzip -j $downloadedFile \*.otb -d $out/share/fonts/misc
-  '';
 
   meta = with lib; {
     description = "A bitmap programming font optimized for coziness";
@@ -25,4 +18,12 @@ fetchzip rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ brettlyons marsam ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.bdf -d $out/share/fonts/misc
+    unzip -j $downloadedFile \*.otb -d $out/share/fonts/misc
+  '';
+})

--- a/pkgs/data/fonts/d2coding/default.nix
+++ b/pkgs/data/fonts/d2coding/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "1.3.2";
   pname = "d2codingfont";
 
-in fetchzip {
+in (fetchzip {
   name = "${pname}-${version}";
   url = "https://github.com/naver/${pname}/releases/download/VER${version}/D2Coding-Ver${version}-20180524.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*-all.ttc -d $out/share/fonts/truetype/
-  '';
 
   sha256 = "1812r82530wzfki7k9cm35fy6k2lvis7j6w0w8svc784949m1wwj";
 
@@ -29,4 +25,9 @@ in fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ dtzWill ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*-all.ttc -d $out/share/fonts/truetype/
+  '';
+})

--- a/pkgs/data/fonts/doulos-sil/default.nix
+++ b/pkgs/data/fonts/doulos-sil/default.nix
@@ -1,18 +1,14 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "6.101";
+  name = "doulos-sil-${version}";
 in
-  fetchzip rec {
-    name = "doulos-sil-${version}";
+  (fetchzip rec {
+    inherit name;
 
     url = "https://software.sil.org/downloads/r/doulos/DoulosSIL-${version}.zip";
-
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
-    '';
 
     sha256 = "sha256-vYdnudMkkWz6r8pwq98fyO0zcfFBRPmrqlmWxHCOIcc=";
 
@@ -28,4 +24,10 @@ in
       platforms = platforms.all;
       maintainers = [ maintainers.f--t ];
     };
-  }
+  }).overrideAttrs (_: {
+    postFetch = ''
+      mkdir -p $out/share/{doc,fonts}
+      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    '';
+  })

--- a/pkgs/data/fonts/eb-garamond/default.nix
+++ b/pkgs/data/fonts/eb-garamond/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "0.016";
-in fetchzip rec {
   name = "eb-garamond-${version}";
+in (fetchzip rec {
+  inherit name;
 
   url = "https://bitbucket.org/georgd/eb-garamond/downloads/EBGaramond-${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.otf                                          -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*Changes \*README.markdown \*README.xelualatex -d "$out/share/doc/${name}"
-  '';
 
   sha256 = "04jq4mpln85zzbla8ybsjw7vn9qr3r0snmk5zykrm24imq7ripv3";
 
@@ -22,4 +18,10 @@ in fetchzip rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/{doc,fonts}
+    unzip -j $downloadedFile \*.otf                                          -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*Changes \*README.markdown \*README.xelualatex -d "$out/share/doc/${name}"
+  '';
+})

--- a/pkgs/data/fonts/emacs-all-the-icons-fonts/default.nix
+++ b/pkgs/data/fonts/emacs-all-the-icons-fonts/default.nix
@@ -1,16 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "5.0.0";
-in fetchzip {
+in (fetchzip {
   name = "emacs-all-the-icons-fonts-${version}";
 
   url = "https://github.com/domtronn/all-the-icons.el/archive/${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/all-the-icons
-  '';
 
   sha256 = "0vc9bkm4pcc05llcd2c9zr3d88h3zmci0izla5wnw8hg1n0rsrii";
 
@@ -32,4 +28,9 @@ in fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ rlupton20 ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/all-the-icons
+  '';
+})

--- a/pkgs/data/fonts/encode-sans/default.nix
+++ b/pkgs/data/fonts/encode-sans/default.nix
@@ -1,15 +1,10 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
-
-fetchzip rec {
-  name = "encode-sans-1.002";
+let name = "encode-sans-1.002";
+in (fetchzip rec {
+  inherit name;
 
   url = "https://github.com/impallari/Encode-Sans/archive/11162b46892d20f55bd42a00b48cbf06b5871f75.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf                    -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*README.md \*FONTLOG.txt -d "$out/share/doc/${name}"
-  '';
 
   sha256 = "16mx894zqlwrhnp4rflgayxhxppmsj6k7haxdngajhb30rlwf08p";
 
@@ -28,4 +23,10 @@ fetchzip rec {
     maintainers = with maintainers; [ cmfwyp ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/{doc,fonts}
+    unzip -j $downloadedFile \*.ttf                    -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \*README.md \*FONTLOG.txt -d "$out/share/doc/${name}"
+  '';
+})

--- a/pkgs/data/fonts/ezra-sil/default.nix
+++ b/pkgs/data/fonts/ezra-sil/default.nix
@@ -1,18 +1,14 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "2.51";
+  name = "ezra-sil-${version}";
 in
-  fetchzip rec {
-    name = "ezra-sil-${version}";
+  (fetchzip rec {
+    inherit name;
 
     url = "https://software.sil.org/downloads/r/ezra/EzraSIL-${version}.zip";
-
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
-    '';
 
     sha256 = "sha256-1LGw/RPFeNtEvcBWFWZf8+dABvWye2RfZ/jt8rwQewM=";
 
@@ -23,4 +19,10 @@ in
       platforms = platforms.all;
       maintainers = [ maintainers.kmein ];
     };
-  }
+  }).overrideAttrs (_: {
+    postFetch = ''
+      mkdir -p $out/share/{doc,fonts}
+      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+      unzip -j $downloadedFile \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    '';
+  })

--- a/pkgs/data/fonts/fira-code/default.nix
+++ b/pkgs/data/fonts/fira-code/default.nix
@@ -1,17 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "6.2";
-in fetchzip {
+in (fetchzip {
   name = "fira-code-${version}";
 
   url = "https://github.com/tonsky/FiraCode/releases/download/${version}/Fira_Code_v${version}.zip";
-
-  # only extract the variable font because everything else is a duplicate
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile '*-VF.ttf' -d $out/share/fonts/truetype
-  '';
 
   sha256 = "0l02ivxz3jbk0rhgaq83cqarqxr07xgp7n27l0fh8fbgxwi52djl";
 
@@ -27,4 +22,10 @@ in fetchzip {
     maintainers = [ maintainers.rycee ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  # only extract the variable font because everything else is a duplicate
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile '*-VF.ttf' -d $out/share/fonts/truetype
+  '';
+})

--- a/pkgs/data/fonts/fira-code/symbols.nix
+++ b/pkgs/data/fonts/fira-code/symbols.nix
@@ -1,14 +1,10 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
-fetchzip {
+(fetchzip {
   name = "fira-code-symbols-20160811";
 
   url = "https://github.com/tonsky/FiraCode/files/412440/FiraCode-Regular-Symbol.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile -d $out/share/fonts/opentype
-  '';
 
   sha256 = "19krsp22rin74ix0i19v4bh1c965g18xkmz1n55h6n6qimisnbkm";
 
@@ -23,4 +19,9 @@ fetchzip {
     maintainers = [ maintainers.Profpatsch ];
     homepage = "https://github.com/tonsky/FiraCode/issues/211#issuecomment-239058632";
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile -d $out/share/fonts/opentype
+  '';
+})

--- a/pkgs/data/fonts/fira-mono/default.nix
+++ b/pkgs/data/fonts/fira-mono/default.nix
@@ -1,15 +1,11 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let version = "4.202";
-in fetchzip {
+in (fetchzip {
   name = "fira-mono-${version}";
 
   url = "https://github.com/mozilla/Fira/archive/${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile Fira-${version}/otf/FiraMono\*.otf -d $out/share/fonts/opentype
-  '';
 
   sha256 = "1ci3fxhdwabvfj4nl16pwcgqnh7s2slp8vblribk8zkpx8cbp1dj";
 
@@ -26,4 +22,9 @@ in fetchzip {
     maintainers = [ maintainers.rycee ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile Fira-${version}/otf/FiraMono\*.otf -d $out/share/fonts/opentype
+  '';
+})

--- a/pkgs/data/fonts/fraunces/default.nix
+++ b/pkgs/data/fonts/fraunces/default.nix
@@ -1,19 +1,14 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 let
   version = "1.000";
 in
-fetchzip {
+(fetchzip {
   name = "fraunces-${version}";
 
   url = "https://github.com/undercasetype/Fraunces/releases/download/${version}/UnderCaseType_Fraunces_${version}.zip";
 
   sha256 = "0qgl140qkn9p87x7pk60fd3lj206y5h0fq2xkcj2qiv3sxbqxwqb";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
 
   meta = with lib; {
     description = "A display, “Old Style” soft-serif typeface inspired by early 20th century typefaces";
@@ -22,4 +17,10 @@ fetchzip {
     maintainers = [ maintainers.marsam ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+  '';
+})

--- a/pkgs/data/fonts/galatia-sil/default.nix
+++ b/pkgs/data/fonts/galatia-sil/default.nix
@@ -1,18 +1,14 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "2.1";
+  name = "galatia-sil-${version}";
 in
-  fetchzip rec {
-    name = "galatia-sil-${version}";
+  (fetchzip rec {
+    inherit name;
 
     url = "https://software.sil.org/downloads/r/galatia/GalatiaSIL-${version}.zip";
-
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
-    '';
 
     sha256 = "sha256-zLL/7LMcJul2LilhEafpvm+tiYlgv1y1jj85VvG+wiI=";
 
@@ -26,4 +22,10 @@ in
       platforms = platforms.all;
       maintainers = [ maintainers.kmein ];
     };
-  }
+  }).overrideAttrs (_: {
+    postFetch = ''
+      mkdir -p $out/share/{doc,fonts}
+      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    '';
+  })

--- a/pkgs/data/fonts/gentium-book-basic/default.nix
+++ b/pkgs/data/fonts/gentium-book-basic/default.nix
@@ -1,19 +1,15 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   major = "1";
   minor = "102";
   version = "${major}.${minor}";
-in fetchzip rec {
   name = "gentium-book-basic-${version}";
+in (fetchzip rec {
+  inherit name;
 
   url = "http://software.sil.org/downloads/r/gentium/GentiumBasic_${major}${minor}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf                            -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*/FONTLOG.txt \*/GENTIUM-FAQ.txt -d $out/share/doc/${name}
-  '';
 
   sha256 = "0598zr5f7d6ll48pbfbmmkrybhhdks9b2g3m2g67wm40070ffzmd";
 
@@ -24,4 +20,10 @@ in fetchzip rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/{doc,fonts}
+    unzip -j $downloadedFile \*.ttf                            -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \*/FONTLOG.txt \*/GENTIUM-FAQ.txt -d $out/share/doc/${name}
+  '';
+})

--- a/pkgs/data/fonts/gentium/default.nix
+++ b/pkgs/data/fonts/gentium/default.nix
@@ -1,27 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "6.101";
-in fetchzip rec {
   name = "gentium-${version}";
+in (fetchzip rec {
+  inherit name;
 
   url = "http://software.sil.org/downloads/r/gentium/GentiumPlus-${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -l $downloadedFile
-    unzip -j $downloadedFile \*.ttf \
-      -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \
-      \*/FONTLOG.txt \
-      \*/README.txt \
-      -d $out/share/doc/${name}
-    unzip -j $downloadedFile \
-      \*/documentation/\*.html \
-      \*/documentation/\*.txt \
-      -x \*/documentation/source/\* \
-      -d $out/share/doc/${name}/documentation
-  '';
 
   sha256 = "sha256-+T5aUlqQYDWRp4/4AZzsREHgjAnOeUB6qn1GAI0A5hE=";
 
@@ -48,4 +34,20 @@ in fetchzip rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/{doc,fonts}
+    unzip -l $downloadedFile
+    unzip -j $downloadedFile \*.ttf \
+      -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \
+      \*/FONTLOG.txt \
+      \*/README.txt \
+      -d $out/share/doc/${name}
+    unzip -j $downloadedFile \
+      \*/documentation/\*.html \
+      \*/documentation/\*.txt \
+      -x \*/documentation/source/\* \
+      -d $out/share/doc/${name}/documentation
+  '';
+})

--- a/pkgs/data/fonts/gyre/default.nix
+++ b/pkgs/data/fonts/gyre/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   baseName = "gyre-fonts";
   version = "2.005";
-in fetchzip {
+in (fetchzip {
   name="${baseName}-${version}";
 
   url = "http://www.gust.org.pl/projects/e-foundry/tex-gyre/whole/tg-${version}otf.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/truetype
-  '';
 
   sha256 = "17amdpahs6kn7hk3dqxpff1s095cg1caxzij3mxjbbxp8zy0l111";
 
@@ -29,4 +25,9 @@ in fetchzip {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ bergey ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/truetype
+  '';
+})

--- a/pkgs/data/fonts/hack/default.nix
+++ b/pkgs/data/fonts/hack/default.nix
@@ -1,16 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "3.003";
-in fetchzip {
+in (fetchzip {
   name = "hack-font-${version}";
 
   url = "https://github.com/chrissimpkins/Hack/releases/download/v${version}/Hack-v${version}-ttf.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/hack
-  '';
 
   sha256 = "1l6ih6v7dqali5c7zh6z2xnbf9h2wz0ag6fdgszmqd5lnhw39v6s";
 
@@ -37,4 +33,9 @@ in fetchzip {
     maintainers = with maintainers; [ dywedir ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/hack
+  '';
+})

--- a/pkgs/data/fonts/hasklig/default.nix
+++ b/pkgs/data/fonts/hasklig/default.nix
@@ -1,16 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "1.1";
-in fetchzip {
+in (fetchzip {
   name = "hasklig-${version}";
 
   url = "https://github.com/i-tu/Hasklig/releases/download/${version}/Hasklig-${version}.zip";
-
-  postFetch = ''
-    unzip $downloadedFile
-    install -m444 -Dt $out/share/fonts/opentype *.otf
-  '';
 
   sha256 = "0xxyx0nkapviqaqmf3b610nq17k20afirvc72l32pfspsbxz8ybq";
 
@@ -21,4 +17,9 @@ in fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ davidrusu Profpatsch ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    unzip $downloadedFile
+    install -m444 -Dt $out/share/fonts/opentype *.otf
+  '';
+})

--- a/pkgs/data/fonts/hyperscrypt/default.nix
+++ b/pkgs/data/fonts/hyperscrypt/default.nix
@@ -1,3 +1,4 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { fetchzip, lib }:
 
 let
@@ -5,15 +6,10 @@ let
   pname = "HyperScrypt";
 in
 
-fetchzip {
+(fetchzip {
   name = "${lib.toLower pname}-font-${version}";
   url = "https://gitlab.com/StudioTriple/Hyper-Scrypt/-/archive/${version}/Hyper-Scrypt-${version}.zip";
   sha256 = "01pf5p2scmw02s0gxnibiwxbpzczphaaapv0v4s7svk9aw2gmc0m";
-  postFetch = ''
-    mkdir -p $out/share/fonts/{truetype,opentype}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/${pname}.ttf
-    unzip -j $downloadedFile \*${pname}.otf -d $out/share/fonts/opentype/${pname}.otf
-  '';
 
   meta = with lib; {
     homepage = "http://velvetyne.fr/fonts/hyper-scrypt/";
@@ -37,4 +33,10 @@ fetchzip {
     maintainers = with maintainers; [ leenaars ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/{truetype,opentype}
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/${pname}.ttf
+    unzip -j $downloadedFile \*${pname}.otf -d $out/share/fonts/opentype/${pname}.otf
+  '';
+})

--- a/pkgs/data/fonts/ibm-plex/default.nix
+++ b/pkgs/data/fonts/ibm-plex/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "6.0.1";
 
-in fetchzip {
+in (fetchzip {
   name = "ibm-plex-${version}";
 
   url = "https://github.com/IBM/plex/releases/download/v${version}/OpenType.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile "OpenType/*/*.otf" -x "OpenType/IBM-Plex-Sans-JP/unhinted/*" -d $out/share/fonts/opentype
-  '';
 
   sha256 = "sha256-HxO0L5Q6WJQBqtg64cczzuRcSYi4jEqbOzEWxDmqFp8=";
 
@@ -23,4 +19,9 @@ in fetchzip {
     platforms = platforms.all;
     maintainers = [ maintainers.romildo ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile "OpenType/*/*.otf" -x "OpenType/IBM-Plex-Sans-JP/unhinted/*" -d $out/share/fonts/opentype
+  '';
+})

--- a/pkgs/data/fonts/inter/default.nix
+++ b/pkgs/data/fonts/inter/default.nix
@@ -1,16 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "3.19";
-in fetchzip {
+in (fetchzip {
   name = "inter-${version}";
 
   url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
 
   sha256 = "sha256-8p15thg3xyvCA/8dH2jGQoc54nzESFDyv5m47FgWrSI=";
 
@@ -21,5 +17,10 @@ in fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ demize dtzWill ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+  '';
+})
 

--- a/pkgs/data/fonts/ipaexfont/default.nix
+++ b/pkgs/data/fonts/ipaexfont/default.nix
@@ -1,14 +1,10 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
-fetchzip {
+(fetchzip {
   name = "ipaexfont-004.01";
 
   url = "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/opentype
-  '';
 
   sha256 = "0wp369kri33kb1mmiq4lpl9i4xnacw9fj63ycmkmlkq64s8qnjnx";
 
@@ -25,4 +21,9 @@ fetchzip {
     license = licenses.ipa;
     maintainers = with maintainers; [ gebner ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/opentype
+  '';
+})

--- a/pkgs/data/fonts/ipafont/default.nix
+++ b/pkgs/data/fonts/ipafont/default.nix
@@ -1,14 +1,10 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
-fetchzip {
+(fetchzip {
   name = "ipafont-003.03";
 
   url = "https://moji.or.jp/wp-content/ipafont/IPAfont/IPAfont00303.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/opentype
-  '';
 
   sha256 = "0lrjd0bfy36f9j85m12afg5nvr5id3sig2nmzs5qifskbd7mqv9h";
 
@@ -23,4 +19,9 @@ fetchzip {
     license = lib.licenses.ipa;
     maintainers = [ lib.maintainers.auntie ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/opentype
+  '';
+})

--- a/pkgs/data/fonts/jost/default.nix
+++ b/pkgs/data/fonts/jost/default.nix
@@ -1,15 +1,11 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 {lib, fetchzip}:
 
 let
   version = "3.5";
-in fetchzip {
+in (fetchzip {
   name = "jost-${version}";
   url = "https://github.com/indestructible-type/Jost/releases/download/${version}/Jost.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
 
   sha256="0l78vhmbsyfmrva5wc76pskhxqryyg8q5xddpj9g5wqsddy525dq";
 
@@ -19,4 +15,9 @@ in fetchzip {
     license = licenses.ofl;
     maintainers = [ maintainers.ar1a ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+  '';
+})

--- a/pkgs/data/fonts/kawkab-mono/default.nix
+++ b/pkgs/data/fonts/kawkab-mono/default.nix
@@ -1,14 +1,10 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
-fetchzip {
+(fetchzip {
   name = "kawkab-mono-20151015";
 
   url = "http://makkuk.com/kawkab-mono/downloads/kawkab-mono-0.1.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
 
   sha256 = "1vfrb7xs817najplncg7zl9j5yxj8qnwb7aqm2v9p9xwafa4d2yd";
 
@@ -17,6 +13,9 @@ fetchzip {
     homepage = "https://makkuk.com/kawkab-mono/";
     license = lib.licenses.ofl;
   };
-}
-
-
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+  '';
+})

--- a/pkgs/data/fonts/lato/default.nix
+++ b/pkgs/data/fonts/lato/default.nix
@@ -1,14 +1,10 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
-fetchzip {
+(fetchzip {
   name = "lato-2.0";
 
   url = "https://www.latofonts.com/download/Lato2OFL.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/lato
-  '';
 
   sha256 = "1amwn6vcaggxrd2s4zw21s2pr47zmzdf2xfy4x9lxa2cd9bkhvg5";
 
@@ -36,4 +32,9 @@ fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ chris-martin ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/lato
+  '';
+})

--- a/pkgs/data/fonts/lmmath/default.nix
+++ b/pkgs/data/fonts/lmmath/default.nix
@@ -1,17 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "1.959";
-in fetchzip rec {
+in (fetchzip rec {
   name = "lmmath-${version}";
 
   url = "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip";
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/
-    mkdir -p $out/share/doc/latinmodern-math-${version}/
-    unzip -j $downloadedFile "*/otf/*.otf" -d $out/share/fonts/opentype/
-    unzip -j $downloadedFile "*/doc/*.txt" -d $out/share/doc/latinmodern-math-${version}/
-  '';
   sha256 = "05k145bxgxjh7i9gx1ahigxfpc2v2vwzsy2mc41jvvg51kjr8fnn";
 
   meta = with lib; {
@@ -24,4 +19,11 @@ in fetchzip rec {
     maintainers = with maintainers; [ siddharthist ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/opentype/
+    mkdir -p $out/share/doc/latinmodern-math-${version}/
+    unzip -j $downloadedFile "*/otf/*.otf" -d $out/share/fonts/opentype/
+    unzip -j $downloadedFile "*/doc/*.txt" -d $out/share/doc/latinmodern-math-${version}/
+  '';
+})

--- a/pkgs/data/fonts/mno16/default.nix
+++ b/pkgs/data/fonts/mno16/default.nix
@@ -1,21 +1,22 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   pname = "mno16";
   version = "1.0";
-in fetchzip rec {
+in (fetchzip rec {
   name = "${pname}-${version}";
   url = "https://github.com/sevmeyer/${pname}/releases/download/${version}/${name}.zip";
   sha256 = "1x06nl281fcjk6g1p4cgrgxakmwcci6vvasskaygsqlzxd8ig87w";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/
-  '';
 
   meta = with lib; {
     description = "minimalist monospaced font";
     homepage = "https://sev.dev/fonts/mno16";
     license = licenses.cc0;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/
+  '';
+})

--- a/pkgs/data/fonts/mononoki/default.nix
+++ b/pkgs/data/fonts/mononoki/default.nix
@@ -1,16 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "1.3";
-in fetchzip {
+in (fetchzip {
   name = "mononoki-${version}";
 
   url = "https://github.com/madmalik/mononoki/releases/download/${version}/mononoki.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/mononoki
-    unzip -j $downloadedFile -d $out/share/fonts/mononoki
-  '';
 
   sha256 = "sha256-K2uOpJRmQ1NcDZfh6rorCF0MvGHFCsSW8J7Ue9OC/OY=";
 
@@ -20,4 +16,9 @@ in fetchzip {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/mononoki
+    unzip -j $downloadedFile -d $out/share/fonts/mononoki
+  '';
+})

--- a/pkgs/data/fonts/nanum-gothic-coding/default.nix
+++ b/pkgs/data/fonts/nanum-gothic-coding/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "VER2.5";
   fullName = "NanumGothicCoding-2.5";
 
-in fetchzip {
+in (fetchzip {
   name = "nanum-gothic-coding";
   url = "https://github.com/naver/nanumfont/releases/download/${version}/${fullName}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/NanumGothicCoding
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/NanumGothicCoding
-  '';
 
   sha256 = "0b3pkhd6xn6393zi0dhj3ah08w1y1ji9fl6584bi0c8lanamf2pc";
 
@@ -22,4 +18,9 @@ in fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/NanumGothicCoding
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/NanumGothicCoding
+  '';
+})

--- a/pkgs/data/fonts/national-park/default.nix
+++ b/pkgs/data/fonts/national-park/default.nix
@@ -1,16 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   pname = "national-park-typeface";
   version = "206464";
-in fetchzip {
+in (fetchzip {
   name = "${pname}-${version}";
   url = "https://files.cargocollective.com/c${version}/NationalPark.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile National\*.otf -d $out/share/fonts/opentype/
-  '';
 
   sha256 = "044gh4xcasp8i9ny6z4nmns1am2pk5krc4ann2afq35v9bnl2q5d";
 
@@ -21,4 +17,9 @@ in fetchzip {
     license = licenses.ofl;
     maintainers = with maintainers; [ dtzWill ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile National\*.otf -d $out/share/fonts/opentype/
+  '';
+})

--- a/pkgs/data/fonts/norwester/default.nix
+++ b/pkgs/data/fonts/norwester/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "1.2";
   pname = "norwester";
-in fetchzip {
+in (fetchzip {
   name = "${pname}-${version}";
 
   url = "http://jamiewilson.io/norwester/assets/norwester.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -D -j $downloadedFile ${pname}-v${version}/${pname}.otf -d $out/share/fonts/opentype/
-  '';
 
   sha256 = "1npsaiiz9g5z6315lnmynwcnrfl37fyxc7w1mhkw1xbzcnv74z4r";
 
@@ -22,4 +18,9 @@ in fetchzip {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/opentype
+    unzip -D -j $downloadedFile ${pname}-v${version}/${pname}.otf -d $out/share/fonts/opentype/
+  '';
+})

--- a/pkgs/data/fonts/oldstandard/default.nix
+++ b/pkgs/data/fonts/oldstandard/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "2.2";
-in fetchzip rec {
   name = "oldstandard-${version}";
+in (fetchzip rec {
+  inherit name;
 
   url = "https://github.com/akryukov/oldstand/releases/download/v${version}/${name}.otf.zip";
-
-  postFetch = ''
-    unzip $downloadedFile
-    install -m444 -Dt $out/share/fonts/opentype *.otf
-    install -m444 -Dt $out/share/doc/${name}    FONTLOG.txt
-  '';
 
   sha256 = "1qwfsyp51grr56jcnkkmnrnl3r20pmhp9zh9g88kp64m026cah6n";
 
@@ -22,4 +18,10 @@ in fetchzip rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    unzip $downloadedFile
+    install -m444 -Dt $out/share/fonts/opentype *.otf
+    install -m444 -Dt $out/share/doc/${name}    FONTLOG.txt
+  '';
+})

--- a/pkgs/data/fonts/open-dyslexic/default.nix
+++ b/pkgs/data/fonts/open-dyslexic/default.nix
@@ -1,17 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "2016-06-23";
-in fetchzip {
+in (fetchzip {
   name = "open-dyslexic-${version}";
 
   url = "https://github.com/antijingoist/open-dyslexic/archive/20160623-Stable.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.otf       -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*/README.md -d $out/share/doc/open-dyslexic
-  '';
 
   sha256 = "1vl8z5rknh2hpr2f0v4b2qgs5kclx5pzyk8al7243k5db82a2cyi";
 
@@ -22,4 +17,10 @@ in fetchzip {
     platforms = platforms.all;
     maintainers = [maintainers.rycee];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/{doc,fonts}
+    unzip -j $downloadedFile \*.otf       -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*/README.md -d $out/share/doc/open-dyslexic
+  '';
+})

--- a/pkgs/data/fonts/overpass/default.nix
+++ b/pkgs/data/fonts/overpass/default.nix
@@ -1,18 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "3.0.5";
-in fetchzip rec {
   name = "overpass-${version}";
+in (fetchzip rec {
+  inherit name;
 
   url = "https://github.com/RedHatOfficial/Overpass/releases/download/v${version}/overpass-${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts $out/share/doc
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.md  -d $out/share/doc/${name}
-  '';
 
   sha256 = "1fpyhd6x3i3g0xxjmyfnjsri1kkvci15fv7jp1bnza7k0hz0bnha";
 
@@ -23,4 +18,11 @@ in fetchzip rec {
     platforms = platforms.all;
     maintainers = [ maintainers.rycee ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts $out/share/doc
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.md  -d $out/share/doc/${name}
+  '';
+})

--- a/pkgs/data/fonts/paratype-pt/mono.nix
+++ b/pkgs/data/fonts/paratype-pt/mono.nix
@@ -1,18 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
-fetchzip {
+(fetchzip {
   name = "paratype-pt-mono";
 
   urls = [
     "https://company.paratype.com/system/attachments/631/original/ptmono.zip"
     "http://rus.paratype.ru/system/attachments/631/original/ptmono.zip"
   ];
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.txt -d $out/share/doc/paratype
-  '';
 
   sha256 = "07kl82ngby55khvzsvn831ddpc0q8djgz2y6gsjixkyjfdk2xjjm";
 
@@ -28,5 +23,10 @@ fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ raskin ];
   };
-}
-
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/{doc,fonts}
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.txt -d $out/share/doc/paratype
+  '';
+})

--- a/pkgs/data/fonts/paratype-pt/sans.nix
+++ b/pkgs/data/fonts/paratype-pt/sans.nix
@@ -1,18 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
-fetchzip {
+(fetchzip {
   name = "paratype-pt-sans";
 
   urls = [
     "https://company.paratype.com/system/attachments/629/original/ptsans.zip"
     "http://rus.paratype.ru/system/attachments/629/original/ptsans.zip"
   ];
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.txt -d $out/share/doc/paratype
-  '';
 
   sha256 = "01fkd417gv98jf3a6zyfi9w2dkqsbddy1vacga2672yf0kh1z1r0";
 
@@ -28,5 +23,10 @@ fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ raskin ];
   };
-}
-
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/{doc,fonts}
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.txt -d $out/share/doc/paratype
+  '';
+})

--- a/pkgs/data/fonts/paratype-pt/serif.nix
+++ b/pkgs/data/fonts/paratype-pt/serif.nix
@@ -1,18 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
-fetchzip {
+(fetchzip {
   name = "paratype-pt-serif";
 
   urls = [
     "https://company.paratype.com/system/attachments/634/original/ptserif.zip"
     "http://rus.paratype.ru/system/attachments/634/original/ptserif.zip"
   ];
-
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.txt -d $out/share/doc/paratype
-  '';
 
   sha256 = "1iw5qi4ag3yp1lwmi91lb18gr768bqwl46xskaqnkhr9i9qp0v6d";
 
@@ -28,5 +23,10 @@ fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ raskin ];
   };
-}
-
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/{doc,fonts}
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.txt -d $out/share/doc/paratype
+  '';
+})

--- a/pkgs/data/fonts/public-sans/default.nix
+++ b/pkgs/data/fonts/public-sans/default.nix
@@ -1,17 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "2.001";
-in fetchzip {
+in (fetchzip {
   name = "public-sans-${version}";
 
   url = "https://github.com/uswds/public-sans/releases/download/v${version}/public-sans-v${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
 
   sha256 = "sha256-Ba7D4J72GZQsGn0KINRib9BmHsAnoEsAwAOC+M3CkMU=";
 
@@ -23,4 +18,10 @@ in fetchzip {
     maintainers = with maintainers; [ dtzWill ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+  '';
+})

--- a/pkgs/data/fonts/quattrocento-sans/default.nix
+++ b/pkgs/data/fonts/quattrocento-sans/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "2.0";
-in fetchzip rec {
   name = "quattrocento-sans-${version}";
+in (fetchzip rec {
+  inherit name;
 
   url = "https://web.archive.org/web/20170709124317/http://www.impallari.com/media/releases/quattrocento-sans-v${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{fonts,doc}
-    unzip -j $downloadedFile '*/QuattrocentoSans*.otf' -d $out/share/fonts/opentype
-    unzip -j $downloadedFile '*/FONTLOG.txt'           -d $out/share/doc/${name}
-  '';
 
   sha256 = "0g8hnn92ks4y0jbizwj7yfa097lk887wqkqpqjdmc09sd2n44343";
 
@@ -22,4 +18,10 @@ in fetchzip rec {
     platforms = platforms.all;
     maintainers = [maintainers.rycee];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/{fonts,doc}
+    unzip -j $downloadedFile '*/QuattrocentoSans*.otf' -d $out/share/fonts/opentype
+    unzip -j $downloadedFile '*/FONTLOG.txt'           -d $out/share/doc/${name}
+  '';
+})

--- a/pkgs/data/fonts/quattrocento/default.nix
+++ b/pkgs/data/fonts/quattrocento/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "1.1";
-in fetchzip rec {
   name = "quattrocento-${version}";
+in (fetchzip rec {
+  inherit name;
 
   url = "https://web.archive.org/web/20170707001804/http://www.impallari.com/media/releases/quattrocento-v${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/{fonts,doc}
-    unzip -j $downloadedFile \*.otf        -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*FONTLOG.txt -d $out/share/doc/${name}
-  '';
 
   sha256 = "0f8l19y61y20sszn8ni8h9kgl0zy1gyzychg22z5k93ip4h7kfd0";
 
@@ -22,4 +18,10 @@ in fetchzip rec {
     platforms = platforms.all;
     maintainers = [maintainers.rycee];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/{fonts,doc}
+    unzip -j $downloadedFile \*.otf        -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*FONTLOG.txt -d $out/share/doc/${name}
+  '';
+})

--- a/pkgs/data/fonts/roboto/default.nix
+++ b/pkgs/data/fonts/roboto/default.nix
@@ -1,16 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "2.138";
-in fetchzip {
+in (fetchzip {
   name = "roboto-${version}";
 
   url = "https://github.com/google/roboto/releases/download/v${version}/roboto-unhinted.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -x __MACOSX/\* -d $out/share/fonts/truetype
-  '';
 
   sha256 = "1s3c48wwvvwd3p4w3hfkri5v2c54j2bdxmd3bjv54klc5mrlh6z3";
 
@@ -26,4 +22,9 @@ in fetchzip {
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.romildo ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.ttf -x __MACOSX/\* -d $out/share/fonts/truetype
+  '';
+})

--- a/pkgs/data/fonts/scheherazade/default.nix
+++ b/pkgs/data/fonts/scheherazade/default.nix
@@ -1,3 +1,4 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip, version ? "3.300" }:
 
 let
@@ -6,20 +7,12 @@ let
     "2.100" = "1g5f5f9gzamkq3kqyf7vbzvl4rdj3wmjf6chdrbxksrm3rnb926z";
     "3.300" = "1bja1ma1mnna0qlk3dis31cvq5z1kgcqj7wjp8ml03zc5mpa2wb2";
   }."${version}";
-
-in fetchzip rec {
   name = "scheherazade${lib.optionalString new "-new"}-${version}";
 
-  url = "http://software.sil.org/downloads/r/scheherazade/Scheherazade${lib.optionalString new "New"}-${version}.zip";
+in (fetchzip rec {
+  inherit name;
 
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -l $downloadedFile
-    unzip -j $downloadedFile \*.ttf                        -d $out/share/fonts/truetype
-    unzip    $downloadedFile \*/documentation/\*           -d $out/share/doc/
-    mv $out/share/doc/* $out/share/doc/${name}
-    unzip -j $downloadedFile \*/FONTLOG.txt  \*/README.txt -d $out/share/doc/${name}
-  '';
+  url = "http://software.sil.org/downloads/r/scheherazade/Scheherazade${lib.optionalString new "New"}-${version}.zip";
 
   inherit sha256;
 
@@ -47,4 +40,13 @@ in fetchzip rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/{doc,fonts}
+    unzip -l $downloadedFile
+    unzip -j $downloadedFile \*.ttf                        -d $out/share/fonts/truetype
+    unzip    $downloadedFile \*/documentation/\*           -d $out/share/doc/
+    mv $out/share/doc/* $out/share/doc/${name}
+    unzip -j $downloadedFile \*/FONTLOG.txt  \*/README.txt -d $out/share/doc/${name}
+  '';
+})

--- a/pkgs/data/fonts/source-code-pro/default.nix
+++ b/pkgs/data/fonts/source-code-pro/default.nix
@@ -1,16 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "2.038";
-in fetchzip {
+in (fetchzip {
   name = "source-code-pro-${version}";
 
   url = "https://github.com/adobe-fonts/source-code-pro/releases/download/${version}R-ro%2F1.058R-it%2F1.018R-VAR/OTF-source-code-pro-${version}R-ro-1.058R-it.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
 
   sha256 = "027cf62zj27q7l3d4sqzdfgz423lzysihdg8cvmkk6z910a1v368";
 
@@ -21,4 +17,9 @@ in fetchzip {
     homepage = "https://adobe-fonts.github.io/source-code-pro/";
     license = lib.licenses.ofl;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+  '';
+})

--- a/pkgs/data/fonts/source-han-code-jp/default.nix
+++ b/pkgs/data/fonts/source-han-code-jp/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   pname = "source-han-code-jp";
   version = "2.012R";
-in fetchzip {
+in (fetchzip {
   name = "${pname}-${version}";
 
   url = "https://github.com/adobe-fonts/${pname}/archive/${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
 
   sha256 = "16y5as1k864ghy3vzp8svr3q0sw57rv53za3f48700ksvxz5pwry";
 
@@ -22,4 +18,9 @@ in fetchzip {
     homepage = "https://blogs.adobe.com/CCJKType/2015/06/source-han-code-jp.html";
     license = lib.licenses.ofl;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+  '';
+})

--- a/pkgs/data/fonts/source-han/default.nix
+++ b/pkgs/data/fonts/source-han/default.nix
@@ -1,3 +1,4 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { stdenvNoCC
 , lib
 , fetchzip
@@ -18,11 +19,11 @@ let
       lib.toUpper (lib.substring 0 1 family) +
       lib.substring 1 (lib.stringLength family) family;
     in
-    fetchzip {
+    (fetchzip {
       name = "source-han-${family}-${lib.removeSuffix "R" rev}";
 
       url = "https://github.com/adobe-fonts/source-han-${family}/releases/download/${rev}/SourceHan${Family}.ttc${zip}";
-      inherit sha256 postFetch;
+      inherit sha256;
 
       meta = {
         description = "An open source Pan-CJK ${description} typeface";
@@ -30,7 +31,7 @@ let
         license = lib.licenses.ofl;
         maintainers = with lib.maintainers; [ taku0 emily ];
       };
-    };
+    }).overrideAttrs (_: { inherit postFetch; });
 in
 {
   sans = makePackage {

--- a/pkgs/data/fonts/source-sans-pro/default.nix
+++ b/pkgs/data/fonts/source-sans-pro/default.nix
@@ -1,3 +1,4 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 # Source Sans Pro got renamed to Source Sans 3 (see
@@ -6,17 +7,10 @@
 # with older documents/templates/etc.
 let
   version = "3.006";
-in fetchzip {
+in (fetchzip {
   name = "source-sans-pro-${version}";
 
   url = "https://github.com/adobe-fonts/source-sans/archive/${version}R.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/{opentype,truetype,variable}
-    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
-    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
-    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
-  '';
 
   sha256 = "sha256-uWr/dFyLF65v0o6+oN/3RQoe4ziPspzGB1rgiBkoTYY=";
 
@@ -27,4 +21,11 @@ in fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ ttuegel ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/{opentype,truetype,variable}
+    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
+    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
+    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
+  '';
+})

--- a/pkgs/data/fonts/source-sans/default.nix
+++ b/pkgs/data/fonts/source-sans/default.nix
@@ -1,18 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "3.046";
-in fetchzip {
+in (fetchzip {
   name = "source-sans-${version}";
 
   url = "https://github.com/adobe-fonts/source-sans/archive/${version}R.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/{opentype,truetype,variable}
-    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
-    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
-    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
-  '';
 
   sha256 = "1wxdinnliq0xqbjrs0sqykwaggkmyqawfq862d9xn05g1pnxda94";
 
@@ -23,4 +17,11 @@ in fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ ttuegel ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/{opentype,truetype,variable}
+    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
+    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
+    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
+  '';
+})

--- a/pkgs/data/fonts/source-serif-pro/default.nix
+++ b/pkgs/data/fonts/source-serif-pro/default.nix
@@ -1,3 +1,4 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 # Source Serif Pro got renamed to Source Serif 4 (see
@@ -6,17 +7,10 @@
 # with older documents/templates/etc.
 let
   version = "3.001";
-in fetchzip {
+in (fetchzip {
   name = "source-serif-pro-${version}";
 
   url = "https://github.com/adobe-fonts/source-serif/releases/download/${version}R/source-serif-pro-${version}R.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/{opentype,truetype,variable}
-    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
-    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
-    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
-  '';
 
   sha256 = "sha256-rYWk8D41QMuuSP+cQMk8ttT7uX3a7gBk4OqjA7K9udk=";
 
@@ -27,4 +21,11 @@ in fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ ttuegel ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/{opentype,truetype,variable}
+    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
+    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
+    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
+  '';
+})

--- a/pkgs/data/fonts/source-serif/default.nix
+++ b/pkgs/data/fonts/source-serif/default.nix
@@ -1,18 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "4.004";
-in fetchzip {
+in (fetchzip {
   name = "source-serif-${version}";
 
   url = "https://github.com/adobe-fonts/source-serif/releases/download/${version}R/source-serif-${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/{opentype,truetype,variable}
-    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
-    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
-    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
-  '';
 
   sha256 = "06814hcp20abca6p0ii61f23g6h1ibqyhq30lsva59wbwx5iha0h";
 
@@ -23,4 +17,11 @@ in fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ ttuegel ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/{opentype,truetype,variable}
+    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
+    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
+    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
+  '';
+})

--- a/pkgs/data/fonts/stix-two/default.nix
+++ b/pkgs/data/fonts/stix-two/default.nix
@@ -1,19 +1,14 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 let
   version = "2.13";
 in
-fetchzip {
+(fetchzip {
   name = "stix-two-${version}";
 
   url = "https://github.com/stipub/stixfonts/raw/v${version}/zipfiles/STIX${builtins.replaceStrings [ "." ] [ "_" ] version}-all.zip";
 
   sha256 = "sha256-cBtZe/oq4bQCscSAhJ4YuTSghDleD9O/+3MHOJyI50o=";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
 
   meta = with lib; {
     homepage = "https://www.stixfonts.org/";
@@ -22,4 +17,10 @@ fetchzip {
     platforms = platforms.all;
     maintainers = [ maintainers.rycee ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+  '';
+})

--- a/pkgs/data/fonts/sudo/default.nix
+++ b/pkgs/data/fonts/sudo/default.nix
@@ -1,16 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "0.64";
-in fetchzip {
+in (fetchzip {
   name = "sudo-font-${version}";
   url = "https://github.com/jenskutilek/sudo-font/releases/download/v${version}/sudo.zip";
   sha256 = "sha256-ewLTeIVY76eq5mHTnjIsJ5Q2CMuBqXJzxvjZTONPsr8=";
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/
-  '';
   meta = with lib; {
     description = "Font for programmers and command line users";
     homepage = "https://www.kutilek.de/sudo-font/";
@@ -19,4 +16,9 @@ in fetchzip {
     maintainers = with maintainers; [ dtzWill ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/
+  '';
+})

--- a/pkgs/data/fonts/terminus-font-ttf/default.nix
+++ b/pkgs/data/fonts/terminus-font-ttf/default.nix
@@ -1,22 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "4.49.1";
-in fetchzip {
+in (fetchzip {
   name = "terminus-font-ttf-${version}";
 
   url = "https://files.ax86.net/terminus-ttf/files/${version}/terminus-ttf-${version}.zip";
-
-  postFetch = ''
-    unzip -j $downloadedFile
-
-    for i in *.ttf; do
-      local destname="$(echo "$i" | sed -E 's|-[[:digit:].]+\.ttf$|.ttf|')"
-      install -Dm 644 "$i" "$out/share/fonts/truetype/$destname"
-    done
-
-    install -Dm 644 COPYING "$out/share/doc/terminus-font-ttf/COPYING"
-  '';
 
   sha256 = "sha256-UaTnCamIRN/3xZsYt5nYzvykXQ3ri94a047sWOJ2RfU=";
 
@@ -30,4 +20,15 @@ in fetchzip {
     license = licenses.ofl;
     maintainers = with maintainers; [ ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    unzip -j $downloadedFile
+
+    for i in *.ttf; do
+      local destname="$(echo "$i" | sed -E 's|-[[:digit:].]+\.ttf$|.ttf|')"
+      install -Dm 644 "$i" "$out/share/fonts/truetype/$destname"
+    done
+
+    install -Dm 644 COPYING "$out/share/doc/terminus-font-ttf/COPYING"
+  '';
+})

--- a/pkgs/data/fonts/theano/default.nix
+++ b/pkgs/data/fonts/theano/default.nix
@@ -1,18 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "2.0";
-in fetchzip rec {
   name = "theano-${version}";
+in (fetchzip rec {
+  inherit name;
 
   url = "https://github.com/akryukov/theano/releases/download/v${version}/theano-${version}.otf.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    mkdir -p $out/share/doc/${name}
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.txt -d "$out/share/doc/${name}"
-  '';
 
   sha256 = "1my1symb7k80ys33iphsxvmf6432wx6vjdnxhzhkgrang1rhx1h8";
 
@@ -23,4 +18,11 @@ in fetchzip rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${name}
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.txt -d "$out/share/doc/${name}"
+  '';
+})

--- a/pkgs/data/fonts/times-newer-roman/default.nix
+++ b/pkgs/data/fonts/times-newer-roman/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "unstable-2018-09-11";
 in
-fetchzip {
+(fetchzip {
   name = "times-newer-roman-${version}";
 
   url = "https://web.archive.org/web/20210609022835/https://timesnewerroman.com/assets/TimesNewerRoman.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
 
   hash = "sha256-Hx59RYLLwfimEQjEEes0lCpg6iql46DFwhQ7kVGiEzc=";
 
@@ -22,4 +18,9 @@ fetchzip {
     maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+  '';
+})

--- a/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
+++ b/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "2.2";
 in
-fetchzip {
+(fetchzip {
   name = "ultimate-oldschool-pc-font-pack-${version}";
   url = "https://int10h.org/oldschool-pc-fonts/download/oldschool_pc_font_pack_v${version}_linux.zip";
   sha256 = "sha256-BOA2fMa2KT3Bkpvj/0DzrzuZbl3RARvNn4qbI/+dApU=";
-
-  postFetch= ''
-    mkdir -p $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
 
   meta = with lib; {
     description = "The Ultimate Oldschool PC Font Pack (TTF Fonts)";
@@ -20,4 +16,9 @@ fetchzip {
     license = licenses.cc-by-sa-40;
     maintainers = [ maintainers.endgame ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch= ''
+    mkdir -p $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
+  '';
+})

--- a/pkgs/data/fonts/undefined-medium/default.nix
+++ b/pkgs/data/fonts/undefined-medium/default.nix
@@ -1,14 +1,10 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
-
-fetchzip rec {
-  name = "undefined-medium-1.0";
+let name = "undefined-medium-1.0";
+in (fetchzip rec {
+  inherit name;
 
   url = "https://github.com/andirueckel/undefined-medium/archive/v1.0.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile ${name}/fonts/otf/\*.otf -d $out/share/fonts/opentype
-  '';
 
   sha256 = "1wa04jzbffshwcxm705yb5wja8wakn8j7fvim1mlih2z1sqw0njk";
 
@@ -23,4 +19,9 @@ fetchzip rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile ${name}/fonts/otf/\*.otf -d $out/share/fonts/opentype
+  '';
+})

--- a/pkgs/data/fonts/vollkorn/default.nix
+++ b/pkgs/data/fonts/vollkorn/default.nix
@@ -1,14 +1,23 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, stdenv, fetchzip }:
 let
   pname = "vollkorn";
   version = "4.105";
 in
-fetchzip {
+(fetchzip {
   name = "${pname}-${version}";
   url = "http://vollkorn-typeface.com/download/vollkorn-${builtins.replaceStrings ["."] ["-"] version}.zip";
   sha256 = "0srff2nqs7353mqcpmvaq156lamfh621py4h1771n0l9ix2c8mss";
   stripRoot = false;
 
+  meta = with lib; {
+    homepage = "http://vollkorn-typeface.com/";
+    description = "The free and healthy typeface for bread and butter use";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.schmittlauch ];
+  };
+}).overrideAttrs (_: {
   postFetch = ''
     mkdir -pv $out/share/{doc/${pname}-${version},fonts/{opentype,truetype,WOFF,WOFF2}}
     unzip $downloadedFile
@@ -18,12 +27,4 @@ fetchzip {
     cp -v WOFF/*.woff $out/share/fonts/WOFF
     cp -v WOFF2/*.woff2 $out/share/fonts/WOFF2
   '';
-
-  meta = with lib; {
-    homepage = "http://vollkorn-typeface.com/";
-    description = "The free and healthy typeface for bread and butter use";
-    license = licenses.ofl;
-    platforms = platforms.all;
-    maintainers = [ maintainers.schmittlauch ];
-  };
-}
+})

--- a/pkgs/data/fonts/weather-icons/default.nix
+++ b/pkgs/data/fonts/weather-icons/default.nix
@@ -1,18 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "2.0.12";
-in fetchzip {
+in (fetchzip {
   name = "weather-icons-${version}";
 
   url = "https://github.com/erikflowers/weather-icons/archive/refs/tags/${version}.zip";
   sha256 = "sha256-NGPzAloeZa1nCazb+mjAbYw7ZYYDoKpLwcvzg1Ly9oM=";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile weather-icons-${version}/_docs/font-source/weathericons-regular.otf -d $out/share/fonts/opentype
-  '';
-
 
   meta = with lib; {
     description = "Weather Icons";
@@ -26,4 +21,9 @@ in fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ pnelson ];
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile weather-icons-${version}/_docs/font-source/weathericons-regular.otf -d $out/share/fonts/opentype
+  '';
+})

--- a/pkgs/data/fonts/work-sans/default.nix
+++ b/pkgs/data/fonts/work-sans/default.nix
@@ -1,17 +1,13 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "2.010";
 in
-fetchzip {
+(fetchzip {
   name = "work-sans-${version}";
 
   url = "https://github.com/weiweihuanghuang/Work-Sans/archive/refs/tags/v${version}.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile "*/fonts/*.ttf" -d $out/share/fonts/opentype
-  '';
 
   sha256 = "sha256-S4O5EoKY4w/p+MHeHRCmPyQRAOUfEwNiETxMgNcsrws=";
 
@@ -22,4 +18,9 @@ fetchzip {
     maintainers = [ maintainers.marsam ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile "*/fonts/*.ttf" -d $out/share/fonts/opentype
+  '';
+})

--- a/pkgs/data/fonts/yanone-kaffeesatz/default.nix
+++ b/pkgs/data/fonts/yanone-kaffeesatz/default.nix
@@ -1,14 +1,10 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
-fetchzip {
+(fetchzip {
   name = "yanone-kaffeesatz-2004";
 
   url = "https://yanone.de/2015/data/UIdownloads/Yanone%20Kaffeesatz.zip";
-
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
 
   sha256 = "190c4wx7avy3kp98lsyml7kc0jw7csf5n79af2ypbkhsadfsy8di";
 
@@ -19,4 +15,9 @@ fetchzip {
     homepage = "https://yanone.de/fonts/kaffeesatz/";
     license = lib.licenses.ofl;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+  '';
+})

--- a/pkgs/data/fonts/zilla-slab/default.nix
+++ b/pkgs/data/fonts/zilla-slab/default.nix
@@ -1,16 +1,12 @@
+# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
 { lib, fetchzip }:
 
 let
   version = "1.002";
-in fetchzip {
+in (fetchzip {
   name = "zilla-slab-${version}";
 
   url = "https://github.com/mozilla/zilla-slab/releases/download/v${version}/Zilla-Slab-Fonts-v${version}.zip";
-  postFetch = ''
-    unzip $downloadedFile
-    mkdir -p $out/share/fonts/truetype
-    cp -v zilla-slab/ttf/*.ttf $out/share/fonts/truetype/
-  '';
   sha256 = "1b1ys28hyjcl4qwbnsyi6527nj01g3d6id9jl23fv6f8fjm4ph0f";
 
   meta = with lib; {
@@ -30,4 +26,10 @@ in fetchzip {
     maintainers = with maintainers; [ caugner ];
     platforms = platforms.all;
   };
-}
+}).overrideAttrs (_: {
+  postFetch = ''
+    unzip $downloadedFile
+    mkdir -p $out/share/fonts/truetype
+    cp -v zilla-slab/ttf/*.ttf $out/share/fonts/truetype/
+  '';
+})


### PR DESCRIPTION
This is a rebased version of https://github.com/NixOS/nixpkgs/pull/193478 with comments inserted
thank you @chkno 

###### Description of changes
description from https://github.com/NixOS/nixpkgs/pull/193478 
#173430 changed the semantics of fetchzip's postFetch, making it extend rather than replace the default postFetch logic.  This broke many packages, but the automatic checks failed to alert about this because they didn't try to rebuild anything because the output hashes had not changed.

This change fixes 78 fonts -- Free fonts that use fetchzip to fetch a zip file and are not otherwise broken (eg: 404).  There are other packages that still need similar treatment.

I confirmed that all of these fonts are broken before this change and fixed after this change.

This change mechanically restores the previous behaviour.  No hashes are changed.

Example of a build failure before this change (to reproduce more easily, choose a packge not already in your Nix store and build with `--option substituters ""`):
```
$ nix-build --option substituters "" . -A inter
this derivation will be built:
  /nix/store/a5glk1jsmpdphrsiw1kvq0jk4x5pdxds-inter-3.19.drv
building '/nix/store/a5glk1jsmpdphrsiw1kvq0jk4x5pdxds-inter-3.19.drv'...

trying https://github.com/rsms/inter/releases/download/v3.19/Inter-3.19.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 21.1M  100 21.1M    0     0  8812k      0  0:00:02  0:00:02 --:--:-- 10.1M
unpacking source archive /build/Inter-3.19.zip
error: zip file must contain a single file or directory.
hint: Pass stripRoot=false; to fetchzip to assume flat list of files.
error: builder for '/nix/store/a5glk1jsmpdphrsiw1kvq0jk4x5pdxds-inter-3.19.drv' failed with exit code 1;
       last 9 log lines:
       >
       > trying https://github.com/rsms/inter/releases/download/v3.19/Inter-3.19.zip
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > 100 21.1M  100 21.1M    0     0  8812k      0  0:00:02  0:00:02 --:--:-- 10.1M
       > unpacking source archive /build/Inter-3.19.zip
       > error: zip file must contain a single file or directory.
       > hint: Pass stripRoot=false; to fetchzip to assume flat list of files.
       For full logs, run 'nix log /nix/store/a5glk1jsmpdphrsiw1kvq0jk4x5pdxds-inter-3.19.drv'.
```

This package building successfully after this change:
```
$ nix-build --option substituters "" . -A inter
this derivation will be built:
  /nix/store/caqs123fp3bw9pf69as09wrq4810kc16-inter-3.19.drv
building '/nix/store/caqs123fp3bw9pf69as09wrq4810kc16-inter-3.19.drv'...

trying https://github.com/rsms/inter/releases/download/v3.19/Inter-3.19.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 21.1M  100 21.1M    0     0  10.3M      0  0:00:02  0:00:02 --:--:-- 11.1M
Archive:  /build/file
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-Bold.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-Regular.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-SemiBoldItalic.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-Thin.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-Light.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-ExtraLightItalic.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-Medium.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-SemiBold.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-BlackItalic.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-MediumItalic.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-Black.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-Italic.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-ExtraBold.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-ThinItalic.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-ExtraLight.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-ExtraBoldItalic.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-BoldItalic.otf
  inflating: /nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19/share/fonts/opentype/Inter-LightItalic.otf
/nix/store/yl1mzbsz49pha0ngx9xgvrirjp9h56c9-inter-3.19
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
