### PR TITLE
vtk, vtkWithQt5: bump from vtk_8 to vtk_9

### DIFF
--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -39,7 +39,7 @@
 , soqt
 , spaceNavSupport ? stdenv.isLinux
 , swig
-, vtk
+, vtk_8
 , wrapQtAppsHook
 , wrapGAppsHook
 , xercesc
@@ -97,7 +97,7 @@ mkDerivation rec {
     shiboken2
     soqt
     swig
-    vtk
+    vtk_8
     xercesc
     zlib
   ] ++ lib.optionals spaceNavSupport [

--- a/pkgs/applications/science/electronics/appcsxcad/default.nix
+++ b/pkgs/applications/science/electronics/appcsxcad/default.nix
@@ -5,7 +5,7 @@
 , csxcad
 , qcsxcad
 , hdf5
-, vtkWithQt5
+, vtk_8_withQt5
 , qtbase
 , fparser
 , tinyxml
@@ -32,7 +32,7 @@ mkDerivation {
     csxcad
     qcsxcad
     hdf5
-    vtkWithQt5
+    vtk_8_withQt5
     qtbase
     fparser
     tinyxml

--- a/pkgs/applications/science/electronics/csxcad/default.nix
+++ b/pkgs/applications/science/electronics/csxcad/default.nix
@@ -5,7 +5,7 @@
 , tinyxml
 , hdf5
 , cgal_5
-, vtk
+, vtk_8
 , boost
 , gmp
 , mpfr
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     boost
     gmp
     mpfr
-    vtk
+    vtk_8
     fparser
     tinyxml
     hdf5

--- a/pkgs/applications/science/electronics/openems/default.nix
+++ b/pkgs/applications/science/electronics/openems/default.nix
@@ -5,7 +5,7 @@
 , fparser
 , tinyxml
 , hdf5
-, vtk
+, vtk_8
 , boost
 , zlib
 , cmake
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
     fparser
     tinyxml
     hdf5
-    vtk
+    vtk_8
     boost
     zlib
     csxcad

--- a/pkgs/applications/science/physics/elmerfem/default.nix
+++ b/pkgs/applications/science/physics/elmerfem/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, git, gfortran, mpi, blas, liblapack, pkg-config, libGL, libGLU, opencascade, libsForQt5, vtkWithQt5}:
+{ lib, stdenv, fetchFromGitHub, cmake, git, gfortran, mpi, blas, liblapack, pkg-config, libGL, libGLU, opencascade, libsForQt5, vtk_8_withQt5}:
 
 stdenv.mkDerivation rec {
   pname = "elmerfem";
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     libGL
     libGLU
     opencascade
-    vtkWithQt5
+    vtk_8_withQt5
   ];
 
   preConfigure = ''

--- a/pkgs/applications/video/rtabmap/default.nix
+++ b/pkgs/applications/video/rtabmap/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, cmake, opencv, pcl, libusb1, eigen
 , wrapQtAppsHook, qtbase, g2o, ceres-solver, libpointmatcher, octomap, freenect
-, libdc1394, librealsense, libGL, libGLU, vtkWithQt5, wrapGAppsHook, liblapack
+, libdc1394, librealsense, libGL, libGLU, vtk_8_withQt5, wrapGAppsHook, liblapack
 , xorg }:
 
 stdenv.mkDerivation rec {
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     qtbase
     libGL
     libGLU
-    vtkWithQt5
+    vtk_8_withQt5
   ];
 
   # Disable warnings that are irrelevant to us as packagers

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , cmake
 , enableVTK ? true
-, vtk
+, vtk_8
 , ApplicationServices
 , Cocoa
 , enablePython ? false
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   buildInputs = lib.optionals enableVTK [
-    vtk
+    vtk_8
   ] ++ lib.optionals stdenv.isDarwin [
     ApplicationServices
     Cocoa

--- a/pkgs/development/libraries/itk/generic.nix
+++ b/pkgs/development/libraries/itk/generic.nix
@@ -1,7 +1,7 @@
 { version, rev, sourceSha256 }:
 
 { lib, stdenv, fetchFromGitHub, cmake, makeWrapper
-, pkg-config, libX11, libuuid, xz, vtk, Cocoa }:
+, pkg-config, libX11, libuuid, xz, vtk_8, Cocoa }:
 
 stdenv.mkDerivation rec {
   pname = "itk";
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ cmake xz makeWrapper ];
-  buildInputs = [ libX11 libuuid vtk ] ++ lib.optionals stdenv.isDarwin [ Cocoa ];
+  buildInputs = [ libX11 libuuid vtk_8 ] ++ lib.optionals stdenv.isDarwin [ Cocoa ];
 
   postInstall = ''
     wrapProgram "$out/bin/h5c++" --prefix PATH ":" "${pkg-config}/bin"

--- a/pkgs/development/libraries/opencascade/default.nix
+++ b/pkgs/development/libraries/opencascade/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, libGL, libGLU, libXmu, cmake, ninja,
-  pkg-config, fontconfig, freetype, expat, freeimage, vtk, gl2ps, tbb,
+  pkg-config, fontconfig, freetype, expat, freeimage, vtk_8, gl2ps, tbb,
   OpenCL, Cocoa
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ninja pkg-config ];
   buildInputs = [
-    libGL libGLU libXmu freetype fontconfig expat freeimage vtk
+    libGL libGLU libXmu freetype fontconfig expat freeimage vtk_8
     gl2ps tbb
   ]
     ++ optionals stdenv.isDarwin [OpenCL Cocoa]

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -22,7 +22,7 @@
 , enablePython    ? false, pythonPackages ? null
 , enableGtk2      ? false, gtk2
 , enableGtk3      ? false, gtk3
-, enableVtk       ? false, vtk
+, enableVtk       ? false, vtk_8
 , enableFfmpeg    ? false, ffmpeg
 , enableGStreamer ? false, gst_all_1
 , enableTesseract ? false, tesseract, leptonica
@@ -188,7 +188,7 @@ stdenv.mkDerivation {
     ++ lib.optional enablePython pythonPackages.python
     ++ lib.optional enableGtk2 gtk2
     ++ lib.optional enableGtk3 gtk3
-    ++ lib.optional enableVtk vtk
+    ++ lib.optional enableVtk vtk_8
     ++ lib.optional enableJPEG libjpeg
     ++ lib.optional enablePNG libpng
     ++ lib.optional enableTIFF libtiff

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -48,7 +48,7 @@
 , enableGtk3 ? false
 , gtk3
 , enableVtk ? false
-, vtk
+, vtk_8
 , enableFfmpeg ? true
 , ffmpeg
 , enableGStreamer ? true
@@ -253,7 +253,7 @@ stdenv.mkDerivation {
     ++ lib.optional (stdenv.buildPlatform == stdenv.hostPlatform) hdf5
     ++ lib.optional enableGtk2 gtk2
     ++ lib.optional enableGtk3 gtk3
-    ++ lib.optional enableVtk vtk
+    ++ lib.optional enableVtk vtk_8
     ++ lib.optional enableJPEG libjpeg
     ++ lib.optional enablePNG libpng
     ++ lib.optional enableTIFF libtiff

--- a/pkgs/development/libraries/pcl/default.nix
+++ b/pkgs/development/libraries/pcl/default.nix
@@ -6,7 +6,7 @@
 , qhull
 , flann
 , boost
-, vtk
+, vtk_8
 , eigen
 , pkg-config
 , qtbase
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     libpng
     libtiff
     qhull
-    vtk
+    vtk_8
   ];
 
   cmakeFlags = lib.optionals stdenv.isDarwin [

--- a/pkgs/development/libraries/science/biology/mirtk/default.nix
+++ b/pkgs/development/libraries/science/biology/mirtk/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, gtest, fetchFromGitHub, cmake, boost, eigen, python3, vtk, zlib, tbb }:
+{ lib, stdenv, gtest, fetchFromGitHub, cmake, boost, eigen, python3, vtk_8, zlib, tbb }:
 
 stdenv.mkDerivation rec {
   version = "2.0.0";
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ cmake gtest ];
-  buildInputs = [ boost eigen python3 vtk zlib tbb ];
+  buildInputs = [ boost eigen python3 vtk_8 zlib tbb ];
 
   meta = with lib; {
     homepage = "https://github.com/BioMedIA/MIRTK";

--- a/pkgs/development/libraries/science/electronics/qcsxcad/default.nix
+++ b/pkgs/development/libraries/science/electronics/qcsxcad/default.nix
@@ -4,7 +4,7 @@
 , cmake
 , csxcad
 , tinyxml
-, vtkWithQt5
+, vtk_8_withQt5
 , qtbase
 }:
 
@@ -33,7 +33,7 @@ mkDerivation {
   buildInputs = [
     csxcad
     tinyxml
-    vtkWithQt5
+    vtk_8_withQt5
     qtbase
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11071,7 +11071,7 @@ with pkgs;
   rocket = libsForQt5.callPackage ../tools/graphics/rocket { };
 
   rtabmap = libsForQt5.callPackage ../applications/video/rtabmap/default.nix {
-    pcl = pcl.override { vtk = vtkWithQt5; };
+    pcl = pcl.override { vtk_8 = vtk_8_withQt5; };
   };
 
   rtaudio = callPackage ../development/libraries/audio/rtaudio {
@@ -23444,8 +23444,8 @@ with pkgs;
 
   vtk_9_withQt5 = vtk_9.override { enableQt = true; };
 
-  vtk = vtk_8;
-  vtkWithQt5 = vtk_8_withQt5;
+  vtk = vtk_9;
+  vtkWithQt5 = vtk_9_withQt5;
 
   vulkan-caps-viewer = libsForQt5.callPackage ../tools/graphics/vulkan-caps-viewer { };
 


### PR DESCRIPTION
###### Description of changes

Pins `vtk` to `vtk_9` instead of `vtk_8` and similarly for `vtkWithQt5`.  Originally attempted in #178367.

At the moment this is meant to be a no-op so I haven't cherry-picked package updates from the previous PR.

Result of `nixpkgs-review pr` on x64-NixOS:

```
4 packages built:
vtk vtkWithQt5 vtk_8 vtk_8_withQt5
```

@wegank @veprbl 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
