### PR TITLE
treewide: remove global with lib; statements in pkgs

### DIFF
--- a/pkgs/applications/audio/asunder/default.nix
+++ b/pkgs/applications/audio/asunder/default.nix
@@ -9,8 +9,6 @@
 #, aacSupport ? false, TODO: neroAacEnc
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   version = "2.9.7";
   pname = "asunder";
@@ -23,20 +21,20 @@ stdenv.mkDerivation rec {
   buildInputs = [ gtk2 libcddb ];
 
   runtimeDeps =
-    optional mp3Support lame ++
-    optional oggSupport vorbis-tools ++
-    optional flacSupport flac ++
-    optional opusSupport opusTools ++
-    optional wavpackSupport wavpack ++
-    optional monkeysAudioSupport monkeysAudio ++
+    lib.optional mp3Support lame ++
+    lib.optional oggSupport vorbis-tools ++
+    lib.optional flacSupport flac ++
+    lib.optional opusSupport opusTools ++
+    lib.optional wavpackSupport wavpack ++
+    lib.optional monkeysAudioSupport monkeysAudio ++
     [ cdparanoia ];
 
   postInstall = ''
     wrapProgram "$out/bin/asunder" \
-      --prefix PATH : "${makeBinPath runtimeDeps}"
+      --prefix PATH : "${lib.makeBinPath runtimeDeps}"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A graphical Audio CD ripper and encoder for Linux";
     homepage = "http://littlesvr.ca/asunder/index.php";
     license = licenses.gpl2;

--- a/pkgs/applications/audio/carla/default.nix
+++ b/pkgs/applications/audio/carla/default.nix
@@ -5,8 +5,6 @@
   withGtk2 ? true, gtk2 ? null,
   withGtk3 ? true, gtk3 ? null }:
 
-with lib;
-
 assert withFrontend -> python3Packages ? pyqt5;
 assert withQt -> qtbase != null;
 assert withQt -> wrapQtAppsHook != null;
@@ -30,13 +28,13 @@ stdenv.mkDerivation rec {
 
   pythonPath = with python3Packages; [
     rdflib pyliblo
-  ] ++ optional withFrontend pyqt5;
+  ] ++ lib.optional withFrontend pyqt5;
 
   buildInputs = [
     file liblo alsa-lib fluidsynth jack2 libpulseaudio libsndfile
-  ] ++ optional withQt qtbase
-    ++ optional withGtk2 gtk2
-    ++ optional withGtk3 gtk3;
+  ] ++ lib.optional withQt qtbase
+    ++ lib.optional withGtk2 gtk2
+    ++ lib.optional withGtk3 gtk3;
 
   propagatedBuildInputs = pythonPath;
 

--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -39,8 +39,6 @@
 #, vtxSupport ? true, libayemu ? null
 }:
 
-with lib;
-
 assert samplerateSupport -> jackSupport;
 
 # vorbis and tremor are mutually exclusive
@@ -113,16 +111,16 @@ stdenv.mkDerivation rec {
 
   patches = [ ./option-debugging.patch ];
 
-  configurePhase = "./configure " + concatStringsSep " " ([
+  configurePhase = "./configure " + lib.concatStringsSep " " ([
     "prefix=$out"
     "CONFIG_WAV=y"
-  ] ++ concatMap (a: a.flags) opts);
+  ] ++ lib.concatMap (a: a.flags) opts);
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ ncurses ]
     ++ lib.optional stdenv.cc.isClang clangGCC
     ++ lib.optionals stdenv.isDarwin [ libiconv CoreAudio AudioUnit VideoToolbox ]
-    ++ flatten (concatMap (a: a.deps) opts);
+    ++ lib.flatten (lib.concatMap (a: a.deps) opts);
 
   makeFlags = [ "LD=$(CC)" ];
 

--- a/pkgs/applications/audio/crip/default.nix
+++ b/pkgs/applications/audio/crip/default.nix
@@ -16,8 +16,6 @@
 , which
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "crip";
   version = "3.9";
@@ -29,7 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ perlPackages.perl perlPackages.CDDB_get ];
   nativeBuildInputs = [ makeWrapper ];
 
-  toolDeps = makeBinPath [
+  toolDeps = lib.makeBinPath [
     cdparanoia
     coreutils
     eject
@@ -46,7 +44,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin/
 
-    for script in ${escapeShellArgs scripts}; do
+    for script in ${lib.escapeShellArgs scripts}; do
       cp $script $out/bin/
 
       substituteInPlace $out/bin/$script \
@@ -63,6 +61,6 @@ stdenv.mkDerivation rec {
     description = "Terminal-based ripper/encoder/tagger tool for creating Ogg Vorbis/FLAC files";
     license = lib.licenses.gpl1Only;
     platforms = lib.platforms.linux;
-    maintainers = [ maintainers.endgame ];
+    maintainers = [ lib.maintainers.endgame ];
   };
 }

--- a/pkgs/applications/audio/fmit/default.nix
+++ b/pkgs/applications/audio/fmit/default.nix
@@ -7,8 +7,6 @@ assert alsaSupport -> alsa-lib != null;
 assert jackSupport -> libjack2 != null;
 assert portaudioSupport -> portaudio != null;
 
-with lib;
-
 mkDerivation rec {
   pname = "fmit";
   version = "1.2.14";
@@ -22,9 +20,9 @@ mkDerivation rec {
 
   nativeBuildInputs = [ qmake itstool wrapQtAppsHook ];
   buildInputs = [ fftw qtbase qtmultimedia ]
-    ++ optionals alsaSupport [ alsa-lib ]
-    ++ optionals jackSupport [ libjack2 ]
-    ++ optionals portaudioSupport [ portaudio ];
+    ++ lib.optionals alsaSupport [ alsa-lib ]
+    ++ lib.optionals jackSupport [ libjack2 ]
+    ++ lib.optionals portaudioSupport [ portaudio ];
 
   postPatch = ''
     substituteInPlace fmit.pro --replace '$$FMITVERSIONGITPRO' '${version}'
@@ -32,13 +30,13 @@ mkDerivation rec {
 
   preConfigure = ''
     qmakeFlags="$qmakeFlags \
-      CONFIG+=${optionalString alsaSupport "acs_alsa"} \
-      CONFIG+=${optionalString jackSupport "acs_jack"} \
-      CONFIG+=${optionalString portaudioSupport "acs_portaudio"} \
+      CONFIG+=${lib.optionalString alsaSupport "acs_alsa"} \
+      CONFIG+=${lib.optionalString jackSupport "acs_jack"} \
+      CONFIG+=${lib.optionalString portaudioSupport "acs_portaudio"} \
       PREFIXSHORTCUT=$out"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Free Musical Instrument Tuner";
     longDescription = ''
       FMIT is a graphical utility for tuning musical instruments, with error

--- a/pkgs/applications/audio/goattracker/default.nix
+++ b/pkgs/applications/audio/goattracker/default.nix
@@ -8,12 +8,11 @@
 , isStereo ? false
 }:
 
-with lib;
 let
-  pname = "goattracker" + optionalString isStereo "-stereo";
+  pname = "goattracker" + lib.optionalString isStereo "-stereo";
   desktopItem = makeDesktopItem {
     name = pname;
-    desktopName = "GoatTracker 2" + optionalString isStereo " Stereo";
+    desktopName = "GoatTracker 2" + lib.optionalString isStereo " Stereo";
     genericName = "Music Tracker";
     exec = if isStereo
       then "gt2stereo"
@@ -30,7 +29,7 @@ in stdenv.mkDerivation rec {
     else "2.76"; # normal
 
   src = fetchurl {
-    url = "mirror://sourceforge/goattracker2/GoatTracker_${version}${optionalString isStereo "_Stereo"}.zip";
+    url = "mirror://sourceforge/goattracker2/GoatTracker_${version}${lib.optionalString isStereo "_Stereo"}.zip";
     sha256 = if isStereo
       then "1hiig2d152sv9kazwz33i56x1c54h5sh21ipkqnp6qlnwj8x1ksy"  # stereo
       else "0d7a3han4jw4bwiba3j87racswaajgl3pj4sb5lawdqdxicv3dn1"; # normal
@@ -63,11 +62,11 @@ in stdenv.mkDerivation rec {
 
   meta = {
     description = "A crossplatform music editor for creating Commodore 64 music. Uses reSID library by Dag Lem and supports alternatively HardSID & CatWeasel devices"
-      + optionalString isStereo " - Stereo version";
+      + lib.optionalString isStereo " - Stereo version";
     homepage = "https://cadaver.github.io/tools.html";
     downloadPage = "https://sourceforge.net/projects/goattracker2/";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ fgaz ];
-    platforms = platforms.all;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ fgaz ];
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/applications/audio/musescore/darwin.nix
+++ b/pkgs/applications/audio/musescore/darwin.nix
@@ -5,17 +5,15 @@ let
   appName = "MuseScore ${builtins.head versionComponents}";
 in
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "musescore-darwin";
-  version = concatStringsSep "." versionComponents;
+  version = lib.concatStringsSep "." versionComponents;
 
   # The disk image contains the .app and a symlink to /Applications.
   sourceRoot = "${appName}.app";
 
   src = fetchurl {
-    url =  "https://github.com/musescore/MuseScore/releases/download/v${concatStringsSep "." (take 3 versionComponents)}/MuseScore-${version}.dmg";
+    url = "https://github.com/musescore/MuseScore/releases/download/v${lib.concatStringsSep "." (lib.take 3 versionComponents)}/MuseScore-${version}.dmg";
     sha256 = "sha256-lHckfhTTrDzaGwlbnZ5w0O1gMPbRmrmgATIGMY517l0=";
   };
 

--- a/pkgs/applications/audio/ncmpc/default.nix
+++ b/pkgs/applications/audio/ncmpc/default.nix
@@ -12,8 +12,6 @@
 , pcreSupport ? false, pcre ? null
 }:
 
-with lib;
-
 assert pcreSupport -> pcre != null;
 
 stdenv.mkDerivation rec {
@@ -28,13 +26,13 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ glib ncurses libmpdclient boost ]
-    ++ optional pcreSupport pcre;
+    ++ lib.optional pcreSupport pcre;
   nativeBuildInputs = [ meson ninja pkg-config gettext ];
 
   mesonFlags = [
     "-Dlirc=disabled"
     "-Ddocumentation=disabled"
-  ] ++ optional (!pcreSupport) "-Dregex=disabled";
+  ] ++ lib.optional (!pcreSupport) "-Dregex=disabled";
 
   meta = with lib; {
     description = "Curses-based interface for MPD (music player daemon)";

--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -1,15 +1,13 @@
 { lib, stdenv, fetchurl, libX11, libXext, libXcursor, libXrandr, libjack2, alsa-lib
 , mpg123, releasePath ? null }:
 
-with lib;
-
 # To use the full release version:
 # 1) Sign into https://backstage.renoise.com and download the release version to some stable location.
 # 2) Override the releasePath attribute to point to the location of the newly downloaded bundle.
 # Note: Renoise creates an individual build for each license which screws somewhat with the
 # use of functions like requireFile as the hash will be different for every user.
 let
-  urlVersion = replaceStrings [ "." ] [ "_" ];
+  urlVersion = lib.replaceStrings [ "." ] [ "_" ];
 in
 
 stdenv.mkDerivation rec {
@@ -80,7 +78,7 @@ stdenv.mkDerivation rec {
     description = "Modern tracker-based DAW";
     homepage = "https://www.renoise.com/";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    license = licenses.unfree;
+    license = lib.licenses.unfree;
     maintainers = [];
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/applications/blockchains/bitcoin-knots/default.nix
+++ b/pkgs/applications/blockchains/bitcoin-knots/default.nix
@@ -23,7 +23,6 @@
 , withWallet ? true
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = if withGui then "bitcoin-knots" else "bitcoind-knots";
   version = "23.0.knots20220529";
@@ -35,24 +34,24 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs =
     [ autoreconfHook pkg-config ]
-    ++ optionals stdenv.isLinux [ util-linux ]
-    ++ optionals stdenv.isDarwin [ hexdump ]
-    ++ optionals (stdenv.isDarwin && stdenv.isAarch64) [ autoSignDarwinBinariesHook ]
-    ++ optionals withGui [ wrapQtAppsHook ];
+    ++ lib.optionals stdenv.isLinux [ util-linux ]
+    ++ lib.optionals stdenv.isDarwin [ hexdump ]
+    ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [ autoSignDarwinBinariesHook ]
+    ++ lib.optionals withGui [ wrapQtAppsHook ];
 
   buildInputs = [ boost libevent miniupnpc zeromq zlib ]
-    ++ optionals withWallet [ db48 sqlite ]
-    ++ optionals withGui [ qrencode qtbase qttools ];
+    ++ lib.optionals withWallet [ db48 sqlite ]
+    ++ lib.optionals withGui [ qrencode qtbase qttools ];
 
   configureFlags = [
     "--with-boost-libdir=${boost.out}/lib"
     "--disable-bench"
-  ] ++ optionals (!doCheck) [
+  ] ++ lib.optionals (!doCheck) [
     "--disable-tests"
     "--disable-gui-tests"
-  ] ++ optionals (!withWallet) [
+  ] ++ lib.optionals (!withWallet) [
     "--disable-wallet"
-  ] ++ optionals withGui [
+  ] ++ lib.optionals withGui [
     "--with-gui=qt5"
     "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
   ];
@@ -65,7 +64,7 @@ stdenv.mkDerivation rec {
     [ "LC_ALL=en_US.UTF-8" ]
     # QT_PLUGIN_PATH needs to be set when executing QT, which is needed when testing Bitcoin's GUI.
     # See also https://github.com/NixOS/nixpkgs/issues/24256
-    ++ optional withGui "QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}";
+    ++ lib.optional withGui "QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}";
 
   enableParallelBuilding = true;
 
@@ -73,7 +72,7 @@ stdenv.mkDerivation rec {
     smoke-test = nixosTests.bitcoind-knots;
   };
 
-  meta = {
+  meta = with lib; {
     description = "A derivative of Bitcoin Core with a collection of improvements";
     homepage = "https://bitcoinknots.org/";
     maintainers = with maintainers; [ prusnak mmahut ];

--- a/pkgs/applications/blockchains/bitcoin-unlimited/default.nix
+++ b/pkgs/applications/blockchains/bitcoin-unlimited/default.nix
@@ -3,10 +3,8 @@
 , withGui, wrapQtAppsHook ? null, qtbase ? null, qttools ? null
 , Foundation, ApplicationServices, AppKit }:
 
-with lib;
-
 stdenv.mkDerivation rec {
-  pname = "bitcoin" + optionalString (!withGui) "d" + "-unlimited";
+  pname = "bitcoin" + lib.optionalString (!withGui) "d" + "-unlimited";
   version = "1.10.0.0";
 
   src = fetchFromGitLab {
@@ -17,19 +15,19 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config autoreconfHook python3 ]
-    ++ optionals withGui [ wrapQtAppsHook qttools ];
+    ++ lib.optionals withGui [ wrapQtAppsHook qttools ];
   buildInputs = [ openssl db48 boost zlib
                   miniupnpc util-linux protobuf libevent ]
-                  ++ optionals withGui [ qtbase qttools qrencode ]
-                  ++ optionals stdenv.isDarwin [ Foundation ApplicationServices AppKit ];
+                  ++ lib.optionals withGui [ qtbase qttools qrencode ]
+                  ++ lib.optionals stdenv.isDarwin [ Foundation ApplicationServices AppKit ];
 
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
-                     ++ optionals withGui [ "--with-gui=qt5"
+                     ++ lib.optionals withGui [ "--with-gui=qt5"
                                             "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
                                           ];
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     description = "Peer-to-peer electronic cash system (Unlimited client)";
     longDescription= ''
       Bitcoin is a free open source peer-to-peer electronic cash system that is

--- a/pkgs/applications/blockchains/bitcoin/default.nix
+++ b/pkgs/applications/blockchains/bitcoin/default.nix
@@ -23,7 +23,6 @@
 , withWallet ? true
 }:
 
-with lib;
 let
   desktop = fetchurl {
     # c2e5f3e is the last commit when the debian/bitcoin-qt.desktop file was changed
@@ -45,16 +44,16 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs =
     [ autoreconfHook pkg-config ]
-    ++ optionals stdenv.isLinux [ util-linux ]
-    ++ optionals stdenv.isDarwin [ hexdump ]
-    ++ optionals (stdenv.isDarwin && stdenv.isAarch64) [ autoSignDarwinBinariesHook ]
-    ++ optionals withGui [ wrapQtAppsHook ];
+    ++ lib.optionals stdenv.isLinux [ util-linux ]
+    ++ lib.optionals stdenv.isDarwin [ hexdump ]
+    ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [ autoSignDarwinBinariesHook ]
+    ++ lib.optionals withGui [ wrapQtAppsHook ];
 
   buildInputs = [ boost libevent miniupnpc zeromq zlib ]
-    ++ optionals withWallet [ db48 sqlite ]
-    ++ optionals withGui [ qrencode qtbase qttools ];
+    ++ lib.optionals withWallet [ db48 sqlite ]
+    ++ lib.optionals withGui [ qrencode qtbase qttools ];
 
-  postInstall = optionalString withGui ''
+  postInstall = lib.optionalString withGui ''
     install -Dm644 ${desktop} $out/share/applications/bitcoin-qt.desktop
     substituteInPlace $out/share/applications/bitcoin-qt.desktop --replace "Icon=bitcoin128" "Icon=bitcoin"
     install -Dm644 share/pixmaps/bitcoin256.png $out/share/pixmaps/bitcoin.png
@@ -63,12 +62,12 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-boost-libdir=${boost.out}/lib"
     "--disable-bench"
-  ] ++ optionals (!doCheck) [
+  ] ++ lib.optionals (!doCheck) [
     "--disable-tests"
     "--disable-gui-tests"
-  ] ++ optionals (!withWallet) [
+  ] ++ lib.optionals (!withWallet) [
     "--disable-wallet"
-  ] ++ optionals withGui [
+  ] ++ lib.optionals withGui [
     "--with-gui=qt5"
     "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
   ];
@@ -81,7 +80,7 @@ stdenv.mkDerivation rec {
     [ "LC_ALL=en_US.UTF-8" ]
     # QT_PLUGIN_PATH needs to be set when executing QT, which is needed when testing Bitcoin's GUI.
     # See also https://github.com/NixOS/nixpkgs/issues/24256
-    ++ optional withGui "QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}";
+    ++ lib.optional withGui "QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}";
 
   enableParallelBuilding = true;
 
@@ -89,7 +88,7 @@ stdenv.mkDerivation rec {
     smoke-test = nixosTests.bitcoind;
   };
 
-  meta = {
+  meta = with lib; {
     description = "Peer-to-peer electronic cash system";
     longDescription = ''
       Bitcoin is a free open source peer-to-peer electronic cash system that is

--- a/pkgs/applications/blockchains/btcdeb/default.nix
+++ b/pkgs/applications/blockchains/btcdeb/default.nix
@@ -5,7 +5,6 @@
 , openssl
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "btcdeb";
   version = "unstable-2022-04-03";
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [ openssl ];
 
-  meta = {
+  meta = with lib; {
     description = "Bitcoin Script Debugger";
     homepage = "https://github.com/bitcoin-core/btcdeb";
     license = licenses.mit;

--- a/pkgs/applications/blockchains/digibyte/default.nix
+++ b/pkgs/applications/blockchains/digibyte/default.nix
@@ -15,13 +15,11 @@
 , wrapQtAppsHook ? null
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "digibyte";
   version = "7.17.3";
 
-  name = pname + toString (optional (!withGui) "d") + "-" + version;
+  name = pname + toString (lib.optional (!withGui) "d") + "-" + version;
 
   src = fetchFromGitHub {
     owner = "digibyte-core";
@@ -34,7 +32,7 @@ stdenv.mkDerivation rec {
     autoreconfHook
     pkg-config
     hexdump
-  ] ++ optionals withGui [
+  ] ++ lib.optionals withGui [
     wrapQtAppsHook
   ];
 
@@ -44,7 +42,7 @@ stdenv.mkDerivation rec {
     libevent
     db4
     zeromq
-  ] ++ optionals withGui [
+  ] ++ lib.optionals withGui [
     qtbase
     qttools
     protobuf
@@ -54,12 +52,12 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
       "--with-boost-libdir=${boost.out}/lib"
-  ] ++ optionals withGui [
+  ] ++ lib.optionals withGui [
       "--with-gui=qt5"
       "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
   ];
 
-  meta = {
+  meta = with lib; {
     description = "DigiByte (DGB) is a rapidly growing decentralized, global blockchain";
     homepage = "https://digibyte.io/";
     license = licenses.mit;

--- a/pkgs/applications/blockchains/dogecoin/default.nix
+++ b/pkgs/applications/blockchains/dogecoin/default.nix
@@ -6,9 +6,8 @@
 , withGui, withUpnp ? true, withUtils ? true, withWallet ? true
 , withZmq ? true, zeromq, util-linux ? null, Cocoa ? null }:
 
-with lib;
 stdenv.mkDerivation rec {
-  pname = "dogecoin" + optionalString (!withGui) "d";
+  pname = "dogecoin" + lib.optionalString (!withGui) "d";
   version = "1.14.6";
 
   src = fetchFromGitHub {
@@ -18,32 +17,32 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-PmbmmA2Mq07dwB3cI7A9c/ewtu0I+sWvQT39Yekm/sU=";
   };
 
-  preConfigure = optionalString withGui ''
-    export LRELEASE=${getDev qttools}/bin/lrelease
+  preConfigure = lib.optionalString withGui ''
+    export LRELEASE=${lib.getDev qttools}/bin/lrelease
   '';
 
   nativeBuildInputs = [ pkg-config autoreconfHook util-linux ]
-    ++ optionals withGui [ wrapQtAppsHook qttools ];
+    ++ lib.optionals withGui [ wrapQtAppsHook qttools ];
 
   buildInputs = [ openssl protobuf boost zlib libevent ]
-    ++ optionals withGui [ qtbase qrencode ]
-    ++ optionals withUpnp [ miniupnpc ]
-    ++ optionals withWallet [ db5 ]
-    ++ optionals withZmq [ zeromq ]
-    ++ optionals stdenv.isDarwin [ Cocoa ];
+    ++ lib.optionals withGui [ qtbase qrencode ]
+    ++ lib.optionals withUpnp [ miniupnpc ]
+    ++ lib.optionals withWallet [ db5 ]
+    ++ lib.optionals withZmq [ zeromq ]
+    ++ lib.optionals stdenv.isDarwin [ Cocoa ];
 
   configureFlags = [
     "--with-incompatible-bdb"
     "--with-boost-libdir=${boost.out}/lib"
-  ] ++ optionals (!withGui) [ "--with-gui=no" ]
-    ++ optionals (!withUpnp) [ "--without-miniupnpc" ]
-    ++ optionals (!withUtils) [ "--without-utils" ]
-    ++ optionals (!withWallet) [ "--disable-wallet" ]
-    ++ optionals (!withZmq) [ "--disable-zmq" ];
+  ] ++ lib.optionals (!withGui) [ "--with-gui=no" ]
+    ++ lib.optionals (!withUpnp) [ "--without-miniupnpc" ]
+    ++ lib.optionals (!withUtils) [ "--without-utils" ]
+    ++ lib.optionals (!withWallet) [ "--disable-wallet" ]
+    ++ lib.optionals (!withZmq) [ "--disable-zmq" ];
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     description = "Wow, such coin, much shiba, very rich";
     longDescription = ''
       Dogecoin is a decentralized, peer-to-peer digital currency that

--- a/pkgs/applications/blockchains/elements/default.nix
+++ b/pkgs/applications/blockchains/elements/default.nix
@@ -22,7 +22,6 @@
 , withWallet ? true
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = if withGui then "elements" else "elementsd";
   version = "22.0.2";
@@ -36,24 +35,24 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs =
     [ autoreconfHook pkg-config ]
-    ++ optionals stdenv.isLinux [ util-linux ]
-    ++ optionals stdenv.isDarwin [ hexdump ]
-    ++ optionals (stdenv.isDarwin && stdenv.isAarch64) [ autoSignDarwinBinariesHook ]
-    ++ optionals withGui [ wrapQtAppsHook ];
+    ++ lib.optionals stdenv.isLinux [ util-linux ]
+    ++ lib.optionals stdenv.isDarwin [ hexdump ]
+    ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [ autoSignDarwinBinariesHook ]
+    ++ lib.optionals withGui [ wrapQtAppsHook ];
 
   buildInputs = [ boost libevent miniupnpc zeromq zlib ]
-    ++ optionals withWallet [ db48 sqlite ]
-    ++ optionals withGui [ qrencode qtbase qttools ];
+    ++ lib.optionals withWallet [ db48 sqlite ]
+    ++ lib.optionals withGui [ qrencode qtbase qttools ];
 
   configureFlags = [
     "--with-boost-libdir=${boost.out}/lib"
     "--disable-bench"
-  ] ++ optionals (!doCheck) [
+  ] ++ lib.optionals (!doCheck) [
     "--disable-tests"
     "--disable-gui-tests"
-  ] ++ optionals (!withWallet) [
+  ] ++ lib.optionals (!withWallet) [
     "--disable-wallet"
-  ] ++ optionals withGui [
+  ] ++ lib.optionals withGui [
     "--with-gui=qt5"
     "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
   ];
@@ -70,11 +69,11 @@ stdenv.mkDerivation rec {
     [ "LC_ALL=en_US.UTF-8" ]
     # QT_PLUGIN_PATH needs to be set when executing QT, which is needed when testing Bitcoin's GUI.
     # See also https://github.com/NixOS/nixpkgs/issues/24256
-    ++ optional withGui "QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}";
+    ++ lib.optional withGui "QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}";
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     description = "Open Source implementation of advanced blockchain features extending the Bitcoin protocol";
     longDescription= ''
       The Elements blockchain platform is a collection of feature experiments and extensions to the

--- a/pkgs/applications/blockchains/litecoin/default.nix
+++ b/pkgs/applications/blockchains/litecoin/default.nix
@@ -9,10 +9,8 @@
 , fmt
 }:
 
-with lib;
-
 mkDerivation rec {
-  pname = "litecoin" + optionalString (!withGui) "d";
+  pname = "litecoin" + lib.optionalString (!withGui) "d";
   version = "0.21.2.1";
 
   src = fetchFromGitHub {
@@ -25,11 +23,11 @@ mkDerivation rec {
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [ openssl db48 boost zlib zeromq fmt
                   miniupnpc glib protobuf util-linux libevent ]
-                  ++ optionals stdenv.isDarwin [ AppKit ]
-                  ++ optionals withGui [ qtbase qttools qrencode ];
+                  ++ lib.optionals stdenv.isDarwin [ AppKit ]
+                  ++ lib.optionals withGui [ qtbase qttools qrencode ];
 
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
-                   ++ optionals withGui [
+                   ++ lib.optionals withGui [
                       "--with-gui=qt5"
                       "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin" ];
 
@@ -40,7 +38,7 @@ mkDerivation rec {
     ./src/test/test_litecoin
   '';
 
-  meta = {
+  meta = with lib; {
     broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
     description = "A lite version of Bitcoin using scrypt as a proof-of-work algorithm";
     longDescription= ''

--- a/pkgs/applications/blockchains/particl-core/default.nix
+++ b/pkgs/applications/blockchains/particl-core/default.nix
@@ -14,8 +14,6 @@
 , python3
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "particl-core";
   version = "23.0.3.0";
@@ -33,7 +31,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--disable-bench"
     "--with-boost-libdir=${boost.out}/lib"
-  ] ++ optionals (!doCheck) [
+  ] ++ lib.optionals (!doCheck) [
     "--enable-tests=no"
   ];
 
@@ -42,7 +40,7 @@ stdenv.mkDerivation rec {
   preCheck = "patchShebangs test";
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     broken = (stdenv.isLinux && stdenv.isAarch64);
     description = "Privacy-Focused Marketplace & Decentralized Application Platform";
     longDescription = ''

--- a/pkgs/applications/blockchains/vertcoin/default.nix
+++ b/pkgs/applications/blockchains/vertcoin/default.nix
@@ -16,13 +16,11 @@
 , wrapQtAppsHook ? null
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "vertcoin";
   version = "0.18.0";
 
-  name = pname + toString (optional (!withGui) "d") + "-" + version;
+  name = pname + toString (lib.optional (!withGui) "d") + "-" + version;
 
   src = fetchFromGitHub {
     owner = pname + "-project";
@@ -35,7 +33,7 @@ stdenv.mkDerivation rec {
     autoreconfHook
     pkg-config
     hexdump
-  ] ++ optionals withGui [
+  ] ++ lib.optionals withGui [
     wrapQtAppsHook
   ];
 
@@ -46,7 +44,7 @@ stdenv.mkDerivation rec {
     db4
     zeromq
     gmp
-  ] ++ optionals withGui [
+  ] ++ lib.optionals withGui [
     qtbase
     qttools
     protobuf
@@ -56,12 +54,12 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
       "--with-boost-libdir=${boost.out}/lib"
-  ] ++ optionals withGui [
+  ] ++ lib.optionals withGui [
       "--with-gui=qt5"
       "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
   ];
 
-  meta = {
+  meta = with lib; {
     description = "A digital currency with mining decentralisation and ASIC resistance as a key focus";
     homepage = "https://vertcoin.org/";
     license = licenses.mit;

--- a/pkgs/applications/blockchains/wownero/default.nix
+++ b/pkgs/applications/blockchains/wownero/default.nix
@@ -2,7 +2,6 @@
 , readline, libsodium, rapidjson
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "wownero";
   version = "0.8.0.1";
@@ -41,7 +40,7 @@ stdenv.mkDerivation rec {
     "-DMANUAL_SUBMODULES=ON"
   ];
 
-  meta = {
+  meta = with lib; {
     description = ''
       A privacy-centric memecoin that was fairly launched on April 1, 2018 with
       no pre-mine, stealth-mine or ICO

--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -30,8 +30,6 @@
 , yelp-tools
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "lightdm";
   version = "1.32.0";
@@ -69,7 +67,7 @@ stdenv.mkDerivation rec {
     libxklavier
     pam
     polkit
-  ] ++ optional withQt5 qtbase;
+  ] ++ lib.optional withQt5 qtbase;
 
   patches = [
     # Adds option to disable writing dmrc files
@@ -96,7 +94,7 @@ stdenv.mkDerivation rec {
     "--sysconfdir=/etc"
     "--disable-tests"
     "--disable-dmrc"
-  ] ++ optional withQt5 "--enable-liblightdm-qt5";
+  ] ++ lib.optional withQt5 "--enable-liblightdm-qt5";
 
   installFlags = [
     "sysconfdir=${placeholder "out"}/etc"
@@ -120,7 +118,7 @@ stdenv.mkDerivation rec {
   };
 
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/canonical/lightdm";
     description = "A cross-desktop display manager";
     platforms = platforms.linux;

--- a/pkgs/applications/editors/codeblocks/default.nix
+++ b/pkgs/applications/editors/codeblocks/default.nix
@@ -2,8 +2,6 @@
 , contribPlugins ? false, hunspell, gamin, boost, wrapGAppsHook
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   name = "${pname}-${lib.optionalString contribPlugins "full-"}${version}";
   version = "20.03";
@@ -16,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config file zip wrapGAppsHook ];
   buildInputs = [ wxGTK31 gtk3 ]
-    ++ optionals contribPlugins [ hunspell gamin boost ];
+    ++ lib.optionals contribPlugins [ hunspell gamin boost ];
   enableParallelBuilding = true;
   patches = [
     ./writable-projects.patch
@@ -56,16 +54,16 @@ stdenv.mkDerivation rec {
     })
   ];
   preConfigure = "substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file";
-  postConfigure = optionalString stdenv.isLinux "substituteInPlace libtool --replace ldconfig ${stdenv.cc.libc.bin}/bin/ldconfig";
-  configureFlags = [ "--enable-pch=no" ] ++ optionals contribPlugins [
-    ("--with-contrib-plugins" + optionalString stdenv.isDarwin "=all,-FileManager,-NassiShneiderman")
+  postConfigure = lib.optionalString stdenv.isLinux "substituteInPlace libtool --replace ldconfig ${stdenv.cc.libc.bin}/bin/ldconfig";
+  configureFlags = [ "--enable-pch=no" ] ++ lib.optionals contribPlugins [
+    ("--with-contrib-plugins" + lib.optionalString stdenv.isDarwin "=all,-FileManager,-NassiShneiderman")
     "--with-boost-libdir=${boost}/lib"
   ];
-  postInstall = optionalString stdenv.isDarwin ''
+  postInstall = lib.optionalString stdenv.isDarwin ''
     ln -s $out/lib/codeblocks/plugins $out/share/codeblocks/plugins
   '';
 
-  meta = {
+  meta = with lib; {
     maintainers = [ maintainers.linquize ];
     platforms = platforms.all;
     description = "The open source, cross platform, free C, C++ and Fortran IDE";

--- a/pkgs/applications/editors/howl/default.nix
+++ b/pkgs/applications/editors/howl/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl, makeWrapper, pkg-config, gtk3, librsvg }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "howl";
   version = "0.6";
@@ -27,7 +25,7 @@ stdenv.mkDerivation rec {
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://howl.io/";
     description = "A general purpose, fast and lightweight editor with a keyboard-centric minimalistic user interface";
     license = licenses.mit;

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -11,15 +11,13 @@
 , vmopts ? null
 }:
 
-with lib;
-
 let
   platforms = lib.platforms.linux ++ [ "x86_64-darwin" "aarch64-darwin" ];
   ideaPlatforms = [ "x86_64-darwin" "i686-darwin" "i686-linux" "x86_64-linux" "aarch64-darwin" ];
 
   inherit (stdenv.hostPlatform) system;
 
-  versions = builtins.fromJSON (readFile (./versions.json));
+  versions = builtins.fromJSON (lib.readFile (./versions.json));
   versionKey = if stdenv.isLinux then "linux" else system;
   products = versions.${versionKey} or (throw "Unsupported system: ${system}");
 
@@ -42,11 +40,11 @@ let
         maintainers = with maintainers; [ edwtjo mic92 ];
       };
     }).overrideAttrs (attrs: {
-      nativeBuildInputs = (attrs.nativeBuildInputs or []) ++ optionals (stdenv.isLinux) [
+      nativeBuildInputs = (attrs.nativeBuildInputs or []) ++ lib.optionals (stdenv.isLinux) [
         autoPatchelfHook
         patchelf
       ];
-      buildInputs = (attrs.buildInputs or []) ++ optionals (stdenv.isLinux) [
+      buildInputs = (attrs.buildInputs or []) ++ lib.optionals (stdenv.isLinux) [
         python3
         stdenv.cc.cc
         libdbusmenu
@@ -54,7 +52,7 @@ let
         expat
       ];
       dontAutoPatchelf = true;
-      postFixup = (attrs.postFixup or "") + optionalString (stdenv.isLinux) ''
+      postFixup = (attrs.postFixup or "") + lib.optionalString (stdenv.isLinux) ''
         (
           cd $out/clion
           # bundled cmake does not find libc
@@ -217,7 +215,7 @@ let
         '';
         maintainers = with maintainers; [ ];
       };
-    }).overrideAttrs (finalAttrs: previousAttrs: optionalAttrs cythonSpeedup {
+    }).overrideAttrs (finalAttrs: previousAttrs: lib.optionalAttrs cythonSpeedup {
       buildInputs = with python3.pkgs; [ python3 setuptools ];
       preInstall = ''
       echo "compiling cython debug speedups"

--- a/pkgs/applications/editors/jetbrains/linux.nix
+++ b/pkgs/applications/editors/jetbrains/linux.nix
@@ -5,10 +5,8 @@
 
 { pname, product, productShort ? product, version, src, wmClass, jdk, meta, extraLdPath ? [], extraWrapperArgs ? [] }@args:
 
-with lib;
-
-let loName = toLower productShort;
-    hiName = toUpper productShort;
+let loName = lib.toLower productShort;
+    hiName = lib.toUpper productShort;
     vmoptsName = loName
                + lib.optionalString stdenv.hostPlatform.is64bit "64"
                + ".vmoptions";
@@ -29,7 +27,7 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
     startupWMClass = wmClass;
   };
 
-  vmoptsFile = optionalString (vmopts != null) (writeText vmoptsName vmopts);
+  vmoptsFile = lib.optionalString (vmopts != null) (writeText vmoptsName vmopts);
 
   nativeBuildInputs = [ makeWrapper patchelf unzip ];
 

--- a/pkgs/applications/editors/jucipp/default.nix
+++ b/pkgs/applications/editors/jucipp/default.nix
@@ -3,13 +3,11 @@
   libXdmcp, libxkbcommon, libpthreadstubs, wrapGAppsHook, aspellDicts, gtkmm3,
   coreutils, glibc, dbus, openssl, libxml2, gnumake, ctags }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "juicipp";
   version = "1.2.3";
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/cppit/jucipp";
     description = "A lightweight, platform independent C++-IDE with support for C++11, C++14, and experimental C++17 features depending on libclang version";
     license = licenses.mit;

--- a/pkgs/applications/editors/kakoune/default.nix
+++ b/pkgs/applications/editors/kakoune/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "kakoune-unwrapped";
   version = "2022.10.31";
@@ -33,7 +31,7 @@ stdenv.mkDerivation rec {
     ln -s --relative "$autoload_target" autoload
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "http://kakoune.org/";
     description = "A vim inspired text editor";
     license = licenses.publicDomain;

--- a/pkgs/applications/editors/nano/default.nix
+++ b/pkgs/applications/editors/nano/default.nix
@@ -4,8 +4,6 @@
 
 assert enableNls -> (gettext != null);
 
-with lib;
-
 let
   nixSyntaxHighlight = fetchFromGitHub {
     owner = "seitz";
@@ -23,7 +21,7 @@ in stdenv.mkDerivation rec {
     sha256 = "V7p1Hpt1GfD23e5QUgLjh8dd3kQMH3qhuTEMw4FAaDY=";
   };
 
-  nativeBuildInputs = [ texinfo ] ++ optional enableNls gettext;
+  nativeBuildInputs = [ texinfo ] ++ lib.optional enableNls gettext;
   buildInputs = [ ncurses ];
 
   outputs = [ "out" "info" ];
@@ -71,7 +69,7 @@ in stdenv.mkDerivation rec {
     '';
   };
 
-  meta = {
+  meta = with lib; {
     homepage = "https://www.nano-editor.org/";
     description = "A small, user-friendly console text editor";
     license = licenses.gpl3Plus;

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -5,8 +5,6 @@
 , python3Packages
 , callPackage
 }:
-with lib;
-
 neovim:
 
 let
@@ -32,7 +30,7 @@ let
   }@args:
   let
 
-    wrapperArgsStr = if isString wrapperArgs then wrapperArgs else lib.escapeShellArgs wrapperArgs;
+    wrapperArgsStr = if lib.isString wrapperArgs then wrapperArgs else lib.escapeShellArgs wrapperArgs;
 
     # If configure != {}, we can't generate the rplugin.vim file with e.g
     # NVIM_SYSTEM_RPLUGIN_MANIFEST *and* NVIM_RPLUGIN_MANIFEST env vars set in
@@ -43,7 +41,7 @@ let
     finalMakeWrapperArgs =
       [ "${neovim}/bin/nvim" "${placeholder "out"}/bin/nvim" ]
       ++ [ "--set" "NVIM_SYSTEM_RPLUGIN_MANIFEST" "${placeholder "out"}/rplugin.vim" ]
-      ++ optionals wrapRc [ "--add-flags" "-u ${writeText "init.vim" neovimRcContent}" ]
+      ++ lib.optionals wrapRc [ "--add-flags" "-u ${writeText "init.vim" neovimRcContent}" ]
       ;
   in
   assert withPython2 -> throw "Python2 support has been removed from the neovim wrapper, please remove withPython2 and python2Env.";
@@ -57,22 +55,22 @@ let
         substitute ${neovim}/share/applications/nvim.desktop $out/share/applications/nvim.desktop \
           --replace 'Name=Neovim' 'Name=Neovim wrapper'
       ''
-      + optionalString withPython3 ''
+      + lib.optionalString withPython3 ''
         makeWrapper ${python3Env.interpreter} $out/bin/nvim-python3 --unset PYTHONPATH
       ''
-      + optionalString (rubyEnv != null) ''
+      + lib.optionalString (rubyEnv != null) ''
         ln -s ${rubyEnv}/bin/neovim-ruby-host $out/bin/nvim-ruby
       ''
-      + optionalString withNodeJs ''
+      + lib.optionalString withNodeJs ''
         ln -s ${nodePackages.neovim}/bin/neovim-node-host $out/bin/nvim-node
       ''
-      + optionalString vimAlias ''
+      + lib.optionalString vimAlias ''
         ln -s $out/bin/nvim $out/bin/vim
       ''
-      + optionalString viAlias ''
+      + lib.optionalString viAlias ''
         ln -s $out/bin/nvim $out/bin/vi
       ''
-      + optionalString (manifestRc != null) (let
+      + lib.optionalString (manifestRc != null) (let
         manifestWrapperArgs =
           [ "${neovim}/bin/nvim" "${placeholder "out"}/bin/nvim-wrapper" ];
       in ''

--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -206,7 +206,7 @@ in
       homepage = "https://www.rstudio.com/";
       license = licenses.agpl3Only;
       maintainers = with maintainers; [ ciil cfhammill ];
-      mainProgram = "rstudio" + optionalString server "-server";
+      mainProgram = "rstudio" + lib.optionalString server "-server";
       platforms = platforms.linux;
     };
 

--- a/pkgs/applications/editors/vscode/extensions/ms-vsliveshare-vsliveshare/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vsliveshare-vsliveshare/default.nix
@@ -7,8 +7,6 @@
 , desktop-file-utils, xprop, xsel
 }:
 
-with lib;
-
 let
   # https://docs.microsoft.com/en-us/visualstudio/liveshare/reference/linux#install-prerequisites-manually
   libs = [
@@ -118,12 +116,12 @@ in ((vscode-utils.override { stdenv = gccStdenv; }).buildVscodeMarketplaceExtens
     # which will break when copying over the files.
     mv dotnet_modules/vsls-agent{,-wrapped}
     makeWrapper $PWD/dotnet_modules/vsls-agent{-wrapped,} \
-      --prefix LD_LIBRARY_PATH : "${makeLibraryPath libs}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath libs}" \
       --set LD_PRELOAD $PWD/dotnet_modules/noop-syslog.so \
       --set DOTNET_ROOT ${dotnet-sdk_3}
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Live Share lets you achieve greater confidence at speed by streamlining collaborative editing, debugging, and more in real-time during development";
     homepage = "https://aka.ms/vsls-docs";
     license = licenses.unfree;

--- a/pkgs/applications/emulators/atari800/default.nix
+++ b/pkgs/applications/emulators/atari800/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook
 , zlib, SDL, readline, libGLU, libGL, libX11 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "atari800";
   version = "5.0.0";
@@ -9,7 +8,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "atari800";
     repo = "atari800";
-    rev = "ATARI800_${replaceStrings ["."] ["_"] version}";
+    rev = "ATARI800_${lib.replaceStrings ["."] ["_"] version}";
     sha256 = "sha256-+eJXhqPyU0GhmzF7DbteTXzEnn5klCor9Io/UgXQfQg=";
   };
 
@@ -27,7 +26,7 @@ stdenv.mkDerivation rec {
     "--enable-riodevice"
   ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://atari800.github.io/";
     description = "An Atari 8-bit emulator";
     longDescription = ''

--- a/pkgs/applications/emulators/xcpc/default.nix
+++ b/pkgs/applications/emulators/xcpc/default.nix
@@ -3,7 +3,6 @@
   , motifSupport ? false, lesstif
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   version = "20070122";
   pname = "xcpc";
@@ -16,10 +15,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ glib libdsk libXaw libX11 libXext ]
-    ++ optional libDSKSupport libdsk
-    ++ optional motifSupport lesstif;
+    ++ lib.optional libDSKSupport libdsk
+    ++ lib.optional motifSupport lesstif;
 
-  meta = {
+  meta = with lib; {
     description = "A portable Amstrad CPC 464/664/6128 emulator written in C";
     homepage = "https://www.xcpc-emulator.net";
     license = licenses.gpl2Plus;

--- a/pkgs/applications/file-managers/noice/default.nix
+++ b/pkgs/applications/file-managers/noice/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchgit, ncurses, conf ? null }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "noice";
   version = "0.8";
@@ -18,8 +16,8 @@ stdenv.mkDerivation rec {
     substituteInPlace noice.c --replace 'printw(str);' 'printw("%s", str);'
   '';
 
-  configFile = optionalString (conf!=null) (builtins.toFile "config.def.h" conf);
-  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
+  configFile = lib.optionalString (conf!=null) (builtins.toFile "config.def.h" conf);
+  preBuild = lib.optionalString (conf!=null) "cp ${configFile} config.def.h";
 
   buildInputs = [ ncurses ];
 
@@ -27,7 +25,7 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
 
-  meta = {
+  meta = with lib; {
     description = "Small ncurses-based file browser";
     homepage = "https://git.2f30.org/noice/";
     license = licenses.bsd2;

--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -2,7 +2,6 @@
 , extraPythonPackages ? (ps: [ ])
 , libsForQt5
 }:
-with lib;
 let
   qgis-unwrapped = libsForQt5.callPackage ./unwrapped.nix {  };
 in symlinkJoin rec {

--- a/pkgs/applications/gis/qgis/ltr.nix
+++ b/pkgs/applications/gis/qgis/ltr.nix
@@ -2,7 +2,6 @@
 , extraPythonPackages ? (ps: [ ])
 , libsForQt5
 }:
-with lib;
 let
   qgis-ltr-unwrapped = libsForQt5.callPackage ./unwrapped-ltr.nix {  };
 in symlinkJoin rec {

--- a/pkgs/applications/graphics/drawpile/default.nix
+++ b/pkgs/applications/graphics/drawpile/default.nix
@@ -36,8 +36,6 @@
 , enableKisTablet ? false # enable improved graphics tablet support
 }:
 
-with lib;
-
 let
   clientDeps = [
     qtbase
@@ -57,7 +55,7 @@ let
     # optional:
     libmicrohttpd # HTTP admin api
     libsodium # ext-auth support
-  ] ++ optional withSystemd systemd;
+  ] ++ lib.optional withSystemd systemd;
 
   kisDeps = [
     qtx11extras
@@ -82,9 +80,9 @@ in mkDerivation rec {
   buildInputs = [
     karchive
   ]
-  ++ optionals buildClient      clientDeps
-  ++ optionals buildServer      serverDeps
-  ++ optionals enableKisTablet  kisDeps;
+  ++ lib.optionals buildClient      clientDeps
+  ++ lib.optionals buildServer      serverDeps
+  ++ lib.optionals enableKisTablet  kisDeps;
 
   cmakeFlags = [
     "-Wno-dev"
@@ -96,7 +94,7 @@ in mkDerivation rec {
     "-DKIS_TABLET=${boolToFlag enableKisTablet}"
   ];
 
-  meta = {
+  meta = with lib; {
     description = "A collaborative drawing program that allows multiple users to sketch on the same canvas simultaneously";
     homepage = "https://drawpile.net/";
     downloadPage = "https://drawpile.net/download/";

--- a/pkgs/applications/graphics/figma-linux/default.nix
+++ b/pkgs/applications/graphics/figma-linux/default.nix
@@ -6,7 +6,6 @@
 , dpkg
 , ...
 }:
-with lib;
 stdenv.mkDerivation rec {
   pname = "figma-linux";
   version = "0.10.0";
@@ -67,7 +66,7 @@ stdenv.mkDerivation rec {
           --replace "Exec=/opt/figma-linux/figma-linux" "Exec=$out/bin/${pname}"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "unofficial Electron-based Figma desktop app for Linux";
     homepage = "https://github.com/Figma-Linux/figma-linux";
     platforms = [ "x86_64-linux" ];

--- a/pkgs/applications/graphics/gscan2pdf/default.nix
+++ b/pkgs/applications/graphics/gscan2pdf/default.nix
@@ -6,8 +6,6 @@
   # test dependencies
   xvfb-run, liberation_ttf, file, tesseract }:
 
-with lib;
-
 perlPackages.buildPerlPackage rec {
   pname = "gscan2pdf";
   version = "2.12.8";
@@ -126,7 +124,7 @@ perlPackages.buildPerlPackage rec {
       make test
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A GUI to produce PDFs or DjVus from scanned documents";
     homepage = "http://gscan2pdf.sourceforge.net/";
     license = licenses.gpl3;

--- a/pkgs/applications/graphics/image_optim/default.nix
+++ b/pkgs/applications/graphics/image_optim/default.nix
@@ -12,21 +12,19 @@
   withSvgo ? true,           svgo
 }:
 
-with lib;
-
 let
   optionalDepsPath = []
-    ++ optional withPngcrush pngcrush
-    ++ optional withPngout pngout
-    ++ optional withAdvpng advancecomp
-    ++ optional withOptipng optipng
-    ++ optional withPngquant pngquant
-    ++ optional withJhead jhead
-    ++ optional withJpegoptim jpegoptim
-    ++ optional withJpegrecompress jpeg-archive
-    ++ optional withJpegtran libjpeg
-    ++ optional withGifsicle gifsicle
-    ++ optional withSvgo svgo;
+    ++ lib.optional withPngcrush pngcrush
+    ++ lib.optional withPngout pngout
+    ++ lib.optional withAdvpng advancecomp
+    ++ lib.optional withOptipng optipng
+    ++ lib.optional withPngquant pngquant
+    ++ lib.optional withJhead jhead
+    ++ lib.optional withJpegoptim jpegoptim
+    ++ lib.optional withJpegrecompress jpeg-archive
+    ++ lib.optional withJpegtran libjpeg
+    ++ lib.optional withGifsicle gifsicle
+    ++ lib.optional withSvgo svgo;
 in
 
 bundlerApp {
@@ -39,7 +37,7 @@ bundlerApp {
 
   postBuild = ''
     wrapProgram $out/bin/image_optim \
-      --prefix PATH : ${lib.escapeShellArg (makeBinPath optionalDepsPath)}
+      --prefix PATH : ${lib.escapeShellArg (lib.makeBinPath optionalDepsPath)}
   '';
 
   passthru.updateScript = bundlerUpdateScript "image_optim";

--- a/pkgs/applications/graphics/rx/default.nix
+++ b/pkgs/applications/graphics/rx/default.nix
@@ -3,8 +3,6 @@
 , xorg ? null
 , libGL ? null }:
 
-with lib;
-
 rustPlatform.buildRustPackage rec {
   pname = "rx";
   version = "0.5.2";
@@ -20,7 +18,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ cmake pkg-config makeWrapper ];
 
-  buildInputs = optionals stdenv.isLinux
+  buildInputs = lib.optionals stdenv.isLinux
   (with xorg; [
     # glfw-sys dependencies:
     libX11 libXrandr libXinerama libXcursor libXi libXext
@@ -29,13 +27,13 @@ rustPlatform.buildRustPackage rec {
   # FIXME: GLFW (X11) requires DISPLAY env variable for all tests
   doCheck = false;
 
-  postInstall = optionalString stdenv.isLinux ''
+  postInstall = lib.optionalString stdenv.isLinux ''
     mkdir -p $out/share/applications
     cp $src/rx.desktop $out/share/applications
     wrapProgram $out/bin/rx --prefix LD_LIBRARY_PATH : ${libGL}/lib
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Modern and extensible pixel editor implemented in Rust";
     homepage = "https://rx.cloudhead.io/";
     license = licenses.gpl3;

--- a/pkgs/applications/graphics/sane/config.nix
+++ b/pkgs/applications/graphics/sane/config.nix
@@ -2,7 +2,6 @@
 
 { paths, disabledDefaultBackends ? [] }:
 
-with lib;
 let
 installSanePath = path: ''
       if [ -e "${path}/lib/sane" ]; then
@@ -48,6 +47,6 @@ stdenv.mkDerivation {
 
     mkdir -p $out/etc/sane.d $out/etc/sane.d/dll.d $out/lib/sane
   ''
-  + (concatMapStrings installSanePath paths)
-  + (concatMapStrings disableBackend disabledDefaultBackends);
+  + (lib.concatMapStrings installSanePath paths)
+  + (lib.concatMapStrings disableBackend disabledDefaultBackends);
 }

--- a/pkgs/applications/graphics/sxiv/default.nix
+++ b/pkgs/applications/graphics/sxiv/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, libXft, imlib2, giflib, libexif, conf ? null }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "sxiv";
   version = "26";
@@ -13,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0xaawlfdy7b277m38mgg4423kd7p1ffn0dq4hciqs6ivbb3q9c4f";
   };
 
-  configFile = optionalString (conf!=null) (builtins.toFile "config.def.h" conf);
-  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
+  configFile = lib.optionalString (conf!=null) (builtins.toFile "config.def.h" conf);
+  preBuild = lib.optionalString (conf!=null) "cp ${configFile} config.def.h";
 
   buildInputs = [ libXft imlib2 giflib libexif ];
 
@@ -29,6 +27,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/muennich/sxiv";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with maintainers; [ jfrankenau ];
+    maintainers = with lib.maintainers; [ jfrankenau ];
   };
 }

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -16,7 +16,6 @@
 , embree, gmp, libharu
 }:
 
-with lib;
 let
   python = python310Packages.python;
   optix = fetchzip {
@@ -38,7 +37,7 @@ stdenv.mkDerivation rec {
   patches = lib.optional stdenv.isDarwin ./darwin.patch;
 
   nativeBuildInputs = [ cmake makeWrapper python310Packages.wrapPython llvmPackages.llvm.dev ]
-    ++ optionals cudaSupport [ addOpenGLRunpath ];
+    ++ lib.optionals cudaSupport [ addOpenGLRunpath ];
   buildInputs =
     [ boost ffmpeg gettext glew ilmbase
       freetype libjpeg libpng libsamplerate libsndfile libtiff libwebp
@@ -63,10 +62,10 @@ stdenv.mkDerivation rec {
     else [
       llvmPackages.openmp SDL Cocoa CoreGraphics ForceFeedback OpenAL OpenGL
     ])
-    ++ optional jackaudioSupport libjack2
-    ++ optional cudaSupport cudaPackages.cudatoolkit
-    ++ optional colladaSupport opencollada
-    ++ optional spaceNavSupport libspnav;
+    ++ lib.optional jackaudioSupport libjack2
+    ++ lib.optional cudaSupport cudaPackages.cudatoolkit
+    ++ lib.optional colladaSupport opencollada
+    ++ lib.optional spaceNavSupport libspnav;
   pythonPath = with python310Packages; [ numpy requests ];
 
   postPatch = ''
@@ -118,16 +117,16 @@ stdenv.mkDerivation rec {
       "-DWITH_IMAGE_OPENJPEG=ON"
       "-DWITH_OPENCOLLADA=${if colladaSupport then "ON" else "OFF"}"
     ]
-    ++ optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.isDarwin [
       "-DWITH_CYCLES_OSL=OFF" # requires LLVM
       "-DWITH_OPENVDB=OFF" # OpenVDB currently doesn't build on darwin
 
       "-DLIBDIR=/does-not-exist"
     ]
     # Clang doesn't support "-export-dynamic"
-    ++ optional stdenv.cc.isClang "-DPYTHON_LINKFLAGS="
-    ++ optional jackaudioSupport "-DWITH_JACK=ON"
-    ++ optionals cudaSupport [
+    ++ lib.optional stdenv.cc.isClang "-DPYTHON_LINKFLAGS="
+    ++ lib.optional jackaudioSupport "-DWITH_JACK=ON"
+    ++ lib.optionals cudaSupport [
       "-DWITH_CYCLES_CUDA_BINARIES=ON"
       "-DWITH_CYCLES_DEVICE_OPTIX=ON"
       "-DOPTIX_ROOT_DIR=${optix}"
@@ -137,7 +136,7 @@ stdenv.mkDerivation rec {
 
   # Since some dependencies are built with gcc 6, we need gcc 6's
   # libstdc++ in our RPATH. Sigh.
-  NIX_LDFLAGS = optionalString cudaSupport "-rpath ${stdenv.cc.cc.lib}/lib";
+  NIX_LDFLAGS = lib.optionalString cudaSupport "-rpath ${stdenv.cc.cc.lib}/lib";
 
   blenderExecutable =
     placeholder "out" + (if stdenv.isDarwin then "/Applications/Blender.app/Contents/MacOS/Blender" else "/bin/blender");
@@ -154,7 +153,7 @@ stdenv.mkDerivation rec {
 
   # Set RUNPATH so that libcuda and libnvrtc in /run/opengl-driver(-32)/lib can be
   # found. See the explanation in libglvnd.
-  postFixup = optionalString cudaSupport ''
+  postFixup = lib.optionalString cudaSupport ''
     for program in $out/bin/blender $out/bin/.blender-wrapped; do
       isELF "$program" || continue
       addOpenGLRunpath "$program"

--- a/pkgs/applications/misc/electrum/update.nix
+++ b/pkgs/applications/misc/electrum/update.nix
@@ -10,8 +10,6 @@
 , nix
 }:
 
-with lib;
-
 let
   downloadPageUrl = "https://download.electrum.org";
 
@@ -23,7 +21,7 @@ writeScript "update-electrum" ''
 
 set -eu -o pipefail
 
-export PATH=${makeBinPath [
+export PATH=${lib.makeBinPath [
   common-updater-scripts
   coreutils
   curl
@@ -50,7 +48,7 @@ sigFile=$srcFile.asc
 export GNUPGHOME=$PWD/gnupg
 mkdir -m 700 -p "$GNUPGHOME"
 
-gpg --batch --recv-keys ${concatStringsSep " " (map (x: "'${x}'") signingKeys)}
+gpg --batch --recv-keys ${lib.concatStringsSep " " (map (x: "'${x}'") signingKeys)}
 gpg --batch --verify "$sigFile" "$srcFile"
 
 sha256=$(nix-prefetch-url --type sha256 "file://$PWD/$srcFile")

--- a/pkgs/applications/misc/elogind/default.nix
+++ b/pkgs/applications/misc/elogind/default.nix
@@ -25,8 +25,6 @@
 , enableSystemd ? false
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "elogind";
   version = "246.10";
@@ -72,7 +70,7 @@ stdenv.mkDerivation rec {
     "-Dsysconfdir=${placeholder "out"}/etc"
   ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/elogind/elogind";
     description = ''The systemd project's "logind", extracted to a standalone package'';
     platforms = platforms.linux; # probably more

--- a/pkgs/applications/misc/gammu/default.nix
+++ b/pkgs/applications/misc/gammu/default.nix
@@ -4,8 +4,6 @@
 , postgresSupport ? false, postgresql ? null
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "gammu";
   version = "1.42.0";
@@ -31,10 +29,10 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   buildInputs = [ bash bluez libusb1 curl gettext sqlite libiconv ]
-  ++ optionals dbiSupport [ libdbi libdbiDrivers ]
-  ++ optionals postgresSupport [ postgresql ];
+  ++ lib.optionals dbiSupport [ libdbi libdbiDrivers ]
+  ++ lib.optionals postgresSupport [ postgresql ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://wammu.eu/gammu/";
     description = "Command line utility and library to control mobile phones";
     license = licenses.gpl2;

--- a/pkgs/applications/misc/get_iplayer/default.nix
+++ b/pkgs/applications/misc/get_iplayer/default.nix
@@ -1,7 +1,5 @@
 { lib, fetchFromGitHub, atomicparsley, flvstreamer, ffmpeg, makeWrapper, perl, perlPackages, rtmpdump}:
 
-with lib;
-
 perlPackages.buildPerlPackage rec {
   pname = "get_iplayer";
   version = "3.27";
@@ -26,11 +24,11 @@ perlPackages.buildPerlPackage rec {
   installPhase = ''
     mkdir -p $out/bin $out/share/man/man1
     cp get_iplayer $out/bin
-    wrapProgram $out/bin/get_iplayer --suffix PATH : ${makeBinPath [ atomicparsley ffmpeg flvstreamer rtmpdump ]} --prefix PERL5LIB : $PERL5LIB
+    wrapProgram $out/bin/get_iplayer --suffix PATH : ${lib.makeBinPath [ atomicparsley ffmpeg flvstreamer rtmpdump ]} --prefix PERL5LIB : $PERL5LIB
     cp get_iplayer.1 $out/share/man/man1
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Downloads TV and radio from BBC iPlayer";
     license = licenses.gpl3Plus;
     homepage = "https://squarepenguin.co.uk/";

--- a/pkgs/applications/misc/k2pdfopt/default.nix
+++ b/pkgs/applications/misc/k2pdfopt/default.nix
@@ -8,8 +8,6 @@
 , enableTesseract ? true, leptonica, tesseract4
 }:
 
-with lib;
-
 # k2pdfopt is a pain to package. It requires modified versions of mupdf,
 # leptonica, and tesseract.  Instead of shipping patches for these upstream
 # packages, k2pdfopt includes just the modified source files for these
@@ -140,12 +138,12 @@ in stdenv.mkDerivation rec {
     };
   in
     [ zlib libpng ] ++
-    optional enableGSL gsl ++
-    optional enableGhostScript ghostscript ++
-    optional enableMuPDF mupdf_modded ++
-    optional enableDJVU djvulibre ++
-    optional enableGOCR gocr ++
-    optionals enableTesseract [ leptonica_modded tesseract_modded ];
+    lib.optional enableGSL gsl ++
+    lib.optional enableGhostScript ghostscript ++
+    lib.optional enableMuPDF mupdf_modded ++
+    lib.optional enableDJVU djvulibre ++
+    lib.optional enableGOCR gocr ++
+    lib.optionals enableTesseract [ leptonica_modded tesseract_modded ];
 
   dontUseCmakeBuildDir = true;
 
@@ -157,7 +155,7 @@ in stdenv.mkDerivation rec {
     install -D -m 755 k2pdfopt $out/bin/k2pdfopt
   '';
 
-  preFixup = optionalString enableTesseract ''
+  preFixup = lib.optionalString enableTesseract ''
     wrapProgram $out/bin/k2pdfopt --set-default TESSDATA_PREFIX ${tesseract4}/share/tessdata
   '';
 

--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -37,8 +37,6 @@
 , nixosTests
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "keepassxc";
   version = "2.7.4";
@@ -50,13 +48,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-amedKK9nplLVJTldeabN3/c+g/QesrdH+qx+rba2/4s=";
   };
 
-  NIX_CFLAGS_COMPILE = optionalString stdenv.cc.isClang [
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang [
     "-Wno-old-style-cast"
     "-Wno-error"
     "-D__BIG_ENDIAN__=${if stdenv.isBigEndian then "1" else "0"}"
   ];
 
-  NIX_LDFLAGS = optionalString stdenv.isDarwin "-rpath ${libargon2}/lib";
+  NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-rpath ${libargon2}/lib";
 
   patches = [
     ./darwin.patch
@@ -67,13 +65,13 @@ stdenv.mkDerivation rec {
     "-DWITH_GUI_TESTS=ON"
     "-DWITH_XC_UPDATECHECK=OFF"
   ]
-  ++ (optional (!withKeePassX11) "-DWITH_XC_X11=OFF")
-  ++ (optional (withKeePassFDOSecrets && stdenv.isLinux) "-DWITH_XC_FDOSECRETS=ON")
-  ++ (optional (withKeePassYubiKey && stdenv.isLinux) "-DWITH_XC_YUBIKEY=ON")
-  ++ (optional withKeePassBrowser "-DWITH_XC_BROWSER=ON")
-  ++ (optional withKeePassKeeShare "-DWITH_XC_KEESHARE=ON")
-  ++ (optional withKeePassNetworking "-DWITH_XC_NETWORKING=ON")
-  ++ (optional withKeePassSSHAgent "-DWITH_XC_SSHAGENT=ON");
+  ++ (lib.optional (!withKeePassX11) "-DWITH_XC_X11=OFF")
+  ++ (lib.optional (withKeePassFDOSecrets && stdenv.isLinux) "-DWITH_XC_FDOSECRETS=ON")
+  ++ (lib.optional (withKeePassYubiKey && stdenv.isLinux) "-DWITH_XC_YUBIKEY=ON")
+  ++ (lib.optional withKeePassBrowser "-DWITH_XC_BROWSER=ON")
+  ++ (lib.optional withKeePassKeeShare "-DWITH_XC_KEESHARE=ON")
+  ++ (lib.optional withKeePassNetworking "-DWITH_XC_NETWORKING=ON")
+  ++ (lib.optional withKeePassSSHAgent "-DWITH_XC_SSHAGENT=ON");
 
   doCheck = true;
   checkPhase = ''
@@ -112,14 +110,14 @@ stdenv.mkDerivation rec {
     readline
     zlib
   ]
-  ++ optional (stdenv.isDarwin && withKeePassTouchID) darwin.apple_sdk.frameworks.LocalAuthentication
-  ++ optional stdenv.isDarwin qtmacextras
-  ++ optional stdenv.isLinux libusb1
-  ++ optional withKeePassX11 qtx11extras;
+  ++ lib.optional (stdenv.isDarwin && withKeePassTouchID) darwin.apple_sdk.frameworks.LocalAuthentication
+  ++ lib.optional stdenv.isDarwin qtmacextras
+  ++ lib.optional stdenv.isLinux libusb1
+  ++ lib.optional withKeePassX11 qtx11extras;
 
   passthru.tests = nixosTests.keepassxc;
 
-  meta = {
+  meta = with lib; {
     description = "Offline password manager with many features.";
     longDescription = ''
       A community fork of KeePassX, which is itself a port of KeePass Password Safe.

--- a/pkgs/applications/misc/rm-improved/default.nix
+++ b/pkgs/applications/misc/rm-improved/default.nix
@@ -1,7 +1,5 @@
 { fetchFromGitHub, rustPlatform, lib }:
 
-with lib;
-
 rustPlatform.buildRustPackage rec {
   pname = "rm-improved";
   version = "0.13.0";
@@ -15,7 +13,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0d065xia4mwdhxkiqfg7pic6scfzipzmsvvx7l6l97w62lzpiqx3";
   };
 
-  meta = {
+  meta = with lib; {
     description = "Replacement for rm with focus on safety, ergonomics and performance";
     homepage = "https://github.com/nivekuil/rip";
     maintainers = with maintainers; [ nils-degroot ];

--- a/pkgs/applications/misc/slstatus/default.nix
+++ b/pkgs/applications/misc/slstatus/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchgit, pkg-config, writeText, libX11, conf ? null, patches ? [] }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "slstatus";
   version = "unstable-2019-02-16";
@@ -12,8 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0kayyhpmppybhwndxgabw48wsk9v8x9xdb05xrly9szkw3jbvgw4";
   };
 
-  configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
-  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
+  configFile = lib.optionalString (conf!=null) (writeText "config.def.h" conf);
+  preBuild = lib.optionalString (conf!=null) "cp ${configFile} config.def.h";
 
   inherit patches;
 
@@ -24,7 +22,7 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "PREFIX=$(out)" ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://tools.suckless.org/slstatus/";
     description = "status monitor for window managers that use WM_NAME like dwm";
     license = licenses.isc;

--- a/pkgs/applications/misc/veracrypt/default.nix
+++ b/pkgs/applications/misc/veracrypt/default.nix
@@ -14,14 +14,12 @@
 , btrfs-progs
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "veracrypt";
   version = "1.25.9";
 
   src = fetchurl {
-    url = "https://launchpad.net/${pname}/trunk/${toLower version}/+download/VeraCrypt_${version}_Source.tar.bz2";
+    url = "https://launchpad.net/${pname}/trunk/${lib.toLower version}/+download/VeraCrypt_${version}_Source.tar.bz2";
     sha256 = "sha256-drbhgYS8IaQdKUn/Y9ch1JBUpxbO/zpL13tcNRC3lK8=";
   };
 
@@ -54,7 +52,7 @@ stdenv.mkDerivation rec {
       --replace "Icon=veracrypt" "Icon=veracrypt.xpm"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Free Open-Source filesystem on-the-fly encryption";
     homepage = "https://www.veracrypt.fr/";
     license = with licenses; [ asl20 /* and */ unfree /* TrueCrypt License version 3.0 */ ];

--- a/pkgs/applications/misc/xsuspender/default.nix
+++ b/pkgs/applications/misc/xsuspender/default.nix
@@ -1,8 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, makeWrapper, pkg-config
 , glib, libwnck, procps }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "xsuspender";
   version = "1.3";
@@ -21,10 +19,10 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/xsuspender \
-      --prefix PATH : "${makeBinPath [ procps ]}"
+      --prefix PATH : "${lib.makeBinPath [ procps ]}"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Auto-suspend inactive X11 applications";
     homepage = "https://kernc.github.io/xsuspender/";
     license = licenses.wtfpl;

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -6,8 +6,6 @@
 , gtk-mac-integration
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "zathura";
   version = "0.5.2";
@@ -28,7 +26,7 @@ stdenv.mkDerivation rec {
     "-Dsynctex=enabled"
     # Make sure tests are enabled for doCheck
     "-Dtests=enabled"
-  ] ++ optional (!stdenv.isLinux) "-Dseccomp=disabled";
+  ] ++ lib.optional (!stdenv.isLinux) "-Dseccomp=disabled";
 
   nativeBuildInputs = [
     meson ninja pkg-config desktop-file-utils python3.pkgs.sphinx
@@ -38,12 +36,12 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk girara libintl sqlite glib file librsvg
     texlive.bin.core
-  ] ++ optional stdenv.isLinux libseccomp
-    ++ optional stdenv.isDarwin gtk-mac-integration;
+  ] ++ lib.optional stdenv.isLinux libseccomp
+    ++ lib.optional stdenv.isDarwin gtk-mac-integration;
 
   doCheck = !stdenv.isDarwin;
 
-  meta = {
+  meta = with lib; {
     homepage = "https://git.pwmt.org/pwmt/zathura";
     description = "A core component for zathura PDF viewer";
     license = licenses.zlib;

--- a/pkgs/applications/networking/appgate-sdp/default.nix
+++ b/pkgs/applications/networking/appgate-sdp/default.nix
@@ -38,7 +38,7 @@
 , xorg
 , zlib
 }:
-with lib;
+
 let
   deps = [
     alsa-lib
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
   version = "6.0.3";
 
   src = fetchurl {
-    url = "https://bin.appgate-sdp.com/${versions.majorMinor version}/client/appgate-sdp_${version}_amd64.deb";
+    url = "https://bin.appgate-sdp.com/${lib.versions.majorMinor version}/client/appgate-sdp_${version}_amd64.deb";
     sha256 = "sha256-UDyVPoQM78CKVWXgr08An77QTiFVmRNHwQPGaj1jAIM=";
   };
 
@@ -134,16 +134,16 @@ stdenv.mkDerivation rec {
         --replace "/etc/appgate.conf" "$out/etc/appgate.conf"
 
     wrapProgram $out/opt/appgate/service/createdump \
-        --set LD_LIBRARY_PATH "${makeLibraryPath [ stdenv.cc.cc ]}"
+        --set LD_LIBRARY_PATH "${lib.makeLibraryPath [ stdenv.cc.cc ]}"
 
     wrapProgram $out/opt/appgate/appgate-driver \
-        --prefix PATH : ${makeBinPath [ iproute2 networkmanager dnsmasq ]} \
+        --prefix PATH : ${lib.makeBinPath [ iproute2 networkmanager dnsmasq ]} \
         --set LD_LIBRARY_PATH $out/opt/appgate/service
 
     # make xdg-open overrideable at runtime
     makeWrapper $out/opt/appgate/Appgate $out/bin/appgate \
-        --suffix PATH : ${makeBinPath [ xdg-utils ]} \
-        --set LD_LIBRARY_PATH $out/opt/appgate:${makeLibraryPath deps}
+        --suffix PATH : ${lib.makeBinPath [ xdg-utils ]} \
+        --set LD_LIBRARY_PATH $out/opt/appgate:${lib.makeLibraryPath deps}
 
     wrapProgram $out/opt/appgate/linux/set_dns --set PYTHONPATH $PYTHONPATH
   '';

--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -3,8 +3,6 @@
 , enableWideVine, ungoogled
 }:
 
-with lib;
-
 mkChromiumDerivation (base: rec {
   name = "chromium-browser";
   packageName = "chromium";
@@ -76,7 +74,7 @@ mkChromiumDerivation (base: rec {
 
   meta = {
     description = "An open source web browser from Google"
-      + optionalString ungoogled ", with dependencies on Google web services removed";
+      + lib.optionalString ungoogled ", with dependencies on Google web services removed";
     longDescription = ''
       Chromium is an open source web browser from Google that aims to build a
       safer, faster, and more stable way for all Internet users to experience
@@ -86,11 +84,11 @@ mkChromiumDerivation (base: rec {
     homepage = if ungoogled
       then "https://github.com/Eloston/ungoogled-chromium"
       else "https://www.chromium.org/";
-    maintainers = with maintainers; if ungoogled
+    maintainers = with lib.maintainers; if ungoogled
       then [ squalus primeos michaeladler ]
       else [ primeos thefloweringash ];
-    license = if enableWideVine then licenses.unfree else licenses.bsd3;
-    platforms = platforms.linux;
+    license = if enableWideVine then lib.licenses.unfree else lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
     mainProgram = "chromium";
     hydraPlatforms = if (channel == "stable" || channel == "ungoogled-chromium")
       then ["aarch64-linux" "x86_64-linux"]

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -51,8 +51,6 @@
 
 buildFun:
 
-with lib;
-
 let
   python3WithPackages = python3.withPackages(ps: with ps; [
     ply jinja2 setuptools
@@ -75,16 +73,16 @@ let
     let
       # Serialize Nix types into GN types according to this document:
       # https://source.chromium.org/gn/gn/+/master:docs/language.md
-      mkGnString = value: "\"${escape ["\"" "$" "\\"] value}\"";
+      mkGnString = value: "\"${lib.escape ["\"" "$" "\\"] value}\"";
       sanitize = value:
         if value == true then "true"
         else if value == false then "false"
-        else if isList value then "[${concatMapStringsSep ", " sanitize value}]"
-        else if isInt value then toString value
-        else if isString value then mkGnString value
+        else if lib.isList value then "[${lib.concatMapStringsSep ", " sanitize value}]"
+        else if lib.isInt value then toString value
+        else if lib.isString value then mkGnString value
         else throw "Unsupported type for GN value `${value}'.";
       toFlag = key: value: "${key}=${sanitize value}";
-    in attrs: concatStringsSep " " (attrValues (mapAttrs toFlag attrs));
+    in attrs: lib.concatStringsSep " " (lib.attrValues (lib.mapAttrs toFlag attrs));
 
   # https://source.chromium.org/chromium/chromium/src/+/master:build/linux/unbundle/replace_gn_files.py
   gnSystemLibraries = [
@@ -151,9 +149,9 @@ let
       libdrm wayland mesa.drivers libxkbcommon
       curl
       libepoxy
-    ] ++ optional systemdSupport systemd
-      ++ optionals cupsSupport [ libgcrypt cups ]
-      ++ optional pulseSupport libpulseaudio;
+    ] ++ lib.optional systemdSupport systemd
+      ++ lib.optionals cupsSupport [ libgcrypt cups ]
+      ++ lib.optional pulseSupport libpulseaudio;
 
     patches = [
       # Optional patch to use SOURCE_DATE_EPOCH in compute_build_timestamp.py (should be upstreamed):
@@ -237,10 +235,10 @@ let
       # Allow building against system libraries in official builds
       sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' tools/generate_shim_headers/generate_shim_headers.py
 
-    '' + optionalString stdenv.isAarch64 ''
+    '' + lib.optionalString stdenv.isAarch64 ''
       substituteInPlace build/toolchain/linux/BUILD.gn \
         --replace 'toolprefix = "aarch64-linux-gnu-"' 'toolprefix = ""'
-    '' + optionalString ungoogled ''
+    '' + lib.optionalString ungoogled ''
       ${ungoogler}/utils/prune_binaries.py . ${ungoogler}/pruning.list || echo "some errors"
       ${ungoogler}/utils/patches.py . ${ungoogler}/patches
       ${ungoogler}/utils/domain_substitution.py apply -r ${ungoogler}/domain_regex.list -f ${ungoogler}/domain_substitution.list -c ./ungoogled-domsubcache.tar.gz .
@@ -300,15 +298,15 @@ let
       # as well to avoid incompatibilities (if this continues to be a problem
       # from time to time):
       use_system_libwayland = true;
-    } // optionalAttrs proprietaryCodecs {
+    } // lib.optionalAttrs proprietaryCodecs {
       # enable support for the H.264 codec
       proprietary_codecs = true;
       enable_hangout_services_extension = true;
       ffmpeg_branding = "Chrome";
-    } // optionalAttrs pulseSupport {
+    } // lib.optionalAttrs pulseSupport {
       use_pulseaudio = true;
       link_pulseaudio = true;
-    } // optionalAttrs ungoogled (importTOML ./ungoogled-flags.toml)
+    } // lib.optionalAttrs ungoogled (lib.importTOML ./ungoogled-flags.toml)
     // (extraAttrs.gnFlags or {}));
 
     configurePhase = ''
@@ -317,7 +315,7 @@ let
       # This is to ensure expansion of $out.
       libExecPath="${libExecPath}"
       ${python3}/bin/python3 build/linux/unbundle/replace_gn_files.py --system-libraries ${toString gnSystemLibraries}
-      ${gnChromium}/bin/gn gen --args=${escapeShellArg gnFlags} out/Release | tee gn-gen-outputs.txt
+      ${gnChromium}/bin/gn gen --args=${lib.escapeShellArg gnFlags} out/Release | tee gn-gen-outputs.txt
 
       # Fail if `gn gen` contains a WARNING.
       grep -o WARNING gn-gen-outputs.txt && echo "Found gn WARNING, exiting nix build" && exit 1
@@ -342,7 +340,7 @@ let
       '';
       targets = extraAttrs.buildTargets or [];
       commands = map buildCommand targets;
-    in concatStringsSep "\n" commands;
+    in lib.concatStringsSep "\n" commands;
 
     postFixup = ''
       # Make sure that libGLESv2 is found by dlopen (if using EGL).

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -47,8 +47,6 @@
 , addOpenGLRunpath
 }:
 
-with lib;
-
 let
   opusWithCustomModes = libopus.override {
     withCustomModes = true;
@@ -68,8 +66,8 @@ let
     bzip2 libcap at-spi2-atk at-spi2-core
     libkrb5 libdrm libglvnd mesa coreutils
     libxkbcommon pipewire wayland
-  ] ++ optional pulseSupport libpulseaudio
-    ++ optional libvaSupport libva
+  ] ++ lib.optional pulseSupport libpulseaudio
+    ++ lib.optional libvaSupport libva
     ++ [ gtk3 ];
 
   suffix = if channel != "stable" then "-" + channel else "";
@@ -99,8 +97,8 @@ in stdenv.mkDerivation {
     tar xf data.tar.xz
   '';
 
-  rpath = makeLibraryPath deps + ":" + makeSearchPathOutput "lib" "lib64" deps;
-  binpath = makeBinPath deps;
+  rpath = lib.makeLibraryPath deps + ":" + lib.makeSearchPathOutput "lib" "lib64" deps;
+  binpath = lib.makeBinPath deps;
 
   installPhase = ''
     runHook preInstall
@@ -149,7 +147,7 @@ in stdenv.mkDerivation {
       --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:${addOpenGLRunpath.driverLink}/share" \
       --set CHROME_WRAPPER  "google-chrome-$dist" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
-      --add-flags ${escapeShellArg commandLineArgs}
+      --add-flags ${lib.escapeShellArg commandLineArgs}
 
     for elf in $out/share/google/$appname/{chrome,chrome-sandbox,${crashpadHandlerBinary},nacl_helper}; do
       patchelf --set-rpath $rpath $elf
@@ -159,7 +157,7 @@ in stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A freeware web browser developed by Google";
     homepage = "https://www.google.com/chrome/browser/";
     license = licenses.unfree;

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -53,10 +53,8 @@
 , extraPrefs ? ""
 }:
 
-with lib;
-
 let
-  libPath = makeLibraryPath libPkgs;
+  libPath = lib.makeLibraryPath libPkgs;
 
   libPkgs = [
     atk
@@ -78,13 +76,13 @@ let
     stdenv.cc.libc
     zlib
   ]
-  ++ optionals pulseaudioSupport [ libpulseaudio ]
-  ++ optionals mediaSupport [
+  ++ lib.optionals pulseaudioSupport [ libpulseaudio ]
+  ++ lib.optionals mediaSupport [
     ffmpeg
   ];
 
   # Library search path for the fte transport
-  fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
+  fteLibPath = lib.makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
   version = "11.5.8";
@@ -156,7 +154,7 @@ stdenv.mkDerivation rec {
     libPath=${libPath}:$TBB_IN_STORE:$TBB_IN_STORE/TorBrowser/Tor
 
     # apulse uses a non-standard library path.  For now special-case it.
-    ${optionalString (audioSupport && !pulseaudioSupport) ''
+    ${lib.optionalString (audioSupport && !pulseaudioSupport) ''
       libPath=${apulse}/lib/apulse:$libPath
     ''}
 
@@ -224,7 +222,7 @@ stdenv.mkDerivation rec {
       clearPref("security.sandbox.content.write_path_whitelist");
     ''}
 
-    ${optionalString (extraPrefs != "") ''
+    ${lib.optionalString (extraPrefs != "") ''
       ${extraPrefs}
     ''}
     EOF
@@ -251,14 +249,14 @@ stdenv.mkDerivation rec {
     GeoIPv6File $TBB_IN_STORE/TorBrowser/Data/Tor/geoip6
     EOF
 
-    WRAPPER_LD_PRELOAD=${optionalString useHardenedMalloc
+    WRAPPER_LD_PRELOAD=${lib.optionalString useHardenedMalloc
       "${graphene-hardened-malloc}/lib/libhardened_malloc.so"}
 
-    WRAPPER_XDG_DATA_DIRS=${concatMapStringsSep ":" (x: "${x}/share") [
+    WRAPPER_XDG_DATA_DIRS=${lib.concatMapStringsSep ":" (x: "${x}/share") [
       gnome.adwaita-icon-theme
       shared-mime-info
     ]}
-    WRAPPER_XDG_DATA_DIRS+=":"${concatMapStringsSep ":" (x: "${x}/share/gsettings-schemas/${x.name}") [
+    WRAPPER_XDG_DATA_DIRS+=":"${lib.concatMapStringsSep ":" (x: "${x}/share/gsettings-schemas/${x.name}") [
       glib
       gsettings-desktop-schemas
       gtk3
@@ -270,7 +268,7 @@ stdenv.mkDerivation rec {
     #! ${runtimeShell}
     set -o errexit -o nounset
 
-    PATH=${makeBinPath [ coreutils ]}
+    PATH=${lib.makeBinPath [ coreutils ]}
     export LC_ALL=C
     export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
 
@@ -317,7 +315,7 @@ stdenv.mkDerivation rec {
     : "\''${XDG_RUNTIME_DIR:=/run/user/\$(id -u)}"
     : "\''${XDG_CONFIG_HOME:=\$REAL_HOME/.config}"
 
-    ${optionalString pulseaudioSupport ''
+    ${lib.optionalString pulseaudioSupport ''
       # Figure out some envvars for pulseaudio
       : "\''${PULSE_SERVER:=\$XDG_RUNTIME_DIR/pulse/native}"
       : "\''${PULSE_COOKIE:=\$XDG_CONFIG_HOME/pulse/cookie}"

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -63,26 +63,28 @@ let
 
       passthru = { inherit tests; };
 
-      meta = recursiveUpdate {
-        homepage = "https://hadoop.apache.org/";
-        description = "Framework for distributed processing of large data sets across clusters of computers";
-        license = licenses.asl20;
-        sourceProvenance = with sourceTypes; [ binaryBytecode ];
+      meta = recursiveUpdate
+        {
+          homepage = "https://hadoop.apache.org/";
+          description = "Framework for distributed processing of large data sets across clusters of computers";
+          license = licenses.asl20;
+          sourceProvenance = with sourceTypes; [ binaryBytecode ];
 
-        longDescription = ''
-          The Apache Hadoop software library is a framework that allows for
-          the distributed processing of large data sets across clusters of
-          computers using a simple programming model. It is designed to
-          scale up from single servers to thousands of machines, each
-          offering local computation and storage. Rather than rely on
-          hardware to deliver high-avaiability, the library itself is
-          designed to detect and handle failures at the application layer,
-          so delivering a highly-availabile service on top of a cluster of
-          computers, each of which may be prone to failures.
-        '';
-        maintainers = with maintainers; [ illustris ];
-        platforms = attrNames platformAttrs;
-      } (attrByPath [ stdenv.system "meta" ] {} platformAttrs);
+          longDescription = ''
+            The Apache Hadoop software library is a framework that allows for
+            the distributed processing of large data sets across clusters of
+            computers using a simple programming model. It is designed to
+            scale up from single servers to thousands of machines, each
+            offering local computation and storage. Rather than rely on
+            hardware to deliver high-avaiability, the library itself is
+            designed to detect and handle failures at the application layer,
+            so delivering a highly-availabile service on top of a cluster of
+            computers, each of which may be prone to failures.
+          '';
+          maintainers = with maintainers; [ illustris ];
+          platforms = attrNames platformAttrs;
+        }
+        (attrByPath [ stdenv.system "meta" ] { } platformAttrs);
     };
 in
 {
@@ -91,17 +93,17 @@ in
   hadoop_3_3 = common rec {
     pname = "hadoop";
     platformAttrs = rec {
-        x86_64-linux = {
-          version = "3.3.4";
-          hash = "sha256-akg9GgsSNJDr2N8/cbZOs58zP3i5XwkK61jkM8vCQW0=";
-        };
-        x86_64-darwin = x86_64-linux;
-        aarch64-linux = {
-          version = "3.3.1";
-          hash = "sha256-v1Om2pk0wsgKBghRD2wgTSHJoKd3jkm1wPKAeDcKlgI=";
-          meta.knownVulnerabilities = [ "CVE-2021-37404" "CVE-2021-33036" ];
-        };
-        aarch64-darwin = aarch64-linux;
+      x86_64-linux = {
+        version = "3.3.4";
+        hash = "sha256-akg9GgsSNJDr2N8/cbZOs58zP3i5XwkK61jkM8vCQW0=";
+      };
+      x86_64-darwin = x86_64-linux;
+      aarch64-linux = {
+        version = "3.3.1";
+        hash = "sha256-v1Om2pk0wsgKBghRD2wgTSHJoKd3jkm1wPKAeDcKlgI=";
+        meta.knownVulnerabilities = [ "CVE-2021-37404" "CVE-2021-33036" ];
+      };
+      aarch64-darwin = aarch64-linux;
     };
     untarDir = "${pname}-${platformAttrs.${stdenv.system}.version}";
     jdk = jdk11_headless;

--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -25,8 +25,6 @@
 , pkgsBuildBuild
 }:
 
-with lib;
-
 # k3s is a kinda weird derivation. One of the main points of k3s is the
 # simplicity of it being one binary that can perform several tasks.
 # However, when you have a good package manager (like nix), that doesn't
@@ -73,7 +71,7 @@ let
   # run `grep github.com/kubernetes-sigs/cri-tools go.mod | head -n1 | awk '{print $4}'` in the k3s repo at the tag
   criCtlVersion = "1.25.0-k3s1";
 
-  baseMeta = {
+  baseMeta = with lib; {
     description = "A lightweight Kubernetes distribution";
     license = licenses.asl20;
     homepage = "https://k3s.io";

--- a/pkgs/applications/networking/cluster/spark/default.nix
+++ b/pkgs/applications/networking/cluster/spark/default.nix
@@ -12,8 +12,6 @@
 , R
 }:
 
-with lib;
-
 let
   spark = { pname, version, sha256, extraMeta ? {} }:
     stdenv.mkDerivation rec {
@@ -26,7 +24,7 @@ let
       nativeBuildInputs = [ makeWrapper ];
       buildInputs = [ jdk python3Packages.python ]
         ++ extraPythonPackages
-        ++ optional RSupport R;
+        ++ lib.optional RSupport R;
 
       untarDir = "${pname}-${version}";
       installPhase = ''
@@ -38,12 +36,12 @@ let
         cat > $out/lib/${untarDir}/conf/spark-env.sh <<- EOF
         export JAVA_HOME="${jdk}"
         export SPARK_HOME="$out/lib/${untarDir}"
-      '' + optionalString hadoopSupport ''
+      '' + lib.optionalString hadoopSupport ''
         export SPARK_DIST_CLASSPATH=$(${hadoop}/bin/hadoop classpath)
       '' + ''
         export PYSPARK_PYTHON="${python3Packages.python}/bin/${python3Packages.python.executable}"
         export PYTHONPATH="\$PYTHONPATH:$PYTHONPATH"
-        ${optionalString RSupport ''
+        ${lib.optionalString RSupport ''
           export SPARKR_R_SHELL="${R}/bin/R"
           export PATH="\$PATH:${R}/bin"''}
         EOF
@@ -64,10 +62,10 @@ let
       meta = {
         description = "Apache Spark is a fast and general engine for large-scale data processing";
         homepage = "https://spark.apache.org/";
-        sourceProvenance = with sourceTypes; [ binaryBytecode ];
+        sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
         license = lib.licenses.asl20;
         platforms = lib.platforms.all;
-        maintainers = with maintainers; [ thoughtpolice offline kamilchm illustris ];
+        maintainers = with lib.maintainers; [ thoughtpolice offline kamilchm illustris ];
       } // extraMeta;
     };
 in

--- a/pkgs/applications/networking/droopy/default.nix
+++ b/pkgs/applications/networking/droopy/default.nix
@@ -1,7 +1,5 @@
 { stdenv, lib, fetchFromGitHub, wrapPython, fetchpatch }:
 
-with lib;
-
 stdenv.mkDerivation {
   pname = "droopy";
   version = "20160830";
@@ -32,7 +30,7 @@ stdenv.mkDerivation {
     wrapPythonPrograms
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Mini Web server that let others upload files to your computer";
     homepage = "http://stackp.online.fr/droopy";
     license = licenses.bsd3;

--- a/pkgs/applications/networking/instant-messengers/bitlbee-discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-discord/default.nix
@@ -1,6 +1,5 @@
 { lib, fetchFromGitHub, stdenv, bitlbee, autoreconfHook, pkg-config, glib }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "bitlbee-discord";
   version = "0.4.3";
@@ -21,7 +20,7 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Bitlbee plugin for Discord";
 
     homepage = "https://github.com/sm00th/bitlbee-discord";

--- a/pkgs/applications/networking/instant-messengers/bitlbee-mastodon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-mastodon/default.nix
@@ -1,6 +1,5 @@
 { lib, fetchgit, stdenv, bitlbee, autoreconfHook, pkg-config, glib }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "bitlbee-mastodon";
   version = "1.4.5";
@@ -19,7 +18,7 @@ stdenv.mkDerivation rec {
     export BITLBEE_DATADIR=$out/share/bitlbee
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Bitlbee plugin for Mastodon";
     homepage = "https://alexschroeder.ch/cgit/bitlbee-mastodon/about";
     license = licenses.gpl2Plus;

--- a/pkgs/applications/networking/instant-messengers/bitlbee-steam/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-steam/default.nix
@@ -1,6 +1,5 @@
 { lib, fetchFromGitHub, stdenv, bitlbee, autoconf, automake, libtool, pkg-config, libgcrypt }:
 
-with lib;
 stdenv.mkDerivation rec {
   version = "1.4.2";
   pname = "bitlbee-steam";
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Steam protocol plugin for BitlBee";
 
     homepage = "https://github.com/jgeboski/bitlbee-steam";

--- a/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
@@ -3,7 +3,6 @@
 , enablePam ? false, pam ? null
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "bitlbee";
   version = "3.6";
@@ -13,11 +12,11 @@ stdenv.mkDerivation rec {
     sha256 = "0zhhcbcr59sx9h4maf8zamzv2waya7sbsl7w74gbyilvy93dw5cz";
   };
 
-  nativeBuildInputs = [ pkg-config ] ++ optional doCheck check;
+  nativeBuildInputs = [ pkg-config ] ++ lib.optional doCheck check;
 
   buildInputs = [ gnutls libotr python3 ]
-    ++ optional enableLibPurple pidgin
-    ++ optional enablePam pam;
+    ++ lib.optional enableLibPurple pidgin
+    ++ lib.optional enablePam pam;
 
   propagatedBuildInputs = [ glib ];
 
@@ -25,8 +24,8 @@ stdenv.mkDerivation rec {
     "--otr=1"
     "--ssl=gnutls"
     "--pidfile=/var/lib/bitlbee/bitlbee.pid"
-  ] ++ optional enableLibPurple "--purple=1"
-    ++ optional enablePam "--pam=1";
+  ] ++ lib.optional enableLibPurple "--purple=1"
+    ++ lib.optional enablePam "--pam=1";
 
   patches = [
     # This should be dropped once the issue is fixed upstream.
@@ -46,7 +45,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     description = "IRC instant messaging gateway";
 
     longDescription = ''

--- a/pkgs/applications/networking/instant-messengers/bitlbee/plugins.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/plugins.nix
@@ -1,7 +1,5 @@
 { lib, runCommandLocal, bitlbee }:
 
-with lib;
-
 plugins: runCommandLocal "bitlbee-plugins" {
   inherit plugins;
   buildInputs = [ bitlbee plugins ];

--- a/pkgs/applications/networking/instant-messengers/ratox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ratox/default.nix
@@ -1,10 +1,8 @@
 { lib, stdenv, fetchgit, libtoxcore
 , conf ? null }:
 
-with lib;
-
 let
-  configFile = optionalString (conf!=null) (builtins.toFile "config.h" conf);
+  configFile = lib.optionalString (conf!=null) (builtins.toFile "config.h" conf);
 
 in stdenv.mkDerivation {
   pname = "ratox";
@@ -22,12 +20,12 @@ in stdenv.mkDerivation {
     substituteInPlace config.mk \
       --replace '-lsodium -lopus -lvpx ' ""
 
-    ${optionalString (conf!=null) "cp ${configFile} config.def.h"}
+    ${lib.optionalString (conf!=null) "cp ${configFile} config.def.h"}
   '';
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  meta = {
+  meta = with lib; {
     description = "FIFO based tox client";
     homepage = "http://ratox.2f30.org/";
     license = licenses.isc;

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -65,8 +65,6 @@
 , MetalKit
 }:
 
-with lib;
-
 let
   tg_owt = callPackage ./tg_owt.nix {
     abseil-cpp = (abseil-cpp.override {
@@ -75,7 +73,7 @@ let
       cxxStandard = "20";
     }).overrideAttrs (_: {
       # https://github.com/NixOS/nixpkgs/issues/130963
-      NIX_LDFLAGS = optionalString stdenv.isDarwin "-lc++abi";
+      NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lc++abi";
     });
 
     # tg_owt should use the same compiler
@@ -104,14 +102,14 @@ stdenv.mkDerivation rec {
     ./kotato-10.12-sdk.patch
   ];
 
-  postPatch = optionalString stdenv.isLinux ''
+  postPatch = lib.optionalString stdenv.isLinux ''
     substituteInPlace Telegram/ThirdParty/libtgvoip/os/linux/AudioInputALSA.cpp \
       --replace '"libasound.so.2"' '"${alsa-lib}/lib/libasound.so.2"'
     substituteInPlace Telegram/ThirdParty/libtgvoip/os/linux/AudioOutputALSA.cpp \
       --replace '"libasound.so.2"' '"${alsa-lib}/lib/libasound.so.2"'
     substituteInPlace Telegram/ThirdParty/libtgvoip/os/linux/AudioPulse.cpp \
       --replace '"libpulse.so.0"' '"${libpulseaudio}/lib/libpulse.so.0"'
-  '' + optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     substituteInPlace Telegram/CMakeLists.txt \
       --replace 'COMMAND iconutil' 'COMMAND png2icns' \
       --replace '--convert icns' "" \
@@ -126,7 +124,7 @@ stdenv.mkDerivation rec {
     python3
     wrapQtAppsHook
     removeReferencesTo
-  ] ++ optionals stdenv.isLinux [
+  ] ++ lib.optionals stdenv.isLinux [
     # to build bundled libdispatch
     clang
     extra-cmake-modules
@@ -147,7 +145,7 @@ stdenv.mkDerivation rec {
     rnnoise
     tg_owt
     microsoft_gsl
-  ] ++ optionals stdenv.isLinux [
+  ] ++ lib.optionals stdenv.isLinux [
     kwayland
     alsa-lib
     libpulseaudio
@@ -155,7 +153,7 @@ stdenv.mkDerivation rec {
     glibmm
     jemalloc
     wayland
-  ] ++ optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     Cocoa
     CoreFoundation
     CoreServices
@@ -190,7 +188,7 @@ stdenv.mkDerivation rec {
   ];
 
   # https://github.com/NixOS/nixpkgs/issues/130963
-  NIX_LDFLAGS = optionalString stdenv.isDarwin "-lc++abi";
+  NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lc++abi";
 
   enableParallelBuilding = true;
 
@@ -199,7 +197,7 @@ stdenv.mkDerivation rec {
     "-DDESKTOP_APP_QT6=OFF"
   ];
 
-  installPhase = optionalString stdenv.isDarwin ''
+  installPhase = lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/Applications
     cp -r Kotatogram.app $out/Applications
     ln -s $out/Applications/Kotatogram.app/Contents/MacOS $out/bin
@@ -216,7 +214,7 @@ stdenv.mkDerivation rec {
     inherit tg_owt;
   };
 
-  meta = {
+  meta = with lib; {
     description = "Kotatogram – experimental Telegram Desktop fork";
     longDescription = ''
       Unofficial desktop client for the Telegram messenger, based on Telegram Desktop.

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/with-webkit.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/with-webkit.nix
@@ -1,7 +1,5 @@
 { stdenv, lib, kotatogram-desktop, glib-networking, webkitgtk, makeWrapper }:
 
-with lib;
-
 stdenv.mkDerivation {
   pname = "${kotatogram-desktop.pname}-with-webkit";
   version = kotatogram-desktop.version;
@@ -15,9 +13,9 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     makeWrapper ${kotatogram-desktop}/bin/kotatogram-desktop $out/bin/kotatogram-desktop \
       --prefix GIO_EXTRA_MODULES : ${glib-networking}/lib/gio/modules \
-      --prefix LD_LIBRARY_PATH : ${makeLibraryPath [ webkitgtk ]}
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ webkitgtk ]}
   '';
   meta = kotatogram-desktop.meta // {
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/wavebox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wavebox/default.nix
@@ -3,8 +3,6 @@
 , xorg
 }:
 
-with lib;
-
 let
   bits = "x86_64";
 
@@ -19,7 +17,7 @@ let
     categories = [ "Network" ];
   };
 
-  tarball = "Wavebox_${replaceStrings ["."] ["_"] (toString version)}_linux_${bits}.tar.gz";
+  tarball = "Wavebox_${lib.replaceStrings ["."] ["_"] (toString version)}_linux_${bits}.tar.gz";
 
 in stdenv.mkDerivation {
   pname = "wavebox";
@@ -40,7 +38,7 @@ in stdenv.mkDerivation {
     alsa-lib gtk3 nss
   ];
 
-  runtimeDependencies = [ (getLib udev) libnotify ];
+  runtimeDependencies = [ (lib.getLib udev) libnotify ];
 
   installPhase = ''
     mkdir -p $out/bin $out/opt/wavebox

--- a/pkgs/applications/networking/irc/convos/default.nix
+++ b/pkgs/applications/networking/irc/convos/default.nix
@@ -2,8 +2,6 @@
 , nixosTests
 }:
 
-with lib;
-
 perlPackages.buildPerlPackage rec {
   pname = "convos";
   version = "7.02";
@@ -16,7 +14,7 @@ perlPackages.buildPerlPackage rec {
   };
 
   nativeBuildInputs = [ makeWrapper ]
-    ++ optionals stdenv.isDarwin [ shortenPerlShebang ];
+    ++ lib.optionals stdenv.isDarwin [ shortenPerlShebang ];
 
   buildInputs = with perlPackages; [
     CryptPassphrase CryptPassphraseArgon2 CryptPassphraseBcrypt
@@ -79,7 +77,7 @@ perlPackages.buildPerlPackage rec {
     ln -s $AUTO_SHARE_PATH/public/asset $out/asset
     cp -vR templates $out/templates
     cp cpanfile $out/cpanfile
-  '' + optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     shortenPerlShebang $out/bin/convos
   '' + ''
     wrapProgram $out/bin/convos --set MOJO_HOME $out
@@ -91,6 +89,6 @@ perlPackages.buildPerlPackage rec {
     homepage = "https://convos.chat";
     description = "Convos is the simplest way to use IRC in your browser";
     license = lib.licenses.artistic2;
-    maintainers = with maintainers; [ sgo ];
+    maintainers = with lib.maintainers; [ sgo ];
   };
 }

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -52,8 +52,6 @@
 , enablePluginVcalendar ? true, libical
 }:
 
-with lib;
-
 let
   pythonPkgs = with python3.pkgs; [ python3 wrapPython pygobject3 ];
 
@@ -130,7 +128,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs =
     [ curl gsettings-desktop-schemas glib-networking gtk3 ]
-    ++ concatMap (f: optionals f.enabled f.deps) (filter (f: f ? deps) features)
+    ++ lib.concatMap (f: lib.optionals f.enabled f.deps) (lib.filter (f: f ? deps) features)
   ;
 
   configureFlags =
@@ -141,7 +139,7 @@ in stdenv.mkDerivation rec {
 
       "--disable-gdata-plugin" # Complains about missing libgdata, even when provided
     ] ++
-    (map (feature: map (flag: strings.enableFeature feature.enabled flag) feature.flags) features);
+    (map (feature: map (flag: lib.strings.enableFeature feature.enabled flag) feature.flags) features);
 
   enableParallelBuilding = true;
 
@@ -155,7 +153,7 @@ in stdenv.mkDerivation rec {
     cp claws-mail.desktop $out/share/applications
   '';
 
-  meta = {
+  meta = with lib; {
     description = "The user-friendly, lightweight, and fast email client";
     homepage = "https://www.claws-mail.org/";
     license = licenses.gpl3Plus;

--- a/pkgs/applications/networking/mailreaders/sylpheed/default.nix
+++ b/pkgs/applications/networking/mailreaders/sylpheed/default.nix
@@ -4,8 +4,6 @@
 assert gpgSupport -> gpgme != null;
 assert sslSupport -> openssl != null;
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "sylpheed";
   version = "3.7.0";
@@ -33,17 +31,17 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ gtk2 ]
-    ++ optionals gpgSupport [ gpgme ]
-    ++ optionals sslSupport [ openssl ]
-    ++ optionals stdenv.isDarwin [ Foundation ];
+    ++ lib.optionals gpgSupport [ gpgme ]
+    ++ lib.optionals sslSupport [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [ Foundation ];
 
-  configureFlags = optional gpgSupport "--enable-gpgme"
-    ++ optional sslSupport "--enable-ssl";
+  configureFlags = lib.optional gpgSupport "--enable-gpgme"
+    ++ lib.optional sslSupport "--enable-ssl";
 
   # Undefined symbols for architecture arm64: "_OBJC_CLASS_$_NSAutoreleasePool"
   NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-framework Foundation";
 
-  meta = {
+  meta = with lib; {
     homepage = "https://sylpheed.sraoss.jp/en/";
     description = "Lightweight and user-friendly e-mail client";
     maintainers = with maintainers; [ eelco ];

--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -9,7 +9,6 @@
 assert guiSupport -> (dbus != null);
 assert trackerSearch -> (python3 != null);
 
-with lib;
 mkDerivation rec {
   pname = "qbittorrent";
   version = "4.4.5";
@@ -27,8 +26,8 @@ mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ boost libtorrent-rasterbar qtbase qttools qtsvg ]
-    ++ optional guiSupport dbus # D(esktop)-Bus depends on GUI support
-    ++ optional trackerSearch python3;
+    ++ lib.optional guiSupport dbus # D(esktop)-Bus depends on GUI support
+    ++ lib.optional trackerSearch python3;
 
   # Otherwise qm_gen.pri assumes lrelease-qt5, which does not exist.
   QMAKE_LRELEASE = "lrelease";
@@ -36,13 +35,13 @@ mkDerivation rec {
   configureFlags = [
     "--with-boost-libdir=${boost.out}/lib"
     "--with-boost=${boost.dev}" ]
-    ++ optionals (!guiSupport) [ "--disable-gui" "--enable-systemd" ] # Also place qbittorrent-nox systemd service files
-    ++ optional (!webuiSupport) "--disable-webui"
-    ++ optional debugSupport "--enable-debug";
+    ++ lib.optionals (!guiSupport) [ "--disable-gui" "--enable-systemd" ] # Also place qbittorrent-nox systemd service files
+    ++ lib.optional (!webuiSupport) "--disable-webui"
+    ++ lib.optional debugSupport "--enable-debug";
 
-  qtWrapperArgs = optional trackerSearch "--prefix PATH : ${makeBinPath [ python3 ]}";
+  qtWrapperArgs = lib.optional trackerSearch "--prefix PATH : ${lib.makeBinPath [ python3 ]}";
 
-  meta = {
+  meta = with lib; {
     description = "Featureful free software BitTorrent client";
     homepage    = "https://www.qbittorrent.org/";
     changelog   = "https://github.com/qbittorrent/qBittorrent/blob/release-${version}/Changelog";

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -8,8 +8,6 @@
 
 assert withQt  -> qt5  != null;
 
-with lib;
-
 let
   version = "4.0.2";
   variant = if withQt then "qt" else "cli";
@@ -39,17 +37,17 @@ in stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = [ "-DQT_NO_DEBUG" ];
 
   nativeBuildInputs = [ asciidoctor bison cmake flex makeWrapper pkg-config python3 perl ]
-    ++ optionals withQt [ qt5.wrapQtAppsHook wrapGAppsHook ];
+    ++ lib.optionals withQt [ qt5.wrapQtAppsHook wrapGAppsHook ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   buildInputs = [
     gettext pcre2 libpcap lua5 libssh nghttp2 openssl libgcrypt
     libgpg-error gnutls geoip c-ares glib zlib
-  ] ++ optionals withQt  (with qt5; [ qtbase qtmultimedia qtsvg qttools ])
-    ++ optionals stdenv.isLinux  [ libcap libnl ]
-    ++ optionals stdenv.isDarwin [ SystemConfiguration ApplicationServices gmp ]
-    ++ optionals (withQt && stdenv.isDarwin) (with qt5; [ qtmacextras ]);
+  ] ++ lib.optionals withQt  (with qt5; [ qtbase qtmultimedia qtsvg qttools ])
+    ++ lib.optionals stdenv.isLinux  [ libcap libnl ]
+    ++ lib.optionals stdenv.isDarwin [ SystemConfiguration ApplicationServices gmp ]
+    ++ lib.optionals (withQt && stdenv.isDarwin) (with qt5; [ qtmacextras ]);
 
   strictDeps = true;
 
@@ -72,7 +70,7 @@ in stdenv.mkDerivation {
             install_name_tool -change "$dylib" "$out/lib/$dylib" "$f"
         done
     done
-  '' else optionalString withQt ''
+  '' else lib.optionalString withQt ''
     pwd
     install -Dm644 -t $out/share/applications ../resources/freedesktop/org.wireshark.Wireshark.desktop
 

--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -9,8 +9,6 @@
 , withDebug ? false
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "znc";
   version = "1.8.2";
@@ -23,12 +21,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ openssl ]
-    ++ optional withPerl perl
-    ++ optional withPython python3
-    ++ optional withTcl tcl
-    ++ optional withCyrus cyrus_sasl
-    ++ optional withUnicode icu
-    ++ optional withZlib zlib;
+    ++ lib.optional withPerl perl
+    ++ lib.optional withPython python3
+    ++ lib.optional withTcl tcl
+    ++ lib.optional withCyrus cyrus_sasl
+    ++ lib.optional withUnicode icu
+    ++ lib.optional withZlib zlib;
 
   configureFlags = [
     (lib.enableFeature withPerl "perl")
@@ -36,8 +34,8 @@ stdenv.mkDerivation rec {
     (lib.enableFeature withTcl "tcl")
     (lib.withFeatureAs withTcl "tcl" "${tcl}/lib")
     (lib.enableFeature withCyrus "cyrus")
-  ] ++ optionals (!withIPv6) [ "--disable-ipv6" ]
-    ++ optionals withDebug [ "--enable-debug" ];
+  ] ++ lib.optionals (!withIPv6) [ "--disable-ipv6" ]
+    ++ lib.optionals withDebug [ "--enable-debug" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/office/tryton/default.nix
+++ b/pkgs/applications/office/tryton/default.nix
@@ -16,8 +16,6 @@
 , wrapGAppsHook
 }:
 
-with lib;
-
 python3Packages.buildPythonApplication rec {
   pname = "tryton";
   version = "5.4.2";
@@ -60,7 +58,7 @@ python3Packages.buildPythonApplication rec {
 
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     description = "The client of the Tryton application platform";
     longDescription = ''
       The client for Tryton, a three-tier high-level general purpose

--- a/pkgs/applications/radio/direwolf/default.nix
+++ b/pkgs/applications/radio/direwolf/default.nix
@@ -1,8 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, alsa-lib, espeak, gpsd
 , hamlib, perl, python3, udev }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "direwolf";
   version = "1.6";
@@ -20,7 +18,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     espeak gpsd hamlib perl python3
-  ] ++ (optionals stdenv.isLinux [alsa-lib udev]);
+  ] ++ (lib.optionals stdenv.isLinux [alsa-lib udev]);
 
   postPatch = ''
     substituteInPlace conf/CMakeLists.txt \
@@ -41,7 +39,7 @@ stdenv.mkDerivation rec {
       --replace 'GPSD_API_MAJOR_VERSION > 11' 'GPSD_API_MAJOR_VERSION > 14'
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A Soundcard Packet TNC, APRS Digipeater, IGate, APRStt gateway";
     homepage = "https://github.com/wb2osz/direwolf/";
     license = licenses.gpl2;

--- a/pkgs/applications/science/chemistry/marvin/default.nix
+++ b/pkgs/applications/science/chemistry/marvin/default.nix
@@ -1,14 +1,12 @@
 { lib, stdenv, fetchurl, dpkg, makeWrapper, coreutils, gawk, gnugrep, gnused, jre }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "marvin";
   version = "22.13.0";
 
   src = fetchurl {
     name = "marvin-${version}.deb";
-    url = "http://dl.chemaxon.com/marvin/${version}/marvin_linux_${versions.majorMinor version}.deb";
+    url = "http://dl.chemaxon.com/marvin/${version}/marvin_linux_${lib.versions.majorMinor version}.deb";
     sha256 = "sha256-cZ9SFdKNURhcInM6zZNwoi+WyHAsGCeAgkfpAVi7GYE=";
   };
 
@@ -22,7 +20,7 @@ stdenv.mkDerivation rec {
     wrapBin() {
       makeWrapper $1 $out/bin/$(basename $1) \
         --set INSTALL4J_JAVA_HOME "${jre}" \
-        --prefix PATH : ${makeBinPath [ coreutils gawk gnugrep gnused ]}
+        --prefix PATH : ${lib.makeBinPath [ coreutils gawk gnugrep gnused ]}
     }
     cp -r opt $out
     mkdir -p $out/bin $out/share/pixmaps $out/share/applications
@@ -33,12 +31,12 @@ stdenv.mkDerivation rec {
     for name in cxcalc cxtrain evaluate molconvert mview msketch; do
       wrapBin $out/opt/chemaxon/marvinsuite/bin/$name
     done
-    ${concatStrings (map (name: ''
+    ${lib.concatStrings (map (name: ''
       substitute ${./. + "/${name}.desktop"} $out/share/applications/${name}.desktop --subst-var out
     '') [ "LicenseManager" "MarvinSketch" "MarvinView" ])}
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A chemical modelling, analysis and structure drawing program";
     homepage = "https://chemaxon.com/products/marvin";
     maintainers = with maintainers; [ fusion809 ];

--- a/pkgs/applications/science/electronics/fped/default.nix
+++ b/pkgs/applications/science/electronics/fped/default.nix
@@ -3,7 +3,6 @@
 , pkg-config
 }:
 
-with lib;
 stdenv.mkDerivation {
   pname = "fped";
   version = "unstable-2017-05-11";
@@ -39,7 +38,7 @@ stdenv.mkDerivation {
     gtk2
   ];
 
-  meta = {
+  meta = with lib; {
     description = "An editor that allows the interactive creation of footprints electronic components";
     homepage = "http://projects.qi-hardware.com/index.php/p/fped/";
     license = licenses.gpl2;

--- a/pkgs/applications/science/logic/monosat/default.nix
+++ b/pkgs/applications/science/logic/monosat/default.nix
@@ -3,8 +3,6 @@
   # annoying and break the python library, so let's not bother for now
   includeJava ? !stdenv.hostPlatform.isDarwin, includeGplCode ? true }:
 
-with lib;
-
 let
   boolToCmake = x: if x then "ON" else "OFF";
 
@@ -52,14 +50,14 @@ let
       "-DCMAKE_SKIP_BUILD_RPATH=ON"
     ];
 
-    postInstall = optionalString includeJava ''
+    postInstall = lib.optionalString includeJava ''
       mkdir -p $out/share/java
       cp monosat.jar $out/share/java
     '';
 
     passthru = { inherit python; };
 
-    meta = {
+    meta = with lib; {
       description = "SMT solver for Monotonic Theories";
       platforms   = platforms.unix;
       license     = if includeGplCode then licenses.gpl2 else licenses.mit;

--- a/pkgs/applications/science/math/ripser/default.nix
+++ b/pkgs/applications/science/math/ripser/default.nix
@@ -5,9 +5,7 @@
 , fileFormat ? "lowerTriangularCsv"
 }:
 
-with lib;
-
-assert assertOneOf "fileFormat" fileFormat
+assert lib.assertOneOf "fileFormat" fileFormat
   ["lowerTriangularCsv" "upperTriangularCsv" "dipha"];
 assert useGoogleHashmap -> sparsehash != null;
 

--- a/pkgs/applications/science/math/wolfram-engine/l10ns.nix
+++ b/pkgs/applications/science/math/wolfram-engine/l10ns.nix
@@ -50,8 +50,7 @@ minVersion =
   else majorVersion;
 maxVersion = toString (1 + builtins.fromJSON minVersion);
 in
-with lib;
-findFirst (l: (l.lang == lang
+lib.findFirst (l: (l.lang == lang
                && l.version >= minVersion
                && l.version < maxVersion))
           (throw "Version ${minVersion} in language ${lang} not supported")

--- a/pkgs/applications/science/medicine/aliza/default.nix
+++ b/pkgs/applications/science/medicine/aliza/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchurl, rpmextract, makeWrapper, patchelf, qt4, zlib, libX11, libXt, libSM, libICE, libXext, libGLU, libGL }:
 
-with lib;
 stdenv.mkDerivation {
   pname = "aliza";
   version = "1.98.57";
@@ -49,7 +48,7 @@ stdenv.mkDerivation {
       --prefix LD_LIBRARY_PATH : ${libs}
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Medical imaging software with 2D, 3D and 4D capabilities";
     homepage = "https://www.aliza-dicom-viewer.com";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/applications/science/medicine/dcmtk/default.nix
+++ b/pkgs/applications/science/medicine/dcmtk/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv, fetchFromGitHub, zlib, libtiff, libxml2, openssl, libiconv
 , libpng, cmake, fetchpatch }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "dcmtk";
   version = "3.6.7";
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = {
+  meta = with lib; {
     description =
       "Collection of libraries and applications implementing large parts of the DICOM standard";
     longDescription = ''

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -12,8 +12,6 @@
 , withoutBin ? false
 }:
 
-with lib;
-
 let
   optionOnOff = option: if option then "on" else "off";
 in
@@ -32,15 +30,15 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ boost ];
   nativeBuildInputs = [ cmake perl python3 ]
-    ++ optionals fortranSupport [ gfortran ]
-    ++ optionals buildJavaBindings [ openjdk ]
-    ++ optionals buildPythonBindings [ python3Packages.pybind11 ]
-    ++ optionals buildDocumentation [ fig2dev ghostscript doxygen ]
-    ++ optionals bmfSupport [ eigen ]
-    ++ optionals modelCheckingSupport [ libunwind libevent elfutils ];
+    ++ lib.optionals fortranSupport [ gfortran ]
+    ++ lib.optionals buildJavaBindings [ openjdk ]
+    ++ lib.optionals buildPythonBindings [ python3Packages.pybind11 ]
+    ++ lib.optionals buildDocumentation [ fig2dev ghostscript doxygen ]
+    ++ lib.optionals bmfSupport [ eigen ]
+    ++ lib.optionals modelCheckingSupport [ libunwind libevent elfutils ];
 
   outputs = [ "out" ]
-    ++ optionals buildPythonBindings [ "python" ];
+    ++ lib.optionals buildPythonBindings [ "python" ];
 
   # "Release" does not work. non-debug mode is Debug compiled with optimization
   cmakeBuildType = "Debug";
@@ -69,7 +67,7 @@ stdenv.mkDerivation rec {
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
     "-DCMAKE_SKIP_BUILD_RPATH=ON"
   ];
-  makeFlags = optional debug "VERBOSE=1";
+  makeFlags = lib.optional debug "VERBOSE=1";
 
   # needed to run tests and to ensure correct shabangs in output scripts
   preBuild = ''
@@ -106,7 +104,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = lib.optionals debug [ "fortify" ];
   dontStrip = debug;
 
-  meta = {
+  meta = with lib; {
     description = "Framework for the simulation of distributed applications";
     longDescription = ''
       SimGrid is a toolkit that provides core functionalities for the

--- a/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
@@ -33,8 +33,6 @@ let
     };
 in
 
-with lib;
-
 stdenv.mkDerivation {
   name = "${pname}-unwrapped-${version}";
   inherit pname version;
@@ -49,8 +47,8 @@ stdenv.mkDerivation {
     [ libX11 libXt libXft ncurses  # required to build the terminfo file
       fontconfig freetype libXrender
       libptytty
-    ] ++ optional perlSupport perl
-      ++ optional gdkPixbufSupport gdk-pixbuf;
+    ] ++ lib.optional perlSupport perl
+      ++ lib.optional gdkPixbufSupport gdk-pixbuf;
 
   outputs = [ "out" "terminfo" ];
 
@@ -73,14 +71,14 @@ stdenv.mkDerivation {
     ./patches/9.06-font-width.patch
   ]) ++ [
     ./patches/256-color-resources.patch
-  ]++ optional stdenv.isDarwin ./patches/makefile-phony.patch;
+  ]++ lib.optional stdenv.isDarwin ./patches/makefile-phony.patch;
 
   configureFlags = [
     "--with-terminfo=${placeholder "terminfo"}/share/terminfo"
     "--enable-256-color"
-    (enableFeature perlSupport "perl")
-    (enableFeature unicode3Support "unicode3")
-  ] ++ optional emojiSupport "--enable-wide-glyphs";
+    (lib.enableFeature perlSupport "perl")
+    (lib.enableFeature unicode3Support "unicode3")
+  ] ++ lib.optional emojiSupport "--enable-wide-glyphs";
 
   LDFLAGS = [ "-lfontconfig" "-lXrender" "-lpthread" ];
   CFLAGS = [ "-I${freetype.dev}/include/freetype2" ];
@@ -106,7 +104,7 @@ stdenv.mkDerivation {
 
   passthru.tests.test = nixosTests.terminal-emulators.urxvt;
 
-  meta = {
+  meta = with lib; {
     inherit description;
     homepage = "http://software.schmorp.de/pkg/rxvt-unicode.html";
     downloadPage = "http://dist.schmorp.de/rxvt-unicode/Attic/";

--- a/pkgs/applications/version-management/git-octopus/default.nix
+++ b/pkgs/applications/version-management/git-octopus/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, git, perl, makeWrapper }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "git-octopus";
   version = "1.4";
@@ -13,7 +11,7 @@ stdenv.mkDerivation rec {
   # perl provides shasum
   postInstall = ''
     for f in $out/bin/*; do
-      wrapProgram $f --prefix PATH : ${makeBinPath [ git perl ]}
+      wrapProgram $f --prefix PATH : ${lib.makeBinPath [ git perl ]}
     done
   '';
 
@@ -24,7 +22,7 @@ stdenv.mkDerivation rec {
     sha256 = "14p61xk7jankp6gc26xciag9fnvm7r9vcbhclcy23f4ghf4q4sj1";
   };
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/lesfurets/git-octopus";
     description = "The continuous merge workflow";
     license = licenses.lgpl3;

--- a/pkgs/applications/version-management/gitkraken/default.nix
+++ b/pkgs/applications/version-management/gitkraken/default.nix
@@ -6,8 +6,6 @@
 , e2fsprogs, krb5, libdrm, mesa, unzip, copyDesktopItems, libxshmfence, libxkbcommon
 }:
 
-with lib;
-
 let
   pname = "gitkraken";
   version = "9.0.0";
@@ -33,7 +31,7 @@ let
 
   src = srcs.${stdenv.hostPlatform.system} or throwSystem;
 
-  meta = {
+  meta = with lib; {
     homepage = "https://www.gitkraken.com/";
     description = "The downright luxurious and most popular Git client for Windows, Mac & Linux";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
@@ -48,7 +46,7 @@ let
     dontBuild = true;
     dontConfigure = true;
 
-    libPath = makeLibraryPath [
+    libPath = lib.makeLibraryPath [
       stdenv.cc.cc.lib
       curlWithGnuTls
       udev

--- a/pkgs/applications/version-management/gogs/default.nix
+++ b/pkgs/applications/version-management/gogs/default.nix
@@ -4,7 +4,6 @@
 , pamSupport ? true
 }:
 
-with lib;
 
 buildGoModule rec {
   pname = "gogs";
@@ -27,19 +26,19 @@ buildGoModule rec {
 
   nativeBuildInputs = [ makeWrapper openssh ];
 
-  buildInputs = optional pamSupport pam;
+  buildInputs = lib.optional pamSupport pam;
 
   tags =
-    (  optional sqliteSupport "sqlite"
-    ++ optional pamSupport "pam");
+    (  lib.optional sqliteSupport "sqlite"
+    ++ lib.optional pamSupport "pam");
 
   postInstall = ''
 
     wrapProgram $out/bin/gogs \
-      --prefix PATH : ${makeBinPath [ bash git gzip openssh ]}
+      --prefix PATH : ${lib.makeBinPath [ bash git gzip openssh ]}
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A painless self-hosted Git service";
     homepage = "https://gogs.io";
     license = licenses.mit;

--- a/pkgs/applications/video/vcs/default.nix
+++ b/pkgs/applications/video/vcs/default.nix
@@ -3,7 +3,7 @@
 , util-linux, getopt
 , dejavu_fonts
 }:
-with lib;
+
 let
   version = "1.13.4";
   gopt = if stdenv.isLinux then util-linux else getopt;
@@ -29,10 +29,10 @@ stdenv.mkDerivation {
     mv vcs $out/bin/vcs
     substituteAllInPlace $out/bin/vcs
     chmod +x $out/bin/vcs
-    wrapProgram $out/bin/vcs --argv0 vcs --set PATH "${makeBinPath runtimeDeps}"
+    wrapProgram $out/bin/vcs --argv0 vcs --set PATH "${lib.makeBinPath runtimeDeps}"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Generates contact sheets from video files";
     homepage = "http://p.outlyer.net/vcs";
     license = licenses.cc-by-nc-sa-30;

--- a/pkgs/applications/virtualization/docker/gc.nix
+++ b/pkgs/applications/virtualization/docker/gc.nix
@@ -1,7 +1,5 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper, docker, coreutils, procps, gnused, findutils, gnugrep }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "docker-gc";
   version = "unstable-2015-10-5";
@@ -23,7 +21,7 @@ stdenv.mkDerivation rec {
         --prefix PATH : "${lib.makeBinPath [ docker coreutils procps gnused findutils gnugrep ]}"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Docker garbage collection of containers and images";
     license = licenses.asl20;
     homepage = "https://github.com/spotify/docker-gc";

--- a/pkgs/applications/virtualization/singularity/default.nix
+++ b/pkgs/applications/virtualization/singularity/default.nix
@@ -11,8 +11,6 @@
 , squashfsTools
 , buildGoPackage}:
 
-with lib;
-
 buildGoPackage rec {
   pname = "singularity";
   version = "3.8.7";

--- a/pkgs/applications/virtualization/virt-viewer/default.nix
+++ b/pkgs/applications/virtualization/virt-viewer/default.nix
@@ -34,8 +34,6 @@ assert spiceSupport -> (
   && spice-protocol != null
 );
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "virt-viewer";
   version = "11.0";
@@ -76,16 +74,16 @@ stdenv.mkDerivation rec {
     libvirt-glib
     libxml2
     vte
-  ] ++ optionals spiceSupport ([
+  ] ++ lib.optionals spiceSupport ([
     gdbm
     spice-gtk_libsoup2
     spice-protocol
-  ] ++ optionals stdenv.isLinux [
+  ] ++ lib.optionals stdenv.isLinux [
     libcap
   ]);
 
   # Required for USB redirection PolicyKit rules file
-  propagatedUserEnvPkgs = optional spiceSupport spice-gtk_libsoup2;
+  propagatedUserEnvPkgs = lib.optional spiceSupport spice-gtk_libsoup2;
 
   strictDeps = true;
 
@@ -93,7 +91,7 @@ stdenv.mkDerivation rec {
     patchShebangs build-aux/post_install.py
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A viewer for remote virtual machines";
     maintainers = with maintainers; [ raskin atemu ];
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/applications/virtualization/virtualbox/extpack.nix
+++ b/pkgs/applications/virtualization/virtualbox/extpack.nix
@@ -1,7 +1,5 @@
 { fetchurl, lib, virtualbox }:
 
-with lib;
-
 let
   inherit (virtualbox) version;
 in
@@ -15,7 +13,7 @@ fetchurl rec {
     let value = "29cf8410e2514ea4393f63f5e955b8311787873679fc23ae9a897fb70ef3f84a";
     in assert (builtins.stringLength value) == 64; value;
 
-  meta = {
+  meta = with lib; {
     description = "Oracle Extension pack for VirtualBox";
     license = licenses.virtualbox-puel;
     homepage = "https://www.virtualbox.org/";

--- a/pkgs/applications/virtualization/xen/4.10.nix
+++ b/pkgs/applications/virtualization/xen/4.10.nix
@@ -16,8 +16,6 @@
 assert withInternalSeabios -> !withSeabios;
 assert withInternalOVMF -> !withOVMF;
 
-with lib;
-
 # Patching XEN? Check the XSAs at
 # https://xenbits.xen.org/xsa/
 # and try applying all the ones we don't have yet.
@@ -46,7 +44,7 @@ callPackage (import ./generic.nix (rec {
   };
 
   # Sources needed to build tools and firmwares.
-  xenfiles = optionalAttrs withInternalQemu {
+  xenfiles = lib.optionalAttrs withInternalQemu {
     qemu-xen = {
       src = fetchgit {
         url = "https://xenbits.xen.org/git-http/qemu-xen.git";
@@ -63,7 +61,7 @@ callPackage (import ./generic.nix (rec {
       '';
       meta.description = "Xen's fork of upstream Qemu";
     };
-  } // optionalAttrs withInternalTraditionalQemu {
+  } // lib.optionalAttrs withInternalTraditionalQemu {
     qemu-xen-traditional = {
       src = fetchgit {
         url = "https://xenbits.xen.org/git-http/qemu-xen-traditional.git";
@@ -81,7 +79,7 @@ callPackage (import ./generic.nix (rec {
       '';
       meta.description = "Xen's fork of upstream Qemu that uses old device model";
     };
-  } // optionalAttrs withInternalSeabios {
+  } // lib.optionalAttrs withInternalSeabios {
     "firmware/seabios-dir-remote" = {
       src = fetchgit {
         url = "https://xenbits.xen.org/git-http/seabios.git";
@@ -91,7 +89,7 @@ callPackage (import ./generic.nix (rec {
       patches = [ ./0000-qemu-seabios-enable-ATA_DMA.patch ];
       meta.description = "Xen's fork of Seabios";
     };
-  } // optionalAttrs withInternalOVMF {
+  } // lib.optionalAttrs withInternalOVMF {
     "firmware/ovmf-dir-remote" = {
       src = fetchgit {
         url = "https://xenbits.xen.org/git-http/ovmf.git";
@@ -110,7 +108,7 @@ callPackage (import ./generic.nix (rec {
       };
       meta.description = "Xen's fork of iPXE";
     };
-  } // optionalAttrs withLibHVM {
+  } // lib.optionalAttrs withLibHVM {
     xen-libhvm-dir-remote = {
       src = fetchgit {
         name = "xen-libhvm";
@@ -132,21 +130,21 @@ callPackage (import ./generic.nix (rec {
           Helper library for reading ACPI and SMBIOS firmware values
           from the host system for use with the HVM guest firmware
           pass-through feature in Xen'';
-        license = licenses.bsd2;
+        license = lib.licenses.bsd2;
       };
     };
   };
 
   configureFlags = []
-    ++ optional (!withInternalQemu) "--with-system-qemu" # use qemu from PATH
-    ++ optional (withInternalTraditionalQemu) "--enable-qemu-traditional"
-    ++ optional (!withInternalTraditionalQemu) "--disable-qemu-traditional"
+    ++ lib.optional (!withInternalQemu) "--with-system-qemu" # use qemu from PATH
+    ++ lib.optional (withInternalTraditionalQemu) "--enable-qemu-traditional"
+    ++ lib.optional (!withInternalTraditionalQemu) "--disable-qemu-traditional"
 
-    ++ optional (withSeabios) "--with-system-seabios=${seabios}"
-    ++ optional (!withInternalSeabios && !withSeabios) "--disable-seabios"
+    ++ lib.optional (withSeabios) "--with-system-seabios=${seabios}"
+    ++ lib.optional (!withInternalSeabios && !withSeabios) "--disable-seabios"
 
-    ++ optional (withOVMF) "--with-system-ovmf=${OVMF.fd}/FV/OVMF.fd"
-    ++ optional (withInternalOVMF) "--enable-ovmf";
+    ++ lib.optional (withOVMF) "--with-system-ovmf=${OVMF.fd}/FV/OVMF.fd"
+    ++ lib.optional (withInternalOVMF) "--enable-ovmf";
 
   NIX_CFLAGS_COMPILE = toString [
     # Fix build on Glibc 2.24.

--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -24,19 +24,17 @@ config:
 
 , ...} @ args:
 
-with lib;
-
 let
   #TODO: fix paths instead
-  scriptEnvPath = concatMapStringsSep ":" (x: "${x}/bin") [
+  scriptEnvPath = lib.concatMapStringsSep ":" (x: "${x}/bin") [
     which perl
     coreutils gawk gnused gnugrep diffutils util-linux multipath-tools
     iproute2 inetutils iptables bridge-utils openvswitch nbd drbd
   ];
 
-  withXenfiles = f: concatStringsSep "\n" (mapAttrsToList f config.xenfiles);
+  withXenfiles = f: lib.concatStringsSep "\n" (lib.mapAttrsToList f config.xenfiles);
 
-  withTools = a: f: withXenfiles (name: x: optionalString (hasAttr a x) ''
+  withTools = a: f: withXenfiles (name: x: lib.optionalString (lib.hasAttr a x) ''
     echo "processing ${name}"
     __do() {
       cd "tools/${name}"
@@ -84,7 +82,7 @@ stdenv.mkDerivation (rec {
     python2Packages.markdown fig2dev ghostscript texinfo pandoc
 
     # Others
-  ] ++ (concatMap (x: x.buildInputs or []) (attrValues config.xenfiles))
+  ] ++ (lib.concatMap (x: x.buildInputs or []) (lib.attrValues config.xenfiles))
     ++ (config.buildInputs or []);
 
   prePatch = ''
@@ -170,12 +168,12 @@ stdenv.mkDerivation (rec {
     substituteInPlace tools/xenstat/Makefile \
       --replace /usr/include/curses.h ${ncurses.dev}/include/curses.h
 
-    ${optionalString (builtins.compareVersions config.version "4.8" >= 0) ''
+    ${lib.optionalString (builtins.compareVersions config.version "4.8" >= 0) ''
       substituteInPlace tools/hotplug/Linux/launch-xenstore.in \
         --replace /bin/mkdir mkdir
     ''}
 
-    ${optionalString (builtins.compareVersions config.version "4.6" < 0) ''
+    ${lib.optionalString (builtins.compareVersions config.version "4.6" < 0) ''
       # TODO: use this as a template and support our own if-up scripts instead?
       substituteInPlace tools/hotplug/Linux/xen-backend.rules.in \
         --replace "@XEN_SCRIPT_DIR@" $out/etc/xen/scripts
@@ -185,7 +183,7 @@ stdenv.mkDerivation (rec {
     ''}
 
     ${withTools "patches" (name: x: ''
-      ${concatMapStringsSep "\n" (p: ''
+      ${lib.concatMapStringsSep "\n" (p: ''
         echo "# Patching with ${p}"
         patch -p1 < ${p}
       '') x.patches}
@@ -246,7 +244,7 @@ stdenv.mkDerivation (rec {
   meta = {
     homepage = "http://www.xen.org/";
     description = "Xen hypervisor and related components"
-                + optionalString (args ? meta && args.meta ? description)
+                + lib.optionalString (args ? meta && args.meta ? description)
                                  " (${args.meta.description})";
     longDescription = (args.meta.longDescription or "")
                     + "\nIncludes:\n"

--- a/pkgs/applications/window-managers/fluxbox/default.nix
+++ b/pkgs/applications/window-managers/fluxbox/default.nix
@@ -4,7 +4,6 @@
 , libXinerama
 , imlib2 }:
 
-with lib;
 stdenv.mkDerivation rec {
 
   pname = "fluxbox";
@@ -35,7 +34,7 @@ stdenv.mkDerivation rec {
       --subst-var-by PREFIX "$out"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Full-featured, light-resource X window manager";
     longDescription = ''
       Fluxbox is a X window manager based on Blackbox 0.61.1 window

--- a/pkgs/applications/window-managers/i3/blocks-gaps.nix
+++ b/pkgs/applications/window-managers/i3/blocks-gaps.nix
@@ -4,11 +4,9 @@
               "load_average" "memory" "volume" "wifi" ]
 }:
 
-with lib;
-
 let
   perlscripts = [ "battery" "cpu_usage" "openvpn" "temperature" ];
-  contains_any = l1: l2: 0 < length( intersectLists l1 l2 );
+  contains_any = l1: l2: 0 < lib.length( lib.intersectLists l1 l2 );
 
 in
 stdenv.mkDerivation rec {
@@ -25,24 +23,24 @@ stdenv.mkDerivation rec {
   makeFlags = [ "all" ];
   installFlags = [ "PREFIX=\${out}" "VERSION=${version}" ];
 
-  buildInputs = optional (contains_any scripts perlscripts) perl;
+  buildInputs = lib.optional (contains_any scripts perlscripts) perl;
   nativeBuildInputs = [ makeWrapper ];
 
-  postFixup = optionalString (elem "bandwidth" scripts) ''
+  postFixup = lib.optionalString (lib.elem "bandwidth" scripts) ''
     wrapProgram $out/libexec/i3blocks/bandwidth \
-      --prefix PATH : ${makeBinPath [ iproute2 ]}
-  '' + optionalString (elem "battery" scripts) ''
+      --prefix PATH : ${lib.makeBinPath [ iproute2 ]}
+  '' + lib.optionalString (lib.elem "battery" scripts) ''
     wrapProgram $out/libexec/i3blocks/battery \
-      --prefix PATH : ${makeBinPath [ acpi ]}
-  '' + optionalString (elem "cpu_usage" scripts) ''
+      --prefix PATH : ${lib.makeBinPath [ acpi ]}
+  '' + lib.optionalString (lib.elem "cpu_usage" scripts) ''
     wrapProgram $out/libexec/i3blocks/cpu_usage \
-      --prefix PATH : ${makeBinPath [ sysstat ]}
-  '' + optionalString (elem "iface" scripts) ''
+      --prefix PATH : ${lib.makeBinPath [ sysstat ]}
+  '' + lib.optionalString (lib.elem "iface" scripts) ''
     wrapProgram $out/libexec/i3blocks/iface \
-      --prefix PATH : ${makeBinPath [ iproute2 ]}
-  '' + optionalString (elem "volume" scripts) ''
+      --prefix PATH : ${lib.makeBinPath [ iproute2 ]}
+  '' + lib.optionalString (lib.elem "volume" scripts) ''
     wrapProgram $out/libexec/i3blocks/volume \
-      --prefix PATH : ${makeBinPath [ alsa-utils ]}
+      --prefix PATH : ${lib.makeBinPath [ alsa-utils ]}
   '';
 
   meta = with lib; {

--- a/pkgs/applications/window-managers/i3/blocks.nix
+++ b/pkgs/applications/window-managers/i3/blocks.nix
@@ -1,7 +1,5 @@
 { fetchFromGitHub, fetchpatch, lib, stdenv, autoreconfHook, pkg-config }:
 
-with lib;
-
 stdenv.mkDerivation {
   pname = "i3blocks";
   version = "1.5";
@@ -24,7 +22,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
-  meta = {
+  meta = with lib; {
     description = "A flexible scheduler for your i3bar blocks";
     homepage = "https://github.com/vivien/i3blocks";
     license = licenses.gpl3;

--- a/pkgs/applications/window-managers/sway/wrapper.nix
+++ b/pkgs/applications/window-managers/sway/wrapper.nix
@@ -13,8 +13,6 @@
 
 assert extraSessionCommands != "" -> withBaseWrapper;
 
-with lib;
-
 let
   sway = sway-unwrapped.override { inherit isNixOS enableXWayland; };
   baseWrapper = writeShellScriptBin "sway" ''
@@ -34,24 +32,24 @@ let
 in symlinkJoin {
   name = "sway-${sway.version}";
 
-  paths = (optional withBaseWrapper baseWrapper)
+  paths = (lib.optional withBaseWrapper baseWrapper)
     ++ [ sway ];
 
   strictDeps = false;
   nativeBuildInputs = [ makeWrapper ]
-    ++ (optional withGtkWrapper wrapGAppsHook);
+    ++ (lib.optional withGtkWrapper wrapGAppsHook);
 
-  buildInputs = optionals withGtkWrapper [ gdk-pixbuf glib gtk3 ];
+  buildInputs = lib.optionals withGtkWrapper [ gdk-pixbuf glib gtk3 ];
 
   # We want to run wrapProgram manually
   dontWrapGApps = true;
 
   postBuild = ''
-    ${optionalString withGtkWrapper "gappsWrapperArgsHook"}
+    ${lib.optionalString withGtkWrapper "gappsWrapperArgsHook"}
 
     wrapProgram $out/bin/sway \
-      ${optionalString withGtkWrapper ''"''${gappsWrapperArgs[@]}"''} \
-      ${optionalString (extraOptions != []) "${concatMapStrings (x: " --add-flags " + x) extraOptions}"}
+      ${lib.optionalString withGtkWrapper ''"''${gappsWrapperArgs[@]}"''} \
+      ${lib.optionalString (extraOptions != []) "${lib.concatMapStrings (x: " --add-flags " + x) extraOptions}"}
   '';
 
   passthru = {

--- a/pkgs/build-support/emacs/elpa.nix
+++ b/pkgs/build-support/emacs/elpa.nix
@@ -2,8 +2,6 @@
 
 { lib, stdenv, emacs, texinfo, writeText, gcc }:
 
-with lib;
-
 { pname
 , version
 , src

--- a/pkgs/build-support/emacs/generic.nix
+++ b/pkgs/build-support/emacs/generic.nix
@@ -2,8 +2,6 @@
 
 { lib, stdenv, emacs, texinfo, writeText, gcc, ... }:
 
-with lib;
-
 { pname
 , version ? null
 
@@ -20,14 +18,14 @@ let
   defaultMeta = {
     broken = false;
     platforms = emacs.meta.platforms;
-  } // optionalAttrs ((args.src.meta.homepage or "") != "") {
+  } // lib.optionalAttrs ((args.src.meta.homepage or "") != "") {
     homepage = args.src.meta.homepage;
   };
 
 in
 
 stdenv.mkDerivation ({
-  name = "emacs-${pname}${optionalString (version != null) "-${version}"}";
+  name = "emacs-${pname}${lib.optionalString (version != null) "-${version}"}";
 
   unpackCmd = ''
     case "$curSrc" in

--- a/pkgs/build-support/emacs/melpa.nix
+++ b/pkgs/build-support/emacs/melpa.nix
@@ -3,8 +3,6 @@
 
 { lib, stdenv, fetchFromGitHub, emacs, texinfo, writeText, gcc }:
 
-with lib;
-
 { /*
     pname: Nix package name without special symbols and without version or
     "emacs-" prefix.

--- a/pkgs/build-support/emacs/trivial.nix
+++ b/pkgs/build-support/emacs/trivial.nix
@@ -2,8 +2,6 @@
 
 { callPackage, lib, ... }@envargs:
 
-with lib;
-
 args:
 
 callPackage ./generic.nix envargs ({

--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -34,8 +34,6 @@ in customEmacsPackages.withPackages (epkgs: [ epkgs.evil epkgs.magit ])
 
 { lib, lndir, makeWrapper, runCommand, gcc }: self:
 
-with lib;
-
 let
 
   inherit (self) emacs;
@@ -54,7 +52,7 @@ let
 in
 
 runCommand
-  (appendToName "with-packages" emacs).name
+  (lib.appendToName "with-packages" emacs).name
   {
     nativeBuildInputs = [ emacs lndir makeWrapper ];
     inherit emacs explicitRequires;
@@ -106,7 +104,7 @@ runCommand
         }
         mkdir -p $out/bin
         mkdir -p $out/share/emacs/site-lisp
-        ${optionalString nativeComp ''
+        ${lib.optionalString nativeComp ''
           mkdir -p $out/share/emacs/native-lisp
         ''}
 
@@ -130,7 +128,7 @@ runCommand
         linkEmacsPackage() {
           linkPath "$1" "bin" "bin"
           linkPath "$1" "share/emacs/site-lisp" "share/emacs/site-lisp"
-          ${optionalString nativeComp ''
+          ${lib.optionalString nativeComp ''
             linkPath "$1" "share/emacs/native-lisp" "share/emacs/native-lisp"
           ''}
         }
@@ -161,7 +159,7 @@ runCommand
           (load-file "$emacs/share/emacs/site-lisp/site-start.el"))
         (add-to-list 'load-path "$out/share/emacs/site-lisp")
         (add-to-list 'exec-path "$out/bin")
-        ${optionalString nativeComp ''
+        ${lib.optionalString nativeComp ''
           (add-to-list 'native-comp-eln-load-path "$out/share/emacs/native-lisp/")
         ''}
         EOF
@@ -176,7 +174,7 @@ runCommand
         # Byte-compiling improves start-up time only slightly, but costs nothing.
         $emacs/bin/emacs --batch -f batch-byte-compile "$siteStart" "$subdirs"
 
-        ${optionalString nativeComp ''
+        ${lib.optionalString nativeComp ''
           $emacs/bin/emacs --batch \
             --eval "(add-to-list 'native-comp-eln-load-path \"$out/share/emacs/native-lisp/\")" \
             -f batch-native-compile "$siteStart" "$subdirs"

--- a/pkgs/build-support/fetchrepoproject/default.nix
+++ b/pkgs/build-support/fetchrepoproject/default.nix
@@ -9,22 +9,20 @@
 assert repoRepoRev != "" -> repoRepoURL != "";
 assert createMirror -> !useArchive;
 
-with lib;
-
 let
   extraRepoInitFlags = [
-    (optionalString (repoRepoURL != "") "--repo-url=${repoRepoURL}")
-    (optionalString (repoRepoRev != "") "--repo-branch=${repoRepoRev}")
-    (optionalString (referenceDir != "") "--reference=${referenceDir}")
-    (optionalString (manifestName != "") "--manifest-name=${manifestName}")
+    (lib.optionalString (repoRepoURL != "") "--repo-url=${repoRepoURL}")
+    (lib.optionalString (repoRepoRev != "") "--repo-branch=${repoRepoRev}")
+    (lib.optionalString (referenceDir != "") "--reference=${referenceDir}")
+    (lib.optionalString (manifestName != "") "--manifest-name=${manifestName}")
   ];
 
   repoInitFlags = [
     "--manifest-url=${manifest}"
     "--manifest-branch=${rev}"
     "--depth=1"
-    (optionalString createMirror "--mirror")
-    (optionalString useArchive "--archive")
+    (lib.optionalString createMirror "--mirror")
+    (lib.optionalString useArchive "--archive")
   ] ++ extraRepoInitFlags;
 
   local_manifests = copyPathsToStore localManifests;
@@ -41,7 +39,7 @@ in stdenvNoCC.mkDerivation {
   preferLocalBuild = true;
   enableParallelBuilding = true;
 
-  impureEnvVars = fetchers.proxyImpureEnvVars ++ [
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
     "GIT_PROXY_COMMAND" "SOCKS_SERVER"
   ];
 
@@ -57,20 +55,20 @@ in stdenvNoCC.mkDerivation {
     cd $out
 
     mkdir .repo
-    ${optionalString (local_manifests != []) ''
+    ${lib.optionalString (local_manifests != []) ''
       mkdir .repo/local_manifests
-      for local_manifest in ${concatMapStringsSep " " toString local_manifests}; do
+      for local_manifest in ${lib.concatMapStringsSep " " toString local_manifests}; do
         cp $local_manifest .repo/local_manifests/$(stripHash $local_manifest; echo $strippedName)
       done
     ''}
 
-    repo init ${concatStringsSep " " repoInitFlags}
+    repo init ${lib.concatStringsSep " " repoInitFlags}
     repo sync --jobs=$NIX_BUILD_CORES --current-branch
 
     # TODO: The git-index files (and probably the files in .repo as well) have
     # different contents each time and will therefore change the final hash
     # (i.e. creating a mirror probably won't work).
-    ${optionalString (!createMirror) ''
+    ${lib.optionalString (!createMirror) ''
       rm -rf .repo
       find -type d -name '.git' -prune -exec rm -rf {} +
     ''}

--- a/pkgs/build-support/fetchsourcehut/default.nix
+++ b/pkgs/build-support/fetchsourcehut/default.nix
@@ -9,8 +9,6 @@
 , ... # For hash agility
 } @ args:
 
-with lib;
-
 assert (lib.assertOneOf "vc" vc [ "hg" "git" ]);
 
 let
@@ -38,7 +36,7 @@ let
       fetch = fetchzip;
       arguments = baseArgs // {
         url = "${baseUrl}/archive/${rev}.tar.gz";
-        postFetch = optionalString (vc == "hg") ''
+        postFetch = lib.optionalString (vc == "hg") ''
           rm -f "$out/.hg_archival.txt"
         ''; # impure file; see #12002
       };

--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -10,8 +10,6 @@
 , extraPackages ? [], extraBuildCommands ? ""
 }:
 
-with lib;
-
 let
   stdenv = stdenvNoCC;
   inherit (stdenv) hostPlatform targetPlatform;
@@ -24,7 +22,7 @@ let
                                         (targetPlatform.config + "-");
 
   # See description in cc-wrapper.
-  suffixSalt = replaceStrings ["-" "."] ["_" "_"] targetPlatform.config;
+  suffixSalt = lib.replaceStrings ["-" "."] ["_" "_"] targetPlatform.config;
 
 in
 
@@ -36,7 +34,7 @@ stdenv.mkDerivation {
 
   preferLocalBuild = true;
 
-  outputs = [ "out" ] ++ optionals propagateDoc ([ "man" ] ++ optional (pkg-config ? doc) "doc");
+  outputs = [ "out" ] ++ lib.optionals propagateDoc ([ "man" ] ++ lib.optional (pkg-config ? doc) "doc");
 
   passthru = {
     inherit targetPrefix suffixSalt;
@@ -68,7 +66,7 @@ stdenv.mkDerivation {
 
       echo $pkg-config > $out/nix-support/orig-pkg-config
 
-      wrap ${targetPrefix}${baseBinName} ${./pkg-config-wrapper.sh} "${getBin pkg-config}/bin/${baseBinName}"
+      wrap ${targetPrefix}${baseBinName} ${./pkg-config-wrapper.sh} "${lib.getBin pkg-config}/bin/${baseBinName}"
     ''
     # symlink in share for autoconf to find macros
 
@@ -99,9 +97,9 @@ stdenv.mkDerivation {
     ##
     ## Man page and doc support
     ##
-    + optionalString propagateDoc (''
+    + lib.optionalString propagateDoc (''
       ln -s ${pkg-config.man} $man
-    '' + optionalString (pkg-config ? doc) ''
+    '' + lib.optionalString (pkg-config ? doc) ''
       ln -s ${pkg-config.doc} $doc
     '')
 
@@ -116,7 +114,7 @@ stdenv.mkDerivation {
     + extraBuildCommands;
 
   env = {
-    shell = getBin stdenvNoCC.shell + stdenvNoCC.shell.shellPath or "";
+    shell = lib.getBin stdenvNoCC.shell + stdenvNoCC.shell.shellPath or "";
     wrapperName = "PKG_CONFIG_WRAPPER";
     inherit targetPrefix suffixSalt baseBinName;
   };

--- a/pkgs/build-support/replace-dependency.nix
+++ b/pkgs/build-support/replace-dependency.nix
@@ -19,8 +19,6 @@
 # (and all of its dependencies) without rebuilding further.
 { drv, oldDependency, newDependency, verbose ? true }:
 
-with lib;
-
 let
   warn = if verbose then builtins.trace else (x: y: y);
   references = import (runCommand "references.nix" { exportReferencesGraph = [ "graph" drv ]; } ''
@@ -50,34 +48,34 @@ let
 
   referencesOf = drv: references.${discard (toString drv)};
 
-  dependsOnOldMemo = listToAttrs (map
+  dependsOnOldMemo = lib.listToAttrs (map
     (drv: { name = discard (toString drv);
-            value = elem oldStorepath (referencesOf drv) ||
-                    any dependsOnOld (referencesOf drv);
+            value = lib.elem oldStorepath (referencesOf drv) ||
+                    lib.any dependsOnOld (referencesOf drv);
           }) (builtins.attrNames references));
 
   dependsOnOld = drv: dependsOnOldMemo.${discard (toString drv)};
 
   drvName = drv:
-    discard (substring 33 (stringLength (builtins.baseNameOf drv)) (builtins.baseNameOf drv));
+    discard (lib.substring 33 (lib.stringLength (builtins.baseNameOf drv)) (builtins.baseNameOf drv));
 
   rewriteHashes = drv: hashes: runCommand (drvName drv) { nixStore = "${nix.out}/bin/nix-store"; } ''
     $nixStore --dump ${drv} | sed 's|${baseNameOf drv}|'$(basename $out)'|g' | sed -e ${
-      concatStringsSep " -e " (mapAttrsToList (name: value:
+      lib.concatStringsSep " -e " (lib.mapAttrsToList (name: value:
         "'s|${baseNameOf name}|${baseNameOf value}|g'"
       ) hashes)
     } | $nixStore --restore $out
   '';
 
-  rewrittenDeps = listToAttrs [ {name = discard (toString oldDependency); value = newDependency;} ];
+  rewrittenDeps = lib.listToAttrs [ {name = discard (toString oldDependency); value = newDependency;} ];
 
-  rewriteMemo = listToAttrs (map
+  rewriteMemo = lib.listToAttrs (map
     (drv: { name = discard (toString drv);
             value = rewriteHashes (builtins.storePath drv)
-              (filterAttrs (n: v: builtins.elem (builtins.storePath (discard (toString n))) (referencesOf drv)) rewriteMemo);
+              (lib.filterAttrs (n: v: builtins.elem (builtins.storePath (discard (toString n))) (referencesOf drv)) rewriteMemo);
           })
-    (filter dependsOnOld (builtins.attrNames references))) // rewrittenDeps;
+    (lib.filter dependsOnOld (builtins.attrNames references))) // rewrittenDeps;
 
   drvHash = discard (toString drv);
-in assert (stringLength (drvName (toString oldDependency)) == stringLength (drvName (toString newDependency)));
+in assert (lib.stringLength (drvName (toString oldDependency)) == lib.stringLength (drvName (toString newDependency)));
 rewriteMemo.${drvHash} or (warn "replace-dependency.nix: Derivation ${drvHash} does not depend on ${discard (toString oldDependency)}" drv)

--- a/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
@@ -2,8 +2,6 @@
 , gnome-common, gtk2, pango
 , libxml2Python, perl, intltool, gettext, gtk-mac-integration-gtk2 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "gtksourceview";
   version = "2.10.5";
@@ -13,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "c585773743b1df8a04b1be7f7d90eecdf22681490d6810be54c81a7ae152191e";
   };
 
-  patches = optionals stdenv.isDarwin [
+  patches = lib.optionals stdenv.isDarwin [
     (fetchpatch {
       name = "change-igemacintegration-to-gtkosxapplication.patch";
       url = "https://gitlab.gnome.org/GNOME/gtksourceview/commit/e88357c5f210a8796104505c090fb6a04c213902.patch";
@@ -31,11 +29,11 @@ stdenv.mkDerivation rec {
     atk cairo glib gtk2
     pango libxml2Python perl
     gettext
-  ] ++ optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     gnome-common gtk-mac-integration-gtk2
   ];
 
-  preConfigure = optionalString stdenv.isDarwin ''
+  preConfigure = lib.optionalString stdenv.isDarwin ''
     intltoolize --force
   '';
 

--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -25,8 +25,6 @@
 , mateUpdateScript
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "atril";
   version = "1.26.0";
@@ -54,18 +52,18 @@ stdenv.mkDerivation rec {
     hicolor-icon-theme
     texlive.bin.core # for synctex, used by the pdf back-end
   ]
-  ++ optionals enableDjvu [ djvulibre ]
-  ++ optionals enableEpub [ webkitgtk ]
-  ++ optionals enablePostScript [ libspectre ]
-  ++ optionals enableXps [ libgxps ]
+  ++ lib.optionals enableDjvu [ djvulibre ]
+  ++ lib.optionals enableEpub [ webkitgtk ]
+  ++ lib.optionals enablePostScript [ libspectre ]
+  ++ lib.optionals enableXps [ libgxps ]
   ;
 
   configureFlags = [ ]
-    ++ optionals (enableDjvu) [ "--enable-djvu" ]
-    ++ optionals (enableEpub) [ "--enable-epub" ]
-    ++ optionals (enablePostScript) [ "--enable-ps" ]
-    ++ optionals (enableXps) [ "--enable-xps" ]
-    ++ optionals (enableImages) [ "--enable-pixbuf" ];
+    ++ lib.optionals (enableDjvu) [ "--enable-djvu" ]
+    ++ lib.optionals (enableEpub) [ "--enable-epub" ]
+    ++ lib.optionals (enablePostScript) [ "--enable-ps" ]
+    ++ lib.optionals (enableXps) [ "--enable-xps" ]
+    ++ lib.optionals (enableImages) [ "--enable-pixbuf" ];
 
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 

--- a/pkgs/development/beam-modules/build-erlang-mk.nix
+++ b/pkgs/development/beam-modules/build-erlang-mk.nix
@@ -17,8 +17,6 @@
 , ...
 }@attrs:
 
-with lib;
-
 let
   debugInfoFlag = lib.optionalString (enableDebugInfo || erlang.debugInfo) "+debug_info";
 
@@ -107,4 +105,4 @@ let
     };
   });
 in
-fix pkg
+lib.fix pkg

--- a/pkgs/development/beam-modules/build-hex.nix
+++ b/pkgs/development/beam-modules/build-hex.nix
@@ -5,8 +5,6 @@
 , hexPkg ? name
 , ... }@attrs:
 
-with lib;
-
 let
   pkg = self: builder (attrs // {
 
@@ -17,4 +15,4 @@ let
     };
   });
 in
-  fix pkg
+  lib.fix pkg

--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -15,7 +15,6 @@
 , ...
 }@attrs:
 
-with lib;
 let
   shell = drv: stdenv.mkDerivation {
     name = "interactive-shell-${drv.name}";
@@ -90,5 +89,5 @@ let
     };
   });
 in
-fix pkg
+lib.fix pkg
 

--- a/pkgs/development/beam-modules/build-rebar3.nix
+++ b/pkgs/development/beam-modules/build-rebar3.nix
@@ -16,8 +16,6 @@
 , ...
 }@attrs:
 
-with lib;
-
 let
   debugInfoFlag = lib.optionalString (enableDebugInfo || erlang.debugInfo) "debug-info";
 
@@ -30,7 +28,7 @@ let
     buildInputs = [ drv ];
   };
 
-  customPhases = filterAttrs
+  customPhases = lib.filterAttrs
     (_: v: v != null)
     { inherit setupHook configurePhase buildPhase installPhase; };
 
@@ -40,7 +38,7 @@ let
     inherit version;
 
     buildInputs = buildInputs ++ [ erlang rebar3 openssl libyaml ];
-    propagatedBuildInputs = unique beamDeps;
+    propagatedBuildInputs = lib.unique beamDeps;
 
     inherit src;
 
@@ -85,4 +83,4 @@ let
     };
   } // customPhases);
 in
-fix pkg
+lib.fix pkg

--- a/pkgs/development/beam-modules/fetch-hex.nix
+++ b/pkgs/development/beam-modules/fetch-hex.nix
@@ -6,8 +6,6 @@
 , meta ? { }
 }:
 
-with lib;
-
 stdenv.mkDerivation ({
   pname = "hex-source-${pkg}";
   inherit version;

--- a/pkgs/development/beam-modules/fetch-rebar-deps.nix
+++ b/pkgs/development/beam-modules/fetch-rebar-deps.nix
@@ -7,8 +7,6 @@
 , meta ? { }
 }:
 
-with lib;
-
 stdenv.mkDerivation ({
   pname = "rebar-deps-${name}";
   inherit version;

--- a/pkgs/development/beam-modules/rebar3-release.nix
+++ b/pkgs/development/beam-modules/rebar3-release.nix
@@ -22,15 +22,13 @@
 , ...
 }@attrs:
 
-with lib;
-
 let
   shell = drv: stdenv.mkDerivation {
     name = "interactive-shell-${drv.pname}";
     buildInputs = [ drv ];
   };
 
-  customPhases = filterAttrs
+  customPhases = lib.filterAttrs
     (_: v: v != null)
     { inherit setupHook configurePhase buildPhase installPhase; };
 
@@ -105,4 +103,4 @@ let
       } // (if attrs ? passthru then attrs.passthru else { }));
     } // customPhases);
 in
-fix pkg
+lib.fix pkg

--- a/pkgs/development/compilers/intercal/default.nix
+++ b/pkgs/development/compilers/intercal/default.nix
@@ -3,7 +3,6 @@
 , bison, flex
 , makeWrapper }:
 
-with lib;
 stdenv.mkDerivation rec {
 
   pname = "intercal";
@@ -31,7 +30,7 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/ick --suffix PATH ':' ${stdenv.cc}/bin
   '';
 
-  meta = {
+  meta = with lib; {
     description = "The original esoteric programming language";
     longDescription = ''
       INTERCAL, an abbreviation for "Compiler Language With No

--- a/pkgs/development/compilers/scala/2.x.nix
+++ b/pkgs/development/compilers/scala/2.x.nix
@@ -1,8 +1,6 @@
 { stdenv, lib, fetchurl, makeWrapper, jre, gnugrep, coreutils, writeScript
 , common-updater-scripts, git, gnused, nix, nixfmt, majorVersion }:
 
-with lib;
-
 let
   repo = "git@github.com:scala/scala.git";
 
@@ -102,7 +100,7 @@ stdenv.mkDerivation rec {
     '';
   };
 
-  meta = {
+  meta = with lib; {
     description = "A general purpose programming language";
     longDescription = ''
       Scala is a general purpose programming language designed to express

--- a/pkgs/development/compilers/sdcc/default.nix
+++ b/pkgs/development/compilers/sdcc/default.nix
@@ -1,11 +1,9 @@
 { lib, stdenv, fetchurl, autoconf, bison, boost, flex, texinfo, zlib, gputils ? null
 , excludePorts ? [] }:
 
-with lib;
-
 let
   # choices: mcs51 z80 z180 r2k r3ka gbz80 tlcs90 ds390 ds400 pic14 pic16 hc08 s08 stm8
-  excludedPorts = excludePorts ++ (optionals (gputils == null) [ "pic14" "pic16" ]);
+  excludedPorts = excludePorts ++ (lib.optionals (gputils == null) [ "pic14" "pic16" ]);
 in
 
 stdenv.mkDerivation rec {
@@ -29,7 +27,7 @@ stdenv.mkDerivation rec {
     fi
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Small Device C Compiler";
     longDescription = ''
       SDCC is a retargettable, optimizing ANSI - C compiler suite that targets

--- a/pkgs/development/coq-modules/Cheerios/default.nix
+++ b/pkgs/development/coq-modules/Cheerios/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, StructTact, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname   = "cheerios";
   owner   = "uwplse";
   inherit version;
-  defaultVersion = if versions.range "8.6" "8.16" coq.version then "20200201" else null;
+  defaultVersion = if lib.versions.range "8.6" "8.16" coq.version then "20200201" else null;
   release."20200201".rev    = "9c7f66e57b91f706d70afa8ed99d64ed98ab367d";
   release."20200201".sha256 = "1h55s6lk47bk0lv5ralh81z55h799jbl9mhizmqwqzy57y8wqgs1";
 

--- a/pkgs/development/coq-modules/CoLoR/default.nix
+++ b/pkgs/development/coq-modules/CoLoR/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, bignums, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "color";
   owner = "fblanqui";
   inherit version;
-  defaultVersion = with versions; switch coq.version [
+  defaultVersion = with lib.versions; lib.switch coq.version [
     {case = range "8.12" "8.16"; out = "1.8.2"; }
     {case = range "8.10" "8.11"; out = "1.7.0"; }
     {case = range "8.8"  "8.9";  out = "1.6.0"; }
@@ -26,6 +26,6 @@ with lib; mkCoqDerivation {
   meta = {
     homepage = "https://github.com/fblanqui/color";
     description = "CoLoR is a library of formal mathematical definitions and proofs of theorems on rewriting theory and termination whose correctness has been mechanically checked by the Coq proof assistant.";
-    maintainers = with maintainers; [ jpas jwiegley ];
+    maintainers = with lib.maintainers; [ jpas jwiegley ];
   };
 }

--- a/pkgs/development/coq-modules/HoTT/default.nix
+++ b/pkgs/development/coq-modules/HoTT/default.nix
@@ -1,11 +1,11 @@
 { lib, mkCoqDerivation, autoconf, automake, coq, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "HoTT";
   repo = "Coq-HoTT";
   owner = "HoTT";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.14" "8.16"; out = coq.coq-version; }
   ] null;
   releaseRev = v: "V${v}";
@@ -20,6 +20,6 @@ with lib; mkCoqDerivation {
   meta = {
     homepage = "http://homotopytypetheory.org/";
     description = "Homotopy type theory";
-    maintainers = with maintainers; [ siddharthist ];
+    maintainers = with lib.maintainers; [ siddharthist ];
   };
 }

--- a/pkgs/development/coq-modules/ITree/default.nix
+++ b/pkgs/development/coq-modules/ITree/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, version ? null , paco, coq-ext-lib }:
 
-with lib; mkCoqDerivation rec {
+mkCoqDerivation rec {
   pname = "InteractionTrees";
   owner = "DeepSpec";
   inherit version;
-  defaultVersion = with versions; switch coq.version [
+  defaultVersion = with lib.versions; lib.switch coq.version [
     { case = range "8.10" "8.16";  out = "4.0.0"; }
   ] null;
   release."4.0.0".sha256 = "0h5rhndl8syc24hxq1gch86kj7mpmgr89bxp2hmf28fd7028ijsm";
@@ -12,6 +12,6 @@ with lib; mkCoqDerivation rec {
   propagatedBuildInputs = [ coq-ext-lib paco ];
   meta = {
     description = "A Library for Representing Recursive and Impure Programs in Coq";
-    maintainers = with maintainers; [ larsr ];
+    maintainers = with lib.maintainers; [ larsr ];
   };
 }

--- a/pkgs/development/coq-modules/LibHyps/default.nix
+++ b/pkgs/development/coq-modules/LibHyps/default.nix
@@ -1,11 +1,10 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib;
 mkCoqDerivation {
   pname = "LibHyps";
   owner = "Matafou";
   inherit version;
-  defaultVersion = if (versions.range "8.11" "8.16") coq.version then "2.0.4.1" else null;
+  defaultVersion = if (lib.versions.range "8.11" "8.16") coq.version then "2.0.4.1" else null;
   release = {
     "2.0.4.1".sha256 = "09p89701zhrfdmqlpxw3mziw8yylj1w1skb4b0xpbdwd1vsn4k3h";
   };
@@ -16,6 +15,6 @@ mkCoqDerivation {
 
   meta = {
     description = "Hypotheses manipulation library";
-    license = licenses.mit;
+    license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/coq-modules/StructTact/default.nix
+++ b/pkgs/development/coq-modules/StructTact/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "StructTact";
   owner = "uwplse";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.6" "8.16"; out = "20210328"; }
     { case = range "8.5" "8.13"; out = "20181102"; }
   ] null;

--- a/pkgs/development/coq-modules/VST/default.nix
+++ b/pkgs/development/coq-modules/VST/default.nix
@@ -1,7 +1,5 @@
 { lib, mkCoqDerivation, coq, compcert, ITree, version ? null }:
 
-with lib;
-
 # A few modules that are not built and installed by default
 #  but that may be useful to some users.
 # They depend on ITree.
@@ -11,7 +9,7 @@ let extra_floyd_files = [
   "powerlater.v"
   ]
   # floyd/printf.v is broken in VST 2.9
-  ++ optional (!versions.isGe "8.13" coq.coq-version) "printf.v"
+  ++ lib.optional (!lib.versions.isGe "8.13" coq.coq-version) "printf.v"
   ++ [
   "quickprogram.v"
   ];
@@ -24,7 +22,7 @@ mkCoqDerivation {
   owner = "PrincetonUniversity";
   repo = "VST";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.15" "8.16"; out = "2.11.1"; }
     { case = range "8.14" "8.16"; out = "2.10"; }
     { case = range "8.13" "8.15"; out = "2.9"; }

--- a/pkgs/development/coq-modules/Velisarios/default.nix
+++ b/pkgs/development/coq-modules/Velisarios/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "Velisarios";
   owner = "vrahli";
   inherit version;
-  defaultVersion = if versions.range "8.6" "8.8" coq.coq-version then "20180221" else null;
+  defaultVersion = if lib.versions.range "8.6" "8.8" coq.coq-version then "20180221" else null;
 
   release."20180221".rev    = "e1eee1f10d5d46331a560bd8565ac101229d0d6b";
   release."20180221".sha256 = "0l9885nxy0n955fj1gnijlxl55lyxiv9yjfmz8hmfrn9hl8vv1m2";

--- a/pkgs/development/coq-modules/Verdi/default.nix
+++ b/pkgs/development/coq-modules/Verdi/default.nix
@@ -1,11 +1,11 @@
 { lib, mkCoqDerivation, coq, Cheerios, InfSeqExt, ssreflect, version ? null }:
 
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "verdi";
   owner = "uwplse";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.7" "8.16"; out = "20211026"; }
     { case = range "8.7" "8.14"; out = "20210524"; }
     { case = range "8.7" "8.13"; out = "20200131"; }

--- a/pkgs/development/coq-modules/aac-tactics/default.nix
+++ b/pkgs/development/coq-modules/aac-tactics/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, coq, version ? null }:
-with lib;
 
 mkCoqDerivation {
   pname = "aac-tactics";
@@ -21,7 +20,7 @@ mkCoqDerivation {
   release."8.5.0".sha256 = "sha256-7yNxJn6CH5xS5w/zsXfcZYORa6e5/qS9v8PUq2o02h4=";
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = "8.16"; out = "8.16.0"; }
     { case = "8.15"; out = "8.15.1"; }
     { case = "8.14"; out = "8.14.1"; }
@@ -37,7 +36,7 @@ mkCoqDerivation {
 
   mlPlugin = true;
 
-  meta = {
+  meta = with lib; {
     description = "Coq plugin providing tactics for rewriting universally quantified equations";
     longDescription = ''
       This Coq plugin provides tactics for rewriting universally quantified

--- a/pkgs/development/coq-modules/addition-chains/default.nix
+++ b/pkgs/development/coq-modules/addition-chains/default.nix
@@ -1,6 +1,5 @@
 { lib, mkCoqDerivation, coq, mathcomp-ssreflect, mathcomp-algebra, mathcomp-fingroup, paramcoq
 , version ? null }:
-with lib;
 
 mkCoqDerivation {
   pname = "addition-chains";
@@ -12,7 +11,7 @@ mkCoqDerivation {
   releaseRev = (v: "v${v}");
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.13" "8.16"; out = "0.6"; }
     { case = range "8.11" "8.12"; out = "0.4"; }
   ] null;
@@ -21,7 +20,7 @@ mkCoqDerivation {
 
   useDune = true;
 
-  meta = {
+  meta = with lib; {
     description = "Exponentiation algorithms following addition chains";
     longDescription = ''
       Addition chains are algorithms for computations of the p-th

--- a/pkgs/development/coq-modules/autosubst/default.nix
+++ b/pkgs/development/coq-modules/autosubst/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, coq, mathcomp-ssreflect, version ? null }:
-with lib;
 
 mkCoqDerivation {
   pname = "autosubst";
@@ -8,13 +7,13 @@ mkCoqDerivation {
   release."1.7".sha256 = "sha256-qoyteQ5W2Noxf12uACOVeHhPLvgmTzrvEo6Ts+FKTGI=";
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.10" "8.16"; out = "1.7"; }
   ] null;
 
   propagatedBuildInputs = [ mathcomp-ssreflect ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://www.ps.uni-saarland.de/autosubst/";
     description = "Automation for de Bruijn syntax and substitution in Coq";
     maintainers = with maintainers; [ siraben jwiegley ];

--- a/pkgs/development/coq-modules/bignums/default.nix
+++ b/pkgs/development/coq-modules/bignums/default.nix
@@ -1,11 +1,11 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "bignums";
   owner = "coq";
   displayVersion = { bignums = ""; };
   inherit version;
-  defaultVersion = if versions.isGe "8.6" coq.coq-version
+  defaultVersion = if lib.versions.isGe "8.6" coq.coq-version
     then "${coq.coq-version}.0" else null;
 
   release."8.17.0".sha256 = "sha256-MXYjqN86+3O4hT2ql62U83T5H03E/8ysH8erpvC/oyw=";
@@ -25,5 +25,5 @@ with lib; mkCoqDerivation {
 
   mlPlugin = true;
 
-  meta = { license = licenses.lgpl2; };
+  meta = { license = lib.licenses.lgpl2; };
 }

--- a/pkgs/development/coq-modules/category-theory/default.nix
+++ b/pkgs/development/coq-modules/category-theory/default.nix
@@ -1,6 +1,6 @@
 { lib, mkCoqDerivation, coq, ssreflect, equations, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
 
   pname = "category-theory";
   owner = "jwiegley";
@@ -16,7 +16,7 @@ with lib; mkCoqDerivation {
   release."20180709".sha256 = "0f2nr8dgn1ab7hr7jrdmr1zla9g9h8216q4yf4wnff9qkln8sbbs";
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.14" "8.16"; out = "1.0.0"; }
     { case = range "8.10" "8.15"; out = "20211213"; }
     { case = range "8.8" "8.9"; out = "20190414"; }
@@ -28,6 +28,6 @@ with lib; mkCoqDerivation {
 
   meta = {
     description = "A formalization of category theory in Coq for personal study and practical work";
-    maintainers = with maintainers; [ jwiegley ];
+    maintainers = with lib.maintainers; [ jwiegley ];
   };
 }

--- a/pkgs/development/coq-modules/ceres/default.nix
+++ b/pkgs/development/coq-modules/ceres/default.nix
@@ -1,6 +1,5 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib;
 mkCoqDerivation {
 
   pname = "ceres";
@@ -8,10 +7,10 @@ mkCoqDerivation {
   owner = "Lysxia";
 
   inherit version;
-  defaultVersion = if versions.range "8.8" "8.16" coq.version then "0.4.0" else null;
+  defaultVersion = if lib.versions.range "8.8" "8.16" coq.version then "0.4.0" else null;
   release."0.4.0".sha256 = "sha256:0zwp3pn6fdj0qdig734zdczrls886al06mxqhhabms0jvvqijmbi";
 
-  meta = {
+  meta = with lib; {
     description = "Library for serialization to S-expressions";
     license = licenses.mit;
     maintainers = with maintainers; [ Zimmi48 ];

--- a/pkgs/development/coq-modules/compcert/default.nix
+++ b/pkgs/development/coq-modules/compcert/default.nix
@@ -5,8 +5,6 @@
 , version ? null
 }:
 
-with lib;
-
 let compcert = mkCoqDerivation rec {
 
   pname = "compcert";
@@ -15,7 +13,7 @@ let compcert = mkCoqDerivation rec {
   inherit version;
   releaseRev = v: "v${v}";
 
-  defaultVersion =  with versions; switch coq.version [
+  defaultVersion =  with lib.versions; lib.switch coq.version [
       { case = range "8.14" "8.16"; out = "3.11"; }
       { case = isEq "8.13"        ; out = "3.10"; }
       { case = isEq "8.12"       ; out = "3.9"; }
@@ -84,7 +82,7 @@ let compcert = mkCoqDerivation rec {
 }; in
 compcert.overrideAttrs (o:
   {
-    patches = with versions; switch [ coq.version o.version ] [
+    patches = with lib.versions; lib.switch [ coq.version o.version ] [
       { cases = [ (range "8.12.2" "8.13.2") "3.8" ];
         out = [
           # Support for Coq 8.12.2

--- a/pkgs/development/coq-modules/contribs/default.nix
+++ b/pkgs/development/coq-modules/contribs/default.nix
@@ -1,16 +1,16 @@
 { lib, mkCoqDerivation, coq, callPackage }:
 
-with lib; let mkContrib = pname: coqs: param:
+  let mkContrib = pname: coqs: param:
   let contribVersion = {version ? null}: mkCoqDerivation ({
       inherit pname version;
       owner = "coq-contribs";
       mlPlugin = true;
-    } // optionalAttrs (builtins.elem coq.coq-version coqs) ({
+    } // lib.optionalAttrs (builtins.elem coq.coq-version coqs) ({
       defaultVersion = param.version;
       release = { "${param.version}" = { inherit (param) rev sha256; }; };
     } // (removeAttrs param [ "version" "rev" "sha256" ]))
   ); in
-  makeOverridable contribVersion {} ; in
+  lib.makeOverridable contribVersion {} ; in
 {
   aac-tactics = mkContrib "aac-tactics" [ "8.7" "8.8" ] {
     "8.7" = {

--- a/pkgs/development/coq-modules/coq-bits/default.nix
+++ b/pkgs/development/coq-modules/coq-bits/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, mathcomp-algebra, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "coq-bits";
   repo = "bits";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.10" "8.16"; out = "1.1.0"; }
     { case = range "8.7"  "8.15"; out = "1.0.0"; }
   ] null;
@@ -14,7 +14,7 @@ with lib; mkCoqDerivation {
 
   propagatedBuildInputs = [ mathcomp-algebra ];
 
-  meta = {
+  meta = with lib; {
     description = "A formalization of bitset operations in Coq";
     license = licenses.asl20;
     maintainers = with maintainers; [ ptival ];

--- a/pkgs/development/coq-modules/coq-ext-lib/default.nix
+++ b/pkgs/development/coq-modules/coq-ext-lib/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib; mkCoqDerivation rec {
+mkCoqDerivation rec {
   pname = "coq-ext-lib";
   owner = "coq-ext-lib";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.11" "8.16"; out = "0.11.7"; }
     { case = range "8.8" "8.16"; out = "0.11.6"; }
     { case = range "8.8" "8.14"; out = "0.11.4"; }
@@ -30,6 +30,6 @@ with lib; mkCoqDerivation rec {
 
   meta = {
     description = "A collection of theories and plugins that may be useful in other Coq developments";
-    maintainers = with maintainers; [ jwiegley ptival ];
+    maintainers = with lib.maintainers; [ jwiegley ptival ];
   };
 }

--- a/pkgs/development/coq-modules/coq-haskell/default.nix
+++ b/pkgs/development/coq-modules/coq-haskell/default.nix
@@ -1,11 +1,11 @@
 { lib, mkCoqDerivation, coq, ssreflect, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
 
   pname = "coq-haskell";
   owner = "jwiegley";
   inherit version;
-  defaultVersion = if versions.range "8.5" "8.8" coq.coq-version then "20171215" else null;
+  defaultVersion = if lib.versions.range "8.5" "8.8" coq.coq-version then "20171215" else null;
   release."20171215".rev    = "e2cf8b270c2efa3b56fab1ef6acc376c2c3de968";
   release."20171215".sha256 = "09dq1vvshhlhgjccrhqgbhnq2hrys15xryfszqq11rzpgvl2zgdv";
 
@@ -16,6 +16,6 @@ with lib; mkCoqDerivation {
 
   meta = {
     description = "A library for formalizing Haskell types and functions in Coq";
-    maintainers = with maintainers; [ jwiegley ];
+    maintainers = with lib.maintainers; [ jwiegley ];
   };
 }

--- a/pkgs/development/coq-modules/coq-record-update/default.nix
+++ b/pkgs/development/coq-modules/coq-record-update/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib; mkCoqDerivation rec {
+ mkCoqDerivation rec {
   pname = "coq-record-update";
   owner = "tchajed";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.10" "8.16";  out = "0.3.1"; }
   ] null;
   release."0.3.1".sha256 = "sha256-DyGxO2tqmYZZluXN6Oy5Tw6fuLMyuyxonj8CCToWKkk=";
@@ -13,6 +13,6 @@ with lib; mkCoqDerivation rec {
   buildFlags = [ "NO_TEST=1" ];
   meta = {
     description = "Library to create Coq record update functions";
-    maintainers = with maintainers; [ ineol ];
+    maintainers = with lib.maintainers; [ ineol ];
   };
 }

--- a/pkgs/development/coq-modules/coqeal/default.nix
+++ b/pkgs/development/coq-modules/coqeal/default.nix
@@ -2,14 +2,12 @@
   mathcomp-real-closed,
   lib, version ? null }:
 
-with lib;
-
 (mkCoqDerivation {
 
   pname = "CoqEAL";
 
   inherit version;
-  defaultVersion = with versions; switch [ coq.version mathcomp.version ]  [
+  defaultVersion = with lib.versions; lib.switch [ coq.version mathcomp.version ]  [
       { cases = [ (range "8.13" "8.16") (isGe "1.13.0") ]; out = "1.1.1"; }
       { cases = [ (range "8.10" "8.15") (isGe "1.12.0") ]; out = "1.1.0"; }
       { cases = [ (isGe "8.10") (range "1.11.0" "1.12.0") ]; out = "1.0.5"; }
@@ -28,9 +26,9 @@ with lib;
 
   meta = {
     description = "CoqEAL - The Coq Effective Algebra Library";
-    license = licenses.mit;
+    license = lib.licenses.mit;
   };
 }).overrideAttrs (o: {
   propagatedBuildInputs = o.propagatedBuildInputs
-  ++ optional (versions.isGe "1.1" o.version || o.version == "dev") mathcomp-real-closed;
+  ++ lib.optional (lib.versions.isGe "1.1" o.version || o.version == "dev") mathcomp-real-closed;
 })

--- a/pkgs/development/coq-modules/coqhammer/default.nix
+++ b/pkgs/development/coq-modules/coqhammer/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   inherit version;
   pname = "coqhammer";
   owner = "lukaszcz";
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = "8.15"; out = "1.3.2-coq8.15"; }
     { case = "8.14"; out = "1.3.2-coq8.14"; }
     { case = "8.13"; out = "1.3.2-coq8.13"; }
@@ -57,7 +57,7 @@ with lib; mkCoqDerivation {
 
   mlPlugin = true;
 
-  meta = {
+  meta = with lib; {
     homepage = "http://cl-informatik.uibk.ac.at/cek/coqhammer/";
     description = "Automation for Dependent Type Theory";
     license = licenses.lgpl21;

--- a/pkgs/development/coq-modules/coqide/default.nix
+++ b/pkgs/development/coq-modules/coqide/default.nix
@@ -8,14 +8,14 @@
 , coq
 , version ? null }:
 
-with lib; mkCoqDerivation rec {
+mkCoqDerivation rec {
   pname = "coqide";
   inherit version;
 
   inherit (coq) src;
   release."${coq.version}" = {};
 
-  defaultVersion = if versions.isGe "8.14" coq.version then coq.version else null;
+  defaultVersion = if lib.versions.isGe "8.14" coq.version then coq.version else null;
 
   preConfigure = ''
     patchShebangs dev/tools/

--- a/pkgs/development/coq-modules/coqprime/default.nix
+++ b/pkgs/development/coq-modules/coqprime/default.nix
@@ -1,11 +1,11 @@
 { which, lib, mkCoqDerivation, coq, bignums, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
 
   pname = "coqprime";
   owner = "thery";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.12" "8.16"; out = "8.15"; }
     { case = range "8.10" "8.11"; out = "8.10"; }
     { case = range "8.8"  "8.9";  out = "8.8"; }

--- a/pkgs/development/coq-modules/coqtail-math/default.nix
+++ b/pkgs/development/coq-modules/coqtail-math/default.nix
@@ -1,12 +1,10 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib;
-
 mkCoqDerivation {
   pname = "coqtail-math";
   owner = "coq-community";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.11" "8.15"; out = "8.14"; }
     { case = range "8.11" "8.13"; out = "20201124"; }
   ] null;
@@ -15,7 +13,7 @@ mkCoqDerivation {
   release."20201124".rev    = "5c22c3d7dcd8cf4c47cf84a281780f5915488e9e";
   release."20201124".sha256 = "sha256-wd+Lh7dpAD4zfpyKuztDmSFEZo5ZiFrR8ti2jUCVvoQ=";
   mlPlugin = true;
-  meta = {
+  meta = with lib; {
     license = licenses.lgpl3Only;
     maintainers = [ maintainers.siraben ];
   };

--- a/pkgs/development/coq-modules/coquelicot/default.nix
+++ b/pkgs/development/coq-modules/coquelicot/default.nix
@@ -1,12 +1,12 @@
 { lib, mkCoqDerivation, autoconf,
   coq, ssreflect, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "coquelicot";
   owner = "coquelicot";
   domain = "gitlab.inria.fr";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.8" "8.16"; out = "3.2.0"; }
     { case = range "8.8" "8.13"; out = "3.1.0"; }
     { case = range "8.5" "8.9";  out = "3.0.2"; }
@@ -20,7 +20,7 @@ with lib; mkCoqDerivation {
   propagatedBuildInputs = [ ssreflect ];
   useMelquiondRemake.logpath = "Coquelicot";
 
-  meta = {
+  meta =  with lib; {
     homepage = "http://coquelicot.saclay.inria.fr/";
     description = "A Coq library for Reals";
     license = licenses.lgpl3;

--- a/pkgs/development/coq-modules/corn/default.nix
+++ b/pkgs/development/coq-modules/corn/default.nix
@@ -1,9 +1,9 @@
 { lib, mkCoqDerivation, coq, bignums, math-classes, version ? null }:
 
-with lib; mkCoqDerivation rec {
+mkCoqDerivation rec {
   pname = "corn";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = "8.6"; out = "8.8.1"; }
     { case = (range "8.11" "8.16"); out = "8.16.0"; }
     { case = (range "8.7"  "8.15"); out = "8.13.0"; }
@@ -21,7 +21,7 @@ with lib; mkCoqDerivation rec {
 
   propagatedBuildInputs = [ bignums math-classes ];
 
-  meta = {
+  meta =  with lib; {
     homepage = "http://c-corn.github.io/";
     license = licenses.gpl2;
     description = "A Coq library for constructive analysis";

--- a/pkgs/development/coq-modules/deriving/default.nix
+++ b/pkgs/development/coq-modules/deriving/default.nix
@@ -1,14 +1,13 @@
 { lib, mkCoqDerivation, coq, version ? null
 , ssreflect
 }:
-with lib;
 
 mkCoqDerivation {
   pname = "deriving";
   owner = "arthuraa";
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.11" "8.16"; out = "0.1.0"; }
   ] null;
 
@@ -20,7 +19,7 @@ mkCoqDerivation {
 
   mlPlugin = true;
 
-  meta = {
+  meta = with lib; {
     description = "Generic instances of MathComp classes";
     license = licenses.mit;
     maintainers = [ maintainers.vbgl ];

--- a/pkgs/development/coq-modules/dpdgraph/default.nix
+++ b/pkgs/development/coq-modules/dpdgraph/default.nix
@@ -1,14 +1,13 @@
 { lib, mkCoqDerivation, autoreconfHook, coq, version ? null }:
 
-with lib;
-let hasWarning = versionAtLeast coq.ocamlPackages.ocaml.version "4.08"; in
+let hasWarning = lib.versionAtLeast coq.ocamlPackages.ocaml.version "4.08"; in
 
 mkCoqDerivation {
   pname = "dpdgraph";
   owner = "Karmaki";
   repo = "coq-dpdgraph";
   inherit version;
-  defaultVersion = switch coq.coq-version [
+  defaultVersion = lib.switch coq.coq-version [
     { case = "8.16"; out = "1.0+8.16"; }
     { case = "8.15"; out = "1.0+8.15"; }
     { case = "8.14"; out = "1.0+8.14"; }
@@ -47,11 +46,11 @@ mkCoqDerivation {
 
   # dpd_compute.ml uses deprecated Pervasives.compare
   # Versions prior to 0.6.5 do not have the WARN_ERR build flag
-  preConfigure = optionalString hasWarning ''
+  preConfigure = lib.optionalString hasWarning ''
     substituteInPlace Makefile.in --replace "-warn-error +a " ""
   '';
 
-  buildFlags = optional hasWarning "WARN_ERR=";
+  buildFlags = lib.optional hasWarning "WARN_ERR=";
 
   preInstall = ''
     mkdir -p $out/bin
@@ -59,7 +58,7 @@ mkCoqDerivation {
 
   extraInstallFlags = [ "BINDIR=$(out)/bin" ];
 
-  meta = {
+  meta = with lib; {
     description = "Build dependency graphs between Coq objects";
     license = licenses.lgpl21;
     maintainers = with maintainers; [ vbgl ];

--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -1,11 +1,11 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib; (mkCoqDerivation {
+(mkCoqDerivation {
   pname = "equations";
   owner = "mattam82";
   repo = "Coq-Equations";
   inherit version;
-  defaultVersion = switch coq.coq-version [
+  defaultVersion = lib.switch coq.coq-version [
     { case = "8.16"; out = "1.3+8.16"; }
     { case = "8.15"; out = "1.3+8.15"; }
     { case = "8.14"; out = "1.3+8.14"; }
@@ -57,11 +57,11 @@ with lib; (mkCoqDerivation {
 
   mlPlugin = true;
 
-  meta = {
+  meta = with lib; {
     homepage = "https://mattam82.github.io/Coq-Equations/";
     description = "A plugin for Coq to add dependent pattern-matching";
     maintainers = with maintainers; [ jwiegley ];
   };
 }).overrideAttrs (o: {
-  preBuild = "coq_makefile -f _CoqProject -o Makefile${optionalString (versionAtLeast o.version "1.2.1" || o.version == "dev") ".coq"}";
+  preBuild = "coq_makefile -f _CoqProject -o Makefile${lib.optionalString (lib.versionAtLeast o.version "1.2.1" || o.version == "dev") ".coq"}";
 })

--- a/pkgs/development/coq-modules/extructures/default.nix
+++ b/pkgs/development/coq-modules/extructures/default.nix
@@ -2,14 +2,13 @@
 , ssreflect
 , deriving
 }:
-with lib;
 
 (mkCoqDerivation {
   pname = "extructures";
   owner = "arthuraa";
 
   inherit version;
-  defaultVersion = with versions; switch [coq.coq-version ssreflect.version] [
+  defaultVersion = with lib.versions; lib.switch [coq.coq-version ssreflect.version] [
     { cases = [(range "8.11" "8.16") (isGe "1.12.0") ]; out = "0.3.1"; }
     { cases = [(range "8.11" "8.14") (isLe "1.12.0") ]; out = "0.3.0"; }
     { cases = [(range "8.10" "8.12") (isLe "1.12.0") ]; out = "0.2.2"; }
@@ -23,7 +22,7 @@ with lib;
 
   propagatedBuildInputs = [ ssreflect ];
 
-  meta = {
+  meta = with lib; {
     description = "Finite data structures with extensional reasoning";
     license = licenses.mit;
     maintainers = [ maintainers.vbgl ];
@@ -31,5 +30,5 @@ with lib;
 
 }).overrideAttrs (o: {
   propagatedBuildInputs = o.propagatedBuildInputs
-  ++ optional (versionAtLeast o.version "0.3.0") deriving;
+  ++ lib.optional (lib.versionAtLeast o.version "0.3.0") deriving;
 })

--- a/pkgs/development/coq-modules/fiat/HEAD.nix
+++ b/pkgs/development/coq-modules/fiat/HEAD.nix
@@ -1,6 +1,6 @@
 {lib, mkCoqDerivation, coq, python27, version ? null }:
 
-with lib; mkCoqDerivation rec {
+mkCoqDerivation rec {
   pname = "fiat";
   owner = "mit-plv";
   repo = "fiat";
@@ -29,6 +29,6 @@ with lib; mkCoqDerivation rec {
   meta = {
     homepage = "http://plv.csail.mit.edu/fiat/";
     description = "A library for the Coq proof assistant for synthesizing efficient correct-by-construction programs from declarative specifications";
-    maintainers = with maintainers; [ jwiegley ];
+    maintainers = with lib.maintainers; [ jwiegley ];
   };
 }

--- a/pkgs/development/coq-modules/flocq/default.nix
+++ b/pkgs/development/coq-modules/flocq/default.nix
@@ -1,12 +1,12 @@
 { lib, bash, autoconf, automake,
   mkCoqDerivation, coq, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "flocq";
   owner = "flocq";
   domain = "gitlab.inria.fr";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.14" "8.16"; out = "4.1.0"; }
     { case = range "8.7" "8.15"; out = "3.4.3"; }
     { case = range "8.5" "8.8"; out = "2.6.1"; }
@@ -22,7 +22,7 @@ with lib; mkCoqDerivation {
   mlPlugin = true;
   useMelquiondRemake.logpath = "Flocq";
 
-  meta = {
+  meta = with lib; {
     description = "A floating-point formalization for the Coq system";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ jwiegley ];

--- a/pkgs/development/coq-modules/fourcolor/default.nix
+++ b/pkgs/development/coq-modules/fourcolor/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, coq, mathcomp, version ? null }:
-with lib;
 
 mkCoqDerivation {
   pname = "fourcolor";
@@ -12,15 +11,15 @@ mkCoqDerivation {
   release."1.2.5".sha256 = "sha256-3qOPNCRjGK2UdHGMSqElpIXhAPVCklpeQgZwf9AFals=";
 
   inherit version;
-  defaultVersion = with versions; switch [ coq.version mathcomp.version ] [
+  defaultVersion = with lib.versions; lib.switch [ coq.version mathcomp.version ] [
     { cases = [ (isGe "8.11") (isGe "1.12") ]; out = "1.2.5"; }
     { cases = [ (isGe "8.11") (range "1.11" "1.14") ]; out = "1.2.4"; }
-    { cases = [ (isLe "8.13") (pred.inter (isGe "1.11.0") (isLt "1.13")) ]; out = "1.2.3"; }
+    { cases = [ (isLe "8.13") (lib.pred.inter (isGe "1.11.0") (isLt "1.13")) ]; out = "1.2.3"; }
   ] null;
 
   propagatedBuildInputs = [ mathcomp.algebra mathcomp.ssreflect mathcomp.fingroup ];
 
-  meta = {
+  meta =  with lib; {
     description = "Formal proof of the Four Color Theorem ";
     maintainers = with maintainers; [ siraben ];
     license = licenses.cecill-b;

--- a/pkgs/development/coq-modules/gaia-hydras/default.nix
+++ b/pkgs/development/coq-modules/gaia-hydras/default.nix
@@ -1,7 +1,7 @@
 { lib, mkCoqDerivation, coq, hydra-battles, gaia,
   mathcomp-zify, mathcomp, version ? null }:
 
-with lib; mkCoqDerivation rec {
+mkCoqDerivation rec {
   pname = "gaia-hydras";
   repo = "hydra-battles";
 
@@ -10,7 +10,7 @@ with lib; mkCoqDerivation rec {
   releaseRev = (v: "v${v}");
 
   inherit version;
-  defaultVersion = with versions; switch [coq.coq-version mathcomp.version] [
+  defaultVersion = with lib.versions; lib.switch [coq.coq-version mathcomp.version] [
     { cases = [ (range "8.14" "8.16") (isGe "1.12.0") ]; out = "0.6"; }
     { cases = [ (range "8.13" "8.14") (isGe "1.12.0") ]; out = "0.5"; }
   ] null;
@@ -23,7 +23,7 @@ with lib; mkCoqDerivation rec {
 
   useDune = true;
 
-  meta = {
+  meta = with lib; {
     description = "Comparison between ordinals in Gaia and Hydra battles";
     longDescription = ''
       The Gaia and Hydra battles projects develop different notions of ordinals.

--- a/pkgs/development/coq-modules/gaia/default.nix
+++ b/pkgs/development/coq-modules/gaia/default.nix
@@ -1,6 +1,6 @@
 { lib, mkCoqDerivation, coq, mathcomp, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "gaia";
 
   release."1.11".sha256 = "sha256:0gwb0blf37sv9gb0qpn34dab71zdcx7jsnqm3j9p58qw65cgsqn5";
@@ -11,7 +11,7 @@ with lib; mkCoqDerivation {
   releaseRev = (v: "v${v}");
 
   inherit version;
-  defaultVersion = with versions; switch [ coq.version mathcomp.version ] [
+  defaultVersion = with lib.versions; lib.switch [ coq.version mathcomp.version ] [
     { cases = [ (range "8.10" "8.16") (isGe "1.12.0") ]; out = "1.15"; }
     { cases = [ (range "8.10" "8.12") "1.11.0" ]; out = "1.11"; }
   ] null;
@@ -19,7 +19,7 @@ with lib; mkCoqDerivation {
   propagatedBuildInputs =
     [ mathcomp.ssreflect mathcomp.algebra mathcomp.fingroup ];
 
-  meta = {
+  meta = with lib; {
     description = "Implementation of books from Bourbaki's Elements of Mathematics in Coq";
     maintainers = with maintainers; [ Zimmi48 ];
     license = licenses.mit;

--- a/pkgs/development/coq-modules/gappalib/default.nix
+++ b/pkgs/development/coq-modules/gappalib/default.nix
@@ -1,12 +1,12 @@
 { which, lib, mkCoqDerivation, autoconf, coq, flocq, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "gappalib";
   repo = "coq";
   owner = "gappa";
   domain = "gitlab.inria.fr";
   inherit version;
-  defaultVersion = if versions.range "8.8" "8.16" coq.coq-version then "1.5.2" else null;
+  defaultVersion = if lib.versions.range "8.8" "8.16" coq.coq-version then "1.5.2" else null;
   release."1.5.2".sha256 = "sha256-A021Bhqz5r2CZBayfjIiWrCIfUlejcQAfbTmOaf6QTM=";
   release."1.5.1".sha256 = "1806bq1z6q5rq2ma7d5kfbqfyfr755hjg0dq7b2llry8fx9cxjsg";
   release."1.5.0".sha256 = "1i1c0gakffxqqqqw064cbvc243yl325hxd50jmczr6mk18igk41n";
@@ -19,7 +19,7 @@ with lib; mkCoqDerivation {
   propagatedBuildInputs = [ flocq ];
   useMelquiondRemake.logpath = "Gappa";
 
-  meta = {
+  meta = with lib; {
     description = "Coq support library for Gappa";
     license = licenses.lgpl21;
     maintainers = [ maintainers.vbgl ];

--- a/pkgs/development/coq-modules/goedel/default.nix
+++ b/pkgs/development/coq-modules/goedel/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, coq, hydra-battles, pocklington, version ? null }:
-with lib;
 
 mkCoqDerivation {
   pname = "goedel";
@@ -11,13 +10,13 @@ mkCoqDerivation {
   release."8.13.0".sha256 = "0sqqkmj6wsk4xmhrnqkhcsbsrqjzn2gnk67nqzgrmjpw5danz8y5";
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.11" "8.16"; out = "8.13.0"; }
   ] null;
 
   propagatedBuildInputs = [ hydra-battles pocklington ];
 
-  meta = {
+  meta = with lib; {
     description = "The Gödel-Rosser 1st incompleteness theorem in Coq";
     maintainers = with maintainers; [ siraben ];
     license = licenses.mit;

--- a/pkgs/development/coq-modules/graph-theory/default.nix
+++ b/pkgs/development/coq-modules/graph-theory/default.nix
@@ -1,8 +1,6 @@
 { lib, mkCoqDerivation, coq, mathcomp-algebra, mathcomp-finmap, mathcomp-fingroup
 , hierarchy-builder, version ? null }:
 
-with lib;
-
 mkCoqDerivation {
   pname = "graph-theory";
 
@@ -11,13 +9,13 @@ mkCoqDerivation {
   releaseRev = v: "v${v}";
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.13" "8.16"; out = "0.9"; }
   ] null;
 
   propagatedBuildInputs = [ mathcomp-algebra mathcomp-finmap mathcomp-fingroup hierarchy-builder ];
 
-  meta = {
+  meta = with lib; {
     description = "Library of formalized graph theory results in Coq";
     longDescription = ''
       A library of formalized graph theory results, including various

--- a/pkgs/development/coq-modules/heq/default.nix
+++ b/pkgs/development/coq-modules/heq/default.nix
@@ -5,13 +5,13 @@ let fetcher = {rev, repo, owner, sha256, domain, ...}:
     url = "https://${domain}/${owner}/${repo}/download/${repo}-${rev}.zip";
     inherit sha256;
    }; in
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "heq";
   repo = "Heq";
   owner = "gil.hur";
   domain = "sf.snu.ac.kr";
   inherit version fetcher;
-  defaultVersion = if versions.isLt "8.8" coq.coq-version then "0.92" else null;
+  defaultVersion = if lib.versions.isLt "8.8" coq.coq-version then "0.92" else null;
   release."0.92".sha256 = "0cf8y6728n81wwlbpq3vi7l2dbzi7759klypld4gpsjjp1y1fj74";
 
   mlPlugin = true;
@@ -22,6 +22,6 @@ with lib; mkCoqDerivation {
   meta = {
     homepage = "https://ropas.snu.ac.kr/~gil.hur/Heq/";
     description = "Heq : a Coq library for Heterogeneous Equality";
-    maintainers = with maintainers; [ jwiegley ];
+    maintainers = with lib.maintainers; [ jwiegley ];
   };
 }

--- a/pkgs/development/coq-modules/hierarchy-builder/default.nix
+++ b/pkgs/development/coq-modules/hierarchy-builder/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, coq-elpi, version ? null }:
 
-with lib; let hb = mkCoqDerivation {
+let hb = mkCoqDerivation {
   pname = "hierarchy-builder";
   owner = "math-comp";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.15" "8.16"; out = "1.4.0"; }
     { case = range "8.13" "8.14"; out = "1.2.0"; }
     { case = range "8.12" "8.13"; out = "1.1.0"; }
@@ -25,16 +25,16 @@ with lib; let hb = mkCoqDerivation {
 
   extraInstallFlags = [ "VFILES=structures.v" ];
 
-  meta = {
+  meta = with lib; {
     description = "High level commands to declare a hierarchy based on packed classes";
     maintainers = with maintainers; [ cohencyril siraben ];
     license = licenses.mit;
   };
 }; in
 hb.overrideAttrs (o:
-  optionalAttrs (versions.isGe "1.2.0" o.version || o.version == "dev")
+  lib.optionalAttrs (lib.versions.isGe "1.2.0" o.version || o.version == "dev")
     { buildPhase = "make build"; }
   //
-  optionalAttrs (versions.isGe "1.1.0" o.version || o.version == "dev")
+  lib.optionalAttrs (lib.versions.isGe "1.1.0" o.version || o.version == "dev")
   { installFlags = [ "DESTDIR=$(out)" ] ++ o.installFlags; }
 )

--- a/pkgs/development/coq-modules/hydra-battles/default.nix
+++ b/pkgs/development/coq-modules/hydra-battles/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, coq, equations, LibHyps, version ? null }:
-with lib;
 
 (mkCoqDerivation {
   pname = "hydra-battles";
@@ -11,14 +10,14 @@ with lib;
   releaseRev = (v: "v${v}");
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.13" "8.16"; out = "0.6"; }
     { case = range "8.11" "8.12"; out = "0.4"; }
   ] null;
 
   useDune = true;
 
-  meta = {
+  meta = with lib; {
     description = "Exploration of some properties of Kirby and Paris' hydra battles, with the help of Coq";
     longDescription = ''
       An exploration of some properties of Kirby and Paris' hydra
@@ -33,5 +32,5 @@ with lib;
   };
 }).overrideAttrs(o:
   let inherit (o) version; in {
-    propagatedBuildInputs = [ equations ] ++ optional (versions.isGe "0.6" version || version == "dev") LibHyps;
+    propagatedBuildInputs = [ equations ] ++ lib.optional (lib.versions.isGe "0.6" version || version == "dev") LibHyps;
   })

--- a/pkgs/development/coq-modules/iris/default.nix
+++ b/pkgs/development/coq-modules/iris/default.nix
@@ -1,11 +1,11 @@
 { lib, mkCoqDerivation, coq, stdpp, version ? null }:
 
-with lib; mkCoqDerivation rec {
+mkCoqDerivation rec {
   pname = "iris";
   domain = "gitlab.mpi-sws.org";
   owner = "iris";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.13" "8.16"; out = "4.0.0"; }
     { case = range "8.12" "8.14"; out = "3.5.0"; }
     { case = range "8.11" "8.13"; out = "3.4.0"; }
@@ -26,7 +26,7 @@ with lib; mkCoqDerivation rec {
     fi
   '';
 
-  meta = {
+  meta = with lib; {
     description = "The Coq development of the Iris Project";
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];

--- a/pkgs/development/coq-modules/itauto/default.nix
+++ b/pkgs/development/coq-modules/itauto/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, coq, version ? null }:
-with lib;
 
 mkCoqDerivation rec {
   pname = "itauto";
@@ -11,7 +10,7 @@ mkCoqDerivation rec {
   release."8.14.0".sha256 = "sha256:1k6pqhv4dwpkwg81f2rlfg40wh070ks1gy9r0ravm2zhsbxqcfc9";
   release."8.13+no".sha256 = "sha256-gXoxtLcHPoyjJkt7WqvzfCMCQlh6kL2KtCGe3N6RC/A=";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = isEq "8.16"; out = "8.16.0"; }
     { case = isEq "8.15"; out = "8.15.0"; }
     { case = isEq "8.14"; out = "8.14.0"; }
@@ -22,7 +21,7 @@ mkCoqDerivation rec {
   nativeBuildInputs = (with coq.ocamlPackages; [ ocamlbuild ]);
   enableParallelBuilding = false;
 
-  meta = {
+  meta =  with lib; {
     description = "A reflexive SAT solver parameterised by a leaf tactic and Nelson-Oppen support";
     maintainers = with maintainers; [ siraben ];
     license = licenses.gpl3Plus;

--- a/pkgs/development/coq-modules/ltac2/default.nix
+++ b/pkgs/development/coq-modules/ltac2/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, which, coq, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "ltac2";
   owner = "coq";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = "8.10"; out = "0.3"; }
     { case = "8.9";  out = "0.2"; }
     { case = "8.8";  out = "0.1"; }
@@ -19,7 +19,7 @@ with lib; mkCoqDerivation {
 
   mlPlugin = true;
 
-  meta = {
+  meta = with lib; {
     description = "A robust and expressive tactic language for Coq";
     maintainers = [ maintainers.vbgl ];
     license = licenses.lgpl21;

--- a/pkgs/development/coq-modules/math-classes/default.nix
+++ b/pkgs/development/coq-modules/math-classes/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, bignums, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
 
   pname = "math-classes";
   inherit version;
-  defaultVersion = if versions.range "8.6" "8.16" coq.coq-version then "8.15.0" else null;
+  defaultVersion = if lib.versions.range "8.6" "8.16" coq.coq-version then "8.15.0" else null;
   release."8.12.0".sha256 = "14nd6a08zncrl5yg2gzk0xf4iinwq4hxnsgm4fyv07ydbkxfb425";
   release."8.13.0".sha256 = "1ln7ziivfbxzbdvlhbvyg3v30jgblncmwcsam6gg3d1zz6r7cbby";
   release."8.15.0".sha256 = "10w1hm537k6jx8a8vghq1yx12rsa0sjk2ipv3scgir71ln30hllw";
@@ -14,6 +14,6 @@ with lib; mkCoqDerivation {
   meta = {
     homepage = "https://math-classes.github.io";
     description = "A library of abstract interfaces for mathematical structures in Coq.";
-    maintainers = with maintainers; [ siddharthist jwiegley ];
+    maintainers = with lib.maintainers; [ siddharthist jwiegley ];
   };
 }

--- a/pkgs/development/coq-modules/mathcomp-abel/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-abel/default.nix
@@ -7,7 +7,7 @@ mkCoqDerivation {
   owner = "math-comp";
 
   inherit version;
-  defaultVersion = with lib; with versions; switch [ coq.version mathcomp.version ]  [
+  defaultVersion = with lib; with versions; lib.switch [ coq.version mathcomp.version ]  [
       { cases = [ (range "8.10" "8.16") (range "1.12.0" "1.15.0") ]; out = "1.2.1"; }
       { cases = [ (range "8.10" "8.15") (range "1.12.0" "1.14.0") ]; out = "1.2.0"; }
       { cases = [ (range "8.10" "8.14") (range "1.11.0" "1.12.0") ]; out = "1.1.2"; }

--- a/pkgs/development/coq-modules/mathcomp-algebra-tactics/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-algebra-tactics/default.nix
@@ -1,14 +1,14 @@
 { lib, mkCoqDerivation, coq, mathcomp-algebra,
   coq-elpi, mathcomp-zify, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   namePrefix = [ "coq" "mathcomp" ];
   pname = "algebra-tactics";
   owner = "math-comp";
   inherit version;
 
-  defaultVersion = with versions;
-     switch [ coq.coq-version mathcomp-algebra.version ] [
+  defaultVersion = with lib.versions;
+     lib.switch [ coq.coq-version mathcomp-algebra.version ] [
        { cases = [ (range "8.13" "8.16") (isGe "1.12") ]; out = "1.0.0"; }
      ] null;
 
@@ -18,6 +18,6 @@ with lib; mkCoqDerivation {
 
   meta = {
     description = "Ring and field tactics for Mathematical Components";
-    maintainers = with maintainers; [ cohencyril ];
+    maintainers = with lib.maintainers; [ cohencyril ];
   };
 }

--- a/pkgs/development/coq-modules/mathcomp-analysis/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-analysis/default.nix
@@ -21,7 +21,7 @@ let
   release."0.3.1".sha256 = "1iad288yvrjv8ahl9v18vfblgqb1l5z6ax644w49w9hwxs93f2k8";
   release."0.2.3".sha256 = "0p9mr8g1qma6h10qf7014dv98ln90dfkwn76ynagpww7qap8s966";
 
-  defaultVersion = with versions; switch [ coq.version mathcomp.version ]  [
+  defaultVersion = with versions; lib.switch [ coq.version mathcomp.version ]  [
       { cases = [ (isGe "8.14") (isGe "1.13.0") ];               out = "0.5.3"; }
       { cases = [ (isGe "8.14") (range "1.13" "1.15") ];         out = "0.5.2"; }
       { cases = [ (isGe "8.13") (range "1.13" "1.14") ];         out = "0.5.1"; }
@@ -40,7 +40,7 @@ let
       classical-deps = [ mathcomp.algebra mathcomp-finmap hierarchy-builder ];
       analysis-deps = [ mathcomp.field mathcomp-bigenough ];
       intra-deps = if package == "single" then []
-        else map mathcomp_ (head (splitList (pred.equal package) packages));
+        else map mathcomp_ (head (splitList (lib.pred.equal package) packages));
       pkgpath = if package == "single" then "."
         else if package == "analysis" then "theories" else "${package}";
       pname = if package == "single" then "mathcomp-analysis-single"

--- a/pkgs/development/coq-modules/mathcomp-bigenough/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-bigenough/default.nix
@@ -1,6 +1,6 @@
 { coq, mkCoqDerivation, mathcomp, lib, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
 
   namePrefix = [ "coq" "mathcomp" ];
   pname = "bigenough";
@@ -11,7 +11,7 @@ with lib; mkCoqDerivation {
     "1.0.1".sha256 = "sha256:02f4dv4rz72liciwxb2k7acwx6lgqz4381mqyq5854p3nbyn06aw";
   };
   inherit version;
-  defaultVersion = with versions; switch coq.version [
+  defaultVersion = with lib.versions; lib.switch coq.version [
     { case = range "8.10" "8.16"; out = "1.0.1"; }
     { case = range "8.5"  "8.14"; out = "1.0.0"; }
   ] null;
@@ -20,6 +20,6 @@ with lib; mkCoqDerivation {
 
   meta = {
     description = "A small library to do epsilon - N reasonning";
-    license = licenses.cecill-b;
+    license = lib.licenses.cecill-b;
   };
 }

--- a/pkgs/development/coq-modules/mathcomp-finmap/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-finmap/default.nix
@@ -1,12 +1,12 @@
 { coq, mkCoqDerivation, mathcomp, lib, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
 
   namePrefix = [ "coq" "mathcomp" ];
   pname = "finmap";
   owner = "math-comp";
   inherit version;
-  defaultVersion = with versions; switch [ coq.version mathcomp.version ]  [
+  defaultVersion = with lib.versions; lib.switch [ coq.version mathcomp.version ]  [
       { cases = [ (range "8.13" "8.16")  (isGe "1.12") ];         out = "1.5.2"; }
       { cases = [ (isGe "8.10")          (isGe "1.11") ];         out = "1.5.1"; }
       { cases = [ (range "8.7" "8.11")   "1.11.0" ];              out = "1.5.0"; }
@@ -33,6 +33,6 @@ with lib; mkCoqDerivation {
 
   meta = {
     description = "A finset and finmap library";
-    license = licenses.cecill-b;
+    license = lib.licenses.cecill-b;
   };
 }

--- a/pkgs/development/coq-modules/mathcomp-real-closed/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-real-closed/default.nix
@@ -1,7 +1,7 @@
 { coq, mkCoqDerivation, mathcomp, mathcomp-bigenough,
   lib, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
 
   namePrefix = [ "coq" "mathcomp" ];
   pname = "real-closed";
@@ -17,7 +17,7 @@ with lib; mkCoqDerivation {
     "1.0.1".sha256 = "0j81gkjbza5vg89v4n9z598mfdbql416963rj4b8fzm7dp2r4rxg";
   };
 
-  defaultVersion = with versions; switch [ coq.version mathcomp.version ]  [
+  defaultVersion = with lib.versions; lib.switch [ coq.version mathcomp.version ]  [
       { cases = [ (isGe "8.13")  (isGe "1.12.0") ]; out = "1.1.3"; }
       { cases = [ (isGe "8.10")  (isGe "1.12.0") ]; out = "1.1.2"; }
       { cases = [ (isGe "8.7")   "1.11.0" ]; out = "1.1.1"; }
@@ -37,6 +37,6 @@ with lib; mkCoqDerivation {
 
   meta = {
     description = "Mathematical Components Library on real closed fields";
-    license = licenses.cecill-c;
+    license = lib.licenses.cecill-c;
   };
 }

--- a/pkgs/development/coq-modules/mathcomp-tarjan/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-tarjan/default.nix
@@ -1,14 +1,15 @@
 { coq, mkCoqDerivation, mathcomp-ssreflect, mathcomp-fingroup,
   lib, version ? null }@args:
-with lib; mkCoqDerivation {
+
+mkCoqDerivation {
 
   namePrefix = [ "coq" "mathcomp" ];
   pname = "tarjan";
   owner = "math-comp";
 
   inherit version;
-  defaultVersion = with versions;
-    switch [ coq.version mathcomp-ssreflect.version ] [{
+  defaultVersion = with lib.versions;
+    lib.switch [ coq.version mathcomp-ssreflect.version ] [{
       cases = [ (range "8.10" "8.16") (isGe "1.12.0") ]; out = "1.0.0";
   }] null;
   release."1.0.0".sha256 = "sha256:0r459r0makshzwlygw6kd4lpvdjc43b3x5y9aa8x77f2z5gymjq1";
@@ -17,6 +18,6 @@ with lib; mkCoqDerivation {
 
   meta = {
     description = "Proofs of Tarjan and Kosaraju connected components algorithms";
-    license = licenses.cecill-b;
+    license = lib.licenses.cecill-b;
   };
 }

--- a/pkgs/development/coq-modules/mathcomp-word/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-word/default.nix
@@ -1,6 +1,5 @@
 { coq, mkCoqDerivation, mathcomp, lib, version ? null }:
 
-with lib;
 mkCoqDerivation {
   namePrefix = [ "coq" "mathcomp" ];
   pname = "word";
@@ -15,13 +14,13 @@ mkCoqDerivation {
   release."1.0".sha256 = "sha256:0703m97rnivcbc7vvbd9rl2dxs6l8n52cbykynw61c6w9rhxspcg";
 
   inherit version;
-  defaultVersion = with versions; switch [ coq.version mathcomp.version ] [
+  defaultVersion = with lib.versions; lib.switch [ coq.version mathcomp.version ] [
     { cases = [ (range "8.12" "8.16") (isGe "1.12") ]; out = "2.0"; }
   ] null;
 
   propagatedBuildInputs = [ mathcomp.algebra mathcomp.ssreflect mathcomp.fingroup ];
 
-  meta = {
+  meta = with lib; {
     description = "Yet Another Coq Library on Machine Words";
     maintainers = [ maintainers.vbgl ];
     license = licenses.mit;

--- a/pkgs/development/coq-modules/mathcomp-zify/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-zify/default.nix
@@ -1,14 +1,14 @@
 { lib, mkCoqDerivation, coq, mathcomp-algebra, mathcomp-ssreflect,  mathcomp-fingroup, version ? null }:
 
-with lib; mkCoqDerivation rec {
+mkCoqDerivation rec {
   namePrefix = [ "coq" "mathcomp" ];
   pname = "zify";
   repo = "mczify";
   owner = "math-comp";
   inherit version;
 
-  defaultVersion = with versions;
-     switch [ coq.coq-version mathcomp-algebra.version ] [
+  defaultVersion = with lib.versions;
+     lib.switch [ coq.coq-version mathcomp-algebra.version ] [
        { cases = [ (range "8.13" "8.16") (isGe "1.12") ]; out = "1.1.0+1.12+8.13"; }
      ] null;
 
@@ -19,6 +19,6 @@ with lib; mkCoqDerivation rec {
 
   meta = {
     description = "Micromega tactics for Mathematical Components";
-    maintainers = with maintainers; [ cohencyril ];
+    maintainers = with lib.maintainers; [ cohencyril ];
   };
 }

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -18,7 +18,7 @@ let
   repo  = "math-comp";
   owner = "math-comp";
   withDoc = single && (args.withDoc or false);
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with versions; lib.switch coq.coq-version [
       { case = range "8.14" "8.16"; out = "1.15.0"; }
       { case = range "8.11" "8.15"; out = "1.14.0"; }
       { case = range "8.11" "8.15"; out = "1.13.0"; }
@@ -50,7 +50,7 @@ let
 
   mathcomp_ = package: let
       mathcomp-deps = if package == "single" then []
-        else map mathcomp_ (head (splitList (pred.equal package) packages));
+        else map mathcomp_ (head (splitList (lib.pred.equal package) packages));
       pkgpath = if package == "single" then "mathcomp" else "mathcomp/${package}";
       pname = if package == "single" then "mathcomp" else "mathcomp-${package}";
       pkgallMake = ''

--- a/pkgs/development/coq-modules/metacoq/default.nix
+++ b/pkgs/development/coq-modules/metacoq/default.nix
@@ -5,7 +5,7 @@ with builtins // lib;
 let
   repo  = "metacoq";
   owner = "MetaCoq";
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with versions; lib.switch coq.coq-version [
       { case = "8.11"; out = "1.0-beta2-8.11"; }
       { case = "8.12"; out = "1.0-beta2-8.12"; }
       # Do not provide 8.13 because it does not compile with equations 1.3 provided by default (only 1.2.3)
@@ -34,7 +34,7 @@ let
 
   metacoq_ = package: let
       metacoq-deps = if package == "single" then []
-        else map metacoq_ (head (splitList (pred.equal package) packages));
+        else map metacoq_ (head (splitList (lib.pred.equal package) packages));
       pkgpath = if package == "single" then "./" else "./${package}";
       pname = if package == "all" then "metacoq" else "metacoq-${package}";
       pkgallMake = ''

--- a/pkgs/development/coq-modules/metalib/default.nix
+++ b/pkgs/development/coq-modules/metalib/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "metalib";
   owner = "plclub";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.14" "8.16"; out = "8.15"; }
     { case = range "8.10" "8.13"; out = "8.10"; }
   ] null;
@@ -14,7 +14,7 @@ with lib; mkCoqDerivation {
 
   sourceRoot = "source/Metalib";
 
-  meta = {
+  meta = with lib; {
     license = licenses.mit;
     maintainers = [ maintainers.jwiegley ];
   };

--- a/pkgs/development/coq-modules/multinomials/default.nix
+++ b/pkgs/development/coq-modules/multinomials/default.nix
@@ -1,6 +1,6 @@
 { coq, mkCoqDerivation, mathcomp, mathcomp-finmap, mathcomp-bigenough,
   lib, version ? null, useDune ? false }@args:
-with lib; mkCoqDerivation {
+ mkCoqDerivation {
 
   namePrefix = [ "coq" "mathcomp" ];
   pname = "multinomials";
@@ -8,7 +8,7 @@ with lib; mkCoqDerivation {
   owner = "math-comp";
 
   inherit version;
-  defaultVersion =  with versions; switch [ coq.version mathcomp.version ] [
+  defaultVersion =  with lib.versions; lib.switch [ coq.version mathcomp.version ] [
       { cases = [ (isGe "8.10") (isGe "1.12.0") ];      out = "1.5.5"; }
       { cases = [ (range "8.10" "8.12") "1.12.0" ];             out = "1.5.3"; }
       { cases = [ (range "8.7" "8.12")  "1.11.0" ];             out = "1.5.2"; }
@@ -31,7 +31,7 @@ with lib; mkCoqDerivation {
     "1.0".sha256   = "1qmbxp1h81cy3imh627pznmng0kvv37k4hrwi2faa101s6bcx55m";
   };
 
-  useDuneifVersion = v: versions.isGe "1.5.3" v || v == "dev";
+  useDuneifVersion = v: lib.versions.isGe "1.5.3" v || v == "dev";
 
   preConfigure = ''
     patchShebangs configure || true
@@ -42,7 +42,7 @@ with lib; mkCoqDerivation {
 
   meta = {
     description = "A Coq/SSReflect Library for Monoidal Rings and Multinomials";
-    license = licenses.cecill-c;
+    license = lib.licenses.cecill-c;
   };
 }
-// optionalAttrs (args?useDune) { inherit useDune; }
+// lib.optionalAttrs (args?useDune) { inherit useDune; }

--- a/pkgs/development/coq-modules/odd-order/default.nix
+++ b/pkgs/development/coq-modules/odd-order/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, mathcomp, version ? null }:
-with lib;
 
 mkCoqDerivation {
   pname = "odd-order";
@@ -11,7 +10,7 @@ mkCoqDerivation {
   releaseRev = v: "mathcomp-odd-order.${v}";
 
   inherit version;
-  defaultVersion = with versions; switch mathcomp.character.version [
+  defaultVersion = with lib.versions; lib.switch mathcomp.character.version [
     { case = (range "1.13.0" "1.15.0"); out = "1.14.0"; }
     { case = (range "1.12.0" "1.14.0"); out = "1.13.0"; }
     { case = (range "1.10.0" "1.12.0"); out = "1.12.0"; }
@@ -27,7 +26,7 @@ mkCoqDerivation {
     mathcomp.all
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Formal proof of the Odd Order Theorem";
     maintainers = with maintainers; [ siraben ];
     license = licenses.cecill-b;

--- a/pkgs/development/coq-modules/paco/default.nix
+++ b/pkgs/development/coq-modules/paco/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "paco";
   owner = "snu-sf";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.12" "8.16"; out = "4.1.2"; }
     { case = range "8.9" "8.13"; out = "4.1.1"; }
     { case = range "8.6" "8.13"; out = "4.0.2"; }
@@ -27,6 +27,6 @@ with lib; mkCoqDerivation {
   meta = {
     homepage = "http://plv.mpi-sws.org/paco/";
     description = "A Coq library implementing parameterized coinduction";
-    maintainers = with maintainers; [ jwiegley ptival ];
+    maintainers = with lib.maintainers; [ jwiegley ptival ];
   };
 }

--- a/pkgs/development/coq-modules/paramcoq/default.nix
+++ b/pkgs/development/coq-modules/paramcoq/default.nix
@@ -1,9 +1,9 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "paramcoq";
   inherit version;
-  defaultVersion = with versions; switch coq.version [
+  defaultVersion = with lib.versions; lib.switch coq.version [
     { case = range "8.10" "8.16"; out = "1.1.3+coq${coq.coq-version}"; }
     { case = range "8.7"  "8.13"; out = "1.1.2+coq${coq.coq-version}"; }
   ] null;
@@ -24,7 +24,7 @@ with lib; mkCoqDerivation {
   release."1.1.2+coq8.7".sha256  = "09n0ky7ldb24by7yf5j3hv410h85x50ksilf7qacl7xglj4gy5hj";
   releaseRev = v: "v${v}";
   mlPlugin = true;
-  meta = {
+  meta = with lib; {
     description = "Coq plugin for parametricity";
     license = licenses.mit;
     maintainers = [ maintainers.vbgl ];

--- a/pkgs/development/coq-modules/parsec/default.nix
+++ b/pkgs/development/coq-modules/parsec/default.nix
@@ -1,6 +1,5 @@
 { lib, mkCoqDerivation, coq, ceres, coq-ext-lib, version ? null }:
 
-with lib;
 mkCoqDerivation {
 
   pname = "parsec";
@@ -11,14 +10,14 @@ mkCoqDerivation {
   releaseRev = (v: "v${v}");
 
   inherit version;
-  defaultVersion = with versions; switch coq.version [
+  defaultVersion = with lib.versions; lib.switch coq.version [
     { case = range "8.12" "8.16"; out = "0.1.1"; }
     { case = range "8.12" "8.13"; out = "0.1.0"; }
   ] null;
   release."0.1.1".sha256 = "sha256:1c0l18s68pzd4c8i3jimh2yz0pqm4g38pca4bm7fr18r8xmqf189";
   release."0.1.0".sha256 = "sha256:01avfcqirz2b9wjzi9iywbhz9szybpnnj3672dgkfsimyg9jgnsr";
 
-  meta = {
+  meta = with lib; {
     description = "Library for serialization to S-expressions";
     license = licenses.bsd3;
     maintainers = with maintainers; [ Zimmi48 ];

--- a/pkgs/development/coq-modules/pocklington/default.nix
+++ b/pkgs/development/coq-modules/pocklington/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, coq, version ? null }:
-with lib;
 
 mkCoqDerivation {
   pname = "pocklington";
@@ -9,11 +8,11 @@ mkCoqDerivation {
   release."8.12.0".sha256 = "sha256-0xBrw9+4g14niYdNqp0nx00fPJoSSnaDSDEaIVpPfjs=";
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = isGe "8.7"; out = "8.12.0"; }
   ] null;
 
-  meta = {
+  meta = with lib; {
     description = "Pocklington's criterion for primality in Coq";
     maintainers = with maintainers; [ siraben ];
     license = licenses.mit;

--- a/pkgs/development/coq-modules/reglang/default.nix
+++ b/pkgs/development/coq-modules/reglang/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, coq, ssreflect, version ? null }:
-with lib;
 
 mkCoqDerivation {
   pname = "reglang";
@@ -9,14 +8,14 @@ mkCoqDerivation {
   release."1.1.2".sha256 = "sha256-SEnMilLNxh6a3oiDNGLaBr8quQ/nO2T9Fwdf/1il2Yk=";
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.10" "8.16"; out = "1.1.2"; }
   ] null;
 
 
   propagatedBuildInputs = [ ssreflect ];
 
-  meta = {
+  meta = with lib; {
     description = "Regular Language Representations in Coq";
     maintainers = with maintainers; [ siraben ];
     license = licenses.cecill-b;

--- a/pkgs/development/coq-modules/relation-algebra/default.nix
+++ b/pkgs/development/coq-modules/relation-algebra/default.nix
@@ -1,12 +1,11 @@
 { lib, mkCoqDerivation, coq, aac-tactics, mathcomp, version ? null }:
-with lib;
 
 mkCoqDerivation {
   pname = "relation-algebra";
   owner = "damien-pous";
 
   releaseRev = v:
-    if versions.isGe "1.7.6" v
+    if lib.versions.isGe "1.7.6" v
     then "v.${v}"
     else "v${v}";
 
@@ -20,7 +19,7 @@ mkCoqDerivation {
   release."1.7.1".sha256 = "sha256-WWVMcR6z8rT4wzZPb8SlaVWGe7NC8gScPqawd7bltQA=";
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = isEq "8.16"; out = "1.7.8"; }
     { case = isEq "8.15"; out = "1.7.7"; }
     { case = isEq "8.14"; out = "1.7.6"; }
@@ -35,7 +34,7 @@ mkCoqDerivation {
 
   propagatedBuildInputs = [ aac-tactics mathcomp.ssreflect ];
 
-  meta = {
+  meta = with lib; {
     description = "Relation algebra library for Coq";
     maintainers = with maintainers; [ siraben ];
     license = licenses.gpl3Plus;

--- a/pkgs/development/coq-modules/semantics/default.nix
+++ b/pkgs/development/coq-modules/semantics/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, coq, version ? null }:
-with lib;
 
 mkCoqDerivation rec {
   pname = "semantics";
@@ -15,7 +14,7 @@ mkCoqDerivation rec {
   release."8.6.0".sha256 = "sha256-GltkGQ3tJqUPAbdDkqqvKLLhMOap50XvGaCkjshiNdY=";
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.10" "8.16"; out = "8.14.0"; }
     { case = "8.9"; out = "8.9.0"; }
     { case = "8.8"; out = "8.8.0"; }
@@ -34,7 +33,7 @@ mkCoqDerivation rec {
     done
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A survey of programming language semantics styles in Coq";
     longDescription = ''
       A survey of semantics styles in Coq, from natural semantics through

--- a/pkgs/development/coq-modules/serapi/default.nix
+++ b/pkgs/development/coq-modules/serapi/default.nix
@@ -17,7 +17,7 @@ in
   inherit version release;
 
   defaultVersion =  with versions;
-    switch coq.version [
+    lib.switch coq.version [
       { case = isEq "8.16"; out = "8.16.0+0.16.0"; }
       { case = isEq "8.15"; out = "8.15.0+0.15.0"; }
       { case = isEq "8.14"; out = "8.14.0+0.14.0"; }

--- a/pkgs/development/coq-modules/simple-io/default.nix
+++ b/pkgs/development/coq-modules/simple-io/default.nix
@@ -1,11 +1,11 @@
 { lib, callPackage, mkCoqDerivation, coq, coq-ext-lib, version ? null }:
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "simple-io";
   owner = "Lysxia";
   repo = "coq-simple-io";
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.11" "8.16"; out = "1.7.0"; }
     { case = range "8.7"  "8.13"; out = "1.3.0"; }
   ] null;
@@ -21,7 +21,7 @@ with lib; mkCoqDerivation {
 
   passthru.tests.HelloWorld = callPackage ./test.nix {};
 
-  meta = {
+  meta = with lib; {
     description = "Purely functional IO for Coq";
     license = licenses.mit;
     maintainers = [ maintainers.vbgl ];

--- a/pkgs/development/coq-modules/smpl/default.nix
+++ b/pkgs/development/coq-modules/smpl/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, coq, version ? null }:
-with lib;
 
 mkCoqDerivation {
   pname = "smpl";
@@ -13,7 +12,7 @@ mkCoqDerivation {
   releaseRev = v: "v${v}";
 
   inherit version;
-  defaultVersion = with versions; switch coq.version [
+  defaultVersion = with lib.versions; lib.switch coq.version [
     { case = isEq "8.15"; out = "8.15"; }
     { case = isEq "8.14"; out = "8.14"; }
     { case = "8.13.2"; out = "8.13"; }
@@ -23,7 +22,7 @@ mkCoqDerivation {
 
   mlPlugin = true;
 
-  meta = {
+  meta = with lib; {
     description = "A Coq plugin providing an extensible tactic similar to first";
     maintainers = with maintainers; [ siraben ];
     license = licenses.mit;

--- a/pkgs/development/coq-modules/smtcoq/default.nix
+++ b/pkgs/development/coq-modules/smtcoq/default.nix
@@ -1,5 +1,4 @@
 { lib, stdenv, gcc10StdenvCompat, pkgs, mkCoqDerivation, coq, trakt, veriT, zchaff, fetchurl, version ? null }:
-with lib;
 
 let
   # version of veriT that works with SMTCoq
@@ -23,7 +22,7 @@ mkCoqDerivation {
   release."2021-09-17".sha256 = "sha256-bF7ES+tXraaAJwVEwAMx3CUESpNlAUerQjr4d2eaGJQ=";
 
   inherit version;
-  defaultVersion = with versions; switch coq.version [
+  defaultVersion = with lib.versions; lib.switch coq.version [
     { case = isEq "8.13"; out = "2021-09-17"; }
   ] null;
 
@@ -34,7 +33,7 @@ mkCoqDerivation {
   # This is meant to ease future troubleshooting of cvc4 build failures
   passthru = { inherit cvc4; };
 
-  meta = {
+  meta = with lib; {
     description = "Communication between Coq and SAT/SMT solvers ";
     maintainers = with maintainers; [ siraben ];
     license = licenses.cecill-b;

--- a/pkgs/development/coq-modules/stdpp/default.nix
+++ b/pkgs/development/coq-modules/stdpp/default.nix
@@ -1,11 +1,11 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib; mkCoqDerivation rec {
+mkCoqDerivation rec {
   pname = "stdpp";
   inherit version;
   domain = "gitlab.mpi-sws.org";
   owner = "iris";
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.13" "8.16"; out = "1.8.0"; }
     { case = range "8.12" "8.14"; out = "1.6.0"; }
     { case = range "8.11" "8.13"; out = "1.5.0"; }
@@ -24,7 +24,7 @@ with lib; mkCoqDerivation rec {
     fi
   '';
 
-  meta = {
+  meta = with lib; {
     description = "An extended “Standard Library” for Coq";
     license = licenses.bsd3;
     maintainers = [ maintainers.vbgl ];

--- a/pkgs/development/coq-modules/tlc/default.nix
+++ b/pkgs/development/coq-modules/tlc/default.nix
@@ -1,11 +1,11 @@
 { lib, mkCoqDerivation, coq, version ? null }:
 
-with lib; (mkCoqDerivation {
+(mkCoqDerivation {
   pname = "tlc";
   owner = "charguer";
   inherit version;
   displayVersion = { tlc = false; };
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.13" "8.16"; out = "20211215"; }
     { case = range "8.12" "8.13"; out = "20210316"; }
     { case = range "8.10" "8.12"; out = "20200328"; }
@@ -16,14 +16,14 @@ with lib; (mkCoqDerivation {
   release."20200328".sha256 = "16vzild9gni8zhgb3qhmka47f8zagdh03k6nssif7drpim8233lx";
   release."20181116".sha256 = "032lrbkxqm9d3fhf6nv1kq2z0mqd3czv3ijlbsjwnfh12xck4vpl";
 
-  meta = {
+  meta = with lib; {
     homepage = "http://www.chargueraud.org/softs/tlc/";
     description = "A non-constructive library for Coq";
     license = licenses.free;
     maintainers = [ maintainers.vbgl ];
   };
 }).overrideAttrs (x:
-  if versionAtLeast x.version "20210316"
+  if lib.versionAtLeast x.version "20210316"
   then {}
   else {
     installFlags = [ "CONTRIB=$(out)/lib/coq/${coq.coq-version}/user-contrib" ];

--- a/pkgs/development/coq-modules/topology/default.nix
+++ b/pkgs/development/coq-modules/topology/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, coq, mathcomp, zorns-lemma, version ? null }:
-with lib;
 
 mkCoqDerivation rec {
   pname = "topology";
@@ -15,7 +14,7 @@ mkCoqDerivation rec {
   release."8.6.0".sha256 = "sha256-eu/dBEFo3y6vnXlJljUD4hds6+qgAPQVvsuspyGHcj8=";
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.10" "8.16"; out = "9.0.0"; }
     { case = "8.9"; out = "8.9.0"; }
     { case = "8.8"; out = "8.8.0"; }
@@ -25,9 +24,9 @@ mkCoqDerivation rec {
 
   propagatedBuildInputs = [ zorns-lemma ];
 
-  useDuneifVersion = versions.isGe "9.0";
+  useDuneifVersion = lib.versions.isGe "9.0";
 
-  meta = {
+  meta = with lib; {
     description = "General topology in Coq";
     longDescription = ''
       This library develops some of the basic concepts and results of

--- a/pkgs/development/coq-modules/trakt/default.nix
+++ b/pkgs/development/coq-modules/trakt/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, coq, coq-elpi, version ? null }:
-with lib;
 
 mkCoqDerivation {
   pname = "trakt";
@@ -9,13 +8,13 @@ mkCoqDerivation {
   release."1.0".sha256 = "sha256-Qhw5fWFYxUFO2kIWWz/og+4fuy9aYG27szfNk3IglhY=";
 
   inherit version;
-  defaultVersion = with versions; switch [ coq.version ] [
+  defaultVersion = with lib.versions; lib.switch [ coq.version ] [
     { cases = [ (range "8.13" "8.16") ]; out = "1.0"; }
   ] null;
 
   propagatedBuildInputs = [ coq-elpi ];
 
-  meta = {
+  meta = with lib; {
     description = "A generic goal preprocessing tool for proof automation tactics in Coq";
     maintainers = with maintainers; [ siraben ];
     license = licenses.cecill-b;

--- a/pkgs/development/coq-modules/zorns-lemma/default.nix
+++ b/pkgs/development/coq-modules/zorns-lemma/default.nix
@@ -1,5 +1,4 @@
 { lib, mkCoqDerivation, coq, version ? null }:
-with lib;
 
 (mkCoqDerivation {
   pname = "zorns-lemma";
@@ -16,7 +15,7 @@ with lib;
   release."8.5.0".sha256 = "sha256-mH/v02ObMjbVPYx2H+Jhz+Xp0XRKN67iMAdA1VNFzso=";
 
   inherit version;
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
     { case = range "8.10" "8.16"; out = "9.0.0"; }
     { case = "8.9"; out = "8.9.0"; }
     { case = "8.8"; out = "8.8.0"; }
@@ -25,9 +24,9 @@ with lib;
     { case = "8.5"; out = "8.5.0"; }
   ] null;
 
-  useDuneifVersion = versions.isGe "9.0";
+  useDuneifVersion = lib.versions.isGe "9.0";
 
-  meta = {
+  meta = with lib; {
     description = "Development of basic set theory";
     longDescription = ''
       This Coq library develops some basic set theory.  The main
@@ -37,4 +36,4 @@ with lib;
     maintainers = with maintainers; [ siraben ];
     license = licenses.lgpl21Plus;
   };
-}).overrideAttrs({version, ...}: if versions.isGe "9.0" version then { repo =  "topology"; } else {})
+}).overrideAttrs({version, ...}: if lib.versions.isGe "9.0" version then { repo =  "topology"; } else {})

--- a/pkgs/development/interpreters/lolcode/default.nix
+++ b/pkgs/development/interpreters/lolcode/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, doxygen, cmake, readline }:
 
-with lib;
 stdenv.mkDerivation rec {
 
   pname = "lolcode";
@@ -19,7 +18,7 @@ stdenv.mkDerivation rec {
   # Maybe it clashes with lci scientific logic software package...
   postInstall = "mv $out/bin/lci $out/bin/lolcode-lci";
 
-  meta = {
+  meta = with lib; {
     homepage = "http://lolcode.org";
     description = "An esoteric programming language";
     longDescription = ''

--- a/pkgs/development/interpreters/picolisp/default.nix
+++ b/pkgs/development/interpreters/picolisp/default.nix
@@ -1,5 +1,4 @@
 { lib, stdenv, fetchurl, jdk, w3m, openssl, makeWrapper }:
-with lib;
 
 stdenv.mkDerivation rec {
   pname = "picoLisp";
@@ -9,11 +8,11 @@ stdenv.mkDerivation rec {
     sha256 = "0l51x98bn1hh6kv40sdgp0x09pzg5i8yxbcjvm9n5bxsd6bbk5w2";
   };
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [openssl] ++ optional stdenv.is64bit jdk;
+  buildInputs = [openssl] ++ lib.optional stdenv.is64bit jdk;
   patchPhase = ''
     sed -i "s/which java/command -v java/g" mkAsm
 
-    ${optionalString stdenv.isAarch32 ''
+    ${lib.optionalString stdenv.isAarch32 ''
       sed -i s/-m32//g Makefile
       cat >>Makefile <<EOF
       ext.o: ext.c
@@ -23,7 +22,7 @@ stdenv.mkDerivation rec {
       EOF
     ''}
   '';
-  sourceRoot = ''picoLisp/src${optionalString stdenv.is64bit "64"}'';
+  sourceRoot = ''picoLisp/src${lib.optionalString stdenv.is64bit "64"}'';
   postBuild = ''
     cd ../src; make gate
   '';
@@ -49,7 +48,7 @@ stdenv.mkDerivation rec {
     ln -s "$out/lib/picolisp/lib/el" "$out/share/emacs/site-lisp"
   '';
 
-  meta = {
+  meta = with lib; {
     # darwin: build times out
     broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
     description = "A simple Lisp with an integrated database";

--- a/pkgs/development/interpreters/python/wrap-python.nix
+++ b/pkgs/development/interpreters/python/wrap-python.nix
@@ -3,8 +3,6 @@
 , makePythonHook
 , makeWrapper }:
 
-with lib;
-
 makePythonHook {
       deps = makeWrapper;
       substitutions.sitePackages = python.sitePackages;
@@ -19,7 +17,7 @@ makePythonHook {
 
         mkStringSkipper = labelNum: quote: let
           label = "q${toString labelNum}";
-          isSingle = elem quote [ "\"" "'\"'\"'" ];
+          isSingle = lib.elem quote [ "\"" "'\"'\"'" ];
           endQuote = if isSingle then "[^\\\\]${quote}" else quote;
         in ''
           /^[a-z]?${quote}/ {
@@ -45,8 +43,8 @@ makePythonHook {
           :r
           /\\$|,$/{N;br}
           /__future__|^ |^ *(#.*)?$/{n;br}
-          ${concatImapStrings mkStringSkipper quoteVariants}
-          /^[^# ]/i ${replaceStrings ["\n"] [";"] preamble}
+          ${lib.concatImapStrings mkStringSkipper quoteVariants}
+          /^[^# ]/i ${lib.replaceStrings ["\n"] [";"] preamble}
         }
       '';
 } ./wrap.sh

--- a/pkgs/development/interpreters/ruby/ruby-version.nix
+++ b/pkgs/development/interpreters/ruby/ruby-version.nix
@@ -1,6 +1,6 @@
 # Contains the ruby version heuristics
 { lib }:
-with lib;
+
 let
   # The returned set should be immutable
   rubyVersion = major: minor: tiny: tail:
@@ -10,15 +10,15 @@ let
       # Contains the patch number "223" if tail is "p223" or null
       patchLevel =
         let
-          p = removePrefix "p" tail;
+          p = lib.removePrefix "p" tail;
           isPosInt = num:
-            0 == stringLength
-              (replaceStrings
+            0 == lib.stringLength
+              (lib.replaceStrings
               ["0" "1" "2" "3" "4" "5" "6" "7" "8" "9"]
               [""  ""  ""  ""  ""  ""  ""  ""  ""  "" ]
               num);
         in
-          if hasPrefix "p" tail && isPosInt p then p
+          if lib.hasPrefix "p" tail && isPosInt p then p
           else null;
 
       # Shortcuts
@@ -28,11 +28,11 @@ let
       # Ruby separates lib and gem folders by ABI version which isn't very
       # consistent.
       libDir =
-        if versionAtLeast majMinTiny "2.1.0" then
+        if lib.versionAtLeast majMinTiny "2.1.0" then
           "${majMin}.0"
-        else if versionAtLeast majMinTiny "2.0.0" then
+        else if lib.versionAtLeast majMinTiny "2.0.0" then
           "2.0.0"
-        else if versionAtLeast majMinTiny "1.9.1" then
+        else if lib.versionAtLeast majMinTiny "1.9.1" then
           "1.9.1"
         else
           throw "version ${majMinTiny} is not supported";

--- a/pkgs/development/java-modules/maven-minimal.nix
+++ b/pkgs/development/java-modules/maven-minimal.nix
@@ -1,6 +1,5 @@
 { lib, pkgs }:
 
-with lib;
 with pkgs.javaPackages;
 
 let
@@ -10,7 +9,7 @@ let
   poms = import ./poms.nix { inherit fetchMaven; };
 in {
   # Maven needs all of these to function
-  mavenMinimal = flatten
+  mavenMinimal = lib.flatten
     collections.mavenLibs_2_0_6
     ++ collections.mavenLibs_2_0_9
     ++ collections.mavenLibs_2_2_1

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -11,17 +11,15 @@
 # NOTE: When editing this expression see if the same change applies to
 # SDL2 expression too
 
-with lib;
-
 let
   extraPropagatedBuildInputs = [ ]
-    ++ optionals x11Support [ libXext libICE libXrandr ]
-    ++ optionals (openglSupport && stdenv.isLinux) [ libGL libGLU ]
-    ++ optionals (openglSupport && stdenv.isDarwin) [ OpenGL GLUT ]
-    ++ optional alsaSupport alsa-lib
-    ++ optional pulseaudioSupport libpulseaudio
-    ++ optional stdenv.isDarwin Cocoa;
-  rpath = makeLibraryPath extraPropagatedBuildInputs;
+    ++ lib.optionals x11Support [ libXext libICE libXrandr ]
+    ++ lib.optionals (openglSupport && stdenv.isLinux) [ libGL libGLU ]
+    ++ lib.optionals (openglSupport && stdenv.isDarwin) [ OpenGL GLUT ]
+    ++ lib.optional alsaSupport alsa-lib
+    ++ lib.optional pulseaudioSupport libpulseaudio
+    ++ lib.optional stdenv.isDarwin Cocoa;
+  rpath = lib.makeLibraryPath extraPropagatedBuildInputs;
 in
 
 stdenv.mkDerivation rec {
@@ -40,13 +38,13 @@ stdenv.mkDerivation rec {
   outputBin = "dev"; # sdl-config
 
   nativeBuildInputs = [ pkg-config ]
-    ++ optional stdenv.isLinux libcap;
+    ++ lib.optional stdenv.isLinux libcap;
 
   propagatedBuildInputs = [ libiconv ] ++ extraPropagatedBuildInputs;
 
   buildInputs = [ ]
-    ++ optional (!stdenv.hostPlatform.isMinGW && alsaSupport) audiofile
-    ++ optionals stdenv.isDarwin [ AudioUnit CoreAudio CoreServices Kernel OpenGL ];
+    ++ lib.optional (!stdenv.hostPlatform.isMinGW && alsaSupport) audiofile
+    ++ lib.optionals stdenv.isDarwin [ AudioUnit CoreAudio CoreServices Kernel OpenGL ];
 
   configureFlags = [
     "--disable-oss"
@@ -58,9 +56,9 @@ stdenv.mkDerivation rec {
   #   SDL_X11_SYM(int,_XData32,(Display *dpy,register long *data,unsigned len),(dpy,data,len),return)
   #
   # Please try revert the change that introduced this comment when updating SDL.
-  ] ++ optional stdenv.isDarwin "--disable-x11-shared"
-    ++ optional (!x11Support) "--without-x"
-    ++ optional alsaSupport "--with-alsa-prefix=${alsa-lib.out}/lib";
+  ] ++ lib.optional stdenv.isDarwin "--disable-x11-shared"
+    ++ lib.optional (!x11Support) "--without-x"
+    ++ lib.optional alsaSupport "--with-alsa-prefix=${alsa-lib.out}/lib";
 
   patches = [
     ./find-headers.patch

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -55,8 +55,6 @@
 # NOTE: When editing this expression see if the same change applies to
 # SDL expression too
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "SDL2";
   version = "2.24.2";
@@ -88,40 +86,40 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ pkg-config ];
 
-  nativeBuildInputs = [ pkg-config ] ++ optionals waylandSupport [ wayland wayland-scanner ];
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals waylandSupport [ wayland wayland-scanner ];
 
   propagatedBuildInputs = dlopenPropagatedBuildInputs;
 
   dlopenPropagatedBuildInputs = [ ]
     # Propagated for #include <GLES/gl.h> in SDL_opengles.h.
-    ++ optional openglSupport libGL
+    ++ lib.optional openglSupport libGL
     # Propagated for #include <X11/Xlib.h> and <X11/Xatom.h> in SDL_syswm.h.
-    ++ optionals x11Support [ libX11 xorgproto ];
+    ++ lib.optionals x11Support [ libX11 xorgproto ];
 
-  dlopenBuildInputs = optionals alsaSupport [ alsa-lib audiofile ]
-    ++ optional dbusSupport dbus
-    ++ optional libdecorSupport libdecor
-    ++ optional pipewireSupport pipewire
-    ++ optional pulseaudioSupport libpulseaudio
-    ++ optional udevSupport udev
-    ++ optionals waylandSupport [ wayland wayland-protocols libxkbcommon ]
-    ++ optionals x11Support [ libICE libXi libXScrnSaver libXcursor libXinerama libXext libXrandr libXxf86vm ]
-    ++ optionals drmSupport [ libdrm mesa ];
+  dlopenBuildInputs = lib.optionals alsaSupport [ alsa-lib audiofile ]
+    ++ lib.optional dbusSupport dbus
+    ++ lib.optional libdecorSupport libdecor
+    ++ lib.optional pipewireSupport pipewire
+    ++ lib.optional pulseaudioSupport libpulseaudio
+    ++ lib.optional udevSupport udev
+    ++ lib.optionals waylandSupport [ wayland wayland-protocols libxkbcommon ]
+    ++ lib.optionals x11Support [ libICE libXi libXScrnSaver libXcursor libXinerama libXext libXrandr libXxf86vm ]
+    ++ lib.optionals drmSupport [ libdrm mesa ];
 
   buildInputs = [ libiconv ]
     ++ dlopenBuildInputs
-    ++ optional ibusSupport ibus
-    ++ optional fcitxSupport fcitx
-    ++ optionals stdenv.isDarwin [ AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL ];
+    ++ lib.optional ibusSupport ibus
+    ++ lib.optional fcitxSupport fcitx
+    ++ lib.optionals stdenv.isDarwin [ AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL ];
 
   enableParallelBuilding = true;
 
   configureFlags = [
     "--disable-oss"
-  ] ++ optional (!x11Support) "--without-x"
-  ++ optional alsaSupport "--with-alsa-prefix=${alsa-lib.out}/lib"
-  ++ optional stdenv.targetPlatform.isWindows "--disable-video-opengles"
-  ++ optional stdenv.isDarwin "--disable-sdltest";
+  ] ++ lib.optional (!x11Support) "--without-x"
+  ++ lib.optional alsaSupport "--with-alsa-prefix=${alsa-lib.out}/lib"
+  ++ lib.optional stdenv.targetPlatform.isWindows "--disable-video-opengles"
+  ++ lib.optional stdenv.isDarwin "--disable-sdltest";
 
   # We remove libtool .la files when static libs are requested,
   # because they make the builds of downstream libs like `SDL_tff`
@@ -156,9 +154,9 @@ stdenv.mkDerivation rec {
   # list the symbols used in this way.
   postFixup =
     let
-      rpath = makeLibraryPath (dlopenPropagatedBuildInputs ++ dlopenBuildInputs);
+      rpath = lib.makeLibraryPath (dlopenPropagatedBuildInputs ++ dlopenBuildInputs);
     in
-    optionalString (stdenv.hostPlatform.extensions.sharedLibrary == ".so") ''
+    lib.optionalString (stdenv.hostPlatform.extensions.sharedLibrary == ".so") ''
       for lib in $out/lib/*.so* ; do
         if ! [[ -L "$lib" ]]; then
           patchelf --set-rpath "$(patchelf --print-rpath $lib):${rpath}" "$lib"

--- a/pkgs/development/libraries/apr-util/default.nix
+++ b/pkgs/development/libraries/apr-util/default.nix
@@ -10,8 +10,6 @@ assert sslSupport -> openssl != null;
 assert bdbSupport -> db != null;
 assert ldapSupport -> openldap != null;
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "apr-util";
   version = "1.6.1";
@@ -22,21 +20,21 @@ stdenv.mkDerivation rec {
   };
 
   patches = [ ./fix-libxcrypt-build.patch ]
-    ++ optional stdenv.isFreeBSD ./include-static-dependencies.patch;
+    ++ lib.optional stdenv.isFreeBSD ./include-static-dependencies.patch;
 
   NIX_CFLAGS_LINK = [ "-lcrypt" ];
 
   outputs = [ "out" "dev" ];
   outputBin = "dev";
 
-  nativeBuildInputs = [ makeWrapper ] ++ optional stdenv.isFreeBSD autoreconfHook;
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optional stdenv.isFreeBSD autoreconfHook;
 
   configureFlags = [ "--with-apr=${apr.dev}" "--with-expat=${expat.dev}" ]
-    ++ optional (!stdenv.isCygwin) "--with-crypto"
-    ++ optional sslSupport "--with-openssl=${openssl.dev}"
-    ++ optional bdbSupport "--with-berkeley-db=${db.dev}"
-    ++ optional ldapSupport "--with-ldap=ldap"
-    ++ optionals stdenv.isCygwin
+    ++ lib.optional (!stdenv.isCygwin) "--with-crypto"
+    ++ lib.optional sslSupport "--with-openssl=${openssl.dev}"
+    ++ lib.optional bdbSupport "--with-berkeley-db=${db.dev}"
+    ++ lib.optional ldapSupport "--with-ldap=ldap"
+    ++ lib.optionals stdenv.isCygwin
       [ "--without-pgsql" "--without-sqlite2" "--without-sqlite3"
         "--without-freetds" "--without-berkeley-db" "--without-crypto" ]
     ;
@@ -53,10 +51,10 @@ stdenv.mkDerivation rec {
   '';
 
   propagatedBuildInputs = [ apr expat libiconv libxcrypt ]
-    ++ optional sslSupport openssl
-    ++ optional bdbSupport db
-    ++ optional ldapSupport openldap
-    ++ optional stdenv.isFreeBSD cyrus_sasl;
+    ++ lib.optional sslSupport openssl
+    ++ lib.optional bdbSupport db
+    ++ lib.optional ldapSupport openldap
+    ++ lib.optional stdenv.isFreeBSD cyrus_sasl;
 
   postInstall = ''
     for f in $out/lib/*.la $out/lib/apr-util-1/*.la $dev/bin/apu-1-config; do

--- a/pkgs/development/libraries/asio/generic.nix
+++ b/pkgs/development/libraries/asio/generic.nix
@@ -2,8 +2,6 @@
 , version, sha256, ...
 }:
 
-with lib;
-
 stdenv.mkDerivation {
   pname = "asio";
   inherit version;
@@ -17,7 +15,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ openssl ];
 
-  meta = {
+  meta = with lib; {
     homepage = "http://asio.sourceforge.net/";
     description = "Cross-platform C++ library for network and low-level I/O programming";
     license = licenses.boost;

--- a/pkgs/development/libraries/aspell/dictionaries.nix
+++ b/pkgs/development/libraries/aspell/dictionaries.nix
@@ -1,7 +1,5 @@
 {lib, stdenv, fetchurl, aspell, which, writeScript}:
 
-with lib;
-
 /* HOWTO:
 
    * Add some of these to your profile or systemPackages.
@@ -105,7 +103,7 @@ let
         homepage = "http://ftp.gnu.org/gnu/aspell/dict/0index.html";
       } // (args.meta or {});
 
-    } // lib.optionalAttrs (stdenv.isDarwin && elem language [ "is" "nb" ]) {
+    } // lib.optionalAttrs (stdenv.isDarwin && lib.elem language [ "is" "nb" ]) {
       # tar: Cannot open: Illegal byte sequence
       unpackPhase = ''
         runHook preUnpack
@@ -115,7 +113,7 @@ let
         runHook postUnpack
       '';
 
-      postPatch = getAttr language {
+      postPatch = lib.getAttr language {
         is = ''
           cp icelandic.alias íslenska.alias
           sed -i 's/ .slenska\.alias/ íslenska.alias/g' Makefile.pre
@@ -137,7 +135,7 @@ let
       preBuild = ''
         # Aspell can't handle multiple data-dirs
         # Copy everything we might possibly need
-        ${concatMapStringsSep "\n" (p: ''
+        ${lib.concatMapStringsSep "\n" (p: ''
           cp -a ${p}/lib/aspell/* .
         '') ([ aspell ] ++ langInputs)}
         export ASPELL_CONF="data-dir $(pwd)"

--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -2,7 +2,6 @@
 , pam, libxcrypt, fixDarwinDylibNames, autoreconfHook, enableLdap ? false
 , buildPackages, pruneLibtoolFiles, nixosTests }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "cyrus-sasl";
   version = "2.1.28";
@@ -50,7 +49,7 @@ stdenv.mkDerivation rec {
     inherit (nixosTests) parsedmarc postfix;
   };
 
-  meta = {
+  meta = with lib; {
     homepage = "https://www.cyrusimap.org/sasl";
     description = "Library for adding authentication support to connection-based protocols";
     platforms = platforms.unix;

--- a/pkgs/development/libraries/faac/default.nix
+++ b/pkgs/development/libraries/faac/default.nix
@@ -5,7 +5,6 @@
 
 assert mp4v2Support -> (mp4v2 != null);
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "faac";
   version = "1.30";
@@ -16,19 +15,19 @@ stdenv.mkDerivation rec {
   };
 
   configureFlags = [ ]
-    ++ optional mp4v2Support "--with-external-mp4v2"
-    ++ optional drmSupport "--enable-drm";
+    ++ lib.optional mp4v2Support "--with-external-mp4v2"
+    ++ lib.optional drmSupport "--enable-drm";
 
   hardeningDisable = [ "format" ];
 
   nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [ ]
-    ++ optional mp4v2Support mp4v2;
+    ++ lib.optional mp4v2Support mp4v2;
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     description = "Open source MPEG-4 and MPEG-2 AAC encoder";
     license     = licenses.unfreeRedistributable;
     maintainers = with maintainers; [ codyopel ];

--- a/pkgs/development/libraries/faad2/default.nix
+++ b/pkgs/development/libraries/faad2/default.nix
@@ -11,7 +11,6 @@
 , vlc
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "faad2";
   version = "2.10.1";
@@ -24,7 +23,7 @@ stdenv.mkDerivation rec {
   };
 
   configureFlags = []
-    ++ optional drmSupport "--with-drm";
+    ++ lib.optional drmSupport "--with-drm";
 
   nativeBuildInputs = [ autoreconfHook ];
 
@@ -34,7 +33,7 @@ stdenv.mkDerivation rec {
     ocaml-faad = ocamlPackages.faad;
   };
 
-  meta = {
+  meta = with lib; {
     description = "An open source MPEG-4 and MPEG-2 AAC decoder";
     homepage = "https://sourceforge.net/projects/faac/";
     license     = licenses.gpl2Plus;

--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -14,9 +14,7 @@
 , withDoc ? stdenv.cc.isGNU
 }:
 
-with lib;
-
-assert elem precision [ "single" "double" "long-double" "quad-precision" ];
+assert lib.elem precision [ "single" "double" "long-double" "quad-precision" ];
 
 stdenv.mkDerivation rec {
   pname = "fftw-${precision}";
@@ -31,32 +29,32 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "dev" "man" ]
-    ++ optional withDoc "info"; # it's dev-doc only
+    ++ lib.optional withDoc "info"; # it's dev-doc only
   outputBin = "dev"; # fftw-wisdom
 
   nativeBuildInputs = [ gfortran ];
 
-  buildInputs = optionals stdenv.cc.isClang [
+  buildInputs = lib.optionals stdenv.cc.isClang [
     # TODO: This may mismatch the LLVM version sin the stdenv, see #79818.
     llvmPackages.openmp
-  ] ++ optional enableMpi mpi;
+  ] ++ lib.optional enableMpi mpi;
 
   configureFlags =
     [ "--enable-shared"
       "--enable-threads"
     ]
-    ++ optional (precision != "double") "--enable-${precision}"
+    ++ lib.optional (precision != "double") "--enable-${precision}"
     # all x86_64 have sse2
     # however, not all float sizes fit
-    ++ optional (stdenv.isx86_64 && (precision == "single" || precision == "double") )  "--enable-sse2"
-    ++ optional enableAvx "--enable-avx"
-    ++ optional enableAvx2 "--enable-avx2"
-    ++ optional enableAvx512 "--enable-avx512"
-    ++ optional enableFma "--enable-fma"
+    ++ lib.optional (stdenv.isx86_64 && (precision == "single" || precision == "double") )  "--enable-sse2"
+    ++ lib.optional enableAvx "--enable-avx"
+    ++ lib.optional enableAvx2 "--enable-avx2"
+    ++ lib.optional enableAvx512 "--enable-avx512"
+    ++ lib.optional enableFma "--enable-fma"
     ++ [ "--enable-openmp" ]
-    ++ optional enableMpi "--enable-mpi"
+    ++ lib.optional enableMpi "--enable-mpi"
     # doc generation causes Fortran wrapper generation which hard-codes gcc
-    ++ optional (!withDoc) "--disable-doc";
+    ++ lib.optional (!withDoc) "--disable-doc";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/geis/default.nix
+++ b/pkgs/development/libraries/geis/default.nix
@@ -15,7 +15,6 @@
 , xorgserver
 }:
 
-with lib;
 
 stdenv.mkDerivation rec {
   pname = "geis";
@@ -48,7 +47,7 @@ stdenv.mkDerivation rec {
     gappsWrapperArgs+=(--set PYTHONPATH "$program_PYTHONPATH")
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A library for input gesture recognition";
     homepage = "https://launchpad.net/geis";
     license = licenses.gpl2;

--- a/pkgs/development/libraries/glew/1.10.nix
+++ b/pkgs/development/libraries/glew/1.10.nix
@@ -2,8 +2,6 @@
 , AGL, OpenGL
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "glew";
   version = "1.10.0";
@@ -20,7 +18,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     sed -i 's|lib64|lib|' config/Makefile.linux
-    ${optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    ${lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     sed -i -e 's/\(INSTALL.*\)-s/\1/' Makefile
     ''}
   '';

--- a/pkgs/development/libraries/gloox/default.nix
+++ b/pkgs/development/libraries/gloox/default.nix
@@ -4,7 +4,6 @@
 , idnSupport ? true, libidn
 }:
 
-with lib;
 
 stdenv.mkDerivation rec{
   pname = "gloox";
@@ -16,11 +15,11 @@ stdenv.mkDerivation rec{
   };
 
   buildInputs = [ ]
-    ++ optional zlibSupport zlib
-    ++ optional sslSupport openssl
-    ++ optional idnSupport libidn;
+    ++ lib.optional zlibSupport zlib
+    ++ lib.optional sslSupport openssl
+    ++ lib.optional idnSupport libidn;
 
-  meta = {
+  meta = with lib; {
     description = "A portable high-level Jabber/XMPP library for C++";
     homepage = "http://camaya.net/gloox";
     license = licenses.gpl3;

--- a/pkgs/development/libraries/gtk/2.x.nix
+++ b/pkgs/development/libraries/gtk/2.x.nix
@@ -7,8 +7,6 @@
 , fetchpatch, buildPackages
 }:
 
-with lib;
-
 let
 
   gtkCleanImmodulesCache = substituteAll {
@@ -44,7 +42,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./patches/2.0-immodules.cache.patch
     ./patches/gtk2-theme-paths.patch
-  ] ++ optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     (fetchpatch {
       url = "https://bug557780.bugzilla-attachments.gnome.org/attachment.cgi?id=306776";
       sha256 = "0sp8f1r5c4j2nlnbqgv7s7nxa4cfwigvm033hvhb1ld652pjag4r";
@@ -54,13 +52,13 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = with xorg;
     [ glib cairo pango gdk-pixbuf atk ]
-    ++ optionals (stdenv.isLinux || stdenv.isDarwin) [
+    ++ lib.optionals (stdenv.isLinux || stdenv.isDarwin) [
          libXrandr libXrender libXcomposite libXi libXcursor
        ]
-    ++ optionals stdenv.isDarwin [ libXdamage ]
-    ++ optional xineramaSupport libXinerama
-    ++ optionals cupsSupport [ cups ]
-    ++ optionals stdenv.isDarwin [ AppKit Cocoa ];
+    ++ lib.optionals stdenv.isDarwin [ libXdamage ]
+    ++ lib.optional xineramaSupport libXinerama
+    ++ lib.optionals cupsSupport [ cups ]
+    ++ lib.optionals stdenv.isDarwin [ AppKit Cocoa ];
 
   preConfigure = if (lib.versionAtLeast stdenv.hostPlatform.darwinMinVersion "11" && stdenv.isDarwin) then ''
     MACOSX_DEPLOYMENT_TARGET=10.16
@@ -69,7 +67,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-gdktarget=${gdktarget}"
     "--with-xinput=yes"
-  ] ++ optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     "--disable-glibtest"
     "--disable-introspection"
     "--disable-visibility"
@@ -94,7 +92,7 @@ stdenv.mkDerivation rec {
     inherit gdktarget;
   };
 
-  meta = {
+  meta = with lib; {
     description = "A multi-platform toolkit for creating graphical user interfaces";
     homepage    = "https://www.gtk.org/";
     license     = licenses.lgpl2Plus;

--- a/pkgs/development/libraries/hunspell/wrapper.nix
+++ b/pkgs/development/libraries/hunspell/wrapper.nix
@@ -1,10 +1,9 @@
 { stdenv, lib, hunspell, makeWrapper, dicts ? [] }:
-with lib;
 let
-  searchPath = makeSearchPath "share/hunspell" dicts;
+  searchPath = lib.makeSearchPath "share/hunspell" dicts;
 in
 stdenv.mkDerivation {
-  name = (appendToName "with-dicts" hunspell).name;
+  name = (lib.appendToName "with-dicts" hunspell).name;
   nativeBuildInputs = [ makeWrapper ];
   buildCommand = ''
     makeWrapper ${hunspell.bin}/bin/hunspell $out/bin/hunspell --prefix DICPATH : ${lib.escapeShellArg searchPath}

--- a/pkgs/development/libraries/indicator-application/gtk2.nix
+++ b/pkgs/development/libraries/indicator-application/gtk2.nix
@@ -3,8 +3,6 @@
 , glib, dbus-glib, json-glib
 , gtk2, libindicator-gtk2, libdbusmenu-gtk2, libappindicator-gtk2 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "indicator-application-gtk2";
   version = "12.10.0.1";
@@ -45,7 +43,7 @@ stdenv.mkDerivation rec {
     "localstatedir=\${TMPDIR}"
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Indicator to take menus from applications and place them in the panel (GTK 2 library for Xfce/LXDE)";
     homepage = "https://launchpad.net/indicators-gtk2";
     license = licenses.gpl3;

--- a/pkgs/development/libraries/kerberos/heimdal.nix
+++ b/pkgs/development/libraries/kerberos/heimdal.nix
@@ -4,7 +4,6 @@
 , CoreFoundation, Security, SystemConfiguration
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "heimdal";
   version = "7.8.0";
@@ -22,9 +21,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkg-config python3 perl bison flex texinfo ]
     ++ (with perlPackages; [ JSON ]);
-  buildInputs = optionals (stdenv.isLinux) [ libcap_ng ]
+  buildInputs = lib.optionals (stdenv.isLinux) [ libcap_ng ]
     ++ [ db sqlite openssl libedit openldap pam]
-    ++ optionals (stdenv.isDarwin) [ CoreFoundation Security SystemConfiguration ];
+    ++ lib.optionals (stdenv.isDarwin) [ CoreFoundation Security SystemConfiguration ];
 
   ## ugly, X should be made an option
   configureFlags = [
@@ -42,7 +41,7 @@ stdenv.mkDerivation rec {
     "--with-berkeley-db"
     "--with-berkeley-db-include=${db.dev}/include"
     "--with-openldap=${openldap.dev}"
-  ] ++ optionals (stdenv.isLinux) [
+  ] ++ lib.optionals (stdenv.isLinux) [
     "--with-capng"
   ];
 
@@ -91,7 +90,7 @@ stdenv.mkDerivation rec {
   #  hx_locl.h:67:25: fatal error: pkcs10_asn1.h: No such file or directory
   #enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     description = "An implementation of Kerberos 5 (and some more stuff)";
     license = licenses.bsd3;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/lame/default.nix
+++ b/pkgs/development/libraries/lame/default.nix
@@ -11,7 +11,6 @@
 , debugSupport ? false # Debugging (disables optimizations)
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "lame";
   version = "3.100";
@@ -25,24 +24,24 @@ stdenv.mkDerivation rec {
   outputMan = "out";
 
   nativeBuildInputs = [ ]
-    ++ optional nasmSupport nasm;
+    ++ lib.optional nasmSupport nasm;
 
   buildInputs = [ ]
     #++ optional efenceSupport libefence
     #++ optional mp3xSupport gtk1
-    ++ optional sndfileFileIOSupport libsndfile;
+    ++ lib.optional sndfileFileIOSupport libsndfile;
 
   configureFlags = [
-    (enableFeature nasmSupport "nasm")
-    (enableFeature cpmlSupport "cpml")
+    (lib.enableFeature nasmSupport "nasm")
+    (lib.enableFeature cpmlSupport "cpml")
     #(enableFeature efenceSupport "efence")
     (if sndfileFileIOSupport then "--with-fileio=sndfile" else "--with-fileio=lame")
-    (enableFeature analyzerHooksSupport "analyzer-hooks")
-    (enableFeature decoderSupport "decoder")
-    (enableFeature frontendSupport "frontend")
-    (enableFeature frontendSupport "dynamic-frontends")
+    (lib.enableFeature analyzerHooksSupport "analyzer-hooks")
+    (lib.enableFeature decoderSupport "decoder")
+    (lib.enableFeature frontendSupport "frontend")
+    (lib.enableFeature frontendSupport "dynamic-frontends")
     #(enableFeature mp3xSupport "mp3x")
-    (enableFeature mp3rtpSupport "mp3rtp")
+    (lib.enableFeature mp3rtpSupport "mp3rtp")
     (if debugSupport then "--enable-debug=alot" else "")
   ];
 
@@ -52,7 +51,7 @@ stdenv.mkDerivation rec {
     sed -i '/lame_init_old/d' include/libmp3lame.sym
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A high quality MPEG Audio Layer III (MP3) encoder";
     homepage    = "http://lame.sourceforge.net";
     license     = licenses.lgpl2;

--- a/pkgs/development/libraries/libass/default.nix
+++ b/pkgs/development/libraries/libass/default.nix
@@ -8,7 +8,6 @@
 
 assert fontconfigSupport -> fontconfig != null;
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "libass";
   version = "0.16.0";
@@ -19,18 +18,18 @@ stdenv.mkDerivation rec {
   };
 
   configureFlags = [
-    (enableFeature fontconfigSupport "fontconfig")
-    (enableFeature rasterizerSupport "rasterizer")
-    (enableFeature largeTilesSupport "large-tiles")
+    (lib.enableFeature fontconfigSupport "fontconfig")
+    (lib.enableFeature rasterizerSupport "rasterizer")
+    (lib.enableFeature largeTilesSupport "large-tiles")
   ];
 
   nativeBuildInputs = [ pkg-config yasm ];
 
   buildInputs = [ freetype fribidi harfbuzz ]
-    ++ optional fontconfigSupport fontconfig
-    ++ optional stdenv.isDarwin libiconv;
+    ++ lib.optional fontconfigSupport fontconfig
+    ++ lib.optional stdenv.isDarwin libiconv;
 
-  meta = {
+  meta = with lib; {
     description = "Portable ASS/SSA subtitle renderer";
     homepage    = "https://github.com/libass/libass";
     license     = licenses.isc;

--- a/pkgs/development/libraries/libcollectdclient/default.nix
+++ b/pkgs/development/libraries/libcollectdclient/default.nix
@@ -1,5 +1,4 @@
 { lib, collectd }:
-with lib;
 
 collectd.overrideAttrs (oldAttrs: {
   pname = "libcollectdclient";

--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -5,8 +5,6 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libidn2";
   version = "2.3.2";
@@ -20,14 +18,14 @@ stdenv.mkDerivation rec {
   # Beware: non-bootstrap libidn2 is overridden by ./hack.nix
   outputs = [ "bin" "dev" "out" "info" "devdoc" ];
 
-  patches = optional stdenv.isDarwin ./fix-error-darwin.patch;
+  patches = lib.optional stdenv.isDarwin ./fix-error-darwin.patch;
 
   enableParallelBuilding = true;
 
   # The above patch causes the documentation to be regenerated, so the
   # documentation tools are required.
-  nativeBuildInputs = optionals stdenv.isDarwin [ help2man texinfo ];
-  buildInputs = [ libunistring ] ++ optional stdenv.isDarwin libiconv;
+  nativeBuildInputs = lib.optionals stdenv.isDarwin [ help2man texinfo ];
+  buildInputs = [ libunistring ] ++ lib.optional stdenv.isDarwin libiconv;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   meta = {

--- a/pkgs/development/libraries/libmcrypt/default.nix
+++ b/pkgs/development/libraries/libmcrypt/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl, darwin, disablePosixThreads ? false }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libmcrypt";
   version = "2.5.8";
@@ -11,15 +9,15 @@ stdenv.mkDerivation rec {
     sha256 = "0gipgb939vy9m66d3k8il98rvvwczyaw2ixr8yn6icds9c3nrsz4";
   };
 
-  buildInputs = optional stdenv.isDarwin darwin.cctools;
+  buildInputs = lib.optional stdenv.isDarwin darwin.cctools;
 
-  configureFlags = optionals disablePosixThreads
+  configureFlags = lib.optionals disablePosixThreads
     [ "--disable-posix-threads" ];
 
   meta = {
     description = "Replacement for the old crypt() package and crypt(1) command, with extensions";
     homepage = "http://mcrypt.sourceforge.net";
     license = "GPL";
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/development/libraries/libpcap/default.nix
+++ b/pkgs/development/libraries/libpcap/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl, flex, bison, bluez, pkg-config, withBluez ? false }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libpcap";
   version = "1.10.1";
@@ -12,15 +10,15 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ flex bison ]
-    ++ optionals withBluez [ bluez.dev pkg-config ];
+    ++ lib.optionals withBluez [ bluez.dev pkg-config ];
 
   # We need to force the autodetection because detection doesn't
   # work in pure build environments.
   configureFlags = [
     "--with-pcap=${if stdenv.isLinux then "linux" else "bpf"}"
-  ] ++ optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     "--disable-universal"
-  ] ++ optionals (stdenv.hostPlatform == stdenv.buildPlatform)
+  ] ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform)
     [ "ac_cv_linux_vers=2" ];
 
   postInstall = ''
@@ -29,7 +27,7 @@ stdenv.mkDerivation rec {
     fi
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://www.tcpdump.org";
     description = "Packet Capture Library";
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libqtav/default.nix
+++ b/pkgs/development/libraries/libqtav/default.nix
@@ -17,8 +17,6 @@
 , libva
 }:
 
-with lib;
-
 mkDerivation rec {
   pname = "libqtav";
   version = "unstable-2020-09-10";
@@ -64,7 +62,7 @@ mkDerivation rec {
 
   stripDebugList = [ "lib" "libexec" "bin" "qml" ];
 
-  meta = {
+  meta =  with lib; {
     description = "A multimedia playback framework based on Qt + FFmpeg";
     #license = licenses.lgpl21; # For the libraries / headers only.
     license = licenses.gpl3; # With the examples (under bin) and most likely some of the optional dependencies used.

--- a/pkgs/development/libraries/libspf2/default.nix
+++ b/pkgs/development/libraries/libspf2/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, fetchpatch }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libspf2";
   version = "2.2.12";
@@ -35,7 +33,7 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = {
+  meta = with lib; {
     description = "Implementation of the Sender Policy Framework for SMTP " +
                   "authorization (Helsinki Systems fork)";
     homepage = "https://github.com/helsinki-systems/libspf2";

--- a/pkgs/development/libraries/libtap/default.nix
+++ b/pkgs/development/libraries/libtap/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, cmake, perl }:
 
-with lib;
 stdenv.mkDerivation rec {
 
   pname = "libtap";

--- a/pkgs/development/libraries/libunique/3.x.nix
+++ b/pkgs/development/libraries/libunique/3.x.nix
@@ -3,7 +3,6 @@
 , gtk-doc, docbook_xml_dtd_45, docbook_xsl
 , libxslt, libxml2 }:
 
-with lib;
 stdenv.mkDerivation rec {
 
   majorVer = "3.0";
@@ -23,8 +22,8 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://wiki.gnome.org/Attic/LibUnique";
     description = "A library for writing single instance applications";
-    license = licenses.lgpl21;
-    maintainers = [ maintainers.AndersonTorres ];
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.AndersonTorres ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libutempter/default.nix
+++ b/pkgs/development/libraries/libutempter/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchurl, lib, glib }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libutempter";
   version = "1.2.1";
@@ -28,7 +26,7 @@ stdenv.mkDerivation rec {
     "mandir=\${out}/share/man"
   ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/altlinux/libutempter";
     description = "Interface for terminal emulators such as screen and xterm to record user sessions to utmp and wtmp files";
     longDescription = ''

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -77,13 +77,11 @@
 , zfs
 }:
 
-with lib;
-
 let
   inherit (stdenv) isDarwin isLinux isx86_64;
-  binPath = makeBinPath ([
+  binPath = lib.makeBinPath ([
     dnsmasq
-  ] ++ optionals isLinux [
+  ] ++ lib.optionals isLinux [
     bridge-utils
     dmidecode
     dnsmasq
@@ -95,10 +93,10 @@ let
     numad
     pmutils
     systemd
-  ] ++ optionals enableIscsi [
+  ] ++ lib.optionals enableIscsi [
     libiscsi
     openiscsi
-  ] ++ optionals enableZfs [
+  ] ++ lib.optionals enableZfs [
     zfs
   ]);
 in
@@ -148,17 +146,17 @@ stdenv.mkDerivation rec {
 
     substituteInPlace meson.build \
       --replace "'dbus-daemon'," "'${lib.getBin dbus}/bin/dbus-daemon',"
-  '' + optionalString isLinux ''
+  '' + lib.optionalString isLinux ''
     sed -i 's,define PARTED "parted",define PARTED "${parted}/bin/parted",' \
       src/storage/storage_backend_disk.c \
       src/storage/storage_util.c
-  '' + optionalString isDarwin ''
+  '' + lib.optionalString isDarwin ''
     sed -i '/qemucapabilitiestest/d' tests/meson.build
     sed -i '/vircryptotest/d' tests/meson.build
     sed -i '/domaincapstest/d' tests/meson.build
     sed -i '/qemufirmwaretest/d' tests/meson.build
     sed -i '/qemuvhostusertest/d' tests/meson.build
-  '' + optionalString (isDarwin && isx86_64) ''
+  '' + lib.optionalString (isDarwin && isx86_64) ''
     sed -i '/qemucaps2xmltest/d' tests/meson.build
     sed -i '/qemuhotplugtest/d' tests/meson.build
     sed -i '/virnetdaemontest/d' tests/meson.build
@@ -178,9 +176,9 @@ stdenv.mkDerivation rec {
     perl
     perlPackages.XMLXPath
   ]
-  ++ optional (!isDarwin) rpcsvc-proto
+  ++ lib.optional (!isDarwin) rpcsvc-proto
   # NOTE: needed for rpcgen
-  ++ optional isDarwin darwin.developer_cmds;
+  ++ lib.optional isDarwin darwin.developer_cmds;
 
   buildInputs = [
     bash
@@ -197,7 +195,7 @@ stdenv.mkDerivation rec {
     readline
     xhtml1
     yajl
-  ] ++ optionals isLinux [
+  ] ++ lib.optionals isLinux [
     acl
     attr
     audit
@@ -213,17 +211,17 @@ stdenv.mkDerivation rec {
     parted
     systemd
     util-linux
-  ] ++ optionals isDarwin [
+  ] ++ lib.optionals isDarwin [
     AppKit
     Carbon
     gmp
     libiconv
   ]
-  ++ optionals enableCeph [ ceph ]
-  ++ optionals enableGlusterfs [ glusterfs ]
-  ++ optionals enableIscsi [ libiscsi openiscsi ]
-  ++ optionals enableXen [ xen ]
-  ++ optionals enableZfs [ zfs ];
+  ++ lib.optionals enableCeph [ ceph ]
+  ++ lib.optionals enableGlusterfs [ glusterfs ]
+  ++ lib.optionals enableIscsi [ libiscsi openiscsi ]
+  ++ lib.optionals enableXen [ xen ]
+  ++ lib.optionals enableZfs [ zfs ];
 
   preConfigure =
     let
@@ -348,7 +346,7 @@ stdenv.mkDerivation rec {
     # Added in nixpkgs:
     gettext() { "${gettext}/bin/gettext" "$@"; }
     '
-  '' + optionalString isLinux ''
+  '' + lib.optionalString isLinux ''
     for f in $out/lib/systemd/system/*.service ; do
       substituteInPlace $f --replace /bin/kill ${coreutils}/bin/kill
     done
@@ -372,7 +370,7 @@ stdenv.mkDerivation rec {
 
   passthru.tests.libvirtd = nixosTests.libvirtd;
 
-  meta = {
+  meta = with lib; {
     description = "A toolkit to interact with the virtualization capabilities of recent versions of Linux and other OSes";
     homepage = "https://libvirt.org/";
     changelog = "https://gitlab.com/libvirt/libvirt/-/raw/v${version}/NEWS.rst";

--- a/pkgs/development/libraries/libvmi/default.nix
+++ b/pkgs/development/libraries/libvmi/default.nix
@@ -10,8 +10,6 @@
   libvirt,
   xenSupport ? true }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libvmi";
   version = "0.12.0";
@@ -24,16 +22,16 @@ stdenv.mkDerivation rec {
     sha256 = "0wbi2nasb1gbci6cq23g6kq7i10rwi1y7r44rl03icr5prqjpdyv";
   };
 
-  buildInputs = [ glib libvirt json_c ] ++ (optional xenSupport xen);
+  buildInputs = [ glib libvirt json_c ] ++ (lib.optional xenSupport xen);
   nativeBuildInputs = [ autoreconfHook bison flex pkg-config ];
 
-  configureFlags = optional (!xenSupport) "--disable-xen";
+  configureFlags = lib.optional (!xenSupport) "--disable-xen";
 
   # libvmi uses dlopen() for the xen libraries, however autoPatchelfHook doesn't work here
-  postFixup = optionalString xenSupport ''
+  postFixup = lib.optionalString xenSupport ''
     libvmi="$out/lib/libvmi.so.${libVersion}"
     oldrpath=$(patchelf --print-rpath "$libvmi")
-    patchelf --set-rpath "$oldrpath:${makeLibraryPath [ xen ]}" "$libvmi"
+    patchelf --set-rpath "$oldrpath:${lib.makeLibraryPath [ xen ]}" "$libvmi"
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/libytnef/default.nix
+++ b/pkgs/development/libraries/libytnef/default.nix
@@ -1,7 +1,5 @@
 { stdenv, lib, fetchFromGitHub, autoreconfHook }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libytnef";
   version = "2.0";
@@ -15,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  meta = {
+  meta = with lib; {
     inherit (src.meta) homepage;
     description = "Yeraze's TNEF Stream Reader - for winmail.dat files";
     license = licenses.gpl2Plus;

--- a/pkgs/development/libraries/nuspell/wrapper.nix
+++ b/pkgs/development/libraries/nuspell/wrapper.nix
@@ -1,10 +1,10 @@
 { stdenv, lib, nuspell, makeWrapper, dicts ? [] }:
-with lib;
+
 let
-  searchPath = makeSearchPath "share/hunspell" dicts;
+  searchPath = lib.makeSearchPath "share/hunspell" dicts;
 in
 stdenv.mkDerivation {
-  name = (appendToName "with-dicts" nuspell).name;
+  name = (lib.appendToName "with-dicts" nuspell).name;
   nativeBuildInputs = [ makeWrapper ];
   buildCommand = ''
     makeWrapper ${nuspell}/bin/nuspell $out/bin/nuspell --prefix DICPATH : ${lib.escapeShellArg searchPath}

--- a/pkgs/development/libraries/opencascade/default.nix
+++ b/pkgs/development/libraries/opencascade/default.nix
@@ -3,7 +3,6 @@
   OpenCL, Cocoa
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "opencascade-oce";
   version = "0.18.3";
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
     libGL libGLU libXmu freetype fontconfig expat freeimage vtk
     gl2ps tbb
   ]
-    ++ optionals stdenv.isDarwin [OpenCL Cocoa]
+    ++ lib.optionals stdenv.isDarwin [OpenCL Cocoa]
   ;
 
   cmakeFlags = [
@@ -30,7 +29,7 @@ stdenv.mkDerivation rec {
     "-DOCE_WITH_GL2PS=ON"
     "-DOCE_MULTITHREAD_LIBRARY=TBB"
   ]
-  ++ optionals stdenv.isDarwin ["-DOCE_OSX_USE_COCOA=ON" "-DOCE_WITH_OPENCL=ON"];
+  ++ lib.optionals stdenv.isDarwin ["-DOCE_OSX_USE_COCOA=ON" "-DOCE_WITH_OPENCL=ON"];
 
   patches = [
     # Use fontconfig instead of hardcoded directory list
@@ -56,7 +55,7 @@ stdenv.mkDerivation rec {
       --replace FONTCONFIG_LIBRARIES FONTCONFIG_LINK_LIBRARIES
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Open CASCADE Technology, libraries for 3D modeling and numerical simulation";
     homepage = "https://github.com/tpaviot/oce";
     maintainers = [ maintainers.viric ];

--- a/pkgs/development/libraries/pcg-c/default.nix
+++ b/pkgs/development/libraries/pcg-c/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchzip }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   version = "0.94";
   pname = "pcg-c";
@@ -31,8 +29,8 @@ stdenv.mkDerivation rec {
       algorithms for random number generation. Unlike many general-purpose RNGs,
       they are also hard to predict.
     '';
-    platforms = platforms.unix;
-    maintainers = [ maintainers.linus ];
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.linus ];
     broken = stdenv.isi686; # https://github.com/imneme/pcg-c/issues/11
   };
 }

--- a/pkgs/development/libraries/pcre/default.nix
+++ b/pkgs/development/libraries/pcre/default.nix
@@ -3,9 +3,7 @@
 , variant ? null
 }:
 
-with lib;
-
-assert elem variant [ null "cpp" "pcre16" "pcre32" ];
+assert lib.elem variant [ null "cpp" "pcre16" "pcre32" ];
 
 stdenv.mkDerivation rec {
   pname = "pcre"
@@ -21,11 +19,11 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" "doc" "man" ];
 
   # Disable jit on Apple Silicon, https://github.com/zherczeg/sljit/issues/51
-  configureFlags = optional (!(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)) "--enable-jit=auto" ++ [
+  configureFlags = lib.optional (!(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)) "--enable-jit=auto" ++ [
     "--enable-unicode-properties"
     "--disable-cpp"
   ]
-    ++ optional (variant != null) "--enable-${variant}";
+    ++ lib.optional (variant != null) "--enable-${variant}";
 
   # https://bugs.exim.org/show_bug.cgi?id=2173
   patches = [ ./stacksize-detection.patch ];
@@ -40,7 +38,7 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     moveToOutput bin/pcre-config "$dev"
-  '' + optionalString (variant != null) ''
+  '' + lib.optionalString (variant != null) ''
     ln -sf -t "$out/lib/" '${pcre.out}'/lib/libpcre{,posix}.{so.*.*.*,*dylib,*a}
   '';
 
@@ -57,7 +55,7 @@ stdenv.mkDerivation rec {
       PCRE library is free, even for building proprietary software.
     '';
 
-    platforms = platforms.all;
-    maintainers = with maintainers; [ ];
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/libraries/phonon/backends/gstreamer.nix
+++ b/pkgs/development/libraries/phonon/backends/gstreamer.nix
@@ -3,8 +3,6 @@
 , debug ? false
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "phonon-backend-gstreamer";
   version = "4.10.0";

--- a/pkgs/development/libraries/phonon/default.nix
+++ b/pkgs/development/libraries/phonon/default.nix
@@ -12,8 +12,6 @@
 , debug ? false
 }:
 
-with lib;
-
 let
   soname = "phonon4qt5";
   buildsystemdir = "share/cmake/${soname}";

--- a/pkgs/development/libraries/science/math/clmagma/default.nix
+++ b/pkgs/development/libraries/science/math/clmagma/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl, gfortran, opencl-headers, clblas, ocl-icd, mkl, intel-ocl }:
 
-with lib;
-
 let
   incfile = builtins.toFile "make.inc.custom" ''
     CC        = g++

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -32,8 +32,6 @@
 , python3
 }:
 
-with lib;
-
 let blas64_ = blas64; in
 
 let
@@ -121,7 +119,7 @@ let
   blas64 =
     if blas64_ != null
       then blas64_
-      else hasPrefix "x86_64" stdenv.hostPlatform.system;
+      else lib.hasPrefix "x86_64" stdenv.hostPlatform.system;
   # Convert flag values to format OpenBLAS's build expects.
   # `toString` is almost what we need other than bools,
   # which we need to map {true -> 1, false -> 0}
@@ -129,7 +127,7 @@ let
   mkMakeFlagValue = val:
     if !builtins.isBool val then toString val
     else if val then "1" else "0";
-  mkMakeFlagsFromConfig = mapAttrsToList (var: val: "${var}=${mkMakeFlagValue val}");
+  mkMakeFlagsFromConfig = lib.mapAttrsToList (var: val: "${var}=${mkMakeFlagValue val}");
 
   shlibExt = stdenv.hostPlatform.extensions.sharedLibrary;
 

--- a/pkgs/development/libraries/sope/default.nix
+++ b/pkgs/development/libraries/sope/default.nix
@@ -1,6 +1,5 @@
 { gnustep, lib, fetchFromGitHub , libxml2, openssl
 , openldap, mariadb, libmysqlclient, postgresql }:
-with lib;
 
 gnustep.stdenv.mkDerivation rec {
   pname = "sope";
@@ -15,10 +14,10 @@ gnustep.stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
   nativeBuildInputs = [ gnustep.make ];
-  buildInputs = flatten ([ gnustep.base libxml2 openssl ]
-    ++ optional (openldap != null) openldap
-    ++ optionals (mariadb != null) [ libmysqlclient mariadb ]
-    ++ optional (postgresql != null) postgresql);
+  buildInputs = lib.flatten ([ gnustep.base libxml2 openssl ]
+    ++ lib.optional (openldap != null) openldap
+    ++ lib.optionals (mariadb != null) [ libmysqlclient mariadb ]
+    ++ lib.optional (postgresql != null) postgresql);
 
   postPatch = ''
     # Exclude NIX_ variables
@@ -30,9 +29,9 @@ gnustep.stdenv.mkDerivation rec {
   '';
 
   configureFlags = [ "--prefix=" "--disable-debug" "--enable-xml" "--with-ssl=ssl" ]
-    ++ optional (openldap != null) "--enable-openldap"
-    ++ optional (mariadb != null) "--enable-mysql"
-    ++ optional (postgresql != null) "--enable-postgresql";
+    ++ lib.optional (openldap != null) "--enable-openldap"
+    ++ lib.optional (mariadb != null) "--enable-mysql"
+    ++ lib.optional (postgresql != null) "--enable-postgresql";
 
   # Yes, this is ugly.
   preFixup = ''
@@ -40,7 +39,7 @@ gnustep.stdenv.mkDerivation rec {
     rm -rf $out/nix/store
   '';
 
-  meta = {
+  meta = with lib; {
     description = "An extensive set of frameworks which form a complete Web application server environment";
     license = licenses.publicDomain;
     homepage = "https://github.com/inverse-inc/sope";

--- a/pkgs/development/libraries/sqlite/archive-version.nix
+++ b/pkgs/development/libraries/sqlite/archive-version.nix
@@ -1,11 +1,9 @@
 lib: version:
 
-with lib;
-
 let
-  fragments = splitVersion version;
-  major = head fragments;
-  minor = concatMapStrings (fixedWidthNumber 2) (tail fragments);
+  fragments = lib.splitVersion version;
+  major = lib.head fragments;
+  minor = lib.concatMapStrings (lib.fixedWidthNumber 2) (lib.tail fragments);
 in
 
 major + minor + "00"

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -9,14 +9,12 @@
 , enableDeserialize ? false
 }:
 
-with lib;
-
 let
   archiveVersion = import ./archive-version.nix lib;
 in
 
 stdenv.mkDerivation rec {
-  pname = "sqlite${optionalString interactive "-interactive"}";
+  pname = "sqlite${lib.optionalString interactive "-interactive"}";
   version = "3.40.1";
 
   # nixpkgs-update: no auto update
@@ -29,14 +27,14 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" ];
   separateDebugInfo = stdenv.isLinux;
 
-  buildInputs = [ zlib ] ++ optionals interactive [ readline ncurses ];
+  buildInputs = [ zlib ] ++ lib.optionals interactive [ readline ncurses ];
 
   # required for aarch64 but applied for all arches for simplicity
   preConfigure = ''
     patchShebangs configure
   '';
 
-  configureFlags = [ "--enable-threadsafe" ] ++ optional interactive "--enable-readline";
+  configureFlags = [ "--enable-threadsafe" ] ++ lib.optional interactive "--enable-readline";
 
   NIX_CFLAGS_COMPILE = toString ([
     "-DSQLITE_ENABLE_COLUMN_METADATA"
@@ -94,7 +92,7 @@ stdenv.mkDerivation rec {
     inherit sqldiff sqlite-analyzer tracker;
   };
 
-  meta = {
+  meta = with lib; {
     description = "A self-contained, serverless, zero-configuration, transactional SQL database engine";
     downloadPage = "https://sqlite.org/download.html";
     homepage = "https://www.sqlite.org/";

--- a/pkgs/development/libraries/srt/default.nix
+++ b/pkgs/development/libraries/srt/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, openssl
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "srt";
   version = "1.5.1";
@@ -28,7 +27,7 @@ stdenv.mkDerivation rec {
     "-UCMAKE_INSTALL_LIBDIR"
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Secure, Reliable, Transport";
     homepage    = "https://github.com/Haivision/srt";
     license     = licenses.mpl20;

--- a/pkgs/development/libraries/unittest-cpp/default.nix
+++ b/pkgs/development/libraries/unittest-cpp/default.nix
@@ -1,7 +1,5 @@
 {lib, stdenv, fetchFromGitHub, cmake}:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "unittest-cpp";
   version = "2.0.0";
@@ -20,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/unittest-cpp/unittest-cpp";
     description = "Lightweight unit testing framework for C++";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/libraries/xvidcore/default.nix
+++ b/pkgs/development/libraries/xvidcore/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchurl, yasm, autoconf, automake, libtool }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "xvidcore";
   version = "1.3.7";
@@ -13,7 +12,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     # Configure script is not in the root of the source directory
     cd build/generic
-  '' + optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     # Undocumented darwin hack
     substituteInPlace configure --replace "-no-cpp-precomp" ""
   '';
@@ -21,22 +20,22 @@ stdenv.mkDerivation rec {
   configureFlags = [ ]
     # Undocumented darwin hack (assembly is probably disabled due to an
     # issue with nasm, however yasm is now used)
-    ++ optional stdenv.isDarwin "--enable-macosx_module --disable-assembly";
+    ++ lib.optional stdenv.isDarwin "--enable-macosx_module --disable-assembly";
 
   nativeBuildInputs = [ ]
-    ++ optional (!stdenv.isDarwin) yasm;
+    ++ lib.optional (!stdenv.isDarwin) yasm;
 
   buildInputs = [ ]
     # Undocumented darwin hack
-    ++ optionals stdenv.isDarwin [ autoconf automake libtool ];
+    ++ lib.optionals stdenv.isDarwin [ autoconf automake libtool ];
 
   # Don't remove static libraries (e.g. 'libs/*.a') on darwin.  They're needed to
   # compile ffmpeg (and perhaps other things).
-  postInstall = optionalString (!stdenv.isDarwin) ''
+  postInstall = lib.optionalString (!stdenv.isDarwin) ''
     rm $out/lib/*.a
   '';
 
-  meta = {
+  meta = with lib; {
     description = "MPEG-4 video codec for PC";
     homepage    = "https://www.xvid.com/";
     license     = licenses.gpl2;

--- a/pkgs/development/misc/msp430/mspds/binary.nix
+++ b/pkgs/development/misc/msp430/mspds/binary.nix
@@ -1,9 +1,7 @@
 { stdenv, lib, fetchurl, unzip, autoPatchelfHook }:
 
-with lib;
-
 let
-  archPostfix = optionalString (stdenv.is64bit && !stdenv.isDarwin) "_64";
+  archPostfix = lib.optionalString (stdenv.is64bit && !stdenv.isDarwin) "_64";
 in stdenv.mkDerivation rec {
   pname = "msp-debug-stack-bin";
   version = "3.15.1.1";
@@ -26,7 +24,7 @@ in stdenv.mkDerivation rec {
     install -Dm0644 -t $out/include Inc/*.h
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Unfree binary release of the TI MSP430 FET debug driver";
     homepage = "https://www.ti.com/tool/MSPDS";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/development/misc/msp430/mspds/default.nix
+++ b/pkgs/development/misc/msp430/mspds/default.nix
@@ -6,11 +6,10 @@
 , libusb1 ? null
 }:
 
-with lib;
 assert stdenv.isLinux -> libusb1 != null;
 
 let
-  hidapiDriver = optionalString stdenv.isLinux "-libusb";
+  hidapiDriver = lib.optionalString stdenv.isLinux "-libusb";
 
 in stdenv.mkDerivation {
   pname = "msp-debug-stack";
@@ -33,7 +32,7 @@ in stdenv.mkDerivation {
   preBuild = ''
     rm ThirdParty/src/pugixml.cpp
     rm ThirdParty/include/pugi{config,xml}.hpp
-  '' + optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     makeFlagsArray+=(OUTNAME="-install_name ")
   '';
 
@@ -44,9 +43,9 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ unzip ];
   buildInputs = [ boost hidapi pugixml ]
-    ++ optional stdenv.isLinux libusb1;
+    ++ lib.optional stdenv.isLinux libusb1;
 
-  meta = {
+  meta = with lib; {
     description = "TI MSP430 FET debug driver";
     homepage = "https://www.ti.com/tool/MSPDS";
     license = licenses.bsd3;

--- a/pkgs/development/ocaml-modules/elpi/default.nix
+++ b/pkgs/development/ocaml-modules/elpi/default.nix
@@ -11,7 +11,7 @@
 , version ? if lib.versionAtLeast ocaml.version "4.08" then "1.16.5"
     else if lib.versionAtLeast ocaml.version "4.07" then "1.15.2" else "1.14.1"
 }:
-with lib;
+
 let fetched = coqPackages.metaFetch ({
     release."1.16.5".sha256 = "sha256-tKX5/cVPoBeHiUe+qn7c5FIRYCwY0AAukN7vSd/Nz9A=";
     release."1.15.2".sha256 = "sha256-XgopNP83POFbMNyl2D+gY1rmqGg03o++Ngv3zJfCn2s=";
@@ -31,17 +31,17 @@ buildDunePackage rec {
   pname = "elpi";
   inherit (fetched) version src;
 
-  patches = lib.optional (versionAtLeast version "1.16" || version == "dev")
+  patches = lib.optional (lib.versionAtLeast version "1.16" || version == "dev")
     ./atd_2_10.patch;
 
   minimalOCamlVersion = "4.04";
 
   buildInputs = [ perl ncurses ]
-  ++ optional (versionAtLeast version "1.15" || version == "dev") menhir
-  ++ optional (versionAtLeast version "1.16" || version == "dev") atdgen;
+  ++ lib.optional (lib.versionAtLeast version "1.15" || version == "dev") menhir
+  ++ lib.optional (lib.versionAtLeast version "1.16" || version == "dev") atdgen;
 
   propagatedBuildInputs = [ re stdlib-shims ]
-  ++ (if versionAtLeast version "1.15" || version == "dev"
+  ++ (if lib.versionAtLeast version "1.15" || version == "dev"
      then [ menhirLib ]
      else [ camlp5 ]
   )
@@ -50,7 +50,7 @@ buildDunePackage rec {
      else [ ppxlib_0_15 ppx_deriving_0_15 ]
   );
 
-  meta = {
+  meta = with lib; {
     description = "Embeddable λProlog Interpreter";
     license = licenses.lgpl21Plus;
     maintainers = [ maintainers.vbgl ];

--- a/pkgs/development/ocaml-modules/mtime/default.nix
+++ b/pkgs/development/ocaml-modules/mtime/default.nix
@@ -1,8 +1,6 @@
 { stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
 
-with lib;
-
-throwIfNot (versionAtLeast ocaml.version "4.08")
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.08")
   "mtime is not available for OCaml ${ocaml.version}"
 
 stdenv.mkDerivation rec {
@@ -21,7 +19,7 @@ stdenv.mkDerivation rec {
 
   inherit (topkg) buildPhase installPhase;
 
-  meta = {
+  meta = with lib; {
     description = "Monotonic wall-clock time for OCaml";
     homepage = "https://erratique.ch/software/mtime";
     inherit (ocaml.meta) platforms;

--- a/pkgs/development/ocaml-modules/vg/default.nix
+++ b/pkgs/development/ocaml-modules/vg/default.nix
@@ -5,8 +5,6 @@
   htmlcBackend ? true # depends on js_of_ocaml
 }:
 
-with lib;
-
 let
   inherit (lib) optionals versionOlder;
 
@@ -38,14 +36,14 @@ stdenv.mkDerivation {
   strictDeps = true;
 
   buildPhase = topkg.buildPhase
-    + " --with-uutf ${boolToString pdfBackend}"
-    + " --with-otfm ${boolToString pdfBackend}"
-    + " --with-js_of_ocaml ${boolToString htmlcBackend}"
+    + " --with-uutf ${lib.boolToString pdfBackend}"
+    + " --with-otfm ${lib.boolToString pdfBackend}"
+    + " --with-js_of_ocaml ${lib.boolToString htmlcBackend}"
     + " --with-cairo2 false";
 
   inherit (topkg) installPhase;
 
-  meta = {
+  meta = with lib; {
     description = "Declarative 2D vector graphics for OCaml";
     longDescription = ''
     Vg is an OCaml module for declarative 2D vector graphics. In Vg, images

--- a/pkgs/development/python-modules/mohawk/default.nix
+++ b/pkgs/development/python-modules/mohawk/default.nix
@@ -1,6 +1,5 @@
 { lib, buildPythonPackage, fetchPypi, mock, nose, pytest, six }:
 
-with lib;
 buildPythonPackage rec {
   pname = "mohawk";
   version = "1.1.0";
@@ -21,7 +20,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for Hawk HTTP authorization.";
     homepage = "https://github.com/kumar303/mohawk";
-    license = licenses.mpl20;
+    license = lib.licenses.mpl20;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -1,8 +1,6 @@
 { lib, stdenv, fetchurl, jre, writeScript, common-updater-scripts, git, nixfmt
 , nix, coreutils, gnused, disableRemoteLogging ? true }:
 
-with lib;
-
 let
   repo = "git@github.com:lihaoyi/Ammonite.git";
 
@@ -22,7 +20,7 @@ let
       installPhase = ''
         install -Dm755 $src $out/bin/amm
         sed -i '0,/java/{s|java|${jre}/bin/java|}' $out/bin/amm
-      '' + optionalString (disableRemoteLogging) ''
+      '' + lib.optionalString (disableRemoteLogging) ''
         sed -i "0,/ammonite.Main/{s|ammonite.Main'|ammonite.Main' --no-remote-logging|}" $out/bin/amm
         sed -i '1i #!/bin/sh' $out/bin/amm
       '';
@@ -66,7 +64,7 @@ let
         runHook postInstallCheck
       '';
 
-      meta = {
+      meta = with lib; {
         description = "Improved Scala REPL";
         longDescription = ''
           The Ammonite-REPL is an improved Scala REPL, re-implemented from first principles.

--- a/pkgs/development/tools/butane/default.nix
+++ b/pkgs/development/tools/butane/default.nix
@@ -1,7 +1,5 @@
 { lib, fetchFromGitHub, buildGoModule }:
 
-with lib;
-
 buildGoModule rec {
   pname = "butane";
   version = "0.17.0";
@@ -27,7 +25,7 @@ buildGoModule rec {
     mv $out/bin/{internal,butane}
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Translates human-readable Butane configs into machine-readable Ignition configs";
     license = licenses.asl20;
     homepage = "https://github.com/coreos/butane";

--- a/pkgs/development/tools/eclipse-mat/default.nix
+++ b/pkgs/development/tools/eclipse-mat/default.nix
@@ -18,13 +18,12 @@
 , zlib
 }:
 
-with lib;
 let
   pVersion = "1.13.0.20220615";
-  pVersionTriple = splitVersion pVersion;
-  majorVersion = elemAt pVersionTriple 0;
-  minorVersion = elemAt pVersionTriple 1;
-  patchVersion = elemAt pVersionTriple 2;
+  pVersionTriple = lib.splitVersion pVersion;
+  majorVersion = lib.elemAt pVersionTriple 0;
+  minorVersion = lib.elemAt pVersionTriple 1;
+  patchVersion = lib.elemAt pVersionTriple 2;
   baseVersion = "${majorVersion}.${minorVersion}.${patchVersion}";
   jdk = jdk11;
 in

--- a/pkgs/development/tools/iaca/2.1.nix
+++ b/pkgs/development/tools/iaca/2.1.nix
@@ -1,5 +1,4 @@
 { lib, stdenv, makeWrapper, requireFile, gcc, unzip }:
-with lib;
 
 # v2.1: last version with NHM/WSM arch support
 stdenv.mkDerivation rec {
@@ -17,17 +16,17 @@ stdenv.mkDerivation rec {
     cp bin/iaca $out/bin/
     cp lib/* $out/lib
   '';
-  preFixup = let libPath = makeLibraryPath [ stdenv.cc.cc.lib gcc ]; in ''
+  preFixup = let libPath = lib.makeLibraryPath [ stdenv.cc.cc.lib gcc ]; in ''
     patchelf \
         --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 \
         --set-rpath $out/lib:"${libPath}" \
         $out/bin/iaca
   '';
   postFixup = "wrapProgram $out/bin/iaca --set LD_LIBRARY_PATH $out/lib";
-  meta = {
+  meta = with lib; {
     description = "Intel Architecture Code Analyzer";
     homepage = "https://software.intel.com/en-us/articles/intel-architecture-code-analyzer/";
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ kazcw ];

--- a/pkgs/development/tools/iaca/3.0.nix
+++ b/pkgs/development/tools/iaca/3.0.nix
@@ -1,5 +1,4 @@
 { lib, stdenv, requireFile, unzip }:
-with lib;
 
 stdenv.mkDerivation rec {
   pname = "iaca";
@@ -15,10 +14,10 @@ stdenv.mkDerivation rec {
     cp iaca $out/bin
     patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 $out/bin/iaca
   '';
-  meta = {
+  meta = with lib; {
     description = "Intel Architecture Code Analyzer";
     homepage = "https://software.intel.com/en-us/articles/intel-architecture-code-analyzer/";
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ kazcw ];

--- a/pkgs/development/tools/kind/default.nix
+++ b/pkgs/development/tools/kind/default.nix
@@ -1,7 +1,5 @@
 { lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
-with lib;
-
 buildGoModule rec {
   pname = "kind";
   version = "0.17.0";
@@ -36,11 +34,11 @@ buildGoModule rec {
     done
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Kubernetes IN Docker - local clusters for testing Kubernetes";
     homepage    = "https://github.com/kubernetes-sigs/kind";
     maintainers = with maintainers; [ offline rawkode ];
-    license     = lib.licenses.asl20;
+    license     = licenses.asl20;
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/tools/misc/kibana/7.x.nix
+++ b/pkgs/development/tools/misc/kibana/7.x.nix
@@ -9,11 +9,10 @@
 , which
 }:
 
-with lib;
 let
   nodejs = nodejs-16_x;
   inherit (builtins) elemAt;
-  info = splitString "-" stdenv.hostPlatform.system;
+  info = lib.splitString "-" stdenv.hostPlatform.system;
   arch = elemAt info 0;
   plat = elemAt info 1;
   shas =
@@ -50,7 +49,7 @@ in stdenv.mkDerivation rec {
     sed -i 's@NODE=.*@NODE=${nodejs}/bin/node@' $out/libexec/kibana/bin/kibana
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Visualize logs and time-stamped data";
     homepage = "http://www.elasticsearch.org/overview/kibana";
     license = licenses.elastic;

--- a/pkgs/development/tools/misc/pkg-config/default.nix
+++ b/pkgs/development/tools/misc/pkg-config/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl, libiconv, vanilla ? false }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "pkg-config";
   version = "0.29.2";
@@ -17,20 +15,20 @@ stdenv.mkDerivation rec {
   # Process Requires.private properly, see
   # http://bugs.freedesktop.org/show_bug.cgi?id=4738, migrated to
   # https://gitlab.freedesktop.org/pkg-config/pkg-config/issues/28
-  patches = optional (!vanilla) ./requires-private.patch
-    ++ optional stdenv.isCygwin ./2.36.3-not-win32.patch;
+  patches = lib.optional (!vanilla) ./requires-private.patch
+    ++ lib.optional stdenv.isCygwin ./2.36.3-not-win32.patch;
 
   # These three tests fail due to a (desired) behavior change from our ./requires-private.patch
   postPatch = if vanilla then null else ''
     rm -f check/check-requires-private check/check-gtk check/missing
   '';
 
-  buildInputs = optional (stdenv.isCygwin || stdenv.isDarwin || stdenv.isSunOS) libiconv;
+  buildInputs = lib.optional (stdenv.isCygwin || stdenv.isDarwin || stdenv.isSunOS) libiconv;
 
   configureFlags = [ "--with-internal-glib" ]
-    ++ optionals (stdenv.isSunOS) [ "--with-libiconv=gnu" "--with-system-library-path" "--with-system-include-path" "CFLAGS=-DENABLE_NLS" ]
+    ++ lib.optionals (stdenv.isSunOS) [ "--with-libiconv=gnu" "--with-system-library-path" "--with-system-include-path" "CFLAGS=-DENABLE_NLS" ]
        # Can't run these tests while cross-compiling
-    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform)
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform)
        [ "glib_cv_stack_grows=no"
          "glib_cv_uscore=no"
          "ac_cv_func_posix_getpwuid_r=yes"
@@ -42,7 +40,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''rm -f "$out"/bin/*-pkg-config''; # clean the duplicate file
 
-  meta = {
+  meta = with lib; {
     description = "A tool that allows packages to find out information about other packages";
     homepage = "http://pkg-config.freedesktop.org/wiki/";
     platforms = platforms.all;

--- a/pkgs/development/tools/misc/premake/5.nix
+++ b/pkgs/development/tools/misc/premake/5.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, libuuid, cacert, Foundation, readline }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "premake5";
   version = "5.0.0-beta2";
@@ -13,13 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-2R5gq4jaQsp8Ny1oGuIYkef0kn2UG9jMf20vq0714oY=";
   };
 
-  buildInputs = [ libuuid ] ++ optionals stdenv.isDarwin [ Foundation readline ];
+  buildInputs = [ libuuid ] ++ lib.optionals stdenv.isDarwin [ Foundation readline ];
 
   patches = [ ./no-curl-ca.patch ];
   patchPhase = ''
     substituteInPlace contrib/curl/premake5.lua \
       --replace "ca = nil" "ca = '${cacert}/etc/ssl/certs/ca-bundle.crt'"
-  '' + optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     substituteInPlace premake5.lua \
       --replace -mmacosx-version-min=10.4 -mmacosx-version-min=10.5
   '';
@@ -42,7 +40,7 @@ stdenv.mkDerivation rec {
     homepage = "https://premake.github.io";
     description = "A simple build configuration and project generation tool using lua";
     license = lib.licenses.bsd3;
-    platforms = platforms.darwin ++ platforms.linux;
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
     broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -3,8 +3,6 @@
 , withDocumentation ? false, withClangPlugins ? true
 }:
 
-with lib;
-
 let
   # Fetch clang from qt vendor, this contains submodules like this:
   # clang<-clang-tools-extra<-clazy.
@@ -31,7 +29,7 @@ mkDerivation rec {
   };
 
   buildInputs = [ qtbase qtscript qtquickcontrols qtdeclarative elfutils.dev ] ++
-    optionals withClangPlugins [ llvmPackages_8.libclang
+    lib.optionals withClangPlugins [ llvmPackages_8.libclang
                                  clang_qt_vendor
                                  llvmPackages_8.llvm ];
 
@@ -47,9 +45,9 @@ mkDerivation rec {
 
   doCheck = true;
 
-  buildFlags = optional withDocumentation "docs";
+  buildFlags = lib.optional withDocumentation "docs";
 
-  installFlags = [ "INSTALL_ROOT=$(out)" ] ++ optional withDocumentation "install_docs";
+  installFlags = [ "INSTALL_ROOT=$(out)" ] ++ lib.optional withDocumentation "install_docs";
 
   qtWrapperArgs = [ "--set-default PERFPROFILER_PARSER_FILEPATH ${lib.getBin perf}/bin" ];
 
@@ -58,7 +56,7 @@ mkDerivation rec {
       --replace '$$[QT_INSTALL_QML]/QtQuick/Controls' '${qtquickcontrols}/${qtbase.qtQmlPrefix}/QtQuick/Controls'
     substituteInPlace src/libs/libs.pro \
       --replace '$$[QT_INSTALL_QML]/QtQuick/Controls' '${qtquickcontrols}/${qtbase.qtQmlPrefix}/QtQuick/Controls'
-    '' + optionalString withClangPlugins ''
+    '' + lib.optionalString withClangPlugins ''
     # Fix paths for llvm/clang includes directories.
     substituteInPlace src/shared/clang/clang_defines.pri \
       --replace '$$clean_path($${LLVM_LIBDIR}/clang/$${LLVM_VERSION}/include)' '${clang_qt_vendor}/lib/clang/8.0.0/include' \
@@ -72,8 +70,8 @@ mkDerivation rec {
       --replace 'LLVM_CXXFLAGS ~= s,-gsplit-dwarf,' '${lib.concatStringsSep "\n" ["LLVM_CXXFLAGS ~= s,-gsplit-dwarf," "    LLVM_CXXFLAGS += -fno-rtti"]}'
   '';
 
-  preBuild = optionalString withDocumentation ''
-    ln -s ${getLib qtbase}/$qtDocPrefix $NIX_QT5_TMP/share
+  preBuild = lib.optionalString withDocumentation ''
+    ln -s ${lib.getLib qtbase}/$qtDocPrefix $NIX_QT5_TMP/share
   '';
 
   postInstall = ''
@@ -92,7 +90,7 @@ mkDerivation rec {
     '';
     homepage = "https://wiki.qt.io/Category:Tools::QtCreator";
     license = "LGPL";
-    maintainers = [ maintainers.akaWolf ];
+    maintainers = [ lib.maintainers.akaWolf ];
     platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" ];
   };
 }

--- a/pkgs/development/tools/sauce-connect/default.nix
+++ b/pkgs/development/tools/sauce-connect/default.nix
@@ -1,7 +1,5 @@
 { stdenv, lib, fetchurl, zlib, unzip }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "sauce-connect";
   version = "4.5.4";
@@ -24,7 +22,7 @@ stdenv.mkDerivation rec {
   patchPhase = lib.optionalString stdenv.isLinux ''
     patchelf \
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "$out/lib:${makeLibraryPath [zlib]}" \
+      --set-rpath "$out/lib:${lib.makeLibraryPath [zlib]}" \
       bin/sc
   '';
 
@@ -35,7 +33,7 @@ stdenv.mkDerivation rec {
 
   dontStrip = true;
 
-  meta = {
+  meta = with lib; {
     description = "A secure tunneling app for executing tests securely when testing behind firewalls";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;

--- a/pkgs/development/tools/selenium/htmlunit-driver/default.nix
+++ b/pkgs/development/tools/selenium/htmlunit-driver/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "htmlunit-driver-standalone";
   version = "2.27";
@@ -15,7 +13,7 @@ stdenv.mkDerivation rec {
 
   installPhase = "install -D $src $out/share/lib/${pname}-${version}/${pname}-${version}.jar";
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/SeleniumHQ/htmlunit-driver";
     description = "A WebDriver server for running Selenium tests on the HtmlUnit headless browser";
     maintainers = with maintainers; [ coconnor offline ];

--- a/pkgs/development/tools/selenium/selendroid/default.nix
+++ b/pkgs/development/tools/selenium/selendroid/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchurl, makeWrapper, jdk, selenium-server-standalone }:
 
-with lib;
 let
     pname = "selendroid-standalone";
     pluginName = "selendroid-grid-plugin-${version}";
@@ -39,7 +38,7 @@ stdenv.mkDerivation {
       --add-flags "-capabilityMatcher io.selendroid.grid.SelendroidCapabilityMatcher"
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "http://selendroid.io/";
     description = "Test automation for native or hybrid Android apps and the mobile web";
     maintainers = with maintainers; [ offline ];

--- a/pkgs/development/tools/selenium/server/default.nix
+++ b/pkgs/development/tools/selenium/server/default.nix
@@ -1,8 +1,6 @@
 { lib, stdenv, fetchurl, makeWrapper, jre
 , htmlunit-driver, chromedriver, chromeSupport ? true }:
 
-with lib;
-
 let
   minorVersion = "3.141";
   patchVersion = "59";
@@ -26,11 +24,11 @@ in stdenv.mkDerivation rec {
     cp $src $out/share/lib/${pname}-${version}/${pname}-${version}.jar
     makeWrapper ${jre}/bin/java $out/bin/selenium-server \
       --add-flags "-cp $out/share/lib/${pname}-${version}/${pname}-${version}.jar:${htmlunit-driver}/share/lib/${htmlunit-driver.name}/${htmlunit-driver.name}.jar" \
-      ${optionalString chromeSupport "--add-flags -Dwebdriver.chrome.driver=${chromedriver}/bin/chromedriver"} \
+      ${lib.optionalString chromeSupport "--add-flags -Dwebdriver.chrome.driver=${chromedriver}/bin/chromedriver"} \
       --add-flags "org.openqa.grid.selenium.GridLauncherV3"
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "http://www.seleniumhq.org/";
     description = "Selenium Server for remote WebDriver";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];

--- a/pkgs/development/tools/summon/default.nix
+++ b/pkgs/development/tools/summon/default.nix
@@ -1,7 +1,5 @@
 { buildGoModule, fetchFromGitHub, lib, patchResolver ? true }:
 
-with lib;
-
 buildGoModule rec {
   pname = "summon";
   version = "0.8.2";
@@ -19,7 +17,7 @@ buildGoModule rec {
 
   # Patches provider resolver to support resolving unqualified names
   # from $PATH, e.g. `summon -p gopass` instead of `summon -p $(which gopass)`
-  patches = optionals patchResolver [ ./resolve-paths.patch ];
+  patches = lib.optionals patchResolver [ ./resolve-paths.patch ];
 
   postInstall = ''
     mv $out/bin/cmd $out/bin/summon

--- a/pkgs/games/arx-libertatis/default.nix
+++ b/pkgs/games/arx-libertatis/default.nix
@@ -8,8 +8,6 @@
 ,   gdb  ? null
 }:
 
-with lib;
-
 stdenv.mkDerivation {
   pname = "arx-libertatis";
   version = "2020-10-20";
@@ -23,13 +21,13 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     cmake inkscape imagemagick optipng
-  ] ++ optionals withCrashReporter [ wrapQtAppsHook ];
+  ] ++ lib.optionals withCrashReporter [ wrapQtAppsHook ];
 
   buildInputs = [
     zlib boost openal glm
     freetype libGLU SDL2 libepoxy
-  ] ++ optionals withCrashReporter [ qtbase curl ]
-    ++ optionals stdenv.isLinux    [ gdb ];
+  ] ++ lib.optionals withCrashReporter [ qtbase curl ]
+    ++ lib.optionals stdenv.isLinux    [ gdb ];
 
   cmakeFlags = [
     "-DDATA_DIR_PREFIXES=$out/share"
@@ -43,11 +41,11 @@ stdenv.mkDerivation {
     ln -sf \
       ${dejavu_fonts}/share/fonts/truetype/DejaVuSansMono.ttf \
       $out/share/games/arx/misc/dejavusansmono.ttf
-  '' + optionalString withCrashReporter ''
+  '' + lib.optionalString withCrashReporter ''
     wrapQtApp "$out/libexec/arxcrashreporter"
   '';
 
-  meta = {
+  meta = with lib; {
     description = ''
       A cross-platform, open source port of Arx Fatalis, a 2002
       first-person role-playing game / dungeon crawler

--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -32,8 +32,6 @@
 # changes on later launches, but consider extending the wrapper with your
 # desired options instead.
 
-with lib;
-
 let
   callPackage = newScope self;
 
@@ -91,7 +89,7 @@ let
     df-hashes = lib.importJSON ./game.json;
 
     # Aliases for the latest Dwarf Fortress and the selected Therapist install
-    dwarf-fortress = getAttr (versionToName latestVersion) df-games;
+    dwarf-fortress = lib.getAttr (versionToName latestVersion) df-games;
     inherit dwarf-therapist-original;
     dwarf-therapist = dwarf-fortress.dwarf-therapist;
     dwarf-fortress-original = dwarf-fortress.dwarf-fortress;

--- a/pkgs/games/dwarf-fortress/dfhack/default.nix
+++ b/pkgs/games/dwarf-fortress/dfhack/default.nix
@@ -18,8 +18,6 @@
 , dfVersion
 }:
 
-with lib;
-
 let
   dfhack-releases = {
     "0.44.10" = {
@@ -64,8 +62,8 @@ let
   release =
     if lib.isAttrs dfVersion
     then dfVersion
-    else if hasAttr dfVersion dfhack-releases
-    then getAttr dfVersion dfhack-releases
+    else if lib.hasAttr dfVersion dfhack-releases
+    then lib.getAttr dfVersion dfhack-releases
     else throw "[DFHack] Unsupported Dwarf Fortress version: ${dfVersion}";
 
   version = release.dfHackRelease;

--- a/pkgs/games/dwarf-fortress/lazy-pack.nix
+++ b/pkgs/games/dwarf-fortress/lazy-pack.nix
@@ -25,13 +25,11 @@
 , enableSound ? true
 }:
 
-with lib;
-
 let
   dfGame = versionToName dfVersion;
   dwarf-fortress =
-    if hasAttr dfGame df-games
-    then getAttr dfGame df-games
+    if lib.hasAttr dfGame df-games
+    then lib.getAttr dfGame df-games
     else throw "Unknown Dwarf Fortress version: ${dfVersion}";
   dwarf-therapist = dwarf-fortress.dwarf-therapist;
 in

--- a/pkgs/games/dwarf-fortress/twbt/default.nix
+++ b/pkgs/games/dwarf-fortress/twbt/default.nix
@@ -5,8 +5,6 @@
 , dfVersion
 }:
 
-with lib;
-
 let
   twbt-releases = {
     "0.44.10" = {
@@ -44,8 +42,8 @@ let
   };
 
   release =
-    if hasAttr dfVersion twbt-releases
-    then getAttr dfVersion twbt-releases
+    if lib.hasAttr dfVersion twbt-releases
+    then lib.getAttr dfVersion twbt-releases
     else throw "[TWBT] Unsupported Dwarf Fortress version: ${dfVersion}";
 in
 

--- a/pkgs/games/dwarf-fortress/unfuck.nix
+++ b/pkgs/games/dwarf-fortress/unfuck.nix
@@ -19,8 +19,6 @@
 , pkg-config
 }:
 
-with lib;
-
 let
   unfuck-releases = {
     "0.43.05" = {
@@ -66,8 +64,8 @@ let
   };
 
   release =
-    if hasAttr dfVersion unfuck-releases
-    then getAttr dfVersion unfuck-releases
+    if lib.hasAttr dfVersion unfuck-releases
+    then lib.getAttr dfVersion unfuck-releases
     else throw "[unfuck] Unknown Dwarf Fortress version: ${dfVersion}";
 in
 

--- a/pkgs/games/factorio/mods.nix
+++ b/pkgs/games/factorio/mods.nix
@@ -7,7 +7,7 @@
 , allRecommendedMods ? true
 , allOptionalMods ? false
 }:
-with lib;
+
 let
   modDrv = factorio-utils.modDrv { inherit allRecommendedMods allOptionalMods; };
 in

--- a/pkgs/games/factorio/utils.nix
+++ b/pkgs/games/factorio/utils.nix
@@ -1,12 +1,12 @@
 # This file provides a top-level function that will be used by both nixpkgs and nixos
 # to generate mod directories for use at runtime by factorio.
 { lib, stdenv }:
-with lib;
+
 {
   mkModDirDrv = mods: modsDatFile: # a list of mod derivations
     let
       recursiveDeps = modDrv: [modDrv] ++ map recursiveDeps modDrv.deps;
-      modDrvs = unique (flatten (map recursiveDeps mods));
+      modDrvs = lib.unique (lib.flatten (map recursiveDeps mods));
     in
     stdenv.mkDerivation {
       name = "factorio-mod-directory";
@@ -34,10 +34,10 @@ with lib;
         inherit src;
 
         # Use the name of the zip, but endstrip ".zip" and possibly the querystring that gets left in by fetchurl
-        name = replaceStrings ["_"] ["-"] (if name != null then name else removeSuffix ".zip" (head (splitString "?" src.name)));
+        name = lib.replaceStrings ["_"] ["-"] (if name != null then name else lib.removeSuffix ".zip" (lib.head (lib.splitString "?" src.name)));
 
-        deps = deps ++ optionals allOptionalMods optionalDeps
-                    ++ optionals allRecommendedMods recommendedDeps;
+        deps = deps ++ lib.optionals allOptionalMods optionalDeps
+                    ++ lib.optionals allRecommendedMods recommendedDeps;
 
         preferLocalBuild = true;
         buildCommand = ''

--- a/pkgs/games/freecell-solver/default.nix
+++ b/pkgs/games/freecell-solver/default.nix
@@ -2,7 +2,6 @@
 , perl, gmp, libtap, gperf
 , perlPackages, python3 }:
 
-with lib;
 stdenv.mkDerivation rec {
 
   pname = "freecell-solver";
@@ -28,7 +27,7 @@ stdenv.mkDerivation rec {
   # to depend on the generated "is_king.h".
   enableParallelBuilding = false;
 
-  meta = {
+  meta = with lib; {
     description = "A FreeCell automatic solver";
     longDescription = ''
       FreeCell Solver is a program that automatically solves layouts

--- a/pkgs/games/galaxis/default.nix
+++ b/pkgs/games/galaxis/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchurl, ncurses, xmlto }:
 
-with lib;
 stdenv.mkDerivation rec {
 
   pname = "galaxis";
@@ -24,7 +23,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "DESTDIR=$(out)" ];
 
-  meta = {
+  meta = with lib; {
     description = "Rescue lifeboats lost in interstellar space";
     longDescription = ''
       Lifeboats from a crippled interstellar liner are adrift in a starfield. To

--- a/pkgs/games/koboredux/default.nix
+++ b/pkgs/games/koboredux/default.nix
@@ -10,7 +10,6 @@
 , useProprietaryAssets ? true
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "koboredux";
   version = "0.7.5.1";
@@ -23,7 +22,7 @@ stdenv.mkDerivation rec {
       sha256 = "09h9r65z8bar2z89s09j6px0gdq355kjf38rmd85xb2aqwnm6xig";
     })]
     ++
-    (optional useProprietaryAssets (requireFile {
+    (lib.optional useProprietaryAssets (requireFile {
       name = "koboredux-${version}-Linux.tar.bz2";
       sha256 = "11bmicx9i11m4c3dp19jsql0zy4rjf5a28x4hd2wl8h3bf8cdgav";
       message = ''
@@ -48,7 +47,7 @@ stdenv.mkDerivation rec {
     sha256 = "0dwhvis7ghf3mgzjd2rwn8hk3ndlgfwwcqaq581yc5rwd73v6vw4";
   })];
 
-  postPatch = optionalString useProprietaryAssets ''
+  postPatch = lib.optionalString useProprietaryAssets ''
     cp -r ../koboredux-${version}-Linux/sfx/redux data/sfx/
     cp -r ../koboredux-${version}-Linux/gfx/redux data/gfx/
     cp -r ../koboredux-${version}-Linux/gfx/redux_fullscreen data/gfx/
@@ -65,15 +64,15 @@ stdenv.mkDerivation rec {
     audiality2
   ];
 
-  meta = {
+  meta = with lib; {
     description = "A frantic 80's style 2D shooter, similar to XKobo and Kobo Deluxe" +
-      optionalString (!useProprietaryAssets) " (built without proprietary assets)";
+      lib.optionalString (!useProprietaryAssets) " (built without proprietary assets)";
     longDescription = ''
       Kobo Redux is a frantic 80's style 2D shooter, inspired by the look and
       feel of 90's arcade cabinets. The gameplay is fast and unforgiving,
       although with less of the frustrating quirkiness of the actual games
       of the 80's. A true challenge in the spirit of the arcade era!
-    '' + optionalString (!useProprietaryAssets) ''
+    '' + lib.optionalString (!useProprietaryAssets) ''
 
       This version replaces the official proprietary assets with placeholders.
       For the full experience, consider installing "koboredux" instead.

--- a/pkgs/games/lugaru/default.nix
+++ b/pkgs/games/lugaru/default.nix
@@ -1,8 +1,6 @@
 { lib, stdenv, fetchFromGitLab, cmake, openal, pkg-config, libogg,
   libvorbis, SDL2, makeWrapper, libpng, libjpeg_turbo, libGLU }:
 
-with lib;
-
 stdenv.mkDerivation rec {
 
   pname = "lugaru";
@@ -25,7 +23,7 @@ stdenv.mkDerivation rec {
     description = "Third person ninja rabbit fighting game";
     homepage = "https://osslugaru.gitlab.io";
     maintainers = [ ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -39,8 +39,6 @@
 , withTouchSupport ? false
 }:
 
-with lib;
-
 let
   boolToCMake = b: if b then "ON" else "OFF";
 
@@ -82,9 +80,9 @@ let
       "-DCMAKE_INSTALL_MANDIR=share/man"
       "-DCMAKE_INSTALL_LOCALEDIR=share/locale"
 
-    ] ++ optionals buildServer [
+    ] ++ lib.optionals buildServer [
       "-DENABLE_PROMETHEUS=1"
-    ] ++ optionals withTouchSupport [
+    ] ++ lib.optionals withTouchSupport [
       "-DENABLE_TOUCH=TRUE"
     ];
 
@@ -95,11 +93,11 @@ let
     buildInputs = [
       irrlichtmtInput luajit jsoncpp gettext freetype sqlite curl bzip2 ncurses
       gmp libspatialindex
-    ] ++ optionals stdenv.isDarwin [
+    ] ++ lib.optionals stdenv.isDarwin [
       libiconv OpenGL OpenAL Carbon Cocoa
-    ] ++ optionals buildClient [
+    ] ++ lib.optionals buildClient [
       libpng libjpeg libGLU openal libogg libvorbis xorg.libX11
-    ] ++ optionals buildServer [
+    ] ++ lib.optionals buildServer [
       leveldb postgresql hiredis prometheus-cpp
     ];
 

--- a/pkgs/games/openra/common.nix
+++ b/pkgs/games/openra/common.nix
@@ -7,11 +7,9 @@
 , zenity
 }:
 
-with lib;
-
 let
-  path = makeBinPath ([ mono python3 ] ++ optional (zenity != null) zenity);
-  rpath = makeLibraryPath [ lua freetype openal SDL2 ];
+  path = lib.makeBinPath ([ mono python3 ] ++ lib.optional (zenity != null) zenity);
+  rpath = lib.makeLibraryPath [ lua freetype openal SDL2 ];
   mkdirp = makeSetupHook { } ./mkdirp.sh;
 
 in {
@@ -75,7 +73,7 @@ in {
 
     dontStrip = true;
 
-    meta = {
+    meta = with lib; {
       maintainers = with maintainers; [ fusion809 msteen rardiol ];
       license = licenses.gpl3;
       platforms = platforms.linux;

--- a/pkgs/games/openra/engine.nix
+++ b/pkgs/games/openra/engine.nix
@@ -14,9 +14,7 @@
 , engine
 }:
 
-with lib;
-
-stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
+stdenv.mkDerivation (lib.recursiveUpdate packageAttrs rec {
   pname = "openra";
   version = "${engine.name}-${engine.version}";
 
@@ -27,7 +25,7 @@ stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
   configurePhase = ''
     runHook preConfigure
 
-    make version VERSION=${escapeShellArg version}
+    make version VERSION=${lib.escapeShellArg version}
 
     runHook postConfigure
   '';
@@ -48,7 +46,7 @@ stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
   postInstall = ''
     ${wrapLaunchGame ""}
 
-    ${concatStrings (map (mod: ''
+    ${lib.concatStrings (map (mod: ''
       makeWrapper $out/bin/openra $out/bin/openra-${mod} --add-flags Game.Mod=${mod}
     '') engine.mods)}
   '';

--- a/pkgs/games/openra/mod.nix
+++ b/pkgs/games/openra/mod.nix
@@ -14,14 +14,12 @@
 , engine
 }:
 
-with lib;
-
 let
   engineSourceName = engine.src.name or "engine";
   modSourceName = mod.src.name or "mod";
 
 # Based on: https://build.opensuse.org/package/show/home:fusion809/openra-ura
-in stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
+in stdenv.mkDerivation (lib.recursiveUpdate packageAttrs rec {
   name = "${pname}-${version}";
   pname = "openra-${mod.name}";
   inherit (mod) version;
@@ -54,8 +52,8 @@ in stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
   configurePhase = ''
     runHook preConfigure
 
-    make version VERSION=${escapeShellArg version}
-    make -C ${engineSourceName} version VERSION=${escapeShellArg engine.version}
+    make version VERSION=${lib.escapeShellArg version}
+    make -C ${engineSourceName} version VERSION=${lib.escapeShellArg engine.version}
 
     runHook postConfigure
   '';
@@ -67,22 +65,22 @@ in stdenv.mkDerivation (recursiveUpdate packageAttrs rec {
 
     make -C ${engineSourceName} install-engine install-common-mod-files DATA_INSTALL_DIR=$out/lib/${pname}
 
-    cp -r ${engineSourceName}/mods/{${concatStringsSep "," ([ "common" "modcontent" ] ++ engine.mods)}} mods/* \
+    cp -r ${engineSourceName}/mods/{${lib.concatStringsSep "," ([ "common" "modcontent" ] ++ engine.mods)}} mods/* \
       $out/lib/${pname}/mods/
 
     substitute ${./mod-launch-game.sh} $out/lib/${pname}/launch-game.sh \
       --subst-var out \
-      --subst-var-by name ${escapeShellArg mod.name} \
-      --subst-var-by title ${escapeShellArg mod.title} \
-      --subst-var-by assetsError ${escapeShellArg mod.assetsError}
+      --subst-var-by name ${lib.escapeShellArg mod.name} \
+      --subst-var-by title ${lib.escapeShellArg mod.title} \
+      --subst-var-by assetsError ${lib.escapeShellArg mod.assetsError}
     chmod +x $out/lib/${pname}/launch-game.sh
 
     ${wrapLaunchGame "-${mod.name}"}
 
     substitute ${./openra-mod.desktop} $(mkdirp $out/share/applications)/${pname}.desktop \
-      --subst-var-by name ${escapeShellArg mod.name} \
-      --subst-var-by title ${escapeShellArg mod.title} \
-      --subst-var-by description ${escapeShellArg mod.description}
+      --subst-var-by name ${lib.escapeShellArg mod.name} \
+      --subst-var-by title ${lib.escapeShellArg mod.title} \
+      --subst-var-by description ${lib.escapeShellArg mod.description}
 
     cp README.md $(mkdirp $out/share/doc/packages/${pname})/README.md
 

--- a/pkgs/games/robotfindskitten/default.nix
+++ b/pkgs/games/robotfindskitten/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, ncurses }:
 
-with lib;
 stdenv.mkDerivation rec {
 
   pname = "robotfindskitten";
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
     install -Dm644 {nki,$out/share/games/robotfindskitten}/vanilla.nki
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Yet another zen simulation; A simple find-the-kitten game";
     homepage = "http://robotfindskitten.org/";
     license = licenses.gpl2;

--- a/pkgs/games/tinyfugue/default.nix
+++ b/pkgs/games/tinyfugue/default.nix
@@ -3,8 +3,6 @@
 , sslSupport ? true
 }:
 
-with lib;
-
 assert sslSupport -> openssl != null;
 
 stdenv.mkDerivation rec {
@@ -17,11 +15,11 @@ stdenv.mkDerivation rec {
     sha256 = "12fra2fdwqj6ilv9wdkc33rkj343rdcf5jyff4yiwywlrwaa2l1p";
   };
 
-  configureFlags = optional (!sslSupport) "--disable-ssl";
+  configureFlags = lib.optional (!sslSupport) "--disable-ssl";
 
   buildInputs =
     [ ncurses zlib ]
-    ++ optional sslSupport openssl;
+    ++ lib.optional sslSupport openssl;
 
   # Workaround build failure on -fno-common toolchains like upstream
   # gcc-10. Otherwise build fails as:
@@ -29,7 +27,7 @@ stdenv.mkDerivation rec {
   #     `world_decl'; command.o:/build/tf-50b8/src/socket.h:24: first defined here
   NIX_CFLAGS_COMPILE="-fcommon";
 
-  meta = {
+  meta = with lib; {
     homepage = "http://tinyfugue.sourceforge.net/";
     description = "A terminal UI, screen-oriented MUD client";
     longDescription = ''

--- a/pkgs/misc/cups/drivers/samsung/1.00.36/module.nix
+++ b/pkgs/misc/cups/drivers/samsung/1.00.36/module.nix
@@ -15,17 +15,17 @@
 # again after turning the device off and on.  atm i have no idea how
 # to fix this and no time to do more about it.
 {config, pkgs, lib ? pkgs.lib, ...}:
-with lib;
+
 let
   cfg = config.services.samsung-unified-linux-driver_1_00_36;
   pkg = pkgs.samsung-unified-linux-driver_1_00_36;
 in {
   options = {
     services.samsung-unified-linux-driver_1_00_36 = {
-      enable = mkEnableOption "enable samsung-unified-linux-driver_1_00_36";
+      enable = lib.mkEnableOption "enable samsung-unified-linux-driver_1_00_36";
     };
   };
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     services.printing.drivers = [pkg];
     hardware.sane.extraBackends = [pkg];
     environment.etc = {

--- a/pkgs/misc/drivers/sundtek/default.nix
+++ b/pkgs/misc/drivers/sundtek/default.nix
@@ -1,10 +1,8 @@
 { fetchurl, lib, stdenv }:
 
-with lib;
-
 let
   version = "2016-01-26";
-  rpath = makeLibraryPath [ "$out/lib" "$out/bin" ];
+  rpath = lib.makeLibraryPath [ "$out/lib" "$out/bin" ];
   platform = with stdenv;
     if isx86_64 then "64bit"
     else
@@ -42,7 +40,7 @@ in
 
     preferLocalBuild = true;
 
-    meta = {
+    meta = with lib; {
       description = "Sundtek MediaTV driver";
       maintainers = [ maintainers.simonvandel ];
       sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -12,7 +12,6 @@
 , prefix ? ""
 }:
 
-with lib;
 let
   inherit (python3Packages) python dbus-python;
   shouldUsePkg = pkg: if pkg != null && lib.meta.availableOn stdenv.hostPlatform pkg then pkg else null;
@@ -39,7 +38,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config python makeWrapper wafHook ];
   buildInputs = [ libsamplerate libsndfile readline eigen celt
     optDbus optPythonDBus optLibffado optAlsaLib optLibopus
-  ] ++ optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     aften AudioUnit CoreAudio Accelerate libobjc
   ];
 
@@ -52,9 +51,9 @@ stdenv.mkDerivation rec {
   wafConfigureFlags = [
     "--classic"
     "--autostart=${if (optDbus != null) then "dbus" else "classic"}"
-  ] ++ optional (optDbus != null) "--dbus"
-    ++ optional (optLibffado != null) "--firewire"
-    ++ optional (optAlsaLib != null) "--alsa";
+  ] ++ lib.optional (optDbus != null) "--dbus"
+    ++ lib.optional (optLibffado != null) "--firewire"
+    ++ lib.optional (optAlsaLib != null) "--alsa";
 
   postInstall = (if libOnly then ''
     rm -rf $out/{bin,share}
@@ -63,7 +62,7 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/jack_control --set PYTHONPATH $PYTHONPATH
   '');
 
-  meta = {
+  meta = with lib; {
     description = "JACK audio connection kit, version 2 with jackdbus";
     homepage = "https://jackaudio.org";
     license = licenses.gpl2Plus;

--- a/pkgs/misc/libcardiacarrest/default.nix
+++ b/pkgs/misc/libcardiacarrest/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, glib, libpulseaudio }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libcardiacarrest";
   version = "12.2.8"; # <PA API version>.<version>
@@ -42,7 +40,7 @@ stdenv.mkDerivation rec {
       JACK).
     '';
     license = libpulseaudio.meta.license; # "same as PA headers"
-    maintainers = [ maintainers.oxij ]; # also the author
+    maintainers = [ lib.maintainers.oxij ]; # also the author
   };
 
 }

--- a/pkgs/misc/stabber/default.nix
+++ b/pkgs/misc/stabber/default.nix
@@ -2,8 +2,6 @@
 , libmicrohttpd
 }:
 
-with lib;
-
 stdenv.mkDerivation {
   pname = "stabber-unstable";
   version = "2020-06-08";
@@ -22,7 +20,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   buildInputs = [ glib expat libmicrohttpd ];
 
-  meta = {
+  meta = with lib; {
     description = "Stubbed XMPP Server";
     homepage = "https://github.com/profanity-im/stabber";
     license = licenses.gpl3;

--- a/pkgs/os-specific/linux/amdgpu-pro/default.nix
+++ b/pkgs/os-specific/linux/amdgpu-pro/default.nix
@@ -16,8 +16,6 @@
 , kernel ? null
 }:
 
-with lib;
-
 let
 
   bitness = if stdenv.is64bit then "64" else "32";
@@ -54,7 +52,7 @@ in stdenv.mkDerivation rec {
     sourceRoot=root
   '';
 
-  passthru = optionalAttrs (kernel != null) {
+  passthru = lib.optionalAttrs (kernel != null) {
     kmod = stdenv.mkDerivation rec {
       inherit version src postUnpack;
       name = "${pname}-${version}-kmod-${kernel.dev.version}";
@@ -79,7 +77,7 @@ in stdenv.mkDerivation rec {
         popd
       '';
 
-      makeFlags = optionalString (kernel != null) "-C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build modules";
+      makeFlags = lib.optionalString (kernel != null) "-C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build modules";
 
       installPhase = ''
         runHook preInstall
@@ -112,7 +110,7 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" "vulkan" ];
 
-  depLibPath = makeLibraryPath [
+  depLibPath = lib.makeLibraryPath [
     stdenv.cc.cc.lib
     zlib
     libxcb
@@ -150,7 +148,7 @@ in stdenv.mkDerivation rec {
     # short name to allow replacement below
     ln -s lib/dri $out/dri
 
-  '' + optionalString (stdenv.is64bit) ''
+  '' + lib.optionalString (stdenv.is64bit) ''
     mkdir -p $out/etc
     pushd etc
     cp -r modprobe.d udev amd $out/etc

--- a/pkgs/os-specific/linux/conky/default.nix
+++ b/pkgs/os-specific/linux/conky/default.nix
@@ -63,8 +63,6 @@ assert weatherMetarSupport -> curlSupport;
 assert weatherXoapSupport  -> curlSupport && libxml2 != null;
 assert journalSupport      -> systemd != null;
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "conky";
   version = "1.13.1";
@@ -79,7 +77,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     sed -i -e '/include.*CheckIncludeFile)/i include(CheckIncludeFiles)' \
       cmake/ConkyPlatformChecks.cmake
-  '' + optionalString docsSupport ''
+  '' + lib.optionalString docsSupport ''
     # Drop examples, since they contain non-ASCII characters that break docbook2x :(
     sed -i 's/ Example: .*$//' doc/config_settings.xml
 
@@ -92,42 +90,42 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [ glib libXinerama ]
-    ++ optionals docsSupport        [ docbook2x docbook_xsl docbook_xml_dtd_44 libxslt man less ]
-    ++ optional  ncursesSupport     ncurses
-    ++ optionals x11Support         [ freetype xorg.libICE xorg.libX11 xorg.libXext xorg.libXft xorg.libSM ]
-    ++ optional  xdamageSupport     libXdamage
-    ++ optional  imlib2Support      imlib2
-    ++ optional  luaSupport         lua
-    ++ optionals luaImlib2Support   [ toluapp imlib2 ]
-    ++ optionals luaCairoSupport    [ toluapp cairo ]
-    ++ optional  wirelessSupport    wirelesstools
-    ++ optional  curlSupport        curl
-    ++ optional  rssSupport         libxml2
-    ++ optional  weatherXoapSupport libxml2
-    ++ optional  nvidiaSupport      libXNVCtrl
-    ++ optional  pulseSupport       libpulseaudio
-    ++ optional  journalSupport     systemd
+    ++ lib.optionals docsSupport        [ docbook2x docbook_xsl docbook_xml_dtd_44 libxslt man less ]
+    ++ lib.optional  ncursesSupport     ncurses
+    ++ lib.optionals x11Support         [ freetype xorg.libICE xorg.libX11 xorg.libXext xorg.libXft xorg.libSM ]
+    ++ lib.optional  xdamageSupport     libXdamage
+    ++ lib.optional  imlib2Support      imlib2
+    ++ lib.optional  luaSupport         lua
+    ++ lib.optionals luaImlib2Support   [ toluapp imlib2 ]
+    ++ lib.optionals luaCairoSupport    [ toluapp cairo ]
+    ++ lib.optional  wirelessSupport    wirelesstools
+    ++ lib.optional  curlSupport        curl
+    ++ lib.optional  rssSupport         libxml2
+    ++ lib.optional  weatherXoapSupport libxml2
+    ++ lib.optional  nvidiaSupport      libXNVCtrl
+    ++ lib.optional  pulseSupport       libpulseaudio
+    ++ lib.optional  journalSupport     systemd
     ;
 
   cmakeFlags = []
-    ++ optional docsSupport         "-DMAINTAINER_MODE=ON"
-    ++ optional curlSupport         "-DBUILD_CURL=ON"
-    ++ optional (!ibmSupport)       "-DBUILD_IBM=OFF"
-    ++ optional imlib2Support       "-DBUILD_IMLIB2=ON"
-    ++ optional luaCairoSupport     "-DBUILD_LUA_CAIRO=ON"
-    ++ optional luaImlib2Support    "-DBUILD_LUA_IMLIB2=ON"
-    ++ optional (!mpdSupport)       "-DBUILD_MPD=OFF"
-    ++ optional (!ncursesSupport)   "-DBUILD_NCURSES=OFF"
-    ++ optional rssSupport          "-DBUILD_RSS=ON"
-    ++ optional (!x11Support)       "-DBUILD_X11=OFF"
-    ++ optional xdamageSupport      "-DBUILD_XDAMAGE=ON"
-    ++ optional doubleBufferSupport "-DBUILD_XDBE=ON"
-    ++ optional weatherMetarSupport "-DBUILD_WEATHER_METAR=ON"
-    ++ optional weatherXoapSupport  "-DBUILD_WEATHER_XOAP=ON"
-    ++ optional wirelessSupport     "-DBUILD_WLAN=ON"
-    ++ optional nvidiaSupport       "-DBUILD_NVIDIA=ON"
-    ++ optional pulseSupport        "-DBUILD_PULSEAUDIO=ON"
-    ++ optional journalSupport      "-DBUILD_JOURNAL=ON"
+    ++ lib.optional docsSupport         "-DMAINTAINER_MODE=ON"
+    ++ lib.optional curlSupport         "-DBUILD_CURL=ON"
+    ++ lib.optional (!ibmSupport)       "-DBUILD_IBM=OFF"
+    ++ lib.optional imlib2Support       "-DBUILD_IMLIB2=ON"
+    ++ lib.optional luaCairoSupport     "-DBUILD_LUA_CAIRO=ON"
+    ++ lib.optional luaImlib2Support    "-DBUILD_LUA_IMLIB2=ON"
+    ++ lib.optional (!mpdSupport)       "-DBUILD_MPD=OFF"
+    ++ lib.optional (!ncursesSupport)   "-DBUILD_NCURSES=OFF"
+    ++ lib.optional rssSupport          "-DBUILD_RSS=ON"
+    ++ lib.optional (!x11Support)       "-DBUILD_X11=OFF"
+    ++ lib.optional xdamageSupport      "-DBUILD_XDAMAGE=ON"
+    ++ lib.optional doubleBufferSupport "-DBUILD_XDBE=ON"
+    ++ lib.optional weatherMetarSupport "-DBUILD_WEATHER_METAR=ON"
+    ++ lib.optional weatherXoapSupport  "-DBUILD_WEATHER_XOAP=ON"
+    ++ lib.optional wirelessSupport     "-DBUILD_WLAN=ON"
+    ++ lib.optional nvidiaSupport       "-DBUILD_NVIDIA=ON"
+    ++ lib.optional pulseSupport        "-DBUILD_PULSEAUDIO=ON"
+    ++ lib.optional journalSupport      "-DBUILD_JOURNAL=ON"
     ;
 
   # `make -f src/CMakeFiles/conky.dir/build.make src/CMakeFiles/conky.dir/conky.cc.o`:

--- a/pkgs/os-specific/linux/firmware/rtl8192su-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/rtl8192su-firmware/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenvNoCC, fetchFromGitHub }:
-with lib;
+
 stdenvNoCC.mkDerivation {
   pname = "rtl8192su";
   version = "unstable-2016-10-05";

--- a/pkgs/os-specific/linux/firmware/rtl8723bs-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/rtl8723bs-firmware/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenvNoCC, linuxPackages }:
-with lib;
+
 stdenvNoCC.mkDerivation {
   pname = "rtl8723bs-firmware";
   version = linuxPackages.rtl8723bs.version;

--- a/pkgs/os-specific/linux/kernel/gpio-utils.nix
+++ b/pkgs/os-specific/linux/kernel/gpio-utils.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, linux }:
 
-with lib;
-
 stdenv.mkDerivation {
   pname = "gpio-utils";
   version = linux.version;
@@ -15,7 +13,7 @@ stdenv.mkDerivation {
   separateDebugInfo = true;
   installFlags = [ "install" "DESTDIR=$(out)" "bindir=/bin" ];
 
-  meta = {
+  meta = with lib; {
     description = "Linux tools to inspect the gpiochip interface";
     maintainers = with maintainers; [ kwohlfahrt ];
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/kernel/linux-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14.nix
@@ -1,15 +1,13 @@
 { lib, buildPackages, fetchurl, perl, buildLinux, nixosTests, ... } @ args:
 
-with lib;
-
 buildLinux (args // rec {
   version = "4.14.302";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-  modDirVersion = versions.pad 3 version;
+  modDirVersion = lib.versions.pad 3 version;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = versions.majorMinor version;
+  extraMeta.branch = lib.versions.majorMinor version;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-4.19.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.19.nix
@@ -1,15 +1,13 @@
 { lib, buildPackages, fetchurl, perl, buildLinux, nixosTests, ... } @ args:
 
-with lib;
-
 buildLinux (args // rec {
   version = "4.19.269";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-  modDirVersion = versions.pad 3 version;
+  modDirVersion = lib.versions.pad 3 version;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = versions.majorMinor version;
+  extraMeta.branch = lib.versions.majorMinor version;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-5.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.10.nix
@@ -1,15 +1,13 @@
 { lib, buildPackages, fetchurl, perl, buildLinux, nixosTests, ... } @ args:
 
-with lib;
-
 buildLinux (args // rec {
   version = "5.10.163";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-  modDirVersion = versions.pad 3 version;
+  modDirVersion = lib.versions.pad 3 version;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = versions.majorMinor version;
+  extraMeta.branch = lib.versions.majorMinor version;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-5.15.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.15.nix
@@ -1,15 +1,13 @@
 { lib, buildPackages, fetchurl, perl, buildLinux, nixosTests, ... } @ args:
 
-with lib;
-
 buildLinux (args // rec {
   version = "5.15.88";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-  modDirVersion = versions.pad 3 version;
+  modDirVersion = lib.versions.pad 3 version;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = versions.majorMinor version;
+  extraMeta.branch = lib.versions.majorMinor version;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-5.4.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.4.nix
@@ -1,15 +1,13 @@
 { lib, buildPackages, fetchurl, perl, buildLinux, nixosTests, ... } @ args:
 
-with lib;
-
 buildLinux (args // rec {
   version = "5.4.228";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-  modDirVersion = versions.pad 3 version;
+  modDirVersion = lib.versions.pad 3 version;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = versions.majorMinor version;
+  extraMeta.branch = lib.versions.majorMinor version;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-6.0.nix
+++ b/pkgs/os-specific/linux/kernel/linux-6.0.nix
@@ -1,15 +1,13 @@
 { lib, buildPackages, fetchurl, perl, buildLinux, nixosTests, ... } @ args:
 
-with lib;
-
 buildLinux (args // rec {
   version = "6.0.19";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-  modDirVersion = versions.pad 3 version;
+  modDirVersion = lib.versions.pad 3 version;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = versions.majorMinor version;
+  extraMeta.branch = lib.versions.majorMinor version;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-6.1.nix
+++ b/pkgs/os-specific/linux/kernel/linux-6.1.nix
@@ -1,15 +1,13 @@
 { lib, buildPackages, fetchurl, perl, buildLinux, nixosTests, ... } @ args:
 
-with lib;
-
 buildLinux (args // rec {
   version = "6.1.6";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
-  modDirVersion = versions.pad 3 version;
+  modDirVersion = lib.versions.pad 3 version;
 
   # branchVersion needs to be x.y
-  extraMeta.branch = versions.majorMinor version;
+  extraMeta.branch = lib.versions.majorMinor version;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";

--- a/pkgs/os-specific/linux/kernel/linux-testing.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing.nix
@@ -1,13 +1,11 @@
 { lib, buildPackages, fetchurl, perl, buildLinux, nixosTests, ... } @ args:
 
-with lib;
-
 buildLinux (args // rec {
   version = "6.2-rc2";
   extraMeta.branch = lib.versions.majorMinor version;
 
   # modDirVersion needs to be x.y.z, will always add .0
-  modDirVersion = versions.pad 3 version;
+  modDirVersion = lib.versions.pad 3 version;
 
   src = fetchurl {
     url = "https://git.kernel.org/torvalds/t/linux-${version}.tar.gz";

--- a/pkgs/os-specific/linux/libselinux/default.nix
+++ b/pkgs/os-specific/linux/libselinux/default.nix
@@ -5,14 +5,12 @@
 
 assert enablePython -> swig != null && python3 != null;
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libselinux";
   version = "3.3";
   inherit (libsepol) se_url;
 
-  outputs = [ "bin" "out" "dev" "man" ] ++ optional enablePython "py";
+  outputs = [ "bin" "out" "dev" "man" ] ++ lib.optional enablePython "py";
 
   src = fetchurl {
     url = "${se_url}/${version}/libselinux-${version}.tar.gz";
@@ -40,8 +38,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ pkg-config python3 ] ++ optionals enablePython [ swig ];
-  buildInputs = [ libsepol pcre fts ] ++ optionals enablePython [ python3 ];
+  nativeBuildInputs = [ pkg-config python3 ] ++ lib.optionals enablePython [ swig ];
+  buildInputs = [ libsepol pcre fts ] ++ lib.optionals enablePython [ python3 ];
 
   # drop fortify here since package uses it by default, leading to compile error:
   # command-line>:0:0: error: "_FORTIFY_SOURCE" redefined [-Werror]
@@ -61,9 +59,9 @@ stdenv.mkDerivation rec {
 
     "LIBSEPOLA=${lib.getLib libsepol}/lib/libsepol.a"
     "ARCH=${stdenv.hostPlatform.linuxArch}"
-  ] ++ optionals stdenv.hostPlatform.isStatic [
+  ] ++ lib.optionals stdenv.hostPlatform.isStatic [
     "DISABLE_SHARED=y"
-  ] ++ optionals enablePython [
+  ] ++ lib.optionals enablePython [
     "PYTHON=${python3.pythonForBuild.interpreter}"
     "PYTHONLIBDIR=$(py)/${python3.sitePackages}"
   ];
@@ -73,11 +71,11 @@ stdenv.mkDerivation rec {
       --replace "#include <unistd.h>" ""
   '';
 
-  preInstall = optionalString enablePython ''
+  preInstall = lib.optionalString enablePython ''
     mkdir -p $py/${python3.sitePackages}/selinux
   '';
 
-  installTargets = [ "install" ] ++ optional enablePython "install-pywrap";
+  installTargets = [ "install" ] ++ lib.optional enablePython "install-pywrap";
 
   meta = removeAttrs libsepol.meta ["outputsToInstall"] // {
     description = "SELinux core library";

--- a/pkgs/os-specific/linux/libsemanage/default.nix
+++ b/pkgs/os-specific/linux/libsemanage/default.nix
@@ -2,8 +2,6 @@
 , enablePython ? true, swig ? null, python ? null
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libsemanage";
   version = "3.4";
@@ -14,13 +12,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-k7QjohYAuOP7WbuSXUWD0SWPRb6/Y8Kb3jBN/T1S79Y=";
    };
 
-  outputs = [ "out" "dev" "man" ] ++ optional enablePython "py";
+  outputs = [ "out" "dev" "man" ] ++ lib.optional enablePython "py";
 
   strictDeps = true;
 
-  nativeBuildInputs = [ bison flex pkg-config ] ++ optional enablePython swig;
+  nativeBuildInputs = [ bison flex pkg-config ] ++ lib.optional enablePython swig;
   buildInputs = [ libsepol libselinux bzip2 audit ]
-    ++ optional enablePython python;
+    ++ lib.optional enablePython python;
 
   makeFlags = [
     "PREFIX=$(out)"
@@ -43,7 +41,7 @@ stdenv.mkDerivation rec {
   # cc1: all warnings being treated as errors
   NIX_CFLAGS_COMPILE = [ "-Wno-error=clobbered" ];
 
-  installTargets = [ "install" ] ++ optionals enablePython [ "install-pywrap" ];
+  installTargets = [ "install" ] ++ lib.optionals enablePython [ "install-pywrap" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/lxc/default.nix
+++ b/pkgs/os-specific/linux/lxc/default.nix
@@ -6,7 +6,6 @@
 , libcap ? null, systemd ? null
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "lxc";
   version = "4.0.12";
@@ -41,10 +40,10 @@ stdenv.mkDerivation rec {
     "--disable-api-docs"
     "--with-init-script=none"
     "--with-distro=nixos" # just to be sure it is "unknown"
-  ] ++ optional (libapparmor != null) "--enable-apparmor"
-    ++ optional (libselinux != null) "--enable-selinux"
-    ++ optional (libseccomp != null) "--enable-seccomp"
-    ++ optional (libcap != null) "--enable-capabilities"
+  ] ++ lib.optional (libapparmor != null) "--enable-apparmor"
+    ++ lib.optional (libselinux != null) "--enable-selinux"
+    ++ lib.optional (libseccomp != null) "--enable-seccomp"
+    ++ lib.optional (libcap != null) "--enable-capabilities"
     ++ [
     "--disable-examples"
     "--enable-python"
@@ -80,7 +79,7 @@ stdenv.mkDerivation rec {
     popd
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://linuxcontainers.org/";
     description = "Userspace tools for Linux Containers, a lightweight virtualization system";
     license = licenses.lgpl21Plus;

--- a/pkgs/os-specific/linux/lxcfs/default.nix
+++ b/pkgs/os-specific/linux/lxcfs/default.nix
@@ -2,7 +2,6 @@
 , util-linux, makeWrapper
 , enableDebugBuild ? config.lxcfs.enableDebugBuild or false }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "lxcfs";
   version = "4.0.12";
@@ -40,7 +39,7 @@ stdenv.mkDerivation rec {
     patchelf --set-rpath "$(patchelf --print-rpath "$out/bin/lxcfs"):$out/lib" "$out/bin/lxcfs"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "FUSE filesystem for LXC";
     homepage = "https://linuxcontainers.org/lxcfs";
     changelog = "https://linuxcontainers.org/lxcfs/news/";

--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -1,13 +1,11 @@
 { lib, stdenv, fetchurl, kernel, alsa-lib }:
 
-with lib;
-
 let
   bits =
     if stdenv.is64bit then "64"
     else "32";
 
-  libpath = makeLibraryPath [ stdenv.cc.cc stdenv.cc.libc alsa-lib ];
+  libpath = lib.makeLibraryPath [ stdenv.cc.cc stdenv.cc.libc alsa-lib ];
 
 in
 stdenv.mkDerivation rec {
@@ -58,7 +56,7 @@ stdenv.mkDerivation rec {
       "$out"/bin/mwcap-info
   '';
 
-  meta = {
+  meta = with lib; {
     broken = kernel.kernelAtLeast "5.16";
     homepage = "http://www.magewell.com/";
     description = "Linux driver for the Magewell Pro Capture family";

--- a/pkgs/os-specific/linux/rtl8192eu/default.nix
+++ b/pkgs/os-specific/linux/rtl8192eu/default.nix
@@ -1,7 +1,5 @@
 { stdenv, lib, fetchFromGitHub, kernel, bc }:
 
-with lib;
-
 let modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wireless/realtek/rtl8192eu";
 
 in stdenv.mkDerivation rec {

--- a/pkgs/os-specific/linux/rtl8723bs/default.nix
+++ b/pkgs/os-specific/linux/rtl8723bs/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, nukeReferences, kernel }:
-with lib;
+
 stdenv.mkDerivation rec {
   name = "rtl8723bs-${kernel.version}-${version}";
   version = "2017-04-06";
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/hadess/rtl8723bs";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
-    broken = versionAtLeast kernel.version "4.12"; # Now in kernel staging drivers
-    maintainers = with maintainers; [ elitak ];
+    broken = lib.versionAtLeast kernel.version "4.12"; # Now in kernel staging drivers
+    maintainers = with lib.maintainers; [ elitak ];
   };
 }

--- a/pkgs/os-specific/linux/selinux-python/default.nix
+++ b/pkgs/os-specific/linux/selinux-python/default.nix
@@ -3,8 +3,6 @@
 
 # this is python3 only because setools only supports python3
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "selinux-python";
   version = "3.3";
@@ -42,7 +40,7 @@ stdenv.mkDerivation rec {
     wrapPythonPrograms
   '';
 
-  meta = {
+  meta = with lib; {
     description = "SELinux policy core utilities written in Python";
     license = licenses.gpl2;
     homepage = "https://selinuxproject.org";

--- a/pkgs/os-specific/linux/setools/default.nix
+++ b/pkgs/os-specific/linux/setools/default.nix
@@ -3,7 +3,6 @@
 , withGraphics ? false
 }:
 
-with lib;
 with python3.pkgs;
 
 buildPythonApplication rec {
@@ -20,7 +19,7 @@ buildPythonApplication rec {
   nativeBuildInputs = [ cython ];
   buildInputs = [ libsepol ];
   propagatedBuildInputs = [ enum34 libselinux networkx ]
-    ++ optionals withGraphics [ pyqt5 ];
+    ++ lib.optionals withGraphics [ pyqt5 ];
 
   checkInputs = [ tox checkpolicy ];
   preCheck = ''
@@ -33,7 +32,7 @@ buildPythonApplication rec {
     export SEPOL="${lib.getLib libsepol}/lib/libsepol.a"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "SELinux Policy Analysis Tools";
     homepage = "https://github.com/SELinuxProject/setools";
     license = licenses.gpl2;

--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -3,7 +3,6 @@
 , libyamlcpp, nlohmann_json, re2
 }:
 
-with lib;
 let
   # Compare with https://github.com/draios/sysdig/blob/dev/cmake/modules/falcosecurity-libs.cmake
   libsRev = "0.9.1";
@@ -54,7 +53,7 @@ stdenv.mkDerivation rec {
     libyamlcpp
     jsoncpp
     nlohmann_json
-  ] ++ optionals (kernel != null) kernel.moduleBuildDependencies;
+  ] ++ lib.optionals (kernel != null) kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];
 
@@ -82,7 +81,7 @@ stdenv.mkDerivation rec {
     "-DUSE_BUNDLED_TBB=OFF"
     "-DUSE_BUNDLED_RE2=OFF"
     "-DCREATE_TEST_TARGETS=OFF"
-  ] ++ optional (kernel == null) "-DBUILD_DRIVER=OFF";
+  ] ++ lib.optional (kernel == null) "-DBUILD_DRIVER=OFF";
 
   # needed since luajit-2.1.0-beta3
   NIX_CFLAGS_COMPILE = "-DluaL_reg=luaL_Reg -DluaL_getn(L,i)=((int)lua_objlen(L,i))";
@@ -93,7 +92,7 @@ stdenv.mkDerivation rec {
       exit 1
     fi
     cmakeFlagsArray+=(-DCMAKE_EXE_LINKER_FLAGS="-ltbb -lcurl -labsl_synchronization")
-  '' + optionalString (kernel != null) ''
+  '' + lib.optionalString (kernel != null) ''
     export INSTALL_MOD_PATH="$out"
     export KERNELDIR="${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   '';
@@ -106,7 +105,7 @@ stdenv.mkDerivation rec {
       rmdir $out/etc/bash_completion.d
       rmdir $out/etc
     ''
-    + optionalString (kernel != null) ''
+    + lib.optionalString (kernel != null) ''
       make install_driver
       kernel_dev=${kernel.dev}
       kernel_dev=''${kernel_dev#/nix/store/}
@@ -121,12 +120,12 @@ stdenv.mkDerivation rec {
     '';
 
 
-  meta = {
+  meta = with lib; {
     description = "A tracepoint-based system tracing tool for Linux (with clients for other OSes)";
     license = with licenses; [ asl20 gpl2 mit ];
     maintainers = [maintainers.raskin];
     platforms = ["x86_64-linux"] ++ platforms.darwin;
-    broken = kernel != null && versionOlder kernel.version "4.14";
+    broken = kernel != null && lib.versionOlder kernel.version "4.14";
     homepage = "https://sysdig.com/opensource/";
     downloadPage = "https://github.com/draios/sysdig/releases";
   };

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -6,7 +6,6 @@
 , readOnlyModeSSIDs ? false
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   version = "2.10";
 
@@ -64,12 +63,12 @@ stdenv.mkDerivation rec {
     CONFIG_WPS=y
     CONFIG_WPS_ER=y
     CONFIG_WPS_NFS=y
-  '' + optionalString withPcsclite ''
+  '' + lib.optionalString withPcsclite ''
     CONFIG_EAP_SIM=y
     CONFIG_EAP_AKA=y
     CONFIG_EAP_AKA_PRIME=y
     CONFIG_PCSC=y
-  '' + optionalString dbusSupport ''
+  '' + lib.optionalString dbusSupport ''
     CONFIG_CTRL_IFACE_DBUS=y
     CONFIG_CTRL_IFACE_DBUS_NEW=y
     CONFIG_CTRL_IFACE_DBUS_INTRO=y
@@ -90,13 +89,13 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace /usr/local $out
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE \
       -I$(echo "${lib.getDev libnl}"/include/libnl*/) \
-      ${optionalString withPcsclite "-I${lib.getDev pcsclite}/include/PCSC/"}"
+      ${lib.optionalString withPcsclite "-I${lib.getDev pcsclite}/include/PCSC/"}"
   '';
 
   buildInputs = [ openssl libnl ]
-    ++ optional dbusSupport dbus
-    ++ optional withReadline readline
-    ++ optional withPcsclite pcsclite;
+    ++ lib.optional dbusSupport dbus
+    ++ lib.optional withReadline readline
+    ++ lib.optional withPcsclite pcsclite;
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/os-specific/windows/cygwin-setup/default.nix
+++ b/pkgs/os-specific/windows/cygwin-setup/default.nix
@@ -2,8 +2,6 @@
 , zlib, bzip2, xz, libgcrypt
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "cygwin-setup";
   version = "20131101";
@@ -18,9 +16,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake libtool flex bison pkg-config ];
 
   buildInputs = let
-    mkStatic = flip overrideDerivation (o: {
+    mkStatic = lib.flip lib.overrideDerivation (o: {
       dontDisableStatic = true;
-      configureFlags = toList (o.configureFlags or []) ++ [ "--enable-static" ];
+      configureFlags = lib.toList (o.configureFlags or []) ++ [ "--enable-static" ];
       buildInputs = map mkStatic (o.buildInputs or []);
       propagatedBuildInputs = map mkStatic (o.propagatedBuildInputs or []);
     });
@@ -41,6 +39,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://sourceware.org/cygwin-apps/setup.html";
     description = "A tool for installing Cygwin";
-    license = licenses.gpl2Plus;
+    license = lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -2,13 +2,13 @@
 let
   inherit (pkgs) lib formats;
 in
-with lib;
+
 let
 
   evalFormat = format: args: def:
     let
       formatSet = format args;
-      config = formatSet.type.merge [] (imap1 (n: def: {
+      config = formatSet.type.merge [] (lib.imap1 (n: def: {
         # We check the input values, so that
         #  - we don't write nonsensical tests that will impede progress
         #  - the test author has a slightly more realistic view of the
@@ -31,7 +31,7 @@ let
     fi
   '';
 
-  runBuildTests = tests: pkgs.linkFarm "nixpkgs-pkgs-lib-format-tests" (mapAttrsToList (name: value: { inherit name; path = runBuildTest name value; }) (filterAttrs (name: value: value != null) tests));
+  runBuildTests = tests: pkgs.linkFarm "nixpkgs-pkgs-lib-format-tests" (lib.mapAttrsToList (name: value: { inherit name; path = runBuildTest name value; }) (lib.filterAttrs (name: value: value != null) tests));
 
 in runBuildTests {
 
@@ -132,7 +132,7 @@ in runBuildTests {
   };
 
   testIniListToValue = {
-    drv = evalFormat formats.ini { listToValue = concatMapStringsSep ", " (generators.mkValueStringDefault {}); } {
+    drv = evalFormat formats.ini { listToValue = lib.concatMapStringsSep ", " (lib.generators.mkValueStringDefault {}); } {
       foo = {
         bar = [ null true "test" 1.2 10 ];
         baz = false;
@@ -180,7 +180,7 @@ in runBuildTests {
   };
 
   testKeyValueListToValue = {
-    drv = evalFormat formats.keyValue { listToValue = concatMapStringsSep ", " (generators.mkValueStringDefault {}); } {
+    drv = evalFormat formats.keyValue { listToValue = lib.concatMapStringsSep ", " (lib.generators.mkValueStringDefault {}); } {
       bar = [ null true "test" 1.2 10 ];
       baz = false;
       qux = "qux";

--- a/pkgs/servers/corosync/default.nix
+++ b/pkgs/servers/corosync/default.nix
@@ -6,8 +6,6 @@
 , enableSnmp ? false
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "corosync";
   version = "3.1.7";
@@ -21,10 +19,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     kronosnet nss nspr libqb systemd.dev
-  ] ++ optional enableDbus dbus
-    ++ optional enableInfiniBandRdma rdma-core
-    ++ optional enableMonitoring libstatgrab
-    ++ optional enableSnmp net-snmp;
+  ] ++ lib.optional enableDbus dbus
+    ++ lib.optional enableInfiniBandRdma rdma-core
+    ++ lib.optional enableMonitoring libstatgrab
+    ++ lib.optional enableSnmp net-snmp;
 
   configureFlags = [
     "--sysconfdir=/etc"
@@ -34,10 +32,10 @@ stdenv.mkDerivation rec {
     "--enable-qdevices"
     # allows Type=notify in the systemd service
     "--enable-systemd"
-  ] ++ optional enableDbus "--enable-dbus"
-    ++ optional enableInfiniBandRdma "--enable-rdma"
-    ++ optional enableMonitoring "--enable-monitoring"
-    ++ optional enableSnmp "--enable-snmp";
+  ] ++ lib.optional enableDbus "--enable-dbus"
+    ++ lib.optional enableInfiniBandRdma "--enable-rdma"
+    ++ lib.optional enableMonitoring "--enable-monitoring"
+    ++ lib.optional enableSnmp "--enable-snmp";
 
   installFlags = [
     "sysconfdir=$(out)/etc"
@@ -49,7 +47,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  preConfigure = optionalString enableInfiniBandRdma ''
+  preConfigure = lib.optionalString enableInfiniBandRdma ''
     # configure looks for the pkg-config files
     # of librdmacm and libibverbs
     # Howver, rmda-core does not provide a pkg-config file
@@ -66,10 +64,10 @@ stdenv.mkDerivation rec {
   '';
 
   passthru.tests = {
-    inherit (nixosTests) pacemaker;
+    inherit (lib.nixosTests) pacemaker;
   };
 
-  meta = {
+  meta = with lib; {
     homepage = "http://corosync.org/";
     description = "A Group Communication System with features for implementing high availability within applications";
     license = licenses.bsd3;

--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -7,8 +7,6 @@
 , ...
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   version = "2.3.4";
   pname = "tengine";
@@ -22,9 +20,9 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ openssl zlib pcre libxcrypt libxml2 libxslt gd geoip gperftools jemalloc ]
-    ++ concatMap (mod: mod.inputs or []) modules;
+    ++ lib.concatMap (mod: mod.inputs or []) modules;
 
-  patches = singleton (substituteAll {
+  patches = lib.singleton (substituteAll {
     src = ../nginx/nix-etag-1.15.4.patch;
     preInstall = ''
       export nixStoreDir="$NIX_STORE" nixStoreDirLen="''${#NIX_STORE}"
@@ -67,23 +65,23 @@ stdenv.mkDerivation rec {
     "--http-fastcgi-temp-path=/var/cache/nginx/fastcgi"
     "--http-uwsgi-temp-path=/var/cache/nginx/uwsgi"
     "--http-scgi-temp-path=/var/cache/nginx/scgi"
-  ] ++ optionals withDebug [
+  ] ++ lib.optionals withDebug [
     "--with-debug"
-  ] ++ optionals withMail [
+  ] ++ lib.optionals withMail [
     "--with-mail"
     "--with-mail_ssl_module"
-  ] ++ optionals (!withMail) [
+  ] ++ lib.optionals (!withMail) [
     "--without-mail_pop3_module"
     "--without-mail_imap_module"
     "--without-mail_smtp_module"
-  ] ++ optionals withStream [
+  ] ++ lib.optionals withStream [
     "--with-stream"
     "--with-stream_ssl_module"
     "--with-stream_realip_module"
     "--with-stream_geoip_module"
     "--with-stream_ssl_preread_module"
     "--with-stream_sni"
-  ] ++ optionals (!withStream) [
+  ] ++ lib.optionals (!withStream) [
     "--without-stream_limit_conn_module"
     "--without-stream_access_module"
     "--without-stream_geo_module"
@@ -94,16 +92,16 @@ stdenv.mkDerivation rec {
     "--without-stream_upstream_least_conn_module"
     "--without-stream_upstream_random_module"
     "--without-stream_upstream_zone_module"
-  ] ++ optional (gd != null) "--with-http_image_filter_module"
-    ++ optional (with stdenv.hostPlatform; isLinux || isFreeBSD) "--with-file-aio"
+  ] ++ lib.optional (gd != null) "--with-http_image_filter_module"
+    ++ lib.optional (with stdenv.hostPlatform; isLinux || isFreeBSD) "--with-file-aio"
     ++ map (mod: "--add-module=${mod.src}") modules;
 
   NIX_CFLAGS_COMPILE = "-I${libxml2.dev}/include/libxml2 -Wno-error=implicit-fallthrough"
-    + optionalString stdenv.isDarwin " -Wno-error=deprecated-declarations";
+    + lib.optionalString stdenv.isDarwin " -Wno-error=deprecated-declarations";
 
-  preConfigure = (concatMapStringsSep "\n" (mod: mod.preConfigure or "") modules);
+  preConfigure = (lib.concatMapStringsSep "\n" (mod: mod.preConfigure or "") modules);
 
-  hardeningEnable = optional (!stdenv.isDarwin) "pie";
+  hardeningEnable = lib.optional (!stdenv.isDarwin) "pie";
 
   enableParallelBuilding = true;
 
@@ -116,7 +114,7 @@ stdenv.mkDerivation rec {
     tests = nixosTests.nginx-variants.tengine;
   };
 
-  meta = {
+  meta = with lib; {
     description = "A web server based on Nginx and has many advanced features, originated by Taobao";
     homepage    = "https://tengine.taobao.org";
     license     = licenses.bsd2;

--- a/pkgs/servers/http/unit/default.nix
+++ b/pkgs/servers/http/unit/default.nix
@@ -14,8 +14,6 @@
 , withDebug ? false
 }:
 
-with lib;
-
 let
   phpConfig = {
     embedSupport = true;
@@ -43,40 +41,40 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ which ];
 
   buildInputs = [ pcre2.dev ]
-    ++ optionals withPython3 [ python3 ncurses ]
-    ++ optional withPHP80 php80-unit
-    ++ optional withPHP81 php81-unit
-    ++ optional withPerl534 perl534
-    ++ optional withPerl536 perl536
-    ++ optional withPerldevel perldevel
-    ++ optional withRuby_2_7 ruby_2_7
-    ++ optional withRuby_3_0 ruby_3_0
-    ++ optional withRuby_3_1 ruby_3_1
-    ++ optional withSSL openssl;
+    ++ lib.optionals withPython3 [ python3 ncurses ]
+    ++ lib.optional withPHP80 php80-unit
+    ++ lib.optional withPHP81 php81-unit
+    ++ lib.optional withPerl534 perl534
+    ++ lib.optional withPerl536 perl536
+    ++ lib.optional withPerldevel perldevel
+    ++ lib.optional withRuby_2_7 ruby_2_7
+    ++ lib.optional withRuby_3_0 ruby_3_0
+    ++ lib.optional withRuby_3_1 ruby_3_1
+    ++ lib.optional withSSL openssl;
 
   configureFlags = [
     "--control=unix:/run/unit/control.unit.sock"
     "--pid=/run/unit/unit.pid"
     "--user=unit"
     "--group=unit"
-  ] ++ optional withSSL     "--openssl"
-    ++ optional (!withIPv6) "--no-ipv6"
-    ++ optional withDebug   "--debug";
+  ] ++ lib.optional withSSL     "--openssl"
+    ++ lib.optional (!withIPv6) "--no-ipv6"
+    ++ lib.optional withDebug   "--debug";
 
   # Optionally add the PHP derivations used so they can be addressed in the configs
-  usedPhp80 = optionals withPHP80 php80-unit;
-  usedPhp81 = optionals withPHP81 php81-unit;
+  usedPhp80 = lib.optionals withPHP80 php80-unit;
+  usedPhp81 = lib.optionals withPHP81 php81-unit;
 
   postConfigure = ''
-    ${optionalString withPython3    "./configure python --module=python3  --config=python3-config  --lib-path=${python3}/lib"}
-    ${optionalString withPHP80      "./configure php    --module=php80    --config=${php80-unit.unwrapped.dev}/bin/php-config --lib-path=${php80-unit}/lib"}
-    ${optionalString withPHP81      "./configure php    --module=php81    --config=${php81-unit.unwrapped.dev}/bin/php-config --lib-path=${php81-unit}/lib"}
-    ${optionalString withPerl534    "./configure perl   --module=perl534  --perl=${perl534}/bin/perl"}
-    ${optionalString withPerl536    "./configure perl   --module=perl536  --perl=${perl536}/bin/perl"}
-    ${optionalString withPerldevel  "./configure perl   --module=perldev  --perl=${perldevel}/bin/perl"}
-    ${optionalString withRuby_2_7   "./configure ruby   --module=ruby27   --ruby=${ruby_2_7}/bin/ruby"}
-    ${optionalString withRuby_3_0   "./configure ruby   --module=ruby30   --ruby=${ruby_3_0}/bin/ruby"}
-    ${optionalString withRuby_3_1   "./configure ruby   --module=ruby31   --ruby=${ruby_3_1}/bin/ruby"}
+    ${lib.optionalString withPython3    "./configure python --module=python3  --config=python3-config  --lib-path=${python3}/lib"}
+    ${lib.optionalString withPHP80      "./configure php    --module=php80    --config=${php80-unit.unwrapped.dev}/bin/php-config --lib-path=${php80-unit}/lib"}
+    ${lib.optionalString withPHP81      "./configure php    --module=php81    --config=${php81-unit.unwrapped.dev}/bin/php-config --lib-path=${php81-unit}/lib"}
+    ${lib.optionalString withPerl534    "./configure perl   --module=perl534  --perl=${perl534}/bin/perl"}
+    ${lib.optionalString withPerl536    "./configure perl   --module=perl536  --perl=${perl536}/bin/perl"}
+    ${lib.optionalString withPerldevel  "./configure perl   --module=perldev  --perl=${perldevel}/bin/perl"}
+    ${lib.optionalString withRuby_2_7   "./configure ruby   --module=ruby27   --ruby=${ruby_2_7}/bin/ruby"}
+    ${lib.optionalString withRuby_3_0   "./configure ruby   --module=ruby30   --ruby=${ruby_3_0}/bin/ruby"}
+    ${lib.optionalString withRuby_3_1   "./configure ruby   --module=ruby31   --ruby=${ruby_3_1}/bin/ruby"}
   '';
 
   postInstall = ''
@@ -85,7 +83,7 @@ in stdenv.mkDerivation rec {
 
   passthru.tests.unit-php = nixosTests.unit-php;
 
-  meta = {
+  meta = with lib; {
     description = "Dynamic web and application server, designed to run applications in multiple languages";
     homepage    = "https://unit.nginx.org/";
     license     = licenses.asl20;

--- a/pkgs/servers/monitoring/grafana-reporter/default.nix
+++ b/pkgs/servers/monitoring/grafana-reporter/default.nix
@@ -1,7 +1,5 @@
 { lib, buildGoPackage, fetchFromGitHub, tetex, makeWrapper }:
 
-with lib;
-
 buildGoPackage rec {
   pname = "reporter";
   version = "2.3.1";
@@ -20,10 +18,10 @@ buildGoPackage rec {
 
   postInstall = ''
     wrapProgram $out/bin/grafana-reporter \
-      --prefix PATH : ${makeBinPath [ tetex ]}
+      --prefix PATH : ${lib.makeBinPath [ tetex ]}
   '';
 
-  meta = {
+  meta = with lib; {
     description = "PDF report generator from a Grafana dashboard";
     homepage = "https://github.com/IzakMarais/reporter";
     license = licenses.mit;

--- a/pkgs/servers/nats-streaming-server/default.nix
+++ b/pkgs/servers/nats-streaming-server/default.nix
@@ -1,7 +1,5 @@
 { buildGoModule, fetchFromGitHub, lib  }:
 
-with lib;
-
 buildGoModule rec {
   pname   = "nats-streaming-server";
   version = "0.24.6";
@@ -18,7 +16,7 @@ buildGoModule rec {
   # tests fail and ask to `go install`
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     description = "NATS Streaming System Server";
     license = licenses.asl20;
     maintainers = [ maintainers.swdunlop ];

--- a/pkgs/servers/rippled/data-api.nix
+++ b/pkgs/servers/rippled/data-api.nix
@@ -1,7 +1,5 @@
 { lib, fetchFromGitHub, nodePackages }:
 
-with lib;
-
 let
   np = nodePackages.override { generated = ./package.nix; self = np; };
 in nodePackages.buildNodePackage rec {
@@ -15,11 +13,11 @@ in nodePackages.buildNodePackage rec {
     sha256 = "sha256-QEBdYdW55sAz6jshIAr2dSfXuqE/vqA2/kBeoxf75a8=";
   };
 
-  deps = (filter (v: nixType v == "derivation") (attrValues np));
+  deps = (lib.filter (v: lib.nixType v == "derivation") (lib.attrValues np));
 
   meta = {
     description = "Historical ripple data";
     homepage = "https://github.com/ripple/ripple-data-api";
-    maintainers = with maintainers; [ offline ];
+    maintainers = with lib.maintainers; [ offline ];
   };
 }

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -44,8 +44,6 @@
 , enablePam ? (!stdenv.isDarwin), pam
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "samba";
   version = "4.17.4";
@@ -79,10 +77,10 @@ stdenv.mkDerivation rec {
     docbook_xml_dtd_45
     cmocka
     rpcsvc-proto
-  ] ++ optionals stdenv.isLinux [
+  ] ++ lib.optionals stdenv.isLinux [
     buildPackages.stdenv.cc
-  ] ++ optional (stdenv.buildPlatform != stdenv.hostPlatform) samba # asn1_compile/compile_et
-    ++ optionals stdenv.isDarwin [
+  ] ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) samba # asn1_compile/compile_et
+    ++ lib.optionals stdenv.isDarwin [
     fixDarwinDylibNames
   ];
 
@@ -103,18 +101,18 @@ stdenv.mkDerivation rec {
     libtasn1
     tdb
     libxcrypt
-  ] ++ optionals stdenv.isLinux [ liburing systemd ]
-    ++ optionals stdenv.isDarwin [ libiconv ]
-    ++ optionals enableLDAP [ openldap.dev python3Packages.markdown ]
-    ++ optional (enablePrinting && stdenv.isLinux) cups
-    ++ optional enableMDNS avahi
-    ++ optionals enableDomainController [ gpgme lmdb python3Packages.dnspython ]
-    ++ optional enableRegedit ncurses
-    ++ optional (enableCephFS && stdenv.isLinux) (lib.getDev ceph)
-    ++ optionals (enableGlusterFS && stdenv.isLinux) [ glusterfs libuuid ]
-    ++ optional enableAcl acl
-    ++ optional enableLibunwind libunwind
-    ++ optional enablePam pam;
+  ] ++ lib.optionals stdenv.isLinux [ liburing systemd ]
+    ++ lib.optionals stdenv.isDarwin [ libiconv ]
+    ++ lib.optionals enableLDAP [ openldap.dev python3Packages.markdown ]
+    ++ lib.optional (enablePrinting && stdenv.isLinux) cups
+    ++ lib.optional enableMDNS avahi
+    ++ lib.optionals enableDomainController [ gpgme lmdb python3Packages.dnspython ]
+    ++ lib.optional enableRegedit ncurses
+    ++ lib.optional (enableCephFS && stdenv.isLinux) (lib.getDev ceph)
+    ++ lib.optionals (enableGlusterFS && stdenv.isLinux) [ glusterfs libuuid ]
+    ++ lib.optional enableAcl acl
+    ++ lib.optional enableLibunwind libunwind
+    ++ lib.optional enablePam pam;
 
   postPatch = ''
     # Removes absolute paths in scripts
@@ -138,18 +136,18 @@ stdenv.mkDerivation rec {
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     "--disable-rpath"
-  ] ++ optional (!enableDomainController)
+  ] ++ lib.optional (!enableDomainController)
     "--without-ad-dc"
-  ++ optionals (!enableLDAP) [
+  ++ lib.optionals (!enableLDAP) [
     "--without-ldap"
     "--without-ads"
-  ] ++ optional enableLibunwind "--with-libunwind"
-    ++ optional enableProfiling "--with-profiling-data"
-    ++ optional (!enableAcl) "--without-acl-support"
-    ++ optional (!enablePam) "--without-pam"
-    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optional enableLibunwind "--with-libunwind"
+    ++ lib.optional enableProfiling "--with-profiling-data"
+    ++ lib.optional (!enableAcl) "--without-acl-support"
+    ++ lib.optional (!enablePam) "--without-pam"
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "--bundled-libraries=!asn1_compile,!compile_et"
-  ] ++ optionals stdenv.isAarch32 [
+  ] ++ lib.optionals stdenv.isAarch32 [
     # https://bugs.gentoo.org/683148
     "--jobs 1"
   ];
@@ -167,7 +165,7 @@ stdenv.mkDerivation rec {
 
   # Save asn1_compile and compile_et so they are available to run on the build
   # platform when cross-compiling
-  postInstall = optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     mkdir -p "$dev/bin"
     cp bin/asn1_compile bin/compile_et "$dev/bin"
   '';

--- a/pkgs/servers/search/elasticsearch/6.x.nix
+++ b/pkgs/servers/search/elasticsearch/6.x.nix
@@ -10,11 +10,9 @@
 , zlib
 }:
 
-with lib;
-
 stdenv.mkDerivation (rec {
   version = elk6Version;
-  pname = "elasticsearch${optionalString (!enableUnfree) "-oss"}";
+  pname = "elasticsearch${lib.optionalString (!enableUnfree) "-oss"}";
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/elasticsearch/${pname}-${version}.tar.gz";
@@ -38,7 +36,7 @@ stdenv.mkDerivation (rec {
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ jre_headless util-linux ]
-             ++ optionals enableUnfree [ zlib libxcrypt ];
+             ++ lib.optionals enableUnfree [ zlib libxcrypt ];
 
   installPhase = ''
     mkdir -p $out
@@ -47,7 +45,7 @@ stdenv.mkDerivation (rec {
     chmod -x $out/bin/*.*
 
     wrapProgram $out/bin/elasticsearch \
-      --prefix PATH : "${makeBinPath [ util-linux gnugrep coreutils ]}" \
+      --prefix PATH : "${lib.makeBinPath [ util-linux gnugrep coreutils ]}" \
       --set JAVA_HOME "${jre_headless}"
 
     wrapProgram $out/bin/elasticsearch-plugin --set JAVA_HOME "${jre_headless}"
@@ -55,17 +53,17 @@ stdenv.mkDerivation (rec {
 
   passthru = { inherit enableUnfree; };
 
-  meta = {
+  meta = with lib;{
     description = "Open Source, Distributed, RESTful Search Engine";
-    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = if enableUnfree then licenses.elastic else licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [ apeschar basvandijk ];
   };
-} // optionalAttrs enableUnfree {
+} // lib.optionalAttrs enableUnfree {
   dontPatchELF = true;
   nativeBuildInputs = [ makeWrapper ]
-    ++ optional stdenv.isLinux autoPatchelfHook;
+    ++ lib.optional stdenv.isLinux autoPatchelfHook;
   runtimeDependencies = [ zlib ];
   postFixup = lib.optionalString stdenv.isLinux ''
     for exe in $(find $out/modules/x-pack-ml/platform/linux-x86_64/bin -executable -type f); do

--- a/pkgs/servers/search/elasticsearch/7.x.nix
+++ b/pkgs/servers/search/elasticsearch/7.x.nix
@@ -11,11 +11,10 @@
 , zlib
 }:
 
-with lib;
 let
-  info = splitString "-" stdenv.hostPlatform.system;
-  arch = elemAt info 0;
-  plat = elemAt info 1;
+  info = lib.splitString "-" stdenv.hostPlatform.system;
+  arch = lib.elemAt info 0;
+  plat = lib.elemAt info 1;
   shas =
     {
       x86_64-linux   = "7281b79f2bf7421c2d71ab4eecdfd517b86b6788d1651dad315198c564284ea9";
@@ -62,7 +61,7 @@ stdenv.mkDerivation rec {
       --replace 'bin/elasticsearch-keystore' "$out/bin/elasticsearch-keystore"
 
     wrapProgram $out/bin/elasticsearch \
-      --prefix PATH : "${makeBinPath [ util-linux coreutils gnugrep ]}" \
+      --prefix PATH : "${lib.makeBinPath [ util-linux coreutils gnugrep ]}" \
       --set JAVA_HOME "${jre_headless}"
 
     wrapProgram $out/bin/elasticsearch-plugin --set JAVA_HOME "${jre_headless}"
@@ -70,7 +69,7 @@ stdenv.mkDerivation rec {
 
   passthru = { enableUnfree = true; };
 
-  meta = {
+  meta = with lib; {
     description = "Open Source, Distributed, RESTful Search Engine";
     sourceProvenance = with lib.sourceTypes; [
       binaryBytecode

--- a/pkgs/servers/shairport-sync/default.nix
+++ b/pkgs/servers/shairport-sync/default.nix
@@ -6,7 +6,6 @@
 , enableMpris ? stdenv.isLinux
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   version = "3.3.9";
   pname = "shairport-sync";
@@ -29,7 +28,7 @@ stdenv.mkDerivation rec {
     libconfig
     libpulseaudio
     soxr
-  ] ++ optional stdenv.isLinux glib;
+  ] ++ lib.optional stdenv.isLinux glib;
 
   prePatch = ''
     sed -i -e 's/G_BUS_TYPE_SYSTEM/G_BUS_TYPE_SESSION/g' dbus-service.c
@@ -44,9 +43,9 @@ stdenv.mkDerivation rec {
     "--without-configfiles"
     "--sysconfdir=/etc"
   ]
-    ++ optional enableDbus "--with-dbus-interface"
-    ++ optional enableMetadata "--with-metadata"
-    ++ optional enableMpris "--with-mpris-interface";
+    ++ lib.optional enableDbus "--with-dbus-interface"
+    ++ lib.optional enableMetadata "--with-metadata"
+    ++ lib.optional enableMpris "--with-mpris-interface";
 
   meta = with lib; {
     inherit (src.meta) homepage;

--- a/pkgs/servers/shishi/default.nix
+++ b/pkgs/servers/shishi/default.nix
@@ -12,7 +12,6 @@ let
   optLibidn = shouldUsePkg libidn;
   optGnutls = shouldUsePkg gnutls;
 in
-with lib;
 stdenv.mkDerivation rec {
   pname = "shishi";
   version = "1.0.2";
@@ -31,21 +30,21 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--sysconfdir=/etc"
     "--localstatedir=/var"
-    (enableFeature true                "libgcrypt")
-    (enableFeature (optPam != null)    "pam")
-    (enableFeature true                "ipv6")
-    (withFeature   (optLibidn != null) "stringprep")
-    (enableFeature (optGnutls != null) "starttls")
-    (enableFeature true                "des")
-    (enableFeature true                "3des")
-    (enableFeature true                "aes")
-    (enableFeature true                "md")
-    (enableFeature false               "null")
-    (enableFeature true                "arcfour")
+    (lib.enableFeature true                "libgcrypt")
+    (lib.enableFeature (optPam != null)    "pam")
+    (lib.enableFeature true                "ipv6")
+    (lib.withFeature   (optLibidn != null) "stringprep")
+    (lib.enableFeature (optGnutls != null) "starttls")
+    (lib.enableFeature true                "des")
+    (lib.enableFeature true                "3des")
+    (lib.enableFeature true                "aes")
+    (lib.enableFeature true                "md")
+    (lib.enableFeature false               "null")
+    (lib.enableFeature true                "arcfour")
   ];
 
   NIX_CFLAGS_COMPILE
-    = optionalString stdenv.isDarwin "-DBIND_8_COMPAT";
+    = lib.optionalString stdenv.isDarwin "-DBIND_8_COMPAT";
 
   doCheck = true;
 
@@ -54,9 +53,9 @@ stdenv.mkDerivation rec {
   # Fix *.la files
   postInstall = ''
     sed -i $out/lib/libshi{sa,shi}.la \
-  '' + optionalString (optLibidn != null) ''
+  '' + lib.optionalString (optLibidn != null) ''
       -e 's,\(-lidn\),-L${optLibidn.out}/lib \1,' \
-  '' + optionalString (optGnutls != null) ''
+  '' + lib.optionalString (optGnutls != null) ''
       -e 's,\(-lgnutls\),-L${optGnutls.out}/lib \1,' \
   '' + ''
       -e 's,\(-lgcrypt\),-L${libgcrypt.out}/lib \1,' \
@@ -64,7 +63,7 @@ stdenv.mkDerivation rec {
       -e 's,\(-ltasn1\),-L${libtasn1.out}/lib \1,'
   '';
 
-  meta = {
+  meta = with lib; {
     homepage    = "https://www.gnu.org/software/shishi/";
     description = "An implementation of the Kerberos 5 network security system";
     license     = licenses.gpl3Plus;

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -4,8 +4,6 @@
 , version, sha256, ...
 }:
 
-with lib;
-
 stdenv.mkDerivation {
   pname = "mariadb-connector-c";
   inherit version;
@@ -38,7 +36,7 @@ stdenv.mkDerivation {
   '';
 
   # The cmake setup-hook uses $out/lib by default, this is not the case here.
-  preConfigure = optionalString stdenv.isDarwin ''
+  preConfigure = lib.optionalString stdenv.isDarwin ''
     cmakeFlagsArray+=("-DCMAKE_INSTALL_NAME_DIR=$out/lib/mariadb")
   '';
 
@@ -59,7 +57,7 @@ stdenv.mkDerivation {
     install -Dm644 include/ma_config.h $dev/include/mariadb/my_config.h
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Client library that can be used to connect to MySQL or MariaDB";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ globin ];

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -10,8 +10,6 @@
 , withOnlyInstalledCommunityModules ? [ ]
 , withCommunityModules ? [ ] }:
 
-with lib;
-
 let
   luaEnv = lua.withPackages(p: with p; [
       luasocket luasec luaexpat luafilesystem luabitop luadbi-sqlite3 luaunbound
@@ -64,7 +62,7 @@ stdenv.mkDerivation rec {
 
   # the wrapping should go away once lua hook is fixed
   postInstall = ''
-      ${concatMapStringsSep "\n" (module: ''
+      ${lib.concatMapStringsSep "\n" (module: ''
         cp -r $communityModules/mod_${module} $out/lib/prosody/modules/
       '') (lib.lists.unique(nixosModuleDeps ++ withCommunityModules ++ withOnlyInstalledCommunityModules))}
       wrapProgram $out/bin/prosodyctl \
@@ -77,7 +75,7 @@ stdenv.mkDerivation rec {
     tests = { inherit (nixosTests) prosody prosody-mysql; };
   };
 
-  meta = {
+  meta = with lib; {
     description = "Open-source XMPP application server written in Lua";
     license = licenses.mit;
     homepage = "https://prosody.im";

--- a/pkgs/shells/zsh/grml-zsh-config/default.nix
+++ b/pkgs/shells/zsh/grml-zsh-config/default.nix
@@ -1,8 +1,6 @@
 { stdenv, fetchFromGitHub, lib
 , zsh, coreutils, inetutils, procps, txt2tags }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "grml-zsh-config";
   version = "0.19.4";
@@ -17,7 +15,7 @@ stdenv.mkDerivation rec {
   strictDeps = true;
   nativeBuildInputs = [ txt2tags ];
   buildInputs = [ zsh coreutils procps ]
-    ++ optional stdenv.isLinux inetutils;
+    ++ lib.optional stdenv.isLinux inetutils;
 
   buildPhase = ''
     cd doc

--- a/pkgs/shells/zsh/pure-prompt/default.nix
+++ b/pkgs/shells/zsh/pure-prompt/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "pure-prompt";
   version = "1.20.4";
@@ -21,7 +19,7 @@ stdenv.mkDerivation rec {
     cp async.zsh "$OUTDIR/async"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Pretty, minimal and fast ZSH prompt";
     homepage = "https://github.com/sindresorhus/pure";
     license = licenses.mit;

--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -36,8 +36,6 @@
 , xorgserver
 }:
 
-with lib;
-
 let
   inherit (python3.pkgs) cython buildPythonApplication;
 
@@ -206,7 +204,7 @@ in buildPythonApplication rec {
     updateScript = ./update.sh;
   };
 
-  meta = {
+  meta = with lib; {
     homepage = "https://xpra.org/";
     downloadPage = "https://xpra.org/src/";
     description = "Persistent remote applications for X";

--- a/pkgs/tools/admin/pulumi-bin/default.nix
+++ b/pkgs/tools/admin/pulumi-bin/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl, autoPatchelfHook, makeWrapper, installShellFiles }:
 
-with lib;
-
 let
   data = import ./data.nix {};
 in stdenv.mkDerivation {
@@ -16,7 +14,7 @@ in stdenv.mkDerivation {
 
   installPhase = ''
     install -D -t $out/bin/ *
-  '' + optionalString stdenv.isLinux ''
+  '' + lib.optionalString stdenv.isLinux ''
     wrapProgram $out/bin/pulumi --set LD_LIBRARY_PATH "${stdenv.cc.cc.lib}/lib"
   '' + ''
     installShellCompletion --cmd pulumi \
@@ -25,9 +23,9 @@ in stdenv.mkDerivation {
       --zsh  <($out/bin/pulumi completion zsh)
   '';
 
-  nativeBuildInputs = [ installShellFiles ] ++ optionals stdenv.isLinux [ autoPatchelfHook makeWrapper ];
+  nativeBuildInputs = [ installShellFiles ] ++ lib.optionals stdenv.isLinux [ autoPatchelfHook makeWrapper ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://pulumi.io/";
     description = "Pulumi is a cloud development platform that makes creating cloud programs easy and productive";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];

--- a/pkgs/tools/admin/tigervnc/default.nix
+++ b/pkgs/tools/admin/tigervnc/default.nix
@@ -23,8 +23,6 @@
 , nixosTests
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   version = "1.12.0";
   pname = "tigervnc";

--- a/pkgs/tools/backup/bup/default.nix
+++ b/pkgs/tools/backup/bup/default.nix
@@ -7,8 +7,6 @@ assert par2Support -> par2cmdline != null;
 
 let version = "0.32"; in
 
-with lib;
-
 stdenv.mkDerivation {
   pname = "bup";
   inherit version;
@@ -31,7 +29,7 @@ stdenv.mkDerivation {
   postPatch = ''
     patchShebangs .
     substituteInPlace Makefile --replace "-Werror" ""
-  '' + optionalString par2Support ''
+  '' + lib.optionalString par2Support ''
     substituteInPlace cmd/fsck-cmd.py --replace "'par2'" "'${par2cmdline}/bin/par2'"
   '';
 
@@ -49,7 +47,7 @@ stdenv.mkDerivation {
       --prefix PATH : ${git}/bin
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/bup/bup";
     description = "Efficient file backup system based on the git packfile format";
     license = licenses.gpl2Plus;

--- a/pkgs/tools/backup/luckybackup/default.nix
+++ b/pkgs/tools/backup/luckybackup/default.nix
@@ -3,7 +3,6 @@
 , rsync, ssh
 }:
 
-with lib;
 mkDerivation rec {
   pname = "luckybackup";
   version = "0.5.0";
@@ -26,7 +25,7 @@ mkDerivation rec {
     done
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A powerful, fast and reliable backup & sync tool";
     longDescription = ''
       luckyBackup is an application for data back-up and synchronization

--- a/pkgs/tools/bluetooth/bluez-alsa/default.nix
+++ b/pkgs/tools/bluetooth/bluez-alsa/default.nix
@@ -9,8 +9,6 @@
 # TODO: aptxSupport
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "bluez-alsa";
   version = "4.0.0";
@@ -28,7 +26,7 @@ stdenv.mkDerivation rec {
     alsa-lib bluez glib sbc dbus
     readline libbsd ncurses
   ]
-  ++ optional aacSupport fdk_aac;
+  ++ lib.optional aacSupport fdk_aac;
 
   configureFlags = [
     "--with-alsaplugindir=${placeholder "out"}/lib/alsa-lib"
@@ -36,9 +34,9 @@ stdenv.mkDerivation rec {
     "--enable-rfcomm"
     "--enable-hcitop"
   ]
-  ++ optional aacSupport "--enable-aac";
+  ++ lib.optional aacSupport "--enable-aac";
 
-  meta = {
+  meta = with lib; {
     description = "Bluez 5 Bluetooth Audio ALSA Backend";
     longDescription = ''
       Bluez-ALSA (BlueALSA) is an ALSA backend for Bluez 5 audio interface.

--- a/pkgs/tools/filesystems/squashfuse/default.nix
+++ b/pkgs/tools/filesystems/squashfuse/default.nix
@@ -1,8 +1,6 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, libtool, fuse,
   pkg-config, lz4, xz, zlib, lzo, zstd }:
 
-with lib;
-
 stdenv.mkDerivation rec {
 
   pname = "squashfuse";
@@ -22,7 +20,7 @@ stdenv.mkDerivation rec {
     description = "FUSE filesystem to mount squashfs archives";
     homepage = "https://github.com/vasi/squashfuse";
     maintainers = [  ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
     license = "BSD-2-Clause";
   };
 }

--- a/pkgs/tools/graphics/gifsicle/default.nix
+++ b/pkgs/tools/graphics/gifsicle/default.nix
@@ -3,8 +3,6 @@
 , static ? stdenv.hostPlatform.isStatic
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "gifsicle";
   version = "1.93";
@@ -14,11 +12,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-kvZweXMr9MHaCH5q4JBSBYRuWsd3ulyqZtEqc6qUNEc=";
   };
 
-  buildInputs = optionals gifview [ xorgproto libXt libX11 ];
+  buildInputs = lib.optionals gifview [ xorgproto libXt libX11 ];
 
-  configureFlags = optional (!gifview) "--disable-gifview";
+  configureFlags = lib.optional (!gifview) "--disable-gifview";
 
-  LDFLAGS = optionalString static "-static";
+  LDFLAGS = lib.optionalString static "-static";
 
   doCheck = true;
   checkPhase = ''
@@ -29,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "Command-line tool for creating, editing, and getting information about GIF images and animations";
     homepage = "https://www.lcdf.org/gifsicle/";
     license = lib.licenses.gpl2;
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ zimbatm ];
   };
 }

--- a/pkgs/tools/graphics/ldgallery/viewer/default.nix
+++ b/pkgs/tools/graphics/ldgallery/viewer/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, pkgs, pandoc, CoreServices }:
 
-with lib;
-
 let
   # Note for maintainers:
   # * keep version in sync with the ldgallery compiler
@@ -21,13 +19,13 @@ let
   nodePkg = nodePackages.package.override {
     src = "${sourcePkg}/viewer";
     postInstall = "npm run build";
-    buildInputs = optionals stdenv.isDarwin [ CoreServices ];
+    buildInputs = lib.optionals stdenv.isDarwin [ CoreServices ];
   };
 
 in
 
 # making sure that the source and the node package are in sync
-assert versions.majorMinor nodePkg.version == removePrefix "v" sourcePkg.rev;
+assert lib.versions.majorMinor nodePkg.version == lib.removePrefix "v" sourcePkg.rev;
 
 stdenv.mkDerivation {
   pname = nodePkg.packageName;

--- a/pkgs/tools/graphics/optipng/default.nix
+++ b/pkgs/tools/graphics/optipng/default.nix
@@ -4,8 +4,6 @@
 
 # This package comes with its own copy of zlib, libpng and pngxtern
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "optipng";
   version = "0.7.7";
@@ -17,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libpng ];
 
-  LDFLAGS = optional static "-static";
+  LDFLAGS = lib.optional static "-static";
   # Workaround for crash in cexcept.h. See
   # https://github.com/NixOS/nixpkgs/issues/28106
   preConfigure = ''

--- a/pkgs/tools/graphics/pgf/default.nix
+++ b/pkgs/tools/graphics/pgf/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchurl, autoconf, automake, libtool, dos2unix, libpgf, freeimage, doxygen }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "pgf";
   version = "6.14.12";

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -34,8 +34,6 @@
 , nixosTests
 }:
 
-with lib;
-
 let
   python3Runtime = python3.withPackages (ps: with ps; [ pygobject3 ]);
   python3BuildEnv = python3.buildEnv.override {
@@ -88,10 +86,10 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--disable-memconf"
-    (enableFeature (dconf != null) "dconf")
-    (enableFeature (libnotify != null) "libnotify")
-    (enableFeature withWayland "wayland")
-    (enableFeature enableUI "ui")
+    (lib.enableFeature (dconf != null) "dconf")
+    (lib.enableFeature (libnotify != null) "libnotify")
+    (lib.enableFeature withWayland "wayland")
+    (lib.enableFeature enableUI "ui")
     "--enable-gtk4"
     "--enable-install-tests"
     "--with-unicode-emoji-dir=${unicode-emoji}/share/unicode/emoji"
@@ -133,7 +131,7 @@ stdenv.mkDerivation rec {
     isocodes
     json-glib
     libnotify
-  ] ++ optionals withWayland [
+  ] ++ lib.optionals withWayland [
     libxkbcommon
     wayland
   ];
@@ -165,7 +163,7 @@ stdenv.mkDerivation rec {
     };
   };
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/ibus/ibus";
     description = "Intelligent Input Bus, input method framework";
     license = licenses.lgpl21Plus;

--- a/pkgs/tools/inputmethods/uim/default.nix
+++ b/pkgs/tools/inputmethods/uim/default.nix
@@ -18,8 +18,6 @@
 , withMisc ? false, libeb ? null
 }:
 
-with lib;
-
 assert withGtk2 -> gtk2 != null;
 assert withGtk3 -> gtk3 != null;
 
@@ -59,18 +57,18 @@ stdenv.mkDerivation rec {
   buildInputs = [
     ncurses m17n_lib m17n_db expat
   ]
-  ++ optional withAnthy anthy
-  ++ optional withGtk2 gtk2
-  ++ optional withGtk3 gtk3
-  ++ optional withQt4 qt4
-  ++ optionals withQt5 [ qt5.qtbase.bin qt5.qtbase.dev ]
-  ++ optional withLibnotify libnotify
-  ++ optional withSqlite sqlite
-  ++ optionals withNetworking [
+  ++ lib.optional withAnthy anthy
+  ++ lib.optional withGtk2 gtk2
+  ++ lib.optional withGtk3 gtk3
+  ++ lib.optional withQt4 qt4
+  ++ lib.optionals withQt5 [ qt5.qtbase.bin qt5.qtbase.dev ]
+  ++ lib.optional withLibnotify libnotify
+  ++ lib.optional withSqlite sqlite
+  ++ lib.optionals withNetworking [
     curl openssl
   ]
-  ++ optional withFFI libffi
-  ++ optional withMisc libeb;
+  ++ lib.optional withFFI libffi
+  ++ lib.optional withMisc libeb;
 
   prePatch = ''
     patchShebangs *.sh */*.sh */*/*.sh
@@ -113,25 +111,25 @@ stdenv.mkDerivation rec {
     "--with-xft"
     "--with-expat=${expat.dev}"
   ]
-  ++ optional withAnthy "--with-anthy-utf8"
-  ++ optional withGtk2 "--with-gtk2"
-  ++ optional withGtk3 "--with-gtk3"
-  ++ optionals withQt4 [
+  ++ lib.optional withAnthy "--with-anthy-utf8"
+  ++ lib.optional withGtk2 "--with-gtk2"
+  ++ lib.optional withGtk3 "--with-gtk3"
+  ++ lib.optionals withQt4 [
     "--with-qt4"
     "--with-qt4-immodule"
   ]
-  ++ optionals withQt5 [
+  ++ lib.optionals withQt5 [
     "--with-qt5"
     "--with-qt5-immodule"
   ]
-  ++ optional withLibnotify "--enable-notify=libnotify"
-  ++ optional withSqlite "--with-sqlite3"
-  ++ optionals withNetworking [
+  ++ lib.optional withLibnotify "--enable-notify=libnotify"
+  ++ lib.optional withSqlite "--with-sqlite3"
+  ++ lib.optionals withNetworking [
     "--with-curl"
     "--with-openssl-dir=${openssl.dev}"
   ]
-  ++ optional withFFI "--with-ffi"
-  ++ optional withMisc "--with-eb";
+  ++ lib.optional withFFI "--with-ffi"
+  ++ lib.optional withMisc "--with-eb";
 
   # TODO: things in `./configure --help`, but not in nixpkgs
   #--with-canna            Use Canna [default=no]

--- a/pkgs/tools/misc/catimg/default.nix
+++ b/pkgs/tools/misc/catimg/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake } :
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "catimg";
   version = "2.7.0";
@@ -15,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  meta = {
+  meta = with lib; {
     license = licenses.mit;
     homepage = "https://github.com/posva/catimg";
     description = "Insanely fast image printing in your terminal";

--- a/pkgs/tools/misc/desktop-file-utils/default.nix
+++ b/pkgs/tools/misc/desktop-file-utils/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, meson, ninja, glib, libintl }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "desktop-file-utils";
   version = "0.26";
@@ -21,7 +19,7 @@ stdenv.mkDerivation rec {
 
   setupHook = ./setup-hook.sh;
 
-  meta = {
+  meta = with lib; {
     homepage = "http://www.freedesktop.org/wiki/Software/desktop-file-utils";
     description = "Command line utilities for working with .desktop files";
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -13,7 +13,6 @@
 , kbdcompSupport ? false, ckbcomp
 }:
 
-with lib;
 let
   pcSystems = {
     i686-linux.target = "i386";
@@ -40,8 +39,8 @@ let
     riscv64-linux.target = "riscv64";
   };
 
-  canEfi = any (system: stdenv.hostPlatform.system == system) (mapAttrsToList (name: _: name) efiSystemsBuild);
-  inPCSystems = any (system: stdenv.hostPlatform.system == system) (mapAttrsToList (name: _: name) pcSystems);
+  canEfi = lib.any (system: stdenv.hostPlatform.system == system) (lib.mapAttrsToList (name: _: name) efiSystemsBuild);
+  inPCSystems = lib.any (system: stdenv.hostPlatform.system == system) (lib.mapAttrsToList (name: _: name) pcSystems);
 
   version = "2.06";
 
@@ -330,8 +329,8 @@ stdenv.mkDerivation rec {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ bison flex python3 pkg-config gettext freetype autoreconfHook ];
   buildInputs = [ ncurses libusb-compat-0_1 freetype lvm2 fuse libtool bash ]
-    ++ optional doCheck qemu
-    ++ optional zfsSupport zfs;
+    ++ lib.optional doCheck qemu
+    ++ lib.optional zfsSupport zfs;
 
   strictDeps = true;
 
@@ -369,7 +368,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--enable-grub-mount" # dep of os-prober
-  ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     # grub doesn't do cross-compilation as usual and tries to use unprefixed
     # tools to target the host. Provide toolchain information explicitly for
     # cross builds.
@@ -380,9 +379,9 @@ stdenv.mkDerivation rec {
     "TARGET_OBJCOPY=${stdenv.cc.targetPrefix}objcopy"
     "TARGET_RANLIB=${stdenv.cc.targetPrefix}ranlib"
     "TARGET_STRIP=${stdenv.cc.targetPrefix}strip"
-  ] ++ optional zfsSupport "--enable-libzfs"
-    ++ optionals efiSupport [ "--with-platform=efi" "--target=${efiSystemsBuild.${stdenv.hostPlatform.system}.target}" "--program-prefix=" ]
-    ++ optionals xenSupport [ "--with-platform=xen" "--target=${efiSystemsBuild.${stdenv.hostPlatform.system}.target}"];
+  ] ++ lib.optional zfsSupport "--enable-libzfs"
+    ++ lib.optionals efiSupport [ "--with-platform=efi" "--target=${efiSystemsBuild.${stdenv.hostPlatform.system}.target}" "--program-prefix=" ]
+    ++ lib.optionals xenSupport [ "--with-platform=xen" "--target=${efiSystemsBuild.${stdenv.hostPlatform.system}.target}"];
 
   # save target that grub is compiled for
   grubTarget = if efiSupport

--- a/pkgs/tools/misc/grub/pvgrub_image/default.nix
+++ b/pkgs/tools/misc/grub/pvgrub_image/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, grub2_xen }:
 
-with lib;
 let
   efiSystemsBuild = {
     i686-linux.target = "i386";

--- a/pkgs/tools/misc/grub/trusted.nix
+++ b/pkgs/tools/misc/grub/trusted.nix
@@ -18,14 +18,13 @@
 , for_HP_laptop ? false
 }:
 
-with lib;
 let
   pcSystems = {
     i686-linux.target = "i386";
     x86_64-linux.target = "i386";
   };
 
-  inPCSystems = any (system: stdenv.hostPlatform.system == system) (mapAttrsToList (name: _: name) pcSystems);
+  inPCSystems = lib.any (system: stdenv.hostPlatform.system == system) (lib.mapAttrsToList (name: _: name) pcSystems);
 
   version = if for_HP_laptop then "1.2.1" else "1.2.0";
 
@@ -59,7 +58,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autogen flex bison python2 autoconf automake ];
   buildInputs = [ ncurses libusb-compat-0_1 freetype gettext lvm2 ]
-    ++ optional doCheck qemu;
+    ++ lib.optional doCheck qemu;
 
   hardeningDisable = [ "stackprotector" "pic" ];
 

--- a/pkgs/tools/misc/hexd/default.nix
+++ b/pkgs/tools/misc/hexd/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "hexd";
   version = "1.1.0";
@@ -15,7 +13,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  meta = {
+  meta = with lib; {
     description = "Colourful, human-friendly hexdump tool";
     homepage = "https://github.com/FireyFly/hexd";
     maintainers = [ maintainers.FireyFly ];

--- a/pkgs/tools/misc/logstash/6.x.nix
+++ b/pkgs/tools/misc/logstash/6.x.nix
@@ -7,11 +7,9 @@
 , jre
 }:
 
-with lib;
-
 let this = stdenv.mkDerivation rec {
   version = elk6Version;
-  pname = "logstash${optionalString (!enableUnfree) "-oss"}";
+  pname = "logstash${lib.optionalString (!enableUnfree) "-oss"}";
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/logstash/${pname}-${version}.tar.gz";
@@ -63,7 +61,7 @@ let this = stdenv.mkDerivation rec {
     maintainers = with maintainers; [ wjlroe offline basvandijk ];
   };
   passthru.tests =
-    optionalAttrs (!enableUnfree) (
+    lib.optionalAttrs (!enableUnfree) (
       assert this.drvPath == nixosTests.elk.ELK-6.elkPackages.logstash.drvPath;
       {
         elk = nixosTests.elk.ELK-6;

--- a/pkgs/tools/misc/logstash/7.x.nix
+++ b/pkgs/tools/misc/logstash/7.x.nix
@@ -9,12 +9,10 @@
 , jre
 }:
 
-with lib;
-
 let
-  info = splitString "-" stdenv.hostPlatform.system;
-  arch = elemAt info 0;
-  plat = elemAt info 1;
+  info = lib.splitString "-" stdenv.hostPlatform.system;
+  arch = lib.elemAt info 0;
+  plat = lib.elemAt info 1;
   shas =
     if enableUnfree
     then {
@@ -29,7 +27,7 @@ let
     };
   this = stdenv.mkDerivation rec {
     version = elk7Version;
-    pname = "logstash${optionalString (!enableUnfree) "-oss"}";
+    pname = "logstash${lib.optionalString (!enableUnfree) "-oss"}";
 
 
     src = fetchurl {
@@ -79,7 +77,7 @@ let
       maintainers = with maintainers; [ wjlroe offline basvandijk ];
     };
     passthru.tests =
-      optionalAttrs (config.allowUnfree && enableUnfree) (
+      lib.optionalAttrs (config.allowUnfree && enableUnfree) (
         assert this.drvPath == nixosTests.elk.unfree.ELK-7.elkPackages.logstash.drvPath;
         {
           elk = nixosTests.elk.unfree.ELK-7;

--- a/pkgs/tools/misc/moreutils/default.nix
+++ b/pkgs/tools/misc/moreutils/default.nix
@@ -11,7 +11,6 @@
 , darwin
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "moreutils";
   version = "0.67";
@@ -28,7 +27,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   nativeBuildInputs = [ makeWrapper perl libxml2 libxslt docbook-xsl docbook_xml_dtd_44 ];
-  buildInputs = optional stdenv.isDarwin darwin.cctools;
+  buildInputs = lib.optional stdenv.isDarwin darwin.cctools;
 
   propagatedBuildInputs = with perlPackages; [ perl IPCRun TimeDate TimeDuration ];
 
@@ -40,7 +39,7 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/ts --prefix PERL5LIB : $PERL5LIB
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Growing collection of the unix tools that nobody thought to write long ago when unix was young";
     homepage = "https://joeyh.name/code/moreutils/";
     maintainers = with maintainers; [ koral pSub ];

--- a/pkgs/tools/misc/pixd/default.nix
+++ b/pkgs/tools/misc/pixd/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "pixd";
   version = "1.0.0";
@@ -15,7 +13,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  meta = {
+  meta = with lib; {
     description = "Colourful visualization tool for binary files";
     homepage = "https://github.com/FireyFly/pixd";
     maintainers = [ maintainers.FireyFly ];

--- a/pkgs/tools/misc/rmlint/default.nix
+++ b/pkgs/tools/misc/rmlint/default.nix
@@ -20,7 +20,6 @@
 
 assert withGui -> !stdenv.isDarwin;
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "rmlint";
   version = "2.10.1";
@@ -78,7 +77,7 @@ stdenv.mkDerivation rec {
     gappsWrapperArgs+=(--prefix PYTHONPATH : "$(toPythonPath $out):$(toPythonPath ${python3.pkgs.pygobject3}):$(toPythonPath ${python3.pkgs.pycairo})")
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Extremely fast tool to remove duplicates and other lint from your filesystem";
     homepage = "https://rmlint.readthedocs.org";
     platforms = platforms.unix;

--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -5,14 +5,13 @@
 , nixosTests
 }:
 
-with lib;
 let
-  copts = concatStringsSep " " ([
+  copts = lib.concatStringsSep " " ([
     "-DHAVE_IDN"
     "-DHAVE_DNSSEC"
-  ] ++ optionals dbusSupport [
+  ] ++ lib.optionals dbusSupport [
     "-DHAVE_DBUS"
-  ] ++ optionals stdenv.isLinux [
+  ] ++ lib.optionals stdenv.isLinux [
     "-DHAVE_CONNTRACK"
   ]);
 in
@@ -43,7 +42,7 @@ stdenv.mkDerivation rec {
 
   hardeningEnable = [ "pie" ];
 
-  postBuild = optionalString stdenv.isLinux ''
+  postBuild = lib.optionalString stdenv.isLinux ''
     make -C contrib/lease-tools
   '';
 
@@ -51,17 +50,17 @@ stdenv.mkDerivation rec {
   # module can create it in Nix-land?
   postInstall = ''
     install -Dm644 trust-anchors.conf $out/share/dnsmasq/trust-anchors.conf
-  '' + optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     install -Dm644 contrib/MacOSX-launchd/uk.org.thekelleys.dnsmasq.plist \
       $out/Library/LaunchDaemons/uk.org.thekelleys.dnsmasq.plist
     substituteInPlace $out/Library/LaunchDaemons/uk.org.thekelleys.dnsmasq.plist \
       --replace "/usr/local/sbin" "$out/bin"
-  '' + optionalString stdenv.isLinux ''
+  '' + lib.optionalString stdenv.isLinux ''
     install -Dm755 contrib/lease-tools/dhcp_lease_time $out/bin/dhcp_lease_time
     install -Dm755 contrib/lease-tools/dhcp_release $out/bin/dhcp_release
     install -Dm755 contrib/lease-tools/dhcp_release6 $out/bin/dhcp_release6
 
-  '' + optionalString dbusSupport ''
+  '' + lib.optionalString dbusSupport ''
     install -Dm644 dbus/dnsmasq.conf $out/share/dbus-1/system.d/dnsmasq.conf
     mkdir -p $out/share/dbus-1/system-services
     cat <<END > $out/share/dbus-1/system-services/uk.org.thekelleys.dnsmasq.service
@@ -75,8 +74,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ nettle libidn ]
-    ++ optionals dbusSupport [ dbus ]
-    ++ optionals stdenv.isLinux [ libnetfilter_conntrack ];
+    ++ lib.optionals dbusSupport [ dbus ]
+    ++ lib.optionals stdenv.isLinux [ libnetfilter_conntrack ];
 
   passthru.tests = {
     prometheus-exporter = nixosTests.prometheus-exporters.dnsmasq;
@@ -87,7 +86,7 @@ stdenv.mkDerivation rec {
     kubernetes-dns-multi = nixosTests.kubernetes.dns-multi-node;
   };
 
-  meta = {
+  meta = with lib; {
     description = "An integrated DNS, DHCP and TFTP server for small networks";
     homepage = "https://www.thekelleys.org.uk/dnsmasq/doc.html";
     license = licenses.gpl2;

--- a/pkgs/tools/networking/flannel/default.nix
+++ b/pkgs/tools/networking/flannel/default.nix
@@ -1,7 +1,5 @@
 { lib, buildGoModule, fetchFromGitHub, nixosTests }:
 
-with lib;
-
 buildGoModule rec {
   pname = "flannel";
   version = "0.20.2";
@@ -23,7 +21,7 @@ buildGoModule rec {
 
   passthru.tests = { inherit (nixosTests) flannel; };
 
-  meta = {
+  meta = with lib; {
     description = "Network fabric for containers, designed for Kubernetes";
     license = licenses.asl20;
     homepage = "https://github.com/flannel-io/flannel";

--- a/pkgs/tools/networking/logmein-hamachi/default.nix
+++ b/pkgs/tools/networking/logmein-hamachi/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl }:
 
-with lib;
-
 let
   arch =
     if stdenv.hostPlatform.system == "x86_64-linux" then "x64"

--- a/pkgs/tools/networking/ndjbdns/default.nix
+++ b/pkgs/tools/networking/ndjbdns/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, systemd, pkg-config }:
 
-with lib;
-
 stdenv.mkDerivation {
   version = "1.06";
   pname = "ndjbdns";
@@ -15,9 +13,9 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ ]
-    ++ optional stdenv.isLinux systemd;
+    ++ lib.optional stdenv.isLinux systemd;
 
-  meta = {
+  meta = with lib; {
     description = "A brand new release of the Djbdns";
     longDescription = ''
       Djbdns is a fully‐fledged Domain Name System(DNS), originally written by the eminent author of qmail, Dr. D J Bernstein.

--- a/pkgs/tools/networking/ngrok/default.nix
+++ b/pkgs/tools/networking/ngrok/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl }:
 
-with lib;
-
 let versions = lib.importJSON ./versions.json;
     arch = if stdenv.isi686 then "386"
            else if stdenv.isx86_64 then "amd64"
@@ -37,10 +35,10 @@ stdenv.mkDerivation {
   # Stripping causes SEGFAULT on x86_64-darwin
   dontStrip = true;
 
-  meta = {
+  meta = with lib; {
     description = "Allows you to expose a web server running on your local machine to the internet";
     homepage = "https://ngrok.com/";
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
     maintainers = with maintainers; [ bobvanderlinden brodes ];

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -30,7 +30,6 @@
 , linkOpenssl ? true
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   inherit pname version src;
 
@@ -57,12 +56,12 @@ stdenv.mkDerivation rec {
     # This is not the same as the libkrb5 from the inputs! pkgs.libkrb5 is
     # needed here to access krb5-config in order to cross compile. See:
     # https://github.com/NixOS/nixpkgs/pull/107606
-    ++ optional withKerberos pkgs.libkrb5
+    ++ lib.optional withKerberos pkgs.libkrb5
     ++ extraNativeBuildInputs;
   buildInputs = [ zlib openssl libedit ]
-    ++ optional withFIDO libfido2
-    ++ optional withKerberos libkrb5
-    ++ optional stdenv.isLinux pam;
+    ++ lib.optional withFIDO libfido2
+    ++ lib.optional withKerberos libkrb5
+    ++ lib.optional stdenv.isLinux pam;
 
   preConfigure = ''
     # Setting LD causes `configure' and `make' to disagree about which linker
@@ -80,11 +79,11 @@ stdenv.mkDerivation rec {
     "--with-libedit=yes"
     "--disable-strip"
     (if stdenv.isLinux then "--with-pam" else "--without-pam")
-  ] ++ optional (etcDir != null) "--sysconfdir=${etcDir}"
-    ++ optional withFIDO "--with-security-key-builtin=yes"
-    ++ optional withKerberos (assert libkrb5 != null; "--with-kerberos5=${libkrb5}")
-    ++ optional stdenv.isDarwin "--disable-libutil"
-    ++ optional (!linkOpenssl) "--without-openssl"
+  ] ++ lib.optional (etcDir != null) "--sysconfdir=${etcDir}"
+    ++ lib.optional withFIDO "--with-security-key-builtin=yes"
+    ++ lib.optional withKerberos (assert libkrb5 != null; "--with-kerberos5=${libkrb5}")
+    ++ lib.optional stdenv.isDarwin "--disable-libutil"
+    ++ lib.optional (!linkOpenssl) "--without-openssl"
     ++ extraConfigureFlags;
 
   ${if stdenv.hostPlatform.isStatic then "NIX_LDFLAGS" else null}= [ "-laudit" ] ++ lib.optionals withKerberos [ "-lkeyutils" ];
@@ -97,7 +96,7 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
   enableParallelChecking = false;
-  checkInputs = optional (!stdenv.isDarwin) hostname;
+  checkInputs = lib.optional (!stdenv.isDarwin) hostname;
   preCheck = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
     # construct a dummy HOME
     export HOME=$(realpath ../dummy-home)
@@ -145,7 +144,7 @@ stdenv.mkDerivation rec {
   # integration tests hard to get working on darwin with its shaky
   # sandbox
   # t-exec tests fail on musl
-  checkTarget = optional (!stdenv.isDarwin && !stdenv.hostPlatform.isMusl) "t-exec"
+  checkTarget = lib.optional (!stdenv.isDarwin && !stdenv.hostPlatform.isMusl) "t-exec"
     # other tests are less demanding of the environment
     ++ [ "unit" "file-tests" "interop-tests" ];
 
@@ -165,7 +164,7 @@ stdenv.mkDerivation rec {
     borgbackup-integration = nixosTests.borgbackup;
   };
 
-  meta = {
+  meta = with lib; {
     description = "An implementation of the SSH protocol${extraDesc}";
     homepage = "https://www.openssh.com/";
     changelog = "https://www.openssh.com/releasenotes.html";

--- a/pkgs/tools/networking/snabb/default.nix
+++ b/pkgs/tools/networking/snabb/default.nix
@@ -3,8 +3,6 @@
 , fetchFromGitHub
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "snabb";
   version = "2022.10";
@@ -21,7 +19,7 @@ stdenv.mkDerivation rec {
     cp src/snabb $out/bin
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/SnabbCo/snabbswitch";
     description = "Simple and fast packet networking toolkit";
     longDescription = ''

--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -14,8 +14,6 @@
 # strongswan curl plugin may break.
 # See https://wiki.strongswan.org/projects/strongswan/wiki/Curl for more info.
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "strongswan";
   version = "5.9.8"; # Make sure to also update <nixpkgs/nixos/modules/services/networking/strongswan-swanctl/swanctl-params.nix> when upgrading!
@@ -32,10 +30,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config autoreconfHook perl gperf bison flex ];
   buildInputs =
     [ curl gmp python3 ldns unbound openssl pcsclite ]
-    ++ optionals enableTNC [ trousers sqlite libxml2 ]
-    ++ optionals stdenv.isLinux [ systemd.dev pam iptables ]
-    ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ SystemConfiguration ])
-    ++ optionals enableNetworkManager [ networkmanager glib ];
+    ++ lib.optionals enableTNC [ trousers sqlite libxml2 ]
+    ++ lib.optionals stdenv.isLinux [ systemd.dev pam iptables ]
+    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ SystemConfiguration ])
+    ++ lib.optionals enableNetworkManager [ networkmanager glib ];
 
   patches = [
     ./ext_auth-path.patch
@@ -43,7 +41,7 @@ stdenv.mkDerivation rec {
     ./updown-path.patch
   ];
 
-  postPatch = optionalString stdenv.isLinux ''
+  postPatch = lib.optionalString stdenv.isLinux ''
     # glibc-2.26 reorganized internal includes
     sed '1i#include <stdint.h>' -i src/libstrongswan/utils/utils/memory.h
 
@@ -62,16 +60,16 @@ stdenv.mkDerivation rec {
       "--enable-pkcs11" "--enable-eap-sim-pcsc" "--enable-dnscert" "--enable-unbound"
       "--enable-chapoly"
       "--enable-curl" ]
-    ++ optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.isLinux [
       "--enable-farp" "--enable-dhcp"
       "--enable-systemd" "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
       "--enable-xauth-pam"
       "--enable-forecast"
       "--enable-connmark"
       "--enable-af-alg" ]
-    ++ optionals stdenv.isx86_64 [ "--enable-aesni" "--enable-rdrand" ]
-    ++ optional (stdenv.hostPlatform.system == "i686-linux") "--enable-padlock"
-    ++ optionals enableTNC [
+    ++ lib.optionals stdenv.isx86_64 [ "--enable-aesni" "--enable-rdrand" ]
+    ++ lib.optional (stdenv.hostPlatform.system == "i686-linux") "--enable-padlock"
+    ++ lib.optionals enableTNC [
          "--disable-gmp" "--disable-aes" "--disable-md5" "--disable-sha1" "--disable-sha2" "--disable-fips-prf"
          "--enable-eap-tnc" "--enable-eap-ttls" "--enable-eap-dynamic" "--enable-tnccs-20"
          "--enable-tnc-imc" "--enable-imc-os" "--enable-imc-attestation"
@@ -80,11 +78,11 @@ stdenv.mkDerivation rec {
          "--with-tss=trousers"
          "--enable-aikgen"
          "--enable-sqlite" ]
-    ++ optionals enableNetworkManager [
+    ++ lib.optionals enableNetworkManager [
          "--enable-nm"
          "--with-nm-ca-dir=/etc/ssl/certs" ]
     # Taken from: https://wiki.strongswan.org/projects/strongswan/wiki/MacOSX
-    ++ optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.isDarwin [
       "--disable-systemd"
       "--disable-xauth-pam"
       "--disable-kernel-netlink"
@@ -100,11 +98,11 @@ stdenv.mkDerivation rec {
     echo "include /etc/ipsec.secrets" >> $out/etc/ipsec.secrets
   '';
 
-  NIX_LDFLAGS = optionalString stdenv.cc.isGNU "-lgcc_s" ;
+  NIX_LDFLAGS = lib.optionalString stdenv.cc.isGNU "-lgcc_s" ;
 
   passthru.tests = { inherit (nixosTests) strongswan-swanctl; };
 
-  meta = {
+  meta = with lib; {
     description = "OpenSource IPsec-based VPN Solution";
     homepage = "https://www.strongswan.org";
     license = licenses.gpl2Plus;

--- a/pkgs/tools/package-management/nix-serve/default.nix
+++ b/pkgs/tools/package-management/nix-serve/default.nix
@@ -8,8 +8,6 @@
 , nixosTests
 }:
 
-with lib;
-
 let
   rev = "e4675e38ab54942e351c7686e40fabec822120b9";
   sha256 = "1wm24p6pkxl1d7hrvf4ph6mwzawvqi22c60z9xzndn5xfyr4v0yr";
@@ -17,7 +15,7 @@ in
 
 stdenv.mkDerivation {
   pname = "nix-serve";
-  version = "0.2-${substring 0 7 rev}";
+  version = "0.2-${lib.substring 0 7 rev}";
 
   src = fetchFromGitHub {
     owner = "edolstra";
@@ -33,7 +31,7 @@ stdenv.mkDerivation {
     install -Dm0755 nix-serve.psgi $out/libexec/nix-serve/nix-serve.psgi
 
     makeWrapper ${perl.withPackages(p: [ p.DBDSQLite p.Plack p.Starman nix.perl-bindings ])}/bin/starman $out/bin/nix-serve \
-                --prefix PATH : "${makeBinPath [ bzip2 nix ]}" \
+                --prefix PATH : "${lib.makeBinPath [ bzip2 nix ]}" \
                 --add-flags $out/libexec/nix-serve/nix-serve.psgi
   '';
 
@@ -42,7 +40,7 @@ stdenv.mkDerivation {
     nix-serve-ssh = nixosTests.nix-serve-ssh;
   };
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/edolstra/nix-serve";
     description = "A utility for sharing a Nix store as a binary cache";
     maintainers = [ maintainers.eelco ];

--- a/pkgs/tools/security/afl/qemu.nix
+++ b/pkgs/tools/security/afl/qemu.nix
@@ -2,8 +2,6 @@
 , texinfo, libuuid, flex, bison, pixman, autoconf
 }:
 
-with lib;
-
 let
   cpuTarget = if stdenv.hostPlatform.system == "x86_64-linux" then "x86_64-linux-user"
     else if stdenv.hostPlatform.system == "i686-linux" then "i386-linux-user"

--- a/pkgs/tools/security/aflplusplus/qemu.nix
+++ b/pkgs/tools/security/aflplusplus/qemu.nix
@@ -2,8 +2,6 @@
 , texinfo, libuuid, flex, bison, pixman, autoconf
 }:
 
-with lib;
-
 let
   qemuName = "qemu-3.1.0";
   cpuTarget = if stdenv.targetPlatform.system == "x86_64-linux" then "x86_64-linux-user"

--- a/pkgs/tools/security/b2sum/default.nix
+++ b/pkgs/tools/security/b2sum/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, openmp ? null }:
 
-with lib;
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "b2sum";
   version = "20190724";
@@ -24,10 +22,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ openmp ];
 
-  buildFlags = [ (optional (openmp == null) "NO_OPENMP=1") ];
+  buildFlags = [ (lib.optional (openmp == null) "NO_OPENMP=1") ];
   installFlags = [ "PREFIX=$(out)" ];
 
-  meta = {
+  meta = with lib; {
     description = "The b2sum utility is similar to the md5sum or shasum utilities but for BLAKE2";
     homepage = "https://blake2.net";
     license = with licenses; [ asl20 cc0 openssl ];

--- a/pkgs/tools/security/john/default.nix
+++ b/pkgs/tools/security/john/default.nix
@@ -2,8 +2,6 @@
 , gcc, python3Packages, perl, perlPackages, makeWrapper, fetchpatch
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "john";
   version = "1.9.0-jumbo-1";
@@ -83,7 +81,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = {
+  meta = with lib; {
     description = "John the Ripper password cracker";
     license = licenses.gpl2Plus;
     homepage = "https://github.com/openwall/john/";

--- a/pkgs/tools/security/modsecurity/default.nix
+++ b/pkgs/tools/security/modsecurity/default.nix
@@ -3,8 +3,6 @@
 , luaSupport ? false, lua5, perl
 }:
 
-with lib;
-
 let luaValue = if luaSupport then lua5 else "no";
     optional = lib.optional;
 in
@@ -49,7 +47,7 @@ stdenv.mkDerivation rec {
     cp -R * $nginx
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Open source, cross-platform web application firewall (WAF)";
     license = licenses.asl20;
     homepage = "https://www.modsecurity.org/";

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -6,8 +6,6 @@
 , withLua ? true
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "nmap";
   version = "7.93";
@@ -18,7 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [ ./zenmap.patch ]
-    ++ optionals stdenv.cc.isClang [(
+    ++ lib.optionals stdenv.cc.isClang [(
       # Fixes a compile error due an ambiguous reference to bind(2) in
       # nping/EchoServer.cc, which is otherwise resolved to std::bind.
       # https://github.com/nmap/nmap/pull/1363
@@ -29,7 +27,7 @@ stdenv.mkDerivation rec {
       }
     )];
 
-  prePatch = optionalString stdenv.isDarwin ''
+  prePatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace libz/configure \
         --replace /usr/bin/libtool ar \
         --replace 'AR="libtool"' 'AR="ar"' \
@@ -43,7 +41,7 @@ stdenv.mkDerivation rec {
     "--without-zenmap"
   ];
 
-  makeFlags = optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     "AR=${stdenv.cc.bintools.targetPrefix}ar"
     "RANLIB=${stdenv.cc.bintools.targetPrefix}ranlib"
     "CC=${stdenv.cc.targetPrefix}gcc"
@@ -56,7 +54,7 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # fails 3 tests, probably needs the net
 
-  meta = {
+  meta = with lib; {
     description = "A free and open source utility for network discovery and security auditing";
     homepage    = "http://www.nmap.org";
     license     = licenses.gpl2;

--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -11,8 +11,6 @@
 , tombPluginSupport ? false
 }:
 
-with lib;
-
 assert x11Support -> xclip != null;
 assert waylandSupport -> wl-clipboard != null;
 
@@ -35,7 +33,7 @@ let
       name = "pass";
       paths = selected;
       nativeBuildInputs = [ makeWrapper ];
-      buildInputs = concatMap (x: x.buildInputs) selected;
+      buildInputs = lib.concatMap (x: x.buildInputs) selected;
 
       postBuild = ''
         files=$(find $out/bin/ -type f -exec readlink -f {} \;)
@@ -79,7 +77,7 @@ stdenv.mkDerivation rec {
     # dependencies (s.el) here. The user has to do this themselves.
     mkdir -p "$out/share/emacs/site-lisp"
     cp "contrib/emacs/password-store.el" "$out/share/emacs/site-lisp/"
-  '' + optionalString dmenuSupport ''
+  '' + lib.optionalString dmenuSupport ''
     cp "contrib/dmenu/passmenu" "$out/bin/"
   '';
 

--- a/pkgs/tools/security/tcpcrypt/default.nix
+++ b/pkgs/tools/security/tcpcrypt/default.nix
@@ -3,8 +3,6 @@
 , libcap, libpcap, libnfnetlink, libnetfilter_conntrack, libnetfilter_queue
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "tcpcrypt";
   version = "0.5";
@@ -21,11 +19,11 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" ];
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ openssl libpcap ]
-    ++ optionals stdenv.isLinux [ libcap libnfnetlink libnetfilter_conntrack libnetfilter_queue ];
+    ++ lib.optionals stdenv.isLinux [ libcap libnfnetlink libnetfilter_conntrack libnetfilter_queue ];
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     broken = stdenv.isDarwin;
     homepage = "http://tcpcrypt.org/";
     description = "Fast TCP encryption";

--- a/pkgs/tools/security/tor/update.nix
+++ b/pkgs/tools/security/tor/update.nix
@@ -10,8 +10,6 @@
 , nix
 }:
 
-with lib;
-
 let
   downloadPageUrl = "https://dist.torproject.org";
 
@@ -28,7 +26,7 @@ writeScript "update-tor" ''
 
 set -eu -o pipefail
 
-export PATH=${makeBinPath [
+export PATH=${lib.makeBinPath [
   common-updater-scripts
   coreutils
   curl
@@ -63,7 +61,7 @@ sigFile=''${sigUrl##*/}
 export GNUPGHOME=$PWD/gnupg
 mkdir -m 700 -p "$GNUPGHOME"
 
-gpg --batch --recv-keys ${concatStringsSep " " (map (x: "'${x}'") signingKeys)}
+gpg --batch --recv-keys ${lib.concatStringsSep " " (map (x: "'${x}'") signingKeys)}
 gpg --batch --verify "$sigFile" "$checksumFile"
 
 sha256sum -c "$checksumFile"

--- a/pkgs/tools/system/socklog/default.nix
+++ b/pkgs/tools/system/socklog/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "socklog";
   version = "2.1.0";
@@ -49,7 +47,7 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = {
+  meta = with lib; {
     broken = stdenv.isDarwin;
     description = "System and kernel logging services";
     homepage = "http://smarden.org/socklog/";

--- a/pkgs/tools/text/ledger2beancount/default.nix
+++ b/pkgs/tools/text/ledger2beancount/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper, perlPackages, beancount }:
 
-with lib;
-
 let
   perlDeps = with perlPackages; [
     DateCalc
@@ -44,7 +42,7 @@ in stdenv.mkDerivation rec {
       --set PERL5LIB "${perlPackages.makeFullPerlPath perlDeps}"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Ledger to Beancount text-based converter";
     longDescription = ''
       A script to automatically convert Ledger-based textual ledgers to Beancount ones.

--- a/pkgs/tools/video/rtmpdump/default.nix
+++ b/pkgs/tools/video/rtmpdump/default.nix
@@ -12,7 +12,6 @@
 
 assert (gnutlsSupport || opensslSupport);
 
-with lib;
 stdenv.mkDerivation {
   pname = "rtmpdump";
   version = "unstable-2021-02-19";
@@ -36,20 +35,20 @@ stdenv.mkDerivation {
     "prefix=$(out)"
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ]
-    ++ optional gnutlsSupport "CRYPTO=GNUTLS"
-    ++ optional opensslSupport "CRYPTO=OPENSSL"
-    ++ optional stdenv.isDarwin "SYS=darwin"
-    ++ optional stdenv.cc.isClang "CC=clang";
+    ++ lib.optional gnutlsSupport "CRYPTO=GNUTLS"
+    ++ lib.optional opensslSupport "CRYPTO=OPENSSL"
+    ++ lib.optional stdenv.isDarwin "SYS=darwin"
+    ++ lib.optional stdenv.cc.isClang "CC=clang";
 
   propagatedBuildInputs = [ zlib ]
-    ++ optionals gnutlsSupport [ gnutls nettle ]
-    ++ optional opensslSupport openssl;
+    ++ lib.optionals gnutlsSupport [ gnutls nettle ]
+    ++ lib.optional opensslSupport openssl;
 
   outputs = [ "out" "dev" ];
 
   separateDebugInfo = true;
 
-  meta = {
+  meta = with lib; {
     description = "Toolkit for RTMP streams";
     homepage = "https://rtmpdump.mplayerhq.hu/";
     license = licenses.gpl2;


### PR DESCRIPTION
###### Description of changes

I read on some PRs the Feedback that the global `with lib;` statement should be avoided. As people often start by looking on other code when doing their first packages i thought its quite counter effective, that we have a lot of that usage in existing packages and new contributer later on then get told to remove that, which can get quite frustrating.

Thus i spend some time in editing most of the trivial usages out of `pkgs/**`.

I am not 100% sure about the large change, so i would like to gather feedback it can be merged in a this large single commit, or if this should be more splitted.

I tried to follow the rule to replace all `with lib;` with `lib.` but if its for the meta attr. For meta i replaced it with ` meta = with lib; {` if there was no other scoping before that. It there was other scoping i tried to follow that.

There are still about 20 occurrences of global `with lib;`, if the scope does not resolve super trivial.

split prs:

- https://github.com/NixOS/nixpkgs/pull/212006
- https://github.com/NixOS/nixpkgs/pull/212009
- https://github.com/NixOS/nixpkgs/pull/212449
- https://github.com/NixOS/nixpkgs/pull/212454
-  https://github.com/NixOS/nixpkgs/pull/212812

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
