### PR TITLE
libepoxy: fix build without x11 support

### DIFF
--- a/pkgs/development/libraries/libepoxy/default.nix
+++ b/pkgs/development/libraries/libepoxy/default.nix
@@ -50,8 +50,10 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dtests=${if doCheck then "true" else "false"}"
+    "-Degl=${if x11Support then "yes" else "no"}"
     "-Dglx=${if x11Support then "yes" else "no"}"
+    "-Dtests=${lib.boolToString doCheck}"
+    "-Dx11=${lib.boolToString x11Support}"
   ];
 
   NIX_CFLAGS_COMPILE = lib.optionalString x11Support ''-DLIBGL_PATH="${getLib libGL}/lib"'';


### PR DESCRIPTION
###### Description of changes
Fixed this error:
```
libepoxy> In file included from ../include/epoxy/egl.h:46,
libepoxy>                  from ../src/dispatch_common.h:59,
libepoxy>                  from ../src/dispatch_common.c:174:
libepoxy> include/epoxy/egl_generated.h:11:10: fatal error: EGL/eglplatform.h: No such file or directory
libepoxy>    11 | #include "EGL/eglplatform.h"
libepoxy>       |          ^~~~~~~~~~~~~~~~~~~
libepoxy> compilation terminated.
libepoxy> [10/19] Compiling C object 'test/misc defines.p/miscdefines.c.o'
libepoxy> [11/19] Compiling C object 'test/header guards.p/headerguards.c.o'
libepoxy> [12/19] Compiling C object test/gl_version.p/gl_version.c.o
libepoxy> ninja: build stopped: subcommand failed.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
