### PR TITLE
treewide: remove global with lib; in pkgs/{misc,networking}

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -16,7 +16,6 @@
 , embree, gmp, libharu
 }:
 
-with lib;
 let
   python = python310Packages.python;
   optix = fetchzip {
@@ -38,7 +37,7 @@ stdenv.mkDerivation rec {
   patches = lib.optional stdenv.isDarwin ./darwin.patch;
 
   nativeBuildInputs = [ cmake makeWrapper python310Packages.wrapPython llvmPackages.llvm.dev ]
-    ++ optionals cudaSupport [ addOpenGLRunpath ];
+    ++ lib.optionals cudaSupport [ addOpenGLRunpath ];
   buildInputs =
     [ boost ffmpeg gettext glew ilmbase
       freetype libjpeg libpng libsamplerate libsndfile libtiff libwebp
@@ -63,10 +62,10 @@ stdenv.mkDerivation rec {
     else [
       llvmPackages.openmp SDL Cocoa CoreGraphics ForceFeedback OpenAL OpenGL
     ])
-    ++ optional jackaudioSupport libjack2
-    ++ optional cudaSupport cudaPackages.cudatoolkit
-    ++ optional colladaSupport opencollada
-    ++ optional spaceNavSupport libspnav;
+    ++ lib.optional jackaudioSupport libjack2
+    ++ lib.optional cudaSupport cudaPackages.cudatoolkit
+    ++ lib.optional colladaSupport opencollada
+    ++ lib.optional spaceNavSupport libspnav;
   pythonPath = with python310Packages; [ numpy requests ];
 
   postPatch = ''
@@ -118,16 +117,16 @@ stdenv.mkDerivation rec {
       "-DWITH_IMAGE_OPENJPEG=ON"
       "-DWITH_OPENCOLLADA=${if colladaSupport then "ON" else "OFF"}"
     ]
-    ++ optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.isDarwin [
       "-DWITH_CYCLES_OSL=OFF" # requires LLVM
       "-DWITH_OPENVDB=OFF" # OpenVDB currently doesn't build on darwin
 
       "-DLIBDIR=/does-not-exist"
     ]
     # Clang doesn't support "-export-dynamic"
-    ++ optional stdenv.cc.isClang "-DPYTHON_LINKFLAGS="
-    ++ optional jackaudioSupport "-DWITH_JACK=ON"
-    ++ optionals cudaSupport [
+    ++ lib.optional stdenv.cc.isClang "-DPYTHON_LINKFLAGS="
+    ++ lib.optional jackaudioSupport "-DWITH_JACK=ON"
+    ++ lib.optionals cudaSupport [
       "-DWITH_CYCLES_CUDA_BINARIES=ON"
       "-DWITH_CYCLES_DEVICE_OPTIX=ON"
       "-DOPTIX_ROOT_DIR=${optix}"
@@ -137,7 +136,7 @@ stdenv.mkDerivation rec {
 
   # Since some dependencies are built with gcc 6, we need gcc 6's
   # libstdc++ in our RPATH. Sigh.
-  NIX_LDFLAGS = optionalString cudaSupport "-rpath ${stdenv.cc.cc.lib}/lib";
+  NIX_LDFLAGS = lib.optionalString cudaSupport "-rpath ${stdenv.cc.cc.lib}/lib";
 
   blenderExecutable =
     placeholder "out" + (if stdenv.isDarwin then "/Applications/Blender.app/Contents/MacOS/Blender" else "/bin/blender");
@@ -154,7 +153,7 @@ stdenv.mkDerivation rec {
 
   # Set RUNPATH so that libcuda and libnvrtc in /run/opengl-driver(-32)/lib can be
   # found. See the explanation in libglvnd.
-  postFixup = optionalString cudaSupport ''
+  postFixup = lib.optionalString cudaSupport ''
     for program in $out/bin/blender $out/bin/.blender-wrapped; do
       isELF "$program" || continue
       addOpenGLRunpath "$program"

--- a/pkgs/applications/misc/electrum/update.nix
+++ b/pkgs/applications/misc/electrum/update.nix
@@ -10,8 +10,6 @@
 , nix
 }:
 
-with lib;
-
 let
   downloadPageUrl = "https://download.electrum.org";
 
@@ -23,7 +21,7 @@ writeScript "update-electrum" ''
 
 set -eu -o pipefail
 
-export PATH=${makeBinPath [
+export PATH=${lib.makeBinPath [
   common-updater-scripts
   coreutils
   curl
@@ -50,7 +48,7 @@ sigFile=$srcFile.asc
 export GNUPGHOME=$PWD/gnupg
 mkdir -m 700 -p "$GNUPGHOME"
 
-gpg --batch --recv-keys ${concatStringsSep " " (map (x: "'${x}'") signingKeys)}
+gpg --batch --recv-keys ${lib.concatStringsSep " " (map (x: "'${x}'") signingKeys)}
 gpg --batch --verify "$sigFile" "$srcFile"
 
 sha256=$(nix-prefetch-url --type sha256 "file://$PWD/$srcFile")

--- a/pkgs/applications/misc/elogind/default.nix
+++ b/pkgs/applications/misc/elogind/default.nix
@@ -25,8 +25,6 @@
 , enableSystemd ? false
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "elogind";
   version = "246.10";
@@ -72,7 +70,7 @@ stdenv.mkDerivation rec {
     "-Dsysconfdir=${placeholder "out"}/etc"
   ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/elogind/elogind";
     description = ''The systemd project's "logind", extracted to a standalone package'';
     platforms = platforms.linux; # probably more

--- a/pkgs/applications/misc/gammu/default.nix
+++ b/pkgs/applications/misc/gammu/default.nix
@@ -4,8 +4,6 @@
 , postgresSupport ? false, postgresql ? null
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "gammu";
   version = "1.42.0";
@@ -31,10 +29,10 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   buildInputs = [ bash bluez libusb1 curl gettext sqlite libiconv ]
-  ++ optionals dbiSupport [ libdbi libdbiDrivers ]
-  ++ optionals postgresSupport [ postgresql ];
+  ++ lib.optionals dbiSupport [ libdbi libdbiDrivers ]
+  ++ lib.optionals postgresSupport [ postgresql ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://wammu.eu/gammu/";
     description = "Command line utility and library to control mobile phones";
     license = licenses.gpl2;

--- a/pkgs/applications/misc/get_iplayer/default.nix
+++ b/pkgs/applications/misc/get_iplayer/default.nix
@@ -1,7 +1,5 @@
 { lib, fetchFromGitHub, atomicparsley, flvstreamer, ffmpeg, makeWrapper, perl, perlPackages, rtmpdump}:
 
-with lib;
-
 perlPackages.buildPerlPackage rec {
   pname = "get_iplayer";
   version = "3.27";
@@ -26,11 +24,11 @@ perlPackages.buildPerlPackage rec {
   installPhase = ''
     mkdir -p $out/bin $out/share/man/man1
     cp get_iplayer $out/bin
-    wrapProgram $out/bin/get_iplayer --suffix PATH : ${makeBinPath [ atomicparsley ffmpeg flvstreamer rtmpdump ]} --prefix PERL5LIB : $PERL5LIB
+    wrapProgram $out/bin/get_iplayer --suffix PATH : ${lib.makeBinPath [ atomicparsley ffmpeg flvstreamer rtmpdump ]} --prefix PERL5LIB : $PERL5LIB
     cp get_iplayer.1 $out/share/man/man1
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Downloads TV and radio from BBC iPlayer";
     license = licenses.gpl3Plus;
     homepage = "https://squarepenguin.co.uk/";

--- a/pkgs/applications/misc/k2pdfopt/default.nix
+++ b/pkgs/applications/misc/k2pdfopt/default.nix
@@ -8,8 +8,6 @@
 , enableTesseract ? true, leptonica, tesseract4
 }:
 
-with lib;
-
 # k2pdfopt is a pain to package. It requires modified versions of mupdf,
 # leptonica, and tesseract.  Instead of shipping patches for these upstream
 # packages, k2pdfopt includes just the modified source files for these
@@ -140,12 +138,12 @@ in stdenv.mkDerivation rec {
     };
   in
     [ zlib libpng ] ++
-    optional enableGSL gsl ++
-    optional enableGhostScript ghostscript ++
-    optional enableMuPDF mupdf_modded ++
-    optional enableDJVU djvulibre ++
-    optional enableGOCR gocr ++
-    optionals enableTesseract [ leptonica_modded tesseract_modded ];
+    lib.optional enableGSL gsl ++
+    lib.optional enableGhostScript ghostscript ++
+    lib.optional enableMuPDF mupdf_modded ++
+    lib.optional enableDJVU djvulibre ++
+    lib.optional enableGOCR gocr ++
+    lib.optionals enableTesseract [ leptonica_modded tesseract_modded ];
 
   dontUseCmakeBuildDir = true;
 
@@ -157,7 +155,7 @@ in stdenv.mkDerivation rec {
     install -D -m 755 k2pdfopt $out/bin/k2pdfopt
   '';
 
-  preFixup = optionalString enableTesseract ''
+  preFixup = lib.optionalString enableTesseract ''
     wrapProgram $out/bin/k2pdfopt --set-default TESSDATA_PREFIX ${tesseract4}/share/tessdata
   '';
 

--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -37,8 +37,6 @@
 , nixosTests
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "keepassxc";
   version = "2.7.4";
@@ -50,13 +48,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-amedKK9nplLVJTldeabN3/c+g/QesrdH+qx+rba2/4s=";
   };
 
-  NIX_CFLAGS_COMPILE = optionalString stdenv.cc.isClang [
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang [
     "-Wno-old-style-cast"
     "-Wno-error"
     "-D__BIG_ENDIAN__=${if stdenv.isBigEndian then "1" else "0"}"
   ];
 
-  NIX_LDFLAGS = optionalString stdenv.isDarwin "-rpath ${libargon2}/lib";
+  NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-rpath ${libargon2}/lib";
 
   patches = [
     ./darwin.patch
@@ -67,13 +65,13 @@ stdenv.mkDerivation rec {
     "-DWITH_GUI_TESTS=ON"
     "-DWITH_XC_UPDATECHECK=OFF"
   ]
-  ++ (optional (!withKeePassX11) "-DWITH_XC_X11=OFF")
-  ++ (optional (withKeePassFDOSecrets && stdenv.isLinux) "-DWITH_XC_FDOSECRETS=ON")
-  ++ (optional (withKeePassYubiKey && stdenv.isLinux) "-DWITH_XC_YUBIKEY=ON")
-  ++ (optional withKeePassBrowser "-DWITH_XC_BROWSER=ON")
-  ++ (optional withKeePassKeeShare "-DWITH_XC_KEESHARE=ON")
-  ++ (optional withKeePassNetworking "-DWITH_XC_NETWORKING=ON")
-  ++ (optional withKeePassSSHAgent "-DWITH_XC_SSHAGENT=ON");
+  ++ (lib.optional (!withKeePassX11) "-DWITH_XC_X11=OFF")
+  ++ (lib.optional (withKeePassFDOSecrets && stdenv.isLinux) "-DWITH_XC_FDOSECRETS=ON")
+  ++ (lib.optional (withKeePassYubiKey && stdenv.isLinux) "-DWITH_XC_YUBIKEY=ON")
+  ++ (lib.optional withKeePassBrowser "-DWITH_XC_BROWSER=ON")
+  ++ (lib.optional withKeePassKeeShare "-DWITH_XC_KEESHARE=ON")
+  ++ (lib.optional withKeePassNetworking "-DWITH_XC_NETWORKING=ON")
+  ++ (lib.optional withKeePassSSHAgent "-DWITH_XC_SSHAGENT=ON");
 
   doCheck = true;
   checkPhase = ''
@@ -112,14 +110,14 @@ stdenv.mkDerivation rec {
     readline
     zlib
   ]
-  ++ optional (stdenv.isDarwin && withKeePassTouchID) darwin.apple_sdk.frameworks.LocalAuthentication
-  ++ optional stdenv.isDarwin qtmacextras
-  ++ optional stdenv.isLinux libusb1
-  ++ optional withKeePassX11 qtx11extras;
+  ++ lib.optional (stdenv.isDarwin && withKeePassTouchID) darwin.apple_sdk.frameworks.LocalAuthentication
+  ++ lib.optional stdenv.isDarwin qtmacextras
+  ++ lib.optional stdenv.isLinux libusb1
+  ++ lib.optional withKeePassX11 qtx11extras;
 
   passthru.tests = nixosTests.keepassxc;
 
-  meta = {
+  meta = with lib; {
     description = "Offline password manager with many features.";
     longDescription = ''
       A community fork of KeePassX, which is itself a port of KeePass Password Safe.

--- a/pkgs/applications/misc/rm-improved/default.nix
+++ b/pkgs/applications/misc/rm-improved/default.nix
@@ -1,7 +1,5 @@
 { fetchFromGitHub, rustPlatform, lib }:
 
-with lib;
-
 rustPlatform.buildRustPackage rec {
   pname = "rm-improved";
   version = "0.13.0";
@@ -15,7 +13,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0d065xia4mwdhxkiqfg7pic6scfzipzmsvvx7l6l97w62lzpiqx3";
   };
 
-  meta = {
+  meta = with lib; {
     description = "Replacement for rm with focus on safety, ergonomics and performance";
     homepage = "https://github.com/nivekuil/rip";
     maintainers = with maintainers; [ nils-degroot ];

--- a/pkgs/applications/misc/slstatus/default.nix
+++ b/pkgs/applications/misc/slstatus/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchgit, pkg-config, writeText, libX11, conf ? null, patches ? [] }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "slstatus";
   version = "unstable-2019-02-16";
@@ -12,8 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0kayyhpmppybhwndxgabw48wsk9v8x9xdb05xrly9szkw3jbvgw4";
   };
 
-  configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
-  preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
+  configFile = lib.optionalString (conf!=null) (writeText "config.def.h" conf);
+  preBuild = lib.optionalString (conf!=null) "cp ${configFile} config.def.h";
 
   inherit patches;
 
@@ -24,7 +22,7 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "PREFIX=$(out)" ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://tools.suckless.org/slstatus/";
     description = "status monitor for window managers that use WM_NAME like dwm";
     license = licenses.isc;

--- a/pkgs/applications/misc/veracrypt/default.nix
+++ b/pkgs/applications/misc/veracrypt/default.nix
@@ -14,14 +14,12 @@
 , btrfs-progs
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "veracrypt";
   version = "1.25.9";
 
   src = fetchurl {
-    url = "https://launchpad.net/${pname}/trunk/${toLower version}/+download/VeraCrypt_${version}_Source.tar.bz2";
+    url = "https://launchpad.net/${pname}/trunk/${lib.toLower version}/+download/VeraCrypt_${version}_Source.tar.bz2";
     sha256 = "sha256-drbhgYS8IaQdKUn/Y9ch1JBUpxbO/zpL13tcNRC3lK8=";
   };
 
@@ -54,7 +52,7 @@ stdenv.mkDerivation rec {
       --replace "Icon=veracrypt" "Icon=veracrypt.xpm"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Free Open-Source filesystem on-the-fly encryption";
     homepage = "https://www.veracrypt.fr/";
     license = with licenses; [ asl20 /* and */ unfree /* TrueCrypt License version 3.0 */ ];

--- a/pkgs/applications/misc/xsuspender/default.nix
+++ b/pkgs/applications/misc/xsuspender/default.nix
@@ -1,8 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, makeWrapper, pkg-config
 , glib, libwnck, procps }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "xsuspender";
   version = "1.3";
@@ -21,10 +19,10 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/xsuspender \
-      --prefix PATH : "${makeBinPath [ procps ]}"
+      --prefix PATH : "${lib.makeBinPath [ procps ]}"
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Auto-suspend inactive X11 applications";
     homepage = "https://kernc.github.io/xsuspender/";
     license = licenses.wtfpl;

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -6,8 +6,6 @@
 , gtk-mac-integration
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "zathura";
   version = "0.5.2";
@@ -28,7 +26,7 @@ stdenv.mkDerivation rec {
     "-Dsynctex=enabled"
     # Make sure tests are enabled for doCheck
     "-Dtests=enabled"
-  ] ++ optional (!stdenv.isLinux) "-Dseccomp=disabled";
+  ] ++ lib.optional (!stdenv.isLinux) "-Dseccomp=disabled";
 
   nativeBuildInputs = [
     meson ninja pkg-config desktop-file-utils python3.pkgs.sphinx
@@ -38,12 +36,12 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk girara libintl sqlite glib file librsvg
     texlive.bin.core
-  ] ++ optional stdenv.isLinux libseccomp
-    ++ optional stdenv.isDarwin gtk-mac-integration;
+  ] ++ lib.optional stdenv.isLinux libseccomp
+    ++ lib.optional stdenv.isDarwin gtk-mac-integration;
 
   doCheck = !stdenv.isDarwin;
 
-  meta = {
+  meta = with lib; {
     homepage = "https://git.pwmt.org/pwmt/zathura";
     description = "A core component for zathura PDF viewer";
     license = licenses.zlib;

--- a/pkgs/applications/networking/appgate-sdp/default.nix
+++ b/pkgs/applications/networking/appgate-sdp/default.nix
@@ -38,7 +38,7 @@
 , xorg
 , zlib
 }:
-with lib;
+
 let
   deps = [
     alsa-lib
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
   version = "6.0.3";
 
   src = fetchurl {
-    url = "https://bin.appgate-sdp.com/${versions.majorMinor version}/client/appgate-sdp_${version}_amd64.deb";
+    url = "https://bin.appgate-sdp.com/${lib.versions.majorMinor version}/client/appgate-sdp_${version}_amd64.deb";
     sha256 = "sha256-UDyVPoQM78CKVWXgr08An77QTiFVmRNHwQPGaj1jAIM=";
   };
 
@@ -134,16 +134,16 @@ stdenv.mkDerivation rec {
         --replace "/etc/appgate.conf" "$out/etc/appgate.conf"
 
     wrapProgram $out/opt/appgate/service/createdump \
-        --set LD_LIBRARY_PATH "${makeLibraryPath [ stdenv.cc.cc ]}"
+        --set LD_LIBRARY_PATH "${lib.makeLibraryPath [ stdenv.cc.cc ]}"
 
     wrapProgram $out/opt/appgate/appgate-driver \
-        --prefix PATH : ${makeBinPath [ iproute2 networkmanager dnsmasq ]} \
+        --prefix PATH : ${lib.makeBinPath [ iproute2 networkmanager dnsmasq ]} \
         --set LD_LIBRARY_PATH $out/opt/appgate/service
 
     # make xdg-open overrideable at runtime
     makeWrapper $out/opt/appgate/Appgate $out/bin/appgate \
-        --suffix PATH : ${makeBinPath [ xdg-utils ]} \
-        --set LD_LIBRARY_PATH $out/opt/appgate:${makeLibraryPath deps}
+        --suffix PATH : ${lib.makeBinPath [ xdg-utils ]} \
+        --set LD_LIBRARY_PATH $out/opt/appgate:${lib.makeLibraryPath deps}
 
     wrapProgram $out/opt/appgate/linux/set_dns --set PYTHONPATH $PYTHONPATH
   '';

--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -3,8 +3,6 @@
 , enableWideVine, ungoogled
 }:
 
-with lib;
-
 mkChromiumDerivation (base: rec {
   name = "chromium-browser";
   packageName = "chromium";
@@ -76,7 +74,7 @@ mkChromiumDerivation (base: rec {
 
   meta = {
     description = "An open source web browser from Google"
-      + optionalString ungoogled ", with dependencies on Google web services removed";
+      + lib.optionalString ungoogled ", with dependencies on Google web services removed";
     longDescription = ''
       Chromium is an open source web browser from Google that aims to build a
       safer, faster, and more stable way for all Internet users to experience
@@ -86,11 +84,11 @@ mkChromiumDerivation (base: rec {
     homepage = if ungoogled
       then "https://github.com/Eloston/ungoogled-chromium"
       else "https://www.chromium.org/";
-    maintainers = with maintainers; if ungoogled
+    maintainers = with lib.maintainers; if ungoogled
       then [ squalus primeos michaeladler ]
       else [ primeos thefloweringash ];
-    license = if enableWideVine then licenses.unfree else licenses.bsd3;
-    platforms = platforms.linux;
+    license = if enableWideVine then lib.licenses.unfree else lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
     mainProgram = "chromium";
     hydraPlatforms = if (channel == "stable" || channel == "ungoogled-chromium")
       then ["aarch64-linux" "x86_64-linux"]

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -51,8 +51,6 @@
 
 buildFun:
 
-with lib;
-
 let
   python3WithPackages = python3.withPackages(ps: with ps; [
     ply jinja2 setuptools
@@ -75,16 +73,16 @@ let
     let
       # Serialize Nix types into GN types according to this document:
       # https://source.chromium.org/gn/gn/+/master:docs/language.md
-      mkGnString = value: "\"${escape ["\"" "$" "\\"] value}\"";
+      mkGnString = value: "\"${lib.escape ["\"" "$" "\\"] value}\"";
       sanitize = value:
         if value == true then "true"
         else if value == false then "false"
-        else if isList value then "[${concatMapStringsSep ", " sanitize value}]"
-        else if isInt value then toString value
-        else if isString value then mkGnString value
+        else if lib.isList value then "[${lib.concatMapStringsSep ", " sanitize value}]"
+        else if lib.isInt value then toString value
+        else if lib.isString value then mkGnString value
         else throw "Unsupported type for GN value `${value}'.";
       toFlag = key: value: "${key}=${sanitize value}";
-    in attrs: concatStringsSep " " (attrValues (mapAttrs toFlag attrs));
+    in attrs: lib.concatStringsSep " " (lib.attrValues (lib.mapAttrs toFlag attrs));
 
   # https://source.chromium.org/chromium/chromium/src/+/master:build/linux/unbundle/replace_gn_files.py
   gnSystemLibraries = [
@@ -151,9 +149,9 @@ let
       libdrm wayland mesa.drivers libxkbcommon
       curl
       libepoxy
-    ] ++ optional systemdSupport systemd
-      ++ optionals cupsSupport [ libgcrypt cups ]
-      ++ optional pulseSupport libpulseaudio;
+    ] ++ lib.optional systemdSupport systemd
+      ++ lib.optionals cupsSupport [ libgcrypt cups ]
+      ++ lib.optional pulseSupport libpulseaudio;
 
     patches = [
       # Optional patch to use SOURCE_DATE_EPOCH in compute_build_timestamp.py (should be upstreamed):
@@ -237,10 +235,10 @@ let
       # Allow building against system libraries in official builds
       sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' tools/generate_shim_headers/generate_shim_headers.py
 
-    '' + optionalString stdenv.isAarch64 ''
+    '' + lib.optionalString stdenv.isAarch64 ''
       substituteInPlace build/toolchain/linux/BUILD.gn \
         --replace 'toolprefix = "aarch64-linux-gnu-"' 'toolprefix = ""'
-    '' + optionalString ungoogled ''
+    '' + lib.optionalString ungoogled ''
       ${ungoogler}/utils/prune_binaries.py . ${ungoogler}/pruning.list || echo "some errors"
       ${ungoogler}/utils/patches.py . ${ungoogler}/patches
       ${ungoogler}/utils/domain_substitution.py apply -r ${ungoogler}/domain_regex.list -f ${ungoogler}/domain_substitution.list -c ./ungoogled-domsubcache.tar.gz .
@@ -300,15 +298,15 @@ let
       # as well to avoid incompatibilities (if this continues to be a problem
       # from time to time):
       use_system_libwayland = true;
-    } // optionalAttrs proprietaryCodecs {
+    } // lib.optionalAttrs proprietaryCodecs {
       # enable support for the H.264 codec
       proprietary_codecs = true;
       enable_hangout_services_extension = true;
       ffmpeg_branding = "Chrome";
-    } // optionalAttrs pulseSupport {
+    } // lib.optionalAttrs pulseSupport {
       use_pulseaudio = true;
       link_pulseaudio = true;
-    } // optionalAttrs ungoogled (importTOML ./ungoogled-flags.toml)
+    } // lib.optionalAttrs ungoogled (lib.importTOML ./ungoogled-flags.toml)
     // (extraAttrs.gnFlags or {}));
 
     configurePhase = ''
@@ -317,7 +315,7 @@ let
       # This is to ensure expansion of $out.
       libExecPath="${libExecPath}"
       ${python3}/bin/python3 build/linux/unbundle/replace_gn_files.py --system-libraries ${toString gnSystemLibraries}
-      ${gnChromium}/bin/gn gen --args=${escapeShellArg gnFlags} out/Release | tee gn-gen-outputs.txt
+      ${gnChromium}/bin/gn gen --args=${lib.escapeShellArg gnFlags} out/Release | tee gn-gen-outputs.txt
 
       # Fail if `gn gen` contains a WARNING.
       grep -o WARNING gn-gen-outputs.txt && echo "Found gn WARNING, exiting nix build" && exit 1
@@ -342,7 +340,7 @@ let
       '';
       targets = extraAttrs.buildTargets or [];
       commands = map buildCommand targets;
-    in concatStringsSep "\n" commands;
+    in lib.concatStringsSep "\n" commands;
 
     postFixup = ''
       # Make sure that libGLESv2 is found by dlopen (if using EGL).

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -47,8 +47,6 @@
 , addOpenGLRunpath
 }:
 
-with lib;
-
 let
   opusWithCustomModes = libopus.override {
     withCustomModes = true;
@@ -68,8 +66,8 @@ let
     bzip2 libcap at-spi2-atk at-spi2-core
     libkrb5 libdrm libglvnd mesa coreutils
     libxkbcommon pipewire wayland
-  ] ++ optional pulseSupport libpulseaudio
-    ++ optional libvaSupport libva
+  ] ++ lib.optional pulseSupport libpulseaudio
+    ++ lib.optional libvaSupport libva
     ++ [ gtk3 ];
 
   suffix = if channel != "stable" then "-" + channel else "";
@@ -99,8 +97,8 @@ in stdenv.mkDerivation {
     tar xf data.tar.xz
   '';
 
-  rpath = makeLibraryPath deps + ":" + makeSearchPathOutput "lib" "lib64" deps;
-  binpath = makeBinPath deps;
+  rpath = lib.makeLibraryPath deps + ":" + lib.makeSearchPathOutput "lib" "lib64" deps;
+  binpath = lib.makeBinPath deps;
 
   installPhase = ''
     runHook preInstall
@@ -149,7 +147,7 @@ in stdenv.mkDerivation {
       --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:${addOpenGLRunpath.driverLink}/share" \
       --set CHROME_WRAPPER  "google-chrome-$dist" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
-      --add-flags ${escapeShellArg commandLineArgs}
+      --add-flags ${lib.escapeShellArg commandLineArgs}
 
     for elf in $out/share/google/$appname/{chrome,chrome-sandbox,${crashpadHandlerBinary},nacl_helper}; do
       patchelf --set-rpath $rpath $elf
@@ -159,7 +157,7 @@ in stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A freeware web browser developed by Google";
     homepage = "https://www.google.com/chrome/browser/";
     license = licenses.unfree;

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -53,10 +53,8 @@
 , extraPrefs ? ""
 }:
 
-with lib;
-
 let
-  libPath = makeLibraryPath libPkgs;
+  libPath = lib.makeLibraryPath libPkgs;
 
   libPkgs = [
     atk
@@ -78,13 +76,13 @@ let
     stdenv.cc.libc
     zlib
   ]
-  ++ optionals pulseaudioSupport [ libpulseaudio ]
-  ++ optionals mediaSupport [
+  ++ lib.optionals pulseaudioSupport [ libpulseaudio ]
+  ++ lib.optionals mediaSupport [
     ffmpeg
   ];
 
   # Library search path for the fte transport
-  fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
+  fteLibPath = lib.makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
   version = "11.5.8";
@@ -156,7 +154,7 @@ stdenv.mkDerivation rec {
     libPath=${libPath}:$TBB_IN_STORE:$TBB_IN_STORE/TorBrowser/Tor
 
     # apulse uses a non-standard library path.  For now special-case it.
-    ${optionalString (audioSupport && !pulseaudioSupport) ''
+    ${lib.optionalString (audioSupport && !pulseaudioSupport) ''
       libPath=${apulse}/lib/apulse:$libPath
     ''}
 
@@ -224,7 +222,7 @@ stdenv.mkDerivation rec {
       clearPref("security.sandbox.content.write_path_whitelist");
     ''}
 
-    ${optionalString (extraPrefs != "") ''
+    ${lib.optionalString (extraPrefs != "") ''
       ${extraPrefs}
     ''}
     EOF
@@ -251,14 +249,14 @@ stdenv.mkDerivation rec {
     GeoIPv6File $TBB_IN_STORE/TorBrowser/Data/Tor/geoip6
     EOF
 
-    WRAPPER_LD_PRELOAD=${optionalString useHardenedMalloc
+    WRAPPER_LD_PRELOAD=${lib.optionalString useHardenedMalloc
       "${graphene-hardened-malloc}/lib/libhardened_malloc.so"}
 
-    WRAPPER_XDG_DATA_DIRS=${concatMapStringsSep ":" (x: "${x}/share") [
+    WRAPPER_XDG_DATA_DIRS=${lib.concatMapStringsSep ":" (x: "${x}/share") [
       gnome.adwaita-icon-theme
       shared-mime-info
     ]}
-    WRAPPER_XDG_DATA_DIRS+=":"${concatMapStringsSep ":" (x: "${x}/share/gsettings-schemas/${x.name}") [
+    WRAPPER_XDG_DATA_DIRS+=":"${lib.concatMapStringsSep ":" (x: "${x}/share/gsettings-schemas/${x.name}") [
       glib
       gsettings-desktop-schemas
       gtk3
@@ -270,7 +268,7 @@ stdenv.mkDerivation rec {
     #! ${runtimeShell}
     set -o errexit -o nounset
 
-    PATH=${makeBinPath [ coreutils ]}
+    PATH=${lib.makeBinPath [ coreutils ]}
     export LC_ALL=C
     export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive
 
@@ -317,7 +315,7 @@ stdenv.mkDerivation rec {
     : "\''${XDG_RUNTIME_DIR:=/run/user/\$(id -u)}"
     : "\''${XDG_CONFIG_HOME:=\$REAL_HOME/.config}"
 
-    ${optionalString pulseaudioSupport ''
+    ${lib.optionalString pulseaudioSupport ''
       # Figure out some envvars for pulseaudio
       : "\''${PULSE_SERVER:=\$XDG_RUNTIME_DIR/pulse/native}"
       : "\''${PULSE_COOKIE:=\$XDG_CONFIG_HOME/pulse/cookie}"

--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -25,8 +25,6 @@
 , pkgsBuildBuild
 }:
 
-with lib;
-
 # k3s is a kinda weird derivation. One of the main points of k3s is the
 # simplicity of it being one binary that can perform several tasks.
 # However, when you have a good package manager (like nix), that doesn't
@@ -73,7 +71,7 @@ let
   # run `grep github.com/kubernetes-sigs/cri-tools go.mod | head -n1 | awk '{print $4}'` in the k3s repo at the tag
   criCtlVersion = "1.26.0-rc.0-k3s1";
 
-  baseMeta = {
+  baseMeta = with lib; {
     description = "A lightweight Kubernetes distribution";
     license = licenses.asl20;
     homepage = "https://k3s.io";

--- a/pkgs/applications/networking/cluster/spark/default.nix
+++ b/pkgs/applications/networking/cluster/spark/default.nix
@@ -12,8 +12,6 @@
 , R
 }:
 
-with lib;
-
 let
   spark = { pname, version, sha256, extraMeta ? {} }:
     stdenv.mkDerivation rec {
@@ -26,7 +24,7 @@ let
       nativeBuildInputs = [ makeWrapper ];
       buildInputs = [ jdk python3Packages.python ]
         ++ extraPythonPackages
-        ++ optional RSupport R;
+        ++ lib.optional RSupport R;
 
       untarDir = "${pname}-${version}";
       installPhase = ''
@@ -38,12 +36,12 @@ let
         cat > $out/lib/${untarDir}/conf/spark-env.sh <<- EOF
         export JAVA_HOME="${jdk}"
         export SPARK_HOME="$out/lib/${untarDir}"
-      '' + optionalString hadoopSupport ''
+      '' + lib.optionalString hadoopSupport ''
         export SPARK_DIST_CLASSPATH=$(${hadoop}/bin/hadoop classpath)
       '' + ''
         export PYSPARK_PYTHON="${python3Packages.python}/bin/${python3Packages.python.executable}"
         export PYTHONPATH="\$PYTHONPATH:$PYTHONPATH"
-        ${optionalString RSupport ''
+        ${lib.optionalString RSupport ''
           export SPARKR_R_SHELL="${R}/bin/R"
           export PATH="\$PATH:${R}/bin"''}
         EOF
@@ -64,10 +62,10 @@ let
       meta = {
         description = "Apache Spark is a fast and general engine for large-scale data processing";
         homepage = "https://spark.apache.org/";
-        sourceProvenance = with sourceTypes; [ binaryBytecode ];
+        sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
         license = lib.licenses.asl20;
         platforms = lib.platforms.all;
-        maintainers = with maintainers; [ thoughtpolice offline kamilchm illustris ];
+        maintainers = with lib.maintainers; [ thoughtpolice offline kamilchm illustris ];
       } // extraMeta;
     };
 in

--- a/pkgs/applications/networking/droopy/default.nix
+++ b/pkgs/applications/networking/droopy/default.nix
@@ -1,7 +1,5 @@
 { stdenv, lib, fetchFromGitHub, wrapPython, fetchpatch }:
 
-with lib;
-
 stdenv.mkDerivation {
   pname = "droopy";
   version = "20160830";
@@ -32,7 +30,7 @@ stdenv.mkDerivation {
     wrapPythonPrograms
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Mini Web server that let others upload files to your computer";
     homepage = "http://stackp.online.fr/droopy";
     license = licenses.bsd3;

--- a/pkgs/applications/networking/instant-messengers/bitlbee-discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-discord/default.nix
@@ -1,6 +1,5 @@
 { lib, fetchFromGitHub, stdenv, bitlbee, autoreconfHook, pkg-config, glib }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "bitlbee-discord";
   version = "0.4.3";
@@ -21,7 +20,7 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Bitlbee plugin for Discord";
 
     homepage = "https://github.com/sm00th/bitlbee-discord";

--- a/pkgs/applications/networking/instant-messengers/bitlbee-mastodon/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-mastodon/default.nix
@@ -1,6 +1,5 @@
 { lib, fetchgit, stdenv, bitlbee, autoreconfHook, pkg-config, glib }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "bitlbee-mastodon";
   version = "1.4.5";
@@ -19,7 +18,7 @@ stdenv.mkDerivation rec {
     export BITLBEE_DATADIR=$out/share/bitlbee
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Bitlbee plugin for Mastodon";
     homepage = "https://alexschroeder.ch/cgit/bitlbee-mastodon/about";
     license = licenses.gpl2Plus;

--- a/pkgs/applications/networking/instant-messengers/bitlbee-steam/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-steam/default.nix
@@ -1,6 +1,5 @@
 { lib, fetchFromGitHub, stdenv, bitlbee, autoconf, automake, libtool, pkg-config, libgcrypt }:
 
-with lib;
 stdenv.mkDerivation rec {
   version = "1.4.2";
   pname = "bitlbee-steam";
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Steam protocol plugin for BitlBee";
 
     homepage = "https://github.com/jgeboski/bitlbee-steam";

--- a/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
@@ -3,7 +3,6 @@
 , enablePam ? false, pam ? null
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "bitlbee";
   version = "3.6";
@@ -13,11 +12,11 @@ stdenv.mkDerivation rec {
     sha256 = "0zhhcbcr59sx9h4maf8zamzv2waya7sbsl7w74gbyilvy93dw5cz";
   };
 
-  nativeBuildInputs = [ pkg-config ] ++ optional doCheck check;
+  nativeBuildInputs = [ pkg-config ] ++ lib.optional doCheck check;
 
   buildInputs = [ gnutls libotr python3 ]
-    ++ optional enableLibPurple pidgin
-    ++ optional enablePam pam;
+    ++ lib.optional enableLibPurple pidgin
+    ++ lib.optional enablePam pam;
 
   propagatedBuildInputs = [ glib ];
 
@@ -25,8 +24,8 @@ stdenv.mkDerivation rec {
     "--otr=1"
     "--ssl=gnutls"
     "--pidfile=/var/lib/bitlbee/bitlbee.pid"
-  ] ++ optional enableLibPurple "--purple=1"
-    ++ optional enablePam "--pam=1";
+  ] ++ lib.optional enableLibPurple "--purple=1"
+    ++ lib.optional enablePam "--pam=1";
 
   patches = [
     # This should be dropped once the issue is fixed upstream.
@@ -46,7 +45,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     description = "IRC instant messaging gateway";
 
     longDescription = ''

--- a/pkgs/applications/networking/instant-messengers/bitlbee/plugins.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/plugins.nix
@@ -1,7 +1,5 @@
 { lib, runCommandLocal, bitlbee }:
 
-with lib;
-
 plugins: runCommandLocal "bitlbee-plugins" {
   inherit plugins;
   buildInputs = [ bitlbee plugins ];

--- a/pkgs/applications/networking/instant-messengers/ratox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ratox/default.nix
@@ -1,10 +1,8 @@
 { lib, stdenv, fetchgit, libtoxcore
 , conf ? null }:
 
-with lib;
-
 let
-  configFile = optionalString (conf!=null) (builtins.toFile "config.h" conf);
+  configFile = lib.optionalString (conf!=null) (builtins.toFile "config.h" conf);
 
 in stdenv.mkDerivation {
   pname = "ratox";
@@ -22,12 +20,12 @@ in stdenv.mkDerivation {
     substituteInPlace config.mk \
       --replace '-lsodium -lopus -lvpx ' ""
 
-    ${optionalString (conf!=null) "cp ${configFile} config.def.h"}
+    ${lib.optionalString (conf!=null) "cp ${configFile} config.def.h"}
   '';
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  meta = {
+  meta = with lib; {
     description = "FIFO based tox client";
     homepage = "http://ratox.2f30.org/";
     license = licenses.isc;

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -65,8 +65,6 @@
 , MetalKit
 }:
 
-with lib;
-
 let
   tg_owt = callPackage ./tg_owt.nix {
     abseil-cpp = abseil-cpp.override {
@@ -99,14 +97,14 @@ stdenv.mkDerivation rec {
     ./shortcuts-binary-path.patch
   ];
 
-  postPatch = optionalString stdenv.isLinux ''
+  postPatch = lib.optionalString stdenv.isLinux ''
     substituteInPlace Telegram/ThirdParty/libtgvoip/os/linux/AudioInputALSA.cpp \
       --replace '"libasound.so.2"' '"${alsa-lib}/lib/libasound.so.2"'
     substituteInPlace Telegram/ThirdParty/libtgvoip/os/linux/AudioOutputALSA.cpp \
       --replace '"libasound.so.2"' '"${alsa-lib}/lib/libasound.so.2"'
     substituteInPlace Telegram/ThirdParty/libtgvoip/os/linux/AudioPulse.cpp \
       --replace '"libpulse.so.0"' '"${libpulseaudio}/lib/libpulse.so.0"'
-  '' + optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     sed -i "13i#import <CoreAudio/CoreAudio.h>" Telegram/lib_webrtc/webrtc/mac/webrtc_media_devices_mac.mm
     substituteInPlace Telegram/CMakeLists.txt \
       --replace 'COMMAND iconutil' 'COMMAND png2icns' \
@@ -122,7 +120,7 @@ stdenv.mkDerivation rec {
     python3
     wrapQtAppsHook
     removeReferencesTo
-  ] ++ optionals stdenv.isLinux [
+  ] ++ lib.optionals stdenv.isLinux [
     # to build bundled libdispatch
     clang
     extra-cmake-modules
@@ -143,7 +141,7 @@ stdenv.mkDerivation rec {
     rnnoise
     tg_owt
     microsoft_gsl
-  ] ++ optionals stdenv.isLinux [
+  ] ++ lib.optionals stdenv.isLinux [
     kwayland
     alsa-lib
     libpulseaudio
@@ -151,7 +149,7 @@ stdenv.mkDerivation rec {
     glibmm
     jemalloc
     wayland
-  ] ++ optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     Cocoa
     CoreFoundation
     CoreServices
@@ -192,7 +190,7 @@ stdenv.mkDerivation rec {
     "-DDESKTOP_APP_QT6=OFF"
   ];
 
-  installPhase = optionalString stdenv.isDarwin ''
+  installPhase = lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/Applications
     cp -r Kotatogram.app $out/Applications
     ln -s $out/Applications/Kotatogram.app/Contents/MacOS $out/bin
@@ -209,7 +207,7 @@ stdenv.mkDerivation rec {
     inherit tg_owt;
   };
 
-  meta = {
+  meta = with lib; {
     description = "Kotatogram – experimental Telegram Desktop fork";
     longDescription = ''
       Unofficial desktop client for the Telegram messenger, based on Telegram Desktop.

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/with-webkit.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/with-webkit.nix
@@ -1,7 +1,5 @@
 { stdenv, lib, kotatogram-desktop, glib-networking, webkitgtk, makeWrapper }:
 
-with lib;
-
 stdenv.mkDerivation {
   pname = "${kotatogram-desktop.pname}-with-webkit";
   version = kotatogram-desktop.version;
@@ -15,9 +13,9 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     makeWrapper ${kotatogram-desktop}/bin/kotatogram-desktop $out/bin/kotatogram-desktop \
       --prefix GIO_EXTRA_MODULES : ${glib-networking}/lib/gio/modules \
-      --prefix LD_LIBRARY_PATH : ${makeLibraryPath [ webkitgtk ]}
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ webkitgtk ]}
   '';
   meta = kotatogram-desktop.meta // {
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/wavebox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wavebox/default.nix
@@ -3,8 +3,6 @@
 , xorg
 }:
 
-with lib;
-
 let
   bits = "x86_64";
 
@@ -19,7 +17,7 @@ let
     categories = [ "Network" ];
   };
 
-  tarball = "Wavebox_${replaceStrings ["."] ["_"] (toString version)}_linux_${bits}.tar.gz";
+  tarball = "Wavebox_${lib.replaceStrings ["."] ["_"] (toString version)}_linux_${bits}.tar.gz";
 
 in stdenv.mkDerivation {
   pname = "wavebox";
@@ -40,7 +38,7 @@ in stdenv.mkDerivation {
     alsa-lib gtk3 nss
   ];
 
-  runtimeDependencies = [ (getLib udev) libnotify ];
+  runtimeDependencies = [ (lib.getLib udev) libnotify ];
 
   installPhase = ''
     mkdir -p $out/bin $out/opt/wavebox

--- a/pkgs/applications/networking/irc/convos/default.nix
+++ b/pkgs/applications/networking/irc/convos/default.nix
@@ -2,8 +2,6 @@
 , nixosTests
 }:
 
-with lib;
-
 perlPackages.buildPerlPackage rec {
   pname = "convos";
   version = "7.02";
@@ -16,7 +14,7 @@ perlPackages.buildPerlPackage rec {
   };
 
   nativeBuildInputs = [ makeWrapper ]
-    ++ optionals stdenv.isDarwin [ shortenPerlShebang ];
+    ++ lib.optionals stdenv.isDarwin [ shortenPerlShebang ];
 
   buildInputs = with perlPackages; [
     CryptPassphrase CryptPassphraseArgon2 CryptPassphraseBcrypt
@@ -79,7 +77,7 @@ perlPackages.buildPerlPackage rec {
     ln -s $AUTO_SHARE_PATH/public/asset $out/asset
     cp -vR templates $out/templates
     cp cpanfile $out/cpanfile
-  '' + optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     shortenPerlShebang $out/bin/convos
   '' + ''
     wrapProgram $out/bin/convos --set MOJO_HOME $out
@@ -91,6 +89,6 @@ perlPackages.buildPerlPackage rec {
     homepage = "https://convos.chat";
     description = "Convos is the simplest way to use IRC in your browser";
     license = lib.licenses.artistic2;
-    maintainers = with maintainers; [ sgo ];
+    maintainers = with lib.maintainers; [ sgo ];
   };
 }

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -52,8 +52,6 @@
 , enablePluginVcalendar ? true, libical
 }:
 
-with lib;
-
 let
   pythonPkgs = with python3.pkgs; [ python3 wrapPython pygobject3 ];
 
@@ -130,7 +128,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs =
     [ curl gsettings-desktop-schemas glib-networking gtk3 ]
-    ++ concatMap (f: optionals f.enabled f.deps) (filter (f: f ? deps) features)
+    ++ lib.concatMap (f: lib.optionals f.enabled f.deps) (lib.filter (f: f ? deps) features)
   ;
 
   configureFlags =
@@ -141,7 +139,7 @@ in stdenv.mkDerivation rec {
 
       "--disable-gdata-plugin" # Complains about missing libgdata, even when provided
     ] ++
-    (map (feature: map (flag: strings.enableFeature feature.enabled flag) feature.flags) features);
+    (map (feature: map (flag: lib.strings.enableFeature feature.enabled flag) feature.flags) features);
 
   enableParallelBuilding = true;
 
@@ -155,7 +153,7 @@ in stdenv.mkDerivation rec {
     cp claws-mail.desktop $out/share/applications
   '';
 
-  meta = {
+  meta = with lib; {
     description = "The user-friendly, lightweight, and fast email client";
     homepage = "https://www.claws-mail.org/";
     license = licenses.gpl3Plus;

--- a/pkgs/applications/networking/mailreaders/sylpheed/default.nix
+++ b/pkgs/applications/networking/mailreaders/sylpheed/default.nix
@@ -4,8 +4,6 @@
 assert gpgSupport -> gpgme != null;
 assert sslSupport -> openssl != null;
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "sylpheed";
   version = "3.7.0";
@@ -33,17 +31,17 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ gtk2 ]
-    ++ optionals gpgSupport [ gpgme ]
-    ++ optionals sslSupport [ openssl ]
-    ++ optionals stdenv.isDarwin [ Foundation ];
+    ++ lib.optionals gpgSupport [ gpgme ]
+    ++ lib.optionals sslSupport [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [ Foundation ];
 
-  configureFlags = optional gpgSupport "--enable-gpgme"
-    ++ optional sslSupport "--enable-ssl";
+  configureFlags = lib.optional gpgSupport "--enable-gpgme"
+    ++ lib.optional sslSupport "--enable-ssl";
 
   # Undefined symbols for architecture arm64: "_OBJC_CLASS_$_NSAutoreleasePool"
   NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-framework Foundation";
 
-  meta = {
+  meta = with lib; {
     homepage = "https://sylpheed.sraoss.jp/en/";
     description = "Lightweight and user-friendly e-mail client";
     maintainers = with maintainers; [ eelco ];

--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -9,7 +9,6 @@
 assert guiSupport -> (dbus != null);
 assert trackerSearch -> (python3 != null);
 
-with lib;
 mkDerivation rec {
   pname = "qbittorrent";
   version = "4.4.5";
@@ -27,8 +26,8 @@ mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ boost libtorrent-rasterbar qtbase qttools qtsvg ]
-    ++ optional guiSupport dbus # D(esktop)-Bus depends on GUI support
-    ++ optional trackerSearch python3;
+    ++ lib.optional guiSupport dbus # D(esktop)-Bus depends on GUI support
+    ++ lib.optional trackerSearch python3;
 
   # Otherwise qm_gen.pri assumes lrelease-qt5, which does not exist.
   QMAKE_LRELEASE = "lrelease";
@@ -36,11 +35,11 @@ mkDerivation rec {
   configureFlags = [
     "--with-boost-libdir=${boost.out}/lib"
     "--with-boost=${boost.dev}" ]
-    ++ optionals (!guiSupport) [ "--disable-gui" "--enable-systemd" ] # Also place qbittorrent-nox systemd service files
-    ++ optional (!webuiSupport) "--disable-webui"
-    ++ optional debugSupport "--enable-debug";
+    ++ lib.optionals (!guiSupport) [ "--disable-gui" "--enable-systemd" ] # Also place qbittorrent-nox systemd service files
+    ++ lib.optional (!webuiSupport) "--disable-webui"
+    ++ lib.optional debugSupport "--enable-debug";
 
-  qtWrapperArgs = optional trackerSearch "--prefix PATH : ${makeBinPath [ python3 ]}";
+  qtWrapperArgs = lib.optional trackerSearch "--prefix PATH : ${lib.makeBinPath [ python3 ]}";
 
   postInstall = lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/{Applications,bin}
@@ -48,7 +47,7 @@ mkDerivation rec {
     makeWrapper $out/{Applications/qbittorrent.app/Contents/MacOS,bin}/qbittorrent
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Featureful free software BitTorrent client";
     homepage    = "https://www.qbittorrent.org/";
     changelog   = "https://github.com/qbittorrent/qBittorrent/blob/release-${version}/Changelog";

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -8,8 +8,6 @@
 
 assert withQt  -> qt5  != null;
 
-with lib;
-
 let
   version = "4.0.2";
   variant = if withQt then "qt" else "cli";
@@ -39,17 +37,17 @@ in stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = [ "-DQT_NO_DEBUG" ];
 
   nativeBuildInputs = [ asciidoctor bison cmake flex makeWrapper pkg-config python3 perl ]
-    ++ optionals withQt [ qt5.wrapQtAppsHook wrapGAppsHook ];
+    ++ lib.optionals withQt [ qt5.wrapQtAppsHook wrapGAppsHook ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   buildInputs = [
     gettext pcre2 libpcap lua5 libssh nghttp2 openssl libgcrypt
     libgpg-error gnutls geoip c-ares glib zlib
-  ] ++ optionals withQt  (with qt5; [ qtbase qtmultimedia qtsvg qttools ])
-    ++ optionals stdenv.isLinux  [ libcap libnl ]
-    ++ optionals stdenv.isDarwin [ SystemConfiguration ApplicationServices gmp ]
-    ++ optionals (withQt && stdenv.isDarwin) (with qt5; [ qtmacextras ]);
+  ] ++ lib.optionals withQt  (with qt5; [ qtbase qtmultimedia qtsvg qttools ])
+    ++ lib.optionals stdenv.isLinux  [ libcap libnl ]
+    ++ lib.optionals stdenv.isDarwin [ SystemConfiguration ApplicationServices gmp ]
+    ++ lib.optionals (withQt && stdenv.isDarwin) (with qt5; [ qtmacextras ]);
 
   strictDeps = true;
 
@@ -72,7 +70,7 @@ in stdenv.mkDerivation {
             install_name_tool -change "$dylib" "$out/lib/$dylib" "$f"
         done
     done
-  '' else optionalString withQt ''
+  '' else lib.optionalString withQt ''
     pwd
     install -Dm644 -t $out/share/applications ../resources/freedesktop/org.wireshark.Wireshark.desktop
 

--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -9,8 +9,6 @@
 , withDebug ? false
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "znc";
   version = "1.8.2";
@@ -23,12 +21,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ openssl ]
-    ++ optional withPerl perl
-    ++ optional withPython python3
-    ++ optional withTcl tcl
-    ++ optional withCyrus cyrus_sasl
-    ++ optional withUnicode icu
-    ++ optional withZlib zlib;
+    ++ lib.optional withPerl perl
+    ++ lib.optional withPython python3
+    ++ lib.optional withTcl tcl
+    ++ lib.optional withCyrus cyrus_sasl
+    ++ lib.optional withUnicode icu
+    ++ lib.optional withZlib zlib;
 
   configureFlags = [
     (lib.enableFeature withPerl "perl")
@@ -36,8 +34,8 @@ stdenv.mkDerivation rec {
     (lib.enableFeature withTcl "tcl")
     (lib.withFeatureAs withTcl "tcl" "${tcl}/lib")
     (lib.enableFeature withCyrus "cyrus")
-  ] ++ optionals (!withIPv6) [ "--disable-ipv6" ]
-    ++ optionals withDebug [ "--enable-debug" ];
+  ] ++ lib.optionals (!withIPv6) [ "--disable-ipv6" ]
+    ++ lib.optionals withDebug [ "--enable-debug" ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Description of changes

I am trying to split #211241 into smaller changes to get it into a reviewable bulk and try to approach that in smaller groups by pkgs category.

This PR removes the global `with lib;` statements of `pkgs/{misc,networking}`.
 
I tried to follow the rule to replace all with lib; with lib. but if its for the meta attr. For meta i replaced it with  `meta = with lib; {` if there was no other scoping before that. It there was other scoping i tried to follow that.

`pkgs/networking/cluster/hadoop` was skipped as I the needed change was non trivial for me.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
