### PR TITLE
ocamlPackages.awa: 0.1.0 → 0.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/awa/default.nix
+++ b/pkgs/development/ocaml-modules/awa/default.nix
@@ -8,13 +8,14 @@
 
 buildDunePackage rec {
   pname = "awa";
-  version = "0.1.0";
+  version = "0.1.1";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/awa-ssh/releases/download/v${version}/awa-${version}.tbz";
-    sha256 = "sha256-aPnFDp52oYVHr/56lFw0gtVJ0KvHawyM5FGtpHPOVY8=";
+    hash = "sha256-ae1gTx3Emmkof/2Gnhq0d5RyfkFx21hHkVEVgyPdXuo=";
   };
 
   nativeBuildInputs = [ ppx_cstruct ];

--- a/pkgs/development/ocaml-modules/awa/lwt.nix
+++ b/pkgs/development/ocaml-modules/awa/lwt.nix
@@ -7,6 +7,8 @@ buildDunePackage {
 
   inherit (awa) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [
     awa cstruct mtime lwt mirage-crypto-rng
   ];

--- a/pkgs/development/ocaml-modules/awa/mirage.nix
+++ b/pkgs/development/ocaml-modules/awa/mirage.nix
@@ -8,6 +8,8 @@ buildDunePackage {
 
   inherit (awa) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [
     awa cstruct mtime lwt mirage-flow mirage-clock logs
     duration mirage-time

--- a/pkgs/development/ocaml-modules/hkdf/default.nix
+++ b/pkgs/development/ocaml-modules/hkdf/default.nix
@@ -4,14 +4,13 @@ buildDunePackage rec {
   pname = "hkdf";
   version = "1.0.4";
 
-  minimumOCamlVersion = "4.07";
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/hannesm/ocaml-${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "0nzx6vzbc1hh6vx1ly8df4b16lgps6zjpp9mjycsnnn49bddc9mr";
+    hash = "sha256-uSbW2krEWquZlzXdK7/R91ETFnENeRr6NhAGtv42/Vs=";
   };
-
-  useDune2 = true;
 
   propagatedBuildInputs = [ cstruct mirage-crypto ];
   checkInputs = [ alcotest ];


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/awa-ssh/blob/v0.1.1/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
