### PR TITLE
nixpkgs-hammering: init at unstable-2022-11-15

### DIFF
--- a/pkgs/tools/nix/nixpkgs-hammering/default.nix
+++ b/pkgs/tools/nix/nixpkgs-hammering/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, stdenv
+, makeWrapper
+, python3
+, nix
+}:
+
+let
+  version = "unstable-2022-11-15";
+
+  src = fetchFromGitHub {
+    owner = "jtojnar";
+    repo = "nixpkgs-hammering";
+    rev = "1b038ef38fececb39b65a4cdfa7273ed9d9359b4";
+    hash = "sha256-5wZGGTahP1Tlu+WAgGx8Q9YnnHtyhfScl9j6X3W+Toc=";
+  };
+
+  meta = with lib; {
+    description = "A set of nit-picky rules that aim to point out and explain common mistakes in nixpkgs package pull requests";
+    homepage = "https://github.com/jtojnar/nixpkgs-hammering";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+  };
+
+  rust-checks = rustPlatform.buildRustPackage {
+    pname = "nixpkgs-hammering-rust-checks";
+    inherit version src meta;
+    sourceRoot = "${src.name}/rust-checks";
+    cargoHash = "sha256-YiC9mts6h15ZGdLKKmCVNNdTWDPtbDF0J5pwtjc6YKM=";
+  };
+in
+
+stdenv.mkDerivation {
+  pname = "nixpkgs-hammering";
+
+  inherit version src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ python3 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    AST_CHECK_NAMES=$(find ${rust-checks}/bin -maxdepth 1 -type f -printf "%f:")
+
+    install -Dt $out/bin tools/nixpkgs-hammer
+    wrapProgram $out/bin/nixpkgs-hammer \
+      --prefix PATH : ${lib.makeBinPath [ nix rust-checks ]} \
+      --set AST_CHECK_NAMES ''${AST_CHECK_NAMES%:}
+
+    cp -r lib overlays $out
+
+    runHook postInstall
+  '';
+
+  meta = meta // {
+    mainProgram = "nixpkgs-hammer";
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37554,6 +37554,8 @@ with pkgs;
 
   nixpkgs-fmt = callPackage ../tools/nix/nixpkgs-fmt { };
 
+  nixpkgs-hammering = callPackage ../tools/nix/nixpkgs-hammering { };
+
   rnix-hashes = callPackage ../tools/nix/rnix-hashes { };
 
   nixos-artwork = callPackage ../data/misc/nixos-artwork { };


### PR DESCRIPTION
###### Description of changes

https://github.com/jtojnar/nixpkgs-hammering

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
