### PR TITLE
Fix ocaml packages.megam

### DIFF
--- a/pkgs/applications/science/misc/megam/default.nix
+++ b/pkgs/applications/science/misc/megam/default.nix
@@ -12,6 +12,14 @@ stdenv.mkDerivation {
 
   patches = [ ./ocaml-includes.patch ./ocaml-3.12.patch ];
 
+  postPatch = ''
+    # Deprecated in ocaml 3.10 https://github.com/ocaml/ocaml/commit/f6190f3d0c49c5220d443ee8d03ca5072d68aa87
+    # Deprecated in ocaml 3.08 https://github.com/ocaml/ocaml/commit/0c7aecb88dc696f66f49f3bed54a037361a26b8d
+    substituteInPlace fastdot_c.c --replace copy_double caml_copy_double --replace Bigarray_val Caml_ba_array_val --replace caml_bigarray caml_ba_array
+    # They were already deprecated in 3.12 https://v2.ocaml.org/releases/3.12/htmlman/libref/Array.html
+    substituteInPlace abffs.ml main.ml --replace create_matrix make_matrix
+    substituteInPlace intHashtbl.ml --replace Array.create Array.make
+  '';
   strictDeps = true;
 
   nativeBuildInputs = [ makeWrapper ocaml ];
@@ -20,7 +28,7 @@ stdenv.mkDerivation {
 
   makeFlags = [
     "CAML_INCLUDES=${ocaml}/lib/ocaml/caml"
-    "WITHBIGARRAY=bigarray.cma"
+    ("WITHBIGARRAY=" + lib.optionalString (lib.versionOlder ocaml.version "4.08.0") "bigarray.cma")
   ];
 
   # see https://bugzilla.redhat.com/show_bug.cgi?id=435559

--- a/pkgs/applications/science/misc/megam/ocaml-includes.patch
+++ b/pkgs/applications/science/misc/megam/ocaml-includes.patch
@@ -15,7 +15,7 @@ diff -ru megam_0.92/Makefile megam_0.92-b/Makefile
  
  #WITHCLIBS =-I /usr/lib/ocaml/3.09.2/caml
 -WITHCLIBS =-I /usr/lib/ocaml/caml
-+WITHCLIBS =-I $(CAML_INCLUDES) 
++WITHCLIBS =-I $(CAML_INCLUDES) -I +unix -I +str
  
  ################ End of user's variables #####################
  


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added my patches https://github.com/NixOS/nixpkgs/pull/209898#issuecomment-1381108043 @wegank

for reviewer:

```
nix build --out-link megam .#ocaml-ng.ocamlPackages.megam .#ocaml-ng.ocamlPackages_4_01_0.megam .#ocaml-ng.ocamlPackages_4_02.megam .#ocaml-ng.ocamlPackages_4_03.megam .#ocaml-ng.ocamlPackages_4_04.megam .#ocaml-ng.ocamlPackages_4_05.megam .#ocaml-ng.ocamlPackages_4_06.megam .#ocaml-ng.ocamlPackages_4_07.megam .#ocaml-ng.ocamlPackages_4_08.megam .#ocaml-ng.ocamlPackages_4_09.megam .#ocaml-ng.ocamlPackages_4_10.megam .#ocaml-ng.ocamlPackages_4_11.megam .#ocaml-ng.ocamlPackages_4_12.megam .#ocaml-ng.ocamlPackages_4_13.megam .#ocaml-ng.ocamlPackages_4_14.megam .#ocaml-ng.ocamlPackages_5_0.megam .#ocaml-ng.ocamlPackages_latest.megam
```

`.#ocaml-ng.ocamlPackages_4_00_1.megam` doesn't build on Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
