### PR TITLE
make-symlinks-relative: run on all outputs

### DIFF
--- a/pkgs/build-support/setup-hooks/make-symlinks-relative.sh
+++ b/pkgs/build-support/setup-hooks/make-symlinks-relative.sh
@@ -1,4 +1,6 @@
-postFixupHooks+=(_makeSymlinksRelative)
+# symlinks are often created in postFixup
+# don't use fixupOutputHooks, it is before postFixup
+postFixupHooks+=(_makeSymlinksRelativeInAllOutputs)
 
 # For every symlink in $output that refers to another file in $output
 # ensure that the symlink is relative. This removes references to the output
@@ -25,4 +27,11 @@ _makeSymlinksRelative() {
         ln -snrf "$symlinkTarget" "$f"
 
     done < <(find $prefix -type l -print0)
+}
+
+_makeSymlinksRelativeInAllOutputs() {
+  local output
+  for output in $(getAllOutputNames); do
+    prefix="${!output}" _makeSymlinksRelative
+  done
 }

--- a/pkgs/test/stdenv/hooks.nix
+++ b/pkgs/test/stdenv/hooks.nix
@@ -23,19 +23,29 @@
     };
   make-symlinks-relative = stdenv.mkDerivation {
     name = "test-make-symlinks-relative";
+    outputs = [ "out" "man" ];
     buildCommand = ''
       mkdir -p $out/{bar,baz}
+      mkdir -p $man/share/{x,y}
       source1="$out/bar/foo"
       destination1="$out/baz/foo"
+      source2="$man/share/x/file1"
+      destination2="$man/share/y/file2"
       echo foo > $source1
+      echo foo > $source2
       ln -s $source1 $destination1
+      ln -s $source2 $destination2
       echo "symlink before patching: $(readlink $destination1)"
+      echo "symlink before patching: $(readlink $destination2)"
 
-      _makeSymlinksRelative
+      _makeSymlinksRelativeInAllOutputs
 
       echo "symlink after patching: $(readlink $destination1)"
       ([[ -e $destination1 ]] && echo "symlink isn't broken") || (echo "symlink is broken" && exit 1)
       ([[ $(readlink $destination1) == "../bar/foo" ]] && echo "absolute symlink was made relative") || (echo "symlink was not made relative" && exit 1)
+      echo "symlink after patching: $(readlink $destination2)"
+      ([[ -e $destination2 ]] && echo "symlink isn't broken") || (echo "symlink is broken" && exit 1)
+      ([[ $(readlink $destination2) == "../x/file1" ]] && echo "absolute symlink was made relative") || (echo "symlink was not made relative" && exit 1)
     '';
   };
   move-docs = stdenv.mkDerivation {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
