### PR TITLE
moltenvk: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/os-specific/darwin/moltenvk/default.nix
+++ b/pkgs/os-specific/darwin/moltenvk/default.nix
@@ -25,60 +25,22 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "MoltenVK";
   version = "1.2.0";
 
-  buildInputs = [ AppKit Foundation Metal QuartzCore cereal ]
-    ++ lib.attrValues finalAttrs.passthru;
+  buildInputs = [
+    AppKit
+    Foundation
+    Metal
+    QuartzCore
+    cereal
+    glslang
+    spirv-cross
+    spirv-headers
+    spirv-tools
+    vulkan-headers
+  ];
 
   nativeBuildInputs = [ cctools sigtool xcbuild ];
 
   outputs = [ "out" "bin" "dev" ];
-
-  # MoltenVK requires specific versions of its dependencies.
-  # Pin them here except for cereal, which is four years old and has several CVEs.
-  passthru = {
-    glslang = (glslang.overrideAttrs (old: {
-      src = fetchFromGitHub {
-        owner = "KhronosGroup";
-        repo = "glslang";
-        rev = "5755de46b07e4374c05fb1081f65f7ae1f8cca81";
-        hash = "sha256-huPrQr+lPi7QCF8CufAavHEKGDDimGrcskiojhH9QYk=";
-      };
-      patches = [ ];
-    })).override { inherit (finalAttrs.passthru) spirv-headers spirv-tools; };
-    spirv-cross = spirv-cross.overrideAttrs (old: {
-      cmakeFlags = (old.cmakeFlags or [ ])
-        ++ [ "-DSPIRV_CROSS_NAMESPACE_OVERRIDE=MVK_spirv_cross" ];
-      src = fetchFromGitHub {
-        owner = "KhronosGroup";
-        repo = "SPIRV-Cross";
-        rev = "f09ba2777714871bddb70d049878af34b94fa54d";
-        hash = "sha256-yVpLW1DbcHDuM9Bm3uGhAC0v9XjmpBoU9x7kmWdg6/o=";
-      };
-    });
-    spirv-headers = spirv-headers.overrideAttrs (_: {
-      src = fetchFromGitHub {
-        owner = "KhronosGroup";
-        repo = "spirv-headers";
-        rev = "85a1ed200d50660786c1a88d9166e871123cce39";
-        hash = "sha256-lUWgZYGPu+IaLUrbtyC7R0o3Hq/q7C7BE8r7DAsiC30=";
-      };
-    });
-    spirv-tools = (spirv-tools.overrideAttrs (old: {
-      src = fetchFromGitHub {
-        owner = "KhronosGroup";
-        repo = "spirv-tools";
-        rev = "eb0a36633d2acf4de82588504f951ad0f2cecacb";
-        hash = "sha256-sqjQoz9v9alSPc0ujEcWZxDAWh2S6oAPP1+JZmNCpA0=";
-      };
-    })).override { inherit (finalAttrs.passthru) spirv-headers; };
-    vulkan-headers = vulkan-headers.overrideAttrs (old: {
-      src = fetchFromGitHub {
-        owner = "KhronosGroup";
-        repo = "Vulkan-Headers";
-        rev = "98f440ce6868c94f5ec6e198cc1adda4760e8849";
-        hash = "sha256-EoD48jBoJmIet4BDC6bYxOsKK2358SZ/NcZeM61q/5g=";
-      };
-    });
-  };
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
@@ -98,6 +60,11 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace Scripts/gen_moltenvk_rev_hdr.sh \
       --replace '$'''{BUILT_PRODUCTS_DIR}' "$NIX_BUILD_TOP/$sourceRoot/build/include" \
       --replace '$(git rev-parse HEAD)' ${finalAttrs.src.rev}
+    # Use the SPIRV-Cross packaged in nixpkgs instead of one built specifically for MoltenVK.
+    substituteInPlace MoltenVK/MoltenVK.xcodeproj/project.pbxproj \
+      --replace SPIRV_CROSS_NAMESPACE_OVERRIDE=MVK_spirv_cross SPIRV_CROSS_NAMESPACE_OVERRIDE=spirv_cross
+    substituteInPlace MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj \
+      --replace SPIRV_CROSS_NAMESPACE_OVERRIDE=MVK_spirv_cross SPIRV_CROSS_NAMESPACE_OVERRIDE=spirv_cross
     # Adding all of `usr/include` from the SDK results in header conflicts with `libcxx.dev`.
     # Work around it by symlinking just the SIMD stuff needed by MoltenVK.
     mkdir -p build/include
@@ -108,8 +75,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   NIX_CFLAGS_COMPILE = [
     "-isystem ${lib.getDev libcxx}/include/c++/v1"
-    "-I${finalAttrs.passthru.spirv-cross}/include/spirv_cross"
-    "-I${finalAttrs.passthru.spirv-headers}/include/spirv/unified1/"
+    "-I${lib.getDev spirv-cross}/include/spirv_cross"
+    "-I${lib.getDev spirv-headers}/include/spirv/unified1/"
   ];
 
   buildPhase = ''

--- a/pkgs/os-specific/darwin/moltenvk/default.nix
+++ b/pkgs/os-specific/darwin/moltenvk/default.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "MoltenVK";
-  version = "1.2.0";
+  version = "1.2.1";
 
   buildInputs = [
     AppKit
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "KhronosGroup";
     repo = "MoltenVK";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-PqrKGNGw7nJbirRgIargIV6Jbgoblu+2fn5qdHKI6BI=";
+    hash = "sha256-JqHPKLSFq+8hyOjVZbjh4AsHM8zSF7ZVxlEePmnEC2w=";
   };
 
   patches = [

--- a/pkgs/tools/graphics/spirv-cross/default.nix
+++ b/pkgs/tools/graphics/spirv-cross/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, cmake, python3 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "spirv-cross";
-  version = "MoltenVK-1.1.5";
+  version = "1.3.236.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Cross";
-    rev = version;
-    sha256 = "/t6hAlGY3+bddWg5ERFbqeU4/MAjq+/AEVv1Jy2C0HA=";
+    rev = "sdk-${finalAttrs.version}";
+    hash = "sha256-zx/fjDKgteWizC3O1bL4WSwwPNw2/2m0xCnCiOttgAo=";
   };
 
   nativeBuildInputs = [ cmake python3 ];
@@ -21,4 +21,4 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ Flakebi ];
   };
-}
+})


### PR DESCRIPTION
Updates MoltenVK for the new release using the Vulkan SDK dependencies in nixpkgs instead of overrides.

* Release notes: https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.1

@Flakebi I also bumped spirv-cross to the revision needed by MoltenVK 1.2.1. This presumably obsoletes #157499.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
