### PR TITLE
gmic: 3.1.6 → 3.2.0

### DIFF
--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -2,7 +2,6 @@
 , mkDerivation
 , variant ? "standalone"
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , pkg-config
 , ninja
@@ -59,13 +58,13 @@ assert lib.assertMsg (builtins.all (d: d != null) variants.${variant}.extraDeps 
 
 mkDerivation rec {
   pname = "gmic-qt${lib.optionalString (variant != "standalone") "-${variant}"}";
-  version = "3.1.6";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "c-koi";
     repo = "gmic-qt";
     rev = "v.${version}";
-    sha256 = "sha256-/5wDHvJSMgEheg8YV4W40wUiHz25emIoFnGdfO8i92g=";
+    sha256 = "sha256-I5XC7zbDyBPFj4zul9rshoyeVV0hRQQ3aZQzEvYrgdc=";
   };
 
   nativeBuildInputs = [
@@ -93,15 +92,6 @@ mkDerivation rec {
   cmakeFlags = [
     "-DGMIC_QT_HOST=${if variant == "standalone" then "none" else variant}"
     "-DENABLE_SYSTEM_GMIC:BOOL=ON"
-  ];
-
-  patches = [
-    # NOTE: this should be removed when a new version is released.
-    (fetchpatch {
-      name = "fix_filter_translation_scripts.patch";
-      url = "https://github.com/c-koi/gmic-qt/commit/ccb9f29eda239d0c80663593cd90a6548c935b39.patch";
-      sha256 = "sha256-OzuJ6yGuDJweQ+1uin/pmJqZV79bN9E1Zuo+0iciwzg=";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/tools/graphics/gmic/default.nix
+++ b/pkgs/tools/graphics/gmic/default.nix
@@ -25,15 +25,15 @@
 
 stdenv.mkDerivation rec {
   pname = "gmic";
-  version = "3.1.6";
+  version = "3.2.0";
 
   outputs = [ "out" "lib" "dev" "man" ];
 
   src = fetchFromGitHub {
     owner = "dtschump";
     repo = "gmic";
-    rev = "326ea9b7dc320b3624fe660d7b7d81669ca12e6d";
-    sha256 = "RRCzYMN/IXViiUNnacJV3DNpku3hIHQkHbIrtixExT0=";
+    rev = "v.${version}";
+    hash = "sha256-lrIlzxXWqv046G5uRkBQnjvysaIcv+iDKxjuUEJWqcs=";
   };
 
   # TODO: build this from source
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   gmic_stdlib = fetchurl {
     name = "gmic_stdlib.h";
     url = "http://gmic.eu/gmic_stdlib${lib.replaceStrings ["."] [""] version}.h";
-    sha256 = "adObp8s+2TWaS+X/bQSphWRK6o85h+DGwlIDol6XN/4=";
+    hash = "sha256-kWHzA1Dk7F4IROq/gk+RJllry3BABMbssJxhkQ6Cp2M=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Unbreaks on trunk/main branch: https://hydra.nixos.org/eval/1789458?filter=gmic&compare=1789440&full=

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
