### PR TITLE
apx: init at 1.4.2

### DIFF
--- a/pkgs/tools/package-management/apx/default.nix
+++ b/pkgs/tools/package-management/apx/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, makeWrapper
+, installShellFiles
+, docker
+, distrobox
+}:
+
+buildGoModule rec {
+  pname = "apx";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "Vanilla-OS";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-BswX4Jo/RReM/tXo29V9rIvKjN8ylECPe0oo0FCQcGY=";
+  };
+
+  vendorSha256 = null;
+
+  ldflags = [ "-s" "-w" ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
+
+  postInstall = ''
+    mkdir -p $out/etc/apx
+
+    cat > "$out/etc/apx/config.json" <<EOF
+    {
+      "containername": "apx_managed",
+      "image": "docker.io/library/ubuntu",
+      "pkgmanager": "apt",
+      "distroboxpath": "${distrobox}/bin/distrobox"
+    }
+    EOF
+
+    wrapProgram $out/bin/apx --prefix PATH : ${lib.makeBinPath [ docker distrobox ]}
+
+    installManPage man/apx.1 man/es/apx.1
+  '';
+
+  meta = with lib; {
+    description = "The Vanilla OS package manager";
+    homepage = "https://github.com/Vanilla-OS/apx";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37004,6 +37004,8 @@ with pkgs;
 
   apt = callPackage ../tools/package-management/apt { };
 
+  apx = callPackage ../tools/package-management/apx { };
+
   dpkg = callPackage ../tools/package-management/dpkg { };
 
   dumb = callPackage ../misc/dumb { };


### PR DESCRIPTION
###### Description of changes

Resolves #212083.

https://github.com/Vanilla-OS/apx

I have successfully run `vlc` and `htop` via this. `apx install <package-name>` shows an error (related to distrobox-export) but afterwords `apx run <package-name>` works fine.

We might also want to decide which distro to choose in the default config.json file or whether to skip providing it at all.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
