### PR TITLE
ocamlPackages.paf: add local networking for test

### DIFF
--- a/pkgs/development/ocaml-modules/paf/cohttp.nix
+++ b/pkgs/development/ocaml-modules/paf/cohttp.nix
@@ -47,6 +47,8 @@ buildDunePackage {
     astring
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = paf.meta // {
     description = "A CoHTTP client with its HTTP/AF implementation";
   };

--- a/pkgs/development/ocaml-modules/paf/default.nix
+++ b/pkgs/development/ocaml-modules/paf/default.nix
@@ -61,6 +61,8 @@ buildDunePackage rec {
     alcotest-lwt
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = {
     description = "HTTP/AF and MirageOS";
     license = lib.licenses.mit;


### PR DESCRIPTION
in test we can read this:
```
[exception] Unix.Unix_error(Unix.EPERM, "bind", "")
            Raised by primitive operation at Tcpv4v6_socket.listen.(fun) in file "src/stack-unix/tcpv4v6_socket.ml", line 149, characters 6-50
```

I don't know if their is a finer sandbox option: it doesn't seems.
https://github.com/NixOS/nix/blob/d21f54958ebc3400ca41e0458338e6a90bd47fbe/src/libstore/build/local-derivation-goal.cc#L2114-L2134

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
