### PR TITLE
rsbkb: init at 1.1

### DIFF
--- a/pkgs/tools/text/rsbkb/default.nix
+++ b/pkgs/tools/text/rsbkb/default.nix
@@ -1,0 +1,35 @@
+{ lib,
+  fetchFromGitHub,
+  rustPlatform,
+  enableAppletSymlinks ? true,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rsbkb";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "trou";
+    repo = "rsbkb";
+    rev = "release-${version}";
+    hash = "sha256-SqjeH0eOo+upSfPWh2IW75p1VHMqmzAbCchDrXhvMxs=";
+  };
+  cargoSha256 = "N3Xlw2JzTjqWLiVNCZaomsWQl330kGVlwdz4Gf05TGU=";
+
+  # Setup symlinks for all the utilities,
+  # busybox style
+  postInstall = lib.optionalString enableAppletSymlinks
+    ''
+    cd $out/bin || exit 1
+    path="$(realpath --canonicalize-missing ./rsbkb)"
+    for i in $(./rsbkb list) ; do ln -s $path $i ; done
+    '';
+
+  meta = with lib; {
+    description = "Command line tools to encode/decode things";
+    homepage = "https://github.com/trou/rsbkb";
+    changelog = "https://github.com/trou/rsbkb/releases/tag/release-${version}";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ProducerMatt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5475,6 +5475,8 @@ with pkgs;
 
   rsbep = callPackage ../tools/backup/rsbep { };
 
+  rsbkb = callPackage ../tools/text/rsbkb { };
+
   rsyslog = callPackage ../tools/system/rsyslog {
     withHadoop = false; # Currently Broken
     withKsi = false; # Currently Broken


### PR DESCRIPTION
###### Description of changes

Adds the [rsbkb](https://github.com/trou/rsbkb) et of command-line tools for encoding and decoding things. I.e. converting t/from hexadecimal, URL en/decoding, time code parsing, etc.. Those familiar with CyberChef can consider it a command-line version of its most common functions.

This package features BusyBox-style symlinks for its various functions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
