### PR TITLE
handbrake: 1.5.1 -> 1.6.1

### DIFF
--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -25,7 +25,7 @@
 , numactl
 , writeText
   # Processing, video codecs, containers
-, ffmpeg-full
+, ffmpeg_5-full
 , nv-codec-headers
 , libogg
 , x264
@@ -34,6 +34,7 @@
 , libtheora
 , dav1d
 , zimg
+, svt-av1
   # Codecs, audio
 , libopus
 , lame
@@ -84,57 +85,55 @@
 }:
 
 let
-  version = "1.5.1";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "HandBrake";
     repo = "HandBrake";
     rev = version;
-    sha256 = "1kk11zl1mk37d4cvbc75gfndmma7vy3vkp4gmkyl92kiz6zadhyy";
+    sha256 = "sha256-0MJ1inMNA6s8l2S0wnpM2c7FxOoOHxs9u4E/rgKfjJo=";
   };
 
   # Handbrake maintains a set of ffmpeg patches. In particular, these
   # patches are required for subtitle timing to work correctly. See:
   # https://github.com/HandBrake/HandBrake/issues/4029
-  ffmpeg-version = "4.4.1";
-  ffmpeg-hb = ffmpeg-full.overrideAttrs (old: {
+  ffmpeg-version = "5.1.1";
+  ffmpeg-hb = ffmpeg_5-full.overrideAttrs (old: {
     version = ffmpeg-version;
     src = fetchurl {
       url = "https://www.ffmpeg.org/releases/ffmpeg-${ffmpeg-version}.tar.bz2";
-      hash = "sha256-j8nyCsXtlRFanihWR63Q7t1cwamKA5raFMEyRS+YrEI=";
+      hash = "sha256-zQ4W+QNCEmbVzN3t97g7nldUrvS596fwbOnkyALwVFs=";
     };
-    patches = old.patches or [] ++ [
-      "${src}/contrib/ffmpeg/A01-qsv-scale-fix-green-stripes.patch"
-      "${src}/contrib/ffmpeg/A02-qsv-interpolation.patch"
-      "${src}/contrib/ffmpeg/A03-qsv-dx11-ffmpeg44.patch"
-      "${src}/contrib/ffmpeg/A04-configure-ensure-the-right-libmfx-version-is-used-wh.patch"
-      "${src}/contrib/ffmpeg/A05-qsv-add-includedir-mfx-to-the-search-path-for-old-ve.patch"
-      "${src}/contrib/ffmpeg/A06-qsv-load-user-plugin-for-MFX_VERSION-2.0.patch"
-      "${src}/contrib/ffmpeg/A07-qsv-build-audio-related-code-when-MFX_VERSION-2.0.patch"
-      "${src}/contrib/ffmpeg/A08-qsvenc-don-t-support-multi-frame-encode-when-MFX_VER.patch"
-      "${src}/contrib/ffmpeg/A09-qsvenc-don-t-support-MFX_RATECONTROL_LA_EXT-when-MFX.patch"
-      "${src}/contrib/ffmpeg/A10-qsv-don-t-support-OPAQUE-memory-when-MFX_VERSION-2.0.patch"
-      "${src}/contrib/ffmpeg/A11-qsv-opaque-deinterlace.patch"
-      "${src}/contrib/ffmpeg/A12-qsv-opaque-vpp.patch"
-      "${src}/contrib/ffmpeg/A13-qsv-opaque-hwcontext_qsv.patch"
-      "${src}/contrib/ffmpeg/A14-configure-check-mfxdefs.h-instead-of-mfxvp9.h-for-MF.patch"
-      "${src}/contrib/ffmpeg/A15-configure-allow-user-to-build-FFmpeg-against-oneVPL.patch"
-      "${src}/contrib/ffmpeg/A16-qsv-add-macro-QSV_ONEVPL-for-the-oneVPL-SDK.patch"
-      "${src}/contrib/ffmpeg/A17-qsv-use-a-new-method-to-create-mfx-session-when-usin.patch"
-      "${src}/contrib/ffmpeg/A18-qsv-new-method-hwcontext_qsv.patch"
-      "${src}/contrib/ffmpeg/A19-qsv-fix-session-for-d3d11-device.patch"
-      "${src}/contrib/ffmpeg/A20-mov-read-name-track-tag-written-by-movenc.patch"
-      "${src}/contrib/ffmpeg/A21-movenc-write-3gpp-track-titl-tag.patch"
-      "${src}/contrib/ffmpeg/A22-mov-read-3gpp-udta-tags.patch"
-      "${src}/contrib/ffmpeg/A23-movenc-write-3gpp-track-names-tags-for-all-available.patch"
-      "${src}/contrib/ffmpeg/A24-FFmpeg-devel-amfenc-Add-support-for-pict_type-field.patch"
-      "${src}/contrib/ffmpeg/A25-dvdsubdec-fix-processing-of-partial-packets.patch"
-      "${src}/contrib/ffmpeg/A26-ccaption_dec-return-number-of-bytes-used.patch"
-      "${src}/contrib/ffmpeg/A27-dvdsubdec-return-number-of-bytes-used.patch"
-      "${src}/contrib/ffmpeg/A28-dvdsubdec-use-pts-of-initial-packet.patch"
-      "${src}/contrib/ffmpeg/A29-matroskaenc-aac-extradata-updated.patch"
-      "${src}/contrib/ffmpeg/A30-ccaption_dec-fix-pts-in-real_time-mode.patch"
-      "${src}/contrib/ffmpeg/A32-qsv-fix-decode-10bit-hdr.patch"
+    patches = old.patches or [ ] ++ [
+      "${src}/contrib/ffmpeg/A01-qsv-libavfilter-qsvvpp-change-the-output-frame-s-width-a.patch"
+      "${src}/contrib/ffmpeg/A02-qsv-configure-ensure-enable-libmfx-uses-libmfx-1.x.patch"
+      "${src}/contrib/ffmpeg/A03-qsv-configure-fix-the-check-for-MFX_CODEC_VP9.patch"
+      "${src}/contrib/ffmpeg/A04-qsv-remove-mfx-prefix-from-mfx-headers.patch"
+      "${src}/contrib/ffmpeg/A05-qsv-load-user-plugin-for-MFX_VERSION-2.0.patch"
+      "${src}/contrib/ffmpeg/A06-qsv-build-audio-related-code-when-MFX_VERSION-2.0.patch"
+      "${src}/contrib/ffmpeg/A07-qsvenc-support-multi-frame-encode-when-MFX_VERSION-2.patch"
+      "${src}/contrib/ffmpeg/A08-qsvenc-support-MFX_RATECONTROL_LA_EXT-when-MFX_VERSI.patch"
+      "${src}/contrib/ffmpeg/A09-qsv-support-OPAQUE-memory-when-MFX_VERSION-2.0.patch"
+      "${src}/contrib/ffmpeg/A10-qsv-configure-add-enable-libvpl-option.patch"
+      "${src}/contrib/ffmpeg/A11-qsv-use-a-new-method-to-create-mfx-session-when-usin.patch"
+      "${src}/contrib/ffmpeg/A12-qsv-fix-decode-10bit-hdr.patch"
+      "${src}/contrib/ffmpeg/A13-mov-read-name-track-tag-written-by-movenc.patch"
+      "${src}/contrib/ffmpeg/A14-movenc-write-3gpp-track-titl-tag.patch"
+      "${src}/contrib/ffmpeg/A15-mov-read-3gpp-udta-tags.patch"
+      "${src}/contrib/ffmpeg/A16-movenc-write-3gpp-track-names-tags-for-all-available.patch"
+      "${src}/contrib/ffmpeg/A17-FFmpeg-devel-amfenc-Add-support-for-pict_type-field.patch"
+      "${src}/contrib/ffmpeg/A18-dvdsubdec-fix-processing-of-partial-packets.patch"
+      "${src}/contrib/ffmpeg/A19-ccaption_dec-return-number-of-bytes-used.patch"
+      "${src}/contrib/ffmpeg/A20-dvdsubdec-return-number-of-bytes-used.patch"
+      "${src}/contrib/ffmpeg/A21-dvdsubdec-use-pts-of-initial-packet.patch"
+      "${src}/contrib/ffmpeg/A22-matroskaenc-aac-extradata-updated.patch"
+      "${src}/contrib/ffmpeg/A23-ccaption_dec-fix-pts-in-real_time-mode.patch"
+      "${src}/contrib/ffmpeg/A24-fix-eac3-dowmix.patch"
+      "${src}/contrib/ffmpeg/A25-enable-truehd-pass.patch"
+      "${src}/contrib/ffmpeg/A26-Update-the-min-version-to-1.4.23.0-for-AMF-SDK.patch"
+      "${src}/contrib/ffmpeg/A27-avcodec-amfenc-Fixes-the-color-information-in-the-ou.patch"
+      "${src}/contrib/ffmpeg/A28-avcodec-amfenc-HDR-metadata.patch"
+      "${src}/contrib/ffmpeg/A30-svt-av1-backports.patch"
     ];
   });
 
@@ -151,148 +150,151 @@ let
   inherit (lib) optional optionals optionalString versions;
 
 in
-let self = stdenv.mkDerivation rec {
-  pname = "handbrake";
-  inherit version src;
+let
+  self = stdenv.mkDerivation rec {
+    pname = "handbrake";
+    inherit version src;
 
-  postPatch = ''
-    install -Dm444 ${versionFile} ${versionFile.name}
+    postPatch = ''
+      install -Dm444 ${versionFile} ${versionFile.name}
 
-    patchShebangs scripts
+      patchShebangs scripts
 
-    substituteInPlace libhb/hb.c \
-      --replace 'return hb_version;' 'return "${version}";'
+      substituteInPlace libhb/hb.c \
+        --replace 'return hb_version;' 'return "${version}";'
 
-    # Force using nixpkgs dependencies
-    sed -i '/MODULES += contrib/d' make/include/main.defs
-    sed -e 's/^[[:space:]]*\(meson\|ninja\|nasm\)[[:space:]]*= ToolProbe.*$//g' \
-        -e '/    ## Additional library and tool checks/,/    ## MinGW specific library and tool checks/d' \
-        -i make/configure.py
-  '' + optionalString stdenv.isDarwin ''
-    # Use the Nix-provided libxml2 instead of the patched version available on
-    # the Handbrake website.
-    substituteInPlace libhb/module.defs \
-      --replace '$(CONTRIB.build/)include/libxml2' ${libxml2.dev}/include/libxml2
+      # Force using nixpkgs dependencies
+      sed -i '/MODULES += contrib/d' make/include/main.defs
+      sed -e 's/^[[:space:]]*\(meson\|ninja\|nasm\)[[:space:]]*= ToolProbe.*$//g' \
+          -e '/    ## Additional library and tool checks/,/    ## MinGW specific library and tool checks/d' \
+          -i make/configure.py
+    '' + optionalString stdenv.isDarwin ''
+      # Use the Nix-provided libxml2 instead of the patched version available on
+      # the Handbrake website.
+      substituteInPlace libhb/module.defs \
+        --replace '$(CONTRIB.build/)include/libxml2' ${libxml2.dev}/include/libxml2
 
-    # Prevent the configure script from failing if xcodebuild isn't available,
-    # which it isn't in the Nix context. (The actual build goes fine without
-    # xcodebuild.)
-    sed -e '/xcodebuild = ToolProbe/s/abort=.\+)/abort=False)/' -i make/configure.py
-  '' + optionalString stdenv.isLinux ''
-    # Use the Nix-provided libxml2 instead of the system-provided one.
-    substituteInPlace libhb/module.defs \
-      --replace /usr/include/libxml2 ${libxml2.dev}/include/libxml2
-  '';
-
-  nativeBuildInputs = [
-    autoconf
-    automake
-    libtool
-    m4
-    pkg-config
-    python3
-  ]
-  ++ optionals useGtk [ intltool wrapGAppsHook ];
-
-  buildInputs = [
-    a52dec
-    dav1d
-    ffmpeg-hb
-    fontconfig
-    freetype
-    fribidi
-    harfbuzz
-    jansson
-    lame
-    libass
-    libbluray
-    libdvdcss
-    libdvdnav
-    libdvdread
-    libiconv
-    libjpeg_turbo
-    libogg
-    libopus
-    libsamplerate
-    libtheora
-    libvorbis
-    libvpx
-    libxml2
-    speex
-    x264
-    x265
-    xz
-    zimg
-  ]
-  ++ optional (!stdenv.isDarwin) numactl
-  ++ optionals useGtk [
-    dbus-glib
-    glib
-    gst_all_1.gst-plugins-base
-    gst_all_1.gstreamer
-    gtk3
-    hicolor-icon-theme
-    libappindicator-gtk3
-    libgudev
-    libnotify
-    udev
-  ]
-  ++ optional useFdk fdk_aac
-  ++ optionals stdenv.isDarwin [ AudioToolbox Foundation libobjc VideoToolbox ]
-  # NOTE: 2018-12-27: Handbrake supports nv-codec-headers for Linux only,
-  # look at ./make/configure.py search "enable_nvenc"
-  ++ optional stdenv.isLinux nv-codec-headers;
-
-  configureFlags = [
-    "--disable-df-fetch"
-    "--disable-df-verify"
-    "--disable-gtk-update-checks"
-  ]
-  ++ optional (!useGtk) "--disable-gtk"
-  ++ optional useFdk "--enable-fdk-aac"
-  ++ optional stdenv.isDarwin "--disable-xcode"
-  ++ optional stdenv.hostPlatform.isx86 "--harden";
-
-  # NOTE: 2018-12-27: Check NixOS HandBrake test if changing
-  NIX_LDFLAGS = [ "-lx265" ];
-
-  makeFlags = [ "--directory=build" ];
-
-  passthru.tests = {
-    basic-conversion =
-      let
-        # Big Buck Bunny example, licensed under CC Attribution 3.0.
-        testMkv = fetchurl {
-          url = "https://github.com/Matroska-Org/matroska-test-files/blob/cf0792be144ac470c4b8052cfe19bb691993e3a2/test_files/test1.mkv?raw=true";
-          sha256 = "1hfxbbgxwfkzv85pvpvx55a72qsd0hxjbm9hkl5r3590zw4s75h9";
-        };
-      in
-      runCommand "${pname}-${version}-basic-conversion" { nativeBuildInputs = [ self ]; } ''
-        mkdir -p $out
-        cd $out
-        HandBrakeCLI -i ${testMkv} -o test.mp4 -e x264 -q 20 -B 160
-        test -e test.mp4
-        HandBrakeCLI -i ${testMkv} -o test.mkv -e x264 -q 20 -B 160
-        test -e test.mkv
-      '';
-    version = testers.testVersion { package = self; command = "HandBrakeCLI --version"; };
-  };
-
-  meta = with lib; {
-    homepage = "https://handbrake.fr/";
-    description = "A tool for converting video files and ripping DVDs";
-    longDescription = ''
-      Tool for converting and remuxing video files
-      into selection of modern and widely supported codecs
-      and containers. Very versatile and customizable.
-      Package provides:
-      CLI - `HandbrakeCLI`
-      GTK GUI - `ghb`
+      # Prevent the configure script from failing if xcodebuild isn't available,
+      # which it isn't in the Nix context. (The actual build goes fine without
+      # xcodebuild.)
+      sed -e '/xcodebuild = ToolProbe/s/abort=.\+)/abort=False)/' -i make/configure.py
+    '' + optionalString stdenv.isLinux ''
+      # Use the Nix-provided libxml2 instead of the system-provided one.
+      substituteInPlace libhb/module.defs \
+        --replace /usr/include/libxml2 ${libxml2.dev}/include/libxml2
     '';
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ Anton-Latukha wmertens ];
-    platforms = with platforms; unix;
-    broken = stdenv.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinMinVersion "10.13";
+
+    nativeBuildInputs = [
+      autoconf
+      automake
+      libtool
+      m4
+      pkg-config
+      python3
+    ]
+    ++ optionals useGtk [ intltool wrapGAppsHook ];
+
+    buildInputs = [
+      a52dec
+      dav1d
+      ffmpeg-hb
+      fontconfig
+      freetype
+      fribidi
+      harfbuzz
+      jansson
+      lame
+      libass
+      libbluray
+      libdvdcss
+      libdvdnav
+      libdvdread
+      libiconv
+      libjpeg_turbo
+      libogg
+      libopus
+      libsamplerate
+      libtheora
+      libvorbis
+      libvpx
+      libxml2
+      speex
+      svt-av1
+      x264
+      x265
+      xz
+      zimg
+    ]
+    ++ optional (!stdenv.isDarwin) numactl
+    ++ optionals useGtk [
+      dbus-glib
+      glib
+      gst_all_1.gst-plugins-base
+      gst_all_1.gstreamer
+      gtk3
+      hicolor-icon-theme
+      libappindicator-gtk3
+      libgudev
+      libnotify
+      udev
+    ]
+    ++ optional useFdk fdk_aac
+    ++ optionals stdenv.isDarwin [ AudioToolbox Foundation libobjc VideoToolbox ]
+    # NOTE: 2018-12-27: Handbrake supports nv-codec-headers for Linux only,
+    # look at ./make/configure.py search "enable_nvenc"
+    ++ optional stdenv.isLinux nv-codec-headers;
+
+    configureFlags = [
+      "--disable-df-fetch"
+      "--disable-df-verify"
+      "--disable-gtk-update-checks"
+    ]
+    ++ optional (!useGtk) "--disable-gtk"
+    ++ optional useFdk "--enable-fdk-aac"
+    ++ optional stdenv.isDarwin "--disable-xcode"
+    ++ optional stdenv.hostPlatform.isx86 "--harden";
+
+    # NOTE: 2018-12-27: Check NixOS HandBrake test if changing
+    NIX_LDFLAGS = [ "-lx265" ];
+
+    makeFlags = [ "--directory=build" ];
+
+    passthru.tests = {
+      basic-conversion =
+        let
+          # Big Buck Bunny example, licensed under CC Attribution 3.0.
+          testMkv = fetchurl {
+            url = "https://github.com/Matroska-Org/matroska-test-files/blob/cf0792be144ac470c4b8052cfe19bb691993e3a2/test_files/test1.mkv?raw=true";
+            sha256 = "1hfxbbgxwfkzv85pvpvx55a72qsd0hxjbm9hkl5r3590zw4s75h9";
+          };
+        in
+        runCommand "${pname}-${version}-basic-conversion" { nativeBuildInputs = [ self ]; } ''
+          mkdir -p $out
+          cd $out
+          HandBrakeCLI -i ${testMkv} -o test.mp4 -e x264 -q 20 -B 160
+          test -e test.mp4
+          HandBrakeCLI -i ${testMkv} -o test.mkv -e x264 -q 20 -B 160
+          test -e test.mkv
+        '';
+      version = testers.testVersion { package = self; command = "HandBrakeCLI --version"; };
+    };
+
+    meta = with lib; {
+      homepage = "https://handbrake.fr/";
+      description = "A tool for converting video files and ripping DVDs";
+      longDescription = ''
+        Tool for converting and remuxing video files
+        into selection of modern and widely supported codecs
+        and containers. Very versatile and customizable.
+        Package provides:
+        CLI - `HandbrakeCLI`
+        GTK GUI - `ghb`
+      '';
+      license = licenses.gpl2Only;
+      maintainers = with maintainers; [ Anton-Latukha wmertens ];
+      platforms = with platforms; unix;
+      broken = stdenv.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinMinVersion "10.13";
+    };
   };
-};
-in self
+in
+self

--- a/pkgs/tools/video/svt-av1/default.nix
+++ b/pkgs/tools/video/svt-av1/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ aom bsd3 ];
     maintainers = with maintainers; [ Madouura ];
     platforms = platforms.unix;
-    broken = stdenv.isAarch64; # undefined reference to `cpuinfo_arm_linux_init'
+    # error: use of undeclared identifier 'kCVPixelFormatType_444YpCbCr16BiPlanarVideoRange'
+    broken = stdenv.isAarch64 && stdenv.isDarwin;
   };
 })


### PR DESCRIPTION
Fixes #211297

###### Description of changes
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
