### PR TITLE
ocamlPackages.fdkaac: 0.3.2 → 0.3.3

### DIFF
--- a/pkgs/development/ocaml-modules/bjack/default.nix
+++ b/pkgs/development/ocaml-modules/bjack/default.nix
@@ -4,13 +4,11 @@ buildDunePackage rec {
   pname = "bjack";
   version = "0.1.6";
 
-  useDune2 = true;
-
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-bjack";
     rev = "v${version}";
-    sha256 = "1gf31a8i9byp6npn0x6gydcickn6sf5dnzmqr2c1b9jn2nl7334c";
+    hash = "sha256-jIxxqBVWphWYyLh+24rTxk4WWfPPdGCvNdevFJEKw70=";
   };
 
   buildInputs = [ dune-configurator ] ++ lib.optionals stdenv.isDarwin [ Accelerate CoreAudio ];

--- a/pkgs/development/ocaml-modules/fdkaac/default.nix
+++ b/pkgs/development/ocaml-modules/fdkaac/default.nix
@@ -4,15 +4,13 @@
 
 buildDunePackage rec {
   pname = "fdkaac";
-  version = "0.3.2";
+  version = "0.3.3";
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-fdkaac";
-    rev = version;
-    sha256 = "10i6hsjkrpw7zgx99zvvka3sapd7zy53k7z4b6khj9rdrbrgznv8";
+    rev = "v${version}";
+    hash = "sha256-cTPPQKBq0EFo35eK7TXlszbodHYIg1g7v+yQ/rG7Y9I=";
   };
-
-  useDune2 = true;
 
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ fdk_aac ];

--- a/pkgs/development/ocaml-modules/opus/default.nix
+++ b/pkgs/development/ocaml-modules/opus/default.nix
@@ -4,13 +4,13 @@ buildDunePackage rec {
   pname = "opus";
   version = "0.2.2";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-opus";
     rev = "v${version}";
-    sha256 = "sha256-Ghfqw/J1oLbTJpYJaiB5M79jaA6DACvyxBVE+NjnPkg=";
+    hash = "sha256-Ghfqw/J1oLbTJpYJaiB5M79jaA6DACvyxBVE+NjnPkg=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/ocaml-modules/theora/default.nix
+++ b/pkgs/development/ocaml-modules/theora/default.nix
@@ -4,13 +4,13 @@ buildDunePackage rec {
   pname = "theora";
   version = "0.4.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-theora";
     rev = "v${version}";
-    sha256 = "1sggjmlrx4idkih1ddfk98cgpasq60haj4ykyqbfs22cmii5gpal";
+    hash = "sha256-VN1XYqxMCO0W9tMTqSAwWKv7GErTtRZgnC2SnmmV7+k=";
   };
 
   buildInputs = [ dune-configurator ];

--- a/pkgs/development/ocaml-modules/vorbis/default.nix
+++ b/pkgs/development/ocaml-modules/vorbis/default.nix
@@ -4,13 +4,13 @@ buildDunePackage rec {
   pname = "vorbis";
   version = "0.8.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-vorbis";
     rev = "v${version}";
-    sha256 = "1acy7yvf2y5dggzxw4vmrpdipakr98si3pw5kxw0mh7livn08al8";
+    hash = "sha256-iCoE7I70wAp4n4XfETVKeaob2811E97/e6144bY/nqk=";
   };
 
   buildInputs = [ dune-configurator ];


### PR DESCRIPTION
###### Description of changes

https://github.com/savonet/ocaml-fdkaac/blob/v0.3.3/CHANGES

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
