### PR TITLE
ocamlPackages.lutils: 1.51.2 → 1.54.1

### DIFF
--- a/pkgs/development/ocaml-modules/lutils/default.nix
+++ b/pkgs/development/ocaml-modules/lutils/default.nix
@@ -1,20 +1,18 @@
-{ lib, buildDunePackage, fetchurl, num }:
+{ lib, buildDunePackage, fetchurl, camlp-streams, num }:
 
 buildDunePackage rec {
   pname = "lutils";
-  version = "1.51.2";
-
-  useDune2 = true;
+  version = "1.54.1";
 
   minimalOCamlVersion = "4.02";
 
   src = fetchurl {
-    url = "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutils.1.51.2.tgz";
-    sha512 = "f94696be379c62e888410ec3d940c888ca4b607cf59c2e364e93a2a694da65ebe6d531107198b795e80eecc3c6865eedb02659c7e7c4e15c9b28d74aa35d09f8";
+    url = "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutils.v${version}.tgz";
+    hash = "sha512:d3c3b80286b1aa236ba922d9e18a133721fc80126c8b89520fb811dce9400e217aaa75b5d49e03988be7f6bf5f2e1a391d02ceeaa5ec0a0cd5ce218083a29514";
   };
 
   propagatedBuildInputs = [
-    num
+    camlp-streams num
   ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/lutils/default.nix
+++ b/pkgs/development/ocaml-modules/lutils/default.nix
@@ -18,6 +18,7 @@ buildDunePackage rec {
   meta = with lib; {
     homepage = "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/";
     description = "Tools and libs shared by Verimag/synchronous tools (lustre, lutin, rdbg)";
+    changelog = "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/-/releases/v${version}";
     license = lib.licenses.cecill21;
     mainProgram = "gnuplot-rif";
   };


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
