### PR TITLE
ruby: 2.7.6 -> 2.7.7, 3.0.4 -> 3.0.5

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -273,8 +273,8 @@ in {
   mkRuby = generic;
 
   ruby_2_7 = generic {
-    version = rubyVersion "2" "7" "6" "";
-    sha256 = "042xrdk7hsv4072bayz3f8ffqh61i8zlhvck10nfshllq063n877";
+    version = rubyVersion "2" "7" "7" "";
+    sha256 = "sha256-4QEn22kdf/NkAs/oj0GMjQJaPx7qkgRLFi3XLwuMe5A=";
   };
 
   ruby_3_0 = generic {

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -278,8 +278,8 @@ in {
   };
 
   ruby_3_0 = generic {
-    version = rubyVersion "3" "0" "4" "";
-    sha256 = "0avj4g3s2839b2y4m6pk8kid74r8nj7k0qm2rsdcwjzhg8h7rd3h";
+    version = rubyVersion "3" "0" "5" "";
+    sha256 = "sha256-mvxjgKAnpP4a4aPi7MtrSXucWsBjHBLKVvm3vrSEh3Y=";
   };
 
   ruby_3_1 = generic {

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -1,12 +1,11 @@
 { patchSet, useRailsExpress, ops, patchLevel, fetchpatch }:
 
 {
-  "2.7.6" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/01-fix-with-openssl-dir-option.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/02-fix-broken-tests-caused-by-ad.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/03-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/04-more-detailed-stacktrace.patch"
-    "${patchSet}/patches/ruby/2.7/head/railsexpress/05-malloc-trim.patch"
+  "2.7.7" = ops useRailsExpress [
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch"
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/02-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/03-more-detailed-stacktrace.patch"
+    "${patchSet}/patches/ruby/2.7/head/railsexpress/04-malloc-trim.patch"
   ];
   "3.0.4" = ops useRailsExpress [
     "${patchSet}/patches/ruby/3.0/head/railsexpress/01-fix-with-openssl-dir-option.patch"

--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -7,10 +7,9 @@
     "${patchSet}/patches/ruby/2.7/head/railsexpress/03-more-detailed-stacktrace.patch"
     "${patchSet}/patches/ruby/2.7/head/railsexpress/04-malloc-trim.patch"
   ];
-  "3.0.4" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/01-fix-with-openssl-dir-option.patch"
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/3.0/head/railsexpress/03-malloc-trim.patch"
+  "3.0.5" = ops useRailsExpress [
+    "${patchSet}/patches/ruby/3.0/head/railsexpress/01-improve-gc-stats.patch"
+    "${patchSet}/patches/ruby/3.0/head/railsexpress/02-malloc-trim.patch"
   ];
   "3.1.2" = ops useRailsExpress [
     "${patchSet}/patches/ruby/3.1/head/railsexpress/01-improve-gc-stats.patch"

--- a/pkgs/development/interpreters/ruby/rvm-patchsets.nix
+++ b/pkgs/development/interpreters/ruby/rvm-patchsets.nix
@@ -3,6 +3,6 @@
 fetchFromGitHub {
   owner  = "skaes";
   repo   = "rvm-patchsets";
-  rev    = "a6429bb1a7fb9b5798c22f43338739a6c192b42d";
-  sha256 = "sha256-NpSa+uGQA1rfHNcLzPNTK65J+Wk9ZlzhHFePDA4uuo0=";
+  rev    = "e6574c54a34fe6e4d45aa1433872a22ddfe14cf3";
+  hash   = "sha256-x2KvhgRVJ4Nc5v1j4DggKO1u3otG8HVMxhq4yuUKnds=";
 }


### PR DESCRIPTION
###### Description of changes
Fixes https://github.com/advisories/GHSA-vc47-6rqg-c7f5

3.1.3 not included because it didn't build

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).