### PR TITLE
pdns-recursor: 4.7.3 -> 4.7.4

### DIFF
--- a/pkgs/servers/dns/pdns-recursor/default.nix
+++ b/pkgs/servers/dns/pdns-recursor/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "pdns-recursor";
-  version = "4.7.3";
+  version = "4.7.4";
 
   src = fetchurl {
     url = "https://downloads.powerdns.com/releases/pdns-recursor-${version}.tar.bz2";
-    sha256 = "IG12bMjwGJ951pr2TY2TfsxhpNE+jqZZTXj+MOYUBfI=";
+    sha256 = "F7XHyIHj9AC7O1J92GblzyzWLV0zVmsbcLWMYI2ZaNU=";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
###### Description of changes

Minor update with some bug fixes

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested via `pdns-recursor.tests`
- [ ] Tested compilation of all packages that depend on this change using (pdns-recursor)
- [x] Tested basic functionality of all binary files
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).