### PR TITLE
obs-studio-plugins.obs-livesplit-one: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1621,6 +1621,16 @@
     githubId = 45811;
     name = "Svein Ove Aas";
   };
+  Bauke = {
+    name = "Bauke";
+    email = "me@bauke.xyz";
+    matrix = "@baukexyz:matrix.org";
+    github = "Bauke";
+    githubId = 19501722;
+    keys = [{
+      fingerprint = "C593 27B5 9D0F 2622 23F6  1D03 C1C0 F299 52BC F558";
+    }];
+  };
   bb010g = {
     email = "me@bb010g.com";
     matrix = "@bb010g:matrix.org";

--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -16,6 +16,8 @@
 
   obs-hyperion = qt6Packages.callPackage ./obs-hyperion/default.nix { };
 
+  obs-livesplit-one = callPackage ./obs-livesplit-one { };
+
   obs-move-transition = callPackage ./obs-move-transition.nix { };
 
   obs-multi-rtmp = qt6Packages.callPackage ./obs-multi-rtmp { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-livesplit-one/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-livesplit-one/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, cmake
+, fontconfig
+, obs-studio
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "obs-livesplit-one";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "CryZe";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-C1u4z7iQUETM84kf6S6obw+C0ox8J9gMJoVP3/3ZoYw=";
+  };
+
+  cargoHash = "sha256-mQ0TR4DL4bA5u4IL3RY9aLxU5G6qQ5W5xuNadiXGeB0=";
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ fontconfig obs-studio ];
+
+  postInstall = ''
+    mkdir $out/lib/obs-plugins/
+    mv $out/lib/libobs_livesplit_one.so $out/lib/obs-plugins/obs-livesplit-one.so
+  '';
+
+  meta = with lib; {
+    description = "OBS Studio plugin for adding LiveSplit One as a source";
+    homepage = "https://github.com/CryZe/obs-livesplit-one";
+    license = with licenses; [ asl20 mit ];
+    maintainers = [ maintainers.Bauke ];
+    platforms = obs-studio.meta.platforms;
+  };
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds [obs-livesplit-one](https://github.com/cryze/obs-livesplit-one) as an `obs-studio-plugins` package.

This is the first time I've ever really done anything with Nix besides tinkering with my configuration, so anything I should know would be most appreciated. I did a `nixos-rebuild test` and confirmed the plugin works for me with nixpkgs checked out to `nixos-version --hash`, so as far as I can tell I did it correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
