### PR TITLE
manifest-tool: init at v2.0.6

### DIFF
--- a/pkgs/development/tools/manifest-tool/default.nix
+++ b/pkgs/development/tools/manifest-tool/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, git
+, stdenv
+, testers
+, manifest-tool
+}:
+
+buildGoModule rec {
+  pname = "manifest-tool";
+  version = "2.0.6";
+  gitCommit = "2ed9312726765567a84f2acc44a0c8a6e50f4b7a";
+  modRoot = "v2";
+
+  src = fetchFromGitHub {
+    owner = "estesp";
+    repo = "manifest-tool";
+    rev = "v${version}";
+    sha256 = "sha256-oopk++IdNF6msxOszT0fKxQABgWKbaQZ2aNH9chqWU0=";
+    leaveDotGit = true;
+    postFetch = ''
+      git -C $out rev-parse HEAD > $out/.git-revision
+      rm -rf $out/.git
+    '';
+  };
+
+  vendorHash = null;
+
+  nativeBuildInputs = [ git ];
+
+  preConfigure = ''
+    ldflags="-X main.gitCommit=$(cat .git-revision)"
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = manifest-tool;
+  };
+
+  meta = with lib; {
+    description = "Command line tool to create and query container image manifest list/indexes";
+    homepage = "https://github.com/estesp/manifest-tool";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tricktron ];
+  };
+}

--- a/pkgs/development/tools/manifest-tool/default.nix
+++ b/pkgs/development/tools/manifest-tool/default.nix
@@ -33,6 +33,11 @@ buildGoModule rec {
     ldflags="-X main.gitCommit=$(cat .git-revision)"
   '';
 
+  CGO_ENABLED = if stdenv.hostPlatform.isStatic then "0" else "1";
+  GO_EXTLINK_ENABLED = if stdenv.hostPlatform.isStatic then "0" else "1";
+  ldflags = lib.optionals stdenv.hostPlatform.isStatic [ "-w" "-extldflags" "-static" ];
+  tags = lib.optionals stdenv.hostPlatform.isStatic [ "netgo" ];
+
   passthru.tests.version = testers.testVersion {
     package = manifest-tool;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8893,6 +8893,8 @@ with pkgs;
 
   mani = callPackage ../development/tools/mani { };
 
+  manifest-tool = callPackage ../development/tools/manifest-tool { };
+
   mask = callPackage ../development/tools/mask { };
 
   mathpix-snipping-tool = callPackage ../tools/misc/mathpix-snipping-tool { };


### PR DESCRIPTION
###### Description of changes

Init [manifest-tool](https://github.com/estesp/manifest-tool), a _command line tool to create and query container image manifest list/indexes_.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
