### PR TITLE
radare2: 5.8.0 -> 5.8.2

### DIFF
--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -31,47 +31,33 @@
 
 let
   # FIXME: Compare revision with
-  # https://github.com/radareorg/radare2/blob/master/libr/arch/p/arm/v35arm64/Makefile#L26-L27
+  # https://github.com/radareorg/radare2/blob/master/libr/arch/p/arm/v35/Makefile#L26-L27
   arm64 = fetchFromGitHub {
     owner = "radareorg";
     repo = "vector35-arch-arm64";
-    rev = "c9e7242972837ac11fc94db05fabcb801a8269c9";
-    hash = "sha256-HFQj23GlLAyyzMGnPq40XaPv5qPDHdDlQOo0Hprc9Cs=";
+    rev = "55d73c6bbb94448a5c615933179e73ac618cf876";
+    hash = "sha256-pZxxp5xDg8mgkGEx7LaBSoKxNPyggFYA4um9YaO20LU=";
   };
   armv7 = fetchFromGitHub {
     owner = "radareorg";
     repo = "vector35-arch-armv7";
-    rev = "dde39f69ffea19fc37e681874b12cb4707bc4f30";
-
-    hash = "sha256-bnWQc0dScM9rhIdzf+iVXvMqYWq/bguEAUQPaZRgdlU=";
+    rev = "f270a6cc99644cb8e76055b6fa632b25abd26024";
+    hash = "sha256-YhfgJ7M8ys53jh1clOzj0I2yfJshXQm5zP0L9kMYsmk=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "radare2";
-  version = "5.8.0";
+  version = "5.8.2";
 
   src = fetchFromGitHub {
     owner = "radare";
     repo = "radare2";
     rev = version;
-    hash = "sha256-9bDwtMNru7tG0L735y+Vrcg7Htk/TV9SVZn7WP4Ap4c=";
+    hash = "sha256-jwr3QPgJ6vKSk8yGxndQ69AickP8PorNDuGyJzHMpV4=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "CVE-2022-4843.patch";
-      url = "https://github.com/radareorg/radare2/commit/842f809d4ec6a12af2906f948657281c9ebc8a24.patch";
-      sha256 = "sha256-asEXW9Ox48w9WQhOA9tleXIvynIjsWb6ItKmFTojgbQ=";
-    })
-    (fetchpatch {
-      name = "CVE-2023-0302.patch";
-      url = "https://github.com/radareorg/radare2/commit/961f0e723903011d4f54c2396e44efa91fcc74ce.patch";
-      hash = "sha256-QinRQDIY4p3P+M3Hh9w3Dv3N/2XTaf3N0nUluHPpAvg=";
-    })
-  ];
-
   preBuild = ''
-    pushd ../libr/arch/p/arm/v35arm64
+    pushd ../libr/arch/p/arm/v35
     cp -r ${arm64} arch-arm64
     chmod -R +w arch-arm64
 


### PR DESCRIPTION
###### Description of changes

https://github.com/radareorg/radare2/releases/tag/5.8.2
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>diffoscope</li>
    <li>iaito</li>
    <li>python310Packages.r2pipe</li>
    <li>python311Packages.r2pipe</li>
    <li>radare2</li>
  </ul>
</details>