### PR TITLE
python310Packages.johnnycanencrypt: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/development/python-modules/johnnycanencrypt/default.nix
+++ b/pkgs/development/python-modules/johnnycanencrypt/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchFromGitHub
+, fetchPypi
 , buildPythonPackage
 , rustPlatform
 , llvmPackages
@@ -8,35 +8,30 @@
 , pcsclite
 , nettle
 , httpx
-, numpy
 , pytestCheckHook
 , pythonOlder
+, vcrpy
 , PCSC
 , libiconv
 }:
 
 buildPythonPackage rec {
   pname = "johnnycanencrypt";
-  version = "0.11.0";
-  disabled = pythonOlder "3.7";
+  version = "0.12.0";
+  disabled = pythonOlder "3.8";
 
-  src = fetchFromGitHub {
-    owner = "kushaldas";
-    repo = "johnnycanencrypt";
-    rev = "v${version}";
-    hash = "sha256-YhuYejxuKZEv1xQ1fQcXSkt9I80iJOJ6MecG622JJJo=";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-aGhM/uyYE7l0h6L00qp+HRUVaj7s/tnHWIHJpLAkmR4=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit patches src;
+    inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-r2NU1e3yeZDLOBy9pndGYM3JoH6BBKQkXMLsJR6PTRs=";
+    hash = "sha256-fcwDxkUFtA6LS77xdLktNnZJXmyl/ZzArvIW69SPpmI=";
   };
 
   format = "pyproject";
-
-  # https://github.com/kushaldas/johnnycanencrypt/issues/125
-  patches = [ ./Cargo.lock.patch ];
 
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 
@@ -61,31 +56,23 @@ buildPythonPackage rec {
     libiconv
   ];
 
-  # Needed b/c need to check AFTER python wheel is installed (using Rust Build, not buildPythonPackage)
-  doCheck = false;
-  doInstallCheck = true;
-
-  installCheckInputs = [
+  checkInputs = [
     pytestCheckHook
-    numpy
+    vcrpy
   ];
 
   preCheck = ''
-    export TESTDIR=$(mktemp -d)
-    cp -r tests/ $TESTDIR
-    pushd $TESTDIR
-  '';
-
-  postCheck = ''
-    popd
+    # import from $out
+    rm -r johnnycanencrypt
   '';
 
   pythonImportsCheck = [ "johnnycanencrypt" ];
 
   meta = with lib; {
     homepage = "https://github.com/kushaldas/johnnycanencrypt";
+    changelog = "https://github.com/kushaldas/johnnycanencrypt/blob/v${version}/changelog.md";
     description = "Python module for OpenPGP written in Rust";
-    license = licenses.gpl3Plus;
+    license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ _0x4A6F ];
   };
 }


### PR DESCRIPTION

###### Description of changes
https://github.com/kushaldas/johnnycanencrypt/releases/tag/v0.12.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
