### PR TITLE
powershell: 7.2.4 -> 7.3.2

### DIFF
--- a/pkgs/shells/powershell/default.nix
+++ b/pkgs/shells/powershell/default.nix
@@ -7,10 +7,10 @@ let archString = if stdenv.isAarch64 then "arm64"
     platformString = if stdenv.isDarwin then "osx"
                      else if stdenv.isLinux then "linux"
                      else throw "unsupported platform";
-    platformSha = if (stdenv.isDarwin && stdenv.isx86_64) then "sha256-bcLyf/sIaFoS1xS4RLPPC9lVFa94IfQlWeXhyXUTsd0="
-                     else if (stdenv.isDarwin && stdenv.isAarch64) then "sha256-2UACjUtyQ611iXmwyiWrGwRVA0FT1cLLMKnY0y4SgoQ="
-                     else if (stdenv.isLinux && stdenv.isx86_64) then "sha256-5AZGwxpEqn3X20rCxPcvuqcQib689ui+e0jvri92EdA="
-                     else if (stdenv.isLinux && stdenv.isAarch64) then "sha256-90Sz32hm+EcK3nFJOGGCSqIEtW7w48G8mizXvcLb8WU="
+    platformSha = if (stdenv.isDarwin && stdenv.isx86_64) then "sha256-JKB7Oy+3KWtVo1Aqmc7vZiO88FrF9+8N/tdGlvIQolM="
+                     else if (stdenv.isDarwin && stdenv.isAarch64) then "sha256-9UwB1tT2VaW+favw/KWPziFMSRWcw7AqeeZvbaGOBqc="
+                     else if (stdenv.isLinux && stdenv.isx86_64) then "sha256-kAcT9av4PFZfYqpS0XwKC0IiquUcVtN30Mq649PUnSM="
+                     else if (stdenv.isLinux && stdenv.isAarch64) then "sha256-3Lm9WYVcfkEVfji/h52VqFy1Jo1AiSQ22JhEGiCPzzM="
                      else throw "unsupported platform";
     platformLdLibraryPath = if stdenv.isDarwin then "DYLD_FALLBACK_LIBRARY_PATH"
                      else if stdenv.isLinux then "LD_LIBRARY_PATH"
@@ -20,7 +20,7 @@ let archString = if stdenv.isAarch64 then "arm64"
 in
 stdenv.mkDerivation rec {
   pname = "powershell";
-  version = "7.2.4";
+  version = "7.3.2";
 
   src = fetchzip {
     url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-${platformString}-${archString}.tar.gz";

--- a/pkgs/shells/powershell/getHashes.sh
+++ b/pkgs/shells/powershell/getHashes.sh
@@ -30,6 +30,9 @@ variant: $plat $arch
 hash: $hash
 "
 
+        rm -r $exDest
+        mkdir $exDest
+
     done
 done
 


### PR DESCRIPTION
###### Description of changes

PowerShell: 7.2.4 → 7.3.2
Also fix the `getHashes.sh` maintainer script

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
