### PR TITLE
ytarchive: 2022-05-28 -> 0.3.2

### DIFF
--- a/pkgs/tools/misc/ytarchive/default.nix
+++ b/pkgs/tools/misc/ytarchive/default.nix
@@ -1,17 +1,25 @@
-{ lib, buildGoModule, fetchFromGitHub, makeBinaryWrapper, ffmpeg }:
+{ lib, buildGoModule, fetchFromGitHub, fetchpatch, makeBinaryWrapper, ffmpeg }:
 
 buildGoModule rec {
   pname = "ytarchive";
-  version = "unstable-2022-05-28";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
     owner = "Kethsar";
     repo = "ytarchive";
-    rev = "8d48052f432ec6f78c6aed326e8a1db31ee8e706";
-    sha256 = "sha256-IsG0YPVBzsbHLNs1m/AruDmm0n7vwN9Fj1KMOoQJQ+c=";
+    rev = "v${version}";
+    hash = "sha256-fBYwLGg1h5pn8ZP5vZmzzIEvuXlBJ27p4tv7UVMwOEw=";
   };
 
-  vendorSha256 = "sha256-r9fDFSCDItQ7YSj9aTY1LXRrFE9T3XD0X36ywCfu0R8=";
+  patches = [
+    # Increase the Go version required. See https://github.com/Kethsar/ytarchive/pull/127
+    (fetchpatch {
+      url = "https://github.com/Kethsar/ytarchive/commit/2a995ead4448d03c975378a1932ad975da1a6383.patch";
+      sha256 = "sha256-Y+y/Sp/xOS9tBT+LQQ9vE+4n/2RH10umFEEEEVXgtuc=";
+    })
+  ];
+
+  vendorHash = "sha256-8uTDcu8ucPzck+1dDoySGtc3l1+1USxCfUvdS+ncsnU=";
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 


### PR DESCRIPTION

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/Kethsar/ytarchive/releases/tag/v0.3.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
