### PR TITLE
nix-doc: 0.5.5 -> 0.5.6

### DIFF
--- a/pkgs/tools/package-management/nix-doc/default.nix
+++ b/pkgs/tools/package-management/nix-doc/default.nix
@@ -2,21 +2,21 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nix-doc";
-  version = "0.5.5";
+  version = "0.5.6";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "lf-";
     repo = "nix-doc";
-    sha256 = "sha256-JGzrDSAJMH7BaqGfyfLe041T2f8QdwLlFi11yHo+4JI=";
+    sha256 = "sha256-n2qmu+yMV/ext3MN5lfkfo3ebRf4Uct/WgGP3Ck72WM=";
   };
 
   doCheck = true;
   buildInputs = [ boost nix ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config nix ];
 
-  cargoSha256 = "sha256-o49xT26X1QdkSWDlz//ZgnLs592DkxktyFaY5S4vVTM=";
+  cargoSha256 = "sha256-JrfRmpRSmkL8D0UAT3nY/NWWcNapuVUcd9zNQYUPRo8=";
 
   meta = with lib; {
     description = "An interactive Nix documentation tool";


### PR DESCRIPTION
###### Description of changes

I updated nix-doc to also be compatible with nix 1.13, and added integration tests to ensure the plugin does actually work.

https://github.com/lf-/nix-doc/commit/3f1a551e1ff5f96819363c53badfd5cb5ba9a5bd

I added `nix` to nativeBuildInputs for this new integration tests functionality.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
