### PR TITLE
go-jet: init at 2.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9714,6 +9714,12 @@
     githubId = 3073833;
     name = "Massimo Redaelli";
   };
+  mrityunjaygr8 = {
+    email = "mrityunjaysaxena1996@gmail.com";
+    github = "mrityunjaygr8";
+    name = "Mrityunjay Saxena";
+    githubId = 14573967;
+  };
   mrkkrp = {
     email = "markkarpov92@gmail.com";
     github = "mrkkrp";

--- a/pkgs/development/tools/go-jet/default.nix
+++ b/pkgs/development/tools/go-jet/default.nix
@@ -1,0 +1,53 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-jet";
+  version = "2.9.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = "jet";
+    rev = "v${version}";
+    sha256 = "sha256-1kJaBLZIunexjxjOy55Nw0WMEhrSu+ptMbWVOJ1e5iA=";
+  };
+
+  vendorSha256 = "sha256-mhH9P3waINZhP+jNg3zKlssIL1ZO5xOBHp19Bzq/pSQ=";
+
+  subPackages = [ "cmd/jet" ];
+
+  tags = [
+    "mysql"
+    "golang"
+    "postgres"
+    "sql"
+    "database"
+    "code-generator"
+    "sqlite"
+    "postgresql"
+    "mariadb"
+    "sql-query"
+    "codegenerator"
+    "typesafe"
+    "sql-builder"
+    "datamapper"
+    "code-completion"
+    "sql-queries"
+    "cockroachdb"
+    "sql-query-builder"
+    "sqlbuilder"
+    "typesafety"
+  ];
+
+  postPatch = ''
+    # removing the tests which depend on external data
+    rm -rf tests/{sqlite,postgres,mysql}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/go-jet/jet";
+    description = "Type safe SQL builder with code generation and automatic query result data mapping";
+    maintainers = with maintainers; [ mrityunjaygr8 ];
+    license = licenses.asl20;
+    mainProgram = "jet";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26030,6 +26030,8 @@ with pkgs;
 
   go-migrate = callPackage ../development/tools/go-migrate { };
 
+  go-jet = callPackage ../development/tools/go-jet { };
+
   go-mockery = callPackage ../development/tools/go-mockery { };
 
   gomacro = callPackage ../development/tools/gomacro { };


### PR DESCRIPTION
###### Description of changes
[go-jet](https://github.com/go-jet/jet): Type safe SQL builder with code generation and automatic query result data mapping 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
