### PR TITLE
openshot-qt: 2.6.1 -> 3.0.0

### DIFF
--- a/pkgs/applications/video/openshot-qt/default.nix
+++ b/pkgs/applications/video/openshot-qt/default.nix
@@ -13,13 +13,13 @@
 
 mkDerivationWith python3.pkgs.buildPythonApplication rec {
   pname = "openshot-qt";
-  version = "2.6.1";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "openshot-qt";
     rev = "v${version}";
-    hash = "sha256-29fAg4SDoAFzv6q43Dcs2HdaeKZfPEzlGqCcICiPSF0=";
+    hash = "sha256-h4R2txi038m6tzdKYiXIB8CiqWt2MFFRNerp1CFP5as=";
   };
 
   nativeBuildInputs = [
@@ -44,22 +44,6 @@ mkDerivationWith python3.pkgs.buildPythonApplication rec {
     # tries to create caching directories during install
     export HOME=$(mktemp -d)
   '';
-
-  # Following Arch PKGBUILD for Python 3.10 compatibility
-  # https://github.com/OpenShot/openshot-qt/issues/4608
-  # https://github.com/archlinux/svntogit-community/commits/packages/openshot/trunk
-  patches = [
-    (fetchpatch {
-      name = "video-widget.patch";
-      url = "https://github.com/OpenShot/openshot-qt/commit/9748a13268d66a5949aebc970637b5903756d018.patch";
-      hash = "sha256-QwLtcooDJeYWDp80a1dUFo2so/zEWqqsq5IgkXWX324=";
-    })
-    (fetchpatch {
-      name = "python-3.10-int.patch";
-      url = "https://github.com/OpenShot/openshot-qt/commit/fff785eb1e3e0c30ed6ca57e2d1933aaa807ae22.patch";
-      hash = "sha256-ee/s7rhF71ot5oPkGK+j59mL1B3e72xoH27KFoDL8s8=";
-    })
-  ];
 
   doCheck = false;
 

--- a/pkgs/applications/video/openshot-qt/libopenshot.nix
+++ b/pkgs/applications/video/openshot-qt/libopenshot.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libopenshot";
-  version = "0.2.7";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "libopenshot";
     rev = "v${version}";
-    sha256 = "sha256-aF8wrPxFIjCy5gw72e/WyL/Wcx9tUGDkrqHS+ZDVK0U=";
+    sha256 = "sha256-qe866gFhcbd7yCNXDiZ9Aj0TAiWoJ+r7C5BjtWBKSGA=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

Updates openshot-qt to v3.0.0. Also, closes [#210263](https://github.com/NixOS/nixpkgs/issues/210263).

Made changes to patch applying (removed it) according to [this PKGBUILD](https://github.com/archlinux/svntogit-community/commit/330d265f7a2c8fb3d90c61e4ef7a3fc4693cb17c)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
