### PR TITLE
python3Packages.m2crypto: 0.36.0 -> 0.38.0

### DIFF
--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -1,41 +1,43 @@
 { lib
-, fetchpatch
 , buildPythonPackage
 , fetchPypi
-, pythonOlder
+, fetchpatch
 , swig2
 , openssl
 , typing
+, parameterized
 }:
 
 
 buildPythonPackage rec {
-  version = "0.36.0";
+  version = "0.38.0";
   pname = "M2Crypto";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1hadbdckmjzfb8qzbkafypin6sakfx35j2qx0fsivh757s7c2hhm";
+    sha256 = "sha256-mfImCjCQHJSajcbV+CzVMS/7iryS52YzuvIxu7yy3ss=";
   };
 
   patches = [
+    # Use OpenSSL_version_num() instead of unrealiable parsing of .h file.
     (fetchpatch {
-      url = "https://github.com/void-linux/void-packages/raw/7946d12eb3d815e5ecd4578f1a6133d948694370/srcpkgs/python-M2Crypto/patches/libressl.patch";
-      sha256 = "0z5qnkndg6ma5f5qqrid5m95i9kybsr000v3fdy1ab562kf65a27";
+      url = "https://src.fedoraproject.org/rpms/m2crypto/raw/42951285c800f72e0f0511cec39a7f49e970a05c/f/m2crypto-MR271-opensslversion.patch";
+      hash = "sha256-e1/NHgWza+kum76MUFSofq9Ko3pML67PUfqWjcwIl+A=";
+    })
+    # Changed required to pass tests on OpenSSL 3.0
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/m2crypto/raw/42951285c800f72e0f0511cec39a7f49e970a05c/f/m2crypto-0.38-ossl3-tests.patch";
+      hash = "sha256-B6JKoPh76+CIna6zmrvFj50DIp3pzg8aKyzz+Q5hqQ0=";
+    })
+    # Allow EVP tests fail on non-FIPS algorithms
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/m2crypto/raw/42951285c800f72e0f0511cec39a7f49e970a05c/f/m2crypto-0.38-ossl3-tests-evp.patch";
+      hash = "sha256-jMUAphVBQMFaOJSeYUCQMV3WSe9VDQqG6GY5fDQXZnA=";
     })
   ];
-  patchFlags = [ "-p0" ];
 
-  nativeBuildInputs = [ swig2 ];
-  buildInputs = [ swig2 openssl ];
-
-  propagatedBuildInputs = lib.optional (pythonOlder "3.5") typing;
-
-  preConfigure = ''
-    substituteInPlace setup.py --replace "self.openssl = '/usr'" "self.openssl = '${openssl.dev}'"
-  '';
-
-  doCheck = false; # another test that depends on the network.
+  nativeBuildInputs = [ swig2 openssl ];
+  buildInputs = [ openssl parameterized ];
 
   meta = with lib; {
     description = "A Python crypto and SSL toolkit";
@@ -43,5 +45,4 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ andrew-d ];
   };
-
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5559,10 +5559,7 @@ self: super: with self; {
 
   lzstring = callPackage ../development/python-modules/lzstring { };
 
-  m2crypto = callPackage ../development/python-modules/m2crypto {
-    # https://gitlab.com/m2crypto/m2crypto/-/issues/310
-    openssl = pkgs.openssl_1_1;
-  };
+  m2crypto = callPackage ../development/python-modules/m2crypto { };
 
   m2r = callPackage ../development/python-modules/m2r { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
