### PR TITLE
Dotcolon fonts: migrate to stdenvNoCC, add some more fonts and a collection package

### DIFF
--- a/pkgs/data/fonts/aileron/default.nix
+++ b/pkgs/data/fonts/aileron/default.nix
@@ -1,27 +1,32 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
 let
   majorVersion = "0";
   minorVersion = "102";
-  pname = "aileron";
 in
+stdenvNoCC.mkDerivation (self: {
+  pname = "aileron";
+  version = "${majorVersion}.${minorVersion}";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${self.pname}_${majorVersion}${minorVersion}.zip";
+    hash = "sha256-Ht48gwJZrn0djo1yl6jHZ4+0b710FVwStiC1Zk5YXME=";
+    stripRoot = false;
+  };
 
-  url = "http://dotcolon.net/DL/font/${pname}.zip";
-  sha256 = "04xnzdy9plzd2p02yq367h37m5ygx0w8cpkdv39cc3754ljlsxim";
+  installPhase = ''
+    runHook preInstall
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${pname}/";
+    homepage = "http://dotcolon.net/font/${self.pname}/";
     description = "A helvetica font in nine weights";
     platforms = platforms.all;
-    maintainers = with maintainers; [ leenaars ];
+    maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.cc0;
   };
-}
+})

--- a/pkgs/data/fonts/dotcolon-fonts/default.nix
+++ b/pkgs/data/fonts/dotcolon-fonts/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, symlinkJoin
+, aileron
+, vegur
+, f5_6
+, tenderness
+, medio
+, ferrum
+, seshat
+, penna
+, eunomia
+, route159
+, f1_8
+, nacelle
+, melete
+, fa_1
+}:
+
+symlinkJoin {
+  name = "dotcolon-fonts";
+
+  paths = [
+    aileron
+    vegur
+    f5_6
+    tenderness
+    medio
+    ferrum
+    seshat
+    penna
+    eunomia
+    route159
+    f1_8
+    nacelle
+    melete
+    fa_1
+  ];
+
+  meta = {
+    description = "Font Collection by Sora Sagano";
+
+    homepage = "https://dotcolon.net/";
+
+    license = with lib.licenses; [ cc0 ofl ];
+
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ minijackson ];
+  };
+}

--- a/pkgs/data/fonts/eunomia/default.nix
+++ b/pkgs/data/fonts/eunomia/default.nix
@@ -1,27 +1,32 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
 let
   majorVersion = "0";
   minorVersion = "200";
-  pname = "eunomia";
 in
+stdenvNoCC.mkDerivation (self: {
+  pname = "eunomia";
+  version = "${majorVersion}.${minorVersion}";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${self.pname}_${majorVersion}${minorVersion}.zip";
+    hash = "sha256-Rd2EakaTWjzoEV00tHTgg/bXgJUFfPjCyQUWi7QhFG4=";
+    stripRoot = false;
+  };
 
-  url = "http://dotcolon.net/DL/font/${pname}_${majorVersion}${minorVersion}.zip";
-  sha256 = "0lpmczs1d4p9dy4s0dnvv7bl5cd0f6yzyasfrkxij5s86glps38b";
+  installPhase = ''
+    runHook preInstall
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
   '';
 
   meta = with lib; {
     homepage = "http://dotcolon.net/font/eunomia/";
     description = "A futuristic decorative font";
     platforms = platforms.all;
-    maintainers = with maintainers; [ leenaars ];
+    maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.ofl;
   };
-}
+})

--- a/pkgs/data/fonts/f1_8/default.nix
+++ b/pkgs/data/fonts/f1_8/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+let
+  majorVersion = "1";
+  minorVersion = "101";
+in
+stdenvNoCC.mkDerivation (self: {
+  pname = "f1_8";
+  version = "${majorVersion}.${minorVersion}";
+
+  src = fetchzip {
+    url = "https://note.com/api/v2/attachments/download/d83b2c4ec63d7826acaa76725d261ff4";
+    hash = "sha256-pe1G8WeFAo+KYjjsNwn0JmtXFn9QugE1SeGwaqnl1F0=";
+    stripRoot = false;
+    extension = "zip";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "http://dotcolon.net/font/${self.pname}/";
+    description = "A weighted decorative font";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ minijackson ];
+    license = licenses.ofl;
+  };
+})

--- a/pkgs/data/fonts/f5_6/default.nix
+++ b/pkgs/data/fonts/f5_6/default.nix
@@ -1,27 +1,32 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
 let
   majorVersion = "0";
   minorVersion = "110";
-  pname = "f5_6";
 in
+stdenvNoCC.mkDerivation (self: {
+  pname = "f5_6";
+  version = "${majorVersion}.${minorVersion}";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${self.pname}_${majorVersion}${minorVersion}.zip";
+    hash = "sha256-FeCU+mzR0iO5tixI72XUnhvpGj+WRfKyT3mhBtud3uE=";
+    stripRoot = false;
+  };
 
-  url = "http://dotcolon.net/DL/font/${pname}_${majorVersion}${minorVersion}.zip";
-  sha256 = "04p6lccd26rhjbpq3ddxi5vkk3lk8lqbpnk8lakjzixp3fgdqpp4";
+  installPhase = ''
+    runHook preInstall
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${pname}/";
+    homepage = "http://dotcolon.net/font/${self.pname}/";
     description = "A weighted decorative font";
     platforms = platforms.all;
-    maintainers = with maintainers; [ leenaars ];
+    maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.ofl;
   };
-}
+})

--- a/pkgs/data/fonts/fa_1/default.nix
+++ b/pkgs/data/fonts/fa_1/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+let
+  majorVersion = "0";
+  minorVersion = "100";
+in
+stdenvNoCC.mkDerivation (self: {
+  pname = "fa_1";
+  version = "${majorVersion}.${minorVersion}";
+
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${self.pname}_${majorVersion}${minorVersion}.zip";
+    hash = "sha256-BPJ+wZMYXY/yg5oEgBc5YnswA6A7w6V0gdv+cac0qdc=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "http://dotcolon.net/font/${self.pname}/";
+    description = "A weighted decorative font";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ minijackson ];
+    license = licenses.ofl;
+  };
+})

--- a/pkgs/data/fonts/ferrum/default.nix
+++ b/pkgs/data/fonts/ferrum/default.nix
@@ -1,27 +1,32 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
 let
   majorVersion = "0";
   minorVersion = "200";
-  pname = "ferrum";
 in
+stdenvNoCC.mkDerivation (self: {
+  pname = "ferrum";
+  version = "${majorVersion}.${minorVersion}";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${self.pname}_${majorVersion}${minorVersion}.zip";
+    hash = "sha256-NDJwgFWZgyhMkGRWlY55l2omEw6ju3e3dHCEsWNzQIc=";
+    stripRoot = false;
+  };
 
-  url = "http://dotcolon.net/DL/font/${pname}.zip";
-  sha256 = "1w1b3ch7ik4264f05lxms01ls0aargvlx770a9szm682dfmizn8w";
+  installPhase = ''
+    runHook preInstall
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${pname}/";
+    homepage = "http://dotcolon.net/font/${self.pname}/";
     description = "A decorative font";
     platforms = platforms.all;
-    maintainers = with maintainers; [ leenaars ];
+    maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.cc0;
   };
-}
+})

--- a/pkgs/data/fonts/medio/default.nix
+++ b/pkgs/data/fonts/medio/default.nix
@@ -1,24 +1,29 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
 let
   majorVersion = "0";
   minorVersion = "200";
-  pname = "medio";
 in
+stdenvNoCC.mkDerivation (self: {
+  pname = "medio";
+  version = "${majorVersion}.${minorVersion}";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${self.pname}_${majorVersion}${minorVersion}.zip";
+    hash = "sha256-S+CcwD4zGVk7cIFD6K4NnpE/0mrJq4RnDJC576rhcLQ=";
+    stripRoot = false;
+  };
 
-  url = "http://dotcolon.net/DL/font/${pname}.zip";
-  sha256 = "0gxcmhjlsh2pzsmj78vw4v935ax7hfk533ddlhfhfma52zyxyh7x";
+  installPhase = ''
+    runHook preInstall
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${pname}/";
+    homepage = "http://dotcolon.net/font/${self.pname}/";
     description = "Serif font designed by Sora Sagano";
     longDescription = ''
       Medio is a serif font designed by Sora Sagano, based roughly
@@ -26,7 +31,7 @@ fetchzip {
       but with hairline serifs in the style of a Didone.
     '';
     platforms = platforms.all;
-    maintainers = with maintainers; [ leenaars ];
+    maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.cc0;
   };
-}
+})

--- a/pkgs/data/fonts/melete/default.nix
+++ b/pkgs/data/fonts/melete/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+let
+  majorVersion = "0";
+  minorVersion = "200";
+in
+stdenvNoCC.mkDerivation (self: {
+  pname = "melete";
+  version = "${majorVersion}.${minorVersion}";
+
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${self.pname}_${majorVersion}${minorVersion}.zip";
+    hash = "sha256-y1xtNM1Oy92gOvbr9J71XNxb1JeTzOgxKms3G2YHK00=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "http://dotcolon.net/font/${self.pname}/";
+    description = "A headline typeface that could be used as a movie title";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ minijackson ];
+    license = licenses.ofl;
+  };
+})

--- a/pkgs/data/fonts/nacelle/default.nix
+++ b/pkgs/data/fonts/nacelle/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenvNoCC, fetchzip }:
+
+let
+  majorVersion = "1";
+  minorVersion = "00";
+in
+stdenvNoCC.mkDerivation (self: {
+  pname = "nacelle";
+  version = "${majorVersion}.${minorVersion}";
+
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${self.pname}_${majorVersion}${minorVersion}.zip";
+    hash = "sha256-e4QsPiyfWEAYHWdwR3CkGc2UzuA3hZPYYlWtIubY0Oo=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "http://dotcolon.net/font/${self.pname}/";
+    description = "A improved version of the Aileron font";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ minijackson ];
+    license = licenses.ofl;
+  };
+})

--- a/pkgs/data/fonts/penna/default.nix
+++ b/pkgs/data/fonts/penna/default.nix
@@ -1,24 +1,29 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
 let
   majorVersion = "0";
-  minorVersion = "10";
-  pname = "penna";
+  minorVersion = "100";
 in
+stdenvNoCC.mkDerivation (self: {
+  pname = "penna";
+  version = "${majorVersion}.${minorVersion}";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${self.pname}_${majorVersion}${minorVersion}.zip";
+    hash = "sha256-fmCJnEaoUGdW9JK3J7JSm5D4qOMRW7qVKPgVE7uCH5w=";
+    stripRoot = false;
+  };
 
-  url = "http://dotcolon.net/DL/font/${pname}.zip";
-  sha256 = "0hk15yndm56l6rbdykpkry2flffx0567mgjcqcnsx1iyzwwla5km";
+  installPhase = ''
+    runHook preInstall
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${pname}/";
+    homepage = "http://dotcolon.net/font/${self.pname}/";
     description = "Geometric sans serif designed by Sora Sagano";
     longDescription = ''
      Penna is a geometric sans serif designed by Sora Sagano,
@@ -26,7 +31,7 @@ fetchzip {
      with a small x-height.
     '';
     platforms = platforms.all;
-    maintainers = with maintainers; [ leenaars ];
+    maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.cc0;
   };
-}
+})

--- a/pkgs/data/fonts/route159/default.nix
+++ b/pkgs/data/fonts/route159/default.nix
@@ -1,27 +1,32 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
 let
   majorVersion = "1";
   minorVersion = "10";
-  pname = "route159";
 in
+stdenvNoCC.mkDerivation (self: {
+  pname = "route159";
+  version = "${majorVersion}.${minorVersion}";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${self.pname}_${majorVersion}${minorVersion}.zip";
+    hash = "sha256-1InyBW1LGbp/IU/ql9mvT14W3MTxJdWThFwRH6VHpTU=";
+    stripRoot = false;
+  };
 
-  url = "http://dotcolon.net/DL/font/${pname}_${majorVersion}${minorVersion}.zip";
-  sha256 = "1nv5csg73arvvwpac7ylh4j9n0s3qp79rbv2s4jvs2bf6gqhsq7h";
+  installPhase = ''
+    runHook preInstall
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${pname}/";
+    homepage = "http://dotcolon.net/font/${self.pname}/";
     description = "A weighted sans serif font";
     platforms = platforms.all;
-    maintainers = with maintainers; [ leenaars ];
+    maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.ofl;
   };
-}
+})

--- a/pkgs/data/fonts/seshat/default.nix
+++ b/pkgs/data/fonts/seshat/default.nix
@@ -1,24 +1,29 @@
-{ lib,  fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
 let
   majorVersion = "0";
   minorVersion = "100";
-  pname = "seshat";
 in
+stdenvNoCC.mkDerivation (self: {
+  pname = "seshat";
+  version = "${majorVersion}.${minorVersion}";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${self.pname}_${majorVersion}${minorVersion}.zip";
+    hash = "sha256-XgprDhzAbcTzZw2QOwpCnzusYheYmSlM+ApU+Y0wO2Q=";
+    stripRoot = false;
+  };
 
-  url = "http://dotcolon.net/DL/font/${pname}.zip";
-  sha256 = "1zzgc2d0jrris92p3irmxjhdq8aj99alz0z7dlz25qf37lcilrir";
+  installPhase = ''
+    runHook preInstall
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${pname}/";
+    homepage = "http://dotcolon.net/font/${self.pname}/";
     description = "Roman body font designed for main text by Sora Sagano";
     longDescription = ''
       Seshat is a Roman body font designed for the main text. By
@@ -31,7 +36,7 @@ fetchzip {
       It incorporates symbols and ligatures used in the European region.
     '';
     platforms = platforms.all;
-    maintainers = with maintainers; [ leenaars ];
+    maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.cc0;
   };
-}
+})

--- a/pkgs/data/fonts/tenderness/default.nix
+++ b/pkgs/data/fonts/tenderness/default.nix
@@ -1,27 +1,32 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
 let
   majorVersion = "0";
   minorVersion = "601";
-  pname = "tenderness";
 in
+stdenvNoCC.mkDerivation (self: {
+  pname = "tenderness";
+  version = "${majorVersion}.${minorVersion}";
 
-fetchzip {
-  name = "${pname}-font-${majorVersion}.${minorVersion}";
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${self.pname}_${majorVersion}${minorVersion}.zip";
+    hash = "sha256-bwJKW+rY7/r2pBCSA6HYlaRMsI/U8UdW2vV4tmYuJww=";
+    stripRoot = false;
+  };
 
-  url = "http://dotcolon.net/DL/font/${pname}_${majorVersion}${minorVersion}.zip";
-  sha256 = "0d88l5mzq0k63zsmb8d5w3hfqxy04vpv4j0j8nmj1xv6kikhhybh";
+  installPhase = ''
+    runHook preInstall
 
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/${pname}
-    unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
   '';
 
   meta = with lib; {
-    homepage = "http://dotcolon.net/font/${pname}/";
+    homepage = "http://dotcolon.net/font/${self.pname}/";
     description = "Serif font designed by Sora Sagano with old-style figures";
     platforms = platforms.all;
-    maintainers = with maintainers; [ leenaars ];
+    maintainers = with maintainers; [ leenaars minijackson ];
     license = licenses.ofl;
   };
-}
+})

--- a/pkgs/data/fonts/vegur/default.nix
+++ b/pkgs/data/fonts/vegur/default.nix
@@ -1,26 +1,32 @@
-{ lib, buildPackages, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
 let
-  version = "0.701";
-in fetchzip {
-  name = "vegur-font-${version}";
+  majorVersion = "0";
+  minorVersion = "701";
+in
+stdenvNoCC.mkDerivation (self: {
+  pname = "vegur";
+  version = "${majorVersion}.${minorVersion}";
 
-  # Upstream doesn't version their URLs.
-  # http://dotcolon.net/font/vegur/ → http://dotcolon.net/DL/font/vegur.zip
-  url = "http://download.opensuse.org/repositories/M17N:/fonts/SLE_12_SP3/src/dotcolon-vegur-fonts-0.701-1.4.src.rpm";
+  src = fetchzip {
+    url = "https://dotcolon.net/download/fonts/${self.pname}_${majorVersion}${minorVersion}.zip";
+    hash = "sha256-sGb3mEb3g15ZiVCxEfAanly8zMUopLOOjw8W4qbXLPA=";
+    stripRoot = false;
+  };
 
-  postFetch = ''
-    ${buildPackages.rpmextract}/bin/rpmextract $downloadedFile
-    unzip vegur.zip
-    install -m444 -Dt $out/share/fonts/Vegur *.otf
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+
+    runHook postInstall
   '';
-  sha256 = "0iisi2scq72lyj7pc1f36fhfjnm676n5byl4zaavhbxpdrbc6d1v";
 
   meta = with lib; {
     homepage = "http://dotcolon.net/font/vegur/";
     description = "A humanist sans serif font";
     platforms = platforms.all;
-    maintainers = [ maintainers.samueldr ];
+    maintainers = with maintainers; [ minijackson samueldr ];
     license = licenses.cc0;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26856,6 +26856,8 @@ with pkgs;
 
   eunomia = callPackage ../data/fonts/eunomia { };
 
+  f1_8 = callPackage ../data/fonts/f1_8 { };
+
   f5_6 = callPackage ../data/fonts/f5_6 { };
 
   faba-icon-theme = callPackage ../data/icons/faba-icon-theme { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26836,6 +26836,8 @@ with pkgs;
 
   dosemu_fonts = callPackage ../data/fonts/dosemu-fonts { };
 
+  dotcolon-fonts = callPackage ../data/fonts/dotcolon-fonts { };
+
   e17gtk = callPackage ../data/themes/e17gtk { };
 
   eb-garamond = callPackage ../data/fonts/eb-garamond { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27195,6 +27195,8 @@ with pkgs;
 
   medio = callPackage ../data/fonts/medio { };
 
+  melete = callPackage ../data/fonts/melete { };
+
   mno16 = callPackage ../data/fonts/mno16 { };
 
   mnist = callPackage ../data/machine-learning/mnist { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27231,6 +27231,8 @@ with pkgs;
 
   myrica = callPackage ../data/fonts/myrica { };
 
+  nacelle = callPackage ../data/fonts/nacelle { };
+
   nafees = callPackage ../data/fonts/nafees { };
 
   nanum = callPackage ../data/fonts/nanum {  };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26856,6 +26856,8 @@ with pkgs;
 
   eunomia = callPackage ../data/fonts/eunomia { };
 
+  fa_1 = callPackage ../data/fonts/fa_1 { };
+
   f1_8 = callPackage ../data/fonts/f1_8 { };
 
   f5_6 = callPackage ../data/fonts/f5_6 { };


### PR DESCRIPTION
###### Description of changes

Related: #204925

Pinging @leenaars as maintainer for these fonts. If you want to be maintainer of those new packages, don't hesitate to say so.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
