### PR TITLE
miriway: init at unstable-2022-12-18

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -196,6 +196,7 @@
   ./programs/mdevctl.nix
   ./programs/mepo.nix
   ./programs/mininet.nix
+  ./programs/miriway.nix
   ./programs/mosh.nix
   ./programs/msmtp.nix
   ./programs/mtr.nix

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -395,6 +395,7 @@ in {
   minidlna = handleTest ./minidlna.nix {};
   miniflux = handleTest ./miniflux.nix {};
   minio = handleTest ./minio.nix {};
+  miriway = handleTest ./miriway.nix {};
   misc = handleTest ./misc.nix {};
   mjolnir = handleTest ./matrix/mjolnir.nix {};
   mod_perl = handleTest ./mod_perl.nix {};

--- a/nixos/tests/miriway.nix
+++ b/nixos/tests/miriway.nix
@@ -1,0 +1,126 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "miriway";
+
+  meta = {
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    # FIXME On ARM Miriway inside the VM doesn't receive keyboard inputs, why?
+    broken = pkgs.stdenv.hostPlatform.isAarch;
+  };
+
+  nodes.machine = { config, ... }: {
+    imports = [
+      ./common/auto.nix
+      ./common/user-account.nix
+    ];
+
+    # Seems to very rarely get interrupted by oom-killer
+    virtualisation.memorySize = 2047;
+
+    test-support.displayManager.auto = {
+      enable = true;
+      user = "alice";
+    };
+
+    services.xserver = {
+      enable = true;
+      displayManager.defaultSession = lib.mkForce "miriway";
+    };
+
+    programs.miriway = {
+      enable = true;
+      config = ''
+        add-wayland-extensions=all
+
+        ctrl-alt=t:foot --maximized
+        ctrl-alt=a:env WINIT_UNIX_BACKEND=x11 WAYLAND_DISPLAY=invalid alacritty --option window.startup_mode=maximized
+
+        shell-component=dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY
+
+        shell-component=foot --maximized
+      '';
+    };
+
+    environment = {
+      shellAliases = {
+        test-wayland = "wayland-info | tee /tmp/test-wayland.out && touch /tmp/test-wayland-exit-ok";
+        test-x11 = "glinfo | tee /tmp/test-x11.out && touch /tmp/test-x11-exit-ok";
+      };
+
+      systemPackages = with pkgs; [
+        mesa-demos
+        wayland-utils
+        foot
+        alacritty
+      ];
+
+      # To help with OCR
+      etc."xdg/foot/foot.ini".text = lib.generators.toINI { } {
+        main = {
+          font = "inconsolata:size=16";
+        };
+        colors = rec {
+          foreground = "000000";
+          background = "ffffff";
+          regular2 = foreground;
+        };
+      };
+      etc."xdg/alacritty/alacritty.yml".text = lib.generators.toYAML { } {
+        font = rec {
+          normal.family = "Inconsolata";
+          bold.family = normal.family;
+          italic.family = normal.family;
+          bold_italic.family = normal.family;
+          size = 16;
+        };
+        colors = rec {
+          primary = {
+            foreground = "0x000000";
+            background = "0xffffff";
+          };
+          normal = {
+            green = primary.foreground;
+          };
+        };
+      };
+    };
+
+    fonts.fonts = [ pkgs.inconsolata ];
+  };
+
+  enableOCR = true;
+
+  testScript = { nodes, ... }: ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    # Wait for Miriway to complete startup
+    machine.wait_for_file("/run/user/1000/wayland-0")
+    machine.succeed("pgrep miriway-shell")
+    machine.screenshot("miriway_launched")
+
+    # Test Wayland
+    # We let Miriway start the first terminal, as we might get stuck if it's not ready to process the first keybind
+    # machine.send_key("ctrl-alt-t")
+    machine.wait_for_text("alice@machine")
+    machine.send_chars("test-wayland\n")
+    machine.wait_for_file("/tmp/test-wayland-exit-ok")
+    machine.copy_from_vm("/tmp/test-wayland.out")
+    machine.screenshot("foot_wayland_info")
+    # Only succeeds when a mouse is moved inside an interactive session?
+    # machine.send_chars("exit\n")
+    # machine.wait_until_fails("pgrep foot")
+    machine.succeed("pkill foot")
+
+    # Test XWayland
+    machine.send_key("ctrl-alt-a")
+    machine.wait_for_text("alice@machine")
+    machine.send_chars("test-x11\n")
+    machine.wait_for_file("/tmp/test-x11-exit-ok")
+    machine.copy_from_vm("/tmp/test-x11.out")
+    machine.screenshot("alacritty_glinfo")
+    # Only succeeds when a mouse is moved inside an interactive session?
+    # machine.send_chars("exit\n")
+    # machine.wait_until_fails("pgrep alacritty")
+    machine.succeed("pkill alacritty")
+  '';
+})

--- a/pkgs/applications/window-managers/miriway/default.nix
+++ b/pkgs/applications/window-managers/miriway/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitHub
 , unstableGitUpdater
+, nixosTests
 , cmake
 , pkg-config
 , mir
@@ -43,6 +44,9 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = unstableGitUpdater { };
     providedSessions = [ "miriway" ];
+    tests = {
+      inherit (nixosTests) miriway;
+    };
   };
 
   meta = with lib; {

--- a/pkgs/applications/window-managers/miriway/default.nix
+++ b/pkgs/applications/window-managers/miriway/default.nix
@@ -1,0 +1,76 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, unstableGitUpdater
+, cmake
+, pkg-config
+, mir
+, libxkbcommon
+}:
+
+stdenv.mkDerivation rec {
+  pname = "miriway";
+  version = "unstable-2022-12-18";
+
+  src = fetchFromGitHub {
+    owner = "Miriway";
+    repo = "Miriway";
+    rev = "d294c303cb99b7becb0d6686be9a09f0a1f57596";
+    hash = "sha256-H+IZgI1IQxNl5yAygbDKXkyXajGHV/mp9gEqZcp0TeE=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "\''${CMAKE_INSTALL_PREFIX}/bin" "\''${CMAKE_INSTALL_BINDIR}" \
+      --replace "/usr/share" "\''${CMAKE_INSTALL_DATADIR}" \
+      --replace "/etc" "\''${CMAKE_INSTALL_SYSCONFDIR}"
+
+    sed -i -e '/project(/a include(GNUInstallDirs)' CMakeLists.txt
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    mir
+    libxkbcommon
+  ];
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+    providedSessions = [ "miriway" ];
+  };
+
+  meta = with lib; {
+    description = "Mir based Wayland compositor";
+    longDescription = ''
+      Miriway is a starting point for creating a Wayland based desktop environment using Mir.
+
+      At the core of Miriway is miriway-shell, a Mir based Wayland compositor that provides:
+
+      - A "floating windows" window managament policy;
+      - Support for Wayland (and via Xwayland) X11 applications;
+      - Dynamic workspaces;
+      - Additional Wayland support for "shell components" such as panels and docs; and,
+      - Configurable shortcuts for launching standard apps such as launcher and terminal emulator.
+
+      In addition to miriway-shell, Miriway has:
+
+      - A "terminal emulator finder" script miriway-terminal, that works with most terminal emulators;
+      - A launch script miriway to simplify starting Miriway;
+      - A default configuration file miriway-shell.config; and,
+      - A greeter configuration miriway.desktop so Miriway can be selected at login
+
+      Miriway has been tested with shell components from several desktop environments and there are notes on
+      enabling these in miriway-shell.config.
+    '';
+    homepage = "https://github.com/Miriway/Miriway";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ OPNA2608 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24730,6 +24730,8 @@ with pkgs;
 
   mir = callPackage ../servers/mir { };
 
+  miriway = callPackage ../applications/window-managers/miriway { };
+
   icinga2 = callPackage ../servers/monitoring/icinga2 { };
 
   icinga2-agent = callPackage ../servers/monitoring/icinga2 {


### PR DESCRIPTION
###### Description of changes

- Packages [Miriway](https://github.com/Miriway/Miriway), an example desktop environment based on the Mir Wayland compositor
- Adds a module for enabling Miriway and providing a system-wide configuration, if desired (similar to WMs like Sway or Awesome, the provided default / system-wide config can be copied to a user's home and adjusted as needed there)

<details>
  <summary>An example of a configured session</summary>

```
ctrl-alt=t:tym
enable-x11=
add-wayland-extensions=all

shell-component=dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY

shell-component=waybar
shell-component=wbg Pictures/miriway-wallpaper

shell-meta=s:synapse
```

\+ some tinkering with `waybar`:

  ![image](https://user-images.githubusercontent.com/23431373/213951385-62fd219f-0b73-4b48-8815-097a14d573b6.png)

</details>

I gave writing a `nixosTest` a shot but didn't manage to get Mir to launch in a test VM. It tended to either hard-crash on software rendering due to KMS / EGL stuff being unavailable, or just seemingly do nothing Wayland-y / easy to test on the dummy drivers. Might give this a shot another time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
