### PR TITLE
python3Packages.scipy: schedule as big-parallel on Hydra

### DIFF
--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -67,6 +67,8 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
+  requiredSystemFeatures = [ "big-parallel" ]; # the tests need lots of CPU time
+
   passthru = {
     blas = numpy.blas;
   };


### PR DESCRIPTION
After 9503adb666001 the tests can take many hours or even time out: https://hydra.nixos.org/job/nixpkgs/staging-next/python310Packages.scipy.x86_64-linux#tabs-charts That's because without big-parallel we use --cores 2; I just hope that with big-parallel it won't be exploding like described around the 9503adb666001 commit.

(The usual checklist doesn't apply.)
