### PR TITLE
python310Packages.Pyro4: disable on Python >= 3.11

### DIFF
--- a/pkgs/development/python-modules/pyro4/default.nix
+++ b/pkgs/development/python-modules/pyro4/default.nix
@@ -1,12 +1,12 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, serpent
-, dill
 , cloudpickle
+, dill
+, fetchPypi
 , msgpack
-, isPy27
 , pytestCheckHook
+, pythonAtLeast
+, serpent
 }:
 
 buildPythonPackage rec {
@@ -14,7 +14,9 @@ buildPythonPackage rec {
   version = "4.82";
   format = "setuptools";
 
-  disabled = isPy27;
+  # No support Python >= 3.11
+  # https://github.com/irmen/Pyro4/issues/246
+  disabled = pythonAtLeast "3.11";
 
   src = fetchPypi {
     pname = "Pyro4";
@@ -41,10 +43,9 @@ buildPythonPackage rec {
     PYTHONPATH=tests/PyroTests:$PYTHONPATH
   '';
 
-
-  pytestFlagsArray = [
+  disabledTestPaths = [
     # ignore network related tests, which fail in sandbox
-    "--ignore=tests/PyroTests/test_naming.py"
+    "tests/PyroTests/test_naming.py"
   ];
 
   disabledTests = [
@@ -63,7 +64,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Distributed object middleware for Python (RPC)";
     homepage = "https://github.com/irmen/Pyro4";
-    changelog = "https://github.com/irmen/Pyro4/releases/tag/{version}";
+    changelog = "https://github.com/irmen/Pyro4/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ prusnak ];
   };

--- a/pkgs/development/python-modules/pyro4/default.nix
+++ b/pkgs/development/python-modules/pyro4/default.nix
@@ -37,7 +37,9 @@ buildPythonPackage rec {
   ];
 
   # add testsupport.py to PATH
-  preCheck = "PYTHONPATH=tests/PyroTests:$PYTHONPATH";
+  preCheck = ''
+    PYTHONPATH=tests/PyroTests:$PYTHONPATH
+  '';
 
 
   pytestFlagsArray = [
@@ -61,6 +63,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Distributed object middleware for Python (RPC)";
     homepage = "https://github.com/irmen/Pyro4";
+    changelog = "https://github.com/irmen/Pyro4/releases/tag/{version}";
     license = licenses.mit;
     maintainers = with maintainers; [ prusnak ];
   };

--- a/pkgs/development/python-modules/pyro5/default.nix
+++ b/pkgs/development/python-modules/pyro5/default.nix
@@ -1,36 +1,52 @@
-{ buildPythonPackage
-, fetchPypi
-, lib
+{ lib
 , stdenv
+, buildPythonPackage
+, fetchPypi
 , serpent
 , pythonOlder
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
-  pname = "Pyro5";
+  pname = "pyro5";
   version = "5.14";
+  format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-ZP3OE3sP5TLohhTSRrfJi74KT0JnhsUkU5rNxeaUCGo=";
+    pname = "Pyro5";
+    inherit version;
+    hash = "sha256-ZP3OE3sP5TLohhTSRrfJi74KT0JnhsUkU5rNxeaUCGo=";
   };
 
-  propagatedBuildInputs = [ serpent ];
+  propagatedBuildInputs = [
+    serpent
+  ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
-  # ignore network related tests, which fail in sandbox
-  disabledTests = [ "StartNSfunc" "Broadcast" "GetIP" "TestNameServer" "TestBCSetup" ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  disabledTests = [
+    # Ignore network related tests, which fail in sandbox
+    "StartNSfunc"
+    "Broadcast"
+    "GetIP"
+    "TestNameServer"
+    "TestBCSetup"
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "Socket"
+  ];
+
+  pythonImportsCheck = [
+    "Pyro5"
   ];
 
   meta = with lib; {
     description = "Distributed object middleware for Python (RPC)";
     homepage = "https://github.com/irmen/Pyro5";
+    changelog = "https://github.com/irmen/Pyro5/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
