### PR TITLE
free-proxy: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11238,6 +11238,12 @@
     githubId = 610615;
     name = "Chih-Mao Chen";
   };
+  pkosel = {
+    name = "pkosel";
+    email = "philipp.kosel@gmail.com";
+    github = "pkosel";
+    githubId = 170943;
+  };
   plabadens = {
     name = "Pierre Labadens";
     email = "labadens.pierre+nixpkgs@gmail.com";

--- a/pkgs/development/python-modules/free-proxy/default.nix
+++ b/pkgs/development/python-modules/free-proxy/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, unittestCheckHook
+
+, lxml
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "free_proxy";
+  version = "1.1.0";
+
+  # Pypi does not contain tests
+  src = fetchFromGitHub {
+    owner = "jundymek";
+    repo = "free-proxy";
+    rev = version;
+    sha256 = "sha256-BxhhTAKNeuPa07jP+5G7saED5DO5ZQlhcvwGXAN0+5Y=";
+  };
+
+  propagatedBuildInputs = [
+    lxml
+    requests
+  ];
+
+  checkPhase = ''
+    python test_proxy.py
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/jundymek/free-proxy";
+    description = "Free proxy scraper written in python";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ pkosel ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3573,6 +3573,8 @@ self: super: with self; {
 
   fqdn = callPackage ../development/python-modules/fqdn { };
 
+  free-proxy = callPackage ../development/python-modules/free-proxy { };
+
   freebox-api = callPackage ../development/python-modules/freebox-api { };
 
   freetype-py = callPackage ../development/python-modules/freetype-py { };


### PR DESCRIPTION
###### Description of changes

Add [free-proxy](https://github.com/jundymek/free-proxy), a free proxy scraper written in python.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
