### PR TITLE
treewide: remove empty go vendor hashes

### DIFF
--- a/pkgs/applications/networking/alpnpass/default.nix
+++ b/pkgs/applications/networking/alpnpass/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
     hash = "sha256-hNZqGTV17rFSKLhZzNqH2E4SSb6Jhk7YQ4TN0HnE+9g=";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   meta = with lib; {
     description = "Inspect the plaintext payload inside of proxied TLS connections";

--- a/pkgs/applications/networking/cluster/argo/default.nix
+++ b/pkgs/applications/networking/cluster/argo/default.nix
@@ -22,7 +22,7 @@ let
       hash = "sha256-wchj5KjhTmhc4XVW0sRFCcyx5W9am8TNAIhej3WFWXU=";
     };
 
-    vendorHash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+    vendorHash = null;
 
     excludedPackages = [ "./example" ];
 

--- a/pkgs/development/interpreters/ivy/default.nix
+++ b/pkgs/development/interpreters/ivy/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "sha256-pb/dJfEXz13myT6XadCg0kKd+n9bcHNBc84ES+hDw2Y=";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   subPackages = [ "." ];
 

--- a/pkgs/development/libraries/boringssl/default.nix
+++ b/pkgs/development/libraries/boringssl/default.nix
@@ -20,7 +20,7 @@ buildGoModule {
 
   nativeBuildInputs = [ cmake ninja perl ];
 
-  vendorSha256 = "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
+  vendorSha256 = null;
 
   # hack to get both go and cmake configure phase
   # (if we use postConfigure then cmake will loop runHook postConfigure)

--- a/pkgs/development/tools/asmfmt/default.nix
+++ b/pkgs/development/tools/asmfmt/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
     sha256 = "sha256-YxIVqPGsqxvOY0Qz4Jw5FuO9IbplCICjChosnHrSCgc=";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   # This package comes with its own version of goimports, gofmt and goreturns
   # but these binaries are outdated and are offered by other packages.

--- a/pkgs/development/tools/gllvm/default.nix
+++ b/pkgs/development/tools/gllvm/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "sha256-CoreqnMRuPuv+Ci1uyF3HJCJFwK2jwB79okynv6AHTA=";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   checkInputs = with llvmPackages; [
     clang

--- a/pkgs/development/tools/go-bindata-assetfs/default.nix
+++ b/pkgs/development/tools/go-bindata-assetfs/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     hash = "sha256-yQgIaTl06nmIu8BfmQzrvEnlPQ2GQ/2nnvTmYXCL1oI=";
   };
 
-  vendorHash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorHash = null;
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/development/tools/go-bindata/default.nix
+++ b/pkgs/development/tools/go-bindata/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     hash = "sha256-dEfD5oV2nXLVg+a7PlB6LqhEBosG7eTptqKKDWcQAss=";
   };
 
-  vendorHash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorHash = null;
 
   patches = [
     # Add go modules support

--- a/pkgs/development/tools/go-motion/default.nix
+++ b/pkgs/development/tools/go-motion/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "sha256-bD6Mm9/LOzguoK/xMpVEeT7G8j1shCsMv14wFostlW4=";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/development/tools/goconst/default.nix
+++ b/pkgs/development/tools/goconst/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
     sha256 = "sha256-chBWxOy9V4pO3hMaeCoKwnQxIEYiSejUOD3QDBCpaoE=";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/development/tools/gocyclo/default.nix
+++ b/pkgs/development/tools/gocyclo/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
     sha256 = "sha256-1IwtGUqshpLDyxH5NNkGUads1TKLs48eslNnFylGUPA=";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   meta = with lib; {
     description = "Calculate cyclomatic complexities of functions in Go source code";

--- a/pkgs/development/tools/gotestfmt/default.nix
+++ b/pkgs/development/tools/gotestfmt/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     hash = "sha256-Rb/nIsHISzvqd+jJU4TNrHbailvgGEq4y0JuM9IdA3w=";
   };
 
-  vendorHash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorHash = null;
 
   meta = with lib; {
     description = "Go test output for humans";

--- a/pkgs/development/tools/hostess/default.nix
+++ b/pkgs/development/tools/hostess/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  vendorSha256 = "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
+  vendorSha256 = null;
 
   meta = with lib; {
     description = "An idempotent command-line utility for managing your /etc/hosts* file.";

--- a/pkgs/development/tools/misc/loccount/default.nix
+++ b/pkgs/development/tools/misc/loccount/default.nix
@@ -10,7 +10,7 @@ buildGoModule rec {
     hash = "sha256-9tzDNwWM4uzxC+xqM603l8EIqYrGUUvZgSe6r1EyHi8=";
   };
 
-  vendorHash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorHash = null;
 
   excludedPackages = "tests";
 

--- a/pkgs/development/tools/nasmfmt/default.nix
+++ b/pkgs/development/tools/nasmfmt/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     hash = "sha256-1c7ZOdoM0/Us7cnTT3sds2P5pcCedrCfl0GqQBnf9Rk=";
   };
 
-  vendorHash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorHash = null;
 
   preBuild = ''
     cp ${./go.mod} go.mod

--- a/pkgs/development/tools/wp4nix/default.nix
+++ b/pkgs/development/tools/wp4nix/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
     sha256 = "sha256-WJteeFUMr684yZEtUP13MqRjJ1UAeo48AzOPdLEE65w=";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/servers/mail/listmonk/stuffbin.nix
+++ b/pkgs/servers/mail/listmonk/stuffbin.nix
@@ -4,7 +4,7 @@ buildGoModule rec {
   pname = "stuffbin";
   version = "1.1.0";
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   src = fetchFromGitHub {
     owner = "knadh";

--- a/pkgs/tools/filesystems/stuffbin/default.nix
+++ b/pkgs/tools/filesystems/stuffbin/default.nix
@@ -4,7 +4,7 @@ buildGoModule rec {
   pname = "stuffbin";
   version = "1.1.0";
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   src = fetchFromGitHub {
     owner = "knadh";

--- a/pkgs/tools/misc/envsubst/default.nix
+++ b/pkgs/tools/misc/envsubst/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "0zkgjdlw3d5xh7g45bzxqspxr61ljdli8ng4a1k1gk0dls4sva8n";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   postInstall = ''
     install -Dm444 -t $out/share/doc/${pname} LICENSE *.md

--- a/pkgs/tools/misc/frei/default.nix
+++ b/pkgs/tools/misc/frei/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
     sha256 = "sha256-9CV6B7fRHXl73uI2JRv3RiaFczLHHBOd7/8UoCAwK6w=";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   meta = with lib; {
     description = "Modern replacement for free";

--- a/pkgs/tools/misc/tcat/default.nix
+++ b/pkgs/tools/misc/tcat/default.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
     rev = "v${version}";
     sha256 = "1szzfz5xsx9l8gjikfncgp86hydzpvsi0y5zvikd621xkp7g7l21";
   };
-  vendorSha256 = "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
+  vendorSha256 = null;
   subPackages = ".";
 
   meta = with lib; {

--- a/pkgs/tools/misc/undocker/default.nix
+++ b/pkgs/tools/misc/undocker/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
     hash = "sha256-SmtM25sijcm5NF0ZrSqrRQDXiLMNp8WGAZX9yKvj1rQ=";
   };
 
-  vendorHash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorHash = null;
 
   meta = with lib; {
     homepage = "https://git.sr.ht/~motiejus/undocker";

--- a/pkgs/tools/security/minica/default.nix
+++ b/pkgs/tools/security/minica/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
     sha256 = "sha256-3p6rUFFiWXhX9BBbxqWxRoyRceexvNnqcFCyNi5HoaA=";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/tools/text/cidrgrep/default.nix
+++ b/pkgs/tools/text/cidrgrep/default.nix
@@ -11,7 +11,7 @@ buildGoModule {
     hash = "sha256-Bp1cST6/8ppvpgNxjUpwL498C9vTJmoWOKLJgmWqfEs=";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   postInstall = ''
     mv $out/bin/cmd $out/bin/cidrgrep

--- a/pkgs/tools/text/codesearch/default.nix
+++ b/pkgs/tools/text/codesearch/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "sha256-i03w8PZ31j5EutUZaamZsHz+z4qgX4prePbj5DLA78s=";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/tools/text/goawk/default.nix
+++ b/pkgs/tools/text/goawk/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "sha256-I6KmNPFD8kkYDyek8lR1ZS7biPA/LYGwJqMoA2fG7Wg=";
   };
 
-  vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+  vendorSha256 = null;
 
   checkInputs = [ gawk ];
 


### PR DESCRIPTION
###### Description of changes

see https://github.com/NixOS/nixpkgs/pull/126682

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
