### PR TITLE
nng: 1.5.2 -> 1.6.0-prerelease and to rPackages.nanonext dependencies

### DIFF
--- a/pkgs/development/libraries/nng/default.nix
+++ b/pkgs/development/libraries/nng/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nng";
-  version = "1.5.2";
+  version = "1.6.0-prerelease";
 
   src = fetchFromGitHub {
     owner = "nanomsg";
     repo = "nng";
-    rev = "v${version}";
-    sha256 = "sha256-qbjMLpPk5FxH710Mf8AIraY0mERbaxVVhTT94W0EV+k=";
+    rev = "539e559e65cd8f227c45e4b046ac41c0edcf6c32";
+    sha256 = "sha256-86+f0um25Ywn78S2JrV54K7k3O6ots0q2dCco1aK0xM=";
   };
 
   nativeBuildInputs = [ cmake ninja ]

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -362,6 +362,7 @@ let
     mvabund = [ pkgs.gsl ];
     mwaved = [ pkgs.fftw.dev ];
     mzR = with pkgs; [ zlib netcdf ];
+    nanonext = with pkgs; [ mbedtls nng ];
     ncdf4 = [ pkgs.netcdf ];
     nloptr = with pkgs; [ nlopt pkg-config libiconv ];
     n1qn1 = [ pkgs.gfortran ];


### PR DESCRIPTION
###### Description of changes

Updated nng to 1.6.0-prerelease. The latest version is a requirement of the nanonext R package. Both build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
