### PR TITLE
haskell-docs: nits

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -1,13 +1,13 @@
 # Haskell {#haskell}
 
-The Haskell infrastructure in nixpkgs has two main purposes: The primary purpose
+The Haskell infrastructure in Nixpkgs has two main purposes: The primary purpose
 is to provide a Haskell compiler and build tools as well as infrastructure for
 packaging Haskell-based packages.
 
-The secondary purpose is to provide support for Haskell development environment
+The secondary purpose is to provide support for Haskell development environments
 including prebuilt Haskell libraries. However, in this area sacrifices have been
-made due to self-imposed restrictions in nixpkgs, to lessen the maintenance
-effort and improve performance. (More details in the subsection
+made due to self-imposed restrictions in Nixpkgs, to lessen the maintenance
+effort and to improve performance. (More details in the subsection
 [Limitations.](#haskell-limitations))
 
 ## Available packages {#haskell-available-packages}
@@ -18,17 +18,17 @@ The compiler and most build tools are exposed at the top level:
 * Language specific tools: `cabal-install`, `stack`, `hpack`, …
 
 Many “normal” user facing packages written in Haskell, like `niv` or `cachix`,
-are also exposed at the top level, so there is nothing haskell specific to
+are also exposed at the top level, and there is nothing Haskell specific to
 installing and using them.
 
-All of these packages originally are defined in the `haskellPackages` package
+All of these packages are originally defined in the `haskellPackages` package
 set and are re-exposed with a reduced dependency closure for convenience.
 (see `justStaticExecutables` below)
 
 The `haskellPackages` set includes at least one version of every package from
 Hackage as well as some manually injected packages. This amounts to a lot of
 packages, so it is hidden from `nix-env -qa` by default for performance reasons.
-You can still list all packages in the set like this, though:
+You can still list all packages in the set like this:
 
 ```console
 $ nix-env -f '<nixpkgs>' -qaP -A haskellPackages
@@ -39,22 +39,22 @@ haskellPackages.abacate                                                     abac
 haskellPackages.abc-puzzle                                                  abc-puzzle-0.2.1
 …
 ```
-Also the default set `haskellPackages` is included on [search.nixos.org].
+Also, the `haskellPackages` set is included on [search.nixos.org].
 
 The attribute names in `haskellPackages` always correspond with their name on
-Hackage. Since Hackage allows names that are not valid Nix without extra
-escaping, you sometimes need to extra care when handling attribute names like
-`3dmodels`.
+Hackage. Since Hackage allows names that are not valid Nix without escaping,
+you need to take care when handling attribute names like `3dmodels`.
 
 For packages that are part of [Stackage], we use the version prescribed by a
 Stackage solver (usually the current LTS one) as the default version. For all
 other packages we use the latest version from Hackage. See
-[below](#haskell-available-versions) to learn which versions exactly are provided.
+[below](#haskell-available-versions) to learn which versions are provided
+exactly.
 
 Roughly half of the 16K packages contained in `haskellPackages` don't actually
 build and are marked as broken semi-automatically. Most of those packages are
-deprecated or unmaintained, but sometimes packages that should, don't build.
-Very often fixing them is not a lot of work.
+deprecated or unmaintained, but sometimes packages that should build, do not
+build. Very often fixing them is not a lot of work.
 
 <!--
 TODO(@sternenseemann):
@@ -101,11 +101,11 @@ haskell.compiler.native-bignum.ghcHEAD   ghc-native-bignum-9.7.20221224
 haskell.compiler.ghcjs                   ghcjs-8.10.7
 ```
 
-Every of those compilers has a corresponding attribute set built completely
-using it. However, the non-standard package sets are not tested regularly and
-have less working packages as a result. The corresponding package set for GHC
-9.4.4 is `haskell.packages.ghc944` (in fact `haskellPackages` is just an alias
-for `haskell.packages.ghc924`):
+Each of those compiler versions has a corresponding attribute set built using
+it. However, the non-standard package sets are not tested regularly and, as a
+result, contain fewer working packages. The corresponding package set for GHC
+9.4.4 is `haskell.packages.ghc944`. In fact `haskellPackages` is just an alias
+for `haskell.packages.ghc924`:
 
 ```console
 $ nix-env -f '<nixpkgs>' -qaP -A haskell.packages.ghc924


### PR DESCRIPTION
These are some suggested changes to the new documentation of Haskell in the Nixpkgs manual. They cover sections until, but excluding, the section "Available package versions". I am not an English native speaker, so please correct me and savage these changes!

Also, please let me know if the suggestions are welcome, then I will continue with the next chapter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
