### PR TITLE
openmvs: init at 2.1.0

### DIFF
--- a/pkgs/applications/science/misc/openmvs/default.nix
+++ b/pkgs/applications/science/misc/openmvs/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, cmake, eigen, opencv, cgal, ceres-solver, boost, vcg, glfw, zstd }:
+
+stdenv.mkDerivation rec {
+  version = "2.1.0";
+  pname = "openmvs";
+
+  src = fetchFromGitHub {
+    owner = "cdcseacave";
+    repo = "openmvs";
+    rev = "v${version}";
+    sha256 = "sha256-eqNprBgR0hZnbLKLZLJqjemKxHhDtGblmaSxYlmegsc=";
+    fetchSubmodules = true;
+  };
+
+  # SSE is enabled by default
+  cmakeFlags = lib.optional (!stdenv.isx86_64) "-DOpenMVS_USE_SSE=OFF";
+
+  buildInputs = [ eigen opencv cgal ceres-solver boost vcg glfw zstd ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  meta = {
+    description = "Open Multi-View Stereo reconstruction library";
+    homepage = "https://github.com/cdcseacave/openMVS";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ bouk ];
+  };
+}

--- a/pkgs/development/libraries/CGAL/4.nix
+++ b/pkgs/development/libraries/CGAL/4.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    ./cgal_path.patch
 
     # Pull upstream fix for c++17 (gcc-12):
     #  https://github.com/CGAL/cgal/pull/6109

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, icu, expat, zlib, bzip2, python ? null, fixDarwinDylibNames, libiconv, libxcrypt
+{ lib, stdenv, icu, expat, zlib, bzip2, zstd, xz, python ? null, fixDarwinDylibNames, libiconv, libxcrypt
 , boost-build
 , fetchpatch
 , which
@@ -227,6 +227,8 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ which boost-build ]
     ++ optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
   buildInputs = [ expat zlib bzip2 libiconv ]
+    ++ optional (versionAtLeast version "1.69") zstd
+    ++ optional (versionAtLeast version "1.65") xz
     ++ optional enableIcu icu
     ++ optionals enablePython [ libxcrypt python ]
     ++ optional enableNumpy python.pkgs.numpy;

--- a/pkgs/development/libraries/vcg/default.nix
+++ b/pkgs/development/libraries/vcg/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vcg";
-  version = "1.0.1";
+  version = "2022.02";
 
   src = fetchFromGitHub {
     owner = "cnr-isti-vclab";
     repo = "vcglib";
-    rev = "v${version}";
-    sha256 = "0jh8jc8rn7rci8qr3q03q574fk2hsc3rllysck41j8xkr3rmxz2f";
+    rev = version;
+    sha256 = "sha256-XCjbVlgE0C9UagPj4fraA7BNsM6ONKo66aKQ87gQOfE=";
   };
 
   propagatedBuildInputs = [ eigen ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10273,6 +10273,8 @@ with pkgs;
 
   openmvg = callPackage ../applications/science/misc/openmvg { };
 
+  openmvs = callPackage ../applications/science/misc/openmvs { };
+
   openntpd = callPackage ../tools/networking/openntpd { };
 
   openntpd_nixos = openntpd.override {


### PR DESCRIPTION
###### Description of changes

Init of [https://github.com/cdcseacave/openMVS](openMVS) on version 2.1.0

I had to add the patch to CGAL v4 to make it usable as a library, it was only being used on version 5.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
