### PR TITLE
treewide: fonts: reduce unneeded fetchzips

### DIFF
--- a/pkgs/data/fonts/arphic/default.nix
+++ b/pkgs/data/fonts/arphic/default.nix
@@ -1,22 +1,33 @@
-{ lib, fetchzip, mkfontscale, mkfontdir }:
+{ lib, stdenvNoCC, fetchurl, mkfontdir, mkfontscale }:
 
 let
   version = "0.2.20080216.2";
-in {
-  arphic-ukai = fetchzip {
-    name = "arphic-ukai-${version}";
+in
+{
+  arphic-ukai = stdenvNoCC.mkDerivation rec {
+    pname = "arphic-ukai";
+    inherit version;
 
-    url = "mirror://ubuntu/pool/main/f/fonts-arphic-ukai/fonts-arphic-ukai_${version}.orig.tar.bz2";
+    src = fetchurl {
+      url = "mirror://ubuntu/pool/main/f/fonts-${pname}/fonts-${pname}_${version}.orig.tar.bz2";
+      hash = "sha256-tJaNc1GfT4dH6FVI+4XSG2Zdob8bqQCnxJmXbmqK49I=";
+    };
 
-    postFetch = ''
-      tar -xjvf $downloadedFile --strip-components=1
+    nativeBuildInputs = [
+      mkfontscale
+      mkfontdir
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
       install -D -v ukai.ttc $out/share/fonts/truetype/arphic-ukai.ttc
       cd $out/share/fonts
-      ${mkfontdir}/bin/mkfontdir
-      ${mkfontscale}/bin/mkfontscale
-    '';
+      mkfontdir
+      mkfontscale
 
-    sha256 = "0xi5ycm7ydzpn7cqxv1kcj9vd70nr9wn8v27hmibyjc25y2qdmzl";
+      runHook postInstall
+    '';
 
     meta = with lib; {
       description = "CJK Unicode font Kai style";
@@ -28,20 +39,30 @@ in {
     };
   };
 
-  arphic-uming = fetchzip {
-    name = "arphic-uming-${version}";
+  arphic-uming = stdenvNoCC.mkDerivation rec {
+    pname = "arphic-uming";
+    inherit version;
 
-    url = "mirror://ubuntu/pool/main/f/fonts-arphic-uming/fonts-arphic-uming_${version}.orig.tar.bz2";
+    src = fetchurl {
+      url = "mirror://ubuntu/pool/main/f/fonts-${pname}/fonts-${pname}_${version}.orig.tar.bz2";
+      hash = "sha256-48GeBOp6VltKz/bx5CSAhNLhB1LjBb991sdugIYNwds=";
+    };
 
-    postFetch = ''
-      tar -xjvf $downloadedFile --strip-components=1
+    nativeBuildInputs = [
+      mkfontscale
+      mkfontdir
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
       install -D -v uming.ttc $out/share/fonts/truetype/arphic-uming.ttc
       cd $out/share/fonts
-      ${mkfontdir}/bin/mkfontdir
-      ${mkfontscale}/bin/mkfontscale
-    '';
+      mkfontdir
+      mkfontscale
 
-    sha256 = "16jybvj1cxamm682caj6nsm6l5c60x9mgchp1l2izrw2rvc8x38d";
+      runHook postInstall
+    '';
 
     meta = with lib; {
       description = "CJK Unicode font Ming style";

--- a/pkgs/data/fonts/baekmuk-ttf/default.nix
+++ b/pkgs/data/fonts/baekmuk-ttf/default.nix
@@ -1,15 +1,24 @@
-{ fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-fetchzip rec {
-  name = "baekmuk-ttf-2.2";
+stdenvNoCC.mkDerivation rec {
+  pname = "baekmuk-ttf";
+  version = "2.2";
 
-  url = "http://kldp.net/baekmuk/release/865-${name}.tar.gz";
-  postFetch = ''
-    tar -xzvf $downloadedFile --strip-components=1
+  src = fetchurl {
+    url = "http://kldp.net/baekmuk/release/865-${pname}-${version}.tar.gz";
+    hash = "sha256-CKt9/7VdWIfMlCzjcPXjO3VqVfu06vC5DyRAcOjVGII=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts        ttf/*.ttf
-    install -m444 -Dt $out/share/doc/${name}  COPYRIGHT*
+    install -m444 -Dt $out/share/doc/${pname}-${version}  COPYRIGHT*
+
+    runHook postInstall
   '';
-  sha256 = "1jgsvack1l14q8lbcv4qhgbswi30mf045k37rl772hzcmx0r206g";
 
   meta = {
     description = "Korean font";
@@ -17,4 +26,3 @@ fetchzip rec {
     license = "BSD-like";
   };
 }
-

--- a/pkgs/data/fonts/bakoma-ttf/default.nix
+++ b/pkgs/data/fonts/bakoma-ttf/default.nix
@@ -1,17 +1,25 @@
-{ fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-fetchzip {
-  name = "bakoma-ttf";
+stdenvNoCC.mkDerivation rec {
+  pname = "bakoma-ttf";
+  version = "2.2";
 
-  url = "http://tarballs.nixos.org/sha256/1j1y3cq6ys30m734axc0brdm2q9n2as4h32jws15r7w5fwr991km";
+  src = fetchurl {
+    name = "${pname}.tar.bz2";
+    url = "http://tarballs.nixos.org/sha256/1j1y3cq6ys30m734axc0brdm2q9n2as4h32jws15r7w5fwr991km";
+    hash = "sha256-dYaUMneFn1yC5lIMSLQSNmFRW16AdUXGqWBobzAbPsg=";
+  };
 
-  postFetch = ''
-    tar xjvf $downloadedFile --strip-components=1
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
     cp ttf/*.ttf $out/share/fonts/truetype
-  '';
 
-  sha256 = "0g7i723n00cqx2va05z1h6v3a2ar69gqw4hy6pjj7m0ml906rngc";
+    runHook postInstall
+  '';
 
   meta = {
     description = "TrueType versions of the Computer Modern and AMS TeX Fonts";

--- a/pkgs/data/fonts/caladea/default.nix
+++ b/pkgs/data/fonts/caladea/default.nix
@@ -1,19 +1,26 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "caladea";
   version = "20130214";
-in fetchzip {
-  name = "caladea-${version}";
 
-  url = "https://commondatastorage.googleapis.com/chromeos-localmirror/distfiles/crosextrafonts-${version}.tar.gz";
-  postFetch = ''
-    tar -xzvf $downloadedFile --strip-components=1
+  src = fetchurl {
+    url = "https://commondatastorage.googleapis.com/chromeos-localmirror/distfiles/crosextrafonts-${version}.tar.gz";
+    hash = "sha256-xI0cL9YTycBslZw02nuDiAWeJAjSuxmEXcPtNfduTQk=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/etc/fonts/conf.d
     mkdir -p $out/share/fonts/truetype
     cp -v *.ttf $out/share/fonts/truetype
     cp -v ${./cambria-alias.conf} $out/etc/fonts/conf.d/30-cambria.conf
+
+    runHook postInstall
   '';
-  sha256 = "0kwm42ggr8kvcn3554cpmv90xzam1sdncx7x3zs3bzp88mxrnv1z";
 
   meta = with lib; {
     # This font doesn't appear to have any official web site but this
@@ -27,7 +34,7 @@ in fetchzip {
     '';
     license = licenses.asl20;
     platforms = platforms.all;
-    maintainers = [maintainers.rycee];
+    maintainers = [ maintainers.rycee ];
 
     # Reduce the priority of this package. The intent is that if you
     # also install the `vista-fonts` package, then you probably will

--- a/pkgs/data/fonts/carlito/default.nix
+++ b/pkgs/data/fonts/carlito/default.nix
@@ -1,18 +1,18 @@
-{ lib, fetchzip, stdenvNoCC }:
+{ lib, fetchurl, stdenvNoCC }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "carlito";
   version = "20130920";
 
-  src = fetchzip {
+  src = fetchurl {
     url = "https://commondatastorage.googleapis.com/chromeos-localmirror/distfiles/crosextrafonts-carlito-${version}.tar.gz";
-    sha256 = "sha256-OGDO5WoF7OmiRdLRRrIXMzg276Pgeq1L3Offcl0W2jg=";
+    sha256 = "sha256-S9ErbLwyHBzxbaduLFhcklzpVqCAZ65vbGTv9sz9r1o=";
   };
 
   installPhase = ''
     mkdir -p $out/etc/fonts/conf.d
     mkdir -p $out/share/fonts/truetype
-    cp -v $src/*.ttf $out/share/fonts/truetype
+    cp -v *.ttf $out/share/fonts/truetype
     cp -v ${./calibri-alias.conf} $out/etc/fonts/conf.d/30-calibri.conf
   '';
 
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation rec {
     '';
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = [maintainers.rycee];
+    maintainers = [ maintainers.rycee ];
 
     # Reduce the priority of this package. The intent is that if you
     # also install the `vista-fonts` package, then you probably will

--- a/pkgs/data/fonts/cm-unicode/default.nix
+++ b/pkgs/data/fonts/cm-unicode/default.nix
@@ -1,19 +1,24 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "cm-unicode";
   version = "0.7.0";
-in fetchzip rec {
-  name = "cm-unicode-${version}";
 
-  url = "mirror://sourceforge/cm-unicode/cm-unicode/${version}/${name}-otf.tar.xz";
+  src = fetchurl {
+    url = "mirror://sourceforge/cm-unicode/cm-unicode/${version}/${pname}-${version}-otf.tar.xz";
+    hash = "sha256-VIp+vk1IYbEHW15wMrfGVOPqg1zBZDpgFx+jlypOHCg=";
+  };
 
-  postFetch = ''
-    tar -xJvf $downloadedFile --strip-components=1
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts/opentype *.otf
-    install -m444 -Dt $out/share/doc/${name}    README FontLog.txt
-  '';
+    install -m444 -Dt $out/share/doc/${pname}-${version}    README FontLog.txt
 
-  sha256 = "1rzz7yhqq3lljyqxbg46jfzfd09qgpgx865lijr4sgc94riy1ypn";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://cm-unicode.sourceforge.io/";

--- a/pkgs/data/fonts/crimson/default.nix
+++ b/pkgs/data/fonts/crimson/default.nix
@@ -1,25 +1,32 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "crimson";
   version = "2014.10";
-in fetchzip rec {
-  name = "crimson-${version}";
 
-  url = "https://github.com/skosch/Crimson/archive/fonts-october2014.tar.gz";
+  src = fetchFromGitHub {
+    owner = "skosch";
+    repo = "Crimson";
+    rev = "fonts-october2014";
+    hash = "sha256-Wp9L77q93TRmrAr0P4iH9gm0tqFY0X/xSsuFcd19aAE=";
+  };
 
-  postFetch = ''
-    tar -xzvf $downloadedFile --strip-components=1
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts/opentype "Desktop Fonts/OTF/"*.otf
-    install -m444 -Dt $out/share/doc/${name}    README.md
-  '';
+    install -m444 -Dt $out/share/doc/${pname}-${version}    README.md
 
-  sha256 = "0mg65f0ydyfmb43jqr1f34njpd10w8npw15cbb7z0nxmy4nkl842";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/skosch/Crimson";
     description = "A font family inspired by beautiful oldstyle typefaces";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = [maintainers.rycee];
+    maintainers = [ maintainers.rycee ];
   };
 }

--- a/pkgs/data/fonts/culmus/default.nix
+++ b/pkgs/data/fonts/culmus/default.nix
@@ -1,12 +1,19 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "culmus";
   version = "0.133";
-in fetchzip {
-  name = "culmus-${version}";
-  url = "mirror://sourceforge/culmus/culmus/${version}/culmus-${version}.tar.gz";
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${pname}/${version}/${pname}-${version}.tar.gz";
+    hash = "sha256-wMaHN0LQdUT2us8q1S65yzkpdNVkJ5ONwd+8g5nGTQU=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/{truetype,type1}
     cp -v *.pfa $out/share/fonts/type1/
     cp -v *.afm $out/share/fonts/type1/
@@ -14,8 +21,9 @@ in fetchzip {
     cp -v *.ttf $out/share/fonts/truetype/
     cp -v *.otf $out/share/fonts/truetype/
     cp -v fonts.scale-ttf $out/share/fonts/truetype/fonts.scale
+
+    runHook postInstall
   '';
-  sha256 = "0zqqjcrqmbd4389hqz2dwymkkcxjrq9ylyriiv3gbmzl6l1ffk3g";
 
   meta = {
     description = "Culmus Hebrew fonts";

--- a/pkgs/data/fonts/efont-unicode/default.nix
+++ b/pkgs/data/fonts/efont-unicode/default.nix
@@ -1,12 +1,12 @@
-{ lib, stdenv, fetchzip, libfaketime, xorg }:
+{ lib, stdenv, fetchurl, libfaketime, xorg }:
 
 stdenv.mkDerivation rec {
   pname = "efont-unicode";
   version = "0.4.2";
 
-  src = fetchzip {
+  src = fetchurl {
     url = "http://openlab.ring.gr.jp/efont/dist/unicode-bdf/${pname}-bdf-${version}.tar.bz2";
-    sha256 = "0bib3jgikq8s1m96imw4mlgbl5cbq1bs5sqig74s2l2cdfx3jaqc";
+    sha256 = "sha256-fT7SsYlV3dCQrf0IZfiNI1grj3ngDgr8IkWdg+f9m3M=";
   };
 
   nativeBuildInputs = with xorg;

--- a/pkgs/data/fonts/go-font/default.nix
+++ b/pkgs/data/fonts/go-font/default.nix
@@ -1,22 +1,28 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "go-font";
   version = "2.010";
-  rev = "41969df76e82aeec85fa3821b1e24955ea993001";
-in (fetchzip {
-  name = "go-font-${version}";
-  url = "https://go.googlesource.com/image/+archive/${rev}/font/gofont/ttfs.tar.gz";
-  stripRoot = false;
 
-  postFetch = ''
+  src = fetchzip {
+    url = "https://go.googlesource.com/image/+archive/41969df76e82aeec85fa3821b1e24955ea993001/font/gofont/ttfs.tar.gz";
+    stripRoot = false;
+    hash = "sha256-rdzt51wY4b7HEr7W/0Ar/FB0zMyf+nKLsOT+CRSEP3o=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
     mkdir -p $out/share/doc/go-font
-    mv $out/*.ttf $out/share/fonts/truetype
-    mv $out/README $out/share/doc/go-font/LICENSE
+    mv *.ttf $out/share/fonts/truetype
+    mv README $out/share/doc/go-font/LICENSE
+
+    runHook postInstall
   '';
 
-  sha256 = "175jwq16qjnd2k923n9gcbjizchy7yv4n41dm691sjwrhbl0b13x";
-}) // {
   meta = with lib; {
     homepage = "https://blog.golang.org/go-fonts";
     description = "The Go font family";
@@ -24,6 +30,5 @@ in (fetchzip {
     license = licenses.bsd3;
     maintainers = with maintainers; [ sternenseemann ];
     platforms = lib.platforms.all;
-    hydraPlatforms = [];
   };
 }

--- a/pkgs/data/fonts/gyre/default.nix
+++ b/pkgs/data/fonts/gyre/default.nix
@@ -1,15 +1,25 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
-  baseName = "gyre-fonts";
+stdenvNoCC.mkDerivation rec {
+  pname = "gyre-fonts";
   version = "2.005";
-in (fetchzip {
-  name="${baseName}-${version}";
 
-  url = "http://www.gust.org.pl/projects/e-foundry/tex-gyre/whole/tg-${version}otf.zip";
+  src = fetchzip {
+    url = "http://www.gust.org.pl/projects/e-foundry/tex-gyre/whole/tg-${version}otf.zip";
+    stripRoot = false;
+    hash = "sha256-+6IufuFf+IoLXoZEPlfHUNgRhKrQNBEZ1OwPD9/uOjg=";
+  };
 
-  sha256 = "17amdpahs6kn7hk3dqxpff1s095cg1caxzij3mxjbbxp8zy0l111";
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    cp *.otf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
 
   meta = {
     description = "OpenType fonts from the Gyre project, suitable for use with (La)TeX";
@@ -25,9 +35,4 @@ in (fetchzip {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ bergey ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/truetype
-  '';
-})
+}

--- a/pkgs/data/fonts/hermit/default.nix
+++ b/pkgs/data/fonts/hermit/default.nix
@@ -1,21 +1,24 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "hermit";
   version = "2.0";
-in fetchzip rec {
-  name = "${pname}-${version}";
 
-  url = "https://pcaro.es/d/otf-${name}.tar.gz";
+  src = fetchzip {
+    url = "https://pcaro.es/d/otf-${pname}-${version}.tar.gz";
+    stripRoot = false;
+    hash = "sha256-RYXZ2yJ8BIxsgeEwhXz7g0NnWG3kMPZoJaOLMUQyWWQ=";
+  };
 
-  stripRoot = false;
-  postFetch = ''
-    install -m444 -Dt $out/share/fonts/opentype $out/*.otf
-    shopt -s extglob dotglob
-    rm -rf $out/!(share)
-    shopt -u extglob dotglob
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m444 -Dt $out/share/fonts/opentype *.otf
+
+    runHook postInstall
   '';
-  sha256 = "127hnpxicqya7v1wmzxxqafq3aj1n33i4j5ncflbw6gj5g3bizwl";
 
   meta = with lib; {
     description = "monospace font designed to be clear, pragmatic and very readable";
@@ -25,4 +28,3 @@ in fetchzip rec {
     platforms = platforms.all;
   };
 }
-

--- a/pkgs/data/fonts/julia-mono/default.nix
+++ b/pkgs/data/fonts/julia-mono/default.nix
@@ -1,20 +1,24 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "JuliaMono-ttf";
   version = "0.046";
 
-in
-fetchzip {
-  name = "JuliaMono-ttf-${version}";
-  url = "https://github.com/cormullion/juliamono/releases/download/v${version}/JuliaMono-ttf.tar.gz";
-  sha256 = "sha256-+Ro517m1unQskQFhsT6oiz19aov87/tT1jlP/XB7kFU=";
+  src = fetchzip {
+    url = "https://github.com/cormullion/juliamono/releases/download/v${version}/${pname}.tar.gz";
+    stripRoot = false;
+    hash = "sha256-mq37L3bhUhdjB8z3I9i8+wyLrMSsu/nZrZXOuqE3JlU=";
+  };
 
-  stripRoot = false;
+  dontBuild = true;
 
-  postFetch = ''
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
-    mv $out/*.ttf $out/share/fonts/truetype
-    rm $out/LICENSE
+    mv *.ttf $out/share/fonts/truetype
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/kacst/default.nix
+++ b/pkgs/data/fonts/kacst/default.nix
@@ -1,16 +1,23 @@
-{ fetchzip, lib }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "kacst";
   version = "2.01";
-in
-fetchzip {
-  name = "kacst-${version}";
-  url = "mirror://debian/pool/main/f/fonts-kacst/fonts-kacst_${version}+mry.orig.tar.bz2";
-  sha256 = "sha256-pIO58CXfmKYRKYJ1oI+tjTwlKBRnkZ/CpIM2Xa0CDA4=";
 
-  postFetch = ''
+  src = fetchurl {
+    url = "mirror://debian/pool/main/f/fonts-${pname}/fonts-${pname}_${version}+mry.orig.tar.bz2";
+    hash = "sha256-byiZzpYiMU6kJs+NSISfHPFzAnJtc8toNIbV/fKiMzg=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts
-    tar xjf $downloadedFile --strip-components=1 -C $out/share/fonts
+    cp -R kacst $out/share/fonts
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/khmeros/default.nix
+++ b/pkgs/data/fonts/khmeros/default.nix
@@ -1,20 +1,23 @@
-{ fetchzip, lib }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "khmeros";
   version = "5.0";
-in
-fetchzip {
-  name = "khmeros-${version}";
-  url = "mirror://debian/pool/main/f/fonts-khmeros/fonts-khmeros_${version}.orig.tar.xz";
-  sha256 = "sha256-pS+7RQbGwlBxdCfSVxHmARCAkZrZttwYNlV/CrxqI+w=";
 
-  postFetch = ''
-    unpackDir="$TMPDIR/unpack"
-    mkdir "$unpackDir"
-    cd "$unpackDir"
-    tar xf "$downloadedFile" --strip-components=1
+  src = fetchurl {
+    url = "mirror://debian/pool/main/f/fonts-${pname}/fonts-${pname}_${version}.orig.tar.xz";
+    hash = "sha256-gBcM9YHSuhbxvwfQTvywH/5kN921GOyvGtkROcmcBiw=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts
     cp *.ttf $out/share/fonts
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/lao/default.nix
+++ b/pkgs/data/fonts/lao/default.nix
@@ -1,16 +1,23 @@
-{ fetchzip, lib }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "lao";
   version = "0.0.20060226";
-in
-fetchzip {
-  name = "lao-${version}";
-  url = "mirror://debian/pool/main/f/fonts-lao/fonts-lao_${version}.orig.tar.xz";
-  sha256 = "sha256-Ti3DNOgLR5VBJ1mSe8M+qs4UYbCR7qOPgqxRfmHa+jY=";
 
-  postFetch = ''
+  src = fetchurl {
+    url = "mirror://debian/pool/main/f/fonts-${pname}/fonts-${pname}_${version}.orig.tar.xz";
+    hash = "sha256-DlgdyfhxxzVkNIL+NGsQ+PRlNkCuG3v2OahkIEYx60o=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts
-    tar xf $downloadedFile --strip-components=1 -C $out/share/fonts fonts-lao-${version}/Phetsarath_OT.ttf
+    cp Phetsarath_OT.ttf $out/share/fonts
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/lklug-sinhala/default.nix
+++ b/pkgs/data/fonts/lklug-sinhala/default.nix
@@ -1,16 +1,23 @@
-{ fetchzip, lib }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "lklug-sinhala";
   version = "0.6";
-in
-fetchzip {
-  name = "lklug-sinhala-${version}";
-  url = "mirror://debian/pool/main/f/fonts-lklug-sinhala/fonts-lklug-sinhala_${version}.orig.tar.xz";
-  sha256 = "sha256-Fy+QnAajA4yLf/I1vOQll5pRd0ZLfLe8UXq4XMC9qNc=";
 
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    tar xf $downloadedFile --strip-components=1 -C $out/share/fonts fonts-lklug-sinhala-${version}/lklug.ttf
+  src = fetchurl {
+    url = "mirror://debian/pool/main/f/fonts-${pname}/fonts-${pname}_${version}.orig.tar.xz";
+    hash = "sha256-oPCCa01PMQcCK5fEILgXjrGzoDg+UvxkqK6AgeQaKio=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/lmodern/default.nix
+++ b/pkgs/data/fonts/lmodern/default.nix
@@ -1,26 +1,29 @@
-{ fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-fetchzip {
-  name = "lmodern-2.005";
+stdenvNoCC.mkDerivation rec {
+  pname = "lmodern";
+  version = "2.005";
 
-  url = "mirror://debian/pool/main/l/lmodern/lmodern_2.005.orig.tar.gz";
+  src = fetchurl {
+    url = "mirror://debian/pool/main/l/${pname}/${pname}_${version}.orig.tar.gz";
+    hash = "sha256-xlUuZt6rjW0pX4t6PKWAHkkv3PisGCj7ZwatZPAUNxk=";
+  };
 
-  postFetch = ''
-    tar xzvf $downloadedFile
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
 
     mkdir -p $out/texmf-dist/
     mkdir -p $out/share/fonts/
 
-    cp -r lmodern-2.005/* $out/texmf-dist/
-    cp -r lmodern-2.005/fonts/{opentype,type1} $out/share/fonts/
+    cp -r * $out/texmf-dist/
+    cp -r fonts/{opentype,type1} $out/share/fonts/
 
-    ln -s -r $out/texmf* $out/share/
+    runHook postInstall
   '';
-
-  sha256 = "sha256-ySdKUt8o5FqmpdnYSzbGJ1f9t8VmKYXqPt53e1/E/FA=";
 
   meta = {
     description = "Latin Modern font";
   };
 }
-

--- a/pkgs/data/fonts/luculent/default.nix
+++ b/pkgs/data/fonts/luculent/default.nix
@@ -1,17 +1,24 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let version = "2.0.0"; in
-fetchzip {
-  name = "luculent-${version}";
-  url =  "http://www.eastfarthing.com/luculent/luculent.tar.xz";
+stdenvNoCC.mkDerivation rec {
+  pname = "luculent";
+  version = "2.0.0";
 
-  postFetch = ''
-    tar -xJf $downloadedFile --strip-components=1
+  src = fetchurl {
+    url = "http://www.eastfarthing.com/${pname}/${pname}.tar.xz";
+    hash = "sha256-6NxLnTBnvHmTUTFa2wW0AuKPEbCqzaWQyiFVnF0sBqU=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
     cp *.ttf $out/share/fonts/truetype
-  '';
 
-  sha256 = "1m3g64galwna1xjxb1fczmfplm6c1fn3ra1ln7f0vkm0ah5m4lbv";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "luculent font";

--- a/pkgs/data/fonts/lxgw-wenkai/default.nix
+++ b/pkgs/data/fonts/lxgw-wenkai/default.nix
@@ -1,21 +1,24 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-fetchzip rec {
+stdenvNoCC.mkDerivation rec {
   pname = "lxgw-wenkai";
   version = "1.245.1";
 
-  url = "https://github.com/lxgw/LxgwWenKai/releases/download/v${version}/lxgw-wenkai-v${version}.tar.gz";
+  src = fetchurl {
+    url = "https://github.com/lxgw/LxgwWenKai/releases/download/v${version}/${pname}-v${version}.tar.gz";
+    hash = "sha256-CllpZdTC27fsh6Uo+VERvXBjl/tjdhIfA+v29GXIG44=";
+  };
 
-  postFetch = ''
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
-    mv $out/*.ttf $out/share/fonts/truetype
+    mv *.ttf $out/share/fonts/truetype
 
-    shopt -s extglob dotglob
-    rm -rf $out/!(share)
-    shopt -u extglob dotglob
+    runHook postInstall
   '';
-
-  hash = "sha256-4RQ+aqAZPQH3t6v2KvrNWgYT3J3uMuY34XTuvyLEOeI=";
 
   meta = with lib; {
     homepage = "https://lxgw.github.io/";

--- a/pkgs/data/fonts/marathi-cursive/default.nix
+++ b/pkgs/data/fonts/marathi-cursive/default.nix
@@ -1,19 +1,24 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "marathi-cursive";
   version = "2.0";
-in fetchzip rec {
-  name = "marathi-cursive-${version}";
 
-  url = "https://github.com/MihailJP/MarathiCursive/releases/download/v${version}/MarathiCursive-${version}.tar.xz";
+  src = fetchurl {
+    url = "https://github.com/MihailJP/MarathiCursive/releases/download/v${version}/MarathiCursive-${version}.tar.xz";
+    hash = "sha256-JE9T3UMSYn/JfEWuWHikDJIlt4nZl6GzY98v3vG6di4=";
+  };
 
-  postFetch = ''
-    tar -xJf $downloadedFile --strip-components=1
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts/marathi-cursive *.otf *.ttf
-    install -m444 -Dt $out/share/doc/${name} README *.txt
-  '';
+    install -m444 -Dt $out/share/doc/${pname}-${version} README *.txt
 
-  sha256 = "17pj60ajnjghxhxka8a046mz6vfwr79wnby7xd6pg5hgncin2hgg";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/MihailJP/MarathiCursive";

--- a/pkgs/data/fonts/nanum/default.nix
+++ b/pkgs/data/fonts/nanum/default.nix
@@ -1,20 +1,23 @@
-{ fetchzip, lib }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "nanum";
   version = "20170925";
-in
-fetchzip {
-  name = "nanum-${version}";
-  url = "mirror://ubuntu/pool/universe/f/fonts-nanum/fonts-nanum_${version}.orig.tar.xz";
-  sha256 = "sha256-lSTeQEuMmlQxiQqrx9tNScifE8nMOUDJF3lCfoAFIJk=";
 
-  postFetch = ''
-    unpackDir="$TMPDIR/unpack"
-    mkdir "$unpackDir"
-    cd "$unpackDir"
-    tar xf "$downloadedFile" --strip-components=1
+  src = fetchurl {
+    url = "mirror://ubuntu/pool/universe/f/fonts-${pname}/fonts-${pname}_${version}.orig.tar.xz";
+    hash = "sha256-GlVXH9YUU3wHMkNoz5miBv7N2oUEbwUXlcVoElQ9++4=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts
     cp *.ttf $out/share/fonts
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/oldsindhi/default.nix
+++ b/pkgs/data/fonts/oldsindhi/default.nix
@@ -1,25 +1,30 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "oldsindhi";
   version = "1.0";
-in fetchzip rec {
-  name = "oldsindhi-${version}";
 
-  url = "https://github.com/MihailJP/oldsindhi/releases/download/v${version}/OldSindhi-${version}.tar.xz";
+  src = fetchurl {
+    url = "https://github.com/MihailJP/${pname}/releases/download/v${version}/OldSindhi-${version}.tar.xz";
+    hash = "sha256-jOcl+mo6CJ9Lnn3nAUiXXHCJssovVgLoPrbGxj4uzQs=";
+  };
 
-  postFetch = ''
-    tar -xJf $downloadedFile --strip-components=1
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts/truetype *.ttf
-    install -m444 -Dt $out/share/doc/${name} README *.txt
-  '';
+    install -m444 -Dt $out/share/doc/${pname}-${version} README *.txt
 
-  sha256 = "03c483vbrwz2fpdfbys42fmik9788zxfmjmc4fgq4s2d0mraa0j1";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/MihailJP/oldsindhi";
     description = "Free Sindhi Khudabadi font";
     maintainers = with maintainers; [ mathnerd314 ];
-    license = with licenses; [mit ofl];
+    license = with licenses; [ mit ofl ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/data/fonts/takao/default.nix
+++ b/pkgs/data/fonts/takao/default.nix
@@ -1,20 +1,23 @@
-{ fetchzip, lib }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "takao";
   version = "00303.01";
-in
-fetchzip {
-  name = "takao-${version}";
-  url = "mirror://ubuntu/pool/universe/f/fonts-takao/fonts-takao_${version}.orig.tar.gz";
-  sha256 = "sha256-TlPq3iIv8vHlxYu5dkX/Lf6ediYKQaQ5uMbFvypQM/w=";
 
-  postFetch = ''
-    unpackDir="$TMPDIR/unpack"
-    mkdir "$unpackDir"
-    cd "$unpackDir"
-    tar xf "$downloadedFile" --strip-components=1
+  src = fetchurl {
+    url = "mirror://ubuntu/pool/universe/f/fonts-${pname}/fonts-${pname}_${version}.orig.tar.gz";
+    hash = "sha256-0wjHNv1yStp0q9D0WfwjgUYoUKcCrXA5jFO8PEVgq5k=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts
     cp *.ttf $out/share/fonts
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/tibetan-machine/default.nix
+++ b/pkgs/data/fonts/tibetan-machine/default.nix
@@ -1,16 +1,23 @@
-{ fetchzip, lib }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "tibetan-machine";
   version = "1.901b";
-in
-fetchzip {
-  name = "tibetan-machine-${version}";
-  url = "mirror://debian/pool/main/f/fonts-tibetan-machine/fonts-tibetan-machine_${version}.orig.tar.bz2";
-  sha256 = "sha256-A+RgpFLsP4iTzl0PMRHaNzWGbDR5Qa38lRegNJ96ULo=";
 
-  postFetch = ''
+  src = fetchurl {
+    url = "mirror://debian/pool/main/f/fonts-${pname}/fonts-${pname}_${version}.orig.tar.bz2";
+    hash = "sha256-c/1Sgv7xKHpsJGjY9ZY2qOJHShGHL1robvphFNJOt5w=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts
-    tar xf $downloadedFile --strip-components=1 -C $out/share/fonts ttf-tmuni-${version}/TibMachUni-${version}.ttf
+    cp *.ttf $out/share/fonts
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/ttf-bitstream-vera/default.nix
+++ b/pkgs/data/fonts/ttf-bitstream-vera/default.nix
@@ -1,20 +1,23 @@
-{ lib, fetchzip }:
-let
+{ lib, stdenvNoCC, fetchurl }:
+
+stdenvNoCC.mkDerivation rec {
   pname = "ttf-bitstream-vera";
   version = "1.10";
-in
-fetchzip rec {
-  name = "${pname}-${version}";
 
-  url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${name}.tar.bz2";
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
+    hash = "sha256-21sn33u7MYA269t1rNPpjxvW62YI+3CmfUeM0kPReNw=";
+  };
 
-  postFetch = ''
-    tar -xjf $downloadedFile --strip-components=1
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts/truetype *.ttf
+
+    runHook postInstall
   '';
 
-  sha256 = "179hal4yi3367jg8rsvqx6h2w4s0kn9zzrv8c47sslyg28g39s4m";
-
-  meta = {
-  };
+  meta = { };
 }

--- a/pkgs/data/fonts/unfonts-core/default.nix
+++ b/pkgs/data/fonts/unfonts-core/default.nix
@@ -1,16 +1,22 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "unfonts-core";
   version = "1.0.2-080608";
-in fetchzip {
-  name = "${pname}-${version}";
-  url = "https://kldp.net/unfonts/release/2607-un-fonts-core-${version}.tar.gz";
-  hash = "sha256-k9C7d/SbVLWFzRnDWpOIMtY6cAEIcaLcbxQAqjwuWds=";
 
-  postFetch = ''
-    tar -xzf $downloadedFile --strip-components=1
+  src = fetchurl {
+    url = "https://kldp.net/unfonts/release/2607-un-fonts-core-${version}.tar.gz";
+    hash = "sha256-OwpydPmqt+jw8ZOMAacOFYF2bVG0lLoUVoPzesVXkY4=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts/truetype *.ttf
+
+    runHook postInstall
   '';
 
   meta = with lib; {
@@ -20,7 +26,7 @@ in fetchzip {
       The Un-fonts come from the HLaTeX as type1 fonts in 1998 by Koaunghi Un, he made type1 fonts to use with Korean TeX (HLaTeX) in the late 1990's and released it under the GPL license.
 
       They were converted to TrueType with the FontForge (PfaEdit) by Won-kyu Park in 2003.
-          '';
+    '';
     license = licenses.gpl2;
     platforms = platforms.all;
     maintainers = [ maintainers.ehmry ];

--- a/pkgs/data/fonts/vdrsymbols/default.nix
+++ b/pkgs/data/fonts/vdrsymbols/default.nix
@@ -1,15 +1,22 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-fetchzip {
-  name = "vdrsymbols-20100612";
+stdenvNoCC.mkDerivation rec {
+  pname = "vdrsymbols";
+  version = "20100612";
 
-  url = "http://andreas.vdr-developer.org/fonts/download/vdrsymbols-ttf-20100612.tgz";
+  src = fetchurl {
+    url = "http://andreas.vdr-developer.org/fonts/download/${pname}-ttf-${version}.tgz";
+    hash = "sha256-YxB+JcDkta5are+OQyP/WKDL0vllgn0m26bU9mQ3C/Q=";
+  };
 
-  sha256 = "0wpxns8zqic98c84j18dr4zmj092v07yq07vwwgzblr0rw9n6gzr";
+  dontBuild = true;
 
-  postFetch = ''
-    tar xvzf "$downloadedFile"
-    install -Dm444 -t "$out/share/fonts/truetype" */*.ttf
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 -t "$out/share/fonts/truetype" *.ttf
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/wqy-microhei/default.nix
+++ b/pkgs/data/fonts/wqy-microhei/default.nix
@@ -1,16 +1,23 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-fetchzip rec {
-  name = "wqy-microhei-0.2.0-beta";
+stdenvNoCC.mkDerivation rec {
+  pname = "wqy-microhei";
+  version = "0.2.0";
 
-  url = "mirror://sourceforge/wqy/${name}.tar.gz";
+  src = fetchurl {
+    url = "mirror://sourceforge/wqy/${pname}-${version}-beta.tar.gz";
+    hash = "sha256-KAKsgCOqNqZupudEWFTjoHjTd///QhaTQb0jeHH3IT4=";
+  };
 
-  postFetch = ''
-    tar -xzf $downloadedFile --strip-components=1
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     install -Dm644 wqy-microhei.ttc $out/share/fonts/wqy-microhei.ttc
-  '';
 
-  sha256 = "0i5jh7mkp371fxqmsvn7say075r641yl4hq26isjyrqvb8cv92a9";
+    runHook postInstall
+  '';
 
   meta = {
     description = "A (mainly) Chinese Unicode font";
@@ -20,4 +27,3 @@ fetchzip rec {
     platforms = lib.platforms.all;
   };
 }
-

--- a/pkgs/data/fonts/wqy-zenhei/default.nix
+++ b/pkgs/data/fonts/wqy-zenhei/default.nix
@@ -1,19 +1,24 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "wqy-zenhei";
   version = "0.9.45";
-in fetchzip rec {
-  name = "wqy-zenhei-${version}";
 
-  url = "mirror://sourceforge/wqy/${name}.tar.gz";
+  src = fetchurl {
+    url = "mirror://sourceforge/wqy/${pname}-${version}.tar.gz";
+    hash = "sha256-5LfjBkdb+UJ9F1dXjw5FKJMMhMROqj8WfUxC8RDuddY=";
+  };
 
-  postFetch = ''
-    tar -xzf $downloadedFile --strip-components=1
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts
     install -m644 *.ttc $out/share/fonts/
-  '';
 
-  sha256 = "0hbjq6afcd63nsyjzrjf8fmm7pn70jcly7fjzjw23v36ffi0g255";
+    runHook postInstall
+  '';
 
   meta = {
     description = "A (mainly) Chinese Unicode font";


### PR DESCRIPTION
###### Description of changes

This PR reduces `fetchzip` on tarballs to `fetchurl` in 20+ files, avoiding unneeded introduction of `unzip`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
