### PR TITLE
Espressobin firmware

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16367,4 +16367,10 @@
     github = "franzmondlichtmann";
     githubId = 105480088;
   };
+  ManoftheSea = {
+    name = "Derek LaHousse";
+    email = "dlahouss@mtu.edu";
+    github = "ManoftheSea";
+    githubId = 8259405;
+  };
 }

--- a/pkgs/misc/mox-boot-builder/default.nix
+++ b/pkgs/misc/mox-boot-builder/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, fetchgit
+, buildPackages
+, pkgsCross
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mox-boot-builder";
+  version = "v2022.08.30";
+  src = fetchgit {
+    url = "https://gitlab.nic.cz/turris/mox-boot-builder.git";
+    rev = "0290b2cd9e14041ef7bcd267840f30d6c0a92ceb";
+    hash = "sha256-ZlbgJj/KgiDcF7Jl+wdNJi7iSivBIGF0W1qbrcIWBvk=";
+    fetchSubmodules = false;
+  };
+
+  installDir = "$out";
+
+  nativeBuildInputs = [ pkgsCross.arm-embedded.stdenv.cc ];
+
+  makeFlags = [
+    "CROSS_CM3=${buildPackages.gcc-arm-embedded}/bin/arm-none-eabi-"
+    "wtmi_app.bin"
+  ];
+
+  filesToInstall = ["wtmi_app.bin"];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p ${installDir}
+    cp ${lib.concatStringsSep " " filesToInstall} ${installDir}
+
+    runHook postInstall
+  '';
+  meta = with lib; {
+    description = "BL32 firmware for A3700 SOCs";
+    longDescription = ''
+        This package contains firmware source code for a3700 chips by Marvell
+    '';
+    license = licenses.unfreeRedistributableFirmware;
+    maintainers = [];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/misc/mox-boot-builder/default.nix
+++ b/pkgs/misc/mox-boot-builder/default.nix
@@ -1,36 +1,36 @@
 { stdenv
 , lib
-, fetchgit
+, fetchFromGitLab
 , buildPackages
-, pkgsCross
 }:
 
 stdenv.mkDerivation rec {
-  pname = "mox-boot-builder";
-  version = "v2022.08.30";
-  src = fetchgit {
-    url = "https://gitlab.nic.cz/turris/mox-boot-builder.git";
+  pname = "nic-cz-armada-bl32-unsigned-firmware";
+  version = "v2022.06.11-7-g0290b2c";
+  src = fetchFromGitLab {
+    domain = "gitlab.nic.cz";
+    owner = "turris";
+    repo = "mox-boot-builder";
     rev = "0290b2cd9e14041ef7bcd267840f30d6c0a92ceb";
     hash = "sha256-ZlbgJj/KgiDcF7Jl+wdNJi7iSivBIGF0W1qbrcIWBvk=";
     fetchSubmodules = false;
   };
 
-  installDir = "$out";
-
-  nativeBuildInputs = [ pkgsCross.arm-embedded.stdenv.cc ];
+  nativeBuildInputs = [ 
+    buildPackages.stdenv.cc
+  ];
 
   makeFlags = [
     "CROSS_CM3=${buildPackages.gcc-arm-embedded}/bin/arm-none-eabi-"
+    "WTMI_VERSION=${version}"
     "wtmi_app.bin"
   ];
-
-  filesToInstall = ["wtmi_app.bin"];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p ${installDir}
-    cp ${lib.concatStringsSep " " filesToInstall} ${installDir}
+    mkdir -p $out
+    cp wtmi_app.bin $out
 
     runHook postInstall
   '';
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
         This package contains firmware source code for a3700 chips by Marvell
     '';
     license = licenses.unfreeRedistributableFirmware;
-    maintainers = [];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ manofthesea ];
+    platforms = ["aarch64-linux"];
   };
 }

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -194,6 +194,17 @@ in {
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
+  ubootEspressobin = buildUBoot rec {
+    defconfig = "mvebu_espressobin-88f3720_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    filesToInstall = ["u-boot.bin"];
+    src = fetchurl {
+      url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2";
+      sha256 = "03wm651ix783s4idj223b0nm3r6jrdnrxs1ncs8s128g72nknhk9";
+    };
+    version = "2023.01";
+  };
+
   ubootGuruplug = buildUBoot {
     defconfig = "guruplug_defconfig";
     extraMeta.platforms = ["armv5tel-linux"];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38691,4 +38691,6 @@ with pkgs;
   tubekit-unwrapped = callPackage ../applications/networking/cluster/tubekit { };
 
   resgate = callPackage ../servers/resgate { };
+
+  mox-boot-builder = callPackage ../misc/mox-boot-builder { };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26454,6 +26454,7 @@ with pkgs;
     ubootAmx335xEVM
     ubootClearfog
     ubootCubieboard2
+    ubootEspressobin
     ubootGuruplug
     ubootJetsonTK1
     ubootLibreTechCC


### PR DESCRIPTION
###### Description of changes

Update uboot package to build for the Espressobin SBC

Add mox-boot-builder package to build a trusted environment program for Marvell a3k SOCs

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Platform firmware for this Marvell SOC seems to build backward from the Rockchip method.  Here, u-boot is built without referencing arm-trusted-firmware, and then armTrustedFirmwareA3700 would bring u-boot.bin, wtmi_app.bin, and a few other files that I haven't understood how to bring into Nix.  U-boot is bumped to 2023.01 because there are specific fixes for espressobin that aren't in earlier versions.