### PR TITLE
ecwolf: replace `fetchurl` with `fetchFromBitbucket` & 1.3.3 -> 1.4.0

### DIFF
--- a/pkgs/games/ecwolf/default.nix
+++ b/pkgs/games/ecwolf/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, lib, fetchurl, makeDesktopItem, copyDesktopItems, cmake, pkg-config, zlib, bzip2, libjpeg, SDL, SDL_mixer, gtk2 }:
+{ stdenv, lib, fetchFromBitbucket, makeDesktopItem, copyDesktopItems, cmake, pkg-config, zlib, bzip2, libjpeg, SDL, SDL_mixer, gtk2 }:
 
 stdenv.mkDerivation rec {
   pname = "ecwolf";
   version = "1.3.3";
 
-  src = fetchurl {
-    url = "https://maniacsvault.net/ecwolf/files/ecwolf/1.x/${pname}-${version}-src.tar.xz";
-    sha256 = "1sbdv672dz47la5a5qwmdi1v258k9kc5dkx7cdj2b6gk8nbm2srl";
+  src = fetchFromBitbucket {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "7RjWoABZkN5J7GpG7ie7F3rSrI3Kp3I8KRalZAE92pQ=";
   };
 
   nativeBuildInputs = [ cmake copyDesktopItems pkg-config ];

--- a/pkgs/games/ecwolf/default.nix
+++ b/pkgs/games/ecwolf/default.nix
@@ -1,18 +1,32 @@
-{ stdenv, lib, fetchFromBitbucket, makeDesktopItem, copyDesktopItems, cmake, pkg-config, zlib, bzip2, libjpeg, SDL, SDL_mixer, gtk2 }:
+{ stdenv
+, lib
+, fetchFromBitbucket
+, makeDesktopItem
+, copyDesktopItems
+, cmake
+, pkg-config
+, zlib
+, bzip2
+, libjpeg
+, SDL2
+, SDL2_net
+, SDL2_mixer
+, gtk2
+}:
 
 stdenv.mkDerivation rec {
   pname = "ecwolf";
-  version = "1.3.3";
+  version = "1.4.0";
 
   src = fetchFromBitbucket {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "7RjWoABZkN5J7GpG7ie7F3rSrI3Kp3I8KRalZAE92pQ=";
+    sha256 = "n1G1zvfE1l42fbJ7ZaMdV0QXn45PjMpaaZTDQAOBtYk=";
   };
 
   nativeBuildInputs = [ cmake copyDesktopItems pkg-config ];
-  buildInputs = [ zlib bzip2 libjpeg SDL SDL_mixer gtk2 ];
+  buildInputs = [ zlib bzip2 libjpeg SDL2 SDL2_net SDL2_mixer gtk2 ];
 
   desktopItems = [
     (makeDesktopItem {
@@ -47,6 +61,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    broken = stdenv.isDarwin;
     description = "Enhanched SDL-based port of Wolfenstein 3D for various platforms";
     homepage = "https://maniacsvault.net/ecwolf/";
     license = licenses.gpl2Plus;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This replaces `fetchurl` with `fetchFromBitbucket` to simplify `ecwolf`’s `default.nix` and updates `ecwolf` to 1.4.0. See the individual commit messages for details.

Closes #211388.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
