### PR TITLE
laspy: init at 2.3.0

### DIFF
--- a/pkgs/development/python-modules/laspy/default.nix
+++ b/pkgs/development/python-modules/laspy/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, laszip
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "laspy";
+  version = "2.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Wdbp6kjuZkJh+pp9OVczdsRNgn41/Tdt7nGFvewcQ1w=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    laszip
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "laspy" "laszip" ];
+
+  meta = with lib; {
+    description = "Interface for reading/modifying/creating .LAS LIDAR files";
+    homepage = "https://github.com/laspy/laspy";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ matthewcroughan ];
+  };
+}

--- a/pkgs/development/python-modules/laszip/default.nix
+++ b/pkgs/development/python-modules/laszip/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, scikit-build-core
+, distlib
+, pytestCheckHook
+, pyproject-metadata
+, pathspec
+, pybind11
+, cmake
+, LASzip
+}:
+
+buildPythonPackage rec {
+  pname = "laszip-python";
+  version = "0.2.1";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "tmontaigu";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-ujKoUm2Btu25T7ZrSGqjRc3NR1qqsQU8OwHQDSx8grY=";
+  };
+
+  nativeBuildInputs = [
+    scikit-build-core
+    scikit-build-core.optional-dependencies.pyproject
+    cmake
+  ];
+
+  buildInputs = [
+    pybind11
+    LASzip
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  preBuild = ''
+    cd ..
+  '';
+
+  # There are no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "laszip" ];
+
+  meta = with lib; {
+    description = "Unofficial bindings between Python and LASzip made using pybind11";
+    homepage = "https://github.com/tmontaigu/laszip-python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ matthewcroughan ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5311,6 +5311,8 @@ self: super: with self; {
 
   laspy = callPackage ../development/python-modules/laspy { };
 
+  laszip = callPackage ../development/python-modules/laszip { };
+
   latexcodec = callPackage ../development/python-modules/latexcodec { };
 
   latexify-py = callPackage ../development/python-modules/latexify-py { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5309,6 +5309,8 @@ self: super: with self; {
 
   larynx-train = callPackage ../development/python-modules/larynx-train { };
 
+  laspy = callPackage ../development/python-modules/laspy { };
+
   latexcodec = callPackage ../development/python-modules/latexcodec { };
 
   latexify-py = callPackage ../development/python-modules/latexify-py { };


### PR DESCRIPTION
###### Description of changes

Adds laspy, a pythonic interface for reading/modifying/creating .LAS LIDAR files

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
