### PR TITLE
ladybird: unstable-2022-09-29 -> unstable-2023-01-17

### DIFF
--- a/pkgs/applications/networking/browsers/ladybird/default.nix
+++ b/pkgs/applications/networking/browsers/ladybird/default.nix
@@ -10,28 +10,25 @@
 , nixosTests
 }:
 
-let serenity = fetchFromGitHub {
-  owner = "SerenityOS";
-  repo = "serenity";
-  rev = "a0f3e2c9a2b82117aa7c1a3444ad0d31baa070d5";
-  hash = "sha256-8Xde59ZfdkTD39mYSv0lfFjBHFDWTUwfozE+Q9Yq6C8=";
-};
-in
 stdenv.mkDerivation {
   pname = "ladybird";
-  version = "unstable-2022-09-29";
+  version = "unstable-2023-01-17";
 
-  # Remember to update `serenity` too!
   src = fetchFromGitHub {
     owner = "SerenityOS";
-    repo = "ladybird";
-    rev = "d69ad7332477de33bfd1963026e057d55c6f222d";
-    hash = "sha256-XQj2Bohk8F6dGCAManOmmDP5b/SqEeZXZbLDYPfvi2E=";
+    repo = "serenity";
+    rev = "45e85d20b64862df119f643f24e2d500c76c58f3";
+    hash = "sha256-n2mLg9wNfdMGsJuGj+ukjto9qYjGOIz4cZjgvMGQUrY=";
   };
+
+  sourceRoot = "source/Ladybird";
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace "MACOSX_BUNDLE TRUE" "MACOSX_BUNDLE FALSE"
+    # https://github.com/SerenityOS/serenity/issues/17062
+    substituteInPlace main.cpp \
+      --replace "./SQLServer/SQLServer" "$out/bin/SQLServer"
   '';
 
   nativeBuildInputs = [
@@ -47,17 +44,18 @@ stdenv.mkDerivation {
   ];
 
   cmakeFlags = [
-    "-DSERENITY_SOURCE_DIR=${serenity}"
     # Disable network operations
     "-DENABLE_TIME_ZONE_DATABASE_DOWNLOAD=false"
     "-DENABLE_UNICODE_DATABASE_DOWNLOAD=false"
   ];
 
-  # error: use of undeclared identifier 'aligned_alloc'
-  NIX_CFLAGS_COMPILE = toString (lib.optionals (stdenv.isDarwin && lib.versionOlder stdenv.targetPlatform.darwinSdkVersion "11.0") [
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error"
+  ] ++ lib.optionals (stdenv.isDarwin && lib.versionOlder stdenv.targetPlatform.darwinSdkVersion "11.0") [
+    # error: use of undeclared identifier 'aligned_alloc'
     "-include mm_malloc.h"
     "-Daligned_alloc=_mm_malloc"
-  ]);
+  ];
 
   # https://github.com/NixOS/nixpkgs/issues/201254
   NIX_LDFLAGS = lib.optionalString (stdenv.isLinux && stdenv.isAarch64 && stdenv.cc.isGNU) "-lgcc";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30867,7 +30867,7 @@ with pkgs;
 
   ladybird = qt6Packages.callPackage ../applications/networking/browsers/ladybird {
     # https://github.com/NixOS/nixpkgs/issues/201254
-    stdenv = if stdenv.isDarwin then llvmPackages_14.stdenv else gcc11Stdenv;
+    stdenv = if stdenv.isDarwin then llvmPackages_14.stdenv else gcc12Stdenv;
   };
 
   lazpaint = callPackage ../applications/graphics/lazpaint { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
* update
* work around https://github.com/SerenityOS/serenity/issues/17062

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
