### PR TITLE
mimic3: init at 0.2.4

### DIFF
--- a/pkgs/applications/audio/mimic3/default.nix
+++ b/pkgs/applications/audio/mimic3/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, fetchFromGitHub
+, python3
+, python3Packages
+, onnxruntime
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "mimic3";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "MycroftAI";
+    repo = "mimic3";
+    rev = "refs/tags/release/v${version}";
+    sha256 = "sha256-/uL0YGblDUWTGeIFK0ILadJ6tE0u3sj/ovfoWJ4UkRk=";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace 'epitran==1.17' 'epitran' \
+      --replace 'swagger-ui-py>=21,<22' 'swagger-ui-py'
+
+    substituteInPlace mimic3_tts/tts.py --replace \
+      'providers = None' \
+      'providers = ["DnnlExecutionProvider", "CPUExecutionProvider"]'
+  '';
+
+  # TODO mimic3 can't find libonnxruntime_providers_shared.so
+  buildInputs = [ onnxruntime ];
+
+  propagatedBuildInputs = with python3Packages; [
+    dataclasses-json
+    epitran
+    espeak-phonemizer
+    gruut
+    numpy
+    python3Packages.onnxruntime
+    phonemes2ids
+    quart
+    quart-cors
+    requests
+    swagger-ui-py
+    tqdm
+    xdgenvpy
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/MycroftAI/mimic3/releases/tag/release%2Fv${version}";
+    description = "A fast local neural text to speech engine for Mycroft";
+    homepage = "https://mycroft.ai/mimic-3/";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ felschr ];
+  };
+}

--- a/pkgs/development/python-modules/epitran/default.nix
+++ b/pkgs/development/python-modules/epitran/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, setuptools
+, regex
+, panphon
+, marisa-trie
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "epitran";
+  version = "1.24";
+
+  src = fetchFromGitHub {
+    owner = "dmort27";
+    repo = "epitran";
+    rev = "refs/tags/${version}";
+    hash = "sha256-AH4q8J5oMaUVJ559qe/ZlJXlCcGdxWnxMhnZKCH5Rlk=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'panphon>=0.20' 'panphon'
+  '';
+
+  propagatedBuildInputs = [
+    setuptools
+    regex
+    panphon
+    marisa-trie
+    requests
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/dmort27/epitran/releases/tag/${version}";
+    description = "A tool for transcribing orthographic text as IPA (International Phonetic Alphabet)";
+    homepage = "https://github.com/dmort27/epitran";
+    license = licenses.mit;
+    maintainers = with maintainers; [ felschr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/panphon/default.nix
+++ b/pkgs/development/python-modules/panphon/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, unicodecsv
+, pyyaml
+, regex
+, numpy
+, editdistance
+, munkres
+}:
+
+buildPythonPackage rec {
+  pname = "panphon";
+  version = "0.19.1";
+
+  src = fetchFromGitHub {
+    owner = "dmort27";
+    repo = "panphon";
+    rev = "refs/tags/${version}";
+    hash = "sha256-uKiTOJ3pPy1mZQHNPsEaomXPWRSClSGoY7dpa11lAuI=";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    unicodecsv
+    pyyaml
+    regex
+    numpy
+    editdistance
+    munkres
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/dmort27/panphon/releases/tag/${version}";
+    description = "Python package and data files for manipulating phonological segments (phones, phonemes) in terms of universal phonological features.";
+    homepage = "https://github.com/dmort27/panphon";
+    license = licenses.mit;
+    maintainers = with maintainers; [ felschr ];
+  };
+}

--- a/pkgs/development/python-modules/phonemes2ids/default.nix
+++ b/pkgs/development/python-modules/phonemes2ids/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "phonemes2ids";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "rhasspy";
+    repo = "phonemes2ids";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-av8bdFoGjVhlfm/1SKR6+HWpEoLMcp+oR/+zE9VAeqA=";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/rhasspy/phonemes2ids/releases/tag/v${version}";
+    description = "Flexible tool for assigning integer ids to phonemes";
+    homepage = "https://github.com/rhasspy/phonemes2ids";
+    license = licenses.mit;
+    maintainers = with maintainers; [ felschr ];
+  };
+}

--- a/pkgs/development/python-modules/quart-cors/default.nix
+++ b/pkgs/development/python-modules/quart-cors/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, poetry-core
+, quart
+, pytestCheckHook
+, pytest-cov
+, pytest-asyncio
+}:
+
+buildPythonPackage rec {
+  pname = "quart-cors";
+  version = "0.5.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "pgjones";
+    repo = "quart-cors";
+    rev = "refs/tags/${version}";
+    hash = "sha256-fSSIHv0bXoyOy9Z1ErKqXqrLlq88ghZaCVAmuUb5Y2c";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "quart-testing-rename";
+      url = "https://github.com/pgjones/quart-cors/commit/b7c156cf6a7dc4c4ec7211a851a212c7a2832eab.patch";
+      hash = "sha256-2Wm7BoJNMw3PJR2yiomst4KUKKYX1x3gUXwzcyu1RX0=";
+    })
+  ];
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [ quart ];
+
+  checkInputs = [ pytestCheckHook pytest-cov pytest-asyncio ];
+
+  meta = with lib; {
+    changelog = "https://github.com/pgjones/quart-cors/releases/tag/${version}";
+    description = "Quart-CORS is an extension for Quart to enable and control Cross Origin Resource Sharing, CORS.";
+    homepage = "https://github.com/pgjones/quart-cors";
+    license = licenses.mit;
+    maintainers = with maintainers; [ felschr ];
+  };
+}

--- a/pkgs/development/python-modules/quart/default.nix
+++ b/pkgs/development/python-modules/quart/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, poetry-core
+, aiofiles
+, blinker
+, click
+, hypercorn
+, importlib-metadata
+, itsdangerous
+, jinja2
+, markupsafe
+, pydata-sphinx-theme
+, python-dotenv
+, typing-extensions
+, werkzeug
+, pytestCheckHook
+, pytest-cov
+, pytest-asyncio
+, hypothesis
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "quart";
+  version = "0.18.3";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "pallets";
+    repo = "quart";
+    rev = "refs/tags/${version}";
+    hash = "sha256-aQM8kEhienBG+/zQQ8C/DKiDIMF3l9rq8HSAvg7wvLM=";
+  };
+
+  patches = [
+    # see https://github.com/pallets/quart/issues/202
+    (fetchpatch {
+      name = "fix-py-module-issues";
+      url = "https://github.com/pallets/quart/commit/88b9691a554f8b5676ec5c21d602203a9ab0d401.patch";
+      hash = "sha256-jTeTy24d5aO84PenvJ5efFHuIStVw7ev3qCLyd3PU2U=";
+    })
+  ];
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    aiofiles
+    blinker
+    click
+    hypercorn
+    importlib-metadata
+    itsdangerous
+    jinja2
+    markupsafe
+    pydata-sphinx-theme
+    python-dotenv
+    typing-extensions
+    werkzeug
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-cov
+    pytest-asyncio
+    hypothesis
+    mock
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/pallets/quart/releases/tag/${version}";
+    description = "An async Python micro framework for building web applications.";
+    homepage = "https://github.com/pallets/quart";
+    license = licenses.mit;
+    maintainers = with maintainers; [ felschr ];
+  };
+}

--- a/pkgs/development/python-modules/swagger-ui-py/default.nix
+++ b/pkgs/development/python-modules/swagger-ui-py/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, jinja2
+, pyyaml
+, pytestCheckHook
+, requests
+, uvicorn
+, tornado
+, flask
+, falcon
+, aiohttp
+, bottle
+, sanic
+, quart
+, starlette
+, chalice
+}:
+
+buildPythonPackage rec {
+  pname = "swagger-ui-py";
+  version = "22.07.13";
+
+  src = fetchFromGitHub {
+    owner = "PWZER";
+    repo = "swagger-ui-py";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Mf4pPUsQp7DN6QU31bLx2F5TBhPsDjkEuvGCkakRFPU=";
+  };
+
+  propagatedBuildInputs = [ jinja2 pyyaml ];
+
+  checkInputs = [
+    pytestCheckHook
+    requests
+    uvicorn
+    tornado
+    flask
+    falcon
+    aiohttp
+    bottle
+    sanic
+    quart
+    starlette
+    chalice
+  ];
+
+  # TODO check phase hangs
+  doCheck = false;
+
+  meta = with lib; {
+    changelog = "https://github.com/PWZER/swagger-ui-py/releases/tag/v${version}";
+    description = "Swagger UI for Python web framework, such Tornado, Flask and Sanic.";
+    homepage = "https://pwzer.github.io/swagger-ui-py/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ felschr ];
+  };
+}

--- a/pkgs/development/python-modules/xdgenvpy/default.nix
+++ b/pkgs/development/python-modules/xdgenvpy/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitLab
+, pytestCheckHook
+, pytest-cov
+}:
+
+buildPythonPackage rec {
+  pname = "xdgenvpy";
+  version = "2.3.5";
+
+  src = fetchFromGitLab {
+    owner = "deliberist";
+    repo = "xdgenvpy";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-SZcvLVrHw9SsJ71ULzO3pWmhX4dnV8eG7eiUut4Gp1o=";
+  };
+
+  checkInputs = [ pytestCheckHook pytest-cov ];
+
+  meta = with lib; {
+    changelog = "https://gitlab.com/deliberist/xdgenvpy/-/blob/v${version}/CHANGELOG.md";
+    description = "An XDG Base Directory Specification utility for accessing XDG environment variables.";
+    homepage = "https://gitlab.com/deliberist/xdgenvpy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ felschr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30928,6 +30928,8 @@ with pkgs;
 
   mimic = callPackage ../applications/audio/mimic { };
 
+  mimic3 = callPackage ../applications/audio/mimic3 { };
+
   meh = callPackage ../applications/graphics/meh {};
 
   mixxx = libsForQt5.callPackage ../applications/audio/mixxx { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3049,6 +3049,8 @@ self: super: with self; {
 
   ephemeral-port-reserve = callPackage ../development/python-modules/ephemeral-port-reserve { };
 
+  epitran = callPackage ../development/python-modules/epitran { };
+
   epson-projector = callPackage ../development/python-modules/epson-projector { };
 
   eradicate = callPackage ../development/python-modules/eradicate { };
@@ -6788,6 +6790,8 @@ self: super: with self; {
 
   panflute = callPackage ../development/python-modules/panflute { };
 
+  panphon = callPackage ../development/python-modules/panphon { };
+
   papermill = callPackage ../development/python-modules/papermill { };
 
   openpaperwork-core = callPackage ../applications/office/paperwork/openpaperwork-core.nix { };
@@ -6991,6 +6995,8 @@ self: super: with self; {
   phik = callPackage ../development/python-modules/phik { };
 
   phone-modem = callPackage ../development/python-modules/phone-modem { };
+
+  phonemes2ids = callPackage ../development/python-modules/phonemes2ids { };
 
   phonenumbers = callPackage ../development/python-modules/phonenumbers { };
 
@@ -9717,6 +9723,10 @@ self: super: with self; {
 
   quantum-gateway = callPackage ../development/python-modules/quantum-gateway { };
 
+  quart = callPackage ../development/python-modules/quart { };
+
+  quart-cors = callPackage ../development/python-modules/quart-cors { };
+
   querystring_parser = callPackage ../development/python-modules/querystring-parser { };
 
   questionary = callPackage ../development/python-modules/questionary { };
@@ -11068,6 +11078,8 @@ self: super: with self; {
 
   swagger-ui-bundle = callPackage ../development/python-modules/swagger-ui-bundle { };
 
+  swagger-ui-py = callPackage ../development/python-modules/swagger-ui-py { };
+
   swift = callPackage ../development/python-modules/swift { };
 
   swisshydrodata = callPackage ../development/python-modules/swisshydrodata { };
@@ -12296,6 +12308,8 @@ self: super: with self; {
   xcffib = callPackage ../development/python-modules/xcffib { };
 
   xdg = callPackage ../development/python-modules/xdg { };
+
+  xdgenvpy = callPackage ../development/python-modules/xdgenvpy { };
 
   xdis = callPackage ../development/python-modules/xdis { };
 


### PR DESCRIPTION
###### Description of changes
This is an attempt at packaging mimic3. In its current state it builds, but fails at runtime.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).