### PR TITLE
Fix/unbreak math programming

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1819,7 +1819,6 @@ broken-packages:
   - gloss-banana
   - gloss-export
   - gloss-game
-  - glpk-headers
   - gltf-codec
   - glue
   - g-npm
@@ -3245,7 +3244,6 @@ broken-packages:
   - math-grads
   - math-interpolate
   - math-metric
-  - math-programming
   - matrix-as-xyz
   - matrix-lens
   - matrix-market

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -2726,8 +2726,6 @@ dont-distribute-packages:
  - marvin
  - masakazu-bot
  - matchers
- - math-programming-glpk
- - math-programming-tests
  - mathblog
  - mathlink
  - matsuri


### PR DESCRIPTION
###### Description of changes

This PR marks the `glpk-headers`, `math-programming`, `math-programming-glpk`, and `math-programming-tests` packages as not broken.

Existing versions of these packages were indeed broken. I recently released version 0.5.0 of each of these, and they all build on the current `release-22.11` branch of `nixpkgs`.

Note that this PR has _not_ updated the versions of these packages in the `hackage-packages.nix` file; I suspect that this PR will need to be merged after this file is regenerated in the next few weeks and picks up the newly-released packages above.

###### Testing done

I created a small Haskell project that relies on the new packages, and `nixpkgs` branch `release-22.11`. The resulting project builds. I used the following as `shell.nix`,

```
{ sources ? import ./nix/sources.nix
, pkgsF ? import sources.nixpkgs
}:
let
  config = {
    packageOverrides = pkgs: rec {
      haskellPackages = pkgs.haskellPackages.override {
        overrides = self: super: rec {
          test-nixpkgs = self.callCabal2nix "test-nixpkgs" ./. {};
          math-programming = self.callPackage ./math-programming.nix {};
          math-programming-tests = self.callPackage ./math-programming-tests.nix {};
          math-programming-glpk = self.callPackage ./math-programming-glpk.nix {};
          glpk-headers = self.callPackage ./glpk-headers.nix {};
        };
      };
    };
  };

  pkgs = pkgsF { inherit config; };
in
pkgs.haskellPackages.shellFor {
  packages = p: [ pkgs.haskellPackages.test-nixpkgs
                ];
  buildInputs = [ pkgs.cabal-install
                  pkgs.cabal2nix
                  pkgs.haskell-language-server
                ];
  withHoogle = true;
}
```

where I generated the files `glpk-headers.nix`, `math-programming.nix`, `math-programming-tests.nix`, and `math-programming-glpk.nix` via

```
nix-shell --packages cabal2nix --run 'cabal2nix cabal://math-programming-0.5.0' > math-programming.nix
nix-shell --packages cabal2nix --run 'cabal2nix cabal://math-programming-glpk-0.5.0' > math-programming-glpk.nix
nix-shell --packages cabal2nix --run 'cabal2nix cabal://math-programming-tests-0.5.0' > math-programming-tests.nix
nix-shell --packages cabal2nix --run 'cabal2nix cabal://glpk-headers-0.5.0' > glpk-headers.nix
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
