### PR TITLE
waydroid: Add missing ambiant dependencies

### DIFF
--- a/pkgs/os-specific/linux/waydroid/default.nix
+++ b/pkgs/os-specific/linux/waydroid/default.nix
@@ -4,12 +4,15 @@
 , dnsmasq
 , gawk
 , getent
+, gobject-introspection
+, gtk3
 , kmod
 , lxc
 , iproute2
 , nftables
 , util-linux
 , which
+, wrapGAppsHook
 , xclip
 }:
 
@@ -25,6 +28,15 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-0GBob9BUwiE5cFGdK8AdwsTjTOdc+AIWqUGN/gFfOqI=";
   };
 
+  buildInputs = [
+    gtk3
+  ];
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook
+  ];
+
   propagatedBuildInputs = with python3Packages; [
     gbinder-python
     pyclip
@@ -35,9 +47,14 @@ python3Packages.buildPythonApplication rec {
   dontUsePipInstall = true;
   dontUseSetuptoolsCheck = true;
   dontWrapPythonPrograms = true;
+  dontWrapGApps = true;
 
   installPhase = ''
     make install PREFIX=$out USE_SYSTEMD=0 USE_NFTABLES=1
+  '';
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
 
     wrapProgram $out/lib/waydroid/data/scripts/waydroid-net.sh \
        --prefix PATH ":" ${lib.makeBinPath [ dnsmasq getent iproute2 nftables ]}


### PR DESCRIPTION
Fixes #211741

`waydroid first-launch` would fail due to missing gobject introspection bindings for Gtk.

```
(      ) [        ] ERROR: Namespace Gtk not available
(      ) [        ] See also: <https://github.com/waydroid>
(      ) [        ] Traceback (most recent call last):
  File "/nix/store/7c0jjr0jid4xhfdsv13jiwp7q4jl9khi-waydroid-1.3.3/lib/waydroid/tools/__init__.py", line 113, in main
    actions.remote_init_client(args)
  File "/nix/store/7c0jjr0jid4xhfdsv13jiwp7q4jl9khi-waydroid-1.3.3/lib/waydroid/tools/actions/initializer.py", line 205, in remote_init_client
    gi.require_version("Gtk", "3.0")
  File "/nix/store/y09awdg92zm58958q6bc6chacw35pfgm-python3.10-pygobject-3.42.2/lib/python3.10/site-packages/gi/__init__.py", line 126, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Gtk not available
```

These changes add the necessary environment (the currently idiomatic way to solve such problems) to the existing wrapper.

The use in `preFixup` is necessary, as the gapps wrapper will not have ran the required hooks before.

The addition of `gobject-introspection` is necessary for the wrappers hooks to add GIR repositories to the wrapper args.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
