### PR TITLE
matrix-conduit: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/servers/matrix-conduit/cargo-11192-workaround.patch
+++ b/pkgs/servers/matrix-conduit/cargo-11192-workaround.patch
@@ -1,0 +1,259 @@
+diff --git ruma-appservice-api/Cargo.toml ruma-appservice-api/Cargo.toml
+index b48852c8..8641bc42 100644
+--- ruma-appservice-api/Cargo.toml
++++ ruma-appservice-api/Cargo.toml
+@@ -23,11 +23,11 @@ unstable-msc2409 = []
+ unstable-msc3202 = []
+ 
+ [dependencies]
+-js_int = { workspace = true, features = ["serde"] }
++js_int = { version = "0.2.2", features = ["serde"] }
+ ruma-common = { version = "0.10.5", path = "../ruma-common", features = ["api", "events"] }
+-serde = { workspace = true }
+-serde_json = { workspace = true }
++serde = { version = "1.0.147", features = ["derive"] }
++serde_json = { version = "1.0.87" }
+ 
+ [dev-dependencies]
+-assert_matches = { workspace = true }
++assert_matches = { version = "1.5.0" }
+ serde_yaml = "0.9.14"
+diff --git ruma-client-api/Cargo.toml ruma-client-api/Cargo.toml
+index ddd2e44b..5756c055 100644
+--- ruma-client-api/Cargo.toml
++++ ruma-client-api/Cargo.toml
+@@ -31,16 +31,16 @@ client = []
+ server = []
+ 
+ [dependencies]
+-assign = { workspace = true }
++assign = { version = "1.1.1" }
+ bytes = "1.0.1"
+-http = { workspace = true }
+-js_int = { workspace = true, features = ["serde"] }
++http = { version = "0.2.8" }
++js_int = { version = "0.2.2", features = ["serde"] }
+ js_option = "0.1.1"
+-maplit = { workspace = true }
++maplit = { version = "1.0.2" }
+ percent-encoding = "2.1.0"
+ ruma-common = { version = "0.10.5", path = "../ruma-common", features = ["api", "events"] }
+-serde = { workspace = true }
+-serde_json = { workspace = true }
++serde = { version = "1.0.147", features = ["derive"] }
++serde_json = { version = "1.0.87" }
+ 
+ [dev-dependencies]
+-assert_matches = { workspace = true }
++assert_matches = { version = "1.5.0" }
+diff --git ruma-common/Cargo.toml ruma-common/Cargo.toml
+index 83f22461..4ba11cfb 100644
+--- ruma-common/Cargo.toml
++++ ruma-common/Cargo.toml
+@@ -48,15 +48,15 @@ unstable-sanitize = ["dep:html5ever", "dep:phf"]
+ unstable-unspecified = []
+ 
+ [dependencies]
+-base64 = { workspace = true }
++base64 = { version = "0.20.0" }
+ bytes = "1.0.1"
+ form_urlencoded = "1.0.0"
+ getrandom = { version = "0.2.6", optional = true }
+ html5ever = { version = "0.25.2", optional = true }
+-http = { workspace = true, optional = true }
++http = { version = "0.2.8", optional = true }
+ indexmap = { version = "1.9.1", features = ["serde"] }
+ itoa = "1.0.1"
+-js_int = { workspace = true, features = ["serde"] }
++js_int = { version = "0.2.2", features = ["serde"] }
+ js_option = "0.1.0"
+ konst = { version = "0.2.19", features = ["rust_1_64", "alloc"] }
+ percent-encoding = "2.1.0"
+@@ -66,25 +66,25 @@ rand = { version = "0.8.3", optional = true }
+ regex = { version = "1.5.6", default-features = false, features = ["std", "perf"] }
+ ruma-identifiers-validation = { version = "0.9.0", path = "../ruma-identifiers-validation", default-features = false }
+ ruma-macros = { version = "0.10.5", path = "../ruma-macros" }
+-serde = { workspace = true }
+-serde_json = { workspace = true, features = ["raw_value"] }
+-thiserror = { workspace = true }
+-tracing = { workspace = true, features = ["attributes"] }
++serde = { version = "1.0.147", features = ["derive"] }
++serde_json = { version = "1.0.87", features = ["raw_value"] }
++thiserror = { version = "1.0.37" }
++tracing = { version = "0.1.37", default-features = false, features = ["std", "attributes"] }
+ url = "2.2.2"
+ uuid = { version = "1.0.0", optional = true, features = ["v4"] }
+ wildmatch = "2.0.0"
+ 
+ # dev-dependencies can't be optional, so this is a regular dependency
+-criterion = { workspace = true, optional = true }
++criterion = { version = "0.4.0", optional = true }
+ 
+ [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+ js-sys = { version = "0.3", optional = true }
+ 
+ [dev-dependencies]
+-assert_matches = { workspace = true }
+-assign = { workspace = true }
+-http = { workspace = true }
+-maplit = { workspace = true }
++assert_matches = { version = "1.5.0" }
++assign = { version = "1.1.1" }
++http = { version = "0.2.8" }
++maplit = { version = "1.0.2" }
+ trybuild = "1.0.71"
+ 
+ [[bench]]
+diff --git ruma-federation-api/Cargo.toml ruma-federation-api/Cargo.toml
+index 380d1ed3..a4508a80 100644
+--- ruma-federation-api/Cargo.toml
++++ ruma-federation-api/Cargo.toml
+@@ -26,11 +26,11 @@ unstable-msc3723 = []
+ unstable-unspecified = []
+ 
+ [dependencies]
+-js_int = { workspace = true, features = ["serde"] }
++js_int = { version = "0.2.2", features = ["serde"] }
+ ruma-common = { version = "0.10.5", path = "../ruma-common", features = ["api", "events"] }
+-serde = { workspace = true }
+-serde_json = { workspace = true }
++serde = { version = "1.0.147", features = ["derive"] }
++serde_json = { version = "1.0.87" }
+ 
+ [dev-dependencies]
+-assert_matches = { workspace = true }
+-http = { workspace = true }
++assert_matches = { version = "1.5.0" }
++http = { version = "0.2.8" }
+diff --git ruma-identifiers-validation/Cargo.toml ruma-identifiers-validation/Cargo.toml
+index cd79ba78..28a9cd9e 100644
+--- ruma-identifiers-validation/Cargo.toml
++++ ruma-identifiers-validation/Cargo.toml
+@@ -15,5 +15,5 @@ all-features = true
+ compat = []
+ 
+ [dependencies]
+-js_int = { workspace = true }
+-thiserror = { workspace = true }
++js_int = { version = "0.2.2" }
++thiserror = { version = "1.0.37" }
+diff --git ruma-identity-service-api/Cargo.toml ruma-identity-service-api/Cargo.toml
+index 9dd4bc14..6edf1170 100644
+--- ruma-identity-service-api/Cargo.toml
++++ ruma-identity-service-api/Cargo.toml
+@@ -19,9 +19,9 @@ client = []
+ server = []
+ 
+ [dependencies]
+-js_int = { workspace = true, features = ["serde"] }
++js_int = { version = "0.2.2", features = ["serde"] }
+ ruma-common = { version = "0.10.5", path = "../ruma-common", features = ["api"] }
+-serde = { workspace = true }
++serde = { version = "1.0.147", features = ["derive"] }
+ 
+ [dev-dependencies]
+-serde_json = { workspace = true }
++serde_json = { version = "1.0.87" }
+diff --git ruma-macros/Cargo.toml ruma-macros/Cargo.toml
+index 70a6a7a6..e86c0631 100644
+--- ruma-macros/Cargo.toml
++++ ruma-macros/Cargo.toml
+@@ -23,6 +23,6 @@ proc-macro-crate = "1.0.0"
+ proc-macro2 = "1.0.24"
+ quote = "1.0.8"
+ ruma-identifiers-validation = { version = "0.9.0", path = "../ruma-identifiers-validation", default-features = false }
+-serde = { workspace = true }
++serde = { version = "1.0.147", features = ["derive"] }
+ syn = { version = "1.0.57", features = ["extra-traits", "full", "visit"] }
+ toml = "0.5.9"
+diff --git ruma-push-gateway-api/Cargo.toml ruma-push-gateway-api/Cargo.toml
+index 5d589828..e08144ce 100644
+--- ruma-push-gateway-api/Cargo.toml
++++ ruma-push-gateway-api/Cargo.toml
+@@ -20,7 +20,7 @@ client = []
+ server = []
+ 
+ [dependencies]
+-js_int = { workspace = true, features = ["serde"] }
++js_int = { version = "0.2.2", features = ["serde"] }
+ ruma-common = { version = "0.10.5", path = "../ruma-common", features = ["api", "events"] }
+-serde = { workspace = true }
+-serde_json = { workspace = true }
++serde = { version = "1.0.147", features = ["derive"] }
++serde_json = { version = "1.0.87" }
+diff --git ruma-signatures/Cargo.toml ruma-signatures/Cargo.toml
+index dd1c9951..d06bffd9 100644
+--- ruma-signatures/Cargo.toml
++++ ruma-signatures/Cargo.toml
+@@ -18,16 +18,16 @@ ring-compat = ["dep:subslice"]
+ unstable-exhaustive-types = []
+ 
+ [dependencies]
+-base64 = { workspace = true }
++base64 = { version = "0.20.0" }
+ ed25519-dalek = "1.0.1"
+ pkcs8 = { version = "0.9.0", features = ["alloc"] }
+ # because dalek uses an older version of rand_core
+ rand = { version = "0.7", features = ["getrandom"] }
+ ruma-common = { version = "0.10.5", path = "../ruma-common", features = ["canonical-json"] }
+-serde_json = { workspace = true }
++serde_json = { version = "1.0.87" }
+ sha2 = "0.9.5"
+ subslice = { version = "0.2.3", optional = true }
+-thiserror = { workspace = true }
++thiserror = { version = "1.0.37" }
+ 
+ [dev-dependencies]
+-assert_matches = { workspace = true }
++assert_matches = { version = "1.5.0" }
+diff --git ruma-state-res/Cargo.toml ruma-state-res/Cargo.toml
+index d23556f1..ec6088bc 100644
+--- ruma-state-res/Cargo.toml
++++ ruma-state-res/Cargo.toml
+@@ -19,18 +19,18 @@ unstable-exhaustive-types = []
+ 
+ [dependencies]
+ itertools = "0.10.0"
+-js_int = { workspace = true }
++js_int = { version = "0.2.2" }
+ ruma-common = { version = "0.10.5", path = "../ruma-common", features = ["events"] }
+-serde = { workspace = true }
+-serde_json = { workspace = true }
+-thiserror = { workspace = true }
+-tracing = { workspace = true }
++serde = { version = "1.0.147", features = ["derive"] }
++serde_json = { version = "1.0.87" }
++thiserror = { version = "1.0.37" }
++tracing = { version = "0.1.37", default-features = false, features = ["std"] }
+ 
+ # dev-dependencies can't be optional, so this is a regular dependency
+-criterion = { workspace = true, optional = true }
++criterion = { version = "0.4.0", optional = true }
+ 
+ [dev-dependencies]
+-maplit = { workspace = true }
++maplit = { version = "1.0.2" }
+ rand = "0.8.3"
+ ruma-common = { version = "0.10.5", path = "../ruma-common", features = ["unstable-pdu"] }
+ tracing-subscriber = "0.3.16"
+diff --git ruma/Cargo.toml ruma/Cargo.toml
+index 0b62cff1..05ce9990 100644
+--- ruma/Cargo.toml
++++ ruma/Cargo.toml
+@@ -191,8 +191,8 @@ __ci = [
+ ]
+ 
+ [dependencies]
+-assign = { workspace = true }
+-js_int = { workspace = true }
++assign = { version = "1.1.1" }
++js_int = { version = "0.2.2" }
+ js_option = "0.1.1"
+ 
+ ruma-common = { version = "0.10.5", path = "../ruma-common" }
+@@ -208,4 +208,4 @@ ruma-identity-service-api = { version = "0.6.0", path = "../ruma-identity-servic
+ ruma-push-gateway-api = { version = "0.6.0", path = "../ruma-push-gateway-api", optional = true }
+ 
+ [dev-dependencies]
+-serde = { workspace = true }
++serde = { version = "1.0.147", features = ["derive"] }

--- a/pkgs/servers/matrix-conduit/default.nix
+++ b/pkgs/servers/matrix-conduit/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitLab, stdenv, darwin, nixosTests }:
+{ lib, rustPlatform, fetchFromGitLab, stdenv, darwin, nixosTests, rocksdb_6_23 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "matrix-conduit";
@@ -29,6 +29,9 @@ rustPlatform.buildRustPackage rec {
   buildInputs = lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security
   ];
+
+  ROCKSDB_INCLUDE_DIR = "${rocksdb_6_23}/include";
+  ROCKSDB_LIB_DIR = "${rocksdb_6_23}/lib";
 
   # tests failed on x86_64-darwin with SIGILL: illegal instruction
   doCheck = !(stdenv.isx86_64 && stdenv.isDarwin);

--- a/pkgs/servers/matrix-conduit/default.nix
+++ b/pkgs/servers/matrix-conduit/default.nix
@@ -2,16 +2,25 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "matrix-conduit";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitLab {
     owner = "famedly";
     repo = "conduit";
     rev = "v${version}";
-    sha256 = "sha256-QTXDIvGz12ZxsWmPiMiJ8mBUWoJ2wnaeTZdXcwBh35o=";
+    sha256 = "sha256-GSCpmn6XRbmnfH31R9c6QW3/pez9KHPjI99dR+ln0P4=";
   };
 
-  cargoSha256 = "sha256-vE44I8lQ5VAfZB4WKLRv/xudoZJaFJGTT/UuumTePBU=";
+  # https://github.com/rust-lang/cargo/issues/11192
+  # https://github.com/ruma/ruma/issues/1441
+  postPatch = ''
+    pushd $cargoDepsCopy
+    patch -p0 < ${./cargo-11192-workaround.patch}
+    for p in ruma*; do echo '{"files":{},"package":null}' > $p/.cargo-checksum.json; done
+    popd
+  '';
+
+  cargoSha256 = "sha256-WFoupcuaG7f7KYBn/uzbOzlHHLurOyvm5e1lEcinxC8=";
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook


### PR DESCRIPTION
###### Description of changes

Continuation of https://github.com/NixOS/nixpkgs/pull/211309

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
