### PR TITLE
darwin.dtrace: Fix failing build

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/dtrace/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/dtrace/default.nix
@@ -1,9 +1,9 @@
-{ appleDerivation, xcbuildHook, CoreSymbolication
+{ appleDerivation, xcbuildHook, CoreSymbolication, apple_sdk
 , xnu, bison, flex, darling, stdenv, fixDarwinDylibNames }:
 
 appleDerivation {
   nativeBuildInputs = [ xcbuildHook flex bison fixDarwinDylibNames ];
-  buildInputs = [ CoreSymbolication darling xnu ];
+  buildInputs = [ CoreSymbolication apple_sdk.frameworks.CoreSymbolication darling xnu ];
   # -fcommon: workaround build failure on -fno-common toolchains:
   #   duplicate symbol '_kCSRegionMachHeaderName' in: libproc.o dt_module_apple.o
   NIX_CFLAGS_COMPILE = "-DCTF_OLD_VERSIONS -DPRIVATE -DYYDEBUG=1 -I${xnu}/Library/Frameworks/System.framework/Headers -Wno-error=implicit-function-declaration -fcommon";


### PR DESCRIPTION
###### Description of changes

Fix failing build of darwin.dtrace by:
- adding the second CoreSymbolication package to dtrace's dependencies; and
- adding an alias for the second CoreSymbolication package to avoid having to explicitly name or rename it when calling the dtrace package in the existing contexts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)  (**but see note below**)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

**Note:** Local running of `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` did not find any package changes, and local running of `nix-shell -p nixpkgs-review --run "nixpkgs-review rev -p darwin.dtrace HEAD"` errored out with a message that the package darwin.dtrace was not rebuilt by the PR.  However, building via `nix build <path/to/nixpkgs/checkout>#darwin.dtrace` showed otherwise, failing to build on `master` but building and passing manual testing on this PR's branch.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
