### PR TITLE
 gitprompt-rs: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10418,6 +10418,12 @@
     githubId = 6052922;
     name = "Kirill Struokov";
   };
+  novenary = {
+    email = "streetwalkermc@gmail.com";
+    github = "9ary";
+    githubId = 1155030;
+    name = "novenary";
+  };
   np = {
     email = "np.nix@nicolaspouillard.fr";
     github = "np";

--- a/pkgs/applications/version-management/gitprompt-rs/default.nix
+++ b/pkgs/applications/version-management/gitprompt-rs/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub, rustPlatform, git }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gitprompt-rs";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "9ary";
+    repo = pname;
+    rev = version;
+    sha256 = "00xxz7awk01981daabp8m3kwq127y733ynijiwqgs8xvn4nkg8h6";
+  };
+
+  cargoSha256 = "0avs833vb6q1avjbfygm55s83iy942xgqsx6qdzksry44n35s418";
+
+  postPatch = ''
+     substituteInPlace src/main.rs \
+       --replace 'Command::new("git")' 'Command::new("${git}/bin/git")'
+  '';
+
+  meta = with lib; {
+    description = "Simple Git prompt";
+    homepage = "https://github.com/9ary/gitprompt-rs";
+    license = with licenses; [ mpl20 ];
+    maintainers = with maintainers; [ novenary ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1882,6 +1882,8 @@ with pkgs;
 
   gitnuro = callPackage ../applications/version-management/gitnuro { };
 
+  gitprompt-rs = callPackage ../applications/version-management/gitprompt-rs/default.nix { };
+
   gitsign = callPackage ../applications/version-management/gitsign { };
 
   gitstats = callPackage ../applications/version-management/gitstats { };


### PR DESCRIPTION
###### Description of changes

[gitprompt-rs](https://github.com/9ary/gitprompt-rs) is a very simple git status indicator for your shell prompt. I am the upstream author.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
