### PR TITLE
pythonPackages.nbxmpp: 4.0.0 → 4.0.1; gajim: 1.6.0 → 1.6.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -22,11 +22,11 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gajim";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchurl {
     url = "https://gajim.org/downloads/${lib.versions.majorMinor version}/gajim-${version}.tar.gz";
-    hash = "sha256-gHRB3thDH+CKRXTgrD37e2zf0rVDIVl4Zhxf5lsLjyc=";
+    hash = "sha256-3D87Ou/842WqbaUiJV1hRZFVkZzQ12GXCpRc8F3rKPQ=";
   };
 
   buildInputs = [
@@ -61,8 +61,8 @@ python3.pkgs.buildPythonApplication rec {
   checkPhase = ''
     xvfb-run dbus-run-session \
       --config-file=${dbus}/share/dbus-1/session.conf \
-      ${python3.interpreter} -m unittest discover -s test/gtk -v
-    ${python3.interpreter} -m unittest discover -s test/no_gui -v
+      ${python3.interpreter} -m unittest discover -s test/gui -v
+    ${python3.interpreter} -m unittest discover -s test/common -v
   '';
 
   # necessary for wrapGAppsHook

--- a/pkgs/development/python-modules/nbxmpp/default.nix
+++ b/pkgs/development/python-modules/nbxmpp/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "nbxmpp";
-  version = "4.0.0";
+  version = "4.0.1";
 
   disabled = pythonOlder "3.10";
 
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "gajim";
     repo = "python-nbxmpp";
     rev = version;
-    hash = "sha256-6PYJGlNOZMwHMXwf05IWekJ+haMfg+ooH5On+aYOWSI=";
+    hash = "sha256-PL+qNxeNubGSLqSci4uhRWtOIqs10p+A1VPfTwCLu84=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Fixes & improvements:
 - https://dev.gajim.org/gajim/python-nbxmpp/-/blob/4.0.1/ChangeLog
 - https://dev.gajim.org/gajim/gajim/-/blob/1.6.1/ChangeLog

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
