### PR TITLE
python3Packages.pytikz-allefeld: init at unstable-2022-11-01

### DIFF
--- a/pkgs/development/python-modules/pytikz-allefeld/default.nix
+++ b/pkgs/development/python-modules/pytikz-allefeld/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildPythonPackage
+, pythonOlder
+, pymupdf
+, numpy
+, ipython
+, texlive
+}:
+
+buildPythonPackage rec {
+  pname = "pytikz-allefeld"; # "pytikz" on pypi is a different module
+  version = "unstable-2022-11-01";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "allefeld";
+    repo = "pytikz";
+    rev = "f878ebd6ce5a647b1076228b48181b147a61abc1";
+    hash = "sha256-G59UUkpjttJKNBN0MB/A9CftO8tO3nv8qlTxt3/fKHk=";
+  };
+
+  propagatedBuildInputs = [
+    pymupdf
+    numpy
+    ipython
+  ];
+
+  pythonImportsCheck = [ "tikz" ];
+
+  nativeCheckInputs = [ texlive.combined.scheme-small ];
+  checkPhase = ''
+    runHook preCheck
+    python -c 'if 1:
+      from tikz import *
+      pic = Picture()
+      pic.draw(line([(0, 0), (1, 1)]))
+      print(pic.code())
+      pic.write_image("test.pdf")
+    '
+    test -s test.pdf
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/allefeld/pytikz";
+    description = "A Python interface to TikZ";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ pbsds ];
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10665,6 +10665,8 @@ self: super: with self; {
 
   pytimeparse2 = callPackage ../development/python-modules/pytimeparse2 { };
 
+  pytikz-allefeld = callPackage ../development/python-modules/pytikz-allefeld { };
+
   pytm = callPackage ../development/python-modules/pytm { };
 
   pytmx = callPackage ../development/python-modules/pytmx { };


### PR DESCRIPTION
###### Description of changes

My thesis needs some nice figures, please help me making them reproducible.
I'm not using the name `pytikz`, since there already is a different package on pypi using that name.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
