### PR TITLE
rmate-sh: init at 1.0.2

### DIFF
--- a/pkgs/tools/misc/rmate-sh/default.nix
+++ b/pkgs/tools/misc/rmate-sh/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, patsh
+, hostname
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rmate";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "aurora";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-fmK6h9bqZ0zO3HWfZvPdYuZ6i/0HZ1CA3FUnkS+E9ns=";
+  };
+
+  nativeBuildInputs = [ patsh ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    substituteInPlace rmate \
+      --replace \
+        'echo "hostname"' \
+        'echo "${hostname}/bin/hostname"'
+    patsh -f rmate -s ${builtins.storeDir}
+
+    runHook preBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 rmate $out/bin/rmate
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Remote TextMate 2 implemented as shell script";
+    longDescription = ''
+      TextMate 2 has a nice feature where it is possible to edit
+      files on a remote server using a helper script called 'rmate',
+      which feeds the file back to the editor over a reverse tunnel.
+      This is a rmate implementation in shell!
+    '';
+    homepage = "https://github.com/aurora/rmate";
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5289,6 +5289,8 @@ with pkgs;
 
   rmapi = callPackage ../applications/misc/remarkable/rmapi { };
 
+  rmate-sh = callPackage ../tools/misc/rmate-sh { };
+
   rmview = libsForQt5.callPackage ../applications/misc/remarkable/rmview { };
 
   rm-improved = callPackage ../applications/misc/rm-improved { };


### PR DESCRIPTION
###### Description of changes

I use this constantly whenever i can't be bothered to setup vscode/atom to use SFTP / a remote server.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
