### PR TITLE
qq: remove GTK_IM_MODULE_FILE prefix and add glib to buildInputs to fix input-method not works

### DIFF
--- a/pkgs/applications/networking/instant-messengers/qq/default.nix
+++ b/pkgs/applications/networking/instant-messengers/qq/default.nix
@@ -17,7 +17,6 @@
 , at-spi2-core
 , autoPatchelfHook
 , wrapGAppsHook
-, makeWrapper
 }:
 
 let
@@ -43,7 +42,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     autoPatchelfHook
     wrapGAppsHook
-    makeWrapper
     dpkg
   ];
 
@@ -52,6 +50,7 @@ stdenv.mkDerivation {
     at-spi2-core
     cups
     gtk3
+    glib
     libdrm
     libgcrypt
     libkrb5
@@ -73,9 +72,7 @@ stdenv.mkDerivation {
     substituteInPlace $out/share/applications/qq.desktop \
       --replace "/opt/QQ/qq" "$out/bin/qq" \
       --replace "/usr/share" "$out/share"
-    makeWrapper $out/opt/QQ/qq $out/bin/qq \
-      --argv0 "qq" \
-      --prefix GTK_IM_MODULE_FILE : "/run/current-system/sw/etc/gtk-3.0/immodules.cache"
+    ln -s $out/opt/QQ/qq $out/bin/qq
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Description of changes

https://github.com/NixOS/nixpkgs/issues/210865
https://github.com/NixOS/nixpkgs/pull/210732
Before I found that qq will not read the immodules.cache under /etc/, but I don’t know the reason. In fact, this cause of this is that IBus is depending on a different version of glib to what the applications are depending on. So we can manually enter glib and as buildInputs, then the input method will work fine.
https://nixos.org/manual/nixos/stable/index.html#module-services-input-methods-troubleshooting


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
