### PR TITLE
grpc_cli: init at 1.46.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3725,6 +3725,12 @@
     githubId = 39825;
     name = "Dominik Honnef";
   };
+  doriath = {
+    email = "tomasz.zurkowski@gmail.com";
+    github = "doriath";
+    githubId = 150959;
+    name = "Tomasz Zurkowski";
+  };
   doronbehar = {
     email = "me@doronbehar.com";
     github = "doronbehar";

--- a/pkgs/tools/networking/grpc_cli/default.nix
+++ b/pkgs/tools/networking/grpc_cli/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, automake, cmake, autoconf, curl, numactl }:
+
+stdenv.mkDerivation rec {
+  pname = "grpc_cli";
+  version = "1.46.6";
+  src = fetchFromGitHub {
+    owner = "grpc";
+    repo = "grpc";
+    rev = "v${version}";
+    hash = "sha256-UPenQh6+FBryQiOoeijsXkCZjlMzYljkg2aUtSFJFL4=";
+    fetchSubmodules = true;
+  };
+  nativeBuildInputs = [ automake cmake autoconf ];
+  buildInputs = [ curl numactl ];
+  cmakeFlags = [ "-DgRPC_BUILD_TESTS=ON" ];
+  makeFlags = [ "grpc_cli" ];
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 grpc_cli "$out/bin/grpc_cli"
+
+    runHook postInstall
+  '';
+  meta = with lib; {
+    description = "The command line tool for interacting with grpc services.";
+    homepage = "https://github.com/grpc/grpc";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ doriath ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7819,6 +7819,8 @@ with pkgs;
 
   grpcurl = callPackage ../tools/networking/grpcurl { };
 
+  grpc_cli = callPackage ../tools/networking/grpc_cli { };
+
   grpc-gateway = callPackage ../development/tools/grpc-gateway { };
 
   grpcui = callPackage ../tools/networking/grpcui { };


### PR DESCRIPTION
###### Description of changes

The command line tool for interacting with grpc services.

https://github.com/grpc/grpc/blob/master/doc/command_line_tool.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
