### PR TITLE
gcc: use as(1) from binutils with LLVM bintools

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -25,6 +25,7 @@
 , nativeTools, noLibc ? false, nativeLibc, nativePrefix ? ""
 , propagateDoc ? bintools != null && bintools ? man
 , extraPackages ? [], extraBuildCommands ? ""
+, isGNU ? bintools.isGNU or false, isLLVM ? bintools.isLLVM or false
 , buildPackages ? {}
 , targetPackages ? {}
 , useMacosReexportHack ? false
@@ -108,7 +109,7 @@ stdenv.mkDerivation {
 
   passthru = {
     inherit targetPrefix suffixSalt;
-    inherit bintools libc nativeTools nativeLibc nativePrefix;
+    inherit bintools libc nativeTools nativeLibc nativePrefix isGNU isLLVM;
 
     emacsBufferSetup = pkgs: ''
       ; We should handle propagation here too

--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -13,7 +13,7 @@
 , enableLTO ? !stdenv.hostPlatform.isStatic
 , texinfo ? null
 , perl ? null # optional, for texi2pod (then pod2man)
-, gmp, mpfr, libmpc, gettext, which, patchelf
+, gmp, mpfr, libmpc, gettext, which, patchelf, binutils
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
 , gnatboot ? null
@@ -202,7 +202,7 @@ stdenv.mkDerivation ({
       crossStageStatic libcCross threadsCross
       version
 
-      gmp mpfr libmpc isl
+      binutils gmp mpfr libmpc isl
 
       enableLTO
       enableMultilib

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -13,7 +13,7 @@
 , enableLTO ? !stdenv.hostPlatform.isStatic
 , texinfo ? null
 , perl ? null # optional, for texi2pod (then pod2man)
-, gmp, mpfr, libmpc, gettext, which, patchelf
+, gmp, mpfr, libmpc, gettext, which, patchelf, binutils
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
 , gnatboot ? null
@@ -206,7 +206,7 @@ stdenv.mkDerivation ({
       crossStageStatic libcCross threadsCross
       version
 
-      gmp mpfr libmpc isl
+      binutils gmp mpfr libmpc isl
 
       enableLTO
       enableMultilib

--- a/pkgs/development/compilers/gcc/12/default.nix
+++ b/pkgs/development/compilers/gcc/12/default.nix
@@ -13,7 +13,7 @@
 , enableLTO ? !stdenv.hostPlatform.isStatic
 , texinfo ? null
 , perl ? null # optional, for texi2pod (then pod2man)
-, gmp, mpfr, libmpc, gettext, which, patchelf
+, gmp, mpfr, libmpc, gettext, which, patchelf, binutils
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
 , libucontext ? null
@@ -250,7 +250,7 @@ stdenv.mkDerivation ({
       crossStageStatic libcCross threadsCross
       version
 
-      gmp mpfr libmpc isl
+      binutils gmp mpfr libmpc isl
 
       enableLTO
       enableMultilib

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -12,7 +12,7 @@
 , enableLTO ? !stdenv.hostPlatform.isStatic
 , texinfo ? null
 , perl ? null # optional, for texi2pod (then pod2man); required for Java
-, gmp, mpfr, libmpc, gettext, which, patchelf
+, gmp, mpfr, libmpc, gettext, which, patchelf, binutils
 , cloog ? null, isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null, boehmgc ? null
 , zip ? null, unzip ? null, pkg-config ? null
@@ -207,7 +207,7 @@ stdenv.mkDerivation ({
       crossStageStatic libcCross threadsCross
       version
 
-      gmp mpfr libmpc isl
+      binutils gmp mpfr libmpc isl
       cloog
 
       enableLTO

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -12,7 +12,7 @@
 , enableLTO ? !stdenv.hostPlatform.isStatic
 , texinfo ? null
 , perl ? null # optional, for texi2pod (then pod2man); required for Java
-, gmp, mpfr, libmpc, gettext, which, patchelf
+, gmp, mpfr, libmpc, gettext, which, patchelf, binutils
 , cloog ? null, isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null, boehmgc ? null
 , zip ? null, unzip ? null, pkg-config ? null
@@ -227,7 +227,7 @@ stdenv.mkDerivation ({
       crossStageStatic libcCross threadsCross
       version
 
-      gmp mpfr libmpc isl
+      binutils gmp mpfr libmpc isl
       cloog
 
       enableLTO

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -14,7 +14,7 @@
 , texinfo ? null
 , flex
 , perl ? null # optional, for texi2pod (then pod2man); required for Java
-, gmp, mpfr, libmpc, gettext, which, patchelf
+, gmp, mpfr, libmpc, gettext, which, patchelf, binutils
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null, boehmgc ? null
 , gnatboot ? null
@@ -238,7 +238,7 @@ stdenv.mkDerivation ({
       crossStageStatic libcCross threadsCross
       version
 
-      gmp mpfr libmpc isl
+      binutils gmp mpfr libmpc isl
 
       enableLTO
       enableMultilib

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -11,7 +11,7 @@
 , enableLTO ? !stdenv.hostPlatform.isStatic
 , texinfo ? null
 , perl ? null # optional, for texi2pod (then pod2man)
-, gmp, mpfr, libmpc, gettext, which, patchelf
+, gmp, mpfr, libmpc, gettext, which, patchelf, binutils
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
 , enableMultilib ? false
@@ -206,7 +206,7 @@ stdenv.mkDerivation ({
       crossStageStatic libcCross threadsCross
       version
 
-      gmp mpfr libmpc isl
+      binutils gmp mpfr libmpc isl
 
       enableLTO
       enableMultilib

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -11,7 +11,7 @@
 , enableLTO ? !stdenv.hostPlatform.isStatic
 , texinfo ? null
 , perl ? null # optional, for texi2pod (then pod2man)
-, gmp, mpfr, libmpc, gettext, which, patchelf
+, gmp, mpfr, libmpc, gettext, which, patchelf, binutils
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
 , enableMultilib ? false
@@ -188,7 +188,7 @@ stdenv.mkDerivation ({
       crossStageStatic libcCross threadsCross
       version
 
-      gmp mpfr libmpc isl
+      binutils gmp mpfr libmpc isl
 
       enableLTO
       enableMultilib

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -13,7 +13,7 @@
 , enableLTO ? !stdenv.hostPlatform.isStatic
 , texinfo ? null
 , perl ? null # optional, for texi2pod (then pod2man)
-, gmp, mpfr, libmpc, gettext, which, patchelf
+, gmp, mpfr, libmpc, gettext, which, patchelf, binutils
 , isl ? null # optional, for the Graphite optimization framework.
 , zlib ? null
 , gnatboot ? null
@@ -201,7 +201,7 @@ stdenv.mkDerivation ({
       crossStageStatic libcCross threadsCross
       version
 
-      gmp mpfr libmpc isl
+      binutils gmp mpfr libmpc isl
 
       enableLTO
       enableMultilib

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -5,7 +5,7 @@
 , threadsCross
 , version
 
-, gmp, mpfr, libmpc, isl
+, binutils, gmp, mpfr, libmpc, isl
 , cloog ? null
 
 , enableLTO
@@ -51,7 +51,7 @@ let
   crossConfigureFlags =
     # Ensure that -print-prog-name is able to find the correct programs.
     [
-      "--with-as=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
+      "--with-as=${if targetPackages.stdenv.cc.bintools.isLLVM then binutils else targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-as"
       "--with-ld=${targetPackages.stdenv.cc.bintools}/bin/${targetPlatform.config}-ld"
     ]
     ++ (if crossStageStatic then [

--- a/pkgs/development/compilers/llvm/10/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/10/bintools/default.nix
@@ -5,7 +5,12 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" {
+  preferLocalBuild = true;
+  passthru = {
+    isLLVM = true;
+  };
+} ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/11/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/11/bintools/default.nix
@@ -5,7 +5,12 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" {
+  preferLocalBuild = true;
+  passthru = {
+    isLLVM = true;
+  };
+} ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/12/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/12/bintools/default.nix
@@ -5,7 +5,12 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" {
+  preferLocalBuild = true;
+  passthru = {
+    isLLVM = true;
+  };
+} ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/13/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/13/bintools/default.nix
@@ -5,7 +5,12 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" {
+  preferLocalBuild = true;
+  passthru = {
+    isLLVM = true;
+  };
+} ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/14/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/14/bintools/default.nix
@@ -5,7 +5,12 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" {
+  preferLocalBuild = true;
+  passthru = {
+    isLLVM = true;
+  };
+} ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/7/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/7/bintools/default.nix
@@ -5,7 +5,12 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" {
+  preferLocalBuild = true;
+  passthru = {
+    isLLVM = true;
+  };
+} ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/8/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/8/bintools/default.nix
@@ -5,7 +5,12 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" {
+  preferLocalBuild = true;
+  passthru = {
+    isLLVM = true;
+  };
+} ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/9/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/9/bintools/default.nix
@@ -5,7 +5,12 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" {
+  preferLocalBuild = true;
+  passthru = {
+    isLLVM = true;
+  };
+} ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)

--- a/pkgs/development/compilers/llvm/git/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/git/bintools/default.nix
@@ -5,7 +5,12 @@ let
     if stdenv.hostPlatform != stdenv.targetPlatform
     then "${stdenv.targetPlatform.config}-"
     else "";
-in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+in runCommand "llvm-binutils-${version}" {
+  preferLocalBuild = true;
+  passthru = {
+    isLLVM = true;
+  };
+} ''
    mkdir -p $out/bin
    for prog in ${lld}/bin/*; do
      ln -s $prog $out/bin/${prefix}$(basename $prog)


### PR DESCRIPTION
###### Description of changes

LLVM does not provide a drop-in replacement for as(1).

This makes it possible to build a GNU Fortran cross compiler from GNU to LLVM — e.g. `buildPackages.gfortran` for `{ system = "aarch64-linux"; useLLVM = true; }`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
