### PR TITLE
prometheus: 2.40.3 -> 2.41.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -31,10 +31,10 @@
 }:
 
 let
-  version = "2.40.3";
+  version = "2.41.0";
   webUiStatic = fetchurl {
     url = "https://github.com/prometheus/prometheus/releases/download/v${version}/prometheus-web-ui-${version}.tar.gz";
-    sha256 = "sha256-dvMts9uJNLSp8Qho+yKMLPTy/1c2RgfeEn3UQLIZNc4=";
+    sha256 = "sha256-0EFeAuhQUu+4TCoHsWHTbWTGJLjS37POacP1K42sGqI=";
   };
 in
 buildGoModule rec {
@@ -45,10 +45,10 @@ buildGoModule rec {
     rev = "v${version}";
     owner = "prometheus";
     repo = "prometheus";
-    sha256 = "sha256-Jg8loH0Sji1MmDXUnMtvLTHjNGmkrzZApxvpe2+OqtU=";
+    sha256 = "sha256-J3KDN02m639bUGrnUrqeCLferrqIHaJ2VEBjIqfm/GY=";
   };
 
-  vendorSha256 = "sha256-aRVoEgP84ITQ1D0PsFVJUKH/Uin7s80iQCwzgrfpjoM=";
+  vendorSha256 = "sha256-4Of1euBp5Lka6Bb2UJYUQuRa7t2/B1HaXCWSOqCASYw=";
 
   excludedPackages = [ "documentation/prometheus-mixin" ];
 


### PR DESCRIPTION


###### Description of changes

prometheus 2.40.x is out of support since 12/2022 therefore the update to 2.41.0

between those two releases security critical patches have been added both to prometheus codebase and upstream dependecies, see:
  * 2.40.6 / 2022-12-09 https://github.com/prometheus/prometheus/pull/11690 [SECURITY] Security upgrade from go and upstream dependencies that include security fixes to the net/http and os packages. #11691

  *  2.40.4 / 2022-11-29 https://github.com/advisories/GHSA-7rg2-cxvp-9p7p https://github.com/advisories/GHSA-4v48-4q5m-8vx4 [SECURITY] Fix basic authentication bypass vulnerability (CVE-2022-46146) GHSA-4v48-4q5m-8vx4
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
