### PR TITLE
python310Packages.dcmstack: 0.8 -> 0.9; unbreak

### DIFF
--- a/pkgs/development/python-modules/dcmstack/default.nix
+++ b/pkgs/development/python-modules/dcmstack/default.nix
@@ -1,34 +1,32 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonAtLeast
-, nose
+, pythonOlder
+, pytestCheckHook
 , nibabel
 , pydicom
+, pylibjpeg-libjpeg
 }:
 
 buildPythonPackage rec {
   pname = "dcmstack";
-  version = "0.8";
-
-  disabled = pythonAtLeast "3.8";
-  # https://github.com/moloney/dcmstack/issues/67
+  version = "0.9";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "moloney";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "1n24pp3rqz7ss1z6276fxynnppraxadbl3b9p8ijrcqnpzbzih7p";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-GVzih9H2m2ZGSuZMRuaDG78b95PI3j0WQw5M3l4KNCs=";
   };
 
-  propagatedBuildInputs = [ nibabel pydicom ];
+  propagatedBuildInputs = [
+    nibabel
+    pydicom
+    pylibjpeg-libjpeg
+  ];
 
-  checkInputs = [ nose ];
-  checkPhase = ''
-    runHook preCheck
-    nosetests
-    runHook postCheck
-  '';
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     homepage = "https://github.com/moloney/dcmstack";

--- a/pkgs/development/python-modules/pylibjpeg-libjpeg/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg-libjpeg/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, cython
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "pylibjpeg-libjpeg";
+  version = "1.3.3";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "pydicom";
+    repo = pname;
+    rev = "refs/tags/v.${version}";
+    hash = "sha256-fv3zX+P2DWMdxPKsvSPhPCV8cDX3tAMO/h5coMHBHN8=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cython];
+
+  propagatedBuildInputs = [ numpy ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+  doCheck = false;  # tests try to import 'libjpeg.data', which errors
+
+  pythonImportsCheck = [
+    "libjpeg"
+  ];
+
+  meta = with lib; {
+    description = "A JPEG, JPEG-LS and JPEG XT plugin for pylibjpeg";
+    homepage = "https://github.com/pydicom/pylibjpeg-libjpeg";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8199,6 +8199,8 @@ self: super: with self; {
     inherit (pkgs) libusb1;
   };
 
+  pylibjpeg-libjpeg = callPackage ../development/python-modules/pylibjpeg-libjpeg { };
+
   pyliblo = callPackage ../development/python-modules/pyliblo { };
 
   pylibmc = callPackage ../development/python-modules/pylibmc { };


### PR DESCRIPTION
python310Packages.pylibjpeg-libjpeg: init at 1.3.3

###### Description of changes

Update and unbreak (previous version didn't build with Python>=3.9).

@cfhammill

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
