### PR TITLE
pulumi: 3.49.0 -> 3.51.1

### DIFF
--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     "test/"
   ];
 
-  sourceRoot = "source/sdk/python/lib";
+  sourceRoot = "${src.name}/sdk/python/lib";
 
   # we apply the modifications done in the pulumi/sdk/python/Makefile
   # but without the venv code
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     cp ../../README.md .
     substituteInPlace setup.py \
       --replace "3.0.0" "${version}" \
-      --replace "grpcio==1.47" "grpcio"
+      --replace "grpcio==1.50" "grpcio"
   '';
 
   # Allow local networking in tests on Darwin

--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -14,21 +14,23 @@
 
 buildGoModule rec {
   pname = "pulumi";
-  version = "3.49.0";
+  version = "3.51.1";
 
   # Used in pulumi-language packages, which inherit this prop
-  sdkVendorHash = "sha256-gM3VpX6r/BScUyvk/XefAfbx0qYzdzSBGaWZN+89BS8=";
+  sdkVendorHash = "sha256-y45TlQF8jJeDLeKEI+ZMcEQqwUIrHPjgTaz1QkjTlEI=";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-WO+bTkTIAyaXl3nYwsMUTdovsYibivfGsKz6A7wj2zM=";
+    hash = "sha256-aubkV3bFEYKZ8ZX18C5Ifroqi/idXSi+f25S31752uE=";
+    # Some tests rely on checkout directory name
+    name = "pulumi";
   };
 
-  vendorSha256 = "sha256-q7ZusTYD8l2RyiwP/Wf6dP6AoosWEwpaylbdhfE5cUA=";
+  vendorSha256 = "sha256-zo22fK+M3xGWk7uMvkI1Gmxyv/3PoO76glsDNJ+dCWE=";
 
-  sourceRoot = "source/pkg";
+  sourceRoot = "${src.name}/pkg";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
###### Description of changes

Various new upstream releases:

* [v3.50.0](https://github.com/pulumi/pulumi/releases/tag/v3.50.0)
* [v3.50.1](https://github.com/pulumi/pulumi/releases/tag/v3.50.1)
* [v3.50.2](https://github.com/pulumi/pulumi/releases/tag/v3.50.2)
* [v3.51.0](https://github.com/pulumi/pulumi/releases/tag/v3.51.0)
* [v3.51.1](https://github.com/pulumi/pulumi/releases/tag/v3.51.1)

Supersedes #208883, #209477

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
