### PR TITLE
gsocket: init at 1.4.39

### DIFF
--- a/pkgs/tools/networking/gsocket/default.nix
+++ b/pkgs/tools/networking/gsocket/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "gsocket";
+  version = "1.4.39";
+
+  src = fetchFromGitHub {
+    owner = "hackerschoice";
+    repo = "gsocket";
+    rev = "v${version}";
+    sha256 = "sha256-iSII21X3F4Cb1UqF0aYw23N7CyeTQMmziRioEULx9Zk=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ openssl ];
+  dontDisableStatic = true;
+
+  meta = with lib; {
+    description = "Connect like there is no firewall, securely";
+    homepage = "https://www.gsocket.io";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.msm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4779,6 +4779,8 @@ with pkgs;
 
   gsctl = callPackage ../applications/misc/gsctl { };
 
+  gsocket = callPackage ../tools/networking/gsocket { };
+
   gthree = callPackage ../development/libraries/gthree { };
 
   gtg = callPackage ../applications/office/gtg { };


### PR DESCRIPTION
###### Description of changes

This is not actually my work, I just updated a stale PR #120695

This adds gsocket (https://github.com/hackerschoice/gsocket) to nixpkgs.

Many people (me included) use gsocket often (for a lack of better metric, it has >1k stars on github). I believe it deserves 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
