### PR TITLE
kubo: 0.17.0 -> 0.18.1

### DIFF
--- a/pkgs/applications/networking/kubo/default.nix
+++ b/pkgs/applications/networking/kubo/default.nix
@@ -2,15 +2,15 @@
 
 buildGoModule rec {
   pname = "kubo";
-  version = "0.17.0"; # When updating, also check if the repo version changed and adjust repoVersion below
+  version = "0.18.0"; # When updating, also check if the repo version changed and adjust repoVersion below
   rev = "v${version}";
 
-  passthru.repoVersion = "12"; # Also update kubo-migrator when changing the repo version
+  passthru.repoVersion = "13"; # Also update kubo-migrator when changing the repo version
 
   # Kubo makes changes to it's source tarball that don't match the git source.
   src = fetchurl {
     url = "https://github.com/ipfs/kubo/releases/download/${rev}/kubo-source.tar.gz";
-    hash = "sha256-Ls46Dds8lRP2KTOkjiVWtqB8aqPW5jdQ/xwBcQYIwbQ=";
+    hash = "sha256-qjzecHNTdzMoB3RM72JIY0w7/h+was53T+J5SE5SpTs=";
   };
 
   # tarball contains multiple files/directories
@@ -53,7 +53,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "A global, versioned, peer-to-peer filesystem";
+    description = "An IPFS implementation in Go";
     homepage = "https://ipfs.io/";
     license = licenses.mit;
     platforms = platforms.unix;

--- a/pkgs/applications/networking/kubo/default.nix
+++ b/pkgs/applications/networking/kubo/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "kubo";
-  version = "0.18.0"; # When updating, also check if the repo version changed and adjust repoVersion below
+  version = "0.18.1"; # When updating, also check if the repo version changed and adjust repoVersion below
   rev = "v${version}";
 
   passthru.repoVersion = "13"; # Also update kubo-migrator when changing the repo version
@@ -10,7 +10,7 @@ buildGoModule rec {
   # Kubo makes changes to it's source tarball that don't match the git source.
   src = fetchurl {
     url = "https://github.com/ipfs/kubo/releases/download/${rev}/kubo-source.tar.gz";
-    hash = "sha256-qjzecHNTdzMoB3RM72JIY0w7/h+was53T+J5SE5SpTs=";
+    hash = "sha256-xAOx4QOdD5MfFLqKTQRGMOnTZt14H523/quOLY5gBMk=";
   };
 
   # tarball contains multiple files/directories


### PR DESCRIPTION
###### Description of changes
https://github.com/ipfs/kubo/releases/tag/v0.18.0
https://github.com/ipfs/kubo/releases/tag/v0.18.1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).