### PR TITLE
tests.kernel-config: fix

### DIFF
--- a/pkgs/build-support/testers/expect-failure.sh
+++ b/pkgs/build-support/testers/expect-failure.sh
@@ -34,6 +34,15 @@ echo "testBuildFailure: Original builder produced exit code: $r"
 
 # -----------------------------------------
 # Write the build log to the default output
+#
+# # from stdenv setup.sh
+getAllOutputNames() {
+    if [ -n "$__structuredAttrs" ]; then
+        echo "${!outputs[*]}"
+    else
+        echo "$outputs"
+    fi
+}
 
 outs=( $(getAllOutputNames) )
 defOut=${outs[0]}

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -58,9 +58,10 @@ lib.recurseIntoAttrs {
       inherit hello;
     } ''
       echo "Checking $failed/testBuildFailure.log"
-      grep -F 'testBuildFailure: The builder did not fail, but a failure was expected' $failed/testBuildFailure.log
+      grep -F 'testBuildFailure: The builder did not fail, but a failure was expected' $failed/testBuildFailure.log >/dev/null
       [[ 1 = $(cat $failed/testBuildFailure.exit) ]]
       touch $out
+      echo 'All good.'
     '';
 
     multiOutput = runCommand "testBuildFailure-multiOutput" {

--- a/pkgs/test/kernel.nix
+++ b/pkgs/test/kernel.nix
@@ -32,11 +32,6 @@ let
     { "NIXOS_TEST_BOOLEAN"  = lib.mkDefault no; }
   ];
 
-  optionalNoWins = mkMerge [
-    { NIXOS_FAKE_USB_DEBUG = option yes;}
-    { NIXOS_FAKE_USB_DEBUG = yes;}
-  ];
-
   allOptionalRemainOptional = mkMerge [
     { NIXOS_FAKE_USB_DEBUG = option yes;}
     { NIXOS_FAKE_USB_DEBUG = option yes;}

--- a/pkgs/test/kernel.nix
+++ b/pkgs/test/kernel.nix
@@ -27,10 +27,9 @@ let
     { NIXOS_FAKE_MMC_BLOCK_MINORS = freeform "64"; } # will trigger an error but the message is not great:
   ];
 
-  yesWinsOverNoConfig = mkMerge [
-    # default for "NIXOS_TEST_BOOLEAN" is no
-    { "NIXOS_TEST_BOOLEAN"  = yes; } # yes wins over no by default
-    { "NIXOS_TEST_BOOLEAN"  = no; }
+  mkDefaultWorksConfig = mkMerge [
+    { "NIXOS_TEST_BOOLEAN"  = yes; }
+    { "NIXOS_TEST_BOOLEAN"  = lib.mkDefault no; }
   ];
 
   optionalNoWins = mkMerge [
@@ -57,7 +56,7 @@ runTests {
   };
 
   testYesWinsOverNo = {
-    expr = (getConfig yesWinsOverNoConfig)."NIXOS_TEST_BOOLEAN".tristate;
+    expr = (getConfig mkDefaultWorksConfig)."NIXOS_TEST_BOOLEAN".tristate;
     expected = "y";
   };
 


### PR DESCRIPTION
error: The option `settings.NIXOS_TEST_BOOLEAN.tristate' has conflicting definition values:
- In `structuredExtraConfig': "n"
- In `structuredExtraConfig': "y"

since #90065
yes does not silently win over no###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
