### PR TITLE
Fixes for overrideAttrs (split from #201734)

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -213,7 +213,14 @@ rec {
             outputSpecified = true;
             drvPath = assert condition; drv.${outputName}.drvPath;
             outPath = assert condition; drv.${outputName}.outPath;
-          };
+          } //
+            # TODO: give the derivation control over the outputs.
+            #       `overrideAttrs` may not be the only attribute that needs
+            #       updating when switching outputs.
+            lib.optionalAttrs (passthru?overrideAttrs) {
+              # TODO: also add overrideAttrs when overrideAttrs is not custom, e.g. when not splicing.
+              overrideAttrs = f: (passthru.overrideAttrs f).${outputName};
+            };
         };
 
       outputsList = map outputToAttrListElement outputs;

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -59,6 +59,8 @@ with pkgs;
 
   nixos-functions = callPackage ./nixos-functions {};
 
+  overriding = callPackage ./overriding.nix { };
+
   patch-shebangs = callPackage ./patch-shebangs {};
 
   texlive = callPackage ./texlive {};

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -1,0 +1,23 @@
+{ lib, pkgs, stdenvNoCC }:
+
+let
+  tests =
+    let
+      p = pkgs.python3Packages.xpybutil.overridePythonAttrs (_: { dontWrapPythonPrograms = true; });
+    in
+    [
+      ({
+        name = "overridePythonAttrs";
+        expr = !lib.hasInfix "wrapPythonPrograms" p.postFixup;
+        expected = true;
+      })
+    ];
+in
+
+stdenvNoCC.mkDerivation {
+  name = "test-overriding";
+  passthru = { inherit tests; };
+  buildCommand = ''
+    touch $out
+  '' + lib.concatMapStringsSep "\n" (t: "([[ ${lib.boolToString t.expr} == ${lib.boolToString t.expected} ]] && echo '${t.name} success') || (echo '${t.name} fail' && exit 1)") tests;
+}

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -11,7 +11,40 @@ let
         expr = !lib.hasInfix "wrapPythonPrograms" p.postFixup;
         expected = true;
       })
+      ({
+        name = "repeatedOverrides-pname";
+        expr = repeatedOverrides.pname == "a-better-hello-with-blackjack";
+        expected = true;
+      })
+      ({
+        name = "repeatedOverrides-entangled-pname";
+        expr = repeatedOverrides.entangled.pname == "a-better-figlet-with-blackjack";
+        expected = true;
+      })
     ];
+
+  addEntangled = origOverrideAttrs: f:
+    origOverrideAttrs (
+      lib.composeExtensions f (self: super: {
+        passthru = super.passthru // {
+          entangled = super.passthru.entangled.overrideAttrs f;
+          overrideAttrs = addEntangled self.overrideAttrs;
+        };
+      })
+    );
+
+  entangle = pkg1: pkg2: pkg1.overrideAttrs (self: super: {
+    passthru = super.passthru // {
+      entangled = pkg2;
+      overrideAttrs = addEntangled self.overrideAttrs;
+    };
+  });
+
+  example = entangle pkgs.hello pkgs.figlet;
+
+  overrides1 = example.overrideAttrs (_: super: { pname = "a-better-${super.pname}"; });
+
+  repeatedOverrides = overrides1.overrideAttrs (_: super: { pname = "${super.pname}-with-blackjack"; });
 in
 
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION

###### Description of changes

Fixes from #201734 that don't come with a significant performance impact.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
