### PR TITLE
nixos/make-options-doc: use dummy store for XML conversion

### DIFF
--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -157,9 +157,8 @@ in rec {
   # The actual generation of the xml file is done in nix purely for the convenience
   # of not having to generate the xml some other way
   optionsXML = pkgs.runCommand "options.xml" {} ''
-    export NIX_STORE_DIR=$TMPDIR/store
-    export NIX_STATE_DIR=$TMPDIR/state
     ${pkgs.nix}/bin/nix-instantiate \
+      --store dummy:// \
       --eval --xml --strict ${./optionsJSONtoXML.nix} \
       --argstr file ${optionsJSON}/share/doc/nixos/options.json \
       > "$out"


### PR DESCRIPTION
Mirror of https://gitlab.com/rycee/nmd/-/merge_requests/10

`dummy://` was added in Nix 2.4, but since we use `pkgs.nix` directly this is not an issue. https://nixos.org/manual/nix/unstable/release-notes/rl-2.4.html