### PR TITLE
vtk: 9.2.2 -> 9.2.5

### DIFF
--- a/pkgs/development/libraries/vtk/9.x.nix
+++ b/pkgs/development/libraries/vtk/9.x.nix
@@ -1,5 +1,5 @@
 import ./generic.nix {
   majorVersion = "9.2";
-  minorVersion = "2";
-  sourceSha256 = "sha256-HFsKK+cfrJb/SDGvaeNQ96DqMWiYH3kMAAcJ3PkSEHU=";
+  minorVersion = "5";
+  sourceSha256 = "sha256-Eo1gG6qYDpjuA0IHl0sz+zjSyYq5z0pXVu/bCe1sCUk=";
 }


### PR DESCRIPTION
###### Description of changes

Routine update.

results of `nixpkgs-review pr` on x64-NixOS (the `sfepy` failure is due to failing dep `mpi4py` and `mayavi` is a 3.11 issue):

```
2 packages failed to build:
python310Packages.sfepy python311Packages.mayavi

7 packages built:
f3d python310Packages.mayavi python310Packages.pyvista python310Packages.vtk python311Packages.vtk vtk_9 vtk_9_withQt5
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
