### PR TITLE
fuelup: init at 0.16.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6020,6 +6020,12 @@
     githubId = 55025025;
     name = "Feather Lin";
   };
+  IGI-111 = {
+    email = "igi-111@protonmail.com";
+    github = "IGI-111";
+    githubId = 7190144;
+    name = "IGI-111";
+  };
   igsha = {
     email = "igor.sharonov@gmail.com";
     github = "igsha";

--- a/pkgs/development/tools/fuel/fuelup/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/development/tools/fuel/fuelup/0001-dynamically-patchelf-binaries.patch
@@ -1,0 +1,32 @@
+:100644 100644 9198f1a 0000000 M	src/download.rs
+
+diff --git a/src/download.rs b/src/download.rs
+index 9198f1a..3553cc0 100644
+--- a/src/download.rs
++++ b/src/download.rs
+@@ -309,7 +309,8 @@ pub fn unpack_bins(dir: &Path, dst_dir: &Path) -> Result<Vec<PathBuf>> {
+                 if dst_bin_file.exists() {
+                     fs::remove_file(&dst_bin_file)?;
+                 }
+-                fs::copy(bin_file.path(), dst_bin_file)?;
++                fs::copy(bin_file.path(), &dst_bin_file)?;
++                nix_patchelf(&dst_bin_file);
+                 downloaded.push(dst_dir.join(bin_file_name));
+             }
+ 
+@@ -320,6 +321,15 @@ pub fn unpack_bins(dir: &Path, dst_dir: &Path) -> Result<Vec<PathBuf>> {
+     Ok(downloaded)
+ }
+ 
++fn nix_patchelf(path: &Path) {
++    ::std::process::Command::new("@patchelf@/bin/patchelf")
++        .arg("--set-interpreter")
++        .arg("@dynamicLinker@")
++        .arg(path)
++        .output()
++        .unwrap();
++}
++
+ #[cfg(test)]
+ mod tests {
+     use super::*;

--- a/pkgs/development/tools/fuel/fuelup/default.nix
+++ b/pkgs/development/tools/fuel/fuelup/default.nix
@@ -1,0 +1,71 @@
+{ stdenv, lib, runCommand, patchelf, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "fuelup";
+  version = "0.16.0";
+
+  src = fetchFromGitHub {
+    owner = "FuelLabs";
+    repo = "fuelup";
+    rev = "v${version}";
+    sha256 = "sha256-scvBallzXumYQqzyP8U5yd68pd33IleEFJaGt6YTJVQ=";
+  };
+
+  cargoSha256 = "sha256-bd3FHpB453oYgpu3mkh5CU1h1zcll+wm6VnJ8NO2XzM=";
+
+  nativeBuildInputs = [ ];
+
+  buildInputs = [ ];
+
+  buildFeatures = [ ];
+
+  checkFeatures = [ ];
+
+  patches = lib.optionals stdenv.isLinux [
+    (runCommand "0001-dynamically-patchelf-binaries.patch" {
+      CC = stdenv.cc;
+      patchelf = patchelf;
+    } ''
+      export dynamicLinker=$(cat $CC/nix-support/dynamic-linker)
+      substitute ${./0001-dynamically-patchelf-binaries.patch} $out \
+        --subst-var patchelf \
+        --subst-var dynamicLinker
+    '')
+  ];
+
+  doCheck = !stdenv.isAarch64 && !stdenv.isDarwin;
+
+  postInstall = ''
+    pushd $out/bin
+    binlinks=(
+      forc forc-explore forc-lsp fuel-core forc-deploy
+      forc-fmt forc-run fuel-indexer forc-doc forc-index
+      forc-wallet
+    )
+    for link in ''${binlinks[@]}; do
+      ln -s fuelup $link
+    done
+    popd
+  '';
+
+  preCheck = ''
+    # some tests need a valid home
+    export HOME=$(mktemp -d)
+  '';
+
+  checkFlags = [
+    # some tests use the network, disable them
+    "--skip=fuelup_check"
+    "--skip=fuelup_component_add"
+    "--skip=fuelup_component_add_with_version"
+    "--skip=fuelup_self_update"
+  ];
+
+  meta = with lib; {
+    description = "The Fuel toolchain manager";
+    homepage = "https://fuellabs.github.io/fuelup/latest";
+    license = licenses.asl20;
+    maintainers = [ maintainers.IGI-111 ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19468,6 +19468,8 @@ with pkgs;
 
   fribidi = callPackage ../development/libraries/fribidi { };
 
+  fuelup = callPackage ../development/tools/fuel/fuelup { };
+
   funambol = callPackage ../development/libraries/funambol { };
 
   galer = callPackage ../tools/security/galer { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add a package for [fuelup](https://fuellabs.github.io/fuelup/v0.16.0/), the toolchain manager for the fuel ecosystem, the sway DSL and related tooling.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
