### PR TITLE
phosh: 0.22.0 -> 0.23.0

### DIFF
--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -1,11 +1,13 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, gitUpdater
 , meson
 , ninja
 , pkg-config
 , python3
 , wrapGAppsHook
+, libadwaita
 , libhandy
 , libxkbcommon
 , libgudev
@@ -13,7 +15,7 @@
 , pulseaudio
 , evince
 , glib
-, gtk3
+, gtk4
 , gnome
 , gnome-desktop
 , gcr
@@ -34,7 +36,7 @@
 
 stdenv.mkDerivation rec {
   pname = "phosh";
-  version = "0.22.0";
+  version = "0.23.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -43,10 +45,11 @@ stdenv.mkDerivation rec {
     repo = pname;
     rev = "v${version}";
     fetchSubmodules = true; # including gvc and libcall-ui which are designated as subprojects
-    sha256 = "sha256-q2AYm+zbL4/pRG1wn+MT6IYM8CZt15o48U9+piMPf74=";
+    sha256 = "sha256-EMPqBKrtlwI9SJlqZjyAN5CtV4/BNwc5LapfeCEIYxc=";
   };
 
   nativeBuildInputs = [
+    libadwaita
     meson
     ninja
     pkg-config
@@ -71,7 +74,7 @@ stdenv.mkDerivation rec {
     gnome.gnome-control-center
     gnome-desktop
     gnome.gnome-session
-    gtk3
+    gtk4
     pam
     systemd
     upower
@@ -127,11 +130,16 @@ stdenv.mkDerivation rec {
     ];
 
     tests.phosh = nixosTests.phosh;
+
+    updateScript = gitUpdater {
+      rev-prefix = "v";
+    };
   };
 
   meta = with lib; {
     description = "A pure Wayland shell prototype for GNOME on mobile devices";
     homepage = "https://gitlab.gnome.org/World/Phosh/phosh";
+    changelog = "https://gitlab.gnome.org/World/Phosh/phosh/-/blob/v${version}/debian/changelog";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ masipcat zhaofengli ];
     platforms = platforms.linux;

--- a/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
+++ b/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, gitUpdater
 , meson
 , ninja
 , pkg-config
@@ -17,19 +18,20 @@
 
 stdenv.mkDerivation rec {
   pname = "phosh-mobile-settings";
-  version = "0.21.1";
+  version = "0.23.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "guidog";
     repo = "phosh-mobile-settings";
     rev = "v${version}";
-    sha256 = "sha256-60AXaKSF8bY+Z3TNlIIa7jZwQ2IkHqCbZ3uIlhkx6i0=";
+    sha256 = "sha256-D605efn25Dl3Bj92DZiagcx+MMcRz0GRaWxplBRcZhA=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
+    phosh
     pkg-config
     wrapGAppsHook
   ];
@@ -41,7 +43,6 @@ stdenv.mkDerivation rec {
     libadwaita
     lm_sensors
     phoc
-    phosh
     wayland-protocols
   ];
 
@@ -56,9 +57,14 @@ stdenv.mkDerivation rec {
       --replace 'Exec=phosh-mobile-settings' "Exec=$out/bin/phosh-mobile-settings"
   '';
 
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
+
   meta = with lib; {
     description = "A settings app for mobile specific things";
     homepage = "https://gitlab.gnome.org/guidog/phosh-mobile-settings";
+    changelog = "https://gitlab.gnome.org/guidog/phosh-mobile-settings/-/blob/v${version}/debian/changelog";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ colinsane ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Description of changes

also updated phosh-mobile-settings 0.21.1 -> 0.23.1 while i'm here because they're somewhat coupled (i'm not sure how much phosh-mobile-settings assumes about the phosh installation).

also added `updateScript` to ease future updates:
 ```sh
$ nix-shell maintainers/scripts/update.nix --argstr package phosh
 ```
    
changelog: <https://gitlab.gnome.org/World/Phosh/phosh/-/blob/v0.23.0/debian/changelog>
abbreviated changelog (included inline below): <https://gitlab.gnome.org/World/Phosh/phosh/-/blob/v0.23.0/NEWS>
    
> phosh 0.23.0
> ------------
> Released December 2022
> * New lockscreen plugin for personal/emergency information
> * Allow plugins to have UI to set preferences
> * Ease creating plugin by better examples, improved helpers
>   and less duplication.
> * Switch docs to gi-docgen

###### Things done

**built (but not run) on x86, cross compiled to aarch64, and run/tested on a pinephone.**

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
