### PR TITLE
ivpn{,-service}: init at 3.10.0

### DIFF
--- a/pkgs/tools/networking/ivpn/default.nix
+++ b/pkgs/tools/networking/ivpn/default.nix
@@ -1,0 +1,40 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, wirelesstools
+}:
+
+builtins.mapAttrs (pname: attrs: buildGoModule (attrs // rec {
+  inherit pname;
+  version = "3.10.0";
+  src = fetchFromGitHub {
+    owner = "ivpn";
+    repo = "desktop-app";
+    rev = "v${version}";
+    hash = "sha256-oX1PWIBPDcvBTxstEiN2WosiVUNXJoloppkpcABSi7Y=";
+  };
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/ivpn/desktop-app/daemon/version._version=${version}"
+    "-X github.com/ivpn/desktop-app/daemon/version._time=1970-01-01"
+  ];
+  postInstall = "mv $out/bin/{${attrs.modRoot},${pname}}";
+  meta = with lib; {
+    description = "Official IVPN Desktop app";
+    homepage = "https://www.ivpn.net/apps";
+    changelog = "https://github.com/ivpn/desktop-app/releases/tag/v${version}";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ urandom ];
+  };
+})) {
+  ivpn = {
+    modRoot = "cli";
+    vendorHash = "sha256-5FvKR1Kz91Yi/uILVFyJRnwFZSmZ5qnotXqOI4fKLbY=";
+  };
+  ivpn-service = {
+    modRoot = "daemon";
+    vendorHash = "sha256-9Rk6ruMpyWtQe+90kw4F8OLq7/JcDSrG6ufkfcrS4W8=";
+    buildInputs = [wirelesstools];
+  };
+}

--- a/pkgs/tools/networking/ivpn/default.nix
+++ b/pkgs/tools/networking/ivpn/default.nix
@@ -7,19 +7,25 @@
 builtins.mapAttrs (pname: attrs: buildGoModule (attrs // rec {
   inherit pname;
   version = "3.10.0";
+
   src = fetchFromGitHub {
     owner = "ivpn";
     repo = "desktop-app";
     rev = "v${version}";
     hash = "sha256-oX1PWIBPDcvBTxstEiN2WosiVUNXJoloppkpcABSi7Y=";
   };
+
   ldflags = [
     "-s"
     "-w"
     "-X github.com/ivpn/desktop-app/daemon/version._version=${version}"
     "-X github.com/ivpn/desktop-app/daemon/version._time=1970-01-01"
   ];
-  postInstall = "mv $out/bin/{${attrs.modRoot},${pname}}";
+
+  postInstall = ''
+    mv $out/bin/{${attrs.modRoot},${pname}}
+  '';
+
   meta = with lib; {
     description = "Official IVPN Desktop app";
     homepage = "https://www.ivpn.net/apps";
@@ -35,6 +41,6 @@ builtins.mapAttrs (pname: attrs: buildGoModule (attrs // rec {
   ivpn-service = {
     modRoot = "daemon";
     vendorHash = "sha256-9Rk6ruMpyWtQe+90kw4F8OLq7/JcDSrG6ufkfcrS4W8=";
-    buildInputs = [wirelesstools];
+    buildInputs = [ wirelesstools ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1422,6 +1422,8 @@ with pkgs;
 
   httm = callPackage ../tools/filesystems/httm { };
 
+  inherit (callPackage ../tools/networking/ivpn/default.nix {}) ivpn ivpn-service;
+
   jobber = callPackage ../tools/system/jobber {};
 
   kanata = callPackage ../tools/system/kanata { };


### PR DESCRIPTION
###### Description of changes

Due to ivpn and ivpn-service being separate go modules, albeit the former does replace references to the former based on local paths, we will always need at least two derivations to build these tools.

As a trivial initial implementation, they are wholly separate references at the top level, but they could easily be symlinkJoined, as desired.

As the ivpn gui uses node to package the frontend, this has not been completed at this time. We have also not created any nixos modules, thus things like systemd support for starting ivpn-service on nixos will not work out of the box.

Updates #210200

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
