### PR TITLE
ttf-twemoji: init at 14.0.2

### DIFF
--- a/pkgs/data/fonts/ttf-twemoji/default.nix
+++ b/pkgs/data/fonts/ttf-twemoji/default.nix
@@ -1,0 +1,43 @@
+{ lib
+  , mkDerivation
+  , fetchurl
+  , rpm
+  , cpio
+}:
+
+let
+  _fedrel = "2.fc37";
+in
+mkDerivation rec {
+  pname = "ttf-twemoji";
+  version = "14.0.2";
+
+  src = fetchurl {
+    url = "https://kojipkgs.fedoraproject.org/packages/twitter-twemoji-fonts/${version}/${_fedrel}/noarch/twitter-twemoji-fonts-${version}-${_fedrel}.noarch.rpm";
+    hash = "sha256-GK7JZzHs/9gSViSTPPv3V/LFfdGzj4F50VO5HSqs0VE=";
+  };
+
+  nativeBuildInputs = [
+    rpm
+    cpio
+  ];
+
+  unpackPhase = ''
+    rpm2cpio $src | cpio -i --make-directories
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm755 usr/share/fonts/twemoji/Twemoji.ttf $out/share/fonts/truetype/Twemoji.ttf
+  '';
+
+  meta = with lib; {
+    description = "Twitter Color Emoji for everyone.";
+    homepage = "https://github.com/twitter/twemoji";
+    license = with licenses; [ cc-by-40 mit ];
+    maintainers = with maintainers; [ elnudev ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27554,6 +27554,8 @@ with pkgs;
 
   ttf-tw-moe = callPackage ../data/fonts/ttf-tw-moe { };
 
+  ttf-twemoji = callPackage ../data/fonts/ttf-twemoji { };
+
   twemoji-color-font = callPackage ../data/fonts/twemoji-color-font { };
 
   twitter-color-emoji = callPackage ../data/fonts/twitter-color-emoji { };


### PR DESCRIPTION
###### Description of changes

Added ttf-twemoji, providing Twitter's emoji set in TTF form. This is not redundant with twemoji-color-font, because per the package description SVGinOT fonts don't have full support yet, and it will fallback to font outlines on many applications. The package is based on the AUR package [ttf-twemoji](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=ttf-twemoji) and provides colored emoji with wider support.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
