### PR TITLE
shotgun: fix build, add figsoda as a maintainer

### DIFF
--- a/pkgs/tools/graphics/shotgun/default.nix
+++ b/pkgs/tools/graphics/shotgun/default.nix
@@ -1,12 +1,8 @@
-{ lib, fetchFromGitHub, rustPlatform, pkg-config, libXrandr, libX11 }:
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, libXrandr, libX11 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "shotgun";
   version = "2.3.1";
-
-  nativeBuildInputs = [ pkg-config ];
-
-  buildInputs = [ libXrandr libX11 ];
 
   src = fetchFromGitHub {
     owner = "neXromancers";
@@ -17,12 +13,20 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-UOchXeBX+sDuLhwWQRVFCj9loJUyr4IltiAKsQoh5/c=";
 
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libXrandr libX11 ];
+
+  # build script tries to run git to get the current tag
+  postPatch = ''
+    echo "fn main() {}" > build.rs
+  '';
+
   meta = with lib; {
     description = "Minimal X screenshot utility";
     homepage = "https://github.com/neXromancers/shotgun";
     license = with licenses; [ mpl20 ];
-    maintainers = with maintainers; [ lumi ];
+    maintainers = with maintainers; [ figsoda lumi ];
     platforms = platforms.linux;
-    badPlatforms = [ "aarch64-linux" ];
   };
 }


### PR DESCRIPTION
###### Description of changes
fix build after https://github.com/NixOS/nixpkgs/pull/207804
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
