### PR TITLE
nixos/nextcloud: fix typo in disableImagemagick's option description

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -79,7 +79,7 @@ in {
       (which can be opened e.g. by running `nixos-help`).
     '')
     (mkRemovedOptionModule [ "services" "nextcloud" "disableImagemagick" ] ''
-      Use services.nextcloud.nginx.enableImagemagick instead.
+      Use services.nextcloud.enableImagemagick instead.
     '')
   ];
 


### PR DESCRIPTION
an option services.nextcloud.nginx.enableImagemagick does not exist.

###### Description of changes

just stupid text