### PR TITLE
nheko: build with gcc 11

### DIFF
--- a/pkgs/applications/networking/instant-messengers/nheko/default.nix
+++ b/pkgs/applications/networking/instant-messengers/nheko/default.nix
@@ -1,6 +1,5 @@
 { lib
 , stdenv
-, mkDerivation
 , fetchFromGitHub
 , cmake
 , asciidoc
@@ -26,12 +25,13 @@
 , qttools
 , re2
 , spdlog
+, wrapQtAppsHook
 , voipSupport ? true
 , gst_all_1
 , libnice
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "nheko";
   version = "0.11.1";
 
@@ -47,6 +47,7 @@ mkDerivation rec {
     cmake
     lmdbxx
     pkg-config
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/coeurl/default.nix
+++ b/pkgs/development/libraries/coeurl/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-sN+YSddUOdnJLcnHyWdjNm1PpxCwnkwiqSvyrwUrg6w=";
   };
 
+  NIX_CFLAGS_COMPILE = lib.optional stdenv.isAarch64 "-mno-outline-atomics";
   nativeBuildInputs = [ ninja pkg-config meson ];
 
   buildInputs = [ libevent curl spdlog ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19074,7 +19074,10 @@ with pkgs;
 
   codecserver = callPackage ../applications/audio/codecserver { };
 
-  coeurl = callPackage ../development/libraries/coeurl { };
+  coeurl = callPackage ../development/libraries/coeurl {
+    stdenv = gcc11Stdenv;
+  };
+
 
   coercer = callPackage ../tools/security/coercer { };
 
@@ -22017,7 +22020,9 @@ with pkgs;
 
   mtpfs = callPackage ../tools/filesystems/mtpfs { };
 
-  mtxclient = callPackage ../development/libraries/mtxclient { };
+  mtxclient = callPackage ../development/libraries/mtxclient {
+    stdenv = gcc11Stdenv;
+  };
 
   mu = callPackage ../tools/networking/mu {
     texinfo = texinfo4;
@@ -31535,7 +31540,9 @@ with pkgs;
 
   ngt = callPackage ../development/libraries/ngt { };
 
-  nheko = libsForQt5.callPackage ../applications/networking/instant-messengers/nheko { };
+  nheko = libsForQt5.callPackage ../applications/networking/instant-messengers/nheko {
+    stdenv = gcc11Stdenv;
+  };
 
   nomacs = libsForQt5.callPackage ../applications/graphics/nomacs { };
 


### PR DESCRIPTION
###### Description of changes

This should fix the aarch64 build where stdenv still defaults to gcc 9.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compiling)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
