### PR TITLE
python311Packages.bip_utils: fix build

### DIFF
--- a/pkgs/development/python-modules/bip_utils/default.nix
+++ b/pkgs/development/python-modules/bip_utils/default.nix
@@ -41,6 +41,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
+    changelog = "https://github.com/ebellocchia/bip_utils/blob/${src.rev}/CHANGELOG.md";
     description = "Implementation of BIP39, BIP32, BIP44, BIP49 and BIP84 for wallet seeds, keys and addresses generation";
     homepage = "https://github.com/ebellocchia/bip_utils";
     license = with lib.licenses; [ mit ];

--- a/pkgs/development/python-modules/bip_utils/default.nix
+++ b/pkgs/development/python-modules/bip_utils/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , pythonOlder
 , ecdsa
-, pysha3
 , coincurve
 , pynacl
 , crcmod
@@ -28,7 +27,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     ecdsa
-    pysha3
     cbor2
     pynacl
     coincurve

--- a/pkgs/development/python-modules/py-sr25519-bindings/default.nix
+++ b/pkgs/development/python-modules/py-sr25519-bindings/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "py-sr25519-bindings";
-  version = "0.2.0";
+  version = "0.1.5";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -19,8 +19,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "polkascan";
     repo = "py-sr25519-bindings";
-    rev = "refs/tags/v${version}";
-    sha256 = "sha256-Lu3J0+YeQHHKItOZTT24DlQAUJuE9fd+py6Eb46/MSE=";
+    rev = "a97398b386c10ebe0a1f6c45dea466add0d407ce";
+    sha256 = "sha256-RJfwWeD82J5QqY+qq2bC3vlqT75jUwhTXuIsza4qUzk=";
   };
 
   cargoDeps = rustPlatform.importCargoLock {


### PR DESCRIPTION
@SuperSandro2000 coincurve is still broken

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
