### PR TITLE
python3Packages.dm-tree: Fix build

### DIFF
--- a/pkgs/development/python-modules/dm-env/default.nix
+++ b/pkgs/development/python-modules/dm-env/default.nix
@@ -4,15 +4,17 @@
 , dm-tree
 , numpy
 , absl-py
-, nose }:
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "dm-env";
   version = "1.6";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-pDbrHGVMOeDJhqUWzuIYvqcUC1EPzv9j+X60/P89k94=";
+    hash = "sha256-pDbrHGVMOeDJhqUWzuIYvqcUC1EPzv9j+X60/P89k94=";
   };
 
   buildInputs = [
@@ -22,7 +24,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    nose
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/dm-tree/cmake.patch
+++ b/pkgs/development/python-modules/dm-tree/cmake.patch
@@ -1,13 +1,13 @@
 diff --git a/tree/CMakeLists.txt b/tree/CMakeLists.txt
-index 8f9946c..b9d6e9b 100644
+index 4fd1b1a..f0d072b 100644
 --- a/tree/CMakeLists.txt
 +++ b/tree/CMakeLists.txt
-@@ -50,70 +50,80 @@ if(APPLE)
+@@ -50,70 +50,79 @@ if(APPLE)
    set (CMAKE_FIND_FRAMEWORK LAST)
  endif()
  
 -# Fetch pybind to be able to use pybind11_add_module symbol.
--set(PYBIND_VER v2.6.2)
+-set(PYBIND_VER v2.10.1)
 -include(FetchContent)
 -FetchContent_Declare(
 -  pybind11
@@ -42,7 +42,7 @@ index 8f9946c..b9d6e9b 100644
 +
 +if (NOT pybind11_FOUND)
 +  # Fetch pybind to be able to use pybind11_add_module symbol.
-+  set(PYBIND_VER v2.6.2)
++  set(PYBIND_VER v2.10.1)
 +  include(FetchContent)
 +  FetchContent_Declare(
 +    pybind11
@@ -69,10 +69,7 @@ index 8f9946c..b9d6e9b 100644
  # Define pybind11 tree module.
  pybind11_add_module(_tree tree.h tree.cc)
 -add_dependencies(_tree abseil-cpp)
- 
--if (WIN32 OR MSVC)
--    set(ABSEIL_LIB_PREF "absl")
--    set(LIB_SUFF "lib")
+-
 +find_package(absl)
 +
 +if (NOT absl_FOUND)
@@ -115,6 +112,9 @@ index 8f9946c..b9d6e9b 100644
 +      set(LIB_SUFF "a")
 +  endif()
 +
+-if (WIN32 OR MSVC)
+-    set(ABSEIL_LIB_PREF "absl")
+-    set(LIB_SUFF "lib")
 +  # Link abseil static libs.
 +  # We don't use find_library here to force cmake to build abseil before linking.
 +  set(ABSEIL_LIBS int128 raw_hash_set raw_logging_internal strings throw_delegate)


### PR DESCRIPTION
###### Description of changes

This fixes the build failure described in #210796, but `nixpkgs-review` shows that downstream dependencies still do not build. This is probably for unrelated causes.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).