### PR TITLE
signaldctl: init at 0.6.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signaldctl/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signaldctl/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildGoModule
+, fetchFromGitLab
+, gitUpdater
+}:
+
+buildGoModule rec {
+  pname = "signaldctl";
+  version = "0.6.1";
+  src = fetchFromGitLab {
+    owner = "signald";
+    repo = "signald-go";
+    rev = "v${version}";
+    hash = "sha256-lMJyr4BPZ8V2f//CUkr7CVQ6o8nRyeLBHMDEyLcHSgQ=";
+  };
+
+  vendorHash = "sha256-LGIWAVhDJCg6Ox7U4ZK15K8trjsvSZm4/0jNpIDmG7I=";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    # install only the binary and not any intermediate artifacts like
+    # `generators` which is only used during build
+    cp "$GOPATH/bin/signaldctl" $out/bin
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
+
+  meta = with lib; {
+    description = "A golang library for communicating with signald";
+    homepage = "https://signald.org/signaldctl/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ colinsane ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11708,6 +11708,8 @@ with pkgs;
 
   signald = callPackage ../applications/networking/instant-messengers/signald { };
 
+  signaldctl = callPackage ../applications/networking/instant-messengers/signaldctl { };
+
   signal-cli = callPackage ../applications/networking/instant-messengers/signal-cli { };
 
   inherit (callPackage ../applications/networking/instant-messengers/signal-desktop {}) signal-desktop signal-desktop-beta;


### PR DESCRIPTION
signaldctl is a tool used to administer the signald service (already available in nixpkgs). after enabling the signald service as below:

```nix
{
  services.signald.enable = true;
}
```

then a user can use signaldctl to introspect signald's state. the communication happens over `/run/signald/signald.sock`, so either configure signald to expose that with desired permissions, or run signaldctl as the signald user:
```
$ sudo -u signald -g signald signaldctl account list
┌──────────────┬──────────────────────────────────────┬───────────┐
│ PHONE NUMBER │ UUID                                 │ DEVICE ID │
├──────────────┼──────────────────────────────────────┼───────────┤
│ +1XXXXXXXXXX │ XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX │         1 │
└──────────────┴──────────────────────────────────────┴───────────┘
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
