### PR TITLE
python311Packages: random fixes

### DIFF
--- a/pkgs/development/python-modules/apispec/default.nix
+++ b/pkgs/development/python-modules/apispec/default.nix
@@ -39,6 +39,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/marshmallow-code/apispec/blob/${version}/CHANGELOG.rst";
     description = "A pluggable API specification generator with support for the OpenAPI Specification";
     homepage = "https://github.com/marshmallow-code/apispec";
     license = licenses.mit;

--- a/pkgs/development/python-modules/cached-property/default.nix
+++ b/pkgs/development/python-modules/cached-property/default.nix
@@ -1,31 +1,55 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, fetchpatch
 , pytestCheckHook
 , freezegun
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "cached-property";
   version = "1.5.2";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "pydanny";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-DGI8FaEjFd2bDeBDKcA0zDCE+5I6meapVNZgycE1gzs=";
   };
 
-  nativeCheckInputs = [ pytestCheckHook freezegun ];
+  patches = [
+    # Don't use asyncio.coroutine if it's not available, https://github.com/pydanny/cached-property/pull/267
+    (fetchpatch {
+      name = "asyncio-coroutine.patch";
+      url = "https://github.com/pydanny/cached-property/commit/297031687679762849dedeaf24aa3a19116f095b.patch";
+      hash = "sha256-qolrUdaX7db4hE125Lt9ICmPNYsD/uBmQrdO4q5NG3c=";
+    })
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    freezegun
+  ];
 
   disabledTests = [
     # https://github.com/pydanny/cached-property/issues/131
     "test_threads_ttl_expiry"
   ];
 
-  meta = {
+  pythonImportsCheck = [
+    "cached_property"
+  ];
+
+  meta = with lib; {
     description = "A decorator for caching properties in classes";
     homepage = "https://github.com/pydanny/cached-property";
-    license = lib.licenses.bsd3;
-    platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ ericsagnes ];
+    changelog = "https://github.com/pydanny/cached-property/releases/tag/${version}";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ericsagnes ];
   };
 }

--- a/pkgs/development/python-modules/marshmallow-oneofschema/default.nix
+++ b/pkgs/development/python-modules/marshmallow-oneofschema/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "marshmallow-oneofschema";
-  version = "3.0.1";
+  version = "3.0.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "marshmallow-code";
     repo = pname;
     rev = version;
-    hash = "sha256-x0v8WkfjGkP2668QIQiewQViYFDIS2zBWMULcDThWas=";
+    hash = "sha256-Em2jQmvI5IiWREeOX/JAcdOQlpwP7k+cbCirkh82sf0=";
   };
 
   propagatedBuildInputs = [
@@ -35,6 +35,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/marshmallow-code/marshmallow-oneofschema/blob/${src.rev}/CHANGELOG.rst";
     description = "Marshmallow library extension that allows schema (de)multiplexing";
     homepage = "https://github.com/marshmallow-code/marshmallow-oneofschema";
     license = licenses.mit;

--- a/pkgs/development/python-modules/marshmallow/default.nix
+++ b/pkgs/development/python-modules/marshmallow/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "marshmallow";
-  version = "3.16.0";
+  version = "3.19.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "marshmallow-code";
     repo = pname;
     rev = version;
-    hash = "sha256-bR10hYViK7OrAaBpKaeM7S5XyHQZhlGUQTwH/EJ0kME=";
+    hash = "sha256-b1brLHM48t45bwUXk7QreLLmvTzU0sX7Uoc1ZAgGkrE=";
   };
 
   propagatedBuildInputs = [
@@ -37,6 +37,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/marshmallow-code/marshmallow/blob/${src.rev}/CHANGELOG.rst";
     description = "Library for converting complex objects to and from simple Python datatypes";
     homepage = "https://github.com/marshmallow-code/marshmallow";
     license = licenses.mit;

--- a/pkgs/development/python-modules/pyquery/default.nix
+++ b/pkgs/development/python-modules/pyquery/default.nix
@@ -3,18 +3,23 @@
 , cssselect
 , fetchPypi
 , lxml
+, pytestCheckHook
 , pythonOlder
+, requests
+, webob
+, webtest
 }:
 
 buildPythonPackage rec {
   pname = "pyquery";
-  version = "1.4.3";
-  disabled = pythonOlder "3.5";
+  version = "2.0.0";
+  disabled = pythonOlder "3.7";
+
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    extension = "zip";
-    sha256 = "00p6f1dfma65192hc72dxd506491lsq3g5wgxqafi1xpg2w1xia6";
+    hash = "sha256-lj6NTpAmL/bY3sBy6pcoXcN0ovacrXd29AgqvPah2K4=";
   };
 
   propagatedBuildInputs = [
@@ -22,9 +27,22 @@ buildPythonPackage rec {
     lxml
   ];
 
-  # circular dependency on webtest
-  doCheck = false;
   pythonImportsCheck = [ "pyquery" ];
+
+  checkInputs = [
+    pytestCheckHook
+    requests
+    webob
+    (webtest.overridePythonAttrs (_: {
+      # circular dependency
+      doCheck = false;
+    }))
+  ];
+
+  pytestFlagsArray = [
+    # requires network
+    "--deselect=tests/test_pyquery.py::TestWebScrappingEncoding::test_get"
+  ];
 
   meta = with lib; {
     description = "A jquery-like library for Python";

--- a/pkgs/development/python-modules/softlayer/default.nix
+++ b/pkgs/development/python-modules/softlayer/default.nix
@@ -1,50 +1,52 @@
-{ stdenv
-, lib
+{ lib
+, stdenv
 , buildPythonPackage
 , click
 , fetchFromGitHub
 , mock
+, prettytable
 , prompt-toolkit
 , ptable
 , pygments
 , pytestCheckHook
 , pythonOlder
 , requests
+, rich
 , sphinx
 , testtools
 , tkinter
 , urllib3
-, prettytable
-, rich
 , zeep
 }:
 
 buildPythonPackage rec {
   pname = "softlayer";
   version = "6.1.3";
-  disabled = pythonOlder "3.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = "softlayer-python";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-msNW0PeDbs5iq77FBPKKWH0js/PAQz6xfbM0ycMVg5U=";
+    hash = "sha256-msNW0PeDbs5iq77FBPKKWH0js/PAQz6xfbM0ycMVg5U=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-        --replace 'rich == 12.3.0' 'rich >= 12.3.0'
+        --replace "rich ==" "rich >="
   '';
 
   propagatedBuildInputs = [
     click
+    prettytable
     prompt-toolkit
     ptable
     pygments
     requests
-    urllib3
-    prettytable
     rich
+    urllib3
   ];
 
   nativeCheckInputs = [
@@ -64,14 +66,17 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     # Test fails with ConnectionError trying to connect to api.softlayer.com
-    "tests/transports/soap_tests.py"
+    "tests/transports/soap_tests.py.unstable"
   ];
 
-  pythonImportsCheck = [ "SoftLayer" ];
+  pythonImportsCheck = [
+    "SoftLayer"
+  ];
 
   meta = with lib; {
     description = "Python libraries that assist in calling the SoftLayer API";
     homepage = "https://github.com/softlayer/softlayer-python";
+    changelog = "https://github.com/softlayer/softlayer-python/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ onny ];
   };

--- a/pkgs/development/python-modules/webtest-aiohttp/default.nix
+++ b/pkgs/development/python-modules/webtest-aiohttp/default.nix
@@ -2,6 +2,7 @@
 , aiohttp
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , pytest-aiohttp
 , pytestCheckHook
 , pythonOlder
@@ -21,6 +22,14 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "sha256-UuAz/k/Tnumupv3ybFR7PkYHwG3kH7M5oobZykEP+ao=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "python311-compat.patch";
+      url = "https://github.com/sloria/webtest-aiohttp/commit/64e5ab1867ea9ef87901bb2a1a6142566bffc90b.patch";
+      hash = "sha256-OKJGajqJLFMkcbGmGfU9G5hCpJaj24Gs363sI0z7YZw=";
+    })
+  ];
 
   propagatedBuildInputs = [
     webtest

--- a/pkgs/development/python-modules/webtest-aiohttp/default.nix
+++ b/pkgs/development/python-modules/webtest-aiohttp/default.nix
@@ -46,6 +46,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/sloria/webtest-aiohttp/blob/${src.rev}/CHANGELOG.rst";
     description = "Provides integration of WebTest with aiohttp.web applications";
     homepage = "https://github.com/sloria/webtest-aiohttp";
     license = licenses.mit;


### PR DESCRIPTION

###### Description of changes
https://github.com/gawel/pyquery/blob/2.0.0/CHANGES.rst

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
