### PR TITLE
teleport: 11.1.4 -> 11.2.3

### DIFF
--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -23,13 +23,13 @@ let
     owner = "gravitational";
     repo = "teleport";
     rev = "v${version}";
-    hash = "sha256-8S+r5pd8icOljGkxqLsZKmh4+nIwPQErs7RK88q0vOQ=";
+    hash = "sha256-dr+tmWVO7yXRLTvJZoFZzayRWETa8wC/aZ7S/vh8qyk=";
   };
-  version = "11.1.4";
+  version = "11.2.3";
 
   rdpClient = rustPlatform.buildRustPackage rec {
     pname = "teleport-rdpclient";
-    cargoHash = "sha256-XuJTdpb2eIeXnVtuSOlHjZQ8PpwxK4/4siK2S2h6xIw=";
+    cargoHash = "sha256-8NTzX9HeGg9U3bmiZHXHTcKnbJk55YfY2bkjilEyg0g=";
     inherit version src;
 
     buildAndTestSubdir = "lib/srv/desktop/rdp/rdpclient";
@@ -53,16 +53,16 @@ let
   webassets = fetchFromGitHub {
     owner = "gravitational";
     repo = "webassets";
-    # Submodule rev from https://github.com/gravitational/teleport/tree/v11.1.4
-    rev = "5f2597d5987804d37e61da8ae9d1a5a2d6b43ef4";
-    hash = "sha256-meRinI4VsJuRoJznVULHL38bUIu352lf5LRPLlef1OA=";
+    # Submodule rev from https://github.com/gravitational/teleport/tree/v11.2.3
+    rev = "cbddcfda9d5ccba11f02ee61bd305c1f600ee6b0";
+    hash = "sha256-XPcQaMyf6kEj5RDRKjNO5b+n1zj/TpBHcDnGhYVUbts=";
   };
 in
 buildGoModule rec {
   pname = "teleport";
 
   inherit src version;
-  vendorHash = "sha256-nlwBjeh0BlZ3vUQxvaYW0aK5Y2YK1gEar9s1IMJJEMY=";
+  vendorHash = "sha256-rWdRVOaPPK2oXK6fXka4FtuxEkaQf4igm7xlg0wauMs=";
 
   subPackages = [ "tool/tbot" "tool/tctl" "tool/teleport" "tool/tsh" ];
   tags = [ "libfido2" "webassets_embed" ]


### PR DESCRIPTION
###### Description of changes

New upstream version.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).