### PR TITLE
splatmoji: init at 1.2.0

### DIFF
--- a/pkgs/applications/misc/splatmoji/default.nix
+++ b/pkgs/applications/misc/splatmoji/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, bash
+, fetchFromGitHub
+, fpm
+, gitUpdater
+, jq
+, pandoc
+, shunit2
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "splatmoji";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "cspeterson";
+    repo = "splatmoji";
+    rev = "v${version}";
+    sha256 = "sha256-fsZ8FhLP3vAalRJWUEi/0fe0DlwAz5zZeRZqAuwgv/U=";
+  };
+
+  nativeBuildInputs = [
+    bash
+    fpm
+    jq
+    pandoc
+    shunit2
+  ];
+
+  postPatch = ''
+    patchShebangs ./build.sh
+    patchShebangs ./test/unit_tests
+  '';
+
+  buildPhase = ''
+    ./build.sh ${version} dir
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R build/usr/* $out
+
+    patchShebangs $out/bin/splatmoji
+    # splatmoji refers to its lib and data by absolute path
+    sed -i "s:/usr/lib/splatmoji:$out/lib/splatmoji:g" $out/bin/splatmoji
+    sed -i -r "s:/usr/share/+splatmoji:$out/share/splatmoji:g" $out/lib/splatmoji/functions
+  '';
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
+
+  meta = with lib; {
+    description = "Quickly look up and input emoji and/or emoticons/kaomoji on your GNU/Linux desktop via pop-up menu";
+    homepage = "https://github.com/cspeterson/splatmoji";
+    changelog = "https://github.com/cspeterson/splatmoji/blob/v${version}/CHANGELOG";
+    license = licenses.mit;
+    maintainers = with maintainers; [ colinsane ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31413,6 +31413,8 @@ with pkgs;
 
   speedread = callPackage ../applications/misc/speedread { };
 
+  splatmoji = callPackage ../applications/misc/splatmoji { };
+
   station = callPackage ../applications/networking/station { };
 
   stochas = callPackage ../applications/audio/stochas { };


### PR DESCRIPTION
splatmoji is an emoji chooser. it claims support for Gnome, KDE, and i3, but keyboard-driven desktops is what it's tailored to.

demo: <https://raw.githubusercontent.com/cspeterson/splatmoji/master/splatmoji.gif>

`~/.config/splatmoji/splatmoji.conf` must exist before use, to define how to interact with the desktop environment. here's my setup for sway:

```ini
# ~/.config/splatmoji/splatmoji.conf
# ensure `xdotool` & others are on PATH (environment.systemPackages) or
# substitute their store path below
history_file=/home/colin/.local/state/splatmoji/history
history_length=5
paste_command=xdotool key ctrl+v
rofi_command=fuzzel -d -i -w 60
xdotool_command=wtype
xsel_command=xsel -b -i
```

then i use it like this to have it type an emoji to whatever's in focus:
```sh
$ splatmoji type
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
