### PR TITLE
zstd: fix cross-compilation on darwin

### DIFF
--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -77,11 +77,13 @@ stdenv.mkDerivation rec {
 
     substituteInPlace ../programs/zstdless \
       --replace "zstdcat" "$bin/bin/zstdcat"
-  '' + lib.optionalString buildContrib ''
-    cp contrib/pzstd/pzstd $bin/bin/pzstd
-  '' + lib.optionalString stdenv.isDarwin ''
-    install_name_tool -change @rpath/libzstd.1.dylib $out/lib/libzstd.1.dylib $bin/bin/pzstd
-  '';
+  '' + lib.optionalString buildContrib (
+    ''
+      cp contrib/pzstd/pzstd $bin/bin/pzstd
+    '' + lib.optionalString stdenv.isDarwin ''
+      install_name_tool -change @rpath/libzstd.1.dylib $out/lib/libzstd.1.dylib $bin/bin/pzstd
+    ''
+  );
 
   outputs = [ "bin" "dev" ]
     ++ lib.optional stdenv.hostPlatform.isUnix "man"


### PR DESCRIPTION
###### Description of changes

Fix `zstd` cross-compilation on darwin.

```
$ nix-build -A zstd.bin --no-out-link
( ... )
/nix/store/rlzarxzpafmlc7q6abmxmrjw9kd70nx9-zstd-1.5.2-bin

$ nix-build -A pkgsCross.aarch64-darwin.zstd.bin --no-out-link
( ... )
[ 94%] Built target zstd
[ 96%] Creating unzstd symlink
[ 98%] Creating zstdmt symlink
[100%] Creating zstdcat symlink
[100%] Built target unzstd
[100%] Built target zstdcat
[100%] Built target zstdmt
installing
/nix/store/lv85xci1wxabc0ji0cj3dx8a8sggkgl6-stdenv-darwin/setup: line 101: install_name_tool: command not found
```

There's no need for install_name_tool to patch `pzstd`, since we don't install that binary anyway when cross-compiling.

After this change, cross compilation succeeds:

```
$ nix-build -A pkgsCross.aarch64-darwin.zstd.bin --no-out-link
( ... )
/nix/store/939p55wrc7avzg9rw7lfb89bj40j1s8m-zstd-aarch64-apple-darwin-1.5.2-bin
```

And the derivation is unchanged for a normal build:

```
$ nix-build -A zstd.bin --no-out-link
/nix/store/rlzarxzpafmlc7q6abmxmrjw9kd70nx9-zstd-1.5.2-bin
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
