### PR TITLE
pikchr: enable tcl support (and related stuff)

### DIFF
--- a/pkgs/applications/editors/poke/default.nix
+++ b/pkgs/applications/editors/poke/default.nix
@@ -80,13 +80,13 @@ in stdenv.mkDerivation rec {
     moveToOutput share/vim "$out"
   '';
 
+  # Prevent tclPackageHook from auto-wrapping all binaries, we only
+  # need to wrap poke-gui
+  dontWrapTclBinaries = true;
+
   postFixup = lib.optionalString guiSupport ''
     wrapProgram "$out/bin/poke-gui" \
       --prefix TCLLIBPATH ' ' "$TCLLIBPATH"
-
-    # Prevent tclPackageHook from auto-wrapping all binaries, we only
-    # need to wrap poke-gui
-    unset TCLLIBPATH
   '';
 
   passthru = {

--- a/pkgs/development/interpreters/tcl/tcl-package-hook.sh
+++ b/pkgs/development/interpreters/tcl/tcl-package-hook.sh
@@ -41,6 +41,8 @@ findInstalledTclPkgs() {
 
 # Wrap any freshly-installed binaries and set up their TCLLIBPATH
 wrapTclBins() {
+    if [ "$dontWrapTclBinaries" ]; then return; fi
+
     if [[ -z "${TCLLIBPATH-}" ]]; then
         echo "skipping automatic Tcl binary wrapping (nothing to do)"
         return

--- a/pkgs/tools/graphics/pikchr/default.nix
+++ b/pkgs/tools/graphics/pikchr/default.nix
@@ -1,6 +1,9 @@
 { lib
 , stdenv
 , fetchfossil
+, tcl
+
+, enableTcl ? true
 }:
 
 stdenv.mkDerivation {
@@ -19,13 +22,26 @@ stdenv.mkDerivation {
     substituteInPlace Makefile --replace open "test -f"
   '';
 
+  nativeBuildInputs = lib.optional enableTcl tcl.tclPackageHook;
+
+  buildInputs = lib.optional enableTcl tcl;
+
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
+  buildFlags = [ "pikchr" ] ++ lib.optional enableTcl "piktcl";
+
   installPhase = ''
+    runHook preInstall
     install -Dm755 pikchr $out/bin/pikchr
     install -Dm755 pikchr.out $out/lib/pikchr.o
     install -Dm644 pikchr.h $out/include/pikchr.h
+  '' + lib.optionalString enableTcl ''
+    cp -r piktcl $out/lib/piktcl
+  '' + ''
+    runHook postInstall
   '';
+
+  dontWrapTclBinaries = true;
 
   doCheck = true;
   checkTarget = "test";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
pikchr has optional tcl support. I enabled it when `tcl` is not null

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
