### PR TITLE
Added packages n98-magerun and n98-magerun2

### DIFF
--- a/pkgs/development/php-packages/n98-magerun/default.nix
+++ b/pkgs/development/php-packages/n98-magerun/default.nix
@@ -31,6 +31,6 @@ mkDerivation {
     license = licenses.mit;
     homepage = "https://magerun.net/";
     changelog = "https://magerun.net/category/magerun/";
-    maintainers = with maintainers; [ offline ] ++ teams.php.members;
+    maintainers = teams.php.member;
   };
 }

--- a/pkgs/development/php-packages/n98-magerun/default.nix
+++ b/pkgs/development/php-packages/n98-magerun/default.nix
@@ -1,0 +1,36 @@
+{ mkDerivation, fetchurl, makeWrapper, unzip, lib, php }:
+
+let
+  pname = "n98-magerun";
+  version = "2.3.0";
+in
+mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://files.magerun.net/n98-magerun-2.3.0.phar";
+    sha256 = "b3e09dafccd4dd505a073c4e8789d78ea3def893cfc475a214e1154bff3aa8e4";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -D $src $out/libexec/n98-magerun/n98-magerun.phar
+    makeWrapper ${php}/bin/php $out/bin/n98-magerun \
+      --add-flags "$out/libexec/n98-magerun/n98-magerun.phar" \
+      --prefix PATH : ${lib.makeBinPath [ unzip ]}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The swiss army knife for Magento developers";
+    license = licenses.mit;
+    homepage = "https://magerun.net/";
+    changelog = "https://magerun.net/category/magerun/";
+    maintainers = with maintainers; [ offline ] ++ teams.php.members;
+  };
+}

--- a/pkgs/development/php-packages/n98-magerun/default.nix
+++ b/pkgs/development/php-packages/n98-magerun/default.nix
@@ -8,7 +8,7 @@ mkDerivation {
   inherit pname version;
 
   src = fetchurl {
-    url = "https://files.magerun.net/n98-magerun-2.3.0.phar";
+    url = "https://files.magerun.net/n98-magerun-${version}.phar";
     sha256 = "b3e09dafccd4dd505a073c4e8789d78ea3def893cfc475a214e1154bff3aa8e4";
   };
 
@@ -19,9 +19,9 @@ mkDerivation {
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
-    install -D $src $out/libexec/n98-magerun/n98-magerun.phar
+    install -D $src $out/libexec/n98-magerun/n98-magerun-${version}.phar
     makeWrapper ${php}/bin/php $out/bin/n98-magerun \
-      --add-flags "$out/libexec/n98-magerun/n98-magerun.phar" \
+      --add-flags "$out/libexec/n98-magerun/n98-magerun-${version}.phar" \
       --prefix PATH : ${lib.makeBinPath [ unzip ]}
     runHook postInstall
   '';

--- a/pkgs/development/php-packages/n98-magerun/default.nix
+++ b/pkgs/development/php-packages/n98-magerun/default.nix
@@ -31,6 +31,6 @@ mkDerivation {
     license = licenses.mit;
     homepage = "https://magerun.net/";
     changelog = "https://magerun.net/category/magerun/";
-    maintainers = teams.php.member;
+    maintainers = teams.php.members;
   };
 }

--- a/pkgs/development/php-packages/n98-magerun2/default.nix
+++ b/pkgs/development/php-packages/n98-magerun2/default.nix
@@ -31,6 +31,6 @@ mkDerivation {
     license = licenses.mit;
     homepage = "https://magerun.net/";
     changelog = "https://magerun.net/category/magerun/";
-    maintainers = with maintainers; [ offline ] ++ teams.php.members;
+    maintainers = teams.php.member;
   };
 }

--- a/pkgs/development/php-packages/n98-magerun2/default.nix
+++ b/pkgs/development/php-packages/n98-magerun2/default.nix
@@ -1,0 +1,36 @@
+{ mkDerivation, fetchurl, makeWrapper, unzip, lib, php }:
+
+let
+  pname = "n98-magerun2";
+  version = "6.1.1";
+in
+mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://files.magerun.net/n98-magerun2-${version}.phar";
+    sha256 = "bf3b68aa35c3b46d0c618b695021e454250956e5e9a467f5da01abf027172245";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -D $src $out/libexec/n98-magerun2/n98-magerun2-${version}.phar
+    makeWrapper ${php}/bin/php $out/bin/n98-magerun2 \
+      --add-flags "$out/libexec/n98-magerun2/n98-magerun2-${version}.phar" \
+      --prefix PATH : ${lib.makeBinPath [ unzip ]}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The swiss army knife for Magento 2 developers";
+    license = licenses.mit;
+    homepage = "https://magerun.net/";
+    changelog = "https://magerun.net/category/magerun/";
+    maintainers = with maintainers; [ offline ] ++ teams.php.members;
+  };
+}

--- a/pkgs/development/php-packages/n98-magerun2/default.nix
+++ b/pkgs/development/php-packages/n98-magerun2/default.nix
@@ -31,6 +31,6 @@ mkDerivation {
     license = licenses.mit;
     homepage = "https://magerun.net/";
     changelog = "https://magerun.net/category/magerun/";
-    maintainers = teams.php.member;
+    maintainers = teams.php.members;
   };
 }

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -174,6 +174,10 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     grumphp = callPackage ../development/php-packages/grumphp { };
 
+    n98-magerun = callPackage ../development/php-packages/n98-magerun { };
+
+    n98-magerun2 = callPackage ../development/php-packages/n98-magerun2 { };
+
     phan = callPackage ../development/php-packages/phan { };
 
     phing = callPackage ../development/php-packages/phing { };


### PR DESCRIPTION
###### Description of changes

Being a magento developer, n98-magerun and n98-magerun2 are very important tools to have.
The website of the project is https://magerun.net

This is the first package I work on and I'm fairly new to nix thus I don't know how to test the package before it's actually merged in the main repo.

###### Things done

Copied the composer package and modified it for the new tools.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).