### PR TITLE
ott: 0.32 → 0.33

### DIFF
--- a/pkgs/applications/science/logic/ott/default.nix
+++ b/pkgs/applications/science/logic/ott/default.nix
@@ -1,18 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, ocaml, opaline }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, ocamlPackages, opaline }:
 
 stdenv.mkDerivation rec {
   pname = "ott";
-  version = "0.32";
+  version = "0.33";
 
   src = fetchFromGitHub {
     owner = "ott-lang";
     repo = "ott";
     rev = version;
-    sha256 = "sha256-vdDsfsIi1gRW1Sowf29VyQ4C5UKyQZaVgS2uTb8VeW4=";
+    hash = "sha256-GzeEiok5kigcmfqf/K/UxvlKkl55zy0vOyiRZ2HyMiE=";
   };
 
   nativeBuildInputs = [ pkg-config opaline ];
-  buildInputs = [ ocaml ];
+  buildInputs = with ocamlPackages; [ ocaml findlib ocamlgraph ];
 
   installTargets = "ott.install";
 


### PR DESCRIPTION
###### Description of changes

Compatibility update: https://github.com/ott-lang/ott/blob/0.33/revision_history.txt#L560-L565

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
