### PR TITLE
python310Packages.urllib3: 1.26.13 -> 1.26.14

### DIFF
--- a/pkgs/development/python-modules/splinter/default.nix
+++ b/pkgs/development/python-modules/splinter/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , isPy27
 , fetchFromGitHub
+, urllib3
 , selenium
 , cssselect
 , django
@@ -13,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "splinter";
-  version = "0.18.1";
+  version = "0.19.0";
 
   disabled = isPy27;
 
@@ -23,25 +24,28 @@ buildPythonPackage rec {
     owner = "cobrateam";
     repo = "splinter";
     rev = "refs/tags/${version}";
-    hash = "sha256-5d39e9omc223ugBfVMIsMZh8+NPVxc6q7p2gwZ0fF0o=";
+    hash = "sha256-K10zrQOM/khVcf+OT4s5UCY8zE2+nWtaAkRLy9/feU0=";
   };
 
   propagatedBuildInputs = [
-    selenium
+    urllib3
   ];
 
+  passthru.optional-dependencies = {
+    "zope.testbrowser" = [ zope-testbrowser lxml cssselect ];
+    django = [ django lxml cssselect ];
+    flask = [ flask lxml cssselect ];
+    selenium = [ selenium ];
+  };
+
   nativeCheckInputs = [
-    cssselect
-    django
-    flask
-    lxml
     pytestCheckHook
-    zope-testbrowser
-  ];
+  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
 
   disabledTests = [
     # driver is present and fails with a different error during loading
     "test_browser_local_driver_not_present"
+    "test_browser_log_missing_drivers"
     "test_local_driver_not_present"
   ];
 
@@ -49,6 +53,7 @@ buildPythonPackage rec {
     "samples"
     # We run neither Chromium nor Firefox nor ...
     "tests/test_async_finder.py"
+    "tests/test_element_is_visible.py"
     "tests/test_html_snapshot.py"
     "tests/test_iframes.py"
     "tests/test_mouse_interaction.py"


### PR DESCRIPTION
###### Description of changes
https://github.com/urllib3/urllib3/releases/tag/1.26.14
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
