### PR TITLE
openmvs: init at 2.1.0

### DIFF
--- a/pkgs/applications/science/misc/openmvs/default.nix
+++ b/pkgs/applications/science/misc/openmvs/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, cmake, eigen, opencv, cgal, ceres-solver, boost, vcg, glfw, zstd }:
+
+let
+  boostWithZstd = boost.overrideAttrs (old: {
+    buildInputs = old.buildInputs ++ [ zstd ];
+  });
+in
+stdenv.mkDerivation rec {
+  version = "2.1.0";
+  pname = "openmvs";
+
+  src = fetchFromGitHub {
+    owner = "cdcseacave";
+    repo = "openmvs";
+    rev = "v${version}";
+    sha256 = "sha256-eqNprBgR0hZnbLKLZLJqjemKxHhDtGblmaSxYlmegsc=";
+    fetchSubmodules = true;
+  };
+
+  # SSE is enabled by default
+  cmakeFlags = lib.optional (!stdenv.isx86_64) "-DOpenMVS_USE_SSE=OFF";
+
+  buildInputs = [ eigen opencv cgal ceres-solver vcg glfw boostWithZstd ];
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  meta = {
+    description = "Open Multi-View Stereo reconstruction library";
+    homepage = "https://github.com/cdcseacave/openMVS";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ bouk ];
+  };
+}

--- a/pkgs/development/libraries/CGAL/4.nix
+++ b/pkgs/development/libraries/CGAL/4.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    ./cgal_path.patch
 
     # Pull upstream fix for c++17 (gcc-12):
     #  https://github.com/CGAL/cgal/pull/6109

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10289,6 +10289,8 @@ with pkgs;
 
   openmvg = callPackage ../applications/science/misc/openmvg { };
 
+  openmvs = callPackage ../applications/science/misc/openmvs { };
+
   openntpd = callPackage ../tools/networking/openntpd { };
 
   openntpd_nixos = openntpd.override {


### PR DESCRIPTION
###### Description of changes


Init of [https://github.com/cdcseacave/openMVS](openMVS) on version 2.1.0

I had to add the patch to CGAL v4 to make it usable as a library, it was only being used on version 5.

The boost override isn't needed if https://github.com/NixOS/nixpkgs/pull/211571 gets merged

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
