### PR TITLE
eunomia-cc: init at 1.0.11

### DIFF
--- a/pkgs/by-name/ec/ecc/package.nix
+++ b/pkgs/by-name/ec/ecc/package.nix
@@ -1,0 +1,124 @@
+{ lib
+, makeWrapper
+, fetchFromGitHub
+, rustPackages
+, pkg-config
+, elfutils
+, zlib
+}:
+let
+  inherit (rustPackages.rustc) llvmPackages;
+  inherit (rustPackages) rustPlatform;
+  bpftool = llvmPackages.stdenv.mkDerivation {
+    pname = "bpftool";
+    version = "unstable-2023-03-11";
+
+    # this fork specialized for some functions
+    # and has eventually been embedded into the ecc binary
+    src = fetchFromGitHub {
+      owner = "eunomia-bpf";
+      repo = "bpftool";
+      rev = "05940344f5db18d0cb1bc1c42e628f132bc93123";
+      hash = "sha256-g2gjixfuGwVnFlqCMGLWVPbtKOSpQI+vZwIZciXFPTc=";
+      fetchSubmodules = true;
+    };
+
+    buildInputs = [
+      llvmPackages.libllvm
+      elfutils
+      zlib
+    ];
+
+    buildPhase = ''
+      make -C src
+    '';
+
+    installPhase = ''
+      # We don't use the default `make install` because we are looking to create a
+      # directory structure compatible with `build.rs` of `ecc`.
+      mkdir -p $out/src/libbpf
+      # some headers are required
+      cp -r src/libbpf/include $out/src/libbpf
+      cp src/bpftool $out/src
+    '';
+  };
+
+  vmlinux-headers = fetchFromGitHub {
+    owner = "eunomia-bpf";
+    repo = "vmlinux";
+    rev = "933f83becb45f5586ed5fd089e60d382aeefb409";
+    hash = "sha256-CVEmKkzdFNLKCbcbeSIoM5QjYVLQglpz6gy7+ZFPgCY=";
+  };
+
+in
+rustPlatform.buildRustPackage rec {
+  pname = "ecc";
+  version = "1.0.11";
+
+  src = fetchFromGitHub {
+    owner = "eunomia-bpf";
+    repo = "eunomia-bpf";
+    rev = "v${version}";
+    hash = "sha256-UiwS+osyC3gtbQH0bWNsx1p3xYr993/FAZ5d5NKnaBM=";
+  };
+
+  sourceRoot = "${src.name}/compiler/cmd";
+
+  cargoHash = "sha256-j2HPSmU/JARfw2mE1IiXFT/dcdxxnp+agC2DN0Kc5nw=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    elfutils
+    zlib
+  ];
+
+  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = "gcc";
+
+  preBuild = ''
+    # `SANDBOX` defined by upstream to disable build-time network access
+    export SANDBOX=1
+    # specify dependencies' location
+    export VMLINUX_DIR=${vmlinux-headers}
+    export BPFTOOL_DIR=${bpftool}
+  '';
+
+  preCheck = ''
+    export HOME=$NIX_BUILD_TOP
+  '';
+
+  checkFlags = [
+    # requires network access
+    "--skip=bpf_compiler::tests::test_generate_custom_btf"
+
+    # FIXME: requires dynamic link `libclang` or clang binary which are not found in check env
+    "--skip=bpf_compiler::tests::test_compile_bpf"
+    "--skip=bpf_compiler::tests::test_export_multi_and_pack"
+    "--skip=document_parser::test::test_parse_empty"
+    "--skip=document_parser::test::test_parse_maps"
+    "--skip=document_parser::test::test_parse_progss"
+    "--skip=document_parser::test::test_parse_variables"
+  ];
+
+  passthru = {
+    inherit bpftool;
+  };
+
+  postFixup = ''
+    wrapProgram $out/bin/ecc-rs \
+      --prefix LIBCLANG_PATH : ${llvmPackages.libclang.lib}/lib \
+      --prefix PATH : ${lib.makeBinPath (with llvmPackages; [clang bintools-unwrapped])}
+  '';
+
+  meta = with lib; {
+    homepage = "https://eunomia.dev";
+    description = "the eBPF compile toolchain for eunomia-bpf";
+    maintainers = with maintainers; [ oluceps ];
+    platforms = platforms.linux;
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
###### Description of changes

An CO-RE compile set to help you focus on writing a single eBPF program in the kernel.
A part of the eunomia-bpf project, a compiler and runtime framework for building, distributing and running CO-RE eBPF programs in multi-languages and Webassembly.

https://github.com/eunomia-bpf/eunomia-bpf

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
