### PR TITLE
go: Add patches to support Sv57 addressing on riscv64

### DIFF
--- a/pkgs/development/compilers/go/1.18.nix
+++ b/pkgs/development/compilers/go/1.18.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, fetchpatch
 , fetchurl
 , tzdata
 , substituteAll
@@ -86,6 +87,12 @@ stdenv.mkDerivation rec {
     })
     ./remove-tools-1.11.patch
     ./go_no_vendor_checks-1.16.patch
+
+    # runtime: support riscv64 SV57 mode
+    (fetchpatch {
+      url = "https://github.com/golang/go/commit/1e3c19f3fee12e5e2b7802a54908a4d4d03960da.patch";
+      sha256 = "sha256-mk/9gXwQEcAkiRemF6GiNU0c0fhDR29/YcKgQR7ONTA=";
+    })
   ];
 
   GOOS = stdenv.targetPlatform.parsed.kernel.name;

--- a/pkgs/development/compilers/go/1.19.nix
+++ b/pkgs/development/compilers/go/1.19.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, fetchpatch
 , fetchurl
 , tzdata
 , substituteAll
@@ -86,6 +87,12 @@ stdenv.mkDerivation rec {
     })
     ./remove-tools-1.11.patch
     ./go_no_vendor_checks-1.16.patch
+
+    # runtime: support riscv64 SV57 mode
+    (fetchpatch {
+      url = "https://github.com/golang/go/commit/1e3c19f3fee12e5e2b7802a54908a4d4d03960da.patch";
+      sha256 = "sha256-mk/9gXwQEcAkiRemF6GiNU0c0fhDR29/YcKgQR7ONTA=";
+    })
   ];
 
   GOOS = stdenv.targetPlatform.parsed.kernel.name;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes Go binaries on platforms with Sv57 addressing (e.g., QEMU with a newer kernel):

```
runtime: lfstack.push invalid packing: node=0xffffff94adc880 cnt=0x1 packed=0xffff94adc8800001 -> node=0xffff94adc880
```

The patch has [landed](https://go-review.googlesource.com/c/go/+/409055) in 1.20. Tested on top of #211717.

Ref: https://github.com/NixOS/nixpkgs/issues/101651

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (on master)
  - [x] riscv64-linux (on master with #211717)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
