### PR TITLE
nextcloud25Packages.apps.recognize: init at 3.3.6

### DIFF
--- a/pkgs/servers/nextcloud/packages/24.json
+++ b/pkgs/servers/nextcloud/packages/24.json
@@ -140,11 +140,21 @@
     ]
   },
   "polls": {
-    "sha256": "b6ef0e8b34cdb5169341e30340bc9cefaa1254a1a6020e951f86e828f8591a11",
-    "url": "https://github.com/nextcloud/polls/releases/download/v3.8.3/polls.tar.gz",
-    "version": "3.8.3",
+    "sha256": "0qdm0hnljkv0df1s929awyjj1gsp3d6xv9llr52cxv66kkfx086y",
+    "url": "https://github.com/nextcloud/polls/releases/download/v3.8.4/polls.tar.gz",
+    "version": "3.8.4",
     "description": "A polls app, similar to Doodle/Dudle with the possibility to restrict access (members, certain groups/users, hidden and public).",
     "homepage": "https://github.com/nextcloud/polls",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "recognize": {
+    "sha256": "0wy59q4774dcifywamsm9hbwnkvr6pkqnqwbxyn2ci8l860va62s",
+    "url": "https://github.com/nextcloud/recognize/releases/download/v3.0.0-beta.3/recognize-3.0.0-beta.3.tar.gz",
+    "version": "3.0.0-beta.3",
+    "description": "This app goes through your media collection and adds fitting tags, automatically categorizing your photos and music.\n\n* 📷 👪 Recognizes faces from contact photos\n* 📷 🏔 Recognizes animals, landscapes, food, vehicles, buildings and other objects\n* 📷 🗼 Recognizes landmarks and monuments\n* 👂 🎵 Recognizes music genres\n* ⚡ Tagging works via Nextcloud's Collaborative Tags, allowing access by any of your apps\n  * 👂 listen to your tagged music with the audioplayer app\n  * 📷 view your tagged photos with the photos app\n\nAfter installation, you can enable tagging in the admin settings.\n\nRequirements:\n- PHP 7.4 and above\n- App \"collaborative tags\" enabled\n- For native speed:\n  - Processor: x86 64-bit (with support for AVX instructions)\n  - System with glibc (usually the norm on Linux; Alpine linux and FreeBSD are *not* such systems)\n- For sub-native speed (using JavaScript mode)\n  - Processor: x86 64-bit, arm64, armv7l (no AVX needed)\n  - System with glibc or musl (incl. Alpine linux)\n- ~4GB of free RAM (if you're cutting it close, make sure you have some swap available)\n\nThe app does not send any sensitive data to cloud providers or similar services. All processing is done on your Nextcloud machine, using Tensorflow.js running in Node.js.",
+    "homepage": "https://github.com/marcelklehr/recognize",
     "licenses": [
       "agpl"
     ]

--- a/pkgs/servers/nextcloud/packages/25.json
+++ b/pkgs/servers/nextcloud/packages/25.json
@@ -120,11 +120,21 @@
     ]
   },
   "polls": {
-    "sha256": "1amywiw91acp4g90wazmqmnw51s7z6rf27bdrzxrcqryd8igsniq",
-    "url": "https://github.com/nextcloud/polls/releases/download/v4.1.0-beta4/polls.tar.gz",
-    "version": "4.1.0-beta4",
+    "sha256": "0cm57d2nf7hc2wrwsss4b7zy17qrhqzj5p3wv7kwfk8i1cbzawx5",
+    "url": "https://github.com/nextcloud/polls/releases/download/v4.1.0-beta6/polls.tar.gz",
+    "version": "4.1.0-beta6",
     "description": "A polls app, similar to Doodle/Dudle with the possibility to restrict access (members, certain groups/users, hidden and public).",
     "homepage": "https://github.com/nextcloud/polls",
+    "licenses": [
+      "agpl"
+    ]
+  },
+  "recognize": {
+    "sha256": "07jgkkb4iy3q6wr9xfp6y41z8vksc742m0snzvdkvnhyxvadi9nz",
+    "url": "https://github.com/nextcloud/recognize/releases/download/v3.3.6/recognize-3.3.6.tar.gz",
+    "version": "3.3.6",
+    "description": "This app goes through your media collection and adds fitting tags, automatically categorizing your photos and music.\n\n* 📷 👪 Recognizes faces from contact photos\n* 📷 🏔 Recognizes animals, landscapes, food, vehicles, buildings and other objects\n* 📷 🗼 Recognizes landmarks and monuments\n* 👂 🎵 Recognizes music genres\n* ⚡ Tagging works via Nextcloud's Collaborative Tags, allowing access by any of your apps\n  * 👂 listen to your tagged music with the audioplayer app\n  * 📷 view your tagged photos with the photos app\n\nAfter installation, you can enable tagging in the admin settings.\n\nRequirements:\n- PHP 7.4 and above\n- App \"collaborative tags\" enabled\n- For native speed:\n  - Processor: x86 64-bit (with support for AVX instructions)\n  - System with glibc (usually the norm on Linux; Alpine linux and FreeBSD are *not* such systems)\n- For sub-native speed (using JavaScript mode)\n  - Processor: x86 64-bit, arm64, armv7l (no AVX needed)\n  - System with glibc or musl (incl. Alpine linux)\n- ~4GB of free RAM (if you're cutting it close, make sure you have some swap available)\n\nThe app does not send any sensitive data to cloud providers or similar services. All processing is done on your Nextcloud machine, using Tensorflow.js running in Node.js.",
+    "homepage": "https://github.com/marcelklehr/recognize",
     "licenses": [
       "agpl"
     ]

--- a/pkgs/servers/nextcloud/packages/nextcloud-apps.json
+++ b/pkgs/servers/nextcloud/packages/nextcloud-apps.json
@@ -14,6 +14,7 @@
 , "notes"
 , "onlyoffice"
 , "polls"
+, "recognize"
 , "registration"
 , "spreed"
 , "tasks"


### PR DESCRIPTION
I get
```
Unable to open "/nix/store/ig7li2s4pyvicprhd50wa08nsv880d7z-source-patched/bin/x64.tar.gz" using mode "w+": fopen(/nix/store/ig7li2s4pyvicprhd50wa08nsv880d7z-source-patched/bin/x64.tar.gz): Failed to open stream: Read-only file system`
Downloading of node binary failed
```
originating in https://github.com/nextcloud/recognize/blob/v3.3.6/lib/Migration/InstallDeps.php when adding it to `extraApps`.

Is there a standard way to declaratively change settings in the databse? In particular, I want to set the path to the Node.js binary. See https://github.com/nextcloud/recognize/blob/v3.3.6/lib/Migration/InstallDeps.php#L76.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
