### PR TITLE
trashy: 1.0.3 -> 2.0.0

### DIFF
--- a/pkgs/tools/misc/trashy/default.nix
+++ b/pkgs/tools/misc/trashy/default.nix
@@ -2,16 +2,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "trashy";
-  version = "1.0.3";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "oberblastmeister";
     repo = "trashy";
     rev = "v${version}";
-    sha256 = "sha256-b50Q7knJzXKDfM1kw6wLvXunhgOXVs+zYvZx/NYqMdk=";
+    sha256 = "sha256-xYSk0M8oNwbwZbKWDXMQlnt7vKi0p3+2Tr4eXCvtHEM=";
   };
 
-  cargoSha256 = "sha256-2hNNLXuAHd1bquhHimniqryTVMfBmPAOossggICScqQ=";
+  cargoSha256 = "sha256-ZWqWtWzb+CLH1ravBb/oV+aPxplEyiC1wEFhvchcLqg=";
+
+  # this patch must be removed after oberblastmeister/trashy#70 is solved or new
+  # version is released.
+  cargoPatches = [ ./lock-version.patch ];
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/tools/misc/trashy/lock-version.patch
+++ b/pkgs/tools/misc/trashy/lock-version.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 7af0268..dc197a0 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -889,7 +889,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "trashy"
+-version = "1.0.3"
++version = "2.0.0"
+ dependencies = [
+  "aho-corasick",
+  "ansi_term",


### PR DESCRIPTION
###### Description of changes

[New release](https://github.com/oberblastmeister/trashy/releases/tag/v2.0.0).

A patch is added due to oberblastmeister/trashy#70.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
