### PR TITLE
python310Packages.yark: 1.2.3 -> 1.2.4

### DIFF
--- a/pkgs/development/python-modules/yark/default.nix
+++ b/pkgs/development/python-modules/yark/default.nix
@@ -1,26 +1,57 @@
-{ lib, buildPythonPackage, fetchPypi,
-  click, colorama, flask, requests, yt-dlp }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, poetry-core
+, pythonRelaxDepsHook
+, click
+, colorama
+, flask
+, requests
+, yt-dlp
+, progress
+}:
 
 buildPythonPackage rec {
   pname = "yark";
-  version = "1.2.3";
+  version = "1.2.4";
+
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-KMnQpEH2Z19Y0jBjqx2rZjmlle2M9bcuDCjDIljQEYY=";
+    sha256 = "fdd50d0e832b4522cbe24433f42ed571a1f199f571c1d0c98472b94a501db9cf";
   };
 
+  pythonRelaxDeps = [
+    "requests"
+  ];
+
+  nativeBuildInputs = [
+    poetry-core
+    pythonRelaxDepsHook
+  ];
+
   propagatedBuildInputs = [
-    click colorama flask requests yt-dlp
+    click
+    colorama
+    flask
+    progress
+    requests
+    yt-dlp
   ];
 
   # There aren't any unit tests. If test discovery runs, it will crash, halting the build.
   # When upstream adds unit tests, please configure them here. Thanks! ~ C.
   doCheck = false;
 
+  pythonImportsCheck = [
+    "yark"
+  ];
+
   meta = with lib; {
     description = "YouTube archiving made simple";
     homepage = "https://github.com/Owez/yark";
     license = licenses.mit;
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
