### PR TITLE
python310Packages.audio-metadata: relax more-itertools constraint

### DIFF
--- a/pkgs/development/python-modules/audio-metadata/default.nix
+++ b/pkgs/development/python-modules/audio-metadata/default.nix
@@ -1,25 +1,36 @@
-{ lib, buildPythonPackage, fetchPypi
+{ lib
+, buildPythonPackage
+, fetchPypi
 , attrs
 , bidict
 , bitstruct
 , more-itertools
 , pprintpp
 , tbm-utils
+, pythonRelaxDepsHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "audio-metadata";
   version = "0.11.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "9e7ba79d49cf048a911d5f7d55bb2715c10be5c127fe5db0987c5fe1aa7335eb";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "'attrs>=18.2,<19.4'" "'attrs'"
-  '';
+  pythonRelaxDeps = [
+    "attrs"
+    "more-itertools"
+  ];
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
 
   propagatedBuildInputs = [
     attrs
@@ -33,9 +44,14 @@ buildPythonPackage rec {
   # No tests
   doCheck = false;
 
+  pythonImportsCheck = [
+    "audio_metadata"
+  ];
+
   meta = with lib; {
     homepage = "https://github.com/thebigmunch/audio-metadata";
     description = "A library for reading and, in the future, writing metadata from audio files";
+    changelog = "https://github.com/thebigmunch/audio-metadata/blob/${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ jakewaksbaum ];
   };

--- a/pkgs/development/python-modules/audio-metadata/default.nix
+++ b/pkgs/development/python-modules/audio-metadata/default.nix
@@ -1,27 +1,40 @@
 { lib
-, buildPythonPackage
-, fetchPypi
 , attrs
 , bidict
 , bitstruct
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
 , more-itertools
+, poetry-core
 , pprintpp
-, tbm-utils
-, pythonRelaxDepsHook
 , pythonOlder
+, pythonRelaxDepsHook
+, tbm-utils
 }:
 
 buildPythonPackage rec {
   pname = "audio-metadata";
   version = "0.11.1";
-  format = "setuptools";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "9e7ba79d49cf048a911d5f7d55bb2715c10be5c127fe5db0987c5fe1aa7335eb";
+  src = fetchFromGitHub {
+    owner = "thebigmunch";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-5ZX4HwbuB9ZmFfHuxaMCrn3R7/znuDsoyqqLql2Nizg=";
   };
+
+  patches = [
+    # Switch to poetry-core, https://github.com/thebigmunch/audio-metadata/pull/41
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/thebigmunch/audio-metadata/commit/dfe91a69ee37e9dcefb692165eb0f9cd36a7e5b8.patch";
+      hash = "sha256-ut3mqgZQu0YFbsTEA13Ch0+aSNl17ndMV0fuIu3n5tc=";
+    })
+  ];
 
   pythonRelaxDeps = [
     "attrs"
@@ -29,6 +42,7 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
+    poetry-core
     pythonRelaxDepsHook
   ];
 
@@ -41,7 +55,7 @@ buildPythonPackage rec {
     tbm-utils
   ];
 
-  # No tests
+  # Tests require ward which is not ready to be used
   doCheck = false;
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/ward/default.nix
+++ b/pkgs/development/python-modules/ward/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildPythonPackage
+, click
+, click-completion
+, click-default-group
+, cucumber-tag-expressions
+, fetchFromGitHub
+, pluggy
+, poetry-core
+, pprintpp
+, pythonOlder
+, pythonRelaxDepsHook
+, rich
+, tomli
+}:
+
+buildPythonPackage rec {
+  pname = "ward";
+  version = "0.67.0b0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "darrenburns";
+    repo = pname;
+    rev = "refs/tags/release%2F${version}";
+    hash = "sha256-4dEMEEPySezgw3dIcYMl56HrhyaYlql9JvtamOn7Y8g=";
+  };
+
+  pythonRelaxDeps = [
+    "rich"
+  ];
+
+  nativeBuildInputs = [
+    poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = [
+    click
+    rich
+    tomli
+    pprintpp
+    cucumber-tag-expressions
+    click-default-group
+    click-completion
+    pluggy
+  ];
+
+  # Fixture is missing. Looks like an issue with the import of the sample file
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "ward"
+  ];
+
+  meta = with lib; {
+    description = "Test framework for Python";
+    homepage = "https://github.com/darrenburns/ward";
+    changelog = "https://github.com/darrenburns/ward/releases/tag/release%2F${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12058,6 +12058,8 @@ self: super: with self; {
 
   warcio = callPackage ../development/python-modules/warcio { };
 
+  ward = callPackage ../development/python-modules/ward { };
+
   warlock = callPackage ../development/python-modules/warlock { };
 
   warrant = callPackage ../development/python-modules/warrant { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
