### PR TITLE
zulu: 11.52.13 -> 11.62.17 and 8.48.0.53 -> 8.68.0.19

### DIFF
--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -21,11 +21,11 @@
 }:
 
 let
-  version = "8.48.0.53";
-  openjdk = "8.0.265";
+  version = "8.68.0.19";
+  openjdk = "8.0.362";
 
-  sha256_linux = "ed32513524b32a83b3b388831c69d1884df5675bd5069c6d1485fd1a060be209";
-  sha256_darwin = "36f189bfbd0255195848835819377474ba9c1c868e3c204633c451c96e21f30a";
+  sha256_linux = "sha256-jNty0iJoXG+sp7v2fGCrwZWCSZfQ4tkYe8ERixQMKL0=";
+  sha256_darwin = "sha256-3/P3puM6a7tCHP5eZM6IzbdPrqnhY1dTa7QWss9M08M=";
 
   platform = if stdenv.isDarwin then "macosx" else "linux";
   hash = if stdenv.isDarwin then sha256_darwin else sha256_linux;

--- a/pkgs/development/compilers/zulu/default.nix
+++ b/pkgs/development/compilers/zulu/default.nix
@@ -22,12 +22,12 @@
 }:
 
 let
-  version = "11.52.13";
-  openjdk = "11.0.13";
+  version = "11.62.17";
+  openjdk = "11.0.18";
 
-  sha256_x64_linux = "77a126669b26b3a89e0117b0f28cddfcd24fcd7699b2c1d35f921487148b9a9f";
-  sha256_x64_darwin = "a96f9f859350f977319ebb5c2a999c182ab6b99b24c60e19d97c54367868a63e";
-  sha256_aarch64_darwin = "dmzfergSUVz39T30PT/6ZtT8JNqv5lzdX7zUsXsFGJg=";
+  sha256_x64_linux = "sha256-b65oEbDzrrsUw+WaX94USBz/QS74yiMiGZPxqzMmmqs=";
+  sha256_x64_darwin = "sha256-nRRWTWiog8bRblmmPIPE5YibA34St3ZrJpZN91qEDUg=";
+  sha256_aarch64_darwin = "sha256-TBTrBxOfGo6MV+Md49P3sDfqVG1e+NraqfVbw9WTppk=";
 
   platform = if stdenv.isDarwin then "macosx" else "linux";
   hash = if stdenv.isAarch64 && stdenv.isDarwin then sha256_aarch64_darwin else if stdenv.isDarwin then sha256_x64_darwin else sha256_x64_linux;


### PR DESCRIPTION
###### Description of changes

There are a couple of vulnerabilities in the current version:
- https://nvd.nist.gov/vuln/detail/CVE-2022-34169
- https://nvd.nist.gov/vuln/detail/CVE-2021-35550

@alexvorobiev 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
