### PR TITLE
Make gprbuild build on Darwin

### DIFF
--- a/pkgs/build-support/setup-hooks/fix-gprbuild-darwin-dylib-names.sh
+++ b/pkgs/build-support/setup-hooks/fix-gprbuild-darwin-dylib-names.sh
@@ -1,0 +1,94 @@
+#shellcheck shell=bash
+
+# On macOS, binaries refer to dynamic library dependencies using
+# either:
+# - paths relative to those in specific environment variables (e.g.
+#   "libicudata.dylib", searched relative to $DYLD_LIBRARY_PATH and
+#   $DYLD_FALLBACK_LIBRARY_PATH);
+# - paths relative to dynamic locations that are denoted by special tokens
+#   (e.g. "@rpath/libicudata.dylib"); or
+# - absolute paths (e.g. "/nix/store/.../lib/libicudata.dylib").
+# (See the dyld(1) man page for an overview.)
+#
+# In Nix, the latter is preferred since it allows programs to just work.  When
+# linking against a library (e.g. "-licudata"), the linker uses the install name
+# embedded in the dylib (which can be shown using "otool -D").  Most packages
+# create dylibs with absolute install names, but some do not.  This setup hook
+# fixes dylibs by setting their install names to their absolute path (using
+# "install_name_tool -id").  It also rewrites references in other dylibs to
+# absolute paths.
+
+#shellcheck disable=SC2016
+fixupOutputHooks+=('fixGPRBuildDarwinDylibNamesIn $prefix')
+
+fixGPRBuildDarwinDylibNamesIn() {
+    if (( $# == 0 )); then
+        echo "Error: no directory specified" >&2
+        exit 1
+    fi
+
+    local dir="$1"
+
+    # The `mapfile -t -d '' array_name < {file_with_NUL_delimiters}` pattern
+    # avoids pitfalls with unsafe characters in file names, and works for bash
+    # 4.4+; see e.g. https://mywiki.wooledge.org/BashProgramming/03 (Working
+    # with files)
+    #
+    # While we only want to change Mach-O executables and dylibs, the dylib
+    # dependencies in them may be to symlinks to the target dylib, so we must
+    # catch those too.
+    mapfile -t -d '' candidates < <( \
+        find -P "$dir" \( \
+                -executable -type f \
+                -o \
+                -name "*.dylib" \
+            \) -print0
+    )
+
+    local -a executables dylibRefs dylibs
+    for c in "${candidates[@]}"; do
+        if [[ "$c" =~ .dylib$ ]]; then
+            dylibRefs+=("$c")
+        fi
+
+        res="$(file --no-dereference "$c")"
+        if [[ "$res" =~ Mach-O.*executable ]]; then
+            executables+=("$c")
+        # There may be Mach-O shared library stubs or fixed virtual memory
+        # shared libraries; we can't change those
+        elif [[ "$res" =~ Mach-O.*linked\ shared\ library &&
+                ! "$res" =~ stub ]]; then
+            dylibs+=("$c")
+        fi
+    done
+
+    local flags=()
+    for dylibRef in "${dylibRefs[@]}"; do
+        flags+=(-change "@rpath/${dylibRef##*/}" "$dylibRef")
+    done
+
+    for exe in "${executables[@]}"; do
+        echo "$exe: fixing executable"
+        fixGPRBuildDarwinDylibNames "$exe" "${flags[@]}"
+    done
+
+    for dylib in "${dylibs[@]}"; do
+        echo "$dylib: fixing dylib"
+        fixGPRBuildDarwinDylibNames "$dylib" "${flags[@]}"
+    done
+}
+
+# First positional parameter is the file to change; remaining positional
+# parameters are the dylib dependencies to rewrite
+fixGPRBuildDarwinDylibNames() {
+    f="$1"
+    shift
+    int_out=$(@targetPrefix@install_name_tool -id "$f" "$@" "$f" 2>&1)
+    result=$?
+    if (( "$result" != 0 )); then
+        echo "$int_out" >&2
+        exit "$result"
+    fi
+}
+
+fixGPRBuildDarwinDylibNamesIn "$@"

--- a/pkgs/development/libraries/ada/xmlada/default.nix
+++ b/pkgs/development/libraries/ada/xmlada/default.nix
@@ -5,6 +5,7 @@
 # use gprbuild-boot since gprbuild proper depends
 # on this xmlada derivation.
 , gprbuild-boot
+, fixGPRBuildDarwinDylibNames
 }:
 
 stdenv.mkDerivation rec {
@@ -22,6 +23,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     gnat
     gprbuild-boot
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ fixGPRBuildDarwinDylibNames ];
+
+  patches = [
+    ./fix-darwin-dylib-names.patch
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/ada/xmlada/fix-darwin-dylib-names.patch
+++ b/pkgs/development/libraries/ada/xmlada/fix-darwin-dylib-names.patch
@@ -1,0 +1,110 @@
+diff --git a/dom/xmlada_dom.gpr b/dom/xmlada_dom.gpr
+index 3dde341..3e76b80 100644
+--- a/dom/xmlada_dom.gpr
++++ b/dom/xmlada_dom.gpr
+@@ -31,8 +31,15 @@ project XmlAda_Dom is
+    for Library_Kind use XmlAda_Shared.Library_Type;
+    for Object_Dir  use "obj/" & Project'Library_Kind;
+    for Library_Dir use "lib/" & Project'Library_Kind;
+-   for Library_Version use "lib" & Project'Library_Name
+-      & XmlAda_Shared.So_Ext & "." & XmlAda_Shared.Version;
++
++   case XmlAda_Shared.So_Ext is
++      when ".dylib" =>
++         for Library_Version use "lib" & Project'Library_Name
++            & "." & XmlAda_Shared.Version & XmlAda_Shared.So_Ext;
++      when others =>
++         for Library_Version use "lib" & Project'Library_Name
++            & XmlAda_Shared.So_Ext & "." & XmlAda_Shared.Version;
++   end case;
+ 
+    package Builder  renames XmlAda_Shared.Builder;
+    package Compiler renames XmlAda_Shared.Compiler;
+diff --git a/input_sources/xmlada_input.gpr b/input_sources/xmlada_input.gpr
+index caed6f6..4d79535 100644
+--- a/input_sources/xmlada_input.gpr
++++ b/input_sources/xmlada_input.gpr
+@@ -30,8 +30,15 @@ project XmlAda_Input is
+    for Library_Kind use XmlAda_Shared.Library_Type;
+    for Object_Dir  use "obj/" & Project'Library_Kind;
+    for Library_Dir use "lib/" & Project'Library_Kind;
+-   for Library_Version use "lib" & Project'Library_Name
+-      & XmlAda_Shared.So_Ext & "." & XmlAda_Shared.Version;
++
++   case XmlAda_Shared.So_Ext is
++      when ".dylib" =>
++         for Library_Version use "lib" & Project'Library_Name
++            & "." & XmlAda_Shared.Version & XmlAda_Shared.So_Ext;
++      when others =>
++         for Library_Version use "lib" & Project'Library_Name
++            & XmlAda_Shared.So_Ext & "." & XmlAda_Shared.Version;
++   end case;
+ 
+    package Builder  renames XmlAda_Shared.Builder;
+    package Compiler renames XmlAda_Shared.Compiler;
+diff --git a/sax/xmlada_sax.gpr b/sax/xmlada_sax.gpr
+index 3df4151..401f213 100644
+--- a/sax/xmlada_sax.gpr
++++ b/sax/xmlada_sax.gpr
+@@ -31,8 +31,15 @@ project XmlAda_Sax is
+    for Library_Kind use XmlAda_Shared.Library_Type;
+    for Object_Dir  use "obj/" & Project'Library_Kind;
+    for Library_Dir use "lib/" & Project'Library_Kind;
+-   for Library_Version use "lib" & Project'Library_Name
+-      & XmlAda_Shared.So_Ext & "." & XmlAda_Shared.Version;
++
++   case XmlAda_Shared.So_Ext is
++      when ".dylib" =>
++         for Library_Version use "lib" & Project'Library_Name
++            & "." & XmlAda_Shared.Version & XmlAda_Shared.So_Ext;
++      when others =>
++         for Library_Version use "lib" & Project'Library_Name
++            & XmlAda_Shared.So_Ext & "." & XmlAda_Shared.Version;
++   end case;
+ 
+    package Builder  renames XmlAda_Shared.Builder;
+    package Compiler renames XmlAda_Shared.Compiler;
+diff --git a/schema/xmlada_schema.gpr b/schema/xmlada_schema.gpr
+index 139d4da..b8b1614 100644
+--- a/schema/xmlada_schema.gpr
++++ b/schema/xmlada_schema.gpr
+@@ -32,8 +32,15 @@ project XmlAda_Schema is
+    for Library_Kind use XmlAda_Shared.Library_Type;
+    for Object_Dir  use "obj/" & Project'Library_Kind;
+    for Library_Dir use "lib/" & Project'Library_Kind;
+-   for Library_Version use "lib" & Project'Library_Name
+-      & XmlAda_Shared.So_Ext & "." & XmlAda_Shared.Version;
++
++   case XmlAda_Shared.So_Ext is
++      when ".dylib" =>
++         for Library_Version use "lib" & Project'Library_Name
++            & "." & XmlAda_Shared.Version & XmlAda_Shared.So_Ext;
++      when others =>
++         for Library_Version use "lib" & Project'Library_Name
++            & XmlAda_Shared.So_Ext & "." & XmlAda_Shared.Version;
++   end case;
+ 
+    package Builder  renames XmlAda_Shared.Builder;
+    package Compiler renames XmlAda_Shared.Compiler;
+diff --git a/unicode/xmlada_unicode.gpr b/unicode/xmlada_unicode.gpr
+index bfd3f00..0673f10 100644
+--- a/unicode/xmlada_unicode.gpr
++++ b/unicode/xmlada_unicode.gpr
+@@ -29,8 +29,15 @@ project XmlAda_Unicode is
+    for Library_Kind use XmlAda_Shared.Library_Type;
+    for Object_Dir  use "obj/" & Project'Library_Kind;
+    for Library_Dir use "lib/" & Project'Library_Kind;
+-   for Library_Version use "lib" & Project'Library_Name
+-      & XmlAda_Shared.So_Ext & "." & XmlAda_Shared.Version;
++
++   case XmlAda_Shared.So_Ext is
++      when ".dylib" =>
++         for Library_Version use "lib" & Project'Library_Name
++            & "." & XmlAda_Shared.Version & XmlAda_Shared.So_Ext;
++      when others =>
++         for Library_Version use "lib" & Project'Library_Name
++            & XmlAda_Shared.So_Ext & "." & XmlAda_Shared.Version;
++   end case;
+ 
+    package Builder  renames XmlAda_Shared.Builder;
+    package Compiler renames XmlAda_Shared.Compiler;

--- a/pkgs/development/tools/build-managers/gprbuild/default.nix
+++ b/pkgs/development/tools/build-managers/gprbuild/default.nix
@@ -6,6 +6,7 @@
 , which
 , gnat
 , xmlada
+, fixGPRBuildDarwinDylibNames
 }:
 
 stdenv.mkDerivation {
@@ -25,7 +26,7 @@ stdenv.mkDerivation {
     gnat
     gprbuild-boot
     which
-  ];
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ fixGPRBuildDarwinDylibNames ];
 
   propagatedBuildInputs = [
     xmlada

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1115,6 +1115,12 @@ with pkgs;
     meta.platforms = lib.platforms.darwin;
   } ../build-support/setup-hooks/fix-darwin-dylib-names.sh;
 
+  fixGPRBuildDarwinDylibNames = makeSetupHook {
+    name = "fix-gprbuild-darwin-dylib-names-hook";
+    substitutions = { inherit (binutils) targetPrefix; };
+    meta.platforms = lib.platforms.darwin;
+  } ../build-support/setup-hooks/fix-gprbuild-darwin-dylib-names.sh;
+
   writeDarwinBundle = callPackage ../build-support/make-darwin-bundle/write-darwin-bundle.nix { };
 
   desktopToDarwinBundle = makeSetupHook {


### PR DESCRIPTION
###### Description of changes

- Enable gprbuild to build and run on Darwin

This indirectly enables multiple other Ada-related packages to build on (x86-64) Darwin that previously could not.  gnatcoll-python3 still fails to build on Darwin, but it could not do so before, so strictly more packages build after this PR than before it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

