### PR TITLE
python3Packages.parsimonious: disable benchmark tests that may fail

### DIFF
--- a/pkgs/development/python-modules/parsimonious/default.nix
+++ b/pkgs/development/python-modules/parsimonious/default.nix
@@ -26,6 +26,14 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTests = [
+    # test_benchmarks.py tests are actually benchmarks and may fail due to
+    # something being unexpectedly slow on a heavily loaded build machine
+    "test_lists_vs_dicts"
+    "test_call_vs_inline"
+    "test_startswith_vs_regex"
+  ];
+
   postPatch = ''
     substituteInPlace setup.py \
       --replace "regex>=2022.3.15" "regex"


### PR DESCRIPTION
###### Description of changes

This disables the benchmark tests in `python3Packages.parsimonious` to fix

```
=================================== FAILURES ===================================
______________________ TestBenchmarks.test_lists_vs_dicts ______________________

self = <parsimonious.tests.test_benchmarks.TestBenchmarks testMethod=test_lists_vs_dicts>

    def test_lists_vs_dicts(self):
        """See what's faster at int key lookup: dicts or lists."""
        list_time = timeit('item = l[9000]', 'l = [0] * 10000')
        dict_time = timeit('item = d[9000]', 'd = {x: 0 for x in range(10000)}')

        # Dicts take about 1.6x as long as lists in Python 2.6 and 2.7.
>       self.assertTrue(list_time < dict_time, '%s < %s' % (list_time, dict_time))
E       AssertionError: False is not true : 0.051286615896970034 < 0.0440241270698607

parsimonious/tests/test_benchmarks.py:16: AssertionError
=========================== short test summary info ============================
FAILED parsimonious/tests/test_benchmarks.py::TestBenchmarks::test_lists_vs_dicts
=================== 1 failed, 82 passed, 2 skipped in 1.19s ====================
```

which I observed when building `python38Packages.parsimonious` on NixOS 22.11: https://gist.github.com/ivan/09f944080f76d200a9734716370fc9a0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

no maintainer, cc'ing the last people to touch it @mweinelt @fabaff

`NOSE_EXCLUDE = "test_benchmarks";` was removed in ff41191d8f85dc8ffe1dde9bb5c06270a904b506