### PR TITLE
python3Packages.sure: disable test on python 3.11 or later

### DIFF
--- a/pkgs/development/python-modules/sure/default.nix
+++ b/pkgs/development/python-modules/sure/default.nix
@@ -5,6 +5,7 @@
 , six
 , mock
 , isPyPy
+, pythonOlder
 , fetchpatch
 }:
 
@@ -26,8 +27,9 @@ buildPythonPackage rec {
     })
   ];
 
-  buildInputs = [ rednose ];
   propagatedBuildInputs = [ six mock ];
+  checkInputs = [ rednose ];
+  doCheck = pythonOlder "3.11";
 
   meta = with lib; {
     description = "Utility belt for automated testing";

--- a/pkgs/development/python-modules/sure/default.nix
+++ b/pkgs/development/python-modules/sure/default.nix
@@ -12,6 +12,8 @@
 buildPythonPackage rec {
   pname = "sure";
   version = "2.0.0";
+  format = "setuptools";
+
   disabled = isPyPy;
 
   src = fetchPypi {
@@ -27,14 +29,26 @@ buildPythonPackage rec {
     })
   ];
 
-  propagatedBuildInputs = [ six mock ];
-  checkInputs = [ rednose ];
+  propagatedBuildInputs = [
+    six
+    mock
+  ];
+
+  checkInputs = [
+    rednose
+  ];
+
   doCheck = pythonOlder "3.11";
+
+  pythonImportsCheck = [
+    "sure"
+  ];
 
   meta = with lib; {
     description = "Utility belt for automated testing";
-    homepage = "https://sure.readthedocs.io/en/latest/";
+    homepage = "https://sure.readthedocs.io/";
+    changelog = "https://github.com/gabrielfalcao/sure/blob/${version}/CHANGELOG.md";
     license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ];
   };
-
 }


### PR DESCRIPTION
As `rednose`, the check input, does not support python 3.11

This unbreaks a series of azure related packages.
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
