### PR TITLE
bibata-cursors: 1.1.2 -> 2.0.3; clickgen: fix build after update to 2.1.3

### DIFF
--- a/pkgs/data/icons/bibata-cursors/default.nix
+++ b/pkgs/data/icons/bibata-cursors/default.nix
@@ -3,45 +3,35 @@
 , fetchFromGitHub
 , fetchurl
 , clickgen
-, unzip
+, attrs
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "bibata-cursors";
-  version = "1.1.2";
+  version = "2.0.3";
 
   src = fetchFromGitHub {
     owner = "ful1e5";
     repo = "Bibata_Cursor";
     rev = "v${version}";
-    sha256 = "1q2wdbrmdnr9mwiilm5cc9im3zwbl7yaj1zpy5wwn44ypq3hcngy";
+    sha256 = "zCk7qgPeae0BfzhxxU2Dk1SOWJQOxiWyJuzH/ri+Gq4=";
   };
 
-  bitmaps = fetchurl {
-    url = "https://github.com/ful1e5/Bibata_Cursor/releases/download/v${version}/bitmaps.zip";
-    sha256 = "1pcn6par0f0syyhzpzmqr3c6b9ri4lprkdd2ncwzdas01p2d9v1i";
-  };
-
-  nativeBuildInputs = [ unzip ];
-
-  buildInputs = [ clickgen ];
+  buildInputs = [ clickgen attrs ];
 
   buildPhase = ''
-    mkdir bitmaps
-    unzip $bitmaps -d bitmaps
-    rm -rf themes
-    cd builder && make build_unix
+    ctgen build.toml -p x11 -d 'bitmaps/Bibata-Modern-Amber' -n 'Bibata-Modern-Amber' -c 'Yellowish and rounded edge bibata cursors.'
+    ctgen build.toml -p x11 -d 'bitmaps/Bibata-Modern-Classic' -n 'Bibata-Modern-Classic' -c 'Black and rounded edge Bibata cursors.'
+    ctgen build.toml -p x11 -d 'bitmaps/Bibata-Modern-Ice' -n 'Bibata-Modern-Ice' -c 'White and rounded edge Bibata cursors.'
+
+    ctgen build.toml -p x11 -d 'bitmaps/Bibata-Original-Amber' -n 'Bibata-Original-Amber' -c 'Yellowish and sharp edge Bibata cursors.'
+    ctgen build.toml -p x11 -d 'bitmaps/Bibata-Original-Classic' -n 'Bibata-Original-Classic' -c 'Black and sharp edge Bibata cursors.'
+    ctgen build.toml -p x11 -d 'bitmaps/Bibata-Original-Ice' -n 'Bibata-Original-Ice' -c 'White and sharp edge Bibata cursors.'
   '';
 
   installPhase = ''
     install -dm 0755 $out/share/icons
-    cd ../
     cp -rf themes/* $out/share/icons/
-  '';
-
-  postPatch = ''
-    substituteInPlace "builder/Makefile" \
-      --replace "/bin/bash" "bash"
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/clickgen/default.nix
+++ b/pkgs/development/python-modules/clickgen/default.nix
@@ -4,9 +4,8 @@
 , pythonOlder
 , fetchFromGitHub
 , pillow
-, libX11
-, libXcursor
-, libpng
+, toml
+, numpy
 , python
 , pytestCheckHook
 }:
@@ -25,21 +24,11 @@ buildPythonPackage rec {
     sha256 = "sha256-qDaSfIeKCbyl3C2iKz9DYQc1oNwTe5xDlGg/yYhakSw=";
   };
 
-  buildInputs = [ libXcursor libX11 libpng ];
-
-  propagatedBuildInputs = [ pillow ];
+  propagatedBuildInputs = [ pillow toml numpy ];
 
   checkInputs = [ pytestCheckHook ];
 
-  postBuild = ''
-    # Needs to build xcursorgen.so
-    cd src/xcursorgen
-    make
-    cd ../..
-  '';
-
   postInstall = ''
-    install -m644 src/xcursorgen/xcursorgen.so $out/${python.sitePackages}/clickgen/xcursorgen.so
     # Copying scripts directory needed by clickgen script at $out/bin/
     cp -R src/clickgen/scripts $out/${python.sitePackages}/clickgen/scripts
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26621,7 +26621,7 @@ with pkgs;
 
   bgnet = callPackage ../data/documentation/bgnet { };
 
-  bibata-cursors = callPackage ../data/icons/bibata-cursors { };
+  bibata-cursors = callPackage ../data/icons/bibata-cursors { attrs = python3Packages.attrs; };
   bibata-extra-cursors = callPackage ../data/icons/bibata-cursors/extra.nix { };
   bibata-cursors-translucent = callPackage ../data/icons/bibata-cursors/translucent.nix { };
 


### PR DESCRIPTION
###### Description of changes

`bibata-extra-cursor` is broken by the update of `clickgen`, but upstream[1] marked this project as archived on Nov 9th, 2022. I'm not sure what to do about this. 

Fixes #203394

[1]: https://github.com/ful1e5/Bibata_Extra_Cursor

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
