### PR TITLE
python3Packages.hdf5plugin: init at 4.1.0

### DIFF
--- a/pkgs/development/python-modules/hdf5plugin/default.nix
+++ b/pkgs/development/python-modules/hdf5plugin/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, h5py
+}:
+
+buildPythonPackage rec {
+  pname = "hdf5plugin";
+  version = "4.1.0";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "silx-kit";
+    repo = "hdf5plugin";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-fFR5t8jHOQc6eDNDhDcntibaveGAmI+j/dVte1tdcyk=";
+  };
+
+  propagatedBuildInputs = [
+    h5py
+  ];
+
+  checkPhase = ''
+    python test/test.py
+  '';
+  pythonImportsCheck = [
+    "hdf5plugin"
+  ];
+
+  preBuild = ''
+    mkdir src/hdf5plugin/plugins
+  '';
+
+  meta = with lib; {
+    description = "Additional compression filters for h5py";
+    longDescription = ''
+      hdf5plugin provides HDF5 compression filters and makes them usable from h5py.
+      Supported encodings: Blosc, Blosc2, BitShuffle, BZip2, FciDecomp, LZ4, SZ, SZ3, Zfp, ZStd
+    '';
+    homepage = "http://www.silx.org/doc/hdf5plugin/latest/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bhipple ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4155,6 +4155,8 @@ self: super: with self; {
 
   hdate = callPackage ../development/python-modules/hdate { };
 
+  hdf5plugin = callPackage ../development/python-modules/hdf5plugin { };
+
   ha-ffmpeg = callPackage ../development/python-modules/ha-ffmpeg { };
 
   ha-philipsjs = callPackage ../development/python-modules/ha-philipsjs{ };


### PR DESCRIPTION
###### Description of changes

the python module `hdf5plugin` provides compression filters and makes them usable from the module `h5py`.
Supported encodings: Blosc, Blosc2, BitShuffle, BZip2, FciDecomp, LZ4, SZ, SZ3, Zfp, ZStd


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
