### PR TITLE
iconv: init (portable attribute for iconv(1))

### DIFF
--- a/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
+++ b/pkgs/tools/inputmethods/skk/skk-dicts/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, buildPackages, libiconv, skktools }:
+{ lib, stdenv, fetchurl, buildPackages, iconv, skktools }:
 
 let
   # kana to kanji
@@ -25,15 +25,13 @@ let
     url = "https://raw.githubusercontent.com/skk-dev/dict/8b35d07a7d2044d48b063d2774d9f9d00bb7cb48/SKK-JISYO.assoc";
     sha256 = "1smcbyv6srrhnpl7ic9nqds9nz3g2dgqngmhzkrdlwmvcpvakp1v";
   };
-
-  iconvBin = if stdenv.isDarwin then libiconv else  buildPackages.stdenv.cc.libc;
 in
 
 stdenv.mkDerivation {
   pname = "skk-dicts-unstable";
   version = "2020-03-24";
   srcs = [ small medium large edict assoc ];
-  nativeBuildInputs = [ skktools ] ++ lib.optional stdenv.isDarwin libiconv;
+  nativeBuildInputs = [ iconv skktools ];
 
   strictDeps = true;
 
@@ -51,8 +49,7 @@ stdenv.mkDerivation {
     for src in $srcs; do
       dst=$out/share/$(dictname $src)
       echo ";;; -*- coding: utf-8 -*-" > $dst  # libskk requires this on the first line
-      ${lib.getBin iconvBin}/bin/iconv \
-        -f EUC-JP -t UTF-8 $src | skkdic-expr2 >> $dst
+      iconv -f EUC-JP -t UTF-8 $src | skkdic-expr2 >> $dst
     done
 
     # combine .L .edict and .assoc for convenience

--- a/pkgs/tools/text/cmigemo/default.nix
+++ b/pkgs/tools/text/cmigemo/default.nix
@@ -1,11 +1,8 @@
 { lib, stdenv, fetchFromGitHub, buildPackages
-, libiconv, nkf, perl, which
+, iconv, nkf, perl, which
 , skk-dicts
 }:
 
-let
-  iconvBin = if stdenv.isDarwin then libiconv else  buildPackages.stdenv.cc.libc;
-in
 stdenv.mkDerivation {
   pname = "cmigemo";
   version = "1.3e";
@@ -17,7 +14,7 @@ stdenv.mkDerivation {
     sha256 = "00a6kdmxp16b8x0p04ws050y39qspd1bqlfq74bkirc55b77a2m1";
   };
 
-  nativeBuildInputs = [ libiconv nkf perl which ];
+  nativeBuildInputs = [ iconv nkf perl which ];
 
   postUnpack = ''
     cp ${skk-dicts}/share/SKK-JISYO.L source/dict/
@@ -26,10 +23,6 @@ stdenv.mkDerivation {
   patches = [ ./no-http-tool-check.patch ];
 
   makeFlags = [ "INSTALL=install" ];
-
-  preBuild = ''
-    makeFlagsArray+=(FILTER_UTF8="${lib.getBin iconvBin}/bin/iconv -t utf-8 -f cp932")
-  '';
 
   buildFlags = [ (if stdenv.isDarwin then "osx-all" else "gcc-all") ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21163,6 +21163,14 @@ with pkgs;
 
   libiconvReal = callPackage ../development/libraries/libiconv { };
 
+  iconv =
+    if lib.elem stdenv.hostPlatform.libc [ "glibc" "musl" ] then
+      lib.getBin stdenv.cc.libc
+    else if stdenv.hostPlatform.isDarwin then
+      lib.getBin darwin.libiconv
+    else
+      lib.getBin libiconvReal;
+
   # On non-GNU systems we need GNU Gettext for libintl.
   libintl = if stdenv.hostPlatform.libc != "glibc" then gettext else null;
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This obsoletes this pattern:

     if stdenv.isDarwin then libiconv
     else buildPackages.stdenv.cc.libc

Which was not portable, as some platforms don't have libiconv in libc, and some of those that do still don't have iconv(1) in their libc package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
