### PR TITLE
Revert "python3Packages.sqlalchemy: 1.4.45 -> 1.4.46"

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy/default.nix
@@ -39,12 +39,12 @@
 
 buildPythonPackage rec {
   pname = "SQLAlchemy";
-  version = "1.4.46";
+  version = "1.4.45"; # TODO: check python3Packages.fastapi when updating to >= 1.4.42
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-aRO4JH2KKS74MVFipRkx4rQM6RaB8bbxj2lwRSAMSjA=";
+    hash = "sha256-/WmFCGAJOj9p/v4KtW0EHt/f4YUQtT2aLq7LovFfp5U=";
   };
 
   nativeBuildInputs = lib.optionals (!isPyPy) [


### PR DESCRIPTION
This reverts commit 915fd5f93cd3ffbf0eb3f629b3dd2edfed56f5c2.

This fixes the buildbot package from the following error:

    error: builder for '/nix/store/i7chps5jxa0q2ymzjbkgh1rgdzdhzfzq-python3.10-buildbot-3.7.0.drv' failed with exit code 1;
    last 25 log lines:
    > ===============================================================================
    > [SKIPPED]
    > Need to install hvac to test VaultAuthenticatorToken
    >
    > buildbot.test.unit.test_secret_in_hvac.TestSecretInVaultAuthenticatorToken.test_authenticate
    > ===============================================================================
    > [SKIPPED]
    > unidiff is required for GitDiffInfo tests
    >
    > buildbot.test.unit.test_steps_git_diffinfo.TestDiffInfo.test_complex_diff
    > buildbot.test.unit.test_steps_git_diffinfo.TestDiffInfo.test_diff_failure
    > buildbot.test.unit.test_steps_git_diffinfo.TestDiffInfo.test_empty_diff
    > buildbot.test.unit.test_steps_git_diffinfo.TestDiffInfo.test_merge_base_failure
    > ===============================================================================
    > [ERROR]
    > Traceback (most recent call last):
    >   File "/nix/store/2m4mif9lkr2afl829asqq7mi94q0d73z-python3.10-twisted-22.10.0/lib/python3.10/site-packages/twisted/trial/_synctest.py", line 1068, in run
    >     warnings.warn_explicit(**w)
    > sqlalchemy.exc.RemovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
