### PR TITLE
stdenv: don't clobber useArray and type in {prepend,append}ToVar

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -206,8 +206,8 @@ addToSearchPath() {
 # syntax when they switch to setting __structuredAttrs = true.
 prependToVar() {
     local -n nameref="$1"
+    local useArray type
 
-    useArray=
     if [ -n "$__structuredAttrs" ]; then
         useArray=true
     else
@@ -239,8 +239,8 @@ prependToVar() {
 # Same as above
 appendToVar() {
     local -n nameref="$1"
+    local useArray type
 
-    useArray=
     if [ -n "$__structuredAttrs" ]; then
         useArray=true
     else


### PR DESCRIPTION
Some other packages, for example ruby gems via buildRubyGem, use a variable called "type" internally, which is overwritten here and causes failures like:

    failure: $gempkg path unspecified

Fix for changes in 11c3127e38dafdf95ca71a85b1591a29b67e0c09.

###### Description of changes

Added `local` to some variables that should be local to a bash function.

Tested by building with `nix-build -A tests.stdenv -A hello -A bundix -A vagrant`, which all succeed.

Intended to fix ruby gem builds, like bundix and vagrant (https://github.com/NixOS/nixpkgs/issues/211153).

cc @Artturin 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

