### PR TITLE
rapidjson: disable checks when cross-compiling

### DIFF
--- a/pkgs/development/libraries/rapidjson/default.nix
+++ b/pkgs/development/libraries/rapidjson/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     runHook postCheck
   '';
 
-  doCheck = !stdenv.hostPlatform.isStatic;
+  doCheck = !stdenv.hostPlatform.isStatic && (stdenv.buildPlatform == stdenv.hostPlatform);
 
   meta = with lib; {
     description = "Fast JSON parser/generator for C++ with both SAX/DOM style API";


### PR DESCRIPTION
###### Description of changes

This package fails to build if checks are enabled when cross-compiling. Tested by building pkgsCross.aarch64-multiplatform.rapidjson

 > [100%] Linking CXX executable ../../bin/unittest
 > /nix/store/ipak3y23yapryhbp3nqcywl25g0wj9h5-aarch64-unknown-linux-gnu-binutils-2.39/bin/aarch64-unknown-linux-gnu-ld: cannot find -lgtest: No such file or directory
 > /nix/store/ipak3y23yapryhbp3nqcywl25g0wj9h5-aarch64-unknown-linux-gnu-binutils-2.39/bin/aarch64-unknown-linux-gnu-ld: cannot find -lgtest_main: No such file or directory
 > collect2: error: ld returned 1 exit status

----

`gtest` is in `nativeCheckInputs`, so it's not clear to me why the checks are failing to build. If someone wants to dig into why its failing thats cool too, but this PR at least gets rapidjson to build when cross-compiling.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
