### PR TITLE
cilium: init at 1.12.5

### DIFF
--- a/pkgs/tools/networking/cilium/default.nix
+++ b/pkgs/tools/networking/cilium/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildGoModule, fetchFromGitHub, subPackages ? [] }:
+
+buildGoModule rec {
+  pname = "cilium";
+  version = "1.12.5";
+
+  src = fetchFromGitHub {
+    owner = "cilium";
+    repo = "cilium";
+    rev = "v${version}";
+    sha256 = "sha256-0l+WENMh4Tewe1FOWhwbOn6b8jYgbifyuFuaGOYX6nk=";
+  };
+
+  vendorSha256 = null;
+
+  ldflags = [
+    "-s" "-w"
+    "-X main.Version=${version}"
+    "-X main.Commit=${version}"
+    "-X main.Program=cilium"
+  ];
+
+  inherit subPackages;
+
+  # level=error msg="unable to open \"/sys/devices/system/cpu/possible\"" error="open /sys/devices/system/cpu/possible: no such file or directory" subsys=datapath-loader
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Cilium CNI plugin";
+    homepage = "https://github.com/cilium/cilium/";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ starcraft66 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -326,6 +326,10 @@ with pkgs;
 
   cfn-nag = callPackage ../development/tools/cfn-nag { };
 
+  buildCilium = subPackages: callPackage ../tools/networking/cilium/default.nix { inherit subPackages; };
+  cilium = buildCilium [];
+  cni-plugin-cilium = buildCilium ["plugins/cilium-cni"];
+
   circumflex = callPackage ../applications/networking/circumflex { };
 
   cxx-rs = callPackage ../development/libraries/cxx-rs { };


### PR DESCRIPTION
###### Description of changes

Adds cilium to packages and simple infrastructure to break cilium down into parts in case someone wants to contribute a fully-fledged module for it. For now I only added the cni plugin as a detachable part for use with [services.kubernetes.kubelet.cni.packages](https://search.nixos.org/options?channel=22.11&from=0&size=50&sort=relevance&type=packages&query=cni).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
