### PR TITLE
zydis: split zycore into separate derivation

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1330,6 +1330,12 @@
     githubId = 55833;
     name = "Troels Henriksen";
   };
+  athre0z = {
+    email = "joel@zyantific.com";
+    github = "athre0z";
+    githubId = 6553158;
+    name = "Joel Höner";
+  };
   atila = {
     name = "Átila Saraiva";
     email = "atilasaraiva@gmail.com";

--- a/pkgs/development/libraries/zydis/default.nix
+++ b/pkgs/development/libraries/zydis/default.nix
@@ -1,9 +1,16 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, callPackage
 , cmake
+, python3
 }:
 
+let
+  zycore = callPackage ./zycore.nix {
+    inherit stdenv fetchFromGitHub cmake;
+  };
+in
 stdenv.mkDerivation rec {
   pname = "zydis";
   version = "4.0.0";
@@ -12,13 +19,28 @@ stdenv.mkDerivation rec {
     owner = "zyantific";
     repo = "zydis";
     rev = "v${version}";
-    fetchSubmodules = true;
-    sha256 = "sha256-WSBi8HUVj/JR0/0pBoEaUKD0kOk41gSW5ZW74fn8b4k=";
+    hash = "sha256-/no/8FNa5LlwhZMSMao4/cwZk6GlamLjqr+isbh6tEI=";
   };
 
-  nativeBuildInputs = [
-    cmake
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ zycore ];
+  cmakeFlags = [
+    "-DZYAN_SYSTEM_ZYCORE=ON"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
   ];
+
+  doCheck = true;
+  checkInputs = [ python3 ];
+  checkPhase = ''
+    pushd ../tests
+    python3 ./regression.py test ../build/ZydisInfo
+    python3 ./regression_encoder.py \
+      ../build/Zydis{Fuzz{ReEncoding,Encoder},TestEncoderAbsolute}
+    popd
+  '';
+
+  passthru = { inherit zycore; };
 
   meta = with lib; {
     homepage = "https://zydis.re/";

--- a/pkgs/development/libraries/zydis/default.nix
+++ b/pkgs/development/libraries/zydis/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     homepage = "https://zydis.re/";
     description = "Fast and lightweight x86/x86-64 disassembler library";
     license = licenses.mit;
-    maintainers = with maintainers; [ jbcrail AndersonTorres ];
+    maintainers = with maintainers; [ jbcrail AndersonTorres athre0z ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/zydis/zycore.nix
+++ b/pkgs/development/libraries/zydis/zycore.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zycore";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner = "zyantific";
+    repo = "zycore-c";
+    rev = "v${version}";
+    hash = "sha256-kplUgrYecymGxz92tEU6H+NNtcN/Ao/tmmqdVo2c7HA=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  # The absolute paths set by the Nix CMake build manager confuse
+  # Zycore's config generation (which appends them to the package path).
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ];
+}


### PR DESCRIPTION
###### Description of changes

This PR splits the Zycore dependency that was previously pulled in via `fetchSubmodules` into a separate derivation. The package previously didn't install the Zycore headers and CMake configs, making it impossible to actually compile any code that uses Zydis because Zydis includes Zycore headers. 

Essentially, the `tl;dr` here is:

- CMake's `install` rule doesn't install headers and config for dependencies
- Zycore is a separate package with separate versions
- Zydis headers `#include`s Zycore headers which are currently not installed

Instead of adding code that manually install the missing files somehow, I figured that it'd probably be most idiomatic to properly build it as a separate derivation. Zycore isn't widely used for anything but a helper to Zydis, so I didn't put it into a completely separate package. I don't feel strongly about that and am also perfectly open to making it a top-level package instead, though I don't think that many people will ever use it.

I also added myself as a maintainer for the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (via qemu)
  - [x] x86_64-darwin (via Rosetta)
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC @jbcrail @AndersonTorres 
