### PR TITLE
libvirt: 8.10.0 -> 9.0.0

### DIFF
--- a/pkgs/development/libraries/libvirt/0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
+++ b/pkgs/development/libraries/libvirt/0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
@@ -305,7 +305,7 @@ diff --git a/src/qemu/meson.build b/src/qemu/meson.build
 index 39f0f615cc..5f6f30f82b 100644
 --- a/src/qemu/meson.build
 +++ b/src/qemu/meson.build
-@@ -175,24 +175,24 @@ if conf.has('WITH_QEMU')
+@@ -200,25 +200,25 @@ if conf.has('WITH_QEMU')
    endif
  
    virt_install_dirs += [
@@ -326,6 +326,7 @@ index 39f0f615cc..5f6f30f82b 100644
 -    localstatedir / 'log' / 'swtpm' / 'libvirt' / 'qemu',
 -    runstatedir / 'libvirt' / 'qemu',
 -    runstatedir / 'libvirt' / 'qemu' / 'dbus',
+-    runstatedir / 'libvirt' / 'qemu' / 'passt',
 -    runstatedir / 'libvirt' / 'qemu' / 'slirp',
 -    runstatedir / 'libvirt' / 'qemu' / 'swtpm',
 +    install_prefix + confdir / 'qemu',
@@ -345,6 +346,7 @@ index 39f0f615cc..5f6f30f82b 100644
 +    install_prefix + localstatedir / 'log' / 'swtpm' / 'libvirt' / 'qemu',
 +    install_prefix + runstatedir / 'libvirt' / 'qemu',
 +    install_prefix + runstatedir / 'libvirt' / 'qemu' / 'dbus',
++    install_prefix + runstatedir / 'libvirt' / 'qemu' / 'passt',
 +    install_prefix + runstatedir / 'libvirt' / 'qemu' / 'slirp',
 +    install_prefix + runstatedir / 'libvirt' / 'qemu' / 'swtpm',
    ]

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -42,7 +42,7 @@
 , attr ? null
 , audit ? null
 , dmidecode ? null
-, fuse ? null
+, fuse3 ? null
 , kmod ? null
 , libapparmor ? null
 , libcap_ng ? null
@@ -114,13 +114,13 @@ stdenv.mkDerivation rec {
   # NOTE: You must also bump:
   # <nixpkgs/pkgs/development/python-modules/libvirt/default.nix>
   # SysVirt in <nixpkgs/pkgs/top-level/perl-packages.nix>
-  version = "8.10.0";
+  version = "9.0.0";
 
   src = fetchFromGitLab {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-MboJLQ0R3l9lUQDjNVACvmxISjypvfxxMHSKF0+k6WM=";
+    sha256 = "sha256-YnkgTl6C3QkvMBGm95JgWmWaP4mAECe9B0wwjOx94p8=";
     fetchSubmodules = true;
   };
 
@@ -201,7 +201,7 @@ stdenv.mkDerivation rec {
     acl
     attr
     audit
-    fuse
+    fuse3
     libapparmor
     libcap_ng
     libnl

--- a/pkgs/development/python-modules/libvirt/default.nix
+++ b/pkgs/development/python-modules/libvirt/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "libvirt";
-  version = "8.10.0";
+  version = "9.0.0";
 
   src = fetchFromGitLab {
     owner = "libvirt";
     repo = "libvirt-python";
     rev = "v${version}";
-    sha256 = "sha256-f2ZWBNCgylKQCmbLCaJsIb5alvZDRZUWQAMOMsxwGbk=";
+    sha256 = "sha256-/u6sctXn4Jmn2bUl1FjjrKpHReaTg+O9LprKXx3OAyU=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22646,12 +22646,12 @@ let
 
   SysVirt = buildPerlModule rec {
     pname = "Sys-Virt";
-    version = "8.10.0";
+    version = "9.0.0";
     src = fetchFromGitLab {
       owner = "libvirt";
       repo = "libvirt-perl";
       rev = "v${version}";
-      hash = "sha256-rVTofRtnYDF5CmWp3SB2+kJZz4u6+OTzNAUwiDrqdTo=";
+      hash = "sha256-QiaB272kxs/Y3/l8KbFy8f9iyOCxhzfA/h2FnfGzmE4=";
     };
     nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = [ pkgs.libvirt CPANChanges TestPod TestPodCoverage XMLXPath ];


### PR DESCRIPTION
###### Description of changes

https://gitlab.com/libvirt/libvirt/-/blob/v9.0.0/NEWS.rst

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
