### PR TITLE
Add OpenPrinting Printer Applications and support libraries (for PPD-less CUPS)

### DIFF
--- a/pkgs/applications/printing/braille-printer-app/default.nix
+++ b/pkgs/applications/printing/braille-printer-app/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, cups
+, liblouis
+}:
+
+stdenv.mkDerivation rec {
+  pname = "braille-printer-app";
+  version = "unstable-2022-11-25";
+
+  src = fetchFromGitHub {
+    owner = "OpenPrinting";
+    repo = pname;
+    rev = "9304787c0797c5d99a5a0d17493c9c2b21865bc8";
+    hash = "sha256-kq1zIqp26I5/4De5PxvDEulhlzn5mQ2HnDNzO6H4Dac=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [
+    cups
+    liblouis
+  ];
+
+  postConfigure = ''
+    # Patch shebangs of generated build scripts
+    patchShebangs filter
+  '';
+
+  makeFlags = [
+    "CUPS_SERVERBIN=$(out)/lib/cups"
+    "CUPS_DATADIR=$(out)/share/cups"
+    "CUPS_SERVERROOT=$(out)/etc/cups"
+  ];
+
+  meta = with lib; {
+    description = "OpenPrinting Braille Printer Application";
+    homepage = "https://github.com/OpenPrinting/braille-printer-app";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tmarkus ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/applications/printing/cups-browsed/default.nix
+++ b/pkgs/applications/printing/cups-browsed/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, cups
+, libcupsfilters
+, libppd
+, glib
+, libresolv
+, withAvahi ? true
+, avahi
+, withLDAP ? true
+, openldap
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cups-browsed";
+  version = "2.0b2";
+
+  src = fetchFromGitHub {
+    owner = "OpenPrinting";
+    repo = "cups-browsed";
+    rev = version;
+    hash = "sha256-IJMavKZVNmniHNC6XbffoP6UzFD9wgzRAKrdsGsrH4E=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [
+    cups
+    glib
+    libppd
+    libcupsfilters
+  ] ++ lib.optionals withAvahi [ avahi ]
+    ++ lib.optionals withLDAP [ openldap ]
+    ++ lib.optionals stdenv.isDarwin [ libresolv ];
+
+  # From weechat:
+  # Fix '_res_9_init: undefined symbol' error
+  CFLAGS = lib.optionalString stdenv.isDarwin "-DBIND_8_COMPAT=1 -lresolv";
+
+  configureFlags = [ "--with-rcdir=no" ]
+    ++ lib.optionals (!withAvahi) [ "--disable-avahi" ]
+    ++ lib.optionals (!withLDAP) [ "--disable-ldap" ];
+
+  makeFlags = [
+    "CUPS_SERVERBIN=$(out)/lib/cups"
+    "CUPS_DATADIR=$(out)/share/cups"
+    "CUPS_SERVERROOT=$(out)/etc/cups"
+  ];
+
+  meta = with lib; {
+    description = "Helper daemon to browse the network for remote CUPS queues and IPP network printers";
+    homepage = "https://github.com/OpenPrinting/cups-browsed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tmarkus ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/applications/printing/lprint/default.nix
+++ b/pkgs/applications/printing/lprint/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, pappl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lprint";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "michaelrsweet";
+    repo = "lprint";
+    rev = "v${version}";
+    hash = "sha256-KgwjYtHbVnAOxzKOevhcohRcsKFsDdYLqrQ2wCc4AVU=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ pappl ];
+
+  meta = with lib; {
+    description = "Label Printer Application";
+    homepage = "https://www.msweet.org/lprint";
+    changelog = "https://github.com/michaelrsweet/lprint/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tmarkus ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/applications/printing/pappl-retrofit/default.nix
+++ b/pkgs/applications/printing/pappl-retrofit/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, cups
+, libcupsfilters
+, libppd
+, pappl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pappl-retrofit";
+  version = "1.0b1";
+
+  src = fetchFromGitHub {
+    owner = "OpenPrinting";
+    repo = "pappl-retrofit";
+    rev = version;
+    hash = "sha256-B39pSTn37iVu3BxlwN/6OmyV9Kvf2KeZnvGGrNeoq1M=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [
+    cups
+    pappl
+    libcupsfilters
+    libppd
+  ];
+
+  postInstall = ''
+    rm -rf $out/var
+  '';
+
+  meta =
+    let homepage = "https://github.com/OpenPrinting/pappl-retrofit";
+    in with lib; {
+      description = "PPD/Classic CUPS driver retro-fit Printer Application Library";
+      inherit homepage;
+      changelog = "${homepage}/releases/tag/${version}";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ tmarkus ];
+      platforms = platforms.unix;
+    };
+}
+

--- a/pkgs/applications/printing/pappl/default.nix
+++ b/pkgs/applications/printing/pappl/default.nix
@@ -1,5 +1,4 @@
 { lib, stdenv, fetchFromGitHub
-, fetchpatch
 , avahi
 , cups
 , gnutls
@@ -13,22 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "pappl";
-  version = "1.1.0";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "michaelrsweet";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-FsmR0fFb9bU9G3oUyJU1eDLcoZ6OQ2//TINlPrW6lU0=";
+    hash = "sha256-96CC6QbtsSvjqQp7VbibvjoqR2HY0pjG4QGZDtw6ok8=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "file-offset-bits-64-linux.patch";
-      url = "https://github.com/michaelrsweet/pappl/commit/7ec4ce4331b6637c54a37943269e05d15ff6dd47.patch";
-      sha256 = "sha256-x5lriopWw6Mn2qjv19flsleEzPMHU4jYWRy0y6hTL5k=";
-    })
-  ];
 
   outputs = [ "out" "dev" ];
 
@@ -63,9 +54,10 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "C-based framework/library for developing CUPS Printer Applications";
-    homepage = "https://github.com/michaelrsweet/pappl";
+    homepage = "https://www.msweet.org/pappl";
+    changelog = "https://github.com/michaelrsweet/pappl/releases/tag/v${version}";
     license = licenses.asl20;
     platforms = platforms.linux; # should also work for darwin, but requires additional work
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ jonringer tmarkus ];
   };
 }

--- a/pkgs/applications/printing/ps-printer-app/default.nix
+++ b/pkgs/applications/printing/ps-printer-app/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, callPackage
+, cups
+, libcupsfilters
+, libppd
+, pappl-retrofit
+, pkg-config
+, pappl
+, systemd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ps-printer-app";
+  version = "unstable-2022-12-08";
+
+  src = fetchFromGitHub {
+    owner = "OpenPrinting";
+    repo = "ps-printer-app";
+    rev = "4a54b0fca81209820a2e6cd9de21d36d9af5b8d9";
+    hash = "sha256-WYie9oXWWJJnV2hgG5+76iWYOfDnIRjYE6uYdRQMGYg=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    cups
+    pappl
+    pappl-retrofit
+    libppd
+    libcupsfilters
+    systemd
+  ];
+
+  installFlags = [
+    "prefix=${placeholder "out"}"
+    "localstatedir=state"
+    "unitdir=${placeholder "out"}/lib/systemd/system"
+  ];
+
+  meta = with lib; {
+    description = "PostScript Printer Application";
+    homepage = "https://github.com/OpenPrinting/ps-printer-app";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tmarkus ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/misc/cups/libcupsfilters-darwin-execvpe.patch
+++ b/pkgs/misc/cups/libcupsfilters-darwin-execvpe.patch
@@ -1,0 +1,13 @@
+--- a/cupsfilters/ghostscript.c	1970-01-01 01:00:01.000000000 +0100
++++ b/cupsfilters/ghostscript.c	2023-02-11 00:28:19.849126731 +0100
+@@ -613,7 +613,9 @@
+     }
+ 
+     // Execute Ghostscript command line ...
+-    execvpe(filename, gsargv, envp);
++    extern char **environ;
++    environ = envp;
++    execvp(filename, gsargv);
+     if (log) log(ld, CF_LOGLEVEL_ERROR,
+ 		 "cfFilterGhostscript: Unable to launch Ghostscript: %s: %s",
+ 		 filename, strerror(errno));

--- a/pkgs/misc/cups/libcupsfilters-syntax-error.patch
+++ b/pkgs/misc/cups/libcupsfilters-syntax-error.patch
@@ -1,0 +1,19 @@
+--- a/cupsfilters/bannertopdf.c	1970-01-01 01:00:01.000000000 +0100
++++ b/cupsfilters/bannertopdf.c	2023-02-11 00:27:27.238967776 +0100
+@@ -797,14 +797,14 @@
+   if (fstat(fileno(s), &st) < 0)
+   {
+     if (log)
+-      log(ld, CF_LOGLEVEL_ERROR, "cfFilterBannerToPDF: Cannot fstat(): %s\n", , strerror(errno));
++      log(ld, CF_LOGLEVEL_ERROR, "cfFilterBannerToPDF: Cannot fstat(): %s\n", strerror(errno));
+     return (1);
+   }
+   fseek(s, 0L, SEEK_SET);
+   if ((buf = malloc(st.st_size + 1)) == NULL)
+   {
+     if (log)
+-      log(ld, CF_LOGLEVEL_ERROR, "cfFilterBannerToPDF: Cannot malloc(): %s\n", , strerror(errno));
++      log(ld, CF_LOGLEVEL_ERROR, "cfFilterBannerToPDF: Cannot malloc(): %s\n", strerror(errno));
+     return (1);
+   }
+   size_t nbytes = fread(buf, 1, st.st_size, s);

--- a/pkgs/misc/cups/libcupsfilters.nix
+++ b/pkgs/misc/cups/libcupsfilters.nix
@@ -1,0 +1,97 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, cups
+, dejavu_fonts
+, dbus
+, freetype
+, fontconfig
+, ghostscript
+, lcms2
+, libexif
+, libjpeg
+, libpng
+, libtiff
+, pkg-config
+, poppler_utils
+, mupdf
+, poppler
+, qpdf
+, withAvahi ? true
+, avahi
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libcupsfilters";
+  version = "2.0b2";
+
+  src = fetchFromGitHub {
+    owner = "OpenPrinting";
+    repo = "libcupsfilters";
+    rev = version;
+    hash = "sha256-jQtBuq3psdSw2UzMtj+wnxguAFPuXWNgSy1Awq5rkFs=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [
+    cups
+    libexif
+    libjpeg
+    libpng
+    libtiff
+    lcms2
+    freetype
+    fontconfig
+    qpdf
+    poppler
+    dbus
+    ghostscript
+    mupdf # used for mutool
+  ] ++ lib.optionals withAvahi [ avahi ];
+
+  configureFlags = [
+    "--with-mutool-path=${lib.getBin mupdf}/bin/mutool"
+    "--with-gs-path=${lib.getBin ghostscript}/bin/gs"
+    "--with-ippfind-path=${lib.getBin cups}/bin/ippfind"
+    "--with-shell=${stdenv.shell}"
+    "--with-test-font-path=${dejavu_fonts}/share/fonts/truetype/DejaVuSans.ttf"
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+  ] ++ lib.optionals (!withAvahi) [ "--disable-avahi" ];
+
+  patches = [
+    # Patch upstream syntax error when !HAVE_OPEN_MEMSTREAM (on darwin)
+    ./libcupsfilters-syntax-error.patch
+  ] ++ lib.optionals (stdenv.hostPlatform.libc != "glibc") [
+    # execvpe is a GNU extension
+    ./libcupsfilters-darwin-execvpe.patch
+  ];
+
+  makeFlags = [
+    "CUPS_SERVERBIN=$(out)/lib/cups"
+    "CUPS_DATADIR=$(out)/share/cups"
+    "CUPS_SERVERROOT=$(out)/etc/cups"
+  ];
+
+  postConfigure = ''
+    # Ensure that bannertopdf can find the PDF templates in
+    # $out. (By default, it assumes that cups and cups-filters are
+    # installed in the same prefix.)
+    substituteInPlace config.h --replace ${cups.out}/share/cups/data $out/share/cups/data
+  '';
+
+  doCheck = true;
+
+  meta =
+    let homepage = "https://github.com/OpenPrinting/libcupsfilters";
+    in with lib; {
+      description = "Support library for filter functions";
+      inherit homepage;
+      changelog = "${homepage}/releases/tag/${version}";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ tmarkus ];
+      platforms = platforms.unix;
+    };
+}
+

--- a/pkgs/misc/cups/libppd-libc-compat.patch
+++ b/pkgs/misc/cups/libppd-libc-compat.patch
@@ -1,0 +1,13 @@
+--- result/ppd/ppd-collection.cxx	1970-01-01 01:00:01.000000000 +0100
++++ mod/ppd/ppd-collection.cxx	2023-02-11 00:16:33.057044216 +0100
+@@ -24,6 +24,10 @@
+ #include "array-private.h"
+ #include <regex.h>
+ #include <sys/wait.h>
++#include <signal.h>
++#include <libgen.h>
++
++extern char **environ;
+ 
+ 
+ //

--- a/pkgs/misc/cups/libppd-zlib.patch
+++ b/pkgs/misc/cups/libppd-zlib.patch
@@ -1,0 +1,25 @@
+--- a/Makefile.am	1970-01-01 01:00:01.000000000 +0100
++++ b/Makefile.am	2023-02-11 00:18:59.837436258 +0100
+@@ -117,9 +117,11 @@
+ 	$(pkgppdinclude_DATA) \
+ 	$(pkgppddefs_DATA)
+ libppd_la_LIBADD = \
++	$(ZLIB_LIBS) \
+ 	$(LIBCUPSFILTERS_LIBS) \
+ 	$(CUPS_LIBS)
+ libppd_la_CFLAGS = \
++	$(ZLIB_CFLAGS) \
+ 	$(LIBCUPSFILTERS_CFLAGS) \
+ 	$(CUPS_CFLAGS)
+ libppd_la_LDFLAGS = \
+--- a/configure.ac	1970-01-01 01:00:01.000000000 +0100
++++ b/configure.ac	2023-02-11 00:19:48.327581295 +0100
+@@ -124,6 +124,8 @@
+ # ========================
+ PKG_CHECK_MODULES([LIBCUPSFILTERS], [libcupsfilters])
+ 
++PKG_CHECK_MODULES([ZLIB], [zlib])
++
+ # =======================================================
+ # Check for whether we want to install the ppdc utilities
+ # =======================================================

--- a/pkgs/misc/cups/libppd.nix
+++ b/pkgs/misc/cups/libppd.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, cups
+, libcupsfilters
+, ghostscript
+, pkg-config
+, poppler_utils
+, mupdf
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libppd";
+  version = "2.0b2";
+
+  src = fetchFromGitHub {
+    owner = "OpenPrinting";
+    repo = "libppd";
+    rev = version;
+    hash = "sha256-4KRJfzK/xeWlXmhUOlvGHsMmKqF6R4e5BiIA+h2UTII=";
+  };
+
+  configureFlags = [
+    "--with-mutool-path=${lib.getBin mupdf}/bin/mutool"
+    "--with-pdftops=pdftops"
+    "--with-pdftops-path=${lib.getBin poppler_utils}/bin/pdftops"
+    "--with-gs-path=${lib.getBin ghostscript}/bin/gs"
+    "--with-pdftocairo-path=${lib.getBin poppler_utils}/bin/pdftocairo"
+    "--with-ippfind-path=${lib.getBin cups}/bin/ippfind"
+    "--disable-acroread"
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+  ];
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [
+    cups
+    ghostscript
+    poppler_utils
+    mupdf
+    libcupsfilters
+    zlib
+  ];
+
+  # Fix missing includes on darwin
+  patches = lib.optionals (stdenv.hostPlatform.libc != "glibc") [
+    ./libppd-libc-compat.patch
+    ./libppd-zlib.patch
+  ];
+
+  postInstall = ''
+    rmdir $out/bin
+  '';
+
+  meta =
+    let homepage = "https://github.com/OpenPrinting/libppd";
+    in with lib; {
+      description = "Legacy support library for PPD files";
+      inherit homepage;
+      changelog = "${homepage}/releases/tag/${version}";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ tmarkus ];
+      platforms = platforms.unix;
+    };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30224,6 +30224,8 @@ with pkgs;
 
   popura = callPackage ../tools/networking/popura {};
 
+  ps-printer-app = callPackage ../applications/printing/ps-printer-app { };
+
   pureref = callPackage ../applications/graphics/pureref { };
 
   shepherd = nodePackages."@nerdwallet/shepherd";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37389,6 +37389,8 @@ with pkgs;
 
   cups-filters = callPackage ../misc/cups/filters.nix { };
 
+  libcupsfilters = callPackage ../misc/cups/libcupsfilters.nix { };
+
   cups-pk-helper = callPackage ../misc/cups/cups-pk-helper.nix { };
 
   cups-kyocera = callPackage ../misc/cups/drivers/kyocera {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28497,6 +28497,8 @@ with pkgs;
 
   bottles-unwrapped = callPackage ../applications/misc/bottles { };
 
+  braille-printer-app = callPackage ../applications/printing/braille-printer-app { };
+
   brave = callPackage ../applications/networking/browsers/brave { };
 
   break-time = callPackage ../applications/misc/break-time {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37391,6 +37391,8 @@ with pkgs;
 
   libcupsfilters = callPackage ../misc/cups/libcupsfilters.nix { };
 
+  libppd = callPackage ../misc/cups/libppd.nix { };
+
   cups-pk-helper = callPackage ../misc/cups/cups-pk-helper.nix { };
 
   cups-kyocera = callPackage ../misc/cups/drivers/kyocera {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30184,6 +30184,8 @@ with pkgs;
 
   levant = callPackage ../applications/networking/cluster/levant { };
 
+  lprint = callPackage ../applications/printing/lprint { };
+
   lwm = callPackage ../applications/window-managers/lwm { };
 
   marker = callPackage ../applications/editors/marker { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10666,6 +10666,8 @@ with pkgs;
 
   pappl = callPackage ../applications/printing/pappl { };
 
+  pappl-retrofit = callPackage ../applications/printing/pappl-retrofit { };
+
   par2cmdline = callPackage ../tools/networking/par2cmdline { };
 
   parallel = callPackage ../tools/misc/parallel { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28789,6 +28789,10 @@ with pkgs;
 
   cuneiform = callPackage ../tools/graphics/cuneiform {};
 
+  cups-browsed = callPackage ../applications/printing/cups-browsed {
+    inherit (darwin) libresolv;
+  };
+
   curseradio = callPackage ../applications/audio/curseradio { };
 
   curtail = callPackage ../applications/graphics/curtail { };


### PR DESCRIPTION
###### Description of changes

CUPS is in the process of moving over to a new architecture based on Printer Applications, where CUPS itself doesn't directly support PPD files anymore.

See the [libcupsfilters README](https://github.com/OpenPrinting/libcupsfilters):
> In the New Architecture for printing we switch to an all-IPP workflow with PPD files and printer driver executables being abolished and classic CUPS printer drivers replaced by Printer Applications (software emulation of driverless IPP printers).
> To conserve the functionality of the CUPS filters which got developed over the last 20+ years into a PPD-less, IPP-driven world without having to maintain and include the legacy PPD support in OS distributions and other system environments, the original cups-filters package got split into 5 separate packages: libcupsfilters, libppd, cups-filters, braille-printer-app, and cups-browsed, with libcupsfilters and braille-printer-app not containing PPD file support code any more and cups-browsed being planned to drop explicit use of PPD files.

Further information can be found in [blog posts](https://openprinting.github.io/achievements) by the OpenPrinting project lead here, for example:
* [cups-filters](https://openprinting.github.io/achievements/#cups-filters)
* [cups-browsed](https://openprinting.github.io/achievements/#cups-browsed)
* [All free drivers in a PPD-less world - OR - All free drivers in Snaps](https://openprinting.github.io/achievements/#all-free-drivers-in-a-ppd-less-world---or---all-free-drivers-in-snaps)

This PR adds the following support libraries:
* `libcupsfilters`
* `libppd`
* `pappl-retrofit`
* (update of existing library `pappl` to 1.3)

And the following printer applications:
* `braille-printer-app`
* `cups-browsed`
* `ps-printer-app`
* `lprint` (could be separated, depends only on pappl)

Since these packages have various interrelated dependencies, I thought it would be a good idea to add them in one PR to simplify the review.

Note: Most added packages are declared as beta-level by upstream. Also, I haven't tested the new packages thoroughly.
This PR does not touch the existing CUPS functionality.

The directory structure is a bit of a mess at the moment. I put the printer applications in `pkgs/applications/printing` (where only `pappl` currently resides), but perhaps it makes more sense to place them somewhere else.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
