### PR TITLE
noto-fonts: 20201206-phase3 -> 23.4.1

### DIFF
--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -24,8 +24,6 @@ let
     Google’s answer to tofu. The name noto is to convey the idea that
     Google’s goal is to see “no more tofu”.  Noto has multiple styles and
     weights, and freely available to all.
-
-    This package also includes the Arimo, Cousine, and Tinos fonts.
   '';
 in
 rec {
@@ -37,13 +35,13 @@ rec {
     }:
     stdenvNoCC.mkDerivation rec {
       inherit pname;
-      version = "20201206-phase3";
+      version = "23.4.1";
 
       src = fetchFromGitHub {
-        owner = "googlefonts";
-        repo = "noto-fonts";
-        rev = "v${version}";
-        hash = "sha256-x60RvCRFLoGe0CNvswROnDkIsUFbWH+/laN8q2qkUPk=";
+        owner = "notofonts";
+        repo = "notofonts.github.io";
+        rev = "noto-monthly-release-${version}";
+        hash = "sha256-hiBbhcwktacuoYJnZcsh7Aej5QIrBNkqrel2NhjNjCU=";
       };
 
       _variants = map (variant: builtins.replaceStrings [ " " ] [ "" ] variant) variants;
@@ -56,16 +54,10 @@ rec {
         # TODO: install OpenType, variable versions?
         local out_ttf=$out/share/fonts/truetype/noto
       '' + (if _variants == [ ] then ''
-        install -m444 -Dt $out_ttf archive/unhinted/*/*-${weights}.ttf
-        install -m444 -Dt $out_ttf archive/hinted/*/*-${weights}.ttf
-        install -m444 -Dt $out_ttf unhinted/*/*/*-${weights}.ttf
-        install -m444 -Dt $out_ttf hinted/*/*/*-${weights}.ttf
+        install -m444 -Dt $out_ttf fonts/*/hinted/ttf/*-${weights}.ttf
       '' else ''
         for variant in $_variants; do
-          install -m444 -Dt $out_ttf archive/unhinted/$variant/*-${weights}.ttf
-          install -m444 -Dt $out_ttf archive/hinted/$variant/*-${weights}.ttf
-          install -m444 -Dt $out_ttf unhinted/*/$variant/*-${weights}.ttf
-          install -m444 -Dt $out_ttf hinted/*/$variant/*-${weights}.ttf
+          install -m444 -Dt $out_ttf fonts/$variant/hinted/ttf/*-${weights}.ttf
         done
       '');
 
@@ -75,7 +67,7 @@ rec {
         inherit longDescription;
         license = licenses.ofl;
         platforms = platforms.all;
-        maintainers = with maintainers; [ mathnerd314 emily ];
+        maintainers = with maintainers; [ mathnerd314 emily jopejoe1 ];
       };
     };
 
@@ -129,8 +121,6 @@ rec {
     variants = [
       "Noto Sans"
       "Noto Serif"
-      "Noto Sans Display"
-      "Noto Serif Display"
       "Noto Sans Mono"
       "Noto Music"
       "Noto Sans Symbols"

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1114,6 +1114,7 @@ mapAliases ({
   nomad_1_1 = throw "nomad_1_1 has been removed because it's outdated. Use a a newer version instead"; # Added 2022-05-22
   nordic-polar = throw "nordic-polar was removed on 2021-05-27, now integrated in nordic"; # Added 2021-05-27
   noto-fonts-cjk = noto-fonts-cjk-sans; # Added 2021-12-16
+  noto-fonts-extra = noto-fonts; # Added 2023-04-08
   nottetris2 = throw "nottetris2 was removed because it is unmaintained by upstream and broken"; # Added 2022-01-15
   now-cli = throw "now-cli has been replaced with nodePackages.vercel"; # Added 2021-08-05
   ntdb = throw "ntdb has been removed: abandoned by upstream"; # Added 2022-04-21

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28168,8 +28168,7 @@ with pkgs;
     noto-fonts-cjk-sans
     noto-fonts-cjk-serif
     noto-fonts-emoji
-    noto-fonts-emoji-blob-bin
-    noto-fonts-extra;
+    noto-fonts-emoji-blob-bin;
 
   nuclear = callPackage ../applications/audio/nuclear { };
 


### PR DESCRIPTION
###### Description of changes
Changes the GitHub repo to https://github.com/notofonts/notofonts.github.io and update the script to handle the new file structure and added my self as maintainer.

A list of updated fonts can be found at https://github.com/notofonts/notofonts.github.io/commits/NotoSerifKhitanSmallScript-v1.000/fonts and specific changes to one font can be found in the font specific repos at https://github.com/notofonts.

Some highlights include:

- Added fonts for Khitan-Small-Script
- Added Some Unicode 14.0 to NotoSans
- Split NotoSansSyriac into multiple fonts
- and more

After some changes, it now closes the following:
closes #170355 
closes #166953
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
