### PR TITLE
standardnotes: 3.129.0 -> 3.139.0

### DIFF
--- a/pkgs/applications/editors/standardnotes/src.json
+++ b/pkgs/applications/editors/standardnotes/src.json
@@ -1,17 +1,13 @@
 {
-  "version": "3.129.0",
+  "version": "3.139.0",
   "appimage": {
     "x86_64-linux": {
-      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.129.0/standard-notes-3.129.0-linux-x86_64.AppImage",
-      "hash": "sha512-JLO2jX9Us6BjqmTZIkVyxy2pqFM/eFGpwi6vXicMOgDB0UsgEMTK+Ww+9g+vJ1KbFRFmlt187qkdSNcevQPt7w=="
+      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.139.0/standard-notes-3.139.0-linux-x86_64.AppImage",
+      "hash": "sha512-0s/tQmP5PINoQB7FOhR5wYuBvynKHpM9uMNmkJs77z84rY+WXOdZRjki6ZeG60niNXr8rUSLOBffy4jyLka6tg=="
     },
     "aarch64-linux": {
-      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.129.0/standard-notes-3.129.0-linux-arm64.AppImage",
-      "hash": "sha512-LGUSRqMrJ+hVHyi/bjI/NkWRVsmY0Kh/wRY9RNJXm0C3dKQSFV8ca4GeY9+VCuJEecR4LGnWp4agS5jPybPP6w=="
-    },
-    "i686-linux": {
-      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.129.0/standard-notes-3.129.0-linux-i386.AppImage",
-      "hash": "sha512-XbQ4hn3QJ61hDC12cK95zsUowbyXPYArHZoRDx5trQ30phtQxtz6nV+pL00m4S9kYeEhsAwk1wXlRq9Ylbz2IA=="
+      "url": "https://github.com/standardnotes/app/releases/download/%40standardnotes/desktop%403.139.0/standard-notes-3.139.0-linux-arm64.AppImage",
+      "hash": "sha512-LralbOiIVQCtQTqmhTtKttdtMz4M14drPFZ00LPFcwzQviLdU2C/od3NUxf5H5piGgqt5TJlgMCOcLIiyoNKFA=="
     }
   }
 }

--- a/pkgs/applications/editors/standardnotes/update.nix
+++ b/pkgs/applications/editors/standardnotes/update.nix
@@ -50,6 +50,5 @@ writeScript "update-standardnotes" ''
 
   updatePlatform x86_64-linux linux-x86_64
   updatePlatform aarch64-linux linux-arm64
-  updatePlatform i686-linux linux-i386
   setJsonKey .version "$newVersion"
 ''


### PR DESCRIPTION
###### Description of changes
- update standardnotes
- drop support for i686-linux because upstream stopped providing binaries (https://github.com/standardnotes/app/releases/tag/%40standardnotes%2Fdesktop%403.139.0)

Basic functionality test passes on x86_64-linux.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
