### PR TITLE
ion: unstable-2021-05-10 -> unstable-2022-11-27

### DIFF
--- a/pkgs/shells/ion/build-script.patch
+++ b/pkgs/shells/ion/build-script.patch
@@ -1,0 +1,17 @@
+--- a/build.rs
++++ b/build.rs
+@@ -23,13 +23,7 @@ fn write_version_file() -> io::Result<()> {
+     let target = env::var("TARGET").unwrap();
+     let version_fname = Path::new(&env::var("OUT_DIR").unwrap()).join("version_string");
+     let mut version_file = File::create(&version_fname)?;
+-    write!(
+-        &mut version_file,
+-        "r#\"ion {} ({})\nrev {}\"#",
+-        version,
+-        target,
+-        get_git_rev()?.trim()
+-    )?;
++    write!(&mut version_file, "r#\"ion {version} ({target})\n\"#")?;
+     Ok(())
+ }
+ 

--- a/pkgs/shells/ion/default.nix
+++ b/pkgs/shells/ion/default.nix
@@ -1,33 +1,45 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, Security, libiconv }:
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, stdenv
+, darwin
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "ion";
-  version = "unstable-2021-05-10";
+  version = "unstable-2022-11-27";
 
   src = fetchFromGitHub {
     owner = "redox-os";
     repo = "ion";
-    rev = "1170b84587bbad260a3ecac8e249a216cb1fd5e9";
-    sha256 = "sha256-lI1GwA3XerRJaC/Z8vTZc6GzRDLjv3w768C+Ui6Q+3Q=";
+    rev = "3bb8966fc99ba223033e1e02b0a6d50fc25cbef4";
+    sha256 = "sha256-6KW/YkMQFeGb1i+1YdADZRW89UruHsfPhMq9Cvxjl/4=";
   };
 
-  cargoSha256 = "sha256-hURpgxc99iIMtzIlR6Kbfqcbu1uYLDHnfVLqgmMbvFA=";
+  cargoSha256 = "sha256-KLKPnj4SmAuspjMPAGLJ8Yy9SxAi6FvGE/FIF58lAH8=";
+
+  patches = [
+    # remove git revision from the build script to fix build
+    ./build-script.patch
+  ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  checkFlags = lib.optionals stdenv.isDarwin [
+    # test assumes linux
+    "--skip=binary::completer::tests::filename_completion"
+  ];
+
+  passthru = {
+    shellPath = "/bin/ion";
+  };
 
   meta = with lib; {
     description = "Modern system shell with simple (and powerful) syntax";
     homepage = "https://gitlab.redox-os.org/redox-os/ion";
     license = licenses.mit;
     maintainers = with maintainers; [ dywedir ];
-  };
-
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    Security
-    libiconv
-  ];
-
-  doCheck = !stdenv.hostPlatform.isDarwin;
-
-  passthru = {
-    shellPath = "/bin/ion";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13709,9 +13709,7 @@ with pkgs;
 
   fzf-git-sh = callPackage ../shells/fzf-git-sh {};
 
-  ion = callPackage ../shells/ion {
-    inherit (darwin) Security;
-  };
+  ion = callPackage ../shells/ion { };
 
   jush = callPackage ../shells/jush { };
 


### PR DESCRIPTION
Diff: https://github.com/redox-os/ion/compare/1170b84587bbad260a3ecac8e249a216cb1fd5e9...3bb8966fc99ba223033e1e02b0a6d50fc25cbef4

also fixes the build

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
