### PR TITLE
postgresqlTestHook: run postgresqlTestSetupPost hook after setting up

### DIFF
--- a/doc/hooks/postgresql-test-hook.section.md
+++ b/doc/hooks/postgresql-test-hook.section.md
@@ -46,6 +46,12 @@ Bash-only variables:
  - `postgresqlEnableTCP`: set to `1` to enable TCP listening. Flaky; not recommended.
  - `postgresqlStartCommands`: defaults to `pg_ctl start`.
 
+## Hooks {#sec-postgresqlTestHook-hooks}
+
+A number of additional hooks are ran in postgresqlTestHook
+
+ - `postgresqlTestSetupPost`: ran after postgresql has been set up.
+
 ## TCP and the Nix sandbox {#sec-postgresqlTestHook-tcp}
 
 `postgresqlEnableTCP` relies on network sandboxing, which is not available on macOS and some custom Nix installations, resulting in flaky tests.

--- a/pkgs/build-support/setup-hooks/postgresql-test-hook/postgresql-test-hook.sh
+++ b/pkgs/build-support/setup-hooks/postgresql-test-hook/postgresql-test-hook.sh
@@ -71,6 +71,8 @@ EOF
   header 'setting up postgresql'
   eval "$postgresqlTestSetupCommands"
 
+  runHook postgresqlTestSetupPost
+
 }
 
 postgresqlStop() {

--- a/pkgs/build-support/setup-hooks/postgresql-test-hook/test.nix
+++ b/pkgs/build-support/setup-hooks/postgresql-test-hook/test.nix
@@ -14,6 +14,9 @@ stdenv.mkDerivation {
     INSERT INTO hello VALUES ('it '||'worked');
     SELECT * FROM hello;
   '';
+  postgresqlTestSetupPost = ''
+    TEST_POST_HOOK_RAN=1
+  '';
   checkPhase = ''
     runHook preCheck
     psql <$sqlPath | grep 'it worked'
@@ -21,7 +24,7 @@ stdenv.mkDerivation {
     runHook postCheck
   '';
   installPhase = ''
-    [[ $TEST_RAN == 1 ]]
+    [[ $TEST_RAN == 1 && $TEST_POST_HOOK_RAN == 1 ]]
     touch $out
   '';
 }


### PR DESCRIPTION
###### Description of changes
Useful for situations like https://github.com/NixOS/nixpkgs/pull/211357#discussion_r1086297389
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
