### PR TITLE
llvmPackages.bintools-unwrapped: add missing symlinks

### DIFF
--- a/pkgs/development/compilers/llvm/10/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/10/bintools/default.nix
@@ -15,15 +15,19 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    done
 
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
    ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
+   ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm
    ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}objcopy
+   ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}strip
    ln -s ${llvm}/bin/llvm-objdump $out/bin/${prefix}objdump
-   ln -s ${llvm}/bin/llvm-ranlib $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-readelf $out/bin/${prefix}readelf
+   ln -s ${llvm}/bin/llvm-readobj $out/bin/${prefix}readelf
    ln -s ${llvm}/bin/llvm-size $out/bin/${prefix}size
-   ln -s ${llvm}/bin/llvm-strip $out/bin/${prefix}strip
+   ln -s ${llvm}/bin/llvm-strings $out/bin/${prefix}strings
+   ln -s ${llvm}/bin/llvm-symbolizer $out/bin/${prefix}addr2line
 
    ln -s ${lld}/bin/lld $out/bin/${prefix}ld
 ''

--- a/pkgs/development/compilers/llvm/10/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/10/bintools/default.nix
@@ -17,7 +17,6 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
    ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm

--- a/pkgs/development/compilers/llvm/11/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/11/bintools/default.nix
@@ -15,15 +15,19 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    done
 
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
    ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
+   ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm
    ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}objcopy
+   ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}strip
    ln -s ${llvm}/bin/llvm-objdump $out/bin/${prefix}objdump
-   ln -s ${llvm}/bin/llvm-ranlib $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-readelf $out/bin/${prefix}readelf
+   ln -s ${llvm}/bin/llvm-readobj $out/bin/${prefix}readelf
    ln -s ${llvm}/bin/llvm-size $out/bin/${prefix}size
-   ln -s ${llvm}/bin/llvm-strip $out/bin/${prefix}strip
+   ln -s ${llvm}/bin/llvm-strings $out/bin/${prefix}strings
+   ln -s ${llvm}/bin/llvm-symbolizer $out/bin/${prefix}addr2line
 
    ln -s ${lld}/bin/lld $out/bin/${prefix}ld
 ''

--- a/pkgs/development/compilers/llvm/11/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/11/bintools/default.nix
@@ -17,7 +17,6 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
    ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm

--- a/pkgs/development/compilers/llvm/12/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/12/bintools/default.nix
@@ -15,15 +15,19 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    done
 
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
    ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
+   ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm
    ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}objcopy
+   ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}strip
    ln -s ${llvm}/bin/llvm-objdump $out/bin/${prefix}objdump
-   ln -s ${llvm}/bin/llvm-ranlib $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-readelf $out/bin/${prefix}readelf
+   ln -s ${llvm}/bin/llvm-readobj $out/bin/${prefix}readelf
    ln -s ${llvm}/bin/llvm-size $out/bin/${prefix}size
-   ln -s ${llvm}/bin/llvm-strip $out/bin/${prefix}strip
+   ln -s ${llvm}/bin/llvm-strings $out/bin/${prefix}strings
+   ln -s ${llvm}/bin/llvm-symbolizer $out/bin/${prefix}addr2line
 
    ln -s ${lld}/bin/lld $out/bin/${prefix}ld
 ''

--- a/pkgs/development/compilers/llvm/12/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/12/bintools/default.nix
@@ -17,7 +17,6 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
    ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm

--- a/pkgs/development/compilers/llvm/13/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/13/bintools/default.nix
@@ -15,15 +15,20 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    done
 
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
    ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
+   ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm
    ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}objcopy
+   ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}strip
    ln -s ${llvm}/bin/llvm-objdump $out/bin/${prefix}objdump
-   ln -s ${llvm}/bin/llvm-ranlib $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-readelf $out/bin/${prefix}readelf
+   ln -s ${llvm}/bin/llvm-rc $out/bin/${prefix}windres
+   ln -s ${llvm}/bin/llvm-readobj $out/bin/${prefix}readelf
    ln -s ${llvm}/bin/llvm-size $out/bin/${prefix}size
-   ln -s ${llvm}/bin/llvm-strip $out/bin/${prefix}strip
+   ln -s ${llvm}/bin/llvm-strings $out/bin/${prefix}strings
+   ln -s ${llvm}/bin/llvm-symbolizer $out/bin/${prefix}addr2line
 
    ln -s ${lld}/bin/lld $out/bin/${prefix}ld
 ''

--- a/pkgs/development/compilers/llvm/13/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/13/bintools/default.nix
@@ -17,7 +17,6 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
    ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm

--- a/pkgs/development/compilers/llvm/14/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/14/bintools/default.nix
@@ -15,15 +15,20 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    done
 
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
    ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
+   ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm
    ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}objcopy
+   ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}strip
    ln -s ${llvm}/bin/llvm-objdump $out/bin/${prefix}objdump
-   ln -s ${llvm}/bin/llvm-ranlib $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-readelf $out/bin/${prefix}readelf
+   ln -s ${llvm}/bin/llvm-rc $out/bin/${prefix}windres
+   ln -s ${llvm}/bin/llvm-readobj $out/bin/${prefix}readelf
    ln -s ${llvm}/bin/llvm-size $out/bin/${prefix}size
-   ln -s ${llvm}/bin/llvm-strip $out/bin/${prefix}strip
+   ln -s ${llvm}/bin/llvm-strings $out/bin/${prefix}strings
+   ln -s ${llvm}/bin/llvm-symbolizer $out/bin/${prefix}addr2line
 
    ln -s ${lld}/bin/lld $out/bin/${prefix}ld
 ''

--- a/pkgs/development/compilers/llvm/14/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/14/bintools/default.nix
@@ -17,7 +17,6 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
    ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm

--- a/pkgs/development/compilers/llvm/7/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/7/bintools/default.nix
@@ -15,15 +15,19 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    done
 
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
    ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
+   ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm
    ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}objcopy
+   ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}strip
    ln -s ${llvm}/bin/llvm-objdump $out/bin/${prefix}objdump
-   ln -s ${llvm}/bin/llvm-ranlib $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-readelf $out/bin/${prefix}readelf
+   ln -s ${llvm}/bin/llvm-readobj $out/bin/${prefix}readelf
    ln -s ${llvm}/bin/llvm-size $out/bin/${prefix}size
-   ln -s ${llvm}/bin/llvm-strip $out/bin/${prefix}strip
+   ln -s ${llvm}/bin/llvm-strings $out/bin/${prefix}strings
+   ln -s ${llvm}/bin/llvm-symbolizer $out/bin/${prefix}addr2line
 
    ln -s ${lld}/bin/lld $out/bin/${prefix}ld
 ''

--- a/pkgs/development/compilers/llvm/7/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/7/bintools/default.nix
@@ -17,7 +17,6 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
    ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm

--- a/pkgs/development/compilers/llvm/8/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/8/bintools/default.nix
@@ -15,15 +15,19 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    done
 
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
    ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
+   ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm
    ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}objcopy
+   ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}strip
    ln -s ${llvm}/bin/llvm-objdump $out/bin/${prefix}objdump
-   ln -s ${llvm}/bin/llvm-ranlib $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-readelf $out/bin/${prefix}readelf
+   ln -s ${llvm}/bin/llvm-readobj $out/bin/${prefix}readelf
    ln -s ${llvm}/bin/llvm-size $out/bin/${prefix}size
-   ln -s ${llvm}/bin/llvm-strip $out/bin/${prefix}strip
+   ln -s ${llvm}/bin/llvm-strings $out/bin/${prefix}strings
+   ln -s ${llvm}/bin/llvm-symbolizer $out/bin/${prefix}addr2line
 
    ln -s ${lld}/bin/lld $out/bin/${prefix}ld
 ''

--- a/pkgs/development/compilers/llvm/8/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/8/bintools/default.nix
@@ -17,7 +17,6 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
    ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm

--- a/pkgs/development/compilers/llvm/9/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/9/bintools/default.nix
@@ -15,15 +15,19 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    done
 
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
    ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
+   ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm
    ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}objcopy
+   ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}strip
    ln -s ${llvm}/bin/llvm-objdump $out/bin/${prefix}objdump
-   ln -s ${llvm}/bin/llvm-ranlib $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-readelf $out/bin/${prefix}readelf
+   ln -s ${llvm}/bin/llvm-readobj $out/bin/${prefix}readelf
    ln -s ${llvm}/bin/llvm-size $out/bin/${prefix}size
-   ln -s ${llvm}/bin/llvm-strip $out/bin/${prefix}strip
+   ln -s ${llvm}/bin/llvm-strings $out/bin/${prefix}strings
+   ln -s ${llvm}/bin/llvm-symbolizer $out/bin/${prefix}addr2line
 
    ln -s ${lld}/bin/lld $out/bin/${prefix}ld
 ''

--- a/pkgs/development/compilers/llvm/9/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/9/bintools/default.nix
@@ -17,7 +17,6 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
    ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm

--- a/pkgs/development/compilers/llvm/git/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/git/bintools/default.nix
@@ -15,15 +15,22 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    done
 
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
+   ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
    ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
+   ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
+   ln -s ${llvm}/bin/llvm-debuginfod $out/bin/${prefix}debuginfod
+   ln -s ${llvm}/bin/llvm-debuginfod-find $out/bin/${prefix}debuginfod-find
    ln -s ${llvm}/bin/llvm-dwp $out/bin/${prefix}dwp
    ln -s ${llvm}/bin/llvm-nm $out/bin/${prefix}nm
    ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}objcopy
+   ln -s ${llvm}/bin/llvm-objcopy $out/bin/${prefix}strip
    ln -s ${llvm}/bin/llvm-objdump $out/bin/${prefix}objdump
-   ln -s ${llvm}/bin/llvm-ranlib $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-readelf $out/bin/${prefix}readelf
+   ln -s ${llvm}/bin/llvm-rc $out/bin/${prefix}windres
+   ln -s ${llvm}/bin/llvm-readobj $out/bin/${prefix}readelf
    ln -s ${llvm}/bin/llvm-size $out/bin/${prefix}size
-   ln -s ${llvm}/bin/llvm-strip $out/bin/${prefix}strip
+   ln -s ${llvm}/bin/llvm-strings $out/bin/${prefix}strings
+   ln -s ${llvm}/bin/llvm-symbolizer $out/bin/${prefix}addr2line
 
    ln -s ${lld}/bin/lld $out/bin/${prefix}ld
 ''

--- a/pkgs/development/compilers/llvm/git/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/git/bintools/default.nix
@@ -17,7 +17,6 @@ in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ar
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}dlltool
    ln -s ${llvm}/bin/llvm-ar $out/bin/${prefix}ranlib
-   ln -s ${llvm}/bin/llvm-as $out/bin/${prefix}as
    ln -s ${llvm}/bin/llvm-cxxfilt $out/bin/${prefix}c++filt
    ln -s ${llvm}/bin/llvm-debuginfod $out/bin/${prefix}debuginfod
    ln -s ${llvm}/bin/llvm-debuginfod-find $out/bin/${prefix}debuginfod-find


### PR DESCRIPTION
###### Description of changes

We were missing symlinks for some programs e.g. strings, which caused
e.g. pkgsLLVM.x264 to fail to build.

Here, I have filled in all the symlinks that LLVM would create if
built with the LLVM_INSTALL_BINUTILS_SYMLINKS option.  Where an
existing symlink's target has changed, it's to avoid a double
indirection e.g. strip -> llvm-strip -> llvm-objcopy has because just
strip -> llvm-objcopy.

There's also the related problem that we are creating a as -> llvm-as
symlink, which doesn't make sense, but I've removed that in a
separate commit so that if it somehow breaks something it's easy to
revert just that change.

"llvm-as is an LLVM IR -> LLVM bitcode assembler not a system
assembler"[1], and therefore should not be linked as "as".

The "as" symlink was removed in https://github.com/NixOS/nixpkgs/commit/46e5ea5af6474a7c5f841fcdb516de64b98995fe ("llvm*: remove symlinks
to llvm-diff, llvm-as and associated LLVM IR utilities."), but that
was partially reverted by https://github.com/NixOS/nixpkgs/commit/b331c72f032389c7156ff1d30117f91c95bbeedb ("llvm: setup some symlinks for
compatibility with binutils"), which restored a bunch of symlinks that
were incorrectly removed, but also incorrectly restored "as".  This
was pointed out[2] at the time but apparently never fixed.

[1]: https://github.com/NixOS/nixpkgs/issues/93523#issue-661663683
[2]: https://github.com/NixOS/nixpkgs/commit/b331c72f032389c7156ff1d30117f91c95bbeedb#commitcomment-40981705

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
