### PR TITLE
lsof: 4.96.5 -> 4.98.0

### DIFF
--- a/pkgs/development/tools/misc/lsof/default.nix
+++ b/pkgs/development/tools/misc/lsof/default.nix
@@ -6,13 +6,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "lsof";
-  version = "4.96.5";
+  version = "4.98.0";
 
   src = fetchFromGitHub {
     owner = "lsof-org";
     repo = "lsof";
     rev = version;
-    hash = "sha256-3ZEGCKc7inbqcE4LuhfKON3C8LebVOlZPEhOHVgx8Lo=";
+    sha256 = "sha256-DQLY0a0sOCZFEJA4Y4b18OcWZw47RyqKZ0mVG0CDVTI=";
   };
 
   patches = [

--- a/pkgs/development/tools/misc/lsof/no-build-info.patch
+++ b/pkgs/development/tools/misc/lsof/no-build-info.patch
@@ -1,6 +1,6 @@
---- a/usage.c	2018-02-14 15:20:32.000000000 +0100
-+++ b/usage.c	2018-10-08 21:57:45.718560869 +0200
-@@ -930,24 +930,6 @@
+--- a/usage.c
++++ b/usage.c
+@@ -931,24 +931,6 @@ usage(err, fh, version)
  		(void) fprintf(stderr, "    configuration info: %s\n", cp);
  #endif	/* defined(LSOF_CINFO) */
  
@@ -19,22 +19,22 @@
 -		    cp1 ? cp1 : "",
 -		    (cp && cp1) ? "@" : "",
 -		    cp  ? cp  : ""
--		);
+-		    );
 -	    }
 -
  #if	defined(LSOF_BLDCMT)
  	    if ((cp = isnullstr(LSOF_BLDCMT)))
  		(void) fprintf(stderr, "    builder's comment: %s\n", cp);
-@@ -959,12 +939,8 @@
+@@ -958,12 +940,6 @@ usage(err, fh, version)
  		(void) fprintf(stderr, "    compiler: %s\n", cp);
  	    if ((cp = isnullstr(LSOF_CCV)))
  		(void) fprintf(stderr, "    compiler version: %s\n", cp);
 -	    if ((cp = isnullstr(LSOF_CCFLAGS)))
 -		(void) fprintf(stderr, "    compiler flags: %s\n", cp);
- 	    if ((cp = isnullstr(LSOF_LDFLAGS)))
- 		(void) fprintf(stderr, "    loader flags: %s\n", cp);
+-	    if ((cp = isnullstr(LSOF_LDFLAGS)))
+-		(void) fprintf(stderr, "    loader flags: %s\n", cp);
 -	    if ((cp = isnullstr(LSOF_SYSINFO)))
 -		(void) fprintf(stderr, "    system info: %s\n", cp);
- 	    (void) report_SECURITY("    ", ".\n");
- 	    (void) report_WARNDEVACCESS("    ", "are", ".\n");
- 	    (void) report_HASKERNIDCK("    K", "is");
+ 	    // display configurations that might affect output
+ 	    char *features[] = {
+ #if	defined(HASEFFNLINK)


### PR DESCRIPTION
Changes: https://github.com/lsof-org/lsof/blob/4.98.0/00DIST#L5437

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
