### PR TITLE
sonobus: init at 1.6.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11419,6 +11419,12 @@
     githubId = 146413;
     name = "Tobias Poschwatta";
   };
+  PowerUser64 = {
+    email = "blakelysnorth@gmail.com";
+    github = "PowerUser64";
+    githubId = 24578572;
+    name = "Blake North";
+  };
   ppenguin = {
     name = "Jeroen Versteeg";
     email = "hieronymusv@gmail.com";

--- a/pkgs/applications/audio/sonobus/default.nix
+++ b/pkgs/applications/audio/sonobus/default.nix
@@ -1,0 +1,83 @@
+{ lib
+, pkg-config
+, stdenv
+, fetchFromGitHub
+, autoPatchelfHook
+, alsa-lib
+, cmake
+, freetype
+, libGL
+, libX11
+, libXcursor
+, libXext
+, libXinerama
+, libXrandr
+, libjack2
+, libopus
+, curl
+, gtk3
+, webkitgtk
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sonobus";
+  version = "1.6.2";
+
+  src = fetchFromGitHub {
+    owner = "sonosaurus";
+    repo = "sonobus";
+    rev = version;
+    sha256 = "sha256-/Pb+PYmoCYA6Qcy/tR1Ejyt+rZ3pfJeWV4j7bQWYE58=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    freetype
+    libjack2
+    libopus
+    curl
+    gtk3
+    webkitgtk
+  ];
+
+  runtimeDependencies = [
+    libGL
+    libX11
+    libXcursor
+    libXext
+    libXinerama
+    libXrandr
+  ];
+
+  postPatch = lib.optionalString (stdenv.isLinux) ''
+    # needs special setup on Linux, dunno if it can work on Darwin
+    # https://github.com/NixOS/nixpkgs/issues/19098
+    # Also, I get issues with linking without that, not sure why
+    sed -i -e '/juce::juce_recommended_lto_flags/d' CMakeLists.txt
+    patchShebangs linux/install.sh
+  '';
+
+  # The program does not provide any CMake install instructions
+  installPhase = lib.optionalString (stdenv.isLinux) ''
+    runHook preInstall
+    cd ../linux
+    ./install.sh "$out"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "High-quality network audio streaming";
+    homepage = "https://sonobus.net/";
+    license = with licenses; [ gpl3Plus ];
+    maintainers = with maintainers; [ PowerUser64 ];
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29842,6 +29842,8 @@ with pkgs;
 
   sonixd = callPackage ../applications/audio/sonixd { };
 
+  sonobus = callPackage ../applications/audio/sonobus { };
+
   sosreport = python3Packages.callPackage ../applications/logging/sosreport { };
 
   spectmorph = callPackage ../applications/audio/spectmorph { };


### PR DESCRIPTION
Co-authored-by: @tobiasBora <tobias.bora@gmail.com>

Please note that this is my first contribution here, so I might have done something wrong. If there's something I need to do differently, please don't hesitate to let me know!

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds SonoBus, an easy-to-use application for low-latency peer-to-peer audio streaming. Homepage: https://sonobus.net/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->