### PR TITLE
hledger-utils: init at 1.12.1 (also init so far unpackaged dependencies)

### DIFF
--- a/pkgs/development/python-modules/drawille/default.nix
+++ b/pkgs/development/python-modules/drawille/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "drawille";
+  version = "0.1.0";
+
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-t4nS8TWbEGKHibIbLfZZycPQxTiEzuJ7DYsa6Twi+8s=";
+  };
+
+  doCheck = false; # pypi package has no tests, git has no tags
+
+  pythonImportsCheck = [
+    "drawille"
+  ];
+
+  meta = with lib; {
+    description = "Drawing in terminal with unicode braille characters";
+    homepage = "https://github.com/asciimoo/drawille";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ nobbz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/drawilleplot/default.nix
+++ b/pkgs/development/python-modules/drawilleplot/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, drawille
+, matplotlib
+}:
+
+buildPythonPackage rec {
+  pname = "drawilleplot";
+  version = "0.1.0";
+
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ZEDroo7KkI2VxdESb2QDX+dPY4UahuuK9L0EddrxJjQ=";
+  };
+
+  doCheck = false; # does not have any tests at all
+
+  propagatedBuildInputs = [
+    drawille
+    matplotlib
+  ];
+
+  pythonImportsCheck = [
+    "drawilleplot"
+  ];
+
+  meta = with lib; {
+    description = "matplotlib backend for graph output in unicode terminals using drawille";
+    homepage = "https://github.com/gooofy/drawilleplot";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ nobbz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/hledger-utils/default.nix
+++ b/pkgs/development/python-modules/hledger-utils/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitLab
+, setuptools
+, setuptools-scm
+, unittestCheckHook
+, hledger
+, perl
+, rich
+, pandas
+, scipy
+, psutil
+, matplotlib
+, drawilleplot
+, asteval
+}:
+
+buildPythonPackage rec {
+  pname = "hledger-utils";
+  version = "1.12.1";
+
+  format = "pyproject";
+
+  src = fetchFromGitLab {
+    owner = "nobodyinperson";
+    repo = "hledger-utils";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-uAFqBNRET3RaWDTyV53onrBs1fjPR4b5rAvg5lweUN0=";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    rich
+    pandas
+    scipy
+    psutil
+    matplotlib
+    drawilleplot
+    asteval
+  ];
+
+  checkInputs = [
+    unittestCheckHook
+  ];
+
+  nativeCheckInputs = [
+    hledger
+    perl
+  ];
+
+  preCheck = ''
+    export PATH=$out/bin:$PATH
+  '';
+
+  meta = with lib; {
+    description = "Utilities extending hledger";
+    homepage = "https://gitlab.com/nobodyinperson/hledger-utils";
+    license = with licenses; [cc0 cc-by-40 gpl3];
+    maintainers = with maintainers; [ nobbz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29831,6 +29831,7 @@ with pkgs;
   hledger-interest = haskell.lib.compose.justStaticExecutables haskellPackages.hledger-interest;
   hledger-ui = haskell.lib.compose.justStaticExecutables haskellPackages.hledger-ui;
   hledger-web = haskell.lib.compose.justStaticExecutables haskellPackages.hledger-web;
+  hledger-utils = with python3.pkgs; toPythonApplication hledger-utils;
 
   homebank = callPackage ../applications/office/homebank {
     gtk = gtk3;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2814,6 +2814,8 @@ self: super: with self; {
 
   dragonfly = callPackage ../development/python-modules/dragonfly { };
 
+  drawille = callPackage ../development/python-modules/drawille { };
+
   dremel3dpy = callPackage ../development/python-modules/dremel3dpy { };
 
   drf-jwt = callPackage ../development/python-modules/drf-jwt { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2816,6 +2816,8 @@ self: super: with self; {
 
   drawille = callPackage ../development/python-modules/drawille { };
 
+  drawilleplot = callPackage ../development/python-modules/drawilleplot { };
+
   dremel3dpy = callPackage ../development/python-modules/dremel3dpy { };
 
   drf-jwt = callPackage ../development/python-modules/drf-jwt { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4319,6 +4319,8 @@ self: super: with self; {
 
   hkdf = callPackage ../development/python-modules/hkdf { };
 
+  hledger-utils = callPackage ../development/python-modules/hledger-utils { };
+
   hlk-sw16 = callPackage ../development/python-modules/hlk-sw16 { };
 
   hmmlearn = callPackage ../development/python-modules/hmmlearn { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds the following three python packages:

* `drawille` at 0.1.0
* `drawilleplot` at 0.1.0
* `hledger-utils` at 1.12.1

Whereas the former have been added as dependencies for the latter.

`hledger-utils` has also been made available as an application at the top-level under the `hledger-utils` attribute, as it provides 2 executables that can be used as a `hledger` "plugin".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
