### PR TITLE
treewide: fonts: remove dontBuild in stdenvNoCC

### DIFF
--- a/pkgs/data/fonts/baekmuk-ttf/default.nix
+++ b/pkgs/data/fonts/baekmuk-ttf/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-CKt9/7VdWIfMlCzjcPXjO3VqVfu06vC5DyRAcOjVGII=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/bakoma-ttf/default.nix
+++ b/pkgs/data/fonts/bakoma-ttf/default.nix
@@ -10,8 +10,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-dYaUMneFn1yC5lIMSLQSNmFRW16AdUXGqWBobzAbPsg=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/caladea/default.nix
+++ b/pkgs/data/fonts/caladea/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-xI0cL9YTycBslZw02nuDiAWeJAjSuxmEXcPtNfduTQk=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/cm-unicode/default.nix
+++ b/pkgs/data/fonts/cm-unicode/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-VIp+vk1IYbEHW15wMrfGVOPqg1zBZDpgFx+jlypOHCg=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/crimson-pro/default.nix
+++ b/pkgs/data/fonts/crimson-pro/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation {
     hash = "sha256-3zFB1AMcC7eNEVA2Mx1OE8rLN9zPzexZ3FtER9wH5ss=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/crimson/default.nix
+++ b/pkgs/data/fonts/crimson/default.nix
@@ -11,8 +11,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-Wp9L77q93TRmrAr0P4iH9gm0tqFY0X/xSsuFcd19aAE=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/culmus/default.nix
+++ b/pkgs/data/fonts/culmus/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-wMaHN0LQdUT2us8q1S65yzkpdNVkJ5ONwd+8g5nGTQU=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/go-font/default.nix
+++ b/pkgs/data/fonts/go-font/default.nix
@@ -10,8 +10,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-rdzt51wY4b7HEr7W/0Ar/FB0zMyf+nKLsOT+CRSEP3o=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/gyre/default.nix
+++ b/pkgs/data/fonts/gyre/default.nix
@@ -10,8 +10,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-+6IufuFf+IoLXoZEPlfHUNgRhKrQNBEZ1OwPD9/uOjg=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/hannom/default.nix
+++ b/pkgs/data/fonts/hannom/default.nix
@@ -10,8 +10,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-Oh8V72tYvVA6Sk0f9UTIkRQYjdUbEB/fmCSaRYfyoP8=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/hermit/default.nix
+++ b/pkgs/data/fonts/hermit/default.nix
@@ -10,8 +10,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-RYXZ2yJ8BIxsgeEwhXz7g0NnWG3kMPZoJaOLMUQyWWQ=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/julia-mono/default.nix
+++ b/pkgs/data/fonts/julia-mono/default.nix
@@ -10,8 +10,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-mq37L3bhUhdjB8z3I9i8+wyLrMSsu/nZrZXOuqE3JlU=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/kacst/default.nix
+++ b/pkgs/data/fonts/kacst/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-byiZzpYiMU6kJs+NSISfHPFzAnJtc8toNIbV/fKiMzg=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/khmeros/default.nix
+++ b/pkgs/data/fonts/khmeros/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-gBcM9YHSuhbxvwfQTvywH/5kN921GOyvGtkROcmcBiw=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/lao/default.nix
+++ b/pkgs/data/fonts/lao/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-DlgdyfhxxzVkNIL+NGsQ+PRlNkCuG3v2OahkIEYx60o=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/lklug-sinhala/default.nix
+++ b/pkgs/data/fonts/lklug-sinhala/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-oPCCa01PMQcCK5fEILgXjrGzoDg+UvxkqK6AgeQaKio=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/lmodern/default.nix
+++ b/pkgs/data/fonts/lmodern/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-xlUuZt6rjW0pX4t6PKWAHkkv3PisGCj7ZwatZPAUNxk=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/luculent/default.nix
+++ b/pkgs/data/fonts/luculent/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-6NxLnTBnvHmTUTFa2wW0AuKPEbCqzaWQyiFVnF0sBqU=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/lxgw-wenkai/default.nix
+++ b/pkgs/data/fonts/lxgw-wenkai/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-Nkd0xXYCnR0NZAk/JCxy+zOlxIxD52Px4F9o2L9mgRE=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/marathi-cursive/default.nix
+++ b/pkgs/data/fonts/marathi-cursive/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-JE9T3UMSYn/JfEWuWHikDJIlt4nZl6GzY98v3vG6di4=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/material-design-icons/default.nix
+++ b/pkgs/data/fonts/material-design-icons/default.nix
@@ -4,8 +4,6 @@ stdenvNoCC.mkDerivation rec {
   pname = "material-design-icons";
   version = "7.1.96";
 
-  dontBuild = true;
-
   src = fetchFromGitHub {
     owner = "Templarian";
     repo = "MaterialDesign-Webfont";

--- a/pkgs/data/fonts/nanum/default.nix
+++ b/pkgs/data/fonts/nanum/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-GlVXH9YUU3wHMkNoz5miBv7N2oUEbwUXlcVoElQ9++4=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/oldsindhi/default.nix
+++ b/pkgs/data/fonts/oldsindhi/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-jOcl+mo6CJ9Lnn3nAUiXXHCJssovVgLoPrbGxj4uzQs=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/takao/default.nix
+++ b/pkgs/data/fonts/takao/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-0wjHNv1yStp0q9D0WfwjgUYoUKcCrXA5jFO8PEVgq5k=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/tibetan-machine/default.nix
+++ b/pkgs/data/fonts/tibetan-machine/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-c/1Sgv7xKHpsJGjY9ZY2qOJHShGHL1robvphFNJOt5w=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/ttf-bitstream-vera/default.nix
+++ b/pkgs/data/fonts/ttf-bitstream-vera/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-21sn33u7MYA269t1rNPpjxvW62YI+3CmfUeM0kPReNw=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/u001/default.nix
+++ b/pkgs/data/fonts/u001/default.nix
@@ -10,8 +10,6 @@ stdenvNoCC.mkDerivation rec {
     stripRoot = false;
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/unfonts-core/default.nix
+++ b/pkgs/data/fonts/unfonts-core/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-OwpydPmqt+jw8ZOMAacOFYF2bVG0lLoUVoPzesVXkY4=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/vdrsymbols/default.nix
+++ b/pkgs/data/fonts/vdrsymbols/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-YxB+JcDkta5are+OQyP/WKDL0vllgn0m26bU9mQ3C/Q=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/wqy-microhei/default.nix
+++ b/pkgs/data/fonts/wqy-microhei/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-KAKsgCOqNqZupudEWFTjoHjTd///QhaTQb0jeHH3IT4=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/wqy-zenhei/default.nix
+++ b/pkgs/data/fonts/wqy-zenhei/default.nix
@@ -9,8 +9,6 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-5LfjBkdb+UJ9F1dXjw5FKJMMhMROqj8WfUxC8RDuddY=";
   };
 
-  dontBuild = true;
-
   installPhase = ''
     runHook preInstall
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
