### PR TITLE
dpdk: 22.07 -> 22.11.1

### DIFF
--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -5,7 +5,13 @@
 , libbsd, numactl, libbpf, zlib, libelf, jansson, openssl, libpcap, rdma-core
 , doxygen, python3, pciutils
 , withExamples ? []
-, shared ? false }:
+, shared ? false
+, machine ? (
+    if stdenv.isx86_64 then "nehalem"
+    else if stdenv.isAarch64 then "generic"
+    else null
+  )
+}:
 
 let
   mod = kernel != null;
@@ -63,8 +69,7 @@ in stdenv.mkDerivation rec {
   # kni kernel driver is currently not compatble with 5.11
   ++ lib.optional (mod && kernel.kernelOlder "5.11") "-Ddisable_drivers=kni"
   ++ lib.optional (!shared) "-Ddefault_library=static"
-  ++ lib.optional stdenv.isx86_64 "-Dmachine=nehalem"
-  ++ lib.optional stdenv.isAarch64 "-Dmachine=generic"
+  ++ lib.optional (machine != null) "-Dmachine=${machine}"
   ++ lib.optional mod "-Dkernel_dir=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ++ lib.optional (withExamples != []) "-Dexamples=${builtins.concatStringsSep "," withExamples}";
 

--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -9,14 +9,14 @@
 
 let
   mod = kernel != null;
-  dpdkVersion = "22.07";
+  dpdkVersion = "22.11.1";
 in stdenv.mkDerivation rec {
   pname = "dpdk";
   version = "${dpdkVersion}" + lib.optionalString mod "-${kernel.version}";
 
   src = fetchurl {
     url = "https://fast.dpdk.org/rel/dpdk-${dpdkVersion}.tar.xz";
-    sha256 = "sha256-n2Tf3gdf21cIy2Leg4uP+4kVdf7R4dKusma6yj38m+o=";
+    sha256 = "sha256-3gdkZfcXSg1ScUuQcuSDenJrqsgtj+fcZEytXIz3TUw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/pktgen/default.nix
+++ b/pkgs/os-specific/linux/pktgen/default.nix
@@ -1,18 +1,39 @@
-{ stdenv, lib, fetchFromGitHub, meson, ninja, pkg-config
-, dpdk, libbsd, libpcap, lua5_3, numactl, util-linux
-, gtk2, which, withGtk ? false
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, meson
+, ninja
+, pkg-config
+, dpdk
+, libbsd
+, libpcap
+, lua5_3
+, numactl
+, util-linux
+, gtk2
+, which
+, withGtk ? false
 }:
 
 stdenv.mkDerivation rec {
   pname = "pktgen";
-  version = "22.04.1";
+  version = "22.07.1";
 
   src = fetchFromGitHub {
     owner = "pktgen";
     repo = "Pktgen-DPDK";
     rev = "pktgen-${version}";
-    sha256 = "0gbag98i2jq0p2hpvfgc3fiqy2sark1dm72hla4sxmn3gljy3p70";
+    sha256 = "sha256-wBLGwVdn3ymUTVv7J/kbQYz4WNIgV246PHg51+FStUo=";
   };
+
+  patches = [
+    (fetchpatch {
+      # Ealier DPDK deprecated some macros, which were finally removed in >= 22.11
+      url = "https://github.com/pktgen/Pktgen-DPDK/commit/089ef94ac04629f7380f5e618443bcacb2cef5ab.patch";
+      sha256 = "sha256-ITU/dIfu7QPpdIVYuCuDhDG9rVF+n8i1YYn9bFmQUME=";
+    })
+  ];
 
   nativeBuildInputs = [ meson ninja pkg-config ];
 


### PR DESCRIPTION
###### Description of changes

* Bump DPDK to the latest LTS release and bump & fix Pktgen for this newer version of DPDK.
* Make it easier for the user to override the CPU family for which DPDK will be optimized.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>7 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_14_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_4_19_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_5_10_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_5_15_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_6_0_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_6_1_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_hardened.dpdk</li>
  </ul>
</details>
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>linuxKernel.packages.linux_testing_bcachefs.dpdk</li>
  </ul>
</details>
<details>
  <summary>16 packages built:</summary>
  <ul>
    <li>dpdk</li>
    <li>linuxKernel.packages.hardkernel_4_14.pktgen</li>
    <li>linuxKernel.packages.linux_4_14.dpdk</li>
    <li>linuxKernel.packages.linux_4_19.dpdk</li>
    <li>linuxKernel.packages.linux_5_10.dpdk</li>
    <li>linuxKernel.packages.linux_5_15.dpdk</li>
    <li>linuxKernel.packages.linux_5_4.dpdk</li>
    <li>linuxKernel.packages.linux_6_0.dpdk</li>
    <li>linuxKernel.packages.linux_6_1.dpdk</li>
    <li>linuxKernel.packages.linux_latest_libre.dpdk</li>
    <li>linuxKernel.packages.linux_libre.dpdk</li>
    <li>linuxKernel.packages.linux_lqx.dpdk</li>
    <li>linuxKernel.packages.linux_xanmod.dpdk</li>
    <li>linuxKernel.packages.linux_xanmod_latest.dpdk (linuxKernel.packages.linux_xanmod_stable.dpdk)</li>
    <li>linuxKernel.packages.linux_zen.dpdk</li>
    <li>spdk</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).