### PR TITLE
cargo-deb: 1.30.0 -> 1.42.0

### DIFF
--- a/pkgs/development/tools/rust/cargo-deb/default.nix
+++ b/pkgs/development/tools/rust/cargo-deb/default.nix
@@ -1,49 +1,41 @@
-{ stdenv
-, lib
-, fetchFromGitHub
+{ lib
 , rustPlatform
-, rust
-, libiconv
-, Security
+, fetchFromGitHub
+, makeWrapper
+, dpkg
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-deb";
-  version = "1.30.0";
+  version = "1.42.0";
 
   src = fetchFromGitHub {
-    owner = "mmstick";
+    owner = "kornelski";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-rAmG6Aj0D9dHVueh1BN1Chhit+XFhqGib1WTvMDy0LI=";
+    hash = "sha256-5IWx9tScm64Rwi6RMsbXl1Eajtc/c5PWaZEDrgibTAY=";
   };
 
-  buildInputs = lib.optionals stdenv.isDarwin [ libiconv Security ];
+  cargoHash = "sha256-nwCfUxIrr4DxKqePu/vwxfLld08+GGXZwQWz6Gltmao=";
 
-  cargoSha256 = "sha256-MEpyEdjLWNZvqE7gJLvQ169tgmJRzec4vqQI9fF3xr8=";
+  nativeBuildInputs = [
+    makeWrapper
+  ];
 
-  preCheck = ''
-    substituteInPlace tests/command.rs \
-      --replace 'target/debug' "target/${rust.toRustTarget stdenv.buildPlatform}/release"
+  # This is an FHS specific assert depending on glibc location
+  checkFlags = [
+    "--skip=dependencies::resolve_test"
+  ];
 
-    # This is an FHS specific assert depending on glibc location
-    substituteInPlace src/dependencies.rs \
-      --replace 'assert!(deps.iter().any(|d| d.starts_with("libc")));' '// no libc assert here'
+  postInstall = ''
+    wrapProgram $out/bin/cargo-deb \
+      --prefix PATH : ${lib.makeBinPath [ dpkg ]}
   '';
 
   meta = with lib; {
-    description = "Generate Debian packages from information in Cargo.toml";
-    homepage = "https://github.com/mmstick/cargo-deb";
+    description = "A cargo subcommand that generates Debian packages from information in Cargo.toml";
+    homepage = "https://github.com/kornelski/cargo-deb";
     license = licenses.mit;
-    # test failures:
-    #   control::tests::generate_scripts_generates_maintainer_scripts_for_unit
-    #   dh_installsystemd::tests::find_units_in_empty_dir_finds_nothing
-    #   dh_lib::tests::apply_with_no_matching_files
-    #   dh_lib::tests::debhelper_script_subst_with_generated_file_only
-    #   dh_lib::tests::debhelper_script_subst_with_no_matching_files
-    #   dh_lib::tests::pkgfile_finds_most_specific_match_without_pkg_file
-    #   dh_lib::tests::pkgfile_finds_most_specific_match_without_unit_file
-    broken = (stdenv.isDarwin && stdenv.isx86_64);
     maintainers = with maintainers; [ Br1ght0ne ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15551,9 +15551,7 @@ with pkgs;
   cargo-deadlinks = callPackage ../development/tools/rust/cargo-deadlinks {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
-  cargo-deb = callPackage ../development/tools/rust/cargo-deb {
-    inherit (darwin.apple_sdk.frameworks) Security;
-  };
+  cargo-deb = callPackage ../development/tools/rust/cargo-deb { };
   cargo-deps = callPackage ../development/tools/rust/cargo-deps { };
   cargo-edit = callPackage ../development/tools/rust/cargo-edit {
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
Diff: https://github.com/kornelski/cargo-deb/compare/v1.30.0...v1.42.0

###### Description of changes

closes https://github.com/NixOS/nixpkgs/pull/200019

ran into warnings  running it on nixos probably because it assumes a fhs distro, but this is better then the current state which doesn't even build

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
