### PR TITLE
ocamlPackages.gluten: 0.2.1 → 0.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/gluten/default.nix
+++ b/pkgs/development/ocaml-modules/gluten/default.nix
@@ -3,24 +3,25 @@
 , faraday
 , fetchurl
 , lib
+, ke
 }:
 
 buildDunePackage rec {
   pname = "gluten";
-  version = "0.2.1";
+  version = "0.3.0";
 
   src = fetchurl {
     url = "https://github.com/anmonteiro/gluten/releases/download/${version}/gluten-${version}.tbz";
-    sha256 = "1pl0mpcprz8hmaiv28p7w51qfcx7s76zdkak0vm5cazbjl38nc46";
+    hash = "sha256-9jctX3G/nQJTGJ7ClSBEiXwxeu0GcT9N+EmPfLuSFOU=";
   };
 
-  minimalOCamlVersion = "4.06";
-
-  useDune2 = true;
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     bigstringaf
     faraday
+    ke
   ];
 
   doCheck = false; # No tests

--- a/pkgs/development/ocaml-modules/gluten/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/gluten/lwt-unix.nix
@@ -7,7 +7,9 @@
 
 buildDunePackage rec {
   pname = "gluten-lwt-unix";
-  inherit (gluten) doCheck meta src useDune2 version;
+  inherit (gluten) doCheck meta src version;
+
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     faraday-lwt-unix

--- a/pkgs/development/ocaml-modules/gluten/lwt.nix
+++ b/pkgs/development/ocaml-modules/gluten/lwt.nix
@@ -5,7 +5,9 @@
 
 buildDunePackage rec {
   pname = "gluten-lwt";
-  inherit (gluten) doCheck meta src useDune2 version;
+  inherit (gluten) doCheck meta src version;
+
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     gluten

--- a/pkgs/development/ocaml-modules/piaf/default.nix
+++ b/pkgs/development/ocaml-modules/piaf/default.nix
@@ -2,7 +2,7 @@
 , buildDunePackage
 , ocaml
 , dune-site
-, fetchzip
+, fetchurl
 , gluten-lwt-unix
 , lib
 , logs
@@ -22,9 +22,11 @@ buildDunePackage rec {
   pname = "piaf";
   version = "0.1.0";
 
-  src = fetchzip {
+  duneVersion = "3";
+
+  src = fetchurl {
     url = "https://github.com/anmonteiro/piaf/releases/download/${version}/piaf-${version}.tbz";
-    sha256 = "0d431kz3bkwlgdamvsv94mzd9631ppcjpv516ii91glzlfdzh5hz";
+    hash = "sha256-AMO+ptGox33Bi7u/H0SaeCU88XORrRU3UbLof3EwcmU=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

https://github.com/anmonteiro/gluten/blob/0.3.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
