### PR TITLE
treewide: use hash instead of sha256

### DIFF
--- a/pkgs/applications/misc/madonctl/default.nix
+++ b/pkgs/applications/misc/madonctl/default.nix
@@ -8,10 +8,10 @@ buildGoModule rec {
     owner = "McKael";
     repo = "madonctl";
     rev = "v${version}";
-    sha256 = "sha256-mo185EKjLkiujAKcAFM1XqkXWvcfYbnv+r3dF9ywaf8=";
+    hash = "sha256-mo185EKjLkiujAKcAFM1XqkXWvcfYbnv+r3dF9ywaf8=";
   };
 
-  vendorSha256 = null;
+  vendorHash = null;
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/development/compilers/go-jsonnet/default.nix
+++ b/pkgs/development/compilers/go-jsonnet/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     hash = "sha256-FgQYnas0qkIedRAA8ApZXLzEylg6PS6+8zzl7j+yOeI=";
   };
 
-  vendorSha256 = "sha256-j1fTOUpLx34TgzW94A/BctLrg9XoTtb3cBizhVJoEEI=";
+  vendorHash = "sha256-j1fTOUpLx34TgzW94A/BctLrg9XoTtb3cBizhVJoEEI=";
 
   patches = [
     # See https://github.com/google/go-jsonnet/issues/653.

--- a/pkgs/development/tools/bingo/default.nix
+++ b/pkgs/development/tools/bingo/default.nix
@@ -8,10 +8,10 @@ buildGoModule rec {
     owner = "bwplotka";
     repo = "bingo";
     rev = "v${version}";
-    sha256 = "sha256-s+vdtMzeHUtUlmMlvgnK83RYoMqS3GqrTnu7LssIK6A=";
+    hash = "sha256-s+vdtMzeHUtUlmMlvgnK83RYoMqS3GqrTnu7LssIK6A=";
   };
 
-  vendorSha256 = "sha256-28p1g+p+guJ0x4/5QDGsGN6gDnZkE4AKF/2cFgNjPDM=";
+  vendorHash = "sha256-28p1g+p+guJ0x4/5QDGsGN6gDnZkE4AKF/2cFgNjPDM=";
 
   postPatch = ''
     rm get_e2e_test.go get_e2e_utils_test.go

--- a/pkgs/development/tools/cue/default.nix
+++ b/pkgs/development/tools/cue/default.nix
@@ -8,7 +8,7 @@ buildGoModule rec {
     owner = "cue-lang";
     repo = "cue";
     rev = "v${version}";
-    sha256 = "sha256-v9MYrijnbtJpTgRZ4hmkaekisOyujldGewCRNbkVzWw=";
+    hash = "sha256-v9MYrijnbtJpTgRZ4hmkaekisOyujldGewCRNbkVzWw=";
   };
 
   postPatch = ''
@@ -16,7 +16,7 @@ buildGoModule rec {
     rm -f cmd/cue/cmd/script_test.go
   '';
 
-  vendorSha256 = "sha256-jTfV8DJlr5LxS3HjOEBkVzBvZKiySrmINumXSUIq2mI=";
+  vendorHash = "sha256-jTfV8DJlr5LxS3HjOEBkVzBvZKiySrmINumXSUIq2mI=";
 
   excludedPackages = [ "internal/ci/updatetxtar" "internal/cmd/embedpkg" "internal/cmd/qgo" "pkg/gen" ];
 

--- a/pkgs/development/tools/gojq/default.nix
+++ b/pkgs/development/tools/gojq/default.nix
@@ -8,10 +8,10 @@ buildGoModule rec {
     owner = "itchyny";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-xJx3ge+8cIGL1j5vnU4JhCcwmXIRhJ66PYnEG223Fbc=";
+    hash = "sha256-xJx3ge+8cIGL1j5vnU4JhCcwmXIRhJ66PYnEG223Fbc=";
   };
 
-  vendorSha256 = "sha256-BnDtHqqU/kFJyeG1g4UZ51eSnUlbQ6eRKTFoz6kxl0s=";
+  vendorHash = "sha256-BnDtHqqU/kFJyeG1g4UZ51eSnUlbQ6eRKTFoz6kxl0s=";
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/tools/audio/dsp/default.nix
+++ b/pkgs/tools/audio/dsp/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     owner = "bmc0";
     repo = "dsp";
     rev = "v${version}";
-    sha256 = "sha256-S1pzVQ/ceNsx0vGmzdDWw2TjPVLiRgzR4edFblWsekY=";
+    hash = "sha256-S1pzVQ/ceNsx0vGmzdDWw2TjPVLiRgzR4edFblWsekY=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/tools/filesystems/go-mtpfs/default.nix
+++ b/pkgs/tools/filesystems/go-mtpfs/default.nix
@@ -8,10 +8,10 @@ buildGoModule rec {
     owner = "hanwen";
     repo = "go-mtpfs";
     rev = "v${version}";
-    sha256 = "sha256-HVfB8/MImgZZLx4tcrlYOfQjpAdHMHshEaSsd+n758w=";
+    hash = "sha256-HVfB8/MImgZZLx4tcrlYOfQjpAdHMHshEaSsd+n758w=";
   };
 
-  vendorSha256 = "sha256-OrAEvD2rF0Y0bvCD9TUv/E429lASsvC3uK3qNvbg734=";
+  vendorHash = "sha256-OrAEvD2rF0Y0bvCD9TUv/E429lASsvC3uK3qNvbg734=";
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/tools/misc/claws/default.nix
+++ b/pkgs/tools/misc/claws/default.nix
@@ -8,10 +8,10 @@ buildGoModule rec {
     rev = version;
     owner = "thehowl";
     repo = pname;
-    sha256 = "sha256-3zzUBeYfu9x3vRGX1DionLnAs1e44tFj8Z1dpVwjdCg=";
+    hash = "sha256-3zzUBeYfu9x3vRGX1DionLnAs1e44tFj8Z1dpVwjdCg=";
   };
 
-  vendorSha256 = "sha256-FP+3Rw5IdCahhx9giQrpepMMtF1pWcyjNglrlu9ju0Q=";
+  vendorHash = "sha256-FP+3Rw5IdCahhx9giQrpepMMtF1pWcyjNglrlu9ju0Q=";
 
   ldflags = [ "-s" "-w" ];
 

--- a/pkgs/tools/system/jump/default.nix
+++ b/pkgs/tools/system/jump/default.nix
@@ -8,10 +8,10 @@ buildGoModule rec {
     owner = "gsamokovarov";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-nlCuotEiAX2+xx7T8jWZo2p4LNLhWXDdcU6DxJprgx0=";
+    hash = "sha256-nlCuotEiAX2+xx7T8jWZo2p4LNLhWXDdcU6DxJprgx0=";
   };
 
-  vendorSha256 = "sha256-nMUqZWdq//q/DNthvpKiYLq8f95O0QoItyX5w4vHzSA=";
+  vendorHash = "sha256-nMUqZWdq//q/DNthvpKiYLq8f95O0QoItyX5w4vHzSA=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
