### PR TITLE
rpiboot: 2021.07.01 -> 20221215-105525

### DIFF
--- a/pkgs/development/misc/rpiboot/default.nix
+++ b/pkgs/development/misc/rpiboot/default.nix
@@ -1,17 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, libusb1 }:
+{ lib, stdenv, fetchFromGitHub, libusb1, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "rpiboot";
-  version = "2021.07.01";
+  version = "20221215-105525";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "usbboot";
-    rev = "v${version}";
-    sha256 = "sha256-BkNyYCrasfiRs7CbJa7tCo2k70TLGcXkOX+zGPyZGGE=";
+    rev = version;
+    hash = "sha256-Y77IrDblXmnpZleJ3zTyiGDYLZ7gNxASXpqUzwS1NCU=";
   };
 
-  nativeBuildInputs = [ libusb1 ];
+  buildInputs = [ libusb1 ];
+  nativeBuildInputs = [ pkg-config ];
 
   patchPhase = ''
     sed -i "s@/usr/@$out/@g" main.c

--- a/pkgs/development/misc/rpiboot/default.nix
+++ b/pkgs/development/misc/rpiboot/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/raspberrypi/usbboot";
     description = "Utility to boot a Raspberry Pi CM/CM3/CM4/Zero over USB";
     license = licenses.asl20;
-    maintainers = with maintainers; [ cartr ];
+    maintainers = with maintainers; [ cartr flokli ];
     platforms = [ "aarch64-linux" "aarch64-darwin" "armv7l-linux" "armv6l-linux" "x86_64-linux" "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
Bump to the latest relase. The current version is outdated and doesn't seem to be able to boot my CM4 to mass storage device mode. This version does, and according to
https://github.com/raspberrypi/usbboot/releases/tag/20221215-105525, it "works on all current Raspberry Pi models and uses the default bootloader that is signed with the secure-boot ROM key".

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
