### PR TITLE
services.openssh: rename several settings

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -503,19 +503,72 @@
         <para>
           A few openssh options have been moved from extraConfig to the
           new freeform option <literal>settings</literal> and renamed as
-          follow:
-          <literal>services.openssh.kbdInteractiveAuthentication</literal>
-          to
-          <literal>services.openssh.settings.KbdInteractiveAuthentication</literal>,
-          <literal>services.openssh.passwordAuthentication</literal> to
-          <literal>services.openssh.settings.PasswordAuthentication</literal>,
-          <literal>services.openssh.useDns</literal> to
-          <literal>services.openssh.settings.UseDns</literal>,
-          <literal>services.openssh.permitRootLogin</literal> to
-          <literal>services.openssh.settings.PermitRootLogin</literal>,
-          <literal>services.openssh.logLevel</literal> to
-          <literal>services.openssh.settings.LogLevel</literal>.
+          follows:
         </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              <literal>services.openssh.forwardX11</literal> to
+              <literal>services.openssh.settings.X11Forwarding</literal>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>services.openssh.kbdInteractiveAuthentication</literal>
+              -&gt;
+              <literal>services.openssh.settings.KbdInteractiveAuthentication</literal>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>services.openssh.passwordAuthentication</literal>
+              to
+              <literal>services.openssh.settings.PasswordAuthentication</literal>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>services.openssh.useDns</literal> to
+              <literal>services.openssh.settings.UseDns</literal>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>services.openssh.permitRootLogin</literal> to
+              <literal>services.openssh.settings.PermitRootLogin</literal>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>services.openssh.logLevel</literal> to
+              <literal>services.openssh.settings.LogLevel</literal>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>services.openssh.kexAlgorithms</literal> to
+              <literal>services.openssh.settings.KexAlgorithms</literal>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>services.openssh.macs</literal> to
+              <literal>services.openssh.settings.Macs</literal>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>services.openssh.cyphers</literal> to
+              <literal>services.openssh.settings.Cyphers</literal>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>services.openssh.gatewayPorts</literal> to
+              <literal>services.openssh.settings.GatewayPorts</literal>
+            </para>
+          </listitem>
+        </itemizedlist>
       </listitem>
       <listitem>
         <para>

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -124,7 +124,17 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The module `usbmuxd` now has the ability to change the package used by the daemon. In case you're experiencing issues with `usbmuxd` you can try an alternative program like `usbmuxd2`. Available as [services.usbmuxd.package](#opt-services.usbmuxd.package)
 
-- A few openssh options have been moved from extraConfig to the new freeform option `settings` and renamed as follow: `services.openssh.kbdInteractiveAuthentication` to `services.openssh.settings.KbdInteractiveAuthentication`, `services.openssh.passwordAuthentication` to `services.openssh.settings.PasswordAuthentication`, `services.openssh.useDns` to `services.openssh.settings.UseDns`, `services.openssh.permitRootLogin` to `services.openssh.settings.PermitRootLogin`, `services.openssh.logLevel` to `services.openssh.settings.LogLevel`.
+- A few openssh options have been moved from extraConfig to the new freeform option `settings` and renamed as follows:
+  - `services.openssh.forwardX11` to `services.openssh.settings.X11Forwarding`
+  - `services.openssh.kbdInteractiveAuthentication` -> `services.openssh.settings.KbdInteractiveAuthentication`
+  - `services.openssh.passwordAuthentication` to `services.openssh.settings.PasswordAuthentication`
+  - `services.openssh.useDns` to `services.openssh.settings.UseDns`
+  - `services.openssh.permitRootLogin` to `services.openssh.settings.PermitRootLogin`
+  - `services.openssh.logLevel` to `services.openssh.settings.LogLevel`
+  - `services.openssh.kexAlgorithms` to `services.openssh.settings.KexAlgorithms`
+  - `services.openssh.macs` to `services.openssh.settings.Macs`
+  - `services.openssh.cyphers` to `services.openssh.settings.Cyphers`
+  - `services.openssh.gatewayPorts` to `services.openssh.settings.GatewayPorts`
 
 - `services.mastodon` gained a tootctl wrapped named `mastodon-tootctl` similar to `nextcloud-occ` which can be executed from any user and switches to the configured mastodon user with sudo and sources the environment variables.
 

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -282,7 +282,7 @@ in
   config = {
 
     programs.ssh.setXAuthLocation =
-      mkDefault (config.services.xserver.enable || config.programs.ssh.forwardX11 || config.services.openssh.forwardX11);
+      mkDefault (config.services.xserver.enable || config.programs.ssh.forwardX11 || config.services.openssh.settings.X11Forwarding);
 
     assertions =
       [ { assertion = cfg.forwardX11 -> cfg.setXAuthLocation;

--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -383,7 +383,7 @@ in
       "d /var/spool/slurmd 755 root root -"
     ];
 
-    services.openssh.forwardX11 = mkIf cfg.client.enable (mkDefault true);
+    services.openssh.settings.X11Forwarding = mkIf cfg.client.enable (mkDefault true);
 
     systemd.services.slurmctld = mkIf (cfg.server.enable) {
       path = with pkgs; [ wrappedSlurm munge coreutils ]

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -13,11 +13,12 @@ let
     else pkgs.buildPackages.openssh;
 
   # reports boolean as yes / no
-  mkValueStringSshd = v:
+  mkValueStringSshd = with lib; v:
         if isInt           v then toString v
         else if isString   v then v
         else if true  ==   v then "yes"
         else if false ==   v then "no"
+        else if isList     v then concatStringsSep "," v
         else throw "unsupported type ${typeOf v}: ${(lib.generators.toPretty {}) v}";
 
   # dont use the "=" operator
@@ -104,6 +105,11 @@ in
     (mkRenamedOptionModule [ "services" "openssh" "useDns" ] [  "services" "openssh" "settings" "UseDns" ])
     (mkRenamedOptionModule [ "services" "openssh" "permitRootLogin" ] [  "services" "openssh" "settings" "PermitRootLogin" ])
     (mkRenamedOptionModule [ "services" "openssh" "logLevel" ] [  "services" "openssh" "settings" "LogLevel" ])
+    (mkRenamedOptionModule [ "services" "openssh" "macs" ] [  "services" "openssh" "settings" "Macs" ])
+    (mkRenamedOptionModule [ "services" "openssh" "cyphers" ] [  "services" "openssh" "settings" "Cyphers" ])
+    (mkRenamedOptionModule [ "services" "openssh" "kexAlgorithms" ] [  "services" "openssh" "settings" "KexAlgorithms" ])
+    (mkRenamedOptionModule [ "services" "openssh" "gatewayPorts" ] [  "services" "openssh" "settings" "GatewayPorts" ])
+    (mkRenamedOptionModule [ "services" "openssh" "forwardX11" ] [  "services" "openssh" "settings" "X11Forwarding" ])
   ];
 
   ###### interface
@@ -128,14 +134,6 @@ in
           If set, {command}`sshd` is socket-activated; that
           is, instead of having it permanently running as a daemon,
           systemd will start an instance for each incoming connection.
-        '';
-      };
-
-      forwardX11 = mkOption {
-        type = types.bool;
-        default = false;
-        description = lib.mdDoc ''
-          Whether to allow X11 connections to be forwarded.
         '';
       };
 
@@ -164,16 +162,6 @@ in
         example = [ "-f AUTHPRIV" "-l INFO" ];
         description = lib.mdDoc ''
           Commandline flags to add to sftp-server.
-        '';
-      };
-
-      gatewayPorts = mkOption {
-        type = types.str;
-        default = "no";
-        description = lib.mdDoc ''
-          Specifies whether remote hosts are allowed to connect to
-          ports forwarded for the client.  See
-          {manpage}`sshd_config(5)`.
         '';
       };
 
@@ -286,63 +274,6 @@ in
         '';
       };
 
-      kexAlgorithms = mkOption {
-        type = types.listOf types.str;
-        default = [
-          "sntrup761x25519-sha512@openssh.com"
-          "curve25519-sha256"
-          "curve25519-sha256@libssh.org"
-          "diffie-hellman-group-exchange-sha256"
-        ];
-        description = lib.mdDoc ''
-          Allowed key exchange algorithms
-
-          Uses the lower bound recommended in both
-          <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-          and
-          <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
-        '';
-      };
-
-      ciphers = mkOption {
-        type = types.listOf types.str;
-        default = [
-          "chacha20-poly1305@openssh.com"
-          "aes256-gcm@openssh.com"
-          "aes128-gcm@openssh.com"
-          "aes256-ctr"
-          "aes192-ctr"
-          "aes128-ctr"
-        ];
-        description = lib.mdDoc ''
-          Allowed ciphers
-
-          Defaults to recommended settings from both
-          <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-          and
-          <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
-        '';
-      };
-
-      macs = mkOption {
-        type = types.listOf types.str;
-        default = [
-          "hmac-sha2-512-etm@openssh.com"
-          "hmac-sha2-256-etm@openssh.com"
-          "umac-128-etm@openssh.com"
-          "hmac-sha2-512"
-          "hmac-sha2-256"
-          "umac-128@openssh.com"
-        ];
-        description = lib.mdDoc ''
-          Allowed MACs
-
-          Defaults to recommended settings from both
-          <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
-          and
-          <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
-        '';
-      };
 
 
       settings = mkOption {
@@ -374,7 +305,13 @@ in
                 ~/.ssh/authorized_keys from and sshd_config Match Host directives.
               '';
             };
-
+            X11Forwarding = mkOption {
+              type = types.bool;
+              default = false;
+              description = lib.mdDoc ''
+                Whether to allow X11 connections to be forwarded.
+              '';
+            };
             PasswordAuthentication = mkOption {
               type = types.bool;
               default = true;
@@ -394,6 +331,70 @@ in
               default = true;
               description = lib.mdDoc ''
                 Specifies whether keyboard-interactive authentication is allowed.
+              '';
+            };
+            GatewayPorts = mkOption {
+              type = types.str;
+              default = "no";
+              description = lib.mdDoc ''
+                Specifies whether remote hosts are allowed to connect to
+                ports forwarded for the client.  See
+                {manpage}`sshd_config(5)`.
+              '';
+            };
+            KexAlgorithms = mkOption {
+              type = types.listOf types.str;
+              default = [
+                "sntrup761x25519-sha512@openssh.com"
+                "curve25519-sha256"
+                "curve25519-sha256@libssh.org"
+                "diffie-hellman-group-exchange-sha256"
+              ];
+              description = lib.mdDoc ''
+                Allowed key exchange algorithms
+
+                Uses the lower bound recommended in both
+                <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
+                and
+                <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
+              '';
+            };
+            Macs = mkOption {
+              type = types.listOf types.str;
+              default = [
+                "hmac-sha2-512-etm@openssh.com"
+                "hmac-sha2-256-etm@openssh.com"
+                "umac-128-etm@openssh.com"
+                "hmac-sha2-512"
+                "hmac-sha2-256"
+                "umac-128@openssh.com"
+              ];
+              description = lib.mdDoc ''
+                Allowed MACs
+
+                Defaults to recommended settings from both
+                <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
+                and
+                <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
+              '';
+            };
+            Ciphers = mkOption {
+              type = types.listOf types.str;
+              default = [
+                "chacha20-poly1305@openssh.com"
+                "aes256-gcm@openssh.com"
+                "aes128-gcm@openssh.com"
+                "aes256-ctr"
+                "aes192-ctr"
+                "aes128-ctr"
+              ];
+              description = lib.mdDoc ''
+                Allowed ciphers
+
+                Defaults to recommended settings from both
+                <https://stribika.github.io/2015/01/04/secure-secure-shell.html>
+                and
+                <https://infosec.mozilla.org/guidelines/openssh#modern-openssh-67>
               '';
             };
           };
@@ -555,17 +556,10 @@ in
         ${optionalString cfgc.setXAuthLocation ''
             XAuthLocation ${pkgs.xorg.xauth}/bin/xauth
         ''}
-
-        X11Forwarding ${if cfg.forwardX11 then "yes" else "no"}
-
         ${optionalString cfg.allowSFTP ''
           Subsystem sftp ${cfg.sftpServerExecutable} ${concatStringsSep " " cfg.sftpFlags}
         ''}
-
-        GatewayPorts ${cfg.gatewayPorts}
-
         PrintMotd no # handled by pam_motd
-
         AuthorizedKeysFile ${toString cfg.authorizedKeysFiles}
         ${optionalString (cfg.authorizedKeysCommand != "none") ''
           AuthorizedKeysCommand ${cfg.authorizedKeysCommand}
@@ -575,13 +569,9 @@ in
         ${flip concatMapStrings cfg.hostKeys (k: ''
           HostKey ${k.path}
         '')}
-
-        KexAlgorithms ${concatStringsSep "," cfg.kexAlgorithms}
-        Ciphers ${concatStringsSep "," cfg.ciphers}
-        MACs ${concatStringsSep "," cfg.macs}
       '';
 
-    assertions = [{ assertion = if cfg.forwardX11 then cfgc.setXAuthLocation else true;
+    assertions = [{ assertion = if cfg.settings.X11Forwarding then cfgc.setXAuthLocation else true;
                     message = "cannot enable X11 forwarding without setting xauth location";}]
       ++ forEach cfg.listenAddresses ({ addr, ... }: {
         assertion = addr != null;


### PR DESCRIPTION
Follow up of https://github.com/NixOS/nixpkgs/pull/193757

... to match the sshd config format (makes transition smoother), namely:
services.openssh.forwardX11 -> services.openssh.settings.X11Forwarding
services.openssh.cyphers -> services.openssh.settings.Cyphers
services.openssh.macs -> services.openssh.settings.Macs
services.openssh.kexAlgorithms -> services.openssh.settings.KexAlgorithms
services.openssh.gatewayPorts -> services.openssh.settings.GatewayPorts

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
