### PR TITLE
python310Packages.anybadge: add missing inputs 

### DIFF
--- a/pkgs/development/python-modules/anybadge/default.nix
+++ b/pkgs/development/python-modules/anybadge/default.nix
@@ -1,8 +1,10 @@
 { lib
-, fetchFromGitHub
 , buildPythonPackage
+, fetchFromGitHub
+, packaging
 , pytestCheckHook
 , pythonOlder
+, requests
 }:
 
 buildPythonPackage rec {
@@ -22,8 +24,23 @@ buildPythonPackage rec {
   # setup.py reads its version from the TRAVIS_TAG environment variable
   TRAVIS_TAG = "v${version}";
 
+  propagatedBuildInputs = [
+    packaging
+  ];
+
   nativeCheckInputs = [
     pytestCheckHook
+    requests
+  ];
+
+  disabledTests = [
+    # Comparison of CLI output fails
+    "test_module_same_output_as_main_cli"
+  ];
+
+  disabledTestPaths = [
+    # No anybadge-server
+    "tests/test_server.py"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/anybadge/default.nix
+++ b/pkgs/development/python-modules/anybadge/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , buildPythonPackage
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -9,11 +10,13 @@ buildPythonPackage rec {
   version = "1.14.0";
   format = "setuptools";
 
+  disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "jongracecox";
     repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-+CkkFCShCYtxKiCWRQcgTFcekc/g7ujQj9MdnG1+a0A=";
+    hash = "sha256-+CkkFCShCYtxKiCWRQcgTFcekc/g7ujQj9MdnG1+a0A=";
   };
 
   # setup.py reads its version from the TRAVIS_TAG environment variable
@@ -30,6 +33,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python tool for generating badges for your projects";
     homepage = "https://github.com/jongracecox/anybadge";
+    changelog = "https://github.com/jongracecox/anybadge/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fabiangd ];
   };


### PR DESCRIPTION
###### Description of changes
Fix build (https://hydra.nixos.org/build/205590502)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
