### PR TITLE
htop: enable extra features

### DIFF
--- a/pkgs/tools/system/htop/default.nix
+++ b/pkgs/tools/system/htop/default.nix
@@ -1,6 +1,8 @@
-{ lib, fetchFromGitHub, stdenv, autoreconfHook
+{ lib, fetchFromGitHub, stdenv, autoreconfHook, pkg-config
 , ncurses
 , IOKit
+, libcap
+, libnl
 , sensorsSupport ? stdenv.isLinux, lm_sensors
 , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd, systemd
 }:
@@ -18,15 +20,23 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-MwtsvdPHcUdegsYj9NGyded5XJQxXri1IM1j4gef1Xk=";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook ]
+    ++ lib.optional stdenv.isLinux pkg-config
+  ;
 
   buildInputs = [ ncurses ]
     ++ lib.optional stdenv.isDarwin IOKit
+    ++ lib.optionals stdenv.isLinux [ libcap libnl ]
     ++ lib.optional sensorsSupport lm_sensors
     ++ lib.optional systemdSupport systemd
   ;
 
   configureFlags = [ "--enable-unicode" "--sysconfdir=/etc" ]
+    ++ lib.optionals stdenv.isLinux [
+      "--enable-affinity"
+      "--enable-capabilities"
+      "--enable-delayacct"
+    ]
     ++ lib.optional sensorsSupport "--with-sensors"
   ;
 


### PR DESCRIPTION
###### Description of changes

I noticed that the IO tab is missing a lot of information on NixOS compared to Arch:
<details>
  <summary>Screenshots</summary>

![Arch Linux](https://wank.party/nf0-.png)
![NixOS 22.11](https://wank.party/DQMg.png)
</details>

~This is due to libnl/delay accounting support not being enabled.~ This is an htop bug, fixed in upstream for the next release.

This enables the following features, following Arch Linux's configuration:
- affinity
- capabilities (allows htop to drop caps when running as root, requires libcap which was already linked in for some reason)
- delay accounting (requires libnl)
- ~OpenVZ and VServer (with feature flags, although these don't add any dependencies)~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).