### PR TITLE
satysfi: rewrite with buildDunePackage

### DIFF
--- a/pkgs/tools/typesetting/satysfi/default.nix
+++ b/pkgs/tools/typesetting/satysfi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, ruby, dune_3, ocamlPackages
+{ lib, stdenv, fetchFromGitHub, ruby, ocamlPackages
 , ipaexfont, junicode, lmodern, lmmath
 }:
 let
@@ -34,7 +34,7 @@ let
     inherit (ocamlPackages.yojson) meta;
   };
 in
-  stdenv.mkDerivation rec {
+  ocamlPackages.buildDunePackage rec {
     pname = "satysfi";
     version = "0.0.8";
     src = fetchFromGitHub {
@@ -51,23 +51,24 @@ in
       $out/share/satysfi
     '';
 
-    DUNE_PROFILE = "release";
+    duneVersion = "3";
 
-    nativeBuildInputs = [ ruby dune_3 ];
+    nativeBuildInputs = with ocamlPackages; [ menhir cppo ];
 
     buildInputs = [ camlpdf otfm yojson-with-position ] ++ (with ocamlPackages; [
-      ocaml findlib menhir menhirLib
-      batteries camlimages core_kernel ppx_deriving uutf omd cppo re
+      menhirLib
+      batteries camlimages core_kernel ppx_deriving uutf omd re
     ]);
 
-    installPhase = ''
-      cp -r ${ipaexfont}/share/fonts/opentype/* lib-satysfi/dist/fonts/
-      cp -r ${junicode}/share/fonts/junicode-ttf/* lib-satysfi/dist/fonts/
-      cp -r ${lmodern}/share/fonts/opentype/public/lm/* lib-satysfi/dist/fonts/
-      cp -r ${lmmath}/share/fonts/opentype/latinmodern-math.otf lib-satysfi/dist/fonts/
-      make install PREFIX=$out LIBDIR=$out/share/satysfi
-      mkdir -p $out/share/satysfi/
+    postInstall = ''
+      mkdir -p $out/share/satysfi/dist/fonts
       cp -r lib-satysfi/dist/ $out/share/satysfi/
+      cp -r \
+        ${ipaexfont}/share/fonts/opentype/* \
+        ${junicode}/share/fonts/junicode-ttf/* \
+        ${lmodern}/share/fonts/opentype/public/lm/* \
+        ${lmmath}/share/fonts/opentype/latinmodern-math.otf \
+        $out/share/satysfi/dist/fonts
     '';
 
     meta = with lib; {


### PR DESCRIPTION
###### Description of changes

While reviewing #210884 I saw this package didn't use `buildDunePackage` I suggested to change but the PR was merged before.

The package build. Both result path before and after this PR have the same files at the same place + It avoid a double copy and also expose the library that was intended to be [public](https://github.com/gfngfn/SATySFi/blob/v0.0.8/src/dune#L3)


New files are:
```
/share/doc/satysfi/CHANGELOG.md
/share/doc/satysfi/LICENSE
/share/doc/satysfi/README-ja.md
/share/doc/satysfi/README.md
```

and folder `/lib/ocaml/4.14.0/site-lib/satysfi` with many `.ml`/`.mli` files.

We can remove the new files with `substituteInPlace src/dune --replace '(public_name satysfi)' ""`

Now that it expose the library should I move it to [ocaml-packages.nix](https://github.com/NixOS/nixpkgs/blob/3fce3e4096e92b4279182c6daa4c51540ff66de7/pkgs/top-level/ocaml-packages.nix#L1635) ?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
