### PR TITLE
oversteer: init at 0.7.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16379,4 +16379,10 @@
     github = "franzmondlichtmann";
     githubId = 105480088;
   };
+  srounce = {
+    name = "Samuel Rounce";
+    email = "me@samuelrounce.co.uk";
+    github = "srounce";
+    githubId = 60792;
+  };
 }

--- a/pkgs/applications/misc/oversteer/default.nix
+++ b/pkgs/applications/misc/oversteer/default.nix
@@ -1,0 +1,76 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, gettext, python3, python3Packages
+, meson, cmake, ninja, udev, appstream, appstream-glib, desktop-file-utils, gtk3
+, wrapGAppsHook, gobject-introspection, bash, }:
+let
+  python = python3.withPackages (p:
+    with p; [
+      pygobject3
+      pyudev
+      pyxdg
+      evdev
+      matplotlib
+      scipy
+      gtk3
+      pygobject3
+    ]);
+
+  version = "0.7.2";
+in stdenv.mkDerivation {
+  inherit version;
+
+  pname = "oversteer";
+
+  src = fetchFromGitHub {
+    owner = "berarma";
+    repo = "oversteer";
+    rev = version;
+    sha256 = "sha256-9MWRb0NXUbB8c+pH0mjUzsz849PmEjsZMhQr4wsmlKI=";
+  };
+
+  buildInputs = [ bash gtk3 ];
+
+  nativeBuildInputs = [
+    pkg-config
+    gettext
+    python
+    wrapGAppsHook
+    gobject-introspection
+    meson
+    udev
+    ninja
+    appstream
+    appstream-glib
+    desktop-file-utils
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  propagatedBuildInputs = [ python gtk3 python3Packages.pygobject3 ];
+
+  mesonFlags = [
+    "--prefix"
+    (placeholder "out")
+    "-Dudev_rules_dir=${placeholder "out"}/lib/udev/rules.d/"
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}"
+    )
+  '';
+
+  postInstall = ''
+    substituteInPlace $out/lib/udev/rules.d/* \
+      --replace /bin/sh ${bash}/bin/sh
+  '';
+
+  patches = [ ./fix-install-dir.patch ];
+
+  meta = with lib; {
+    homepage = "https://github.com/berarma/oversteer";
+    description = "Steering Wheel Manager for Linux";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.srounce ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/misc/oversteer/fix-install-dir.patch
+++ b/pkgs/applications/misc/oversteer/fix-install-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 239acf9..6a06c83 100644
+--- a/meson.build
++++ b/meson.build
+@@ -8,7 +8,7 @@ pymod = import('python')
+ prefix = get_option('prefix')
+ pkgdatadir = join_paths(prefix, get_option('datadir'), meson.project_name())
+ py_installation = pymod.find_installation(get_option('python'))
+-py_path = py_installation.get_path('purelib')
++py_path = py_installation.get_install_dir()
+ 
+ python3_required_modules = ['gi', 'pyudev', 'xdg', 'evdev', 'gettext', 'matplotlib', 'scipy', 'numpy']
+ foreach p : python3_required_modules

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38695,4 +38695,6 @@ with pkgs;
   tubekit-unwrapped = callPackage ../applications/networking/cluster/tubekit { };
 
   resgate = callPackage ../servers/resgate { };
+
+  oversteer = callPackage ../applications/misc/oversteer { };
 }


### PR DESCRIPTION
###### Description of changes

Add Oversteer - Steering Wheel Manager for Linux at version [0.7.2](https://github.com/berarma/oversteer/releases/tag/0.7.2).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
