### PR TITLE
fxload: changed $out/sbin  to $out/bin

### DIFF
--- a/pkgs/os-specific/linux/fxload/default.nix
+++ b/pkgs/os-specific/linux/fxload/default.nix
@@ -15,8 +15,8 @@ stdenv.mkDerivation rec {
 
   # fxload binary exist inside the `examples/bin` directory of `libusb1`
   postFixup = ''
-    mkdir -p $out/sbin
-    ln -s ${passthru.libusb}/examples/bin/fxload $out/sbin/fxload
+    mkdir -p $out/bin
+    ln -s ${passthru.libusb}/examples/bin/fxload $out/bin/fxload
   '';
 
   passthru.libusb = libusb1.override { withExamples = true; };


### PR DESCRIPTION
looks like common practice is to put a $out/sbin symlink to $out/bin. the `fxload` command was not available if only puts on $out/sbin. This will fix it. The real issue I observed was that there was no `/run/current-system/sw/sbin` on `$PATH` but i think there is a fundamental reason why it doesn’t exist hence this patch until i learn more.