### PR TITLE
treewide: remove -ldl linker flags

### DIFF
--- a/pkgs/applications/audio/jack-rack/default.nix
+++ b/pkgs/applications/audio/jack-rack/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   };
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libjack2 ladspaH gtk2 alsa-lib libxml2 lrdf ];
-  NIX_LDFLAGS = "-ldl -lm -lpthread";
+  NIX_LDFLAGS = "-lm -lpthread";
 
   meta = {
     description = ''An effects "rack" for the JACK low latency audio API'';

--- a/pkgs/applications/audio/jamin/default.nix
+++ b/pkgs/applications/audio/jamin/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
   #       `l_notebook1'; jamin-callbacks.o:/build/jamin-0.95.0/src/hdeq.h:64: first defined here
   NIX_CFLAGS_COMPILE = "-fcommon";
 
-  NIX_LDFLAGS = "-ldl";
-
   postInstall = ''
     wrapProgram $out/bin/jamin --set LADSPA_PATH ${ladspaPlugins}/lib/ladspa
   '';

--- a/pkgs/build-support/libredirect/default.nix
+++ b/pkgs/build-support/libredirect/default.nix
@@ -46,14 +46,14 @@ else stdenv.mkDerivation rec {
       -L${llvmPackages_13.clang.libc}/lib \
       -Wl,-install_name,$libName \
       -Wall -std=c99 -O3 -fPIC libredirect.c \
-      -ldl -shared -o "$libName"
+      -shared -o "$libName"
     '' else if stdenv.isDarwin then ''
     $CC -Wall -std=c99 -O3 -fPIC libredirect.c \
       -Wl,-install_name,$out/lib/$libName \
-      -ldl -shared -o "$libName"
+      -shared -o "$libName"
     '' else ''
     $CC -Wall -std=c99 -O3 -fPIC libredirect.c \
-      -ldl -shared -o "$libName"
+      -shared -o "$libName"
     ''}
 
     if [ -n "$doInstallCheck" ]; then

--- a/pkgs/desktops/rox/rox-filer/default.nix
+++ b/pkgs/desktops/rox/rox-filer/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     wrapGAppsHook
   ];
   buildInputs = [ libxml2 gtk shared-mime-info libSM ];
-  NIX_LDFLAGS = "-ldl -lm";
+  NIX_LDFLAGS = "-lm";
 
   patches = [
     ./rox-filer-2.11-in-source-build.patch

--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -181,7 +181,7 @@ stdenv.mkDerivation ({
 
   depsTargetTarget = optional (!crossStageStatic && threadsCross != {} && threadsCross.package != null) threadsCross.package;
 
-  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
+  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm";
 
   preConfigure = (import ../common/pre-configure.nix {
     inherit lib;

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -185,7 +185,7 @@ stdenv.mkDerivation ({
 
   depsTargetTarget = optional (!crossStageStatic && threadsCross != {} && threadsCross.package != null) threadsCross.package;
 
-  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
+  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm";
 
   preConfigure = (import ../common/pre-configure.nix {
     inherit lib;

--- a/pkgs/development/compilers/gcc/12/default.nix
+++ b/pkgs/development/compilers/gcc/12/default.nix
@@ -228,7 +228,7 @@ stdenv.mkDerivation ({
 
   depsTargetTarget = optional (!crossStageStatic && threadsCross != {}) threadsCross.package;
 
-  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
+  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm";
 
 
   preConfigure = (import ../common/pre-configure.nix {

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -219,7 +219,7 @@ stdenv.mkDerivation ({
 
   depsTargetTarget = optional (!crossStageStatic && threadsCross != {}) threadsCross.package;
 
-  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
+  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm";
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -187,7 +187,7 @@ stdenv.mkDerivation ({
   depsTargetTarget = optional (!crossStageStatic && threadsCross != {}) threadsCross.package;
 
   NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.cc.isClang && langFortran) "-Wno-unused-command-line-argument";
-  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
+  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm";
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -169,7 +169,7 @@ stdenv.mkDerivation ({
 
   depsTargetTarget = optional (!crossStageStatic && threadsCross != {}) threadsCross.package;
 
-  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
+  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm";
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -182,7 +182,7 @@ stdenv.mkDerivation ({
 
   depsTargetTarget = optional (!crossStageStatic && threadsCross != {}) threadsCross.package;
 
-  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
+  NIX_LDFLAGS = lib.optionalString  hostPlatform.isSunOS "-lm";
 
   preConfigure = import ../common/pre-configure.nix {
     inherit lib;

--- a/pkgs/development/compilers/tinycc/default.nix
+++ b/pkgs/development/compilers/tinycc/default.nix
@@ -38,7 +38,6 @@ stdenv.mkDerivation rec {
         "-L${variables.libdir}"
         "-Wl,--rpath ${variables.libdir}"
         "-ltcc"
-        "-ldl"
       ];
       variables = rec {
         prefix = "${placeholder "out"}";

--- a/pkgs/games/eboard/default.nix
+++ b/pkgs/games/eboard/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
   '';
 
   NIX_CFLAGS_COMPILE = "-fpermissive";
-  NIX_LDFLAGS = "-ldl";
 
   meta = {
     homepage = "http://www.bergo.eng.br/eboard/";

--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -64,8 +64,8 @@ stdenv.mkDerivation rec {
       ${lib.optionalString enableMySQL ''
         s:^# \(LOOKUP_MYSQL=yes\)$:\1:
         s:^# \(LOOKUP_MYSQL_PC=libmysqlclient\)$:\1:
-        s:^\(LOOKUP_LIBS\)=\(.*\):\1=\2 -lmysqlclient -L${libmysqlclient}/lib/mysql -lssl -ldl -lm -lpthread -lz:
-        s:^# \(LOOKUP_LIBS\)=.*:\1=-lmysqlclient -L${libmysqlclient}/lib/mysql -lssl -ldl -lm -lpthread -lz:
+        s:^\(LOOKUP_LIBS\)=\(.*\):\1=\2 -lmysqlclient -L${libmysqlclient}/lib/mysql -lssl -lm -lpthread -lz:
+        s:^# \(LOOKUP_LIBS\)=.*:\1=-lmysqlclient -L${libmysqlclient}/lib/mysql -lssl -lm -lpthread -lz:
         s:^# \(LOOKUP_INCLUDE\)=.*:\1=-I${libmysqlclient.dev}/include/mysql/:
       ''}
       ${lib.optionalString enableAuthDovecot ''

--- a/pkgs/servers/monitoring/nagios/default.nix
+++ b/pkgs/servers/monitoring/nagios/default.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--localstatedir=/var/lib/nagios" ];
   buildFlags = [ "all" ];
-  CFLAGS = "-ldl";
 
   # Do not create /var directories
   preInstall = ''

--- a/pkgs/servers/nosql/influxdb/default.nix
+++ b/pkgs/servers/nosql/influxdb/default.nix
@@ -33,7 +33,7 @@ let
       Version: ${libflux_version}
       Description: Library for the InfluxData Flux engine
       Cflags: -I/out/include
-      Libs: -L/out/lib -lflux -ldl -lpthread
+      Libs: -L/out/lib -lflux -lpthread
     '';
     passAsFile = [ "pkgcfg" ];
     postInstall = ''

--- a/pkgs/servers/nosql/influxdb2/default.nix
+++ b/pkgs/servers/nosql/influxdb2/default.nix
@@ -51,7 +51,7 @@ let
       Version: ${libflux_version}
       Description: Library for the InfluxData Flux engine
       Cflags: -I/out/include
-      Libs: -L/out/lib -lflux -ldl -lpthread
+      Libs: -L/out/lib -lflux -lpthread
     '';
     passAsFile = [ "pkgcfg" ];
     postInstall = ''

--- a/pkgs/servers/openafs/1.8/default.nix
+++ b/pkgs/servers/openafs/1.8/default.nix
@@ -89,7 +89,6 @@ stdenv.mkDerivation {
     )
   '' + optionalString withTsm ''
     export XBSA_CFLAGS="-Dxbsa -DNEW_XBSA -I${tsm-client}/lib64/sample -DXBSA_TSMLIB=\\\"${tsm-client}/lib64/libApiTSM64.so\\\""
-    export XBSA_XLIBS="-ldl"
   '';
 
   buildFlags = [ "all_nolibafs" ];

--- a/pkgs/tools/graphics/argyllcms/default.nix
+++ b/pkgs/tools/graphics/argyllcms/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
 
       LINKFLAGS +=
         ${lib.concatStringsSep " " (map (x: "-L${x}/lib") buildInputs)}
-        -ldl -lrt -lX11 -lXext -lXxf86vm -lXinerama -lXrandr -lXau -lXdmcp -lXss
+        -lrt -lX11 -lXext -lXxf86vm -lXinerama -lXrandr -lXau -lXdmcp -lXss
         -ljpeg -ltiff -lpng -lssl ;
     '';
   in ''

--- a/pkgs/tools/networking/dsniff/default.nix
+++ b/pkgs/tools/networking/dsniff/default.nix
@@ -60,7 +60,7 @@ in gcc9Stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook rpcsvc-proto ];
   buildInputs = [ glib pcap libtirpc libnsl ];
-  NIX_CFLAGS_LINK = "-lglib-2.0 -lpthread -ldl -ltirpc";
+  NIX_CFLAGS_LINK = "-lglib-2.0 -lpthread -ltirpc";
   NIX_CFLAGS_COMPILE = [ "-I${libtirpc.dev}/include/tirpc" ];
   postPatch = ''
     for patch in debian/patches/*.patch; do


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
With all libcs I'm aware of, libdl is now either empty (Glibc, musl, uclibc, illumos), a symlink to libc or equivalent (Apple), or does not exist (FreeBSD, NetBSD).  So explicitly linking libdl now does nothing for the former platforms, and breaks the build for the latter platforms.

With this patch I've removed -ldl from all overridden linker flags for all free packages in Nixpkgs.  Everything still seems to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
