### PR TITLE
wslu: supply default conf

### DIFF
--- a/pkgs/tools/system/wslu/default.nix
+++ b/pkgs/tools/system/wslu/default.nix
@@ -14,6 +14,15 @@ stdenv.mkDerivation rec {
     hash = "sha256-yhugh836BoSISbTu19ubLOrz5X31Opu5QtCR0DXrbWc=";
   };
 
+  patches = [
+    ./fallback-conf-nix-store.diff
+  ];
+
+  postPatch = ''
+    substituteInPlace src/wslu-header \
+      --subst-var out
+  '';
+
   makeFlags = [
     "DESTDIR=$(out)"
     "PREFIX="

--- a/pkgs/tools/system/wslu/fallback-conf-nix-store.diff
+++ b/pkgs/tools/system/wslu/fallback-conf-nix-store.diff
@@ -1,0 +1,22 @@
+diff --git a/src/wslu-header b/src/wslu-header
+index 5f33925..159c6af 100644
+--- a/src/wslu-header
++++ b/src/wslu-header
+@@ -169,11 +169,17 @@ if [ -f "$HOME/.config/wslu/conf" ]; then
+ 	debug_echo "$HOME/.config/wslu/conf found, sourcing"
+ 	source "$HOME/.config/wslu/conf"
+ fi
++
+ if [ -f "$HOME/.wslurc" ]; then
+ 	debug_echo "$HOME/.wslurc found, sourcing"
+ 	source "$HOME/.wslurc"
+ fi
+ 
++if [ -f "@out@/share/wslu/conf" ]; then
++	debug_echo "@out@/share/wslu/conf found, sourcing"
++	source "@out@/share/wslu/conf"
++fi
++
+ # functions
+ 
+ function help {


### PR DESCRIPTION
This fixes running `wslvar USERNAME` after one of the recent update.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
