### PR TITLE
stdenv: don't include drvs in disallowedRefs as build-time deps.

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -173,6 +173,13 @@ let
   separateDebugInfo' = separateDebugInfo && stdenv.hostPlatform.isLinux && !(stdenv.hostPlatform.useLLVM or false);
   outputs' = outputs ++ lib.optional separateDebugInfo' "debug";
 
+  # Turn a derivation into its outPath without a string context attached.
+  # See the comment at the usage site.
+  unsafeDerivationToUntrackedOutpath = drv:
+    if lib.isDerivation drv
+    then builtins.unsafeDiscardStringContext drv.outPath
+    else drv;
+
   noNonNativeDeps = builtins.length (depsBuildTarget ++ depsBuildTargetPropagated
                                   ++ depsHostHost ++ depsHostHostPropagated
                                   ++ buildInputs ++ propagatedBuildInputs
@@ -446,6 +453,40 @@ else let
         "/bin/sh"
       ];
       __propagatedImpureHostDeps = computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps;
+    } //
+    # If we use derivations directly here, they end up as build-time dependencies.
+    # This is especially problematic in the case of disallowed*, since the disallowed
+    # derivations will be built by nix as build-time dependencies, while those
+    # derivations might take a very long time to build, or might not even build
+    # successfully on the platform used.
+    # We can improve on this situation by instead passing only the outPath,
+    # without an attached string context, to nix. The out path will be a placeholder
+    # which will be replaced by the actual out path if the derivation in question
+    # is part of the final closure (and thus needs to be built). If it is not
+    # part of the final closure, then the placeholder will be passed along,
+    # but in that case we know for a fact that the derivation is not part of the closure.
+    # This means that passing the out path to nix does the right thing in either
+    # case, both for disallowed and allowed references/requisites, and we won't
+    # build the derivation if it wouldn't be part of the closure, saving time and resources.
+    # While the problem is less severe for allowed*, since we want the derivation
+    # to be built eventually, we would still like to get the error early and without
+    # having to wait while nix builds a derivation that might not be used.
+    # See also https://github.com/NixOS/nix/issues/4629
+    lib.optionalAttrs (attrs ? disallowedReferences) {
+      disallowedReferences =
+        map unsafeDerivationToUntrackedOutpath attrs.disallowedReferences;
+    } //
+    lib.optionalAttrs (attrs ? disallowedRequisites) {
+      disallowedRequisites =
+        map unsafeDerivationToUntrackedOutpath attrs.disallowedRequisites;
+    } //
+    lib.optionalAttrs (attrs ? allowedReferences) {
+      allowedReferences =
+        lib.mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedReferences;
+    } //
+    lib.optionalAttrs (attrs ? allowedRequisites) {
+      allowedRequisites =
+        lib.mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
     };
 
   validity = checkMeta { inherit meta attrs; };


### PR DESCRIPTION
Derivations listed as `disallowedReferences` or `disallowedRequisites`, currently end up as build-time dependencies.
This is problematic since the disallowed derivations will be built by nix as build-time dependencies, while those derivations might take a very long time to build, or might not even build successfully on the platform used. However, in order to scan for disallowed references in the final output, knowing the out path is sufficient, and the out path can be calculated from the derivation without needing to build it, saving time and resources.

While the problem is less severe for `allowedReferences` and `allowedRequisites`, since we want the derivation to be built eventually, we would still like to get the error early and without having to wait while nix builds a derivation that might not be used (e.g. if we listed the wrong one).

Before this PR:
```
$ nix-store --query --references (nix-store --query --deriver (nix build --print-out-paths --impure --expr 'with import <nixpkgs> {}; hello.overrideAttrs(_: { disallowedReferences = [ busybox ]; })'))
/nix/store/6xg259477c90a229xwmb53pdfkn6ig3g-default-builder.sh
/nix/store/8xiy49msk7nv3k3rmqzjxsspk3ssdmx8-bash-5.2-p15.drv
/nix/store/49dccsl44fyr6dvq9rwcgfr83girbyld-hello-2.12.1.tar.gz.drv
/nix/store/kh9inglxgaqj5098maivgy9iljbxpjww-stdenv-linux.drv
/nix/store/ip726rdk102f49mfkkkks81bqixrrqli-busybox-1.35.0.drv
```
After this PR:
```
$ nix-store --query --references (nix-store --query --deriver (nix build --print-out-paths --impure --expr 'with import ./. {}; hello.overrideAttrs(_: { disallowedReferences = [ busybox ]; })'))
/nix/store/6xg259477c90a229xwmb53pdfkn6ig3g-default-builder.sh
/nix/store/vqc7gh7myk6jpj642f9w2amygvazvjs6-bash-5.2-p15.drv
/nix/store/5ygyqwm9b47jfsxwck22fva8h15d50dg-stdenv-linux.drv
/nix/store/m58pdpyr80sais1bi36kicwc2bcd0s51-hello-2.12.1.tar.gz.drv
```

Note how in the first case `busybox` ends up as a build-time dependency, and will be built or substituted if it's not yet in the nix store. In the second case, with the changes in this PR, it no longer ends up as a build-time dependency and won't be built or substituted.

There is also [an issue for nix](https://github.com/NixOS/nix/issues/4629) itself to fix this on a lower level, [where the approach implemented in this PR was suggested](https://github.com/NixOS/nix/issues/4629#issuecomment-800873798).
I don't agree with the conclusion on that issue and I think that it is a perfectly sensible use case to disallow references so that they cannot be accidentally included in the future and that we should not expect from our users to have to use `unsafeDiscardStringContext` to get the correct behaviour in that case.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
