### PR TITLE
julia: Use BinaryBuilder for build

### DIFF
--- a/pkgs/development/compilers/julia/1.8-source.nix
+++ b/pkgs/development/compilers/julia/1.8-source.nix
@@ -1,0 +1,53 @@
+{ lib
+, stdenv
+, fetchurl
+, which
+, python3
+, curl
+, xcbuild
+, darwin
+}:
+
+stdenv.mkDerivation rec {
+  pname = "julia-source-with-deps";
+  version = "1.8.5";
+
+  src = fetchurl {
+    url = "https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz";
+    hash = "sha256-NVVAgKS0085S7yICVDBr1CrA2I7/nrhVkqV9BmPbXfI=";
+  };
+
+  nativeBuildInputs = [
+    which
+    python3
+    curl
+  ] ++ lib.optionals stdenv.isDarwin [
+    xcbuild
+    darwin.DarwinTools
+  ];
+
+  dontPatch = true;
+  dontConfigure = true;
+  # Ensure the move-docs.sh hook doesn't move the doc/ directory to share/doc/
+  forceShare = [ "dummy" ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r . "$out/."
+  '';
+
+
+  makeFlags = [ "julia-deps" ];
+  # make julia-deps downloads dependencies from https://cache.julialang.org so this must be a fixed-output derivation
+  outputHash = "0iva2m384vkvxbv8597ririwcmf600my5srn1cv041cscwkpzld5";
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+
+  meta = with lib; {
+    description = "High-level performance-oriented dynamical language for technical computing";
+    homepage = "https://julialang.org/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nickcao ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  };
+}

--- a/pkgs/development/compilers/julia/1.8.nix
+++ b/pkgs/development/compilers/julia/1.8.nix
@@ -1,37 +1,42 @@
 { lib
 , stdenv
 , fetchurl
+, callPackage
 , which
 , python3
+, patchelf
 , gfortran
-, cmake
 , perl
 , gnum4
 , libxml2
 , openssl
+, unzip
+, xcbuild
+, darwin
 }:
 
 stdenv.mkDerivation rec {
   pname = "julia";
   version = "1.8.5";
 
-  src = fetchurl {
-    url = "https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz";
-    hash = "sha256-NVVAgKS0085S7yICVDBr1CrA2I7/nrhVkqV9BmPbXfI=";
-  };
+  src = callPackage ./1.8-source.nix { };
 
   patches = [
     ./patches/1.8/0001-skip-building-doc.patch
-    ./patches/1.8/0002-skip-failing-and-flaky-tests.patch
+    ./patches/1.8/0003-silence-unnecessary-warning.patch
   ];
 
   nativeBuildInputs = [
     which
     python3
+    patchelf
     gfortran
-    cmake
     perl
     gnum4
+    unzip
+  ] ++ lib.optionals stdenv.isDarwin [
+    xcbuild
+    darwin.DarwinTools
   ];
 
   buildInputs = [
@@ -39,15 +44,59 @@ stdenv.mkDerivation rec {
     openssl
   ];
 
-  dontUseCmakeConfigure = true;
+  unpackPhase = ''
+    # Copy source from nix store, so we must update the permissions
+    cp -r "$src/." .
+    chmod -R +rw .
+  '';
 
   postPatch = ''
     patchShebangs .
   '';
 
+  preBuild = ''
+    source_version=$(cat "$src/VERSION")
+    if [ "$source_version" != "$version" ]; then
+      echo "Version of source package '$src' ($source_version) does not equal version of this package ($version)!"
+      exit 1
+    fi
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    # Preserve modified times to prevent rebuild during installCheckPhase
+    cp -rp . "$out/."
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    build_dir=$PWD
+    cd $out
+    # The manifest files contain absolute reference paths to $build_dir/usr/share/julia/stdlib/
+    # Preserve modified times to prevent rebuild during installCheckPhase
+    find usr/manifest/ \
+      -type f \
+      -exec touch -r {} _ref \; \
+      -exec sed -i "s|$build_dir|$out|g" {} \; \
+      -exec touch -r _ref {} \;
+    rm -f _ref
+
+    # Rewrite all symlinks that point to $build_dir absolutely to point to $out relatively
+    find . -type l -lname "*$build_dir*" -print0 | while read -d $'\0' l; do
+      target="$(readlink "$l")";
+      new_target=''${target/#"$build_dir"/"$out"};
+      ln -snrfT "$new_target" "$l"
+    done
+  '';
+
+  # Ensure the move-docs.sh hook doesn't move the doc/ directory to share/doc/
+  forceShare = [ "dummy" ];
+
   makeFlags = [
     "prefix=$(out)"
-    "USE_BINARYBUILDER=0"
     # workaround for https://github.com/JuliaLang/julia/issues/47989
     "USE_INTEL_JITEVENTS=0"
   ] ++ lib.optionals stdenv.isx86_64 [
@@ -56,13 +105,6 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals stdenv.isAarch64 [
     "JULIA_CPU_TARGET=generic;cortex-a57;thunderx2t99;armv8.2-a,crypto,fullfp16,lse,rdm"
   ];
-
-  # remove forbidden reference to $TMPDIR
-  preFixup = ''
-    for file in libcurl.so libgmpxx.so; do
-      patchelf --shrink-rpath --allowed-rpath-prefixes ${builtins.storeDir} "$out/lib/julia/$file"
-    done
-  '';
 
   doInstallCheck = true;
   installCheckTarget = "testall";
@@ -81,6 +123,6 @@ stdenv.mkDerivation rec {
     homepage = "https://julialang.org/";
     license = licenses.mit;
     maintainers = with maintainers; [ nickcao ];
-    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
 }

--- a/pkgs/development/compilers/julia/patches/1.8/0003-silence-unnecessary-warning.patch
+++ b/pkgs/development/compilers/julia/patches/1.8/0003-silence-unnecessary-warning.patch
@@ -1,0 +1,13 @@
+diff --git a/Make.inc b/Make.inc
+index 24f5964e9d..633fdfaea3 100644
+--- a/Make.inc
++++ b/Make.inc
+@@ -156,7 +156,7 @@ endif
+ .SUFFIXES:
+ 
+ # find out if git repository is available
+-ifeq ($(shell [ -e $(JULIAHOME)/.git ] && echo true || echo "Warning: git information unavailable; versioning information limited" >&2), true)
++ifeq ($(shell [ -e $(JULIAHOME)/.git ]), true)
+ NO_GIT := 0
+ else
+ NO_GIT := 1


### PR DESCRIPTION
###### Description of changes

Fixes #123394

This unbreaks the julia 1.8.5 package and makes it available on x86_64-darwin and aarch64-darwin by using BinaryBuilder and the shipped (and partly patched) dependencies of Julia instead of trying to build it with system dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
