### PR TITLE
emacsPackages.perl-completion: fix evaluation and mark as broken

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/perl-completion/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/perl-completion/default.nix
@@ -1,19 +1,17 @@
-{ lib
-, trivial-build
+{ trivialBuild
 , fetchurl
 }:
 
-trivial-build {
-  name = "perl-completion";
+trivialBuild {
+  pname = "perl-completion";
 
   src = fetchurl {
     url = "http://emacswiki.org/emacs/download/perl-completion.el";
     sha256 = "0x6qsgs4hm87k0z9q3g4p6508kc3y123j5jayll3jf3lcl2vm6ks";
   };
 
-  dontUnpack = true;
-
   meta = {
+    broken = true;
     description = "Minor mode provides useful features for editing perl codes";
     homepage = "http://emacswiki.org/emacs/PerlCompletion";
   };


### PR DESCRIPTION
Fix evaluation of perl-completition, which uses `trivial-build` but should be `trivialBuild`.
This leads to an evaluation error pkgs jobsets of the emacs-overlay hydra (https://hydra.nix-community.org/jobset/emacs-overlay/unstable-pkgs).

Additionally, perl-completion does not build as it depends on anything.el which is not in emacsPackages and has not
    seen any updates since 2017. Therefore, it should be marked as broken.

We could also completely remove this package, as it has been broken for quite some time and nobody seems to have noticed.

cc @AndersonTorres 



###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
