### PR TITLE
ton: init at 2023.01

### DIFF
--- a/pkgs/applications/blockchains/ton/default.nix
+++ b/pkgs/applications/blockchains/ton/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, git
+, gperf
+, libmicrohttpd
+, openssl
+, readline
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ton";
+  version = "2023.01";
+
+  src = fetchFromGitHub {
+    owner = "ton-blockchain";
+    repo = "ton";
+    rev = "v${version}";
+    sha256 = "sha256-wb96vh0YcTBFE8EzBItdTf88cvRMLW2XxcGJpNetOi8=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    # without this fails on aarch64-darwin with clang-11: error: the clang compiler does not support '-mcpu=apple-m1'
+    substituteInPlace CMakeLists.txt \
+      --replace 'set(TON_ARCH "apple-m1")' ""
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    git
+  ];
+
+  buildInputs = [
+    gperf
+    libmicrohttpd
+    openssl
+    readline
+    zlib
+  ];
+
+  meta = with lib; {
+    description = "A fully decentralized layer-1 blockchain designed by Telegram";
+    homepage = "https://ton.org/";
+    license = licenses.lgpl2Only;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ misuzu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34535,6 +34535,8 @@ with pkgs;
 
   tessera = callPackage ../applications/blockchains/tessera { };
 
+  ton = callPackage ../applications/blockchains/ton { };
+
   torq = callPackage ../applications/blockchains/torq { };
 
   vertcoin  = libsForQt5.callPackage ../applications/blockchains/vertcoin {


### PR DESCRIPTION
###### Description of changes
https://ton.org/
https://github.com/ton-blockchain/ton

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
