### PR TITLE
treewide: replace http by https when https is a permanent redirection

### DIFF
--- a/pkgs/applications/audio/ario/default.nix
+++ b/pkgs/applications/audio/ario/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "GTK client for MPD (Music player daemon)";
-    homepage = "http://ario-player.sourceforge.net/";
+    homepage = "https://ario-player.sourceforge.net/";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.garrison ];
     platforms = platforms.all;

--- a/pkgs/applications/audio/eq10q/default.nix
+++ b/pkgs/applications/audio/eq10q/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       64 bits floating point internal audio processing.
       Nice GUI with powerful metering for every plugin.
     '';
-    homepage = "http://eq10q.sourceforge.net/";
+    homepage = "https://eq10q.sourceforge.net/";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.magnetophon ];
     platforms = lib.platforms.linux;

--- a/pkgs/applications/audio/espeak/default.nix
+++ b/pkgs/applications/audio/espeak/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Compact open source software speech synthesizer";
-    homepage = "http://espeak.sourceforge.net/";
+    homepage = "https://espeak.sourceforge.net/";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/audio/espeak/edit.nix
+++ b/pkgs/applications/audio/espeak/edit.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Phoneme editor for espeak";
-    homepage = "http://espeak.sourceforge.net/";
+    homepage = "https://espeak.sourceforge.net/";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/audio/flac123/default.nix
+++ b/pkgs/applications/audio/flac123/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ flac libao libogg popt ];
 
   meta = with lib; {
-    homepage = "http://flac-tools.sourceforge.net/";
+    homepage = "https://flac-tools.sourceforge.net/";
     description = "A command-line program for playing FLAC audio files";
     license = licenses.gpl2Plus;
     platforms = platforms.all;

--- a/pkgs/applications/audio/gjay/default.nix
+++ b/pkgs/applications/audio/gjay/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Generates playlists such that each song sounds good following the previous song";
-    homepage = "http://gjay.sourceforge.net/";
+    homepage = "https://gjay.sourceforge.net/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ pSub ];
     platforms = with platforms; linux;

--- a/pkgs/applications/audio/gnaural/default.nix
+++ b/pkgs/applications/audio/gnaural/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Programmable auditory binaural-beat synthesizer";
-    homepage = "http://gnaural.sourceforge.net/";
+    homepage = "https://gnaural.sourceforge.net/";
     maintainers = with maintainers; [ ehmry ];
     license = with licenses; [ gpl2Only ];
   };

--- a/pkgs/applications/audio/id3v2/default.nix
+++ b/pkgs/applications/audio/id3v2/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A command line editor for id3v2 tags";
-    homepage = "http://id3v2.sourceforge.net/";
+    homepage = "https://id3v2.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = with platforms; unix;
   };

--- a/pkgs/applications/audio/jack-rack/default.nix
+++ b/pkgs/applications/audio/jack-rack/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
       be controlled using the ALSA sequencer. It's phat; it turns your
       computer into an effects box.
     '';
-    homepage = "http://jack-rack.sourceforge.net/";
+    homepage = "https://jack-rack.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.astsmtl ];
     platforms = lib.platforms.linux;

--- a/pkgs/applications/audio/keyfinder/default.nix
+++ b/pkgs/applications/audio/keyfinder/default.nix
@@ -33,7 +33,7 @@ mkDerivation rec {
       management, no track suggestions, no media player. Just a fast,
       efficient workflow tool.
     '';
-    homepage = "http://www.ibrahimshaath.co.uk/keyfinder/";
+    homepage = "https://www.ibrahimshaath.co.uk/keyfinder/";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/audio/klick/default.nix
+++ b/pkgs/applications/audio/klick/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   prefixKey = "PREFIX=";
 
   meta = {
-    homepage = "http://das.nasophon.de/klick/";
+    homepage = "https://das.nasophon.de/klick/";
     description = "Advanced command-line metronome for JACK";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;

--- a/pkgs/applications/audio/littlegptracker/default.nix
+++ b/pkgs/applications/audio/littlegptracker/default.nix
@@ -63,8 +63,8 @@ stdenv.mkDerivation rec {
       channels. Additionally, the program can drive MIDI instruments (with the
       gp32 and gp2x a custom MIDI interface is required).
     '';
-    homepage = "http://www.littlegptracker.com/";
-    downloadPage = "http://www.littlegptracker.com/download.php";
+    homepage = "https://www.littlegptracker.com/";
+    downloadPage = "https://www.littlegptracker.com/download.php";
     license = licenses.bsd3;
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;

--- a/pkgs/applications/audio/mp3gain/default.nix
+++ b/pkgs/applications/audio/mp3gain/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Lossless mp3 normalizer with statistical analysis";
-    homepage = "http://mp3gain.sourceforge.net/";
+    homepage = "https://mp3gain.sourceforge.net/";
     license = licenses.lgpl21;
     platforms = platforms.unix;
     maintainers = with maintainers; [ devhell ];

--- a/pkgs/applications/audio/mp3val/default.nix
+++ b/pkgs/applications/audio/mp3val/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
       also other MPEG versions and layers. The tool is also aware of the most
       common types of tags (ID3v1, ID3v2, APEv2).
     '';
-    homepage = "http://mp3val.sourceforge.net/index.shtml";
+    homepage = "https://mp3val.sourceforge.net/index.shtml";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.devhell ];

--- a/pkgs/applications/audio/mpc123/default.nix
+++ b/pkgs/applications/audio/mpc123/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = {
-    homepage = "http://mpc123.sourceforge.net/";
+    homepage = "https://mpc123.sourceforge.net/";
 
     description = "A Musepack (.mpc) audio player";
 

--- a/pkgs/applications/audio/mpg321/default.nix
+++ b/pkgs/applications/audio/mpg321/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Command-line MP3 player";
-    homepage = "http://mpg321.sourceforge.net/";
+    homepage = "https://mpg321.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.unix;
   };

--- a/pkgs/applications/audio/munt/libmt32emu.nix
+++ b/pkgs/applications/audio/munt/libmt32emu.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://munt.sourceforge.net/";
+    homepage = "https://munt.sourceforge.net/";
     description = "A library to emulate Roland MT-32, CM-32L, CM-64 and LAPC-I devices";
     license = with licenses; [ lgpl21Plus ];
     maintainers = with maintainers; [ OPNA2608 ];

--- a/pkgs/applications/audio/munt/mt32emu-qt.nix
+++ b/pkgs/applications/audio/munt/mt32emu-qt.nix
@@ -63,7 +63,7 @@ mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://munt.sourceforge.net/";
+    homepage = "https://munt.sourceforge.net/";
     description = "A synthesizer application built on Qt and libmt32emu";
     longDescription = ''
       mt32emu-qt is a synthesiser application that facilitates both realtime

--- a/pkgs/applications/audio/munt/mt32emu-smf2wav.nix
+++ b/pkgs/applications/audio/munt/mt32emu-smf2wav.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "http://munt.sourceforge.net/";
+    homepage = "https://munt.sourceforge.net/";
     description = "Produces a WAVE file from a Standard MIDI file (SMF)";
     license = with licenses; [ gpl3Plus ];
     maintainers = with maintainers; [ OPNA2608 ];

--- a/pkgs/applications/audio/paulstretch/default.nix
+++ b/pkgs/applications/audio/paulstretch/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
       special effects by "spectral smoothing" the sounds.
       It can transform any sound/music to a texture.
     '';
-    homepage = "http://hypermammut.sourceforge.net/paulstretch/";
+    homepage = "https://hypermammut.sourceforge.net/paulstretch/";
     platforms = platforms.linux;
     license = licenses.gpl2;
   };

--- a/pkgs/applications/audio/ssrc/default.nix
+++ b/pkgs/applications/audio/ssrc/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     '';
 
     version = version;
-    homepage = "http://shibatch.sourceforge.net/";
+    homepage = "https://shibatch.sourceforge.net/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ leenaars];
     platforms = platforms.linux;

--- a/pkgs/applications/audio/streamripper/default.nix
+++ b/pkgs/applications/audio/streamripper/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ glib libogg libvorbis libmad ];
 
   meta = with lib; {
-    homepage = "http://streamripper.sourceforge.net/";
+    homepage = "https://streamripper.sourceforge.net/";
     description = "Application that lets you record streaming mp3 to your hard drive";
     license = licenses.gpl2;
   };

--- a/pkgs/applications/audio/tap-plugins/default.nix
+++ b/pkgs/applications/audio/tap-plugins/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
       TAP Pitch Shifter, TAP Reflector, TAP Reverberator, TAP Rotary Speaker, TAP Scaling Limiter,
       TAP Sigmoid Booster, TAP Stereo Echo, TAP Tremolo, TAP TubeWarmth, TAP Vibrato.
     '';
-    homepage = "http://tap-plugins.sourceforge.net/ladspa.html";
+    homepage = "https://tap-plugins.sourceforge.net/ladspa.html";
     license = licenses.gpl3;
     maintainers = [ maintainers.fps ];
   };

--- a/pkgs/applications/audio/xmp/default.nix
+++ b/pkgs/applications/audio/xmp/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Extended module player";
-    homepage    = "http://xmp.sourceforge.net/";
+    homepage    = "https://xmp.sourceforge.net/";
     license     = licenses.gpl2Plus;
     platforms   = platforms.linux;
   };

--- a/pkgs/applications/audio/xsynth-dssi/default.nix
+++ b/pkgs/applications/audio/xsynth-dssi/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation  rec {
       synths) with user interfaces, permitting them to be hosted
       in-process by audio applications.
     '';
-    homepage = "http://dssi.sourceforge.net/download.html#Xsynth-DSSI";
+    homepage = "https://dssi.sourceforge.net/download.html#Xsynth-DSSI";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.goibhniu ];

--- a/pkgs/applications/audio/zam-plugins/default.nix
+++ b/pkgs/applications/audio/zam-plugins/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    homepage = "http://www.zamaudio.com/?p=976";
+    homepage = "https://www.zamaudio.com/?p=976";
     description = "A collection of LV2/LADSPA/VST/JACK audio plugins by ZamAudio";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.magnetophon ];

--- a/pkgs/applications/blockchains/miniscript/default.nix
+++ b/pkgs/applications/blockchains/miniscript/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description     = "Compiler and inspector for the miniscript Bitcoin policy language";
     longDescription = "Miniscript is a language for writing (a subset of) Bitcoin Scripts in a structured way, enabling analysis, composition, generic signing and more.";
-    homepage        = "http://bitcoin.sipa.be/miniscript/";
+    homepage        = "https://bitcoin.sipa.be/miniscript/";
     license         = licenses.mit;
     platforms       = platforms.linux;
     maintainers     = with maintainers; [ RaghavSood jb55 ];

--- a/pkgs/applications/editors/aewan/default.nix
+++ b/pkgs/applications/editors/aewan/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Ascii-art Editor Without A Name";
-    homepage = "http://aewan.sourceforge.net/";
+    homepage = "https://aewan.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/applications/editors/bvi/default.nix
+++ b/pkgs/applications/editors/bvi/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Hex editor with vim style keybindings";
-    homepage = "http://bvi.sourceforge.net/download.html";
+    homepage = "https://bvi.sourceforge.net/download.html";
     license = licenses.gpl2;
     maintainers = with maintainers; [ pSub ];
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/applications/editors/eclipse/build-eclipse.nix
+++ b/pkgs/applications/editors/eclipse/build-eclipse.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   ''; # */
 
   meta = {
-    homepage = "http://www.eclipse.org/";
+    homepage = "https://www.eclipse.org/";
     inherit description;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/session-management-for-emacs/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/session-management-for-emacs/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
       (add-hook 'after-init-hook 'session-initialize)
     */
     description = "Small session management for emacs";
-    homepage = "http://emacs-session.sourceforge.net/";
+    homepage = "https://emacs-session.sourceforge.net/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/applications/editors/fte/default.nix
+++ b/pkgs/applications/editors/fte/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A free text editor for developers";
-    homepage = "http://fte.sourceforge.net/";
+    homepage = "https://fte.sourceforge.net/";
     license = licenses.gpl2;
     maintainers = [ ];
     platforms = platforms.all;

--- a/pkgs/applications/editors/lifeograph/default.nix
+++ b/pkgs/applications/editors/lifeograph/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://lifeograph.sourceforge.net/wiki/Main_Page";
+    homepage = "https://lifeograph.sourceforge.net/wiki/Main_Page";
     description = "Lifeograph is an off-line and private journal and note taking application";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ wolfangaukang ];

--- a/pkgs/applications/emulators/dgen-sdl/default.nix
+++ b/pkgs/applications/emulators/dgen-sdl/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "http://dgen.sourceforge.net/";
+    homepage = "https://dgen.sourceforge.net/";
     description = "Sega Genesis/Mega Drive emulator";
     longDescription = ''
       DGen/SDL is a free, open source emulator for Sega Genesis/Mega Drive

--- a/pkgs/applications/emulators/fuse-emulator/default.nix
+++ b/pkgs/applications/emulators/fuse-emulator/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    homepage = "http://fuse-emulator.sourceforge.net/";
+    homepage = "https://fuse-emulator.sourceforge.net/";
     description = "ZX Spectrum emulator";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/applications/emulators/melonDS/default.nix
+++ b/pkgs/applications/emulators/melonDS/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   qtWrapperArgs = [ "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libpcap ]}" ];
 
   meta = with lib; {
-    homepage = "http://melonds.kuribo64.net/";
+    homepage = "https://melonds.kuribo64.net/";
     description = "Work in progress Nintendo DS emulator";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ artemist benley shamilton xfix ];

--- a/pkgs/applications/graphics/apngasm/2.nix
+++ b/pkgs/applications/graphics/apngasm/2.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Create highly optimized Animated PNG files from PNG/TGA images";
-    homepage = "http://apngasm.sourceforge.net/";
+    homepage = "https://apngasm.sourceforge.net/";
     license = licenses.zlib;
     maintainers = with maintainers; [ orivej ];
     platforms = platforms.linux;

--- a/pkgs/applications/graphics/autotrace/default.nix
+++ b/pkgs/applications/graphics/autotrace/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://autotrace.sourceforge.net/";
+    homepage = "https://autotrace.sourceforge.net/";
     description = "Utility for converting bitmap into vector graphics";
     platforms = platforms.unix;
     maintainers = with maintainers; [ hodapp ];

--- a/pkgs/applications/graphics/comical/default.nix
+++ b/pkgs/applications/graphics/comical/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Viewer of CBR and CBZ files, often used to store scanned comics";
-    homepage = "http://comical.sourceforge.net/";
+    homepage = "https://comical.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ viric wegank ];
     platforms = with lib.platforms; unix;

--- a/pkgs/applications/graphics/djview/default.nix
+++ b/pkgs/applications/graphics/djview/default.nix
@@ -46,7 +46,7 @@ mkDerivation rec {
   meta = with lib; {
     broken = stdenv.isDarwin;
     description = "A portable DjVu viewer (Qt5) and browser (nsdejavu) plugin";
-    homepage = "http://djvu.sourceforge.net/djview4.html";
+    homepage = "https://djvu.sourceforge.net/djview4.html";
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ Anton-Latukha ];

--- a/pkgs/applications/graphics/fig2dev/default.nix
+++ b/pkgs/applications/graphics/fig2dev/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Tool to convert Xfig files to other formats";
-    homepage = "http://mcj.sourceforge.net/";
+    homepage = "https://mcj.sourceforge.net/";
     license = licenses.xfig;
     platforms = platforms.unix;
     maintainers = with maintainers; [ lesuisse ];

--- a/pkgs/applications/graphics/freepv/default.nix
+++ b/pkgs/applications/graphics/freepv/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Open source panorama viewer using GL";
-    homepage = "http://freepv.sourceforge.net/";
+    homepage = "https://freepv.sourceforge.net/";
     license = [ lib.licenses.lgpl21 ];
   };
 }

--- a/pkgs/applications/graphics/gcolor2/default.nix
+++ b/pkgs/applications/graphics/gcolor2/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Simple GTK 2 color selector";
-    homepage = "http://gcolor2.sourceforge.net/";
+    homepage = "https://gcolor2.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ notthemessiah ];
     platforms = with lib.platforms; unix;

--- a/pkgs/applications/graphics/gocr/default.nix
+++ b/pkgs/applications/graphics/gocr/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://jocr.sourceforge.net/";
+    homepage = "https://jocr.sourceforge.net/";
     description = "GPL Optical Character Recognition";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;

--- a/pkgs/applications/graphics/gpicview/default.nix
+++ b/pkgs/applications/graphics/gpicview/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A simple and fast image viewer for X";
-    homepage = "http://lxde.sourceforge.net/gpicview/";
+    homepage = "https://lxde.sourceforge.net/gpicview/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ lovek323 ];
     platforms = platforms.unix;

--- a/pkgs/applications/graphics/gscan2pdf/default.nix
+++ b/pkgs/applications/graphics/gscan2pdf/default.nix
@@ -128,7 +128,7 @@ perlPackages.buildPerlPackage rec {
 
   meta = {
     description = "A GUI to produce PDFs or DjVus from scanned documents";
-    homepage = "http://gscan2pdf.sourceforge.net/";
+    homepage = "https://gscan2pdf.sourceforge.net/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ pacien ];
   };

--- a/pkgs/applications/graphics/luminance-hdr/default.nix
+++ b/pkgs/applications/graphics/luminance-hdr/default.nix
@@ -25,7 +25,7 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config ];
 
   meta = with lib; {
-    homepage = "http://qtpfsgui.sourceforge.net/";
+    homepage = "https://qtpfsgui.sourceforge.net/";
     description = "A complete open source solution for HDR photography";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/applications/graphics/minidjvu/default.nix
+++ b/pkgs/applications/graphics/minidjvu/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://djvu.sourceforge.net/djview4.html";
+    homepage = "https://djvu.sourceforge.net/djview4.html";
     description = "Black-and-white djvu page encoder and decoder that use interpage information";
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.viric ];

--- a/pkgs/applications/graphics/mtpaint/default.nix
+++ b/pkgs/applications/graphics/mtpaint/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       Due to its simplicity and lack of dependencies it runs well on
       GNU/Linux, Windows and older PC hardware.
     '';
-    homepage = "http://mtpaint.sourceforge.net/";
+    homepage = "https://mtpaint.sourceforge.net/";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.vklquevs ];

--- a/pkgs/applications/graphics/panotools/default.nix
+++ b/pkgs/applications/graphics/panotools/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   #doCheck = true;
 
   meta = {
-    homepage = "http://panotools.sourceforge.net/";
+    homepage = "https://panotools.sourceforge.net/";
     description = "Free software suite for authoring and displaying virtual reality panoramas";
     license = lib.licenses.gpl2Plus;
 

--- a/pkgs/applications/graphics/potrace/default.nix
+++ b/pkgs/applications/graphics/potrace/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.16";
 
   src = fetchurl {
-    url = "http://potrace.sourceforge.net/download/${version}/potrace-${version}.tar.gz";
+    url = "https://potrace.sourceforge.net/download/${version}/potrace-${version}.tar.gz";
     sha256 = "1k3sxgjqq0jnpk9xxys05q32sl5hbf1lbk1gmfxcrmpdgnhli0my";
   };
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with lib; {
-    homepage = "http://potrace.sourceforge.net/";
+    homepage = "https://potrace.sourceforge.net/";
     description = "A tool for tracing a bitmap, which means, transforming a bitmap into a smooth, scalable image";
     platforms = platforms.unix;
     maintainers = [ maintainers.pSub ];

--- a/pkgs/applications/graphics/xournal/default.nix
+++ b/pkgs/applications/graphics/xournal/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://xournal.sourceforge.net/";
+    homepage = "https://xournal.sourceforge.net/";
     description = "Note-taking application (supposes stylus)";
     maintainers = [ maintainers.guibert ];
     license = licenses.gpl2;

--- a/pkgs/applications/misc/audio/sox/default.nix
+++ b/pkgs/applications/misc/audio/sox/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Sample Rate Converter for audio";
-    homepage = "http://sox.sourceforge.net/";
+    homepage = "https://sox.sourceforge.net/";
     maintainers = with maintainers; [ marcweber ];
     license = if enableAMR then licenses.unfree else licenses.gpl2Plus;
     platforms = platforms.unix;

--- a/pkgs/applications/misc/audio/wavrsocvt/default.nix
+++ b/pkgs/applications/misc/audio/wavrsocvt/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   version = "1.0.2.0";
 
   src = fetchurl {
-    url = "http://bricxcc.sourceforge.net/wavrsocvt.tgz";
+    url = "https://bricxcc.sourceforge.net/wavrsocvt.tgz";
     sha256 = "15qlvdfwbiclljj7075ycm78yzqahzrgl4ky8pymix5179acm05h";
   };
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
       supported sample rates in the standard NXT firmware).
       You can then upload these with e.g. nxt-python.
     '';
-    homepage = "http://bricxcc.sourceforge.net/";
+    homepage = "https://bricxcc.sourceforge.net/";
     license = licenses.mpl11;
     maintainers = with maintainers; [ leenaars ];
     platforms = with platforms; linux;

--- a/pkgs/applications/misc/calcoo/default.nix
+++ b/pkgs/applications/misc/calcoo/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://calcoo.sourceforge.net/";
+    homepage = "https://calcoo.sourceforge.net/";
     description = "RPN and algebraic scientific calculator";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ AndersonTorres ];

--- a/pkgs/applications/misc/freemind/default.nix
+++ b/pkgs/applications/misc/freemind/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Mind-mapping software";
-    homepage = "http://freemind.sourceforge.net/wiki/index.php/Main_Page";
+    homepage = "https://freemind.sourceforge.net/wiki/index.php/Main_Page";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/misc/gtk2fontsel/default.nix
+++ b/pkgs/applications/misc/gtk2fontsel/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
       Font selection tool similar to xfontsel implemented using GTK 2.
       Trivial, but useful nonetheless.
     '';
-    homepage = "http://gtk2fontsel.sourceforge.net/";
+    homepage = "https://gtk2fontsel.sourceforge.net/";
     downloadPage = "https://sourceforge.net/projects/gtk2fontsel/";
     license = licenses.gpl2;
     maintainers = [ maintainers.prikhi ];

--- a/pkgs/applications/misc/nanoblogger/default.nix
+++ b/pkgs/applications/misc/nanoblogger/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Small weblog engine written in Bash for the command line";
-    homepage = "http://nanoblogger.sourceforge.net/";
+    homepage = "https://nanoblogger.sourceforge.net/";
     license = lib.licenses.gpl2;
     mainProgram = "nb";
     platforms = lib.platforms.unix;

--- a/pkgs/applications/misc/navipowm/default.nix
+++ b/pkgs/applications/misc/navipowm/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ qmake4Hook ];
 
   meta = {
-    homepage = "http://navipowm.sourceforge.net/";
+    homepage = "https://navipowm.sourceforge.net/";
     description = "Car navigation system";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ ];

--- a/pkgs/applications/misc/spacenav-cube-example/default.nix
+++ b/pkgs/applications/misc/spacenav-cube-example/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    homepage = "http://spacenav.sourceforge.net/";
+    homepage = "https://spacenav.sourceforge.net/";
     description = "An example application to test the spacenavd driver";
     license = licenses.bsd3;
     platforms = platforms.unix;

--- a/pkgs/applications/misc/spnavcfg/default.nix
+++ b/pkgs/applications/misc/spnavcfg/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   meta = with lib; {
-    homepage = "http://spacenav.sourceforge.net/";
+    homepage = "https://spacenav.sourceforge.net/";
     description = "Interactive configuration GUI for space navigator input devices";
     license = licenses.gpl3Plus;
     platforms = platforms.unix;

--- a/pkgs/applications/misc/xcruiser/default.nix
+++ b/pkgs/applications/misc/xcruiser/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       It constructs a virtually 3-D formed universe from a directory
       tree and allows you to "cruise" within a visualized filesystem.
     '';
-    homepage = "http://xcruiser.sourceforge.net/";
+    homepage = "https://xcruiser.sourceforge.net/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ ehmry ];
     platforms = with platforms; linux;

--- a/pkgs/applications/networking/browsers/w3m/default.nix
+++ b/pkgs/applications/networking/browsers/w3m/default.nix
@@ -85,7 +85,7 @@ in stdenv.mkDerivation rec {
   LIBS = lib.optionalString x11Support "-lX11";
 
   meta = with lib; {
-    homepage = "http://w3m.sourceforge.net/";
+    homepage = "https://w3m.sourceforge.net/";
     description = "A text-mode web browser";
     maintainers = with maintainers; [ cstrahan anthonyroussel ];
     platforms = platforms.unix;

--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A Java application which presents a Microsoft Exchange server as local CALDAV, IMAP and SMTP servers";
-    homepage = "http://davmail.sourceforge.net/";
+    homepage = "https://davmail.sourceforge.net/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.all;

--- a/pkgs/applications/networking/instant-messengers/centerim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/centerim/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    homepage = "http://www.centerim.org/";
+    homepage = "https://www.centerim.org/";
     description = "Fork of CenterICQ, a curses instant messaging program";
     license = lib.licenses.gpl2Plus;
     platforms = with lib.platforms; linux;

--- a/pkgs/applications/networking/mailreaders/mailcheck/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailcheck/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Simple command line tool to check for new messages";
-    homepage    = "http://mailcheck.sourceforge.net/";
+    homepage    = "https://mailcheck.sourceforge.net/";
     license     = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ kovirobi ];
     platforms   = lib.platforms.linux;

--- a/pkgs/applications/networking/newsreaders/slrn/default.nix
+++ b/pkgs/applications/networking/newsreaders/slrn/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "The slrn (S-Lang read news) newsreader";
-    homepage = "http://slrn.sourceforge.net/index.html";
+    homepage = "https://slrn.sourceforge.net/index.html";
     maintainers = with maintainers; [ ehmry ];
     license = licenses.gpl2;
     platforms = with platforms; linux;

--- a/pkgs/applications/office/kexi/default.nix
+++ b/pkgs/applications/office/kexi/default.nix
@@ -49,7 +49,7 @@ mkDerivation rec {
       All database objects - tables, queries and forms - are stored in the database,
       making it easy to share data and design.
     '';
-    homepage = "http://kexi-project.org/";
+    homepage = "https://kexi-project.org/";
     maintainers = with maintainers; [ zraexy ];
     platforms = platforms.linux;
     license = with licenses; [ gpl2 lgpl2 ];

--- a/pkgs/applications/office/qnotero/default.nix
+++ b/pkgs/applications/office/qnotero/default.nix
@@ -31,7 +31,7 @@ python3Packages.buildPythonPackage rec {
 
   meta = {
     description = "Quick access to Zotero references";
-    homepage = "http://www.cogsci.nl/software/qnotero";
+    homepage = "https://www.cogsci.nl/software/qnotero";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.nico202 ];

--- a/pkgs/applications/office/timeline/default.nix
+++ b/pkgs/applications/office/timeline/default.nix
@@ -76,8 +76,8 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   meta = with lib; {
-    homepage = "http://thetimelineproj.sourceforge.net/";
-    changelog = "http://thetimelineproj.sourceforge.net/changelog.html";
+    homepage = "https://thetimelineproj.sourceforge.net/";
+    changelog = "https://thetimelineproj.sourceforge.net/changelog.html";
     description = "Display and navigate information on a timeline";
     license = with licenses; [ gpl3Only cc-by-sa-30 ];
     platforms = with platforms; unix;

--- a/pkgs/applications/science/biology/bwa/default.nix
+++ b/pkgs/applications/science/biology/bwa/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A software package for mapping low-divergent sequences against a large reference genome, such as the human genome";
     license     = licenses.gpl3;
-    homepage    = "http://bio-bwa.sourceforge.net/";
+    homepage    = "https://bio-bwa.sourceforge.net/";
     maintainers = with maintainers; [ luispedro ];
     platforms = platforms.x86_64;
   };

--- a/pkgs/applications/science/biology/emboss/default.nix
+++ b/pkgs/applications/science/biology/emboss/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     data in a variety of formats and even allows transparent retrieval of
     sequence data from the web.'';
     license = lib.licenses.gpl2;
-    homepage = "http://emboss.sourceforge.net/";
+    homepage = "https://emboss.sourceforge.net/";
   };
 }

--- a/pkgs/applications/science/biology/samtools/samtools_0_1_19.nix
+++ b/pkgs/applications/science/biology/samtools/samtools_0_1_19.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Tools for manipulating SAM/BAM/CRAM format";
     license = licenses.mit;
-    homepage = "http://samtools.sourceforge.net/";
+    homepage = "https://samtools.sourceforge.net/";
     platforms = platforms.unix;
     maintainers = [ maintainers.unode ];
   };

--- a/pkgs/applications/science/biology/snpeff/default.nix
+++ b/pkgs/applications/science/biology/snpeff/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Genetic variant annotation and effect prediction toolbox";
     license = licenses.lgpl3;
-    homepage = "http://snpeff.sourceforge.net/";
+    homepage = "https://snpeff.sourceforge.net/";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     maintainers = with maintainers; [ jbedo ];
     platforms = platforms.all;

--- a/pkgs/applications/science/biology/subread/default.nix
+++ b/pkgs/applications/science/biology/subread/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ jbedo ];
     platforms = [ "x86_64-darwin" "x86_64-linux" ];
-    homepage = "http://subread.sourceforge.net/";
+    homepage = "https://subread.sourceforge.net/";
   };
 
 }

--- a/pkgs/applications/science/electronics/qfsm/default.nix
+++ b/pkgs/applications/science/electronics/qfsm/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Graphical editor for finite state machines";
-    homepage = "http://qfsm.sourceforge.net/";
+    homepage = "https://qfsm.sourceforge.net/";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/applications/science/logic/cubicle/default.nix
+++ b/pkgs/applications/science/logic/cubicle/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An open source model checker for verifying safety properties of array-based systems";
-    homepage = "http://cubicle.lri.fr/";
+    homepage = "https://cubicle.lri.fr/";
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [ dwarfmaster ];

--- a/pkgs/applications/science/logic/metis-prover/default.nix
+++ b/pkgs/applications/science/logic/metis-prover/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Automatic theorem prover for first-order logic with equality";
-    homepage = "http://www.gilith.com/research/metis/";
+    homepage = "https://www.gilith.com/research/metis/";
     license = licenses.mit;
     maintainers = with maintainers; [ gebner ];
     platforms = platforms.unix;

--- a/pkgs/applications/science/logic/why3/default.nix
+++ b/pkgs/applications/science/logic/why3/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A platform for deductive program verification";
-    homepage    = "http://why3.lri.fr/";
+    homepage    = "https://why3.lri.fr/";
     license     = licenses.lgpl21;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ thoughtpolice vbgl ];

--- a/pkgs/applications/science/math/fricas/default.nix
+++ b/pkgs/applications/science/math/fricas/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   meta = {
-    homepage = "http://fricas.sourceforge.net/";
+    homepage = "https://fricas.sourceforge.net/";
     description = "An advanced computer algebra system";
     license = lib.licenses.bsd3;
 

--- a/pkgs/applications/science/math/weka/default.nix
+++ b/pkgs/applications/science/math/weka/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper unzip ];
 
   # The -Xmx1000M comes suggested from their download page:
-  # http://www.cs.waikato.ac.nz/ml/weka/downloading.html
+  # https://www.cs.waikato.ac.nz/ml/weka/downloading.html
   installPhase = ''
     mkdir -pv $out/share/weka
     cp -Rv * $out/share/weka
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://www.cs.waikato.ac.nz/ml/weka/";
+    homepage = "https://www.cs.waikato.ac.nz/ml/weka/";
     description = "Collection of machine learning algorithms for data mining tasks";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl2Plus;

--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -90,7 +90,7 @@ in stdenv.mkDerivation rec {
       reference or manual for details), but there are also quite a
       few features that make it stand out from the competition.
 
-      See: http://www.gromacs.org/About_Gromacs for details.
+      See: https://www.gromacs.org/About_Gromacs for details.
     '';
     platforms = platforms.unix;
     maintainers = with maintainers; [ sheepforce markuskowa ];

--- a/pkgs/applications/search/grepm/default.nix
+++ b/pkgs/applications/search/grepm/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Wrapper for grepmail utilizing mutt";
-    homepage = "http://www.barsnick.net/sw/grepm.html";
+    homepage = "https://www.barsnick.net/sw/grepm.html";
     license = licenses.free;
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/applications/terminal-emulators/mlterm/default.nix
+++ b/pkgs/applications/terminal-emulators/mlterm/default.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Multi Lingual TERMinal emulator";
-    homepage = "http://mlterm.sourceforge.net/";
+    homepage = "https://mlterm.sourceforge.net/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ vrthra ramkromberg atemu ];
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/applications/terminal-emulators/rxvt/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://rxvt.sourceforge.net/";
+    homepage = "https://rxvt.sourceforge.net/";
     description = "Colour vt102 terminal emulator with less features and lower memory consumption";
     longDescription = ''
       rxvt (acronym for our extended virtual terminal) is a terminal

--- a/pkgs/applications/version-management/git-annex-utils/default.nix
+++ b/pkgs/applications/version-management/git-annex-utils/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
       This is a set of utilities that are handy to use with git-annex repositories.
       Currently there is only one utility gadu, a du like utility for annexed files.
     '';
-    homepage = "http://git-annex.mysteryvortex.com/git-annex-utils.html";
+    homepage = "https://git-annex.mysteryvortex.com/git-annex-utils.html";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ woffs ];
     mainProgram = "gadu";

--- a/pkgs/applications/version-management/gitstats/default.nix
+++ b/pkgs/applications/version-management/gitstats/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://gitstats.sourceforge.net/";
+    homepage = "https://gitstats.sourceforge.net/";
     description = "Git history statistics generator";
     license = licenses.gpl2Plus;
     platforms = platforms.all;

--- a/pkgs/applications/video/dvd-slideshow/default.nix
+++ b/pkgs/applications/video/dvd-slideshow/default.nix
@@ -64,7 +64,7 @@ in stdenv.mkDerivation rec {
 
   meta = {
     description = "Suite of command line programs that creates a slideshow-style video from groups of pictures";
-    homepage = "http://dvd-slideshow.sourceforge.net/wiki/Main_Page";
+    homepage = "https://dvd-slideshow.sourceforge.net/wiki/Main_Page";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.robbinch ];

--- a/pkgs/applications/video/dvdauthor/default.nix
+++ b/pkgs/applications/video/dvdauthor/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Tools for generating DVD files to be played on standalone DVD players";
-    homepage = "http://dvdauthor.sourceforge.net/";
+    homepage = "https://dvdauthor.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.linux ++ platforms.darwin;
   };

--- a/pkgs/applications/video/dvdbackup/default.nix
+++ b/pkgs/applications/video/dvdbackup/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A tool to rip video DVDs from the command line";
-    homepage = "http://dvdbackup.sourceforge.net/";
+    homepage = "https://dvdbackup.sourceforge.net/";
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.bradediger ];
     platforms = lib.platforms.linux;

--- a/pkgs/applications/video/xine-ui/default.nix
+++ b/pkgs/applications/video/xine-ui/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://xine.sourceforge.net/";
+    homepage = "https://xine.sourceforge.net/";
     description = "Xlib-based frontend for Xine video player";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ AndersonTorres ];

--- a/pkgs/applications/window-managers/hackedbox/default.nix
+++ b/pkgs/applications/window-managers/hackedbox/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "A bastard hacked offspring of Blackbox";
-    homepage = "http://github.com/museoa/hackedbox/";
+    homepage = "https://github.com/museoa/hackedbox/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ AndersonTorres ];
     inherit (libX11.meta) platforms;

--- a/pkgs/applications/window-managers/vwm/default.nix
+++ b/pkgs/applications/window-managers/vwm/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses glib libviper libpseudo gpm libvterm ];
 
   meta = with lib; {
-    homepage = "http://vwm.sourceforge.net/";
+    homepage = "https://vwm.sourceforge.net/";
     description = "Dynamic window manager for the console";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ ];

--- a/pkgs/data/fonts/corefonts/default.nix
+++ b/pkgs/data/fonts/corefonts/default.nix
@@ -17,7 +17,7 @@ let
   ];
 
   eula = fetchurl {
-    url = "http://corefonts.sourceforge.net/eula.htm";
+    url = "https://corefonts.sourceforge.net/eula.htm";
     sha256 = "1aqbcnl032g2hd7iy56cs022g47scb0jxxp3mm206x1yqc90vs1c";
   };
 in
@@ -87,7 +87,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    homepage = "http://corefonts.sourceforge.net/";
+    homepage = "https://corefonts.sourceforge.net/";
     description = "Microsoft's TrueType core fonts for the Web";
     platforms = platforms.all;
     license = licenses.unfreeRedistributable;

--- a/pkgs/data/fonts/hyperscrypt/default.nix
+++ b/pkgs/data/fonts/hyperscrypt/default.nix
@@ -12,7 +12,7 @@ in
   sha256 = "01pf5p2scmw02s0gxnibiwxbpzczphaaapv0v4s7svk9aw2gmc0m";
 
   meta = with lib; {
-    homepage = "http://velvetyne.fr/fonts/hyper-scrypt/";
+    homepage = "https://velvetyne.fr/fonts/hyper-scrypt/";
     description = "A modern stencil typeface inspired by stained glass technique";
     longDescription = ''
       The Hyper Scrypt typeface was designed for the Hyper Chapelle

--- a/pkgs/data/fonts/terminus-font/default.nix
+++ b/pkgs/data/fonts/terminus-font/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
       16x32. The styles are normal and bold (except for 6x12), plus
       EGA/VGA-bold for 8x14 and 8x16.
     '';
-    homepage = "http://terminus-font.sourceforge.net/";
+    homepage = "https://terminus-font.sourceforge.net/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ astsmtl ];
   };

--- a/pkgs/data/misc/shared-desktop-ontologies/default.nix
+++ b/pkgs/data/misc/shared-desktop-ontologies/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   meta = with lib; {
-    homepage = "http://oscaf.sourceforge.net/";
+    homepage = "https://oscaf.sourceforge.net/";
     description = "Ontologies necessary for the Nepomuk semantic desktop";
     longDescription = ''
       The shared-desktop-ontologies package brings the semantic web to the

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/xhtml1/default.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/xhtml1/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     ''; # */
 
   meta = {
-    homepage = "http://www.w3.org/TR/xhtml1/";
+    homepage = "https://www.w3.org/TR/xhtml1/";
     description = "DTDs for XHTML 1.0, the Extensible HyperText Markup Language";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/compilers/aspectj/default.nix
+++ b/pkgs/development/compilers/aspectj/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [jre];
 
   meta = {
-    homepage = "http://www.eclipse.org/aspectj/";
+    homepage = "https://www.eclipse.org/aspectj/";
     description = "A seamless aspect-oriented extension to the Java programming language";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     platforms = lib.platforms.unix;

--- a/pkgs/development/compilers/eli/default.nix
+++ b/pkgs/development/compilers/eli/default.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
       construction with extensive libraries implementing common tasks, yet handling
       arbitrary special cases. Output is the C subset of C++.
     '';
-    homepage = "http://eli-project.sourceforge.net/";
+    homepage = "https://eli-project.sourceforge.net/";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ timokau ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/compilers/flasm/default.nix
+++ b/pkgs/development/compilers/flasm/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Assembler and disassembler for Flash (SWF) bytecode";
-    homepage = "http://flasm.sourceforge.net/";
+    homepage = "https://flasm.sourceforge.net/";
     license = licenses.bsd2;
     maintainers = with maintainers; [ siraben ];
     platforms = platforms.all;

--- a/pkgs/development/compilers/gwt/2.4.0.nix
+++ b/pkgs/development/compilers/gwt/2.4.0.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://www.gwtproject.org/";
+    homepage = "https://www.gwtproject.org/";
     description = "A development toolkit for building and optimizing complex browser-based applications";
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;

--- a/pkgs/development/compilers/jasmin/default.nix
+++ b/pkgs/development/compilers/jasmin/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An assembler for the Java Virtual Machine";
-    homepage = "http://jasmin.sourceforge.net/";
+    homepage = "https://jasmin.sourceforge.net/";
     downloadPage = "https://sourceforge.net/projects/jasmin/files/latest/download";
     license = licenses.bsd3;
     maintainers = with maintainers; [ fgaz ];

--- a/pkgs/development/compilers/sdcc/default.nix
+++ b/pkgs/development/compilers/sdcc/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
       Rabbit 3000A). Work is in progress on supporting the Microchip PIC16 and
       PIC18 targets. It can be retargeted for other microprocessors.
     '';
-    homepage = "http://sdcc.sourceforge.net/";
+    homepage = "https://sdcc.sourceforge.net/";
     license = with licenses; if (gputils == null) then gpl2Plus else unfreeRedistributable;
     maintainers = with maintainers; [ bjornfor yorickvp ];
     platforms = platforms.all;

--- a/pkgs/development/compilers/x11basic/default.nix
+++ b/pkgs/development/compilers/x11basic/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://x11-basic.sourceforge.net/";
+    homepage = "https://x11-basic.sourceforge.net/";
     description = "A Basic interpreter and compiler with graphics capabilities";
     license = licenses.gpl2;
     maintainers = with maintainers; [ edwtjo ];

--- a/pkgs/development/coq-modules/HoTT/default.nix
+++ b/pkgs/development/coq-modules/HoTT/default.nix
@@ -18,7 +18,7 @@ with lib; mkCoqDerivation {
   '';
 
   meta = {
-    homepage = "http://homotopytypetheory.org/";
+    homepage = "https://homotopytypetheory.org/";
     description = "Homotopy type theory";
     maintainers = with maintainers; [ siddharthist ];
   };

--- a/pkgs/development/coq-modules/paco/default.nix
+++ b/pkgs/development/coq-modules/paco/default.nix
@@ -25,7 +25,7 @@ with lib; mkCoqDerivation {
   '';
 
   meta = {
-    homepage = "http://plv.mpi-sws.org/paco/";
+    homepage = "https://plv.mpi-sws.org/paco/";
     description = "A Coq library implementing parameterized coinduction";
     maintainers = with maintainers; [ jwiegley ptival ];
   };

--- a/pkgs/development/embedded/xc3sprog/default.nix
+++ b/pkgs/development/embedded/xc3sprog/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Command-line tools for programming FPGAs, microcontrollers and PROMs via JTAG";
-    homepage = "http://xc3sprog.sourceforge.net/";
+    homepage = "https://xc3sprog.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/interpreters/boron/default.nix
+++ b/pkgs/development/interpreters/boron/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://urlan.sourceforge.net/boron/";
+    homepage = "https://urlan.sourceforge.net/boron/";
     description = "Scripting language and C library useful for building DSLs";
     license = licenses.lgpl3Plus;
     platforms = platforms.linux;

--- a/pkgs/development/interpreters/metamath/default.nix
+++ b/pkgs/development/interpreters/metamath/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
       ASCII databases (set.mm and others) are also included in this derivation.
     '';
     homepage = "http://us.metamath.org";
-    downloadPage = "http://us.metamath.org/#downloads";
+    downloadPage = "https://us.metamath.org/#downloads";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.taneb ];
     platforms = platforms.all;

--- a/pkgs/development/interpreters/tinyscheme/default.nix
+++ b/pkgs/development/interpreters/tinyscheme/default.nix
@@ -72,8 +72,8 @@ stdenv.mkDerivation rec {
       TinyScheme is a lightweight Scheme interpreter that implements as large a
       subset of R5RS as was possible without getting very large and complicated.
     '';
-    homepage = "http://tinyscheme.sourceforge.net/";
-    changelog = "http://tinyscheme.sourceforge.net/CHANGES";
+    homepage = "https://tinyscheme.sourceforge.net/";
+    changelog = "https://tinyscheme.sourceforge.net/CHANGES";
     license = licenses.bsdOriginal;
     mainProgram = pname;
     maintainers = [ maintainers.ebzzry ];

--- a/pkgs/development/libraries/AntTweakBar/default.nix
+++ b/pkgs/development/libraries/AntTweakBar/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
       (compatibility and core profiles), DirectX 9, DirectX 10 or DirectX 11
       to interactively tweak parameters on-screen
     '';
-    homepage = "http://anttweakbar.sourceforge.net/";
+    homepage = "https://anttweakbar.sourceforge.net/";
     license = lib.licenses.zlib;
     maintainers = [ lib.maintainers.razvan ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/libraries/SDL_Pango/default.nix
+++ b/pkgs/development/libraries/SDL_Pango/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "Connects the Pango rendering engine to SDL";
     license = licenses.lgpl21Plus;
     platforms = platforms.all;
-    homepage = "http://sdlpango.sourceforge.net/";
+    homepage = "https://sdlpango.sourceforge.net/";
     maintainers = with maintainers; [ puckipedia ];
   };
 }

--- a/pkgs/development/libraries/SDL_stretch/default.nix
+++ b/pkgs/development/libraries/SDL_stretch/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
      description = "Stretch Functions For SDL";
-     homepage = "http://sdl-stretch.sourceforge.net/";
+     homepage = "https://sdl-stretch.sourceforge.net/";
      license = licenses.lgpl2;
      platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/aften/default.nix
+++ b/pkgs/development/libraries/aften/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An audio encoder which generates compressed audio streams based on ATSC A/52 specification";
-    homepage = "http://aften.sourceforge.net/";
+    homepage = "https://aften.sourceforge.net/";
     license = licenses.lgpl21Only;
     platforms = platforms.unix;
     maintainers = with maintainers; [ emilytrau ];

--- a/pkgs/development/libraries/audio/libbs2b/default.nix
+++ b/pkgs/development/libraries/audio/libbs2b/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   meta = {
-    homepage = "http://bs2b.sourceforge.net/";
+    homepage = "https://bs2b.sourceforge.net/";
     description = "Bauer stereophonic-to-binaural DSP library";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;

--- a/pkgs/development/libraries/cutee/default.nix
+++ b/pkgs/development/libraries/cutee/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "C++ Unit Testing Easy Environment";
-    homepage    = "http://www.codesink.org/cutee_unit_testing.html";
+    homepage    = "https://www.codesink.org/cutee_unit_testing.html";
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ leenaars];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/freeglut/default.nix
+++ b/pkgs/development/libraries/freeglut/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       intended to be a full replacement for GLUT, and has only a few
       differences.
     '';
-    homepage = "http://freeglut.sourceforge.net/";
+    homepage = "https://freeglut.sourceforge.net/";
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/libraries/fstrcmp/default.nix
+++ b/pkgs/development/libraries/fstrcmp/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
       comparisons of strings and byte arrays, including multi-byte character
       strings.
     '';
-    homepage = "http://fstrcmp.sourceforge.net/";
+    homepage = "https://fstrcmp.sourceforge.net/";
     downloadPage = "https://sourceforge.net/projects/fstrcmp/";
     license = licenses.gpl3;
     maintainers = [ maintainers.sephalon ];

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
       Grassroots DICOM (GDCM) is an implementation of the DICOM standard designed to be open source so that researchers may access clinical data directly.
       GDCM includes a file format definition and a network communications protocol, both of which should be extended to provide a full set of tools for a researcher or small medical imaging vendor to interface with an existing medical database.
     '';
-    homepage = "http://gdcm.sourceforge.net/";
+    homepage = "https://gdcm.sourceforge.net/";
     license = with licenses; [ bsd3 asl20 ];
     maintainers = with maintainers; [ tfmoraes ];
   };

--- a/pkgs/development/libraries/getdata/default.nix
+++ b/pkgs/development/libraries/getdata/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     platforms = platforms.all;
     maintainers = [ maintainers.vbgl ];
-    homepage = "http://getdata.sourceforge.net/";
+    homepage = "https://getdata.sourceforge.net/";
   };
 }

--- a/pkgs/development/libraries/glew/1.10.nix
+++ b/pkgs/development/libraries/glew/1.10.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An OpenGL extension loading library for C(++)";
-    homepage = "http://glew.sourceforge.net/";
+    homepage = "https://glew.sourceforge.net/";
     license = licenses.free; # different files under different licenses
       #["BSD" "GLX" "SGI-B" "GPL2"]
     platforms = platforms.mesaPlatforms;

--- a/pkgs/development/libraries/glew/default.nix
+++ b/pkgs/development/libraries/glew/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An OpenGL extension loading library for C/C++";
-    homepage = "http://glew.sourceforge.net/";
+    homepage = "https://glew.sourceforge.net/";
     license = with licenses; [ /* modified bsd */ free mit gpl2Only ]; # For full details, see https://github.com/nigels-com/glew#copyright-and-licensing
     platforms = with platforms;
       if enableEGL then

--- a/pkgs/development/libraries/glfw/2.x.nix
+++ b/pkgs/development/libraries/glfw/2.x.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Multi-platform library for creating OpenGL contexts and managing input, including keyboard, mouse, joystick and time";
-    homepage = "http://glfw.sourceforge.net/";
+    homepage = "https://glfw.sourceforge.net/";
     license = licenses.zlib;
     maintainers = [ lib.maintainers.marcweber ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/gsm/default.nix
+++ b/pkgs/development/libraries/gsm/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   version = "1.0.20";
 
   src = fetchurl {
-    url = "http://www.quut.com/gsm/${pname}-${version}.tar.gz";
+    url = "https://www.quut.com/gsm/${pname}-${version}.tar.gz";
     sha256 = "sha256-YxXDhRi4HomcP8LtRjzGI68pxcIxpIwTeyQwIjSukL8=";
   };
 
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Lossy speech compression codec";
-    homepage    = "http://www.quut.com/gsm/";
+    homepage    = "https://www.quut.com/gsm/";
     license     = licenses.bsd2;
     maintainers = with maintainers; [ codyopel raskin ];
     platforms   = platforms.unix;

--- a/pkgs/development/libraries/gtkextra/default.nix
+++ b/pkgs/development/libraries/gtkextra/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ gtk2 glib cairo atk pango libtiff libpng libjpeg ];
 
   meta = with lib; {
-    homepage = "http://gtkextra.sourceforge.net/";
+    homepage = "https://gtkextra.sourceforge.net/";
     description = "GtkExtra is a useful set of widgets for creating GUI's for GTK+.";
     license = licenses.lgpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/gtkspell/3.nix
+++ b/pkgs/development/libraries/gtkspell/3.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "http://gtkspell.sourceforge.net/";
+    homepage = "https://gtkspell.sourceforge.net/";
     description = "Word-processor-style highlighting GtkTextView widget";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/gtkspellmm/default.nix
+++ b/pkgs/development/libraries/gtkspellmm/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "C++ binding for the gtkspell library";
-    homepage = "http://gtkspell.sourceforge.net/";
+    homepage = "https://gtkspell.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/gts/default.nix
+++ b/pkgs/development/libraries/gts/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://gts.sourceforge.net/";
+    homepage = "https://gts.sourceforge.net/";
     license = lib.licenses.lgpl2Plus;
     description = "GNU Triangulated Surface Library";
 

--- a/pkgs/development/libraries/htmlcxx/default.nix
+++ b/pkgs/development/libraries/htmlcxx/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "http://htmlcxx.sourceforge.net/";
+    homepage = "https://htmlcxx.sourceforge.net/";
     description = "A simple non-validating css1 and html parser for C++";
     license = licenses.lgpl2;
     platforms = platforms.all;

--- a/pkgs/development/libraries/incrtcl/default.nix
+++ b/pkgs/development/libraries/incrtcl/default.nix
@@ -30,7 +30,7 @@ tcl.mkTclDerivation rec {
   outputs = [ "out" "dev" "man" ];
 
   meta = with lib; {
-    homepage    = "http://incrtcl.sourceforge.net/";
+    homepage    = "https://incrtcl.sourceforge.net/";
     description = "Object Oriented Enhancements for Tcl/Tk";
     license     = licenses.tcltk;
     platforms   = platforms.unix;

--- a/pkgs/development/libraries/itktcl/default.nix
+++ b/pkgs/development/libraries/itktcl/default.nix
@@ -29,7 +29,7 @@ tcl.mkTclDerivation rec {
   outputs = [ "out" "dev" "man" ];
 
   meta = with lib; {
-    homepage    = "http://incrtcl.sourceforge.net/";
+    homepage    = "https://incrtcl.sourceforge.net/";
     description = "Mega-widget toolkit for incr Tk";
     license     = licenses.tcltk;
     platforms   = platforms.unix;

--- a/pkgs/development/libraries/java/saxon/default.nix
+++ b/pkgs/development/libraries/java/saxon/default.nix
@@ -28,7 +28,7 @@ let
 
       meta = with lib; {
         inherit description license;
-        homepage = "http://saxon.sourceforge.net/";
+        homepage = "https://saxon.sourceforge.net/";
         sourceProvenance = with sourceTypes; [ binaryBytecode ];
         maintainers = with maintainers; [ rvl ];
         platforms = platforms.all;
@@ -44,7 +44,7 @@ in {
       sha256 = "0l5y3y2z4wqgh80f26dwwxwncs8v3nkz3nidv14z024lmk730vs3";
     };
     description = "XSLT 1.0 processor";
-    # http://saxon.sourceforge.net/saxon6.5.3/conditions.html
+    # https://saxon.sourceforge.net/saxon6.5.3/conditions.html
     license = lib.licenses.mpl10;
     java = jre8;
   };

--- a/pkgs/development/libraries/judy/default.nix
+++ b/pkgs/development/libraries/judy/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = false;
 
   meta = {
-    homepage = "http://judy.sourceforge.net/";
+    homepage = "https://judy.sourceforge.net/";
     license = lib.licenses.lgpl21Plus;
     description = "State-of-the-art C library that implements a sparse dynamic array";
     platforms = lib.platforms.unix;

--- a/pkgs/development/libraries/lib3ds/default.nix
+++ b/pkgs/development/libraries/lib3ds/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Library for managing 3D-Studio Release 3 and 4 \".3DS\" files";
-    homepage = "http://lib3ds.sourceforge.net/";
+    homepage = "https://lib3ds.sourceforge.net/";
     license = "LGPL";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/libraries/libHX/default.nix
+++ b/pkgs/development/libraries/libHX/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with lib; {
-    homepage = "http://libhx.sourceforge.net/";
+    homepage = "https://libhx.sourceforge.net/";
     longDescription = ''
       libHX is a C library (with some C++ bindings available) that provides data structures
       and functions commonly needed, such as maps, deques, linked lists, string formatting

--- a/pkgs/development/libraries/libcddb/default.nix
+++ b/pkgs/development/libraries/libcddb/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "C library to access data on a CDDB server (freedb.org)";
-    homepage = "http://libcddb.sourceforge.net/";
+    homepage = "https://libcddb.sourceforge.net/";
     license = licenses.lgpl2Plus;
     mainProgram = "cddb_query";
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libchewing/default.nix
+++ b/pkgs/development/libraries/libchewing/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Intelligent Chinese phonetic input method";
-    homepage = "http://chewing.im/";
+    homepage = "https://chewing.im/";
     license = licenses.lgpl21Only;
     maintainers = [ maintainers.ericsagnes ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libdbi-drivers/default.nix
+++ b/pkgs/development/libraries/libdbi-drivers/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://libdbi-drivers.sourceforge.net/";
+    homepage = "https://libdbi-drivers.sourceforge.net/";
     description = "Database drivers for libdbi";
     platforms = platforms.all;
     license = licenses.lgpl21;

--- a/pkgs/development/libraries/libdbi/default.nix
+++ b/pkgs/development/libraries/libdbi/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "http://libdbi.sourceforge.net/";
+    homepage = "https://libdbi.sourceforge.net/";
     description = "DB independent interface to DB";
     license = licenses.lgpl21;
     platforms = platforms.all;

--- a/pkgs/development/libraries/libdigidocpp/default.nix
+++ b/pkgs/development/libraries/libdigidocpp/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Library for creating DigiDoc signature files";
-    homepage = "http://www.id.ee/";
+    homepage = "https://www.id.ee/";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.jagajaga ];

--- a/pkgs/development/libraries/libgringotts/default.nix
+++ b/pkgs/development/libraries/libgringotts/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A small library to encapsulate data in an encrypted structure";
-    homepage = "http://libgringotts.sourceforge.net/";
+    homepage = "https://libgringotts.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ pSub ];

--- a/pkgs/development/libraries/libid3tag/default.nix
+++ b/pkgs/development/libraries/libid3tag/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "ID3 tag manipulation library";
-    homepage = "http://mad.sourceforge.net/";
+    homepage = "https://mad.sourceforge.net/";
     license = licenses.gpl2;
     maintainers = [ ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libinklevel/default.nix
+++ b/pkgs/development/libraries/libinklevel/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
       project is to create a vendor independent API for retrieving the ink
       level of a printer connected to a Linux or FreeBSD box.
     '';
-    homepage = "http://libinklevel.sourceforge.net/";
+    homepage = "https://libinklevel.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.linux ++ platforms.freebsd;
     maintainers = with maintainers; [ samb96 ];

--- a/pkgs/development/libraries/libipfix/default.nix
+++ b/pkgs/development/libraries/libipfix/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = "-fcommon";
 
   meta = with lib; {
-    homepage = "http://libipfix.sourceforge.net/";
+    homepage = "https://libipfix.sourceforge.net/";
     description = "The libipfix C-library implements the IPFIX protocol defined by the IP Flow Information Export working group of the IETF";
     license = licenses.lgpl3;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libivykis/default.nix
+++ b/pkgs/development/libraries/libivykis/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ file protobufc ];
 
   meta = with lib; {
-    homepage = "http://libivykis.sourceforge.net/";
+    homepage = "https://libivykis.sourceforge.net/";
     description = ''
       A thin wrapper over various OS'es implementation of I/O readiness
       notification facilities

--- a/pkgs/development/libraries/libmodplug/default.nix
+++ b/pkgs/development/libraries/libmodplug/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "MOD playing library";
-    homepage    = "http://modplug-xmms.sourceforge.net/";
+    homepage    = "https://modplug-xmms.sourceforge.net/";
     license     = licenses.publicDomain;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ raskin ];

--- a/pkgs/development/libraries/libnatspec/default.nix
+++ b/pkgs/development/libraries/libnatspec/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ libiconv ];
 
   meta = with lib; {
-    homepage = "http://natspec.sourceforge.net/";
+    homepage = "https://natspec.sourceforge.net/";
     description = "A library intended to smooth national specificities in using of programs";
     platforms = platforms.unix;
     license = licenses.lgpl21;

--- a/pkgs/development/libraries/libofx/default.nix
+++ b/pkgs/development/libraries/libofx/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Opensource implementation of the Open Financial eXchange specification";
-    homepage = "http://libofx.sourceforge.net/";
+    homepage = "https://libofx.sourceforge.net/";
     license = "LGPL";
     platforms = lib.platforms.unix;
     maintainers = [ ];

--- a/pkgs/development/libraries/libosmscout/default.nix
+++ b/pkgs/development/libraries/libosmscout/default.nix
@@ -19,7 +19,7 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "Simple, high-level interfaces for offline location and POI lokup, rendering and routing functionalities based on OpenStreetMap (OSM) data";
-    homepage = "http://libosmscout.sourceforge.net/";
+    homepage = "https://libosmscout.sourceforge.net/";
     license = licenses.lgpl3Plus;
     maintainers = [ maintainers.Thra11 ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libpar2/default.nix
+++ b/pkgs/development/libraries/libpar2/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   CXXFLAGS = lib.optionalString stdenv.cc.isClang "-std=c++11";
 
   meta = {
-    homepage = "http://parchive.sourceforge.net/";
+    homepage = "https://parchive.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
     description = "A library for using Parchives (parity archive volume sets)";
     platforms = lib.platforms.unix;

--- a/pkgs/development/libraries/libpqxx/6.nix
+++ b/pkgs/development/libraries/libpqxx/6.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A C++ library to access PostgreSQL databases";
-    homepage = "http://pqxx.org/development/libpqxx/";
+    homepage = "https://pqxx.org/development/libpqxx/";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.eelco ];

--- a/pkgs/development/libraries/libpqxx/default.nix
+++ b/pkgs/development/libraries/libpqxx/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A C++ library to access PostgreSQL databases";
-    homepage = "http://pqxx.org/development/libpqxx/";
+    homepage = "https://pqxx.org/development/libpqxx/";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.eelco ];

--- a/pkgs/development/libraries/librsb/default.nix
+++ b/pkgs/development/libraries/librsb/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
   checkTarget = "tests";
 
   meta = with lib; {
-    homepage = "http://librsb.sourceforge.net/";
+    homepage = "https://librsb.sourceforge.net/";
     description = "Shared memory parallel sparse matrix and sparse BLAS library";
     longDescription = ''
       Library for sparse matrix computations featuring the Recursive Sparse

--- a/pkgs/development/libraries/librsync/default.nix
+++ b/pkgs/development/libraries/librsync/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Implementation of the rsync remote-delta algorithm";
-    homepage = "http://librsync.sourceforge.net/";
+    homepage = "https://librsync.sourceforge.net/";
     license = licenses.lgpl2Plus;
     mainProgram = "rdiff";
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libspectrum/default.nix
+++ b/pkgs/development/libraries/libspectrum/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with lib; {
-    homepage = "http://fuse-emulator.sourceforge.net/libspectrum.php";
+    homepage = "https://fuse-emulator.sourceforge.net/libspectrum.php";
     description = "ZX Spectrum input and output support library";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libspnav/default.nix
+++ b/pkgs/development/libraries/libspnav/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://spacenav.sourceforge.net/";
+    homepage = "https://spacenav.sourceforge.net/";
     description = "Device driver and SDK for 3Dconnexion 3D input devices";
     longDescription = "A free, compatible alternative, to the proprietary 3Dconnexion device driver and SDK, for their 3D input devices (called 'space navigator', 'space pilot', 'space traveller', etc)";
     license = licenses.bsd3;

--- a/pkgs/development/libraries/libthreadar/default.nix
+++ b/pkgs/development/libraries/libthreadar/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://libthreadar.sourceforge.net/";
+    homepage = "https://libthreadar.sourceforge.net/";
     description = "A C++ library that provides several classes to manipulate threads";
     longDescription = ''
       Libthreadar is a C++ library providing a small set of C++ classes to manipulate

--- a/pkgs/development/libraries/libwmf/default.nix
+++ b/pkgs/development/libraries/libwmf/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "WMF library from wvWare";
-    homepage = "http://wvware.sourceforge.net/libwmf.html";
+    homepage = "https://wvware.sourceforge.net/libwmf.html";
     downloadPage = "https://github.com/caolanm/libwmf/releases";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libwpd/default.nix
+++ b/pkgs/development/libraries/libwpd/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A library for importing and exporting WordPerfect documents";
-    homepage = "http://libwpd.sourceforge.net/";
+    homepage = "https://libwpd.sourceforge.net/";
     license = licenses.lgpl21;
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/libwps/default.nix
+++ b/pkgs/development/libraries/libwps/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-Wno-error=implicit-fallthrough";
 
   meta = with lib; {
-    homepage = "http://libwps.sourceforge.net/";
+    homepage = "https://libwps.sourceforge.net/";
     description = "Microsoft Works document format import filter library";
     platforms = platforms.unix;
     license = licenses.lgpl21;

--- a/pkgs/development/libraries/libxmlxx/default.nix
+++ b/pkgs/development/libraries/libxmlxx/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "http://libxmlplusplus.sourceforge.net/";
+    homepage = "https://libxmlplusplus.sourceforge.net/";
     description = "C++ wrapper for the libxml2 XML parser library";
     license = licenses.lgpl2Plus;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libxmlxx/v3.nix
+++ b/pkgs/development/libraries/libxmlxx/v3.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "http://libxmlplusplus.sourceforge.net/";
+    homepage = "https://libxmlplusplus.sourceforge.net/";
     description = "C++ wrapper for the libxml2 XML parser library, version 3";
     license = licenses.lgpl2Plus;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/libxmp/default.nix
+++ b/pkgs/development/libraries/libxmp/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Extended module player library";
-    homepage    = "http://xmp.sourceforge.net/";
+    homepage    = "https://xmp.sourceforge.net/";
     longDescription = ''
       Libxmp is a library that renders module files to PCM data. It supports
       over 90 mainstream and obscure module formats including Protracker (MOD),

--- a/pkgs/development/libraries/lime/default.nix
+++ b/pkgs/development/libraries/lime/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "End-to-end encryption library for instant messaging. Part of the Linphone project.";
-    homepage = "http://www.linphone.org/technical-corner/lime";
+    homepage = "https://www.linphone.org/technical-corner/lime";
     license = licenses.gpl3Only;
     platforms = platforms.all;
     maintainers = with maintainers; [ jluttine ];

--- a/pkgs/development/libraries/log4cpp/default.nix
+++ b/pkgs/development/libraries/log4cpp/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    homepage    = "http://log4cpp.sourceforge.net/";
+    homepage    = "https://log4cpp.sourceforge.net/";
     description = "A logging framework for C++ patterned after Apache log4j";
     license     = licenses.lgpl21Plus;
     platforms   = platforms.unix;

--- a/pkgs/development/libraries/mac/default.nix
+++ b/pkgs/development/libraries/mac/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "APE codec and decompressor";
-    homepage = "http://www.deb-multimedia.org/dists/testing/main/binary-amd64/package/monkeys-audio.php";
+    homepage = "https://www.deb-multimedia.org/dists/testing/main/binary-amd64/package/monkeys-audio.php";
     license = licenses.unfreeRedistributable;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ jfrankenau ];

--- a/pkgs/development/libraries/martyr/default.nix
+++ b/pkgs/development/libraries/martyr/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Java framework around the IRC protocol to allow application writers easy manipulation of the protocol and client state";
-    homepage = "http://martyr.sourceforge.net/";
+    homepage = "https://martyr.sourceforge.net/";
     license = lib.licenses.lgpl21;
   };
 }

--- a/pkgs/development/libraries/mediastreamer/default.nix
+++ b/pkgs/development/libraries/mediastreamer/default.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A powerful and lightweight streaming engine specialized for voice/video telephony applications. Part of the Linphone project";
-    homepage = "http://www.linphone.org/technical-corner/mediastreamer2";
+    homepage = "https://www.linphone.org/technical-corner/mediastreamer2";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
     maintainers = with maintainers; [ jluttine ];

--- a/pkgs/development/libraries/mimetic/default.nix
+++ b/pkgs/development/libraries/mimetic/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "MIME handling library";
-    homepage    = "http://www.codesink.org/mimetic_mime_library.html";
+    homepage    = "https://www.codesink.org/mimetic_mime_library.html";
     license     = licenses.mit;
     maintainers = with maintainers; [ leenaars];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/mythes/default.nix
+++ b/pkgs/development/libraries/mythes/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ ncurses pkg-config perl ];
 
   meta = {
-    homepage = "http://hunspell.sourceforge.net/";
+    homepage = "https://hunspell.sourceforge.net/";
     description = "Thesaurus library from Hunspell project";
     license = lib.licenses.bsd3;
     inherit (hunspell.meta) platforms;

--- a/pkgs/development/libraries/nco/default.nix
+++ b/pkgs/development/libraries/nco/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "NetCDF Operator toolkit";
     longDescription = "The NCO (netCDF Operator) toolkit manipulates and analyzes data stored in netCDF-accessible formats, including DAP, HDF4, and HDF5";
-    homepage = "http://nco.sourceforge.net/";
+    homepage = "https://nco.sourceforge.net/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ bzizou ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/plib/default.nix
+++ b/pkgs/development/libraries/plib/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     # XXX: The author doesn't use the orthodox SF way to store tarballs.
-    url = "http://plib.sourceforge.net/dist/${pname}-${version}.tar.gz";
+    url = "https://plib.sourceforge.net/dist/${pname}-${version}.tar.gz";
     sha256 = "0cha71mflpa10vh2l7ipyqk67dq2y0k5xbafwdks03fwdyzj4ns8";
   };
 
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
 
     license = lib.licenses.lgpl2Plus;
 
-    homepage = "http://plib.sourceforge.net/";
+    homepage = "https://plib.sourceforge.net/";
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/pslib/default.nix
+++ b/pkgs/development/libraries/pslib/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A C-library for generating multi page PostScript documents";
-    homepage = "http://pslib.sourceforge.net/";
+    homepage = "https://pslib.sourceforge.net/";
     changelog =
       "https://sourceforge.net/p/pslib/git/ci/master/tree/pslib/ChangeLog";
     license = licenses.gpl2;

--- a/pkgs/development/libraries/pstreams/default.nix
+++ b/pkgs/development/libraries/pstreams/default.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation rec {
       POSIX.2 functions popen(3) and pclose(3), using C++ iostreams instead of
       C's stdio library.
     '';
-    homepage = "http://pstreams.sourceforge.net/";
-    downloadPage = "http://pstreams.sourceforge.net/download/";
+    homepage = "https://pstreams.sourceforge.net/";
+    downloadPage = "https://pstreams.sourceforge.net/download/";
     maintainers = with maintainers; [ arthur ];
     license = licenses.boost;
     platforms = platforms.all;

--- a/pkgs/development/libraries/pxlib/default.nix
+++ b/pkgs/development/libraries/pxlib/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Library to read and write Paradox files";
-    homepage = "http://pxlib.sourceforge.net/";
+    homepage = "https://pxlib.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.all;
     maintainers = [ maintainers.winpat ];

--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "PythonQt is a dynamic Python binding for the Qt framework. It offers an easy way to embed the Python scripting language into your C++ Qt applications";
-    homepage = "http://pythonqt.sourceforge.net/";
+    homepage = "https://pythonqt.sourceforge.net/";
     license = licenses.lgpl21;
     platforms = platforms.all;
     maintainers = with maintainers; [ hlolli ];

--- a/pkgs/development/libraries/qjson/default.nix
+++ b/pkgs/development/libraries/qjson/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Lightweight data-interchange format";
-    homepage = "http://qjson.sourceforge.net/";
+    homepage = "https://qjson.sourceforge.net/";
     license = licenses.lgpl21;
   };
 }

--- a/pkgs/development/libraries/quesoglc/default.nix
+++ b/pkgs/development/libraries/quesoglc/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
       provides Unicode support and is designed to be easily ported to any
       platform that supports both FreeType and the OpenGL API.
     '';
-    homepage = "http://quesoglc.sourceforge.net/";
+    homepage = "https://quesoglc.sourceforge.net/";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ astsmtl ];
     platforms = platforms.linux;

--- a/pkgs/development/libraries/rapidxml/default.nix
+++ b/pkgs/development/libraries/rapidxml/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Fast XML DOM-style parser in C++";
-    homepage = "http://rapidxml.sourceforge.net/";
+    homepage = "https://rapidxml.sourceforge.net/";
     license = licenses.boost;
     platforms = platforms.unix;
     maintainers = with maintainers; [ cpages ];

--- a/pkgs/development/libraries/rote/default.nix
+++ b/pkgs/development/libraries/rote/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       ncurses as well so that you may render the virtual screen to the real
       screen when you need to.
     '';
-    homepage = "http://rote.sourceforge.net/";
+    homepage = "https://rote.sourceforge.net/";
     license = licenses.lgpl21;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/science/math/itpp/default.nix
+++ b/pkgs/development/libraries/science/math/itpp/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "IT++ is a C++ library of mathematical, signal processing and communication classes and functions";
-    homepage = "http://itpp.sourceforge.net/";
+    homepage = "https://itpp.sourceforge.net/";
     license = licenses.gpl3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ andrew-d ];

--- a/pkgs/development/libraries/snap7/default.nix
+++ b/pkgs/development/libraries/snap7/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://snap7.sourceforge.net/";
+    homepage = "https://snap7.sourceforge.net/";
     description = "Step7 Open Source Ethernet Communication Suite";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ freezeboy ];

--- a/pkgs/development/libraries/soci/default.nix
+++ b/pkgs/development/libraries/soci/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Database access library for C++";
-    homepage = "http://soci.sourceforge.net/";
+    homepage = "https://soci.sourceforge.net/";
     license = licenses.boost;
     platforms = platforms.all;
     maintainers = with maintainers; [ jluttine ];

--- a/pkgs/development/libraries/tclap/default.nix
+++ b/pkgs/development/libraries/tclap/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "http://tclap.sourceforge.net/";
+    homepage = "https://tclap.sourceforge.net/";
     description = "Templatized C++ Command Line Parser Library";
     platforms = platforms.all;
     license = licenses.mit;

--- a/pkgs/development/libraries/tclx/default.nix
+++ b/pkgs/development/libraries/tclx/default.nix
@@ -17,7 +17,7 @@ tcl.mkTclDerivation rec {
   '';
 
   meta = {
-    homepage = "http://tclx.sourceforge.net/";
+    homepage = "https://tclx.sourceforge.net/";
     description = "Tcl extensions";
     license = lib.licenses.tcltk;
     maintainers = with lib.maintainers; [ kovirobi ];

--- a/pkgs/development/libraries/tix/default.nix
+++ b/pkgs/development/libraries/tix/default.nix
@@ -52,7 +52,7 @@ tcl.mkTclDerivation {
 
   meta = with lib; {
     description = "A widget library for Tcl/Tk";
-    homepage    = "http://tix.sourceforge.net/";
+    homepage    = "https://tix.sourceforge.net/";
     platforms   = platforms.all;
     license     = with licenses; [
       bsd2 # tix

--- a/pkgs/development/libraries/tsocks/default.nix
+++ b/pkgs/development/libraries/tsocks/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Transparent SOCKS v4 proxying library";
-    homepage = "http://tsocks.sourceforge.net/";
+    homepage = "https://tsocks.sourceforge.net/";
     license = lib.licenses.gpl2;
     maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/vxl/default.nix
+++ b/pkgs/development/libraries/vxl/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "C++ Libraries for Computer Vision Research and Implementation";
-    homepage = "http://vxl.sourceforge.net/";
+    homepage = "https://vxl.sourceforge.net/";
     license = "VXL License";
     maintainers = with lib.maintainers; [viric];
     platforms = with lib.platforms; linux;

--- a/pkgs/development/libraries/waffle/default.nix
+++ b/pkgs/development/libraries/waffle/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A cross-platform C library that allows one to defer selection of an OpenGL API and window system until runtime";
-    homepage = "http://www.waffle-gl.org/";
+    homepage = "https://www.waffle-gl.org/";
     license = licenses.bsd2;
     platforms = platforms.mesaPlatforms;
     maintainers = with maintainers; [ Flakebi ];

--- a/pkgs/development/libraries/wildmidi/default.nix
+++ b/pkgs/development/libraries/wildmidi/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
       WildMIDI is a simple software midi player which has a core softsynth
       library that can be use with other applications.
     '';
-    homepage = "http://wildmidi.sourceforge.net/";
+    homepage = "https://wildmidi.sourceforge.net/";
     # The library is LGPLv3, the wildmidi executable is GPLv3
     license = licenses.lgpl3;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/wxSVG/default.nix
+++ b/pkgs/development/libraries/wxSVG/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional stdenv.isDarwin Cocoa;
 
   meta = with lib; {
-    homepage = "http://wxsvg.sourceforge.net/";
+    homepage = "https://wxsvg.sourceforge.net/";
     description = "A SVG manipulation library built with wxWidgets";
     longDescription = ''
       wxSVG is C++ library to create, manipulate and render Scalable Vector

--- a/pkgs/development/libraries/xavs/default.nix
+++ b/pkgs/development/libraries/xavs/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "AVS encoder and decoder";
-    homepage    = "http://xavs.sourceforge.net/";
+    homepage    = "https://xavs.sourceforge.net/";
     license     = licenses.lgpl2;
     platforms   = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ codyopel ];

--- a/pkgs/development/libraries/xine-lib/default.nix
+++ b/pkgs/development/libraries/xine-lib/default.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
 
 
   meta = with lib; {
-    homepage = "http://xine.sourceforge.net/";
+    homepage = "https://xine.sourceforge.net/";
     description = "A high-performance, portable and reusable multimedia playback engine";
     license = with licenses; [ gpl2Plus lgpl2Plus ];
     maintainers = with maintainers; [ AndersonTorres ];

--- a/pkgs/development/libraries/xmlrpc-c/default.nix
+++ b/pkgs/development/libraries/xmlrpc-c/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A lightweight RPC library based on XML and HTTP";
-    homepage = "http://xmlrpc-c.sourceforge.net/";
+    homepage = "https://xmlrpc-c.sourceforge.net/";
     # <xmlrpc-c>/doc/COPYING also lists "Expat license",
     # "ABYSS Web Server License" and "Python 1.5.2 License"
     license = licenses.bsd3;

--- a/pkgs/development/libraries/xylib/default.nix
+++ b/pkgs/development/libraries/xylib/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Portable library for reading files that contain x-y data from powder diffraction, spectroscopy and other experimental methods";
     license = licenses.lgpl21;
-    homepage = "http://xylib.sourceforge.net/";
+    homepage = "https://xylib.sourceforge.net/";
     platforms = platforms.linux;
     maintainers = with maintainers; [ pSub ];
   };

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -424,7 +424,7 @@ buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = {
-    homepage = "http://github.com/JorjBauer/lua-cyrussasl";
+    homepage = "https://github.com/JorjBauer/lua-cyrussasl";
     description = "Cyrus SASL library for Lua 5.1+";
     license.fullName = "BSD";
   };
@@ -593,7 +593,7 @@ buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = {
-    homepage = "http://github.com/lewis6991/gitsigns.nvim";
+    homepage = "https://github.com/lewis6991/gitsigns.nvim";
     description = "Git signs written in pure lua";
     license.fullName = "MIT/X11";
   };
@@ -1038,7 +1038,7 @@ buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = {
-    homepage = "http://github.com/rrthomas/lrexlib";
+    homepage = "https://github.com/rrthomas/lrexlib";
     description = "Regular expression library binding (GNU flavour).";
     license.fullName = "MIT/X11";
   };
@@ -1071,7 +1071,7 @@ buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = {
-    homepage = "http://github.com/rrthomas/lrexlib";
+    homepage = "https://github.com/rrthomas/lrexlib";
     description = "Regular expression library binding (PCRE flavour).";
     maintainers = with lib.maintainers; [ vyp ];
     license.fullName = "MIT/X11";
@@ -1105,7 +1105,7 @@ buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = {
-    homepage = "http://github.com/rrthomas/lrexlib";
+    homepage = "https://github.com/rrthomas/lrexlib";
     description = "Regular expression library binding (POSIX flavour).";
     license.fullName = "MIT/X11";
   };
@@ -1171,7 +1171,7 @@ buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = {
-    homepage = "http://github.com/antirez/lua-cmsgpack";
+    homepage = "https://github.com/antirez/lua-cmsgpack";
     description = "MessagePack C implementation and bindings for Lua 5.1/5.2/5.3";
     license.fullName = "Two-clause BSD";
   };
@@ -1569,7 +1569,7 @@ buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = {
-    homepage = "http://github.com/brimworks/lua-yajl";
+    homepage = "https://github.com/brimworks/lua-yajl";
     description = "Integrate the yajl JSON library with Lua.";
     maintainers = with lib.maintainers; [ pstn ];
     license.fullName = "MIT/X11";
@@ -2086,7 +2086,7 @@ buildLuarocksPackage {
     sha256 = "0hx6my54axjcb3bklr991wji374qq6mwa3ily6dvb72vi2534nwz";
   }).outPath;
   src = fetchzip {
-    url    = "http://github.com/luaposix/luaposix/archive/v34.1.1.zip";
+    url    = "https://github.com/luaposix/luaposix/archive/v34.1.1.zip";
     sha256 = "0863r8c69yx92lalj174qdhavqmcs2cdimjim6k55qj9yn78v9zl";
   };
 
@@ -2094,7 +2094,7 @@ buildLuarocksPackage {
   propagatedBuildInputs = [ bit32 lua ];
 
   meta = {
-    homepage = "http://github.com/luaposix/luaposix/";
+    homepage = "https://github.com/luaposix/luaposix/";
     description = "Lua bindings for POSIX";
     maintainers = with lib.maintainers; [ vyp lblasc ];
     license.fullName = "MIT/X11";
@@ -2329,7 +2329,7 @@ buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = {
-    homepage = "http://github.com/bluebird75/luaunit";
+    homepage = "https://github.com/bluebird75/luaunit";
     description = "A unit testing framework for Lua";
     maintainers = with lib.maintainers; [ lockejan ];
     license.fullName = "BSD";
@@ -2355,7 +2355,7 @@ buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = {
-    homepage = "http://github.com/starwing/luautf8";
+    homepage = "https://github.com/starwing/luautf8";
     description = "A UTF-8 support module for Lua";
     maintainers = with lib.maintainers; [ pstn ];
     license.fullName = "MIT";
@@ -2489,7 +2489,7 @@ buildLuarocksPackage {
     sha256 = "0d0h70kjl5fkq589y1sx8qy8as002dhcf88pf60pghvch002ryi1";
   }).outPath;
   src = fetchzip {
-    url    = "http://github.com/gvvaughan/lyaml/archive/v6.2.8.zip";
+    url    = "https://github.com/gvvaughan/lyaml/archive/v6.2.8.zip";
     sha256 = "0r3jjsd8x2fs1aanki0s1mvpznl16f32c1qfgmicy0icgy5xfch0";
   };
 
@@ -2497,7 +2497,7 @@ buildLuarocksPackage {
   propagatedBuildInputs = [ lua ];
 
   meta = {
-    homepage = "http://github.com/gvvaughan/lyaml";
+    homepage = "https://github.com/gvvaughan/lyaml";
     description = "libYAML binding for Lua";
     maintainers = with lib.maintainers; [ lblasc ];
     license.fullName = "MIT/X11";
@@ -2723,7 +2723,7 @@ buildLuarocksPackage {
   propagatedBuildInputs = [ lua luassert ];
 
   meta = {
-    homepage = "http://github.com/nvim-lua/plenary.nvim";
+    homepage = "https://github.com/nvim-lua/plenary.nvim";
     description = "lua functions you don't want to write ";
     license.fullName = "MIT/X11";
   };
@@ -2779,7 +2779,7 @@ buildLuarocksPackage {
   propagatedBuildInputs = [ lua luaposix ];
 
   meta = {
-    homepage = "http://pjb.com.au/comp/lua/readline.html";
+    homepage = "https://pjb.com.au/comp/lua/readline.html";
     description = "Interface to the readline library";
     license.fullName = "MIT/X11";
   };

--- a/pkgs/development/misc/haskell/hasura/pool.nix
+++ b/pkgs/development/misc/haskell/hasura/pool.nix
@@ -17,7 +17,7 @@ mkDerivation {
     vector
   ];
   testHaskellDepends = [ base hspec ];
-  homepage = "http://github.com/bos/pool";
+  homepage = "https://github.com/bos/pool";
   description = "A high-performance striped resource pooling implementation";
   license = lib.licenses.bsd3;
   maintainers = with lib.maintainers; [ lassulus ];

--- a/pkgs/development/ocaml-modules/gmetadom/default.nix
+++ b/pkgs/development/ocaml-modules/gmetadom/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   meta = {
-    homepage = "http://gmetadom.sourceforge.net/";
+    homepage = "https://gmetadom.sourceforge.net/";
     description = "A collection of librares, each library providing a DOM implementation";
     license = lib.licenses.lgpl21Plus;
     maintainers = [ lib.maintainers.roconnor ];

--- a/pkgs/development/ocaml-modules/note/default.nix
+++ b/pkgs/development/ocaml-modules/note/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   inherit (topkg) buildPhase installPhase;
 
   meta = {
-    homepage = "http://erratique.ch/software/note";
+    homepage = "https://erratique.ch/software/note";
     description = "An OCaml module for functional reactive programming";
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.vbgl ];

--- a/pkgs/development/python-modules/Pmw/default.nix
+++ b/pkgs/development/python-modules/Pmw/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "A toolkit for building high-level compound widgets in Python using the Tkinter module";
-    homepage = "http://pmw.sourceforge.net/";
+    homepage = "https://pmw.sourceforge.net/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ mounium ];
   };

--- a/pkgs/development/python-modules/audiotools/default.nix
+++ b/pkgs/development/python-modules/audiotools/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Utilities and Python modules for handling audio";
-    homepage = "http://audiotools.sourceforge.net/";
+    homepage = "https://audiotools.sourceforge.net/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/crcmod/default.nix
+++ b/pkgs/development/python-modules/crcmod/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python module for generating objects that compute the Cyclic Redundancy Check (CRC)";
-    homepage = "http://crcmod.sourceforge.net/";
+    homepage = "https://crcmod.sourceforge.net/";
     license = licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/ftputil/default.nix
+++ b/pkgs/development/python-modules/ftputil/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "High-level FTP client library (virtual file system and more)";
-    homepage = "http://ftputil.sschwarzer.net/";
+    homepage = "https://ftputil.sschwarzer.net/";
     license = licenses.bsd2;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/holoviews/default.nix
+++ b/pkgs/development/python-modules/holoviews/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python data analysis and visualization seamless and simple";
-    homepage = "http://www.holoviews.org/";
+    homepage = "https://www.holoviews.org/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ costrouc ];
   };

--- a/pkgs/development/python-modules/ipykernel/default.nix
+++ b/pkgs/development/python-modules/ipykernel/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "IPython Kernel for Jupyter";
-    homepage = "http://ipython.org/";
+    homepage = "https://ipython.org/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fridh ];
   };

--- a/pkgs/development/python-modules/ipython_genutils/default.nix
+++ b/pkgs/development/python-modules/ipython_genutils/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Vestigial utilities from IPython";
-    homepage = "http://ipython.org/";
+    homepage = "https://ipython.org/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fridh ];
   };

--- a/pkgs/development/python-modules/ipywidgets/default.nix
+++ b/pkgs/development/python-modules/ipywidgets/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "IPython HTML widgets for Jupyter";
-    homepage = "http://ipython.org/";
+    homepage = "https://ipython.org/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fridh ];
   };

--- a/pkgs/development/python-modules/mip/default.nix
+++ b/pkgs/development/python-modules/mip/default.nix
@@ -68,7 +68,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    homepage = "http://python-mip.com/";
+    homepage = "https://python-mip.com/";
     description = "A collection of Python tools for the modeling and solution of Mixed-Integer Linear programs (MIPs)";
     downloadPage = "https://github.com/coin-or/python-mip/releases";
     changelog = "https://github.com/coin-or/python-mip/releases/tag/${version}";

--- a/pkgs/development/python-modules/myhdl/default.nix
+++ b/pkgs/development/python-modules/myhdl/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A free, open-source package for using Python as a hardware description and verification language.";
-    homepage = "http://www.myhdl.org/";
+    homepage = "https://www.myhdl.org/";
     license = licenses.lgpl21;
     maintainers = with maintainers; [ doronbehar ];
   };

--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -107,7 +107,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Static site generator that requires no database or server-side logic";
-    homepage = "http://getpelican.com/";
+    homepage = "https://getpelican.com/";
     license = licenses.agpl3;
     maintainers = with maintainers; [ offline prikhi ];
   };

--- a/pkgs/development/python-modules/pydispatcher/default.nix
+++ b/pkgs/development/python-modules/pydispatcher/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    homepage = "http://pydispatcher.sourceforge.net/";
+    homepage = "https://pydispatcher.sourceforge.net/";
     description = "Signal-registration and routing infrastructure for use in multiple contexts";
     license = licenses.bsd3;
   };

--- a/pkgs/development/python-modules/pyliblo/default.nix
+++ b/pkgs/development/python-modules/pyliblo/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   buildInputs = [ liblo cython ];
 
   meta = with lib; {
-    homepage = "http://das.nasophon.de/pyliblo/";
+    homepage = "https://das.nasophon.de/pyliblo/";
     description = "Python wrapper for the liblo OSC library";
     license = licenses.lgpl21;
   };

--- a/pkgs/development/python-modules/pyopengl/default.nix
+++ b/pkgs/development/python-modules/pyopengl/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    homepage = "http://pyopengl.sourceforge.net/";
+    homepage = "https://pyopengl.sourceforge.net/";
     description = "PyOpenGL, the Python OpenGL bindings";
     longDescription = ''
       PyOpenGL is the cross platform Python binding to OpenGL and

--- a/pkgs/development/python-modules/pysmf/default.nix
+++ b/pkgs/development/python-modules/pysmf/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   buildInputs = [ libsmf glib ];
 
   meta = with lib; {
-    homepage = "http://das.nasophon.de/pysmf/";
+    homepage = "https://das.nasophon.de/pysmf/";
     description = "Python extension module for reading and writing Standard MIDI Files, based on libsmf.";
     license = licenses.bsd2;
     maintainers = [ ];

--- a/pkgs/development/python-modules/pyx/default.nix
+++ b/pkgs/development/python-modules/pyx/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python package for the generation of PostScript, PDF, and SVG files";
-    homepage = "http://pyx.sourceforge.net/";
+    homepage = "https://pyx.sourceforge.net/";
     license = with licenses; [ gpl2 ];
   };
 }

--- a/pkgs/development/python-modules/traitlets/default.nix
+++ b/pkgs/development/python-modules/traitlets/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Traitlets Python config system";
-    homepage = "http://ipython.org/";
+    homepage = "https://ipython.org/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fridh ];
   };

--- a/pkgs/development/python-modules/xlrd/default.nix
+++ b/pkgs/development/python-modules/xlrd/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    homepage = "http://www.python-excel.org/";
+    homepage = "https://www.python-excel.org/";
     description = "Library for developers to extract data from Microsoft Excel (tm) spreadsheet files";
     license = licenses.bsd0;
   };

--- a/pkgs/development/python-modules/yapsy/default.nix
+++ b/pkgs/development/python-modules/yapsy/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    homepage = "http://yapsy.sourceforge.net/";
+    homepage = "https://yapsy.sourceforge.net/";
     description = "Yet another plugin system";
     license = licenses.bsd0;
     # tests fail and are not using pytest to easily disable them

--- a/pkgs/development/tools/analysis/cccc/default.nix
+++ b/pkgs/development/tools/analysis/cccc/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       on various metrics of the code. Metrics supported include lines of code, McCabe's
       complexity and metrics proposed by Chidamber&Kemerer and Henry&Kafura.
     '';
-    homepage = "http://cccc.sourceforge.net/";
+    homepage = "https://cccc.sourceforge.net/";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.linquize ];

--- a/pkgs/development/tools/analysis/coan/default.nix
+++ b/pkgs/development/tools/analysis/coan/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
       respect to a specified configuration. Dead code removal is an
       application of this sort.
     '';
-    homepage = "http://coan2.sourceforge.net/";
+    homepage = "https://coan2.sourceforge.net/";
     license = licenses.bsd3;
     platforms = platforms.all;
   };

--- a/pkgs/development/tools/analysis/emma/default.nix
+++ b/pkgs/development/tools/analysis/emma/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://emma.sourceforge.net/";
+    homepage = "https://emma.sourceforge.net/";
     description = "A code coverage tool for Java";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     platforms = lib.platforms.unix;

--- a/pkgs/development/tools/analysis/findbugs/default.nix
+++ b/pkgs/development/tools/analysis/findbugs/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A static analysis tool to find bugs in Java programs automatically";
-    homepage = "http://findbugs.sourceforge.net/";
+    homepage = "https://findbugs.sourceforge.net/";
     maintainers = with maintainers; [ pSub ];
     platforms = with platforms; unix;
     sourceProvenance = with sourceTypes; [ binaryBytecode ];

--- a/pkgs/development/tools/analysis/lcov/default.nix
+++ b/pkgs/development/tools/analysis/lcov/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
          HTML output.
       '';
 
-    homepage = "http://ltp.sourceforge.net/coverage/lcov.php";
+    homepage = "https://ltp.sourceforge.net/coverage/lcov.php";
     license = lib.licenses.gpl2Plus;
 
     maintainers = with maintainers; [ dezgeg ];

--- a/pkgs/development/tools/build-managers/remake/default.nix
+++ b/pkgs/development/tools/build-managers/remake/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   # make check fails, see https://github.com/rocky/remake/issues/117
 
   meta = {
-    homepage = "http://bashdb.sourceforge.net/remake/";
+    homepage = "https://bashdb.sourceforge.net/remake/";
     license = lib.licenses.gpl3Plus;
     description = "GNU Make with comprehensible tracing and a debugger";
     platforms = with lib.platforms; linux ++ darwin;

--- a/pkgs/development/tools/build-managers/tup/default.nix
+++ b/pkgs/development/tools/build-managers/tup/default.nix
@@ -66,7 +66,7 @@ in stdenv.mkDerivation rec {
       algorithms to avoid doing unnecessary work. This means you can stay focused on
       your project rather than on your build system.
     '';
-    homepage = "http://gittup.org/tup/";
+    homepage = "https://gittup.org/tup/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ ehmry ];
     platforms = platforms.unix;

--- a/pkgs/development/tools/glslviewer/default.nix
+++ b/pkgs/development/tools/glslviewer/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Live GLSL coding renderer";
-    homepage = "http://patriciogonzalezvivo.com/2015/glslViewer/";
+    homepage = "https://patriciogonzalezvivo.com/2015/glslViewer/";
     license = licenses.bsd3;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.hodapp ];

--- a/pkgs/development/tools/literate-programming/eweb/default.nix
+++ b/pkgs/development/tools/literate-programming/eweb/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://eweb.sourceforge.net/";
+    homepage = "https://eweb.sourceforge.net/";
     description = "An Asciidoc-based literate programming tool, written in Python";
     platforms = platforms.linux;
     license = licenses.gpl3Plus;

--- a/pkgs/development/tools/misc/astyle/default.nix
+++ b/pkgs/development/tools/misc/astyle/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Source code indenter, formatter, and beautifier for C, C++, C# and Java";
-    homepage = "http://astyle.sourceforge.net/";
+    homepage = "https://astyle.sourceforge.net/";
     license = licenses.lgpl3;
     platforms = platforms.unix;
   };

--- a/pkgs/development/tools/misc/bashdb/default.nix
+++ b/pkgs/development/tools/misc/bashdb/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Bash script debugger";
-    homepage = "http://bashdb.sourceforge.net/";
+    homepage = "https://bashdb.sourceforge.net/";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
   };

--- a/pkgs/development/tools/misc/cscope/default.nix
+++ b/pkgs/development/tools/misc/cscope/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
     license = "BSD-style";
 
-    homepage = "http://cscope.sourceforge.net/";
+    homepage = "https://cscope.sourceforge.net/";
 
     maintainers = with lib.maintainers; [viric];
 

--- a/pkgs/development/tools/misc/ctags/default.nix
+++ b/pkgs/development/tools/misc/ctags/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       alternatively, the index entry created for that object).  Many
       programming languages are supported.
     '';
-    homepage = "http://ctags.sourceforge.net/";
+    homepage = "https://ctags.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
 

--- a/pkgs/development/tools/misc/dfu-util/default.nix
+++ b/pkgs/development/tools/misc/dfu-util/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libusb1 ];
 
   src = fetchurl {
-    url = "http://dfu-util.sourceforge.net/releases/${pname}-${version}.tar.gz";
+    url = "https://dfu-util.sourceforge.net/releases/${pname}-${version}.tar.gz";
     sha256 = "sha256-tLU7ohqC7349TEffKVKt9fpJT0mbawtXxYxdBK6P8Z4=";
   };
 

--- a/pkgs/development/tools/misc/gtkperf/default.nix
+++ b/pkgs/development/tools/misc/gtkperf/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Application designed to test GTK performance";
-    homepage = "http://gtkperf.sourceforge.net/";
+    homepage = "https://gtkperf.sourceforge.net/";
     license = with licenses; [ gpl2 ];
     maintainers = with maintainers; [ dtzWill ];
   };

--- a/pkgs/development/tools/misc/itstool/default.nix
+++ b/pkgs/development/tools/misc/itstool/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://itstool.org/";
+    homepage = "https://itstool.org/";
     description = "XML to PO and back again";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.all;

--- a/pkgs/development/tools/misc/qtspim/default.nix
+++ b/pkgs/development/tools/misc/qtspim/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "New user interface for spim, a MIPS simulator";
-    homepage = "http://spimsimulator.sourceforge.net/";
+    homepage = "https://spimsimulator.sourceforge.net/";
     license = licenses.bsdOriginal;
     maintainers = with maintainers; [ emilytrau ];
     platforms = platforms.linux;

--- a/pkgs/development/tools/misc/srecord/default.nix
+++ b/pkgs/development/tools/misc/srecord/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Collection of powerful tools for manipulating EPROM load files";
-    homepage = "http://srecord.sourceforge.net/";
+    homepage = "https://srecord.sourceforge.net/";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.bjornfor ];
     platforms = lib.platforms.unix;

--- a/pkgs/development/tools/misc/swig/2.x.nix
+++ b/pkgs/development/tools/misc/swig/2.x.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "SWIG, an interface compiler that connects C/C++ code to higher-level languages";
-    homepage = "http://swig.org/";
+    homepage = "https://swig.org/";
     # Different types of licenses available: http://www.swig.org/Release/LICENSE .
     license = licenses.gpl3Plus;
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An interface compiler that connects C/C++ code to higher-level languages";
-    homepage = "http://swig.org/";
+    homepage = "https://swig.org/";
     # Different types of licenses available: http://www.swig.org/Release/LICENSE .
     license = licenses.gpl3Plus;
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/development/tools/misc/swig/4.nix
+++ b/pkgs/development/tools/misc/swig/4.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "SWIG, an interface compiler that connects C/C++ code to higher-level languages";
-    homepage = "http://swig.org/";
+    homepage = "https://swig.org/";
     # Different types of licenses available: http://www.swig.org/Release/LICENSE .
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ orivej ];

--- a/pkgs/development/tools/misc/swig/default.nix
+++ b/pkgs/development/tools/misc/swig/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "SWIG, an interface compiler that connects C/C++ code to higher-level languages";
-    homepage = "http://swig.org/";
+    homepage = "https://swig.org/";
     # Different types of licenses available: http://www.swig.org/Release/LICENSE .
     license = licenses.gpl3Plus;
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/development/tools/misc/uncrustify/default.nix
+++ b/pkgs/development/tools/misc/uncrustify/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Source code beautifier for C, C++, C#, ObjectiveC, D, Java, Pawn and VALA";
-    homepage = "http://uncrustify.sourceforge.net/";
+    homepage = "https://uncrustify.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/tools/misc/xspim/default.nix
+++ b/pkgs/development/tools/misc/xspim/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A MIPS32 simulator";
-    homepage = "http://spimsimulator.sourceforge.net/";
+    homepage = "https://spimsimulator.sourceforge.net/";
     license = licenses.bsdOriginal;
     maintainers = with maintainers; [ emilytrau ];
     platforms = platforms.linux;

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     branch = "2.5.35";
-    homepage = "http://flex.sourceforge.net/";
+    homepage = "https://flex.sourceforge.net/";
     description = "A fast lexical analyser generator";
     license = licenses.bsd2;
     platforms = platforms.unix;

--- a/pkgs/development/tools/parsing/jikespg/default.nix
+++ b/pkgs/development/tools/parsing/jikespg/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://jikes.sourceforge.net/";
+    homepage = "https://jikes.sourceforge.net/";
     description = "The Jikes Parser Generator";
     platforms = platforms.all;
     license = licenses.ipl10;

--- a/pkgs/development/tools/pxview/default.nix
+++ b/pkgs/development/tools/pxview/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Program to convert Paradox databases";
-    homepage = "http://pxlib.sourceforge.net/pxview/";
+    homepage = "https://pxlib.sourceforge.net/pxview/";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.winpat ];

--- a/pkgs/development/web/xmlindent/default.nix
+++ b/pkgs/development/web/xmlindent/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "XML stream reformatter";
-    homepage = "http://xmlindent.sourceforge.net/";
+    homepage = "https://xmlindent.sourceforge.net/";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
     maintainers = [ ];

--- a/pkgs/games/chessdb/default.nix
+++ b/pkgs/games/chessdb/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://chessdb.sourceforge.net/";
+    homepage = "https://chessdb.sourceforge.net/";
     description = "A free chess database";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/games/domination/default.nix
+++ b/pkgs/games/domination/default.nix
@@ -88,8 +88,8 @@ in stdenv.mkDerivation {
   };
 
   meta = with lib; {
-    homepage = "http://domination.sourceforge.net/";
-    downloadPage = "http://domination.sourceforge.net/download.shtml";
+    homepage = "https://domination.sourceforge.net/";
+    downloadPage = "https://domination.sourceforge.net/download.shtml";
     description = "A game that is a bit like the board game Risk or RisiKo";
     longDescription = ''
       Domination is a game that is a bit like the well known board game of Risk

--- a/pkgs/games/egoboo/default.nix
+++ b/pkgs/games/egoboo/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "3D dungeon crawling adventure";
 
-    homepage = "http://egoboo.sourceforge.net/";
+    homepage = "https://egoboo.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
 
     # I take it out of hydra as it does not work as well as I'd like

--- a/pkgs/games/fish-fillets-ng/default.nix
+++ b/pkgs/games/fish-fillets-ng/default.nix
@@ -36,6 +36,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
-    homepage = "http://fillets.sourceforge.net/";
+    homepage = "https://fillets.sourceforge.net/";
   };
 }

--- a/pkgs/games/fltrator/default.nix
+++ b/pkgs/games/fltrator/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     description = "A simple retro style arcade side-scroller game";
     longDescription = '' FLTrator is a simple retro style arcade side-scroller game in which you steer a spaceship through a landscape with hostile rockets and other obstacles.
     It has ten different levels and a level editor to create new levels or modify the existing.''; # from https://libregamewiki.org/FLTrator
-    homepage = "http://fltrator.sourceforge.net/";
+    homepage = "https://fltrator.sourceforge.net/";
     platforms = platforms.linux;
     maintainers = [ maintainers.marius851000 ];
     license = licenses.gpl3;

--- a/pkgs/games/garden-of-coloured-lights/default.nix
+++ b/pkgs/games/garden-of-coloured-lights/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Old-school vertical shoot-em-up / bullet hell";
-    homepage = "http://garden.sourceforge.net/drupal/";
+    homepage = "https://garden.sourceforge.net/drupal/";
     maintainers = with maintainers; [ Profpatsch ];
     license = licenses.gpl3;
   };

--- a/pkgs/games/gav/default.nix
+++ b/pkgs/games/gav/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Remake of AV Arcade Volleyball";
-    homepage = "http://gav.sourceforge.net/";
+    homepage = "https://gav.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
   };

--- a/pkgs/games/gogui/default.nix
+++ b/pkgs/games/gogui/default.nix
@@ -22,7 +22,7 @@ in stdenv.mkDerivation {
   meta = {
     maintainers = [ lib.maintainers.cleverca22 ];
     description = "A graphical user interface to programs that play the board game Go and support the Go Text Protocol such as GNU Go";
-    homepage = "http://gogui.sourceforge.net/";
+    homepage = "https://gogui.sourceforge.net/";
     platforms = lib.platforms.unix;
     license = lib.licenses.gpl3;
   };

--- a/pkgs/games/gtetrinet/default.nix
+++ b/pkgs/games/gtetrinet/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
       GTetrinet is a client program for Tetrinet, a multiplayer tetris game
       that is played over the internet.
     '';
-    homepage = "http://gtetrinet.sourceforge.net/";
+    homepage = "https://gtetrinet.sourceforge.net/";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.chris-martin ];

--- a/pkgs/games/hhexen/default.nix
+++ b/pkgs/games/hhexen/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Linux port of Raven Game's Hexen";
-    homepage = "http://hhexen.sourceforge.net/hhexen.html";
+    homepage = "https://hhexen.sourceforge.net/hhexen.html";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ djanatyn ];
   };

--- a/pkgs/games/mars/default.nix
+++ b/pkgs/games/mars/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     chmod +x "$out/bin/mars"
   '';
   meta = with lib; {
-    homepage = "http://mars-game.sourceforge.net/";
+    homepage = "https://mars-game.sourceforge.net/";
     description = "A game about fighting with ships in a 2D space setting";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.astsmtl ];

--- a/pkgs/games/ninvaders/default.nix
+++ b/pkgs/games/ninvaders/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Space Invaders clone based on ncurses";
-    homepage = "http://ninvaders.sourceforge.net/";
+    homepage = "https://ninvaders.sourceforge.net/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ _1000101 ];
     platforms = platforms.all;

--- a/pkgs/games/njam/default.nix
+++ b/pkgs/games/njam/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   patches = [ ./logfile.patch ];
 
   meta = {
-    homepage = "http://trackballs.sourceforge.net/";
+    homepage = "https://trackballs.sourceforge.net/";
     description = "Cross-platform pacman-like game";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;

--- a/pkgs/games/npush/default.nix
+++ b/pkgs/games/npush/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     broken = stdenv.isDarwin;
-    homepage = "http://npush.sourceforge.net/";
+    homepage = "https://npush.sourceforge.net/";
     description = "A Sokoban-like game";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ AndersonTorres ];

--- a/pkgs/games/pioneers/default.nix
+++ b/pkgs/games/pioneers/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Addicting game based on The Settlers of Catan";
-    homepage = "http://pio.sourceforge.net/";  # https does not work
+    homepage = "https://pio.sourceforge.net/";  # https does not work
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ viric ];
     platforms = platforms.linux;

--- a/pkgs/games/quakespasm/default.nix
+++ b/pkgs/games/quakespasm/default.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An engine for iD software's Quake";
-    homepage = "http://quakespasm.sourceforge.net/";
+    homepage = "https://quakespasm.sourceforge.net/";
     longDescription = ''
       QuakeSpasm is a modern, cross-platform Quake 1 engine based on FitzQuake.
       It includes support for 64 bit CPUs and custom music playback, a new sound driver,

--- a/pkgs/games/rigsofrods/default.nix
+++ b/pkgs/games/rigsofrods/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "3D simulator game where you can drive, fly and sail various vehicles";
-    homepage = "http://rigsofrods.sourceforge.net/";
+    homepage = "https://rigsofrods.sourceforge.net/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;

--- a/pkgs/games/rrootage/default.nix
+++ b/pkgs/games/rrootage/default.nix
@@ -74,7 +74,7 @@ in stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Abstract shooter created by Kenta Cho";
-    homepage = "http://rrootage.sourceforge.net/";
+    homepage = "https://rrootage.sourceforge.net/";
     license = licenses.bsd2;
     maintainers = with maintainers; [ fgaz ];
   };

--- a/pkgs/games/scid-vs-pc/default.nix
+++ b/pkgs/games/scid-vs-pc/default.nix
@@ -73,7 +73,7 @@ tcl.mkTclDerivation rec {
 
   meta = with lib; {
     description = "Chess database with play and training functionality";
-    homepage = "http://scidvspc.sourceforge.net/";
+    homepage = "https://scidvspc.sourceforge.net/";
     license = lib.licenses.gpl2;
     maintainers = [ maintainers.paraseba ];
     platforms = lib.platforms.linux;

--- a/pkgs/games/scid/default.nix
+++ b/pkgs/games/scid/default.nix
@@ -53,7 +53,7 @@ tcl.mkTclDerivation {
   meta = {
     description = "Chess database with play and training functionality";
     maintainers = with lib.maintainers; [ agbrooks ];
-    homepage = "http://scid.sourceforge.net/";
+    homepage = "https://scid.sourceforge.net/";
     license = lib.licenses.gpl2;
   };
 }

--- a/pkgs/games/speed-dreams/default.nix
+++ b/pkgs/games/speed-dreams/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Car racing game - TORCS fork with more experimental approach";
-    homepage = "http://speed-dreams.sourceforge.net/";
+    homepage = "https://speed-dreams.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [raskin];
     platforms = lib.platforms.linux;

--- a/pkgs/games/tinyfugue/default.nix
+++ b/pkgs/games/tinyfugue/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE="-fcommon";
 
   meta = {
-    homepage = "http://tinyfugue.sourceforge.net/";
+    homepage = "https://tinyfugue.sourceforge.net/";
     description = "A terminal UI, screen-oriented MUD client";
     longDescription = ''
       TinyFugue, aka "tf", is a flexible, screen-oriented MUD client, for use

--- a/pkgs/games/torcs/default.nix
+++ b/pkgs/games/torcs/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Car racing game";
-    homepage = "http://torcs.sourceforge.net/";
+    homepage = "https://torcs.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [viric];
     platforms = lib.platforms.linux;

--- a/pkgs/games/typespeed/default.nix
+++ b/pkgs/games/typespeed/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.6.5";
   buildInputs = [ ncurses ];
   src = fetchurl {
-    url = "http://typespeed.sourceforge.net/typespeed-${version}.tar.gz";
+    url = "https://typespeed.sourceforge.net/typespeed-${version}.tar.gz";
     sha256 = "5c860385ceed8a60f13217cc0192c4c2b4705c3e80f9866f7d72ff306eb72961";
   };
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A curses based typing game";
-    homepage = "http://typespeed.sourceforge.net/";
+    homepage = "https://typespeed.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = [ maintainers.auntie ];

--- a/pkgs/games/uhexen2/default.nix
+++ b/pkgs/games/uhexen2/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
       HoT includes countless bug fixes, improved music, sound and video modes, opengl improvements,
       support for many operating systems and architectures, and documentation among many others.
     '';
-    homepage = "http://uhexen2.sourceforge.net/";
+    homepage = "https://uhexen2.sourceforge.net/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ xdhampus ];
     platforms = platforms.all;

--- a/pkgs/games/uqm/default.nix
+++ b/pkgs/games/uqm/default.nix
@@ -101,7 +101,7 @@ in stdenv.mkDerivation rec {
         - to adapt the code so that people can more easily make their own
           spin-offs, thereby making zillions more people happy!
     '';
-    homepage = "http://sc2.sourceforge.net/";
+    homepage = "https://sc2.sourceforge.net/";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ jcumming aszlig ];
     platforms = with lib.platforms; linux;

--- a/pkgs/games/zaz/default.nix
+++ b/pkgs/games/zaz/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     broken = stdenv.isDarwin;
     description = "A puzzle game about arranging balls in triplets, like Luxor, Zuma, or Puzzle Bobble";
-    homepage = "http://zaz.sourceforge.net/";
+    homepage = "https://zaz.sourceforge.net/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;

--- a/pkgs/misc/drivers/spacenavd/default.nix
+++ b/pkgs/misc/drivers/spacenavd/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   meta = with lib; {
-    homepage = "http://spacenav.sourceforge.net/";
+    homepage = "https://spacenav.sourceforge.net/";
     description = "Device driver and SDK for 3Dconnexion 3D input devices";
     longDescription = "A free, compatible alternative, to the proprietary 3Dconnexion device driver and SDK, for their 3D input devices (called 'space navigator', 'space pilot', 'space traveller', etc)";
     license = licenses.gpl3Plus;

--- a/pkgs/misc/drivers/xwiimote/default.nix
+++ b/pkgs/misc/drivers/xwiimote/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-doxygen=no" ];
 
   meta = {
-    homepage = "http://dvdhrm.github.io/xwiimote";
+    homepage = "https://dvdhrm.github.io/xwiimote";
     description = "Userspace utilities to control connected Nintendo Wii Remotes";
     platforms = lib.platforms.linux;
     license = lib.licenses.mit;

--- a/pkgs/misc/talkfilters/default.nix
+++ b/pkgs/misc/talkfilters/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Converts English text into text that mimics a stereotyped or humorous dialect";
-    homepage = "http://www.hyperrealm.com/talkfilters/talkfilters.html";
+    homepage = "https://www.hyperrealm.com/talkfilters/talkfilters.html";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ ikervagyok ];
     platforms = with lib.platforms; unix;

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -119,7 +119,7 @@ let
     dontStrip = true;
 
     meta = with lib; {
-      homepage = "http://www.denx.de/wiki/U-Boot/";
+      homepage = "https://www.denx.de/wiki/U-Boot/";
       description = "Boot loader for embedded systems";
       license = licenses.gpl2;
       maintainers = with maintainers; [ bartsch dezgeg samueldr lopsided98 ];

--- a/pkgs/os-specific/linux/conky/default.nix
+++ b/pkgs/os-specific/linux/conky/default.nix
@@ -137,7 +137,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with lib; {
-    homepage = "http://conky.sourceforge.net/";
+    homepage = "https://conky.sourceforge.net/";
     description = "Advanced, highly configurable system monitor based on torsmo";
     maintainers = [ maintainers.guibert ];
     license = licenses.gpl3Plus;

--- a/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
@@ -24,7 +24,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = with lib; {
     description = "Firmware for Intel 2200BG cards";
-    homepage = "http://ipw2200.sourceforge.net/firmware.php";
+    homepage = "https://ipw2200.sourceforge.net/firmware.php";
     license = licenses.unfreeRedistributableFirmware;
     maintainers = with maintainers; [ sternenseemann ];
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/libaio/default.nix
+++ b/pkgs/os-specific/linux/libaio/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Library for asynchronous I/O in Linux";
-    homepage = "http://lse.sourceforge.net/io/aio.html";
+    homepage = "https://lse.sourceforge.net/io/aio.html";
     platforms = lib.platforms.linux;
     license = lib.licenses.lgpl21;
     maintainers = with lib.maintainers; [ ];

--- a/pkgs/os-specific/linux/linuxptp/default.nix
+++ b/pkgs/os-specific/linux/linuxptp/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Implementation of the Precision Time Protocol (PTP) according to IEEE standard 1588 for Linux";
-    homepage = "http://linuxptp.sourceforge.net/";
+    homepage = "https://linuxptp.sourceforge.net/";
     maintainers = [ maintainers.markuskowa ];
     license = licenses.gpl2Only;
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/lksctp-tools/default.nix
+++ b/pkgs/os-specific/linux/lksctp-tools/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Linux Kernel Stream Control Transmission Protocol Tools";
-    homepage = "http://lksctp.sourceforge.net/";
+    homepage = "https://lksctp.sourceforge.net/";
     license = with licenses; [ gpl2 lgpl21 ]; # library is lgpl21
     platforms = platforms.linux;
   };

--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     broken = kernel.kernelAtLeast "5.16";
-    homepage = "http://www.magewell.com/";
+    homepage = "https://www.magewell.com/";
     description = "Linux driver for the Magewell Pro Capture family";
     license = licenses.unfreeRedistributable;
     maintainers = with maintainers; [ MP2E ];

--- a/pkgs/os-specific/linux/roccat-tools/default.nix
+++ b/pkgs/os-specific/linux/roccat-tools/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Tools to configure ROCCAT devices";
-    homepage = "http://roccat.sourceforge.net/";
+    homepage = "https://roccat.sourceforge.net/";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Plus;
   };

--- a/pkgs/os-specific/linux/sysfsutils/default.nix
+++ b/pkgs/os-specific/linux/sysfsutils/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    homepage = "http://linux-diag.sourceforge.net/Sysfsutils.html";
+    homepage = "https://linux-diag.sourceforge.net/Sysfsutils.html";
     longDescription =
       ''
         These are a set of utilites built upon sysfs, a new virtual

--- a/pkgs/os-specific/linux/tunctl/default.nix
+++ b/pkgs/os-specific/linux/tunctl/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://tunctl.sourceforge.net/";
+    homepage = "https://tunctl.sourceforge.net/";
     description = "Utility to set up and maintain TUN/TAP network interfaces";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;

--- a/pkgs/servers/gopher/gofish/default.nix
+++ b/pkgs/servers/gopher/gofish/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A lightweight Gopher server";
-    homepage = "http://gofish.sourceforge.net/";
+    homepage = "https://gofish.sourceforge.net/";
     license = licenses.gpl2;
     maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.unix;

--- a/pkgs/servers/http/apache-modules/mod_python/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_python/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.isDarwin libintl;
 
   meta = with lib; {
-    homepage = "http://modpython.org/";
+    homepage = "https://modpython.org/";
     description = "An Apache module that embeds the Python interpreter within the server";
     platforms = platforms.unix;
     maintainers = with maintainers; [ ];

--- a/pkgs/servers/mail/dkimproxy/default.nix
+++ b/pkgs/servers/mail/dkimproxy/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "SMTP-proxy that signs and/or verifies emails";
-    homepage = "http://dkimproxy.sourceforge.net/";
+    homepage = "https://dkimproxy.sourceforge.net/";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.ekleog ];
     platforms = platforms.all;

--- a/pkgs/servers/mail/dspam/default.nix
+++ b/pkgs/servers/mail/dspam/default.nix
@@ -117,7 +117,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://dspam.sourceforge.net/";
+    homepage = "https://dspam.sourceforge.net/";
     description = "Community Driven Antispam Filter";
     license = licenses.agpl3Plus;
     platforms = platforms.linux;

--- a/pkgs/servers/mail/petidomo/default.nix
+++ b/pkgs/servers/mail/petidomo/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    homepage = "http://petidomo.sourceforge.net/";
+    homepage = "https://petidomo.sourceforge.net/";
     description = "A simple and easy to administer mailing list server";
     license = lib.licenses.gpl3Plus;
 

--- a/pkgs/servers/monitoring/lcdproc/default.nix
+++ b/pkgs/servers/monitoring/lcdproc/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Client/server suite for controlling a wide variety of LCD devices";
-    homepage = "http://lcdproc.org/";
+    homepage = "https://lcdproc.org/";
     license = licenses.gpl2;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.unix;

--- a/pkgs/servers/sql/mssql/jdbc/jtds.nix
+++ b/pkgs/servers/sql/mssql/jdbc/jtds.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Pure Java (type 4) JDBC 3.0 driver for Microsoft SQL Server";
-    homepage = "http://jtds.sourceforge.net/";
+    homepage = "https://jtds.sourceforge.net/";
     license = licenses.lgpl21;
     platforms = platforms.unix;
   };

--- a/pkgs/servers/uftp/default.nix
+++ b/pkgs/servers/uftp/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Encrypted UDP based FTP with multicast";
-    homepage = "http://uftp-multicast.sourceforge.net/";
+    homepage = "https://uftp-multicast.sourceforge.net/";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.fadenb ];
     platforms = with lib.platforms; linux ++ darwin;

--- a/pkgs/tools/X11/imwheel/default.nix
+++ b/pkgs/tools/X11/imwheel/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "http://imwheel.sourceforge.net/";
+    homepage = "https://imwheel.sourceforge.net/";
     description = "Mouse wheel configuration tool for XFree86/Xorg";
     maintainers = with maintainers; [ jhillyerd ];
     platforms = platforms.linux;

--- a/pkgs/tools/X11/xosview2/default.nix
+++ b/pkgs/tools/X11/xosview2/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ libX11 ];
 
   meta = with lib; {
-    homepage = "http://xosview.sourceforge.net/index.html";
+    homepage = "https://xosview.sourceforge.net/index.html";
     description = "Lightweight graphical operating system monitor";
     longDescription = ''
       xosview is a lightweight program that gathers information from your

--- a/pkgs/tools/admin/tightvnc/default.nix
+++ b/pkgs/tools/admin/tightvnc/default.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     license = lib.licenses.gpl2Plus;
-    homepage = "http://vnc-tight.sourceforge.net/";
+    homepage = "https://vnc-tight.sourceforge.net/";
     description = "Improved version of VNC";
 
     longDescription = ''

--- a/pkgs/tools/archivers/s-tar/default.nix
+++ b/pkgs/tools/archivers/s-tar/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
       The way star acts may be modified by additional options.
       Note that unpacking tar archives may be a security risk because star may overwrite existing files.
     '';
-    homepage = "http://cdrtools.sourceforge.net/private/star.html";
+    homepage = "https://cdrtools.sourceforge.net/private/star.html";
     license = lib.licenses.cddl;
     maintainers = [ lib.maintainers.wucke13 ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/tools/audio/abcmidi/default.nix
+++ b/pkgs/tools/audio/abcmidi/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "http://abc.sourceforge.net/abcMIDI/";
+    homepage = "https://abc.sourceforge.net/abcMIDI/";
     downloadPage = "https://ifdo.ca/~seymour/runabc/top.html";
     license = licenses.gpl2Plus;
     description = "Utilities for converting between abc and MIDI";

--- a/pkgs/tools/audio/asap/default.nix
+++ b/pkgs/tools/audio/asap/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "http://asap.sourceforge.net/";
+    homepage = "https://asap.sourceforge.net/";
     mainProgram = "asap-sdl";
     description = "Another Slight Atari Player";
     longDescription = ''

--- a/pkgs/tools/audio/midicsv/default.nix
+++ b/pkgs/tools/audio/midicsv/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.1";
 
   src = fetchurl {
-    url = "http://www.fourmilab.ch/webtools/midicsv/midicsv-${version}.tar.gz";
+    url = "https://www.fourmilab.ch/webtools/midicsv/midicsv-${version}.tar.gz";
     sha256 = "1vvhk2nf9ilfw0wchmxy8l13hbw9cnpz079nsx5srsy4nnd78nkw";
   };
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Losslessly translate MIDI to CSV and back";
-    homepage = "http://www.fourmilab.ch/webtools/midicsv/";
+    homepage = "https://www.fourmilab.ch/webtools/midicsv/";
     license = licenses.publicDomain;
     maintainers = with maintainers; [ orivej ];
     platforms = platforms.all;

--- a/pkgs/tools/backup/luckybackup/default.nix
+++ b/pkgs/tools/backup/luckybackup/default.nix
@@ -37,7 +37,7 @@ mkDerivation rec {
       before proceeding in any data manipulation), reliable and fully
       customizable.
     '';
-    homepage = "http://luckybackup.sourceforge.net/";
+    homepage = "https://luckybackup.sourceforge.net/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.linux;

--- a/pkgs/tools/cd-dvd/cdrdao/default.nix
+++ b/pkgs/tools/cd-dvd/cdrdao/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A tool for recording audio or data CD-Rs in disk-at-once (DAO) mode";
-    homepage = "http://cdrdao.sourceforge.net/";
+    homepage = "https://cdrdao.sourceforge.net/";
     platforms = platforms.linux;
     license = licenses.gpl2;
   };

--- a/pkgs/tools/cd-dvd/cdrtools/default.nix
+++ b/pkgs/tools/cd-dvd/cdrtools/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = false; # parallel building fails on some linux machines
 
   meta = with lib; {
-    homepage = "http://cdrtools.sourceforge.net/private/cdrecord.html";
+    homepage = "https://cdrtools.sourceforge.net/private/cdrecord.html";
     description = "Highly portable CD/DVD/BluRay command line recording software";
     license = with licenses; [ cddl gpl2 lgpl21 ];
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/tools/filesystems/avfs/default.nix
+++ b/pkgs/tools/filesystems/avfs/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    homepage = "http://avf.sourceforge.net/";
+    homepage = "https://avf.sourceforge.net/";
     description = "Virtual filesystem that allows browsing of compressed files";
     platforms = lib.platforms.unix;
     license = lib.licenses.gpl2Only;

--- a/pkgs/tools/filesystems/djmount/default.nix
+++ b/pkgs/tools/filesystems/djmount/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-fcommon";
 
   meta = {
-    homepage = "http://djmount.sourceforge.net/";
+    homepage = "https://djmount.sourceforge.net/";
     description = "UPnP AV client, mounts as a Linux filesystem the media content of compatible UPnP AV devices";
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.jagajaga ];

--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -86,8 +86,8 @@ stdenv.mkDerivation rec {
     '';
   };
   meta = with lib; {
-    homepage = "http://e2fsprogs.sourceforge.net/";
-    changelog = "http://e2fsprogs.sourceforge.net/e2fsprogs-release.html#${version}";
+    homepage = "https://e2fsprogs.sourceforge.net/";
+    changelog = "https://e2fsprogs.sourceforge.net/e2fsprogs-release.html#${version}";
     description = "Tools for creating and checking ext2/ext3/ext4 filesystems";
     license = with licenses; [
       gpl2Plus

--- a/pkgs/tools/filesystems/ext4magic/default.nix
+++ b/pkgs/tools/filesystems/ext4magic/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
       It's much more effective and works much better than extundelete.
     '';
-    homepage = "http://ext4magic.sourceforge.net/ext4magic_en.html";
+    homepage = "https://ext4magic.sourceforge.net/ext4magic_en.html";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.rkoe ];

--- a/pkgs/tools/filesystems/extundelete/default.nix
+++ b/pkgs/tools/filesystems/extundelete/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Utility that can recover deleted files from an ext3 or ext4 partition";
-    homepage = "http://extundelete.sourceforge.net/";
+    homepage = "https://extundelete.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.domenkozar ];

--- a/pkgs/tools/filesystems/genromfs/default.nix
+++ b/pkgs/tools/filesystems/genromfs/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://romfs.sourceforge.net/";
+    homepage = "https://romfs.sourceforge.net/";
     description = "Tool for creating romfs file system images";
     license = licenses.gpl2;
     maintainers = with maintainers; [ ];

--- a/pkgs/tools/filesystems/httpfs/default.nix
+++ b/pkgs/tools/filesystems/httpfs/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "FUSE-based HTTP filesystem for Linux";
 
-    homepage = "http://httpfs.sourceforge.net/";
+    homepage = "https://httpfs.sourceforge.net/";
 
     license = lib.licenses.gpl2Plus;
 

--- a/pkgs/tools/filesystems/mhddfs/default.nix
+++ b/pkgs/tools/filesystems/mhddfs/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.1.39";
 
   src = fetchurl {
-    url = "http://mhddfs.uvw.ru/downloads/mhddfs_${version}.tar.gz";
+    url = "https://mhddfs.uvw.ru/downloads/mhddfs_${version}.tar.gz";
     sha256 = "14ggmh91vv69fp2qpz0nxp0hprlw2wsijss2k2485hb0ci4cabvh";
   };
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://mhddfs.uvw.ru/";
+    homepage = "https://mhddfs.uvw.ru/";
     description = "Combines a several mount points into the single one";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.makefu ];

--- a/pkgs/tools/filesystems/svnfs/default.nix
+++ b/pkgs/tools/filesystems/svnfs/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "FUSE filesystem for accessing Subversion repositories";
-    homepage = "http://www.jmadden.eu/index.php/svnfs/";
+    homepage = "https://www.jmadden.eu/index.php/svnfs/";
     license = lib.licenses.gpl2Only;
     maintainers = [lib.maintainers.marcweber];
     platforms = lib.platforms.unix;

--- a/pkgs/tools/graphics/enblend-enfuse/default.nix
+++ b/pkgs/tools/graphics/enblend-enfuse/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://enblend.sourceforge.net/";
+    homepage = "https://enblend.sourceforge.net/";
     description = "Blends away the seams in a panoramic image mosaic using a multiresolution spline";
     license = licenses.gpl2;
     platforms = with platforms; linux;

--- a/pkgs/tools/graphics/netpbm/default.nix
+++ b/pkgs/tools/graphics/netpbm/default.nix
@@ -118,7 +118,7 @@ stdenv.mkDerivation {
   passthru.updateScript = ./update.sh;
 
   meta = {
-    homepage = "http://netpbm.sourceforge.net/";
+    homepage = "https://netpbm.sourceforge.net/";
     description = "Toolkit for manipulation of graphic images";
     license = lib.licenses.free; # http://netpbm.svn.code.sourceforge.net/p/netpbm/code/trunk/doc/copyright_summary
     platforms = with lib.platforms; linux ++ darwin;

--- a/pkgs/tools/graphics/nifskope/default.nix
+++ b/pkgs/tools/graphics/nifskope/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    homepage = "http://niftools.sourceforge.net/wiki/NifSkope";
+    homepage = "https://niftools.sourceforge.net/wiki/NifSkope";
     description = "A tool for analyzing and editing NetImmerse/Gamebryo '*.nif' files";
     maintainers = with maintainers; [ eelco ];
     platforms = platforms.linux;

--- a/pkgs/tools/graphics/optipng/default.nix
+++ b/pkgs/tools/graphics/optipng/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   '' else null;
 
   meta = with lib; {
-    homepage = "http://optipng.sourceforge.net/";
+    homepage = "https://optipng.sourceforge.net/";
     description = "A PNG optimizer";
     license = licenses.zlib;
     platforms = platforms.unix;

--- a/pkgs/tools/graphics/pfstools/default.nix
+++ b/pkgs/tools/graphics/pfstools/default.nix
@@ -39,7 +39,7 @@ mkDerivation rec {
   patches = [ ./glut.patch ./threads.patch ./pfstools.patch ./pfsalign.patch ];
 
   meta = with lib; {
-    homepage = "http://pfstools.sourceforge.net/";
+    homepage = "https://pfstools.sourceforge.net/";
     description = "Toolkit for manipulation of HDR images";
     platforms = platforms.linux;
     license = licenses.lgpl2;

--- a/pkgs/tools/graphics/ploticus/default.nix
+++ b/pkgs/tools/graphics/ploticus/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
     # Use gd from Nixpkgs instead of the vendored one.
     # This is required for non-ASCII fonts to work:
-    # http://ploticus.sourceforge.net/doc/fonts.html
+    # https://ploticus.sourceforge.net/doc/fonts.html
     ./use-gd-package.patch
   ];
 
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ pSub ];
-    homepage = "http://ploticus.sourceforge.net/";
+    homepage = "https://ploticus.sourceforge.net/";
     platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/tools/graphics/pngnq/default.nix
+++ b/pkgs/tools/graphics/pngnq/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://pngnq.sourceforge.net/";
+    homepage = "https://pngnq.sourceforge.net/";
     description = "A PNG quantizer";
     license = licenses.bsd3;
     maintainers = with maintainers; [ pSub ];

--- a/pkgs/tools/graphics/sng/default.nix
+++ b/pkgs/tools/graphics/sng/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Minilanguage designed to represent the entire contents of a PNG file in an editable form";
-    homepage = "http://sng.sourceforge.net/";
+    homepage = "https://sng.sourceforge.net/";
     license = licenses.zlib;
     maintainers = [ maintainers.dezgeg ];
     platforms = platforms.unix;

--- a/pkgs/tools/misc/bbe/default.nix
+++ b/pkgs/tools/misc/bbe/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A sed-like editor for binary files";
-    homepage = "http://bbe-.sourceforge.net/";
+    homepage = "https://bbe-.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = platforms.all;
     maintainers = [ maintainers.hhm ];

--- a/pkgs/tools/misc/cunit/default.nix
+++ b/pkgs/tools/misc/cunit/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       with a flexible variety of user interfaces.
     '';
 
-    homepage = "http://cunit.sourceforge.net/";
+    homepage = "https://cunit.sourceforge.net/";
 
     license = lib.licenses.lgpl2;
     platforms = lib.platforms.unix;

--- a/pkgs/tools/misc/dbacl/default.nix
+++ b/pkgs/tools/misc/dbacl/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    homepage = "http://dbacl.sourceforge.net/";
+    homepage = "https://dbacl.sourceforge.net/";
     longDescription = "a digramic Bayesian classifier for text recognition.";
     maintainers = [];
     license = lib.licenses.gpl3;

--- a/pkgs/tools/misc/detox/default.nix
+++ b/pkgs/tools/misc/detox/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://detox.sourceforge.net/";
+    homepage = "https://detox.sourceforge.net/";
     description = "Utility designed to clean up filenames";
     longDescription = ''
       Detox is a utility designed to clean up filenames. It replaces

--- a/pkgs/tools/misc/dtach/default.nix
+++ b/pkgs/tools/misc/dtach/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://dtach.sourceforge.net/";
+    homepage = "https://dtach.sourceforge.net/";
     description = "A program that emulates the detach feature of screen";
 
     longDescription = ''

--- a/pkgs/tools/misc/eot-utilities/default.nix
+++ b/pkgs/tools/misc/eot-utilities/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
 
   meta = {
-    homepage = "http://www.w3.org/Tools/eot-utils/";
+    homepage = "https://www.w3.org/Tools/eot-utils/";
     description = "Create Embedded Open Type from OpenType or TrueType font";
     license = lib.licenses.w3c;
     maintainers = with lib.maintainers; [ leenaars ];

--- a/pkgs/tools/misc/expect/default.nix
+++ b/pkgs/tools/misc/expect/default.nix
@@ -38,7 +38,7 @@ tcl.mkTclDerivation rec {
 
   meta = with lib; {
     description = "A tool for automating interactive applications";
-    homepage = "http://expect.sourceforge.net/";
+    homepage = "https://expect.sourceforge.net/";
     license = licenses.publicDomain;
     platforms = platforms.unix;
     maintainers = with maintainers; [ SuperSandro2000 ];

--- a/pkgs/tools/misc/ink/default.nix
+++ b/pkgs/tools/misc/ink/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     longDescription = ''
       Ink is a command line tool for checking the ink level of your locally connected printer on a system which runs Linux or FreeBSD. Canon BJNP network printers are supported too.
     '';
-    homepage = "http://ink.sourceforge.net/";
+    homepage = "https://ink.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.linux ++ platforms.freebsd;
     maintainers = with maintainers; [ samb96 ];

--- a/pkgs/tools/misc/libcpuid/default.nix
+++ b/pkgs/tools/misc/libcpuid/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
 
   meta = with lib; {
-    homepage = "http://libcpuid.sourceforge.net/";
+    homepage = "https://libcpuid.sourceforge.net/";
     description = "A small C library for x86 CPU detection and feature extraction";
     changelog = "https://raw.githubusercontent.com/anrieff/libcpuid/master/ChangeLog";
     license = licenses.bsd2;

--- a/pkgs/tools/misc/limitcpu/default.nix
+++ b/pkgs/tools/misc/limitcpu/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   installFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {
-    homepage = "http://limitcpu.sourceforge.net/";
+    homepage = "https://limitcpu.sourceforge.net/";
     description = "A tool to throttle the CPU usage of programs";
     platforms = with platforms; linux ++ freebsd;
     license = licenses.gpl2;

--- a/pkgs/tools/misc/memtest86+/default.nix
+++ b/pkgs/tools/misc/memtest86+/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "http://www.memtest.org/";
+    homepage = "https://www.memtest.org/";
     description = "A tool to detect memory errors";
     license = lib.licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];

--- a/pkgs/tools/misc/ms-sys/default.nix
+++ b/pkgs/tools/misc/ms-sys/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A program for writing Microsoft-compatible boot records";
-    homepage = "http://ms-sys.sourceforge.net/";
+    homepage = "https://ms-sys.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = with platforms; linux;
   };

--- a/pkgs/tools/misc/pal/default.nix
+++ b/pkgs/tools/misc/pal/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   meta = {
-    homepage = "http://palcal.sourceforge.net/";
+    homepage = "https://palcal.sourceforge.net/";
     description = "Command-line calendar program that can keep track of events";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [viric];

--- a/pkgs/tools/misc/rig/default.nix
+++ b/pkgs/tools/misc/rig/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "CXX=${stdenv.cc.targetPrefix}c++" ];
 
   meta = {
-    homepage = "http://rig.sourceforge.net/";
+    homepage = "https://rig.sourceforge.net/";
     description = "Random identity generator";
     longDescription = ''
       RIG (Random Identity Generator) is a free replacement for a shareware

--- a/pkgs/tools/misc/smc/default.nix
+++ b/pkgs/tools/misc/smc/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
       SMC can also generate GraphViz state diagrams from the input file.
     '';
-    homepage = "http://smc.sourceforge.net/";
+    homepage = "https://smc.sourceforge.net/";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mpl11;
     platforms = platforms.linux;

--- a/pkgs/tools/misc/ttf2pt1/default.nix
+++ b/pkgs/tools/misc/ttf2pt1/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "True Type to Postscript Type 3 converter, fpdf";
-    homepage = "http://ttf2pt1.sourceforge.net/index.html";
+    homepage = "https://ttf2pt1.sourceforge.net/index.html";
     license = "ttf2pt1";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/tools/networking/cdpr/default.nix
+++ b/pkgs/tools/networking/cdpr/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Cisco Discovery Protocol Reporter";
-    homepage = "http://cdpr.sourceforge.net/";
+    homepage = "https://cdpr.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = [ maintainers.sgo ];

--- a/pkgs/tools/networking/cntlm/default.nix
+++ b/pkgs/tools/networking/cntlm/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "NTLM/NTLMv2 authenticating HTTP proxy";
-    homepage = "http://cntlm.sourceforge.net/";
+    homepage = "https://cntlm.sourceforge.net/";
     license = licenses.gpl2;
     maintainers =
       [

--- a/pkgs/tools/networking/dirb/default.nix
+++ b/pkgs/tools/networking/dirb/default.nix
@@ -38,7 +38,7 @@ in stdenv.mkDerivation rec {
 
   meta = {
     description = "A web content scanner";
-    homepage = "http://dirb.sourceforge.net/";
+    homepage = "https://dirb.sourceforge.net/";
     maintainers = with lib.maintainers; [ bennofs ];
     license = with lib.licenses; [ gpl2 ];
     platforms = lib.platforms.unix;

--- a/pkgs/tools/networking/libnids/default.nix
+++ b/pkgs/tools/networking/libnids/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "An E-component of Network Intrusion Detection System which emulates the IP stack of Linux 2.0.x";
-    homepage = "http://libnids.sourceforge.net/";
+    homepage = "https://libnids.sourceforge.net/";
     license = licenses.gpl2;
     maintainers = [ maintainers.symphorien ];
     # probably also bsd and solaris

--- a/pkgs/tools/networking/netcat/default.nix
+++ b/pkgs/tools/networking/netcat/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Utility which reads and writes data across network connections";
-    homepage = "http://netcat.sourceforge.net/";
+    homepage = "https://netcat.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
   };

--- a/pkgs/tools/networking/p2p/gtk-gnutella/default.nix
+++ b/pkgs/tools/networking/p2p/gtk-gnutella/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A GTK Gnutella client, optimized for speed and scalability";
-    homepage = "http://gtk-gnutella.sourceforge.net/"; # Code: https://github.com/gtk-gnutella/gtk-gnutella
+    homepage = "https://gtk-gnutella.sourceforge.net/"; # Code: https://github.com/gtk-gnutella/gtk-gnutella
     changelog = "https://raw.githubusercontent.com/gtk-gnutella/gtk-gnutella/v${version}/ChangeLog";
     maintainers = [ maintainers.doronbehar ];
     license = licenses.gpl2Plus;

--- a/pkgs/tools/networking/pptp/default.nix
+++ b/pkgs/tools/networking/pptp/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "PPTP client for Linux";
-    homepage = "http://pptpclient.sourceforge.net/";
+    homepage = "https://pptpclient.sourceforge.net/";
     license = licenses.gpl2;
     platforms = platforms.linux;
   };

--- a/pkgs/tools/networking/pptpd/default.nix
+++ b/pkgs/tools/networking/pptpd/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage    = "http://poptop.sourceforge.net/dox/";
+    homepage    = "https://poptop.sourceforge.net/dox/";
     description = "The PPTP Server for Linux";
     platforms   = platforms.linux;
     maintainers = with maintainers; [ obadz ];

--- a/pkgs/tools/networking/qodem/default.nix
+++ b/pkgs/tools/networking/qodem/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses SDL gpm miniupnpc ];
 
   meta = with lib; {
-    homepage = "http://qodem.sourceforge.net/";
+    homepage = "https://qodem.sourceforge.net/";
     description = "Re-implementation of the DOS-era Qmodem serial communications package";
     longDescription = ''
       Qodem is a from-scratch clone implementation of the Qmodem

--- a/pkgs/tools/networking/sstp/default.nix
+++ b/pkgs/tools/networking/sstp/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "SSTP client for Linux";
-    homepage = "http://sstp-client.sourceforge.net/";
+    homepage = "https://sstp-client.sourceforge.net/";
     platforms = platforms.linux;
     maintainers = with maintainers; [ ];
     license = licenses.gpl2Plus;

--- a/pkgs/tools/networking/stuntman/default.nix
+++ b/pkgs/tools/networking/stuntman/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "STUNTMAN - an open source STUN server and client";
-    homepage = "http://www.stunprotocol.org/";
+    homepage = "https://www.stunprotocol.org/";
     license = licenses.asl20;
     maintainers = with maintainers; [ mattchrist ];
     platforms = platforms.unix;

--- a/pkgs/tools/networking/traceroute/default.nix
+++ b/pkgs/tools/networking/traceroute/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Tracks the route taken by packets over an IP network";
-    homepage = "http://traceroute.sourceforge.net/";
+    homepage = "https://traceroute.sourceforge.net/";
     changelog = "https://sourceforge.net/projects/traceroute/files/traceroute/traceroute-${version}/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ koral ];

--- a/pkgs/tools/networking/zssh/default.nix
+++ b/pkgs/tools/networking/zssh/default.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
 
   meta = {
     description = "SSH and Telnet client with ZMODEM file transfer capability";
-    homepage = "http://zssh.sourceforge.net/";
+    homepage = "https://zssh.sourceforge.net/";
     license = lib.licenses.gpl2;
     maintainers = [ ]; # required by deepin-terminal
     platforms = lib.platforms.linux;

--- a/pkgs/tools/security/aespipe/default.nix
+++ b/pkgs/tools/security/aespipe/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "AES encrypting or decrypting pipe";
-    homepage = "http://loop-aes.sourceforge.net/aespipe.README";
+    homepage = "https://loop-aes.sourceforge.net/aespipe.README";
     license = licenses.gpl2;
     maintainers = [ maintainers.goibhniu ];
     platforms = platforms.unix;

--- a/pkgs/tools/security/ccrypt/default.nix
+++ b/pkgs/tools/security/ccrypt/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   meta = {
-    homepage = "http://ccrypt.sourceforge.net/";
+    homepage = "https://ccrypt.sourceforge.net/";
     description = "Utility for encrypting and decrypting files and streams with AES-256";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [viric];

--- a/pkgs/tools/security/gnupg-pkcs11-scd/default.nix
+++ b/pkgs/tools/security/gnupg-pkcs11-scd/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     gnupg-pkcs11 is a project to implement a BSD-licensed smart-card
     daemon to enable the use of PKCS#11 tokens with GnuPG.
     '';
-    homepage = "http://gnupg-pkcs11.sourceforge.net/";
+    homepage = "https://gnupg-pkcs11.sourceforge.net/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ matthiasbeyer philandstuff ];
     platforms = platforms.unix;

--- a/pkgs/tools/security/pamtester/default.nix
+++ b/pkgs/tools/security/pamtester/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Utility program to test the PAM facility";
-    homepage = "http://pamtester.sourceforge.net/";
+    homepage = "https://pamtester.sourceforge.net/";
     license = licenses.bsd3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ abbradar ];

--- a/pkgs/tools/security/pdfcrack/default.nix
+++ b/pkgs/tools/security/pdfcrack/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://pdfcrack.sourceforge.net/";
+    homepage = "https://pdfcrack.sourceforge.net/";
     description = "Small command line driven tool for recovering passwords and content from PDF files";
     license = with licenses; [ gpl2Plus ];
     platforms = platforms.all;

--- a/pkgs/tools/security/rhash/default.nix
+++ b/pkgs/tools/security/rhash/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "http://rhash.sourceforge.net/";
+    homepage = "https://rhash.sourceforge.net/";
     description = "Console utility and library for computing and verifying hash sums of files";
     license = licenses.bsd0;
     platforms = platforms.all;

--- a/pkgs/tools/security/trousers/default.nix
+++ b/pkgs/tools/security/trousers/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Trusted computing software stack";
-    homepage    = "http://trousers.sourceforge.net/";
+    homepage    = "https://trousers.sourceforge.net/";
     license     = licenses.bsd3;
     maintainers = [ maintainers.ak ];
     platforms   = platforms.linux;

--- a/pkgs/tools/security/wipe/default.nix
+++ b/pkgs/tools/security/wipe/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Secure file wiping utility";
-    homepage    = "http://wipe.sourceforge.net/";
+    homepage    = "https://wipe.sourceforge.net/";
     license     = licenses.gpl2;
     platforms   = platforms.all;
     maintainers = [ maintainers.abbradar ];

--- a/pkgs/tools/system/bar/default.nix
+++ b/pkgs/tools/system/bar/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Console progress bar";
-    homepage = "http://clpbar.sourceforge.net/";
+    homepage = "https://clpbar.sourceforge.net/";
     license = lib.licenses.gpl2;
     maintainers = [ lib.maintainers.rdnetto ];
     platforms = lib.platforms.all;

--- a/pkgs/tools/system/dcfldd/default.nix
+++ b/pkgs/tools/system/dcfldd/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An enhanced version of GNU dd";
 
-    homepage = "http://dcfldd.sourceforge.net/";
+    homepage = "https://dcfldd.sourceforge.net/";
 
     license = licenses.gpl2;
 

--- a/pkgs/tools/system/dog/default.nix
+++ b/pkgs/tools/system/dog/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://lwn.net/Articles/421072/";
+    homepage = "https://lwn.net/Articles/421072/";
     description = "cat replacement";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ qknight ];

--- a/pkgs/tools/system/foremost/default.nix
+++ b/pkgs/tools/system/foremost/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     sha256 = "0d2zxw0ijg8cd3ksgm8cf8jg128zr5x7z779jar90g9f47pm882h";
-    url = "http://foremost.sourceforge.net/pkg/${pname}-${version}.tar.gz";
+    url = "https://foremost.sourceforge.net/pkg/${pname}-${version}.tar.gz";
   };
 
   patches = [ ./makefile.patch ];
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
       look at the data structures of a given file format allowing for a more
       reliable and faster recovery.
     '';
-    homepage = "http://foremost.sourceforge.net/";
+    homepage = "https://foremost.sourceforge.net/";
     license = licenses.publicDomain;
     maintainers = [ maintainers.jiegec ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/tools/system/gt5/default.nix
+++ b/pkgs/tools/system/gt5/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A diff-capable 'du' browser";
-    homepage = "http://gt5.sourceforge.net/";
+    homepage = "https://gt5.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [viric];
     platforms = with lib.platforms; all;

--- a/pkgs/tools/system/idle3tools/default.nix
+++ b/pkgs/tools/system/idle3tools/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://idle3-tools.sourceforge.net/";
+    homepage = "https://idle3-tools.sourceforge.net/";
     description = "Tool to get/set the infamous idle3 timer in WD HDDs";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [viric];

--- a/pkgs/tools/system/ipmiutil/default.nix
+++ b/pkgs/tools/system/ipmiutil/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An easy-to-use IPMI server management utility";
-    homepage = "http://ipmiutil.sourceforge.net/";
+    homepage = "https://ipmiutil.sourceforge.net/";
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.linux;
     license = licenses.bsd3;

--- a/pkgs/tools/text/multitran/data/default.nix
+++ b/pkgs/tools/text/multitran/data/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = "http://multitran.sourceforge.net/";
+    homepage = "https://multitran.sourceforge.net/";
     description = "Multitran data english-russian";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.unix;

--- a/pkgs/tools/text/multitran/libbtree/default.nix
+++ b/pkgs/tools/text/multitran/libbtree/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://multitran.sourceforge.net/";
+    homepage = "https://multitran.sourceforge.net/";
     description = "Multitran lib: library for reading Multitran's BTREE database format";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;

--- a/pkgs/tools/text/multitran/libfacet/default.nix
+++ b/pkgs/tools/text/multitran/libfacet/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://multitran.sourceforge.net/";
+    homepage = "https://multitran.sourceforge.net/";
     description = "Multitran lib: enchanced locale facets";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;

--- a/pkgs/tools/text/multitran/libmtquery/default.nix
+++ b/pkgs/tools/text/multitran/libmtquery/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://multitran.sourceforge.net/";
+    homepage = "https://multitran.sourceforge.net/";
     description = "Multitran lib: main engine to query translations";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;

--- a/pkgs/tools/text/multitran/libmtsupport/default.nix
+++ b/pkgs/tools/text/multitran/libmtsupport/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://multitran.sourceforge.net/";
+    homepage = "https://multitran.sourceforge.net/";
     description = "Multitran lib: basic useful functions";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;

--- a/pkgs/tools/text/multitran/mtutils/default.nix
+++ b/pkgs/tools/text/multitran/mtutils/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://multitran.sourceforge.net/";
+    homepage = "https://multitran.sourceforge.net/";
     description = "Multitran: simple command line utilities for dictionary maintenance";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [viric];

--- a/pkgs/tools/text/sgml/openjade/default.nix
+++ b/pkgs/tools/text/sgml/openjade/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "An implementation of DSSSL, an ISO standard for formatting SGML (and XML) documents";
     license = lib.licenses.mit;
-    homepage = "http://openjade.sourceforge.net/";
+    homepage = "https://openjade.sourceforge.net/";
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/tools/text/sgml/opensp/default.nix
+++ b/pkgs/tools/text/sgml/opensp/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A suite of SGML/XML processing tools";
     license = licenses.mit;
-    homepage = "http://openjade.sourceforge.net/";
+    homepage = "https://openjade.sourceforge.net/";
     platforms = platforms.unix;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/tools/text/xml/html-xml-utils/default.nix
+++ b/pkgs/tools/text/xml/html-xml-utils/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Utilities for manipulating HTML and XML files";
-    homepage = "http://www.w3.org/Tools/HTML-XML-utils/";
+    homepage = "https://www.w3.org/Tools/HTML-XML-utils/";
     license = licenses.w3c;
     platforms = platforms.all;
   };

--- a/pkgs/tools/text/xml/xmlstarlet/default.nix
+++ b/pkgs/tools/text/xml/xmlstarlet/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A command line tool for manipulating and querying XML data";
-    homepage = "http://xmlstar.sourceforge.net/";
+    homepage = "https://xmlstar.sourceforge.net/";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/tools/typesetting/docbook2x/default.nix
+++ b/pkgs/tools/typesetting/docbook2x/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
       format.
     '';
     license = licenses.mit;
-    homepage = "http://docbook2x.sourceforge.net/";
+    homepage = "https://docbook2x.sourceforge.net/";
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/typesetting/tex/dblatex/default.nix
+++ b/pkgs/tools/typesetting/tex/dblatex/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A program to convert DocBook to DVI, PostScript or PDF via LaTeX or ConTeXt";
-    homepage = "http://dblatex.sourceforge.net/";
+    homepage = "https://dblatex.sourceforge.net/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/tools/video/yamdi/default.nix
+++ b/pkgs/tools/video/yamdi/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Yet Another MetaData Injector for FLV";
-    homepage = "http://yamdi.sourceforge.net/";
+    homepage = "https://yamdi.sourceforge.net/";
     license = licenses.bsd3;
     platforms = platforms.all;
     maintainers = [ maintainers.ryanartecona ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9780,7 +9780,7 @@ let
     propagatedBuildInputs = [ CGI DateTimeFormatStrptime HTMLTableExtract JSON JSONParse LWPProtocolHttps StringUtil TextTemplate ];
     buildInputs = [ TestPod ];
     meta = {
-      homepage = "http://finance-quote.sourceforge.net/";
+      homepage = "https://finance-quote.sourceforge.net/";
       description = "Get stock and mutual fund quotes from various exchanges";
       license = with lib.licenses; [gpl2 ];
     };
@@ -20646,7 +20646,7 @@ let
     propagatedBuildInputs = [ DigestSHA1 URI ];
     meta = {
       description = "Collaborative, content-based spam filtering network agent";
-      homepage = "http://razor.sourceforge.net/";
+      homepage = "https://razor.sourceforge.net/";
       license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };


### PR DESCRIPTION
###### Description of changes

I've create a little python script https://github.com/mothsART/repology-nginx who update package's urls when http can be replace by https (permanent redirection).

###### Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
