### PR TITLE
gnu-cim: init at 5.1

### DIFF
--- a/pkgs/development/compilers/gnu-cim/default.nix
+++ b/pkgs/development/compilers/gnu-cim/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gnu-cim";
+  version = "5.1";
+
+  outputs = ["out" "lib" "man" "info"];
+
+  src = fetchurl {
+    url = "mirror://gnu/cim/cim-${version}.tar.gz";
+    hash = "sha256-uQcXtm7EAFA73WnlN+i38+ip0QbDupoIoErlc2mgaak=";
+  };
+
+  postPatch = ''
+    for fname in lib/{simulation,simset}.c; do
+      substituteInPlace "$fname" \
+        --replace \
+          '#include "../../lib/cim.h"' \
+          '#include "../lib/cim.h"'
+    done
+  '';
+
+  CFLAGS = lib.optionalString stdenv.cc.isClang "-Wno-return-type";
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "A GNU compiler for the programming language Simula";
+    longDescription = ''
+      GNU Cim is a compiler for the programming language Simula.
+      It offers a class concept, separate compilation with full type checking,
+      interface to external C routines, an application package for process
+      simulation and a coroutine concept. Commonly used with the Demos for
+      discrete event modelling.
+    '';
+    homepage = "https://www.gnu.org/software/cim/";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    badPlatforms = [ "aarch64-darwin" ];
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7552,6 +7552,8 @@ with pkgs;
 
   gnucap = callPackage ../applications/science/electronics/gnucap { };
 
+  gnu-cim = callPackage ../development/compilers/gnu-cim { };
+
   gnu-cobol = callPackage ../development/compilers/gnu-cobol { };
 
   gnuclad = callPackage ../applications/graphics/gnuclad { };


### PR DESCRIPTION
###### Description of changes

GNU Cim is a compiler for the programming language Simula. It was the first-ever object-oriented language, and was rumored to be an inspiration for C++. It offers a class concept, separate compilation with full type checking, interface to external C routines, an application package for process simulation and a coroutine concept. 

pages of interest:

* https://www.gnu.org/software/cim/
* http://www.simula67.info/ (borken, i'm in contact about getting it restored, in the meanwhile please view the [archive](https://web.archive.org/web/20160703215256/http://www.simula67.info/))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
