### PR TITLE
python3Packages.flask-security-too: fix compatibility with sqlalchemy

### DIFF
--- a/pkgs/development/python-modules/flask-security-too/default.nix
+++ b/pkgs/development/python-modules/flask-security-too/default.nix
@@ -2,27 +2,28 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
+, fetchpatch
 
-# extras: babel
+  # extras: babel
 , babel
 , flask-babel
 
-# extras: common
+  # extras: common
 , bcrypt
 , bleach
 , flask-mailman
 , qrcode
 
-# extras: fsqla
+  # extras: fsqla
 , flask-sqlalchemy
 , sqlalchemy
 , sqlalchemy-utils
 
-# extras: mfa
+  # extras: mfa
 , cryptography
 , phonenumbers
 
-# propagates
+  # propagates
 , blinker
 , email-validator
 , flask
@@ -32,7 +33,7 @@
 , itsdangerous
 , passlib
 
-# tests
+  # tests
 , argon2-cffi
 , flask-mongoengine
 , mongoengine
@@ -56,6 +57,28 @@ buildPythonPackage rec {
     inherit version;
     hash = "sha256-nSo7fdY9tiE7PnhosXh1eBfVa5l6a43XNvp6vKvrq5Y=";
   };
+
+  patches = [
+    # Fixed issues related to upcomming flask-sqlalchemy 3.0.0 release
+    (fetchpatch {
+      name = "fix-sqlalchemy.patch";
+      url = "https://github.com/Flask-Middleware/flask-security/commit/9632a0eab5d3be4280c185e7e934a57fc24057a2.patch";
+      hash = "sha256-GOFWNhB83KC9R66ZASyag33Paqv+7njGD+oRlhjxZnk=";
+    })
+    # Test fixes for Flask-SQLAlchemy 3.0
+    (fetchpatch {
+      name = "test-fixes-for-sqlalchemy.patch";
+      url = "https://github.com/Flask-Middleware/flask-security/commit/a086bf6886b483266d7c7df5742774dd1d095e7f.patch";
+      hash = "sha256-bGJWaHbJfMytfW4OmCHMn+Bk95sMUKFPQpNN67LLoRY=";
+      excludes = [ ".pre-commit-config.yaml" ];
+    })
+    # Changes for sqlalchemy 2.0.0 compatibility
+    (fetchpatch {
+      name = "fix-backwards-compatibility-for-sqlalchemy.patch";
+      url = "https://github.com/Flask-Middleware/flask-security/commit/4fcaabd90fcf3329c1f76f84fb877b35f8573ed3.patch";
+      hash = "sha256-vhdvHV8KFt6ItctoUExNjEdrhVad0Pt9Atd3lLMyUlM=";
+    })
+  ];
 
   propagatedBuildInputs = [
     blinker

--- a/pkgs/tools/admin/pgadmin/default.nix
+++ b/pkgs/tools/admin/pgadmin/default.nix
@@ -99,6 +99,7 @@ let
         inherit version;
         hash = "sha256-98jKcHDv/+mls7QVWeGvGcmoYOGCspxM7w5/2RjJxoM=";
       };
+      patches = [ ];
       propagatedBuildInputs = oldAttrs.propagatedBuildInputs ++ [
         final.pythonPackages.flask_mail
         final.pythonPackages.pyqrcode


### PR DESCRIPTION
###### Description of changes

Due to the update to sqlalchemy3, flask-security-too stoped working. This pulls in the related patches from upstream, since no new release has been published.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
