### PR TITLE
jazz2: init at 1.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14716,6 +14716,12 @@
     githubId = 187109;
     name = "Bjarki Ágúst Guðmundsson";
   };
+  surfaceflinger = {
+    email = "nat@nekopon.pl";
+    github = "surfaceflinger";
+    githubId = 44725111;
+    name = "nat";
+  };
   suryasr007 = {
     email = "94suryateja@gmail.com";
     github = "suryasr007";

--- a/pkgs/games/jazz2/content.nix
+++ b/pkgs/games/jazz2/content.nix
@@ -1,0 +1,20 @@
+{ jazz2
+, lib
+, runCommand
+}:
+
+runCommand "jazz2-content"
+{
+  inherit (jazz2) version src;
+
+  preferLocalBuild = true;
+
+  meta = with lib; {
+    description = "Assets needed for jazz2";
+    homepage = "https://github.com/deathkiller/jazz2-native";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ surfaceflinger ];
+  };
+} ''
+  cp -r $src/Content $out
+''

--- a/pkgs/games/jazz2/game.nix
+++ b/pkgs/games/jazz2/game.nix
@@ -1,0 +1,47 @@
+{ cmake
+, fetchFromGitHub
+, glew
+, glfw
+, jazz2-content
+, lib
+, libGL
+, libopenmpt
+, libvorbis
+, openal
+, SDL2
+, stdenv
+, xorg
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "jazz2";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "deathkiller";
+    repo = "jazz2-native";
+    rev = version;
+    sha256 = "fi1waoLAcnZB0lX+8+wQFoBYOSvVXYK3JKiu81GGF4U=";
+  };
+
+  patches = [ ./nocontent.patch ];
+
+  buildInputs = [ libGL SDL2 zlib glew glfw openal libvorbis libopenmpt xorg.libSM xorg.libICE xorg.libXext ];
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DNCINE_DOWNLOAD_DEPENDENCIES=OFF"
+    "-DGLFW_INCLUDE_DIR=${glfw}/include/GLFW"
+    "-DLIBOPENMPT_INCLUDE_DIR=${libopenmpt.dev}/include/libopenmpt"
+    "-DNCINE_OVERRIDE_CONTENT_PATH=${jazz2-content}"
+  ];
+
+  meta = with lib; {
+    description = "Open-source Jazz Jackrabbit 2 reimplementation";
+    homepage = "https://github.com/deathkiller/jazz2-native";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ surfaceflinger ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/jazz2/nocontent.patch
+++ b/pkgs/games/jazz2/nocontent.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/ncine_installation.cmake b/cmake/ncine_installation.cmake
+index 9ccb707..89c350f 100644
+--- a/cmake/ncine_installation.cmake
++++ b/cmake/ncine_installation.cmake
+@@ -195,7 +195,6 @@ endif()
+ #endif()
+ 
+ if(NOT EMSCRIPTEN)
+-	install(DIRECTORY "${NCINE_ROOT}/Content/" DESTINATION ${DATA_INSTALL_DESTINATION})
+ else()
+ 	install(FILES "${CMAKE_BINARY_DIR}/${CPACK_EXECUTABLE_NAME}.html" DESTINATION ".")
+ 	install(FILES "${CMAKE_BINARY_DIR}/${CPACK_EXECUTABLE_NAME}.data" DESTINATION ".")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35877,6 +35877,10 @@ with pkgs;
 
   fish-fillets-ng = callPackage ../games/fish-fillets-ng { };
 
+  jazz2 = callPackage ../games/jazz2/game.nix { };
+
+  jazz2-content = callPackage ../games/jazz2/content.nix { };
+
   jumpy = callPackage ../games/jumpy { };
 
   flightgear = libsForQt5.callPackage ../games/flightgear { };


### PR DESCRIPTION
###### Description of changes

Added a derivation for [Jazz² Resurrection](https://github.com/deathkiller/jazz2-native).

I've set few cmake flags so it won't download prebuilt dependencies, cmake also couldn't find 2 libraries so I fixed it up there too.

If you want to play, you will need original assets, preferably from [GOG](https://www.gog.com/en/game/jazz_jackrabbit_2_collection). GOG's installer sadly has to be ran with wine.

In `~/.local/share/Jazz² Resurrection` you should have this structure of all assets:
```
.
└── Source
    ├── HTML
    ├── JCSHelp
    ├── Tiles
    └── UserLevels
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
