### PR TITLE
deno: 1.29.3 -> 1.29.4

### DIFF
--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -85,6 +85,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   passthru.updateScript = ./update/update.ts;
+  passthru.tests = callPackage ./tests { };
 
   meta = with lib; {
     homepage = "https://deno.land/";

--- a/pkgs/development/web/deno/default.nix
+++ b/pkgs/development/web/deno/default.nix
@@ -17,15 +17,15 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "deno";
-  version = "1.29.3";
+  version = "1.29.4";
 
   src = fetchFromGitHub {
     owner = "denoland";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-CH0uri8mnpcojuE8Pil/gsvEfDu/txjCevvGjqhiK1k=";
+    sha256 = "sha256-oCBtqOm/d5dpIv70/Ht0M6izxdvm59LCiDHgcMcwLek=";
   };
-  cargoSha256 = "sha256-I7MIcZeMQzgplza8YAqmuWaX4Gw3ZoDXHyzq/5opO4M=";
+  cargoSha256 = "sha256-Y/1yfCeWleNrk5MgkIoAtkH8e6YSZWa+GF5RgLaZXQA=";
 
   postPatch = ''
     # upstream uses lld on aarch64-darwin for faster builds

--- a/pkgs/development/web/deno/librusty_v8.nix
+++ b/pkgs/development/web/deno/librusty_v8.nix
@@ -11,11 +11,11 @@ let
   };
 in
 fetch_librusty_v8 {
-  version = "0.60.0";
+  version = "0.60.1";
   shas = {
-    x86_64-linux = "sha256-2cq9fpKhx3ctZ5Lo2RofXD5bXfVUUN6bRtG453MQMW4=";
-    aarch64-linux = "sha256-hjVUzCYdGkc3kMC/cSXDFOaqJmMBi83dqqASS5R2158=";
-    x86_64-darwin = "sha256-EyYWfDU0eVFVzSVAHBFUbsppzpHtwe+Fd+z2ZmIub2c=";
-    aarch64-darwin = "sha256-2VyEFqWsPZlkEDvNxkmrMCIKfsO7LAO+VvsjSMcyFUo=";
+    x86_64-linux = "sha256-P8H+XJqrt9jdKM885L1epMldp+stwmEw+0Gtd2x3r4g=";
+    aarch64-linux = "sha256-frHpBP2pL3o4efFLHP2r3zsWJrNT93yYu2Qkxv+7m8Y=";
+    x86_64-darwin = "sha256-taewoYBkyikqWueLSD9dW1EDjzkV68Xplid1UaLZgRM=";
+    aarch64-darwin = "sha256-s2YEVbuYpiT/qrmE37aXk13MetrnJo6l+s1Q2y6b5kU=";
   };
 }

--- a/pkgs/development/web/deno/tests/basic.ts
+++ b/pkgs/development/web/deno/tests/basic.ts
@@ -1,0 +1,1 @@
+console.log(1 + 1)

--- a/pkgs/development/web/deno/tests/default.nix
+++ b/pkgs/development/web/deno/tests/default.nix
@@ -1,0 +1,68 @@
+{ deno, runCommand, lib, testers }:
+let
+  testDenoRun =
+    name:
+    { args ? ""
+    , dir ? ./. + "/${name}"
+    , file ? "index.ts"
+    , expected ? ""
+    , expectFailure ? false
+    }:
+    let
+      command = "deno run ${args} ${dir}/${file}";
+    in
+    runCommand "deno-test-${name}" { nativeBuildInputs = [ deno ]; meta.timeout = 60; } ''
+      HOME=$(mktemp -d)
+      if output=$(${command} 2>&1); then
+        if [[ $output =~ '${expected}' ]]; then
+          echo "Test '${name}' passed"
+          touch $out
+        else
+          echo -n ${lib.escapeShellArg command} >&2
+          echo " output did not match what was expected." >&2
+          echo "The expected was:" >&2
+          echo '${expected}' >&2
+          echo "The output was:" >&2
+          echo "$output" >&2
+          exit 1
+        fi
+      else
+        if [[ "${toString expectFailure}" == "1" ]]; then
+          echo "Test '${name}' failed as expected"
+          touch $out
+          exit 0
+        fi
+        echo -n ${lib.escapeShellArg command} >&2
+        echo " returned a non-zero exit code." >&2
+        echo "$output" >&2
+        exit 1
+      fi
+    '';
+in
+(lib.mapAttrs testDenoRun {
+  basic = {
+    dir = ./.;
+    file = "basic.ts";
+    expected = "2";
+  };
+  import-json = {
+    expected = "hello from JSON";
+  };
+  import-ts = {
+    expected = "hello from ts";
+  };
+  read-file = {
+    args = "--allow-read";
+    expected = "hello from a file";
+  };
+  fail-read-file = {
+    expectFailure = true;
+    dir = ./read-file;
+  };
+}) //
+{
+  version = testers.testVersion {
+    package = deno;
+    command = "deno --version";
+  };
+}

--- a/pkgs/development/web/deno/tests/import-json/data.json
+++ b/pkgs/development/web/deno/tests/import-json/data.json
@@ -1,0 +1,1 @@
+{ "msg": "hello from JSON" }

--- a/pkgs/development/web/deno/tests/import-json/index.ts
+++ b/pkgs/development/web/deno/tests/import-json/index.ts
@@ -1,0 +1,2 @@
+import file from "./data.json" assert { type: "json" };
+console.log(file.msg);

--- a/pkgs/development/web/deno/tests/import-ts/index.ts
+++ b/pkgs/development/web/deno/tests/import-ts/index.ts
@@ -1,0 +1,3 @@
+import { sayHello } from "./lib.ts"
+
+sayHello("ts")

--- a/pkgs/development/web/deno/tests/import-ts/lib.ts
+++ b/pkgs/development/web/deno/tests/import-ts/lib.ts
@@ -1,0 +1,3 @@
+export function sayHello(thing: string) {
+  console.log(`hello from ${thing}`);
+}

--- a/pkgs/development/web/deno/tests/read-file/data.txt
+++ b/pkgs/development/web/deno/tests/read-file/data.txt
@@ -1,0 +1,1 @@
+hello from a file

--- a/pkgs/development/web/deno/tests/read-file/index.ts
+++ b/pkgs/development/web/deno/tests/read-file/index.ts
@@ -1,0 +1,5 @@
+// trim 'file://' prefix
+const thisDir = Deno.mainModule.substring(7, Deno.mainModule.length);
+const getParent = (path: string) => path.substring(0, path.lastIndexOf("/"))
+const text = await Deno.readTextFile(getParent(thisDir) + "/data.txt");
+console.log(text);


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update deno to 1.29.4

Also added some simple tests to run on any auto updates. Covers the bases we usually try.
I have avoided using any remote libraries & used features I expect to be very stable. If these features change then fixing the test should be basic and will also be a sign that we shouldn't just backport the update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
