### PR TITLE
n98-magerun: init at 2.3.0, n98-magerun2: init at 6.1.1

### DIFF
--- a/pkgs/development/tools/misc/n98-magerun/default.nix
+++ b/pkgs/development/tools/misc/n98-magerun/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, makeWrapper, unzip, lib, php80 }:
+
+let
+  pname = "n98-magerun";
+  version = "2.3.0";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "netz98";
+    repo = "n98-magerun1-dist";
+    rev = version;
+    sha256 = "sha256-T7wQmEEYMG0J6+9nRt+tiMuihjnjjQ7UWy1C0vKoQY4=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -D $src/n98-magerun $out/libexec/n98-magerun/n98-magerun-${version}.phar
+    makeWrapper ${php80}/bin/php $out/bin/n98-magerun \
+      --add-flags "$out/libexec/n98-magerun/n98-magerun-${version}.phar" \
+      --prefix PATH : ${lib.makeBinPath [ unzip ]}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The swiss army knife for Magento1/OpenMage developers";
+    license = licenses.mit;
+    homepage = "https://magerun.net/";
+    changelog = "https://magerun.net/category/magerun/";
+    maintainers = teams.php.members;
+  };
+}

--- a/pkgs/development/tools/misc/n98-magerun2/default.nix
+++ b/pkgs/development/tools/misc/n98-magerun2/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, makeWrapper, unzip, lib, php }:
+
+let
+  pname = "n98-magerun2";
+  version = "6.1.1";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "netz98";
+    repo = "n98-magerun2-dist";
+    rev = version;
+    sha256 = "sha256-D2U1kLG6sOpBHDzNQ/LbiFUknvFhK+rkOPgWvW0pNmY=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -D $src/n98-magerun2 $out/libexec/n98-magerun2/n98-magerun2-${version}.phar
+    makeWrapper ${php}/bin/php $out/bin/n98-magerun2 \
+      --add-flags "$out/libexec/n98-magerun2/n98-magerun2-${version}.phar" \
+      --prefix PATH : ${lib.makeBinPath [ unzip ]}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The swiss army knife for Magento2 developers";
+    license = licenses.mit;
+    homepage = "https://magerun.net/";
+    changelog = "https://magerun.net/category/magerun/";
+    maintainers = teams.php.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -528,6 +528,8 @@ with pkgs;
 
   mix2nix = callPackage ../development/tools/mix2nix { };
 
+  n98-magerun = callPackage ../development/tools/misc/n98-magerun { };
+
   prisma-engines = callPackage ../development/tools/database/prisma-engines {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -530,6 +530,8 @@ with pkgs;
 
   n98-magerun = callPackage ../development/tools/misc/n98-magerun { };
 
+  n98-magerun2 = callPackage ../development/tools/misc/n98-magerun2 { };
+
   prisma-engines = callPackage ../development/tools/database/prisma-engines {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

Being a magento developer, n98-magerun (for magento1 and openmage) and n98-magerun2 (for magento2) are very important tools to have.
The website of the project is https://magerun.net

This PR only adds n98-magerun since the building process is completely different between the 2 versions of this software so I think it's better to have a dedicated PR.

This PR follows https://github.com/NixOS/nixpkgs/pull/212249 which had too many problems, this one should be cleaner.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
