### PR TITLE
.github/workflows: Don't run problematic ones for #211832

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip editorconfig]')"
+    if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip editorconfig]') && github.event.number != 211832"
     steps:
     - name: Get list of changed files from PR
       env:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   labels:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'NixOS'
+    if: github.repository_owner == 'NixOS' && github.event.number != 211832
     steps:
     - uses: actions/labeler@v4
       with:


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/211832 broke the workflows for all PR's temporarily because it runs into GitHub API limits. This change to the workflow files just makes sure that the problematic workflows don't run for that specific PR.