### PR TITLE
python3Packages.returns: init at 0.19.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6903,6 +6903,12 @@
     githubId = 10786794;
     name = "Markus Hihn";
   };
+  jessemoore = {
+    email = "jesse@jessemoore.dev";
+    github = "jesseDMoore1994";
+    githubId = 30251156;
+    name = "Jesse Moore";
+  };
   jethro = {
     email = "jethrokuan95@gmail.com";
     github = "jethrokuan";

--- a/pkgs/development/python-modules/returns/default.nix
+++ b/pkgs/development/python-modules/returns/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, anyio
+, curio
+, buildPythonPackage
+, fetchFromGitHub
+, httpx
+, hypothesis
+, mypy
+, poetry-core
+, pytestCheckHook
+, pytest-aio
+, pytest-cov
+, pytest-mypy
+, pytest-mypy-plugins
+, pytest-subtests
+, setuptools
+, trio
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "returns";
+  version = "0.19.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "dry-python";
+    repo = "returns";
+    rev = "refs/tags/${version}";
+    hash = "sha256-yKlW5M7LlK9xF4GiCKtUVrZwwSmFVjCnDhnzaNFcAsU=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    anyio
+    curio
+    httpx
+    hypothesis
+    mypy
+    pytestCheckHook
+    pytest-aio
+    pytest-cov
+    pytest-mypy
+    pytest-mypy-plugins
+    pytest-subtests
+    setuptools
+    trio
+  ];
+
+  pytestFlagsArray = [ "--ignore=typesafety" ];
+
+  meta = with lib; {
+    description = "Make your functions return something meaningful, typed, and safe!";
+    homepage = "returns.rtfd.io";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.jessemoore ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10065,6 +10065,8 @@ self: super: with self; {
 
   retrying = callPackage ../development/python-modules/retrying { };
 
+  returns = callPackage ../development/python-modules/returns { };
+
   retworkx = callPackage ../development/python-modules/retworkx { };
 
   rfc3339 = callPackage ../development/python-modules/rfc3339 { };


### PR DESCRIPTION
###### Description of changes

Returns is a python library that "[m]ake[s] your functions return something meaningful, typed, and safe!". This PR initializes the package from PyPi at the last release (v0.19.0).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
