### PR TITLE
{documentation-highlighter,zsh-clipboard}: Remove dependency on Nix files

### DIFF
--- a/pkgs/misc/documentation-highlighter/default.nix
+++ b/pkgs/misc/documentation-highlighter/default.nix
@@ -7,6 +7,16 @@ runCommand "documentation-highlighter" {
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.grahamc ];
   };
+  src = lib.sources.cleanSourceWith {
+    src = ./.;
+    filter = path: type: lib.elem path (map toString [
+      ./highlight.pack.js
+      ./LICENSE
+      ./loader.js
+      ./mono-blue.css
+      ./README.md
+    ]);
+  };
 } ''
-  cp -r ${./.} $out
+  cp -r "$src" "$out"
 ''

--- a/pkgs/shells/zsh/zsh-clipboard/default.nix
+++ b/pkgs/shells/zsh/zsh-clipboard/default.nix
@@ -4,13 +4,12 @@ stdenv.mkDerivation rec {
   pname = "zsh-clipboard";
   version = "1.0";
 
-  src = ./.;
-
+  dontUnpack = true;
   strictDeps = true;
   dontBuild = true;
 
   installPhase = ''
-    install -D -m0444 -t $out/share/zsh/plugins/clipboard ./clipboard.plugin.zsh
+    install -D -m0444 -T ${./clipboard.plugin.zsh} $out/share/zsh/plugins/clipboard/clipboard.plugin.zsh
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
`pkgs.documentation-highlighter` and `pkgs.zsh-clipboard` currently depend on the Nix files that define them, meaning that they have to be rebuilt whenever those files change. This PR fixes that.

Note that the NixOS and nixpkgs manuals depend on `documentation-highlighter` (ping @grahamc), I verified that they still build.

This was noticed while working on https://github.com/NixOS/nixpkgs/pull/211832.

###### Things done

On x86_64-linux:
- [x] `nix-build -A documentation-highlighter`
- [x] `nix-build -A zsh-clipboard`
- [x] `nix-build nixos/release.nix -A manualHTML.x86_64-linux`
- [x] `nix-build doc`