### PR TITLE
gtkspell2: Build with enchant2

### DIFF
--- a/pkgs/development/libraries/gtkspell/default.nix
+++ b/pkgs/development/libraries/gtkspell/default.nix
@@ -1,4 +1,16 @@
-{lib, stdenv, fetchurl, gtk2, aspell, pkg-config, enchant, intltool}:
+{ stdenv
+, lib
+, fetchurl
+, fetchpatch
+, autoreconfHook
+, docbook_xsl
+, gtk-doc
+, intltool
+, pkg-config
+, aspell
+, enchant
+, gtk2
+}:
 
 stdenv.mkDerivation rec {
   pname = "gtkspell";
@@ -9,8 +21,28 @@ stdenv.mkDerivation rec {
     sha256 = "00hdv28bp72kg1mq2jdz1sdw2b8mb9iclsp7jdqwpck705bdriwg";
   };
 
-  nativeBuildInputs = [ pkg-config intltool ];
-  buildInputs = [aspell gtk2 enchant];
+  patches = [
+    # Build with enchant 2
+    # https://github.com/archlinux/svntogit-packages/tree/packages/gtkspell/trunk
+    (fetchpatch {
+      url = "https://github.com/archlinux/svntogit-packages/raw/17fb30b5196db378c18e7c115f28e97b962b95ff/trunk/enchant-2.diff";
+      sha256 = "0d9409bnapwzwhnfpz3dvl6qalskqa4lzmhrmciazsypbw3ry5rf";
+    })
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    docbook_xsl
+    gtk-doc
+    intltool
+    pkg-config
+  ];
+
+  buildInputs = [
+    aspell
+    enchant
+    gtk2
+  ];
 
   meta = with lib; {
     description = "Word-processor-style highlighting and replacement of misspelled words";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20006,7 +20006,7 @@ with pkgs;
 
   gtksourceviewmm4 = callPackage ../development/libraries/gtksourceviewmm/4.x.nix { };
 
-  gtkspell2 = callPackage ../development/libraries/gtkspell { enchant = enchant1; };
+  gtkspell2 = callPackage ../development/libraries/gtkspell { };
 
   gtkspell3 = callPackage ../development/libraries/gtkspell/3.nix { };
 


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/38506

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of ~~all binary files (usually in `./result/bin/`)~~ pidgin
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Result of `nixpkgs-review pr 211182` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>tdlib-purple</li>
  </ul>
</details>
<details>
  <summary>28 packages built:</summary>
  <ul>
    <li>chatty</li>
    <li>gtkspell2</li>
    <li>pidgin</li>
    <li>pidgin-carbons</li>
    <li>pidgin-indicator</li>
    <li>pidgin-latex</li>
    <li>pidgin-mra</li>
    <li>pidgin-msn-pecan</li>
    <li>pidgin-opensteamworks</li>
    <li>pidgin-osd</li>
    <li>pidgin-otr</li>
    <li>pidgin-sipe</li>
    <li>pidgin-skypeweb</li>
    <li>pidgin-window-merge</li>
    <li>pidgin-xmpp-receipts</li>
    <li>purple-discord</li>
    <li>purple-facebook</li>
    <li>purple-googlechat</li>
    <li>purple-hangouts</li>
    <li>purple-lurch</li>
    <li>purple-matrix</li>
    <li>purple-mm-sms</li>
    <li>purple-plugin-pack</li>
    <li>purple-signald</li>
    <li>purple-slack</li>
    <li>purple-vk-plugin</li>
    <li>purple-xmpp-http-upload</li>
    <li>telepathy-haze</li>
  </ul>
</details>
