### PR TITLE
Update mariadb-connector-c libraries

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -193,6 +193,8 @@ The module update takes care of the new config syntax and the data itself (user 
 
 - `services.prometheus.exporters` has a new exporter to monitor electrical power consumption based on PowercapRAPL sensor called [Scaphandre](https://github.com/hubblo-org/scaphandre), see [#239803](https://github.com/NixOS/nixpkgs/pull/239803) for more details.
 
+- The MariaDB C client library was upgraded from 3.2.x to 3.3.x. It is recomended to review the [upstream release notes](https://mariadb.com/kb/en/mariadb-connector-c-33-release-notes/).
+
 - The module `services.calibre-server` has new options to configure the `host`, `port`, `auth.enable`, `auth.mode` and `auth.userDb` path, see [#216497](https://github.com/NixOS/nixpkgs/pull/216497/) for more details.
 
 - `services.prometheus.exporters` has a new [exporter](https://github.com/hipages/php-fpm_exporter) to monitor PHP-FPM processes, see [#240394](https://github.com/NixOS/nixpkgs/pull/240394) for more details.

--- a/pkgs/servers/sql/mariadb/connector-c/3_1.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/3_1.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./. (args // {
-  version = "3.1.13";
-  sha256 = "0xb8fiissblxb319y5ifqqp86zblwis789ipb753pcb4zpnsaw82";
+  version = "3.1.21";
+  hash = "sha256-PovyQvomT8+vGWS39/QjLauiGkSiuqKQpTrSXdyVyow=";
 })

--- a/pkgs/servers/sql/mariadb/connector-c/3_2.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/3_2.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./. (args // {
-  version = "3.2.5";
-  sha256 = "0w0fimdiiqrrm012iflz8l4rnafryq7y0qqijzxn7nwzxhm9jsr9";
+  version = "3.2.7";
+  hash = "sha256-nXGWJI5ml8Ccc+Fz/psoIEX1XsnXrnQ8HrrQi56lbdo=";
 })

--- a/pkgs/servers/sql/mariadb/connector-c/3_3.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/3_3.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... } @ args:
+
+callPackage ./. (args // {
+  version = "3.3.5";
+  hash = "sha256-ynLrJvbbK++nfkj/lm9xvNPLRLM72Lu4ELZebQEcHlw=";
+})

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -1,12 +1,15 @@
 { lib, stdenv, fetchurl, cmake
-, curl, openssl, zlib
+, curl, openssl, zlib, zstd
 , libiconv
 , version, hash, ...
 }:
 
 with lib;
 
-stdenv.mkDerivation {
+let
+  isVer33 = versionAtLeast version "3.3";
+
+in stdenv.mkDerivation {
   pname = "mariadb-connector-c";
   inherit version;
 
@@ -43,7 +46,7 @@ stdenv.mkDerivation {
   '';
 
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ curl openssl zlib ];
+  propagatedBuildInputs = [ curl openssl zlib ] ++ optional isVer33 zstd;
   buildInputs = [ libiconv ];
 
   postInstall = ''

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, cmake
 , curl, openssl, zlib
 , libiconv
-, version, sha256, ...
+, version, hash, ...
 }:
 
 with lib;
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://downloads.mariadb.com/Connectors/c/connector-c-${version}/mariadb-connector-c-${version}-src.tar.gz";
-    inherit sha256;
+    inherit hash;
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/servers/sql/mariadb/connector-c/default.nix
+++ b/pkgs/servers/sql/mariadb/connector-c/default.nix
@@ -29,8 +29,11 @@ in stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace mariadb_config/mariadb_config.c.in \
-      --replace '-I%s/@INSTALL_INCLUDEDIR@' "-I$dev/include" \
-      --replace '-L%s/@INSTALL_LIBDIR@' "-L$out/lib/mariadb"
+      --replace '#define INCLUDE "-I%s/@INSTALL_INCLUDEDIR@ -I%s/@INSTALL_INCLUDEDIR@/mysql"' "#define INCLUDE \"-I$dev/include -I$dev/include/mysql\"" \
+      --replace '#define LIBS    "-L%s/@INSTALL_LIBDIR@/ -lmariadb"' "#define LIBS    \"-L$out/lib/mariadb -lmariadb\"" \
+      --replace '#define PKG_LIBDIR "%s/@INSTALL_LIBDIR@"' "#define PKG_LIBDIR \"$out/lib/mariadb\"" \
+      --replace '#define PLUGIN_DIR "%s/@INSTALL_PLUGINDIR@"' "#define PLUGIN_DIR \"$out/lib/mariadb/plugin\"" \
+      --replace '#define PKG_PLUGINDIR "%s/@INSTALL_PLUGINDIR@"' "#define PKG_PLUGINDIR \"$out/lib/mariadb/plugin\""
   '' + lib.optionalString stdenv.hostPlatform.isStatic ''
     # Disables all dynamic plugins
     substituteInPlace cmake/plugins.cmake \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26770,9 +26770,11 @@ with pkgs;
   libmysqlclient = libmysqlclient_3_2;
   libmysqlclient_3_1 = mariadb-connector-c_3_1;
   libmysqlclient_3_2 = mariadb-connector-c_3_2;
+  libmysqlclient_3_3 = mariadb-connector-c_3_3;
   mariadb-connector-c = mariadb-connector-c_3_2;
   mariadb-connector-c_3_1 = callPackage ../servers/sql/mariadb/connector-c/3_1.nix { };
   mariadb-connector-c_3_2 = callPackage ../servers/sql/mariadb/connector-c/3_2.nix { };
+  mariadb-connector-c_3_3 = callPackage ../servers/sql/mariadb/connector-c/3_3.nix { };
 
   mariadb-galera = callPackage ../servers/sql/mariadb/galera { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26767,11 +26767,11 @@ with pkgs;
 
   rpcsvc-proto = callPackage ../tools/misc/rpcsvc-proto { };
 
-  libmysqlclient = libmysqlclient_3_2;
+  libmysqlclient = libmysqlclient_3_3;
   libmysqlclient_3_1 = mariadb-connector-c_3_1;
   libmysqlclient_3_2 = mariadb-connector-c_3_2;
   libmysqlclient_3_3 = mariadb-connector-c_3_3;
-  mariadb-connector-c = mariadb-connector-c_3_2;
+  mariadb-connector-c = mariadb-connector-c_3_3;
   mariadb-connector-c_3_1 = callPackage ../servers/sql/mariadb/connector-c/3_1.nix { };
   mariadb-connector-c_3_2 = callPackage ../servers/sql/mariadb/connector-c/3_2.nix { };
   mariadb-connector-c_3_3 = callPackage ../servers/sql/mariadb/connector-c/3_3.nix { };


### PR DESCRIPTION
###### Description of changes
Updated:
- mariadb-connector-c to 3.1.21;
- mariadb-connector-c to 3.2.7;
- init mariadb-connector-c to 3.3.5;

Fixed locate libdir and plugindir.
Befoare PR:
```
Copyright 2011-2020 MariaDB Corporation AB
Get compiler flags for using the MariaDB Connector/C.
Usage: mariadb_config [OPTIONS]
Compiler: GNU 11.3.0
  --cflags        [-I/nix/store/fm0qlsp6agbmvslcr3h4x50035xnd9rs-mariadb-connector-c-3.3.3-dev/include -I/nix/store/fm0qlsp6agbmvslcr3h4x50035xnd9rs-mariadb-connector-c-3.3.3-dev/include/mysql]
  --include       [-I/nix/store/fm0qlsp6agbmvslcr3h4x50035xnd9rs-mariadb-connector-c-3.3.3-dev/include -I/nix/store/fm0qlsp6agbmvslcr3h4x50035xnd9rs-mariadb-connector-c-3.3.3-dev/include/mysql]
  --libs          [-L/nix/store/2dqphviaiyjjlkg3mkdrzrqh2ihx735c-mariadb-connector-c-3.3.3/lib/mariadb/ -lmariadb]
  --libs_r        [-L/nix/store/2dqphviaiyjjlkg3mkdrzrqh2ihx735c-mariadb-connector-c-3.3.3/lib/mariadb/ -lmariadb]
  --libs_sys      [-ldl -lm -lssl -lcrypto]
  --version       [10.8.4]
  --cc_version    [3.3.3]
  --socket        [/run/mysqld/mysqld.sock]
  --port          [3306]
  --plugindir     [/nix/store/fm0qlsp6agbmvslcr3h4x50035xnd9rs-mariadb-connector-c-3.3.3-dev/lib/mariadb/plugin]
  --tlsinfo       [OpenSSL 3.0.7]
  --variable=VAR  VAR is one of:
      pkgincludedir  [/nix/store/fm0qlsp6agbmvslcr3h4x50035xnd9rs-mariadb-connector-c-3.3.3-dev/include/mariadb]
      pkglibdir      [/nix/store/fm0qlsp6agbmvslcr3h4x50035xnd9rs-mariadb-connector-c-3.3.3-dev/lib/mariadb]
      pkgplugindir   [/nix/store/fm0qlsp6agbmvslcr3h4x50035xnd9rs-mariadb-connector-c-3.3.3-dev/lib/mariadb/plugin]

```
After PR:
```
Copyright 2011-2020 MariaDB Corporation AB
Get compiler flags for using the MariaDB Connector/C.
Usage: mariadb_config [OPTIONS]
Compiler: GNU 11.3.0
  --cflags        [-I/nix/store/acq8wvlg3l41k61wchkdq28md39h08hw-mariadb-connector-c-3.3.3-dev/include -I/nix/store/acq8wvlg3l41k61wchkdq28md39h08hw-mariadb-connector-c-3.3.3-dev/include/mysql]
  --include       [-I/nix/store/acq8wvlg3l41k61wchkdq28md39h08hw-mariadb-connector-c-3.3.3-dev/include -I/nix/store/acq8wvlg3l41k61wchkdq28md39h08hw-mariadb-connector-c-3.3.3-dev/include/mysql]
  --libs          [-L/nix/store/dz8lazan3afc8cbb9dhhmcdczym0ap69-mariadb-connector-c-3.3.3/lib/mariadb -lmariadb]
  --libs_r        [-L/nix/store/dz8lazan3afc8cbb9dhhmcdczym0ap69-mariadb-connector-c-3.3.3/lib/mariadb -lmariadb]
  --libs_sys      [-ldl -lm -lssl -lcrypto]
  --version       [10.8.4]
  --cc_version    [3.3.3]
  --socket        [/run/mysqld/mysqld.sock]
  --port          [3306]
  --plugindir     [/nix/store/dz8lazan3afc8cbb9dhhmcdczym0ap69-mariadb-connector-c-3.3.3/lib/mariadb/plugin]
  --tlsinfo       [OpenSSL 3.0.7]
  --variable=VAR  VAR is one of:
      pkgincludedir  [/nix/store/acq8wvlg3l41k61wchkdq28md39h08hw-mariadb-connector-c-3.3.3-dev/include/mariadb]
      pkglibdir      [/nix/store/dz8lazan3afc8cbb9dhhmcdczym0ap69-mariadb-connector-c-3.3.3/lib/mariadb]
      pkgplugindir   [/nix/store/dz8lazan3afc8cbb9dhhmcdczym0ap69-mariadb-connector-c-3.3.3/lib/mariadb/plugin]

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
