### PR TITLE
ladspa-sdk: fix cross and clean up

### DIFF
--- a/pkgs/applications/audio/ladspa-sdk/default.nix
+++ b/pkgs/applications/audio/ladspa-sdk/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchurl }:
+
 stdenv.mkDerivation rec {
   pname = "ladspa-sdk";
   version = "1.15";
@@ -7,11 +8,26 @@ stdenv.mkDerivation rec {
     sha256 = "1vgx54cgsnc3ncl9qbgjbmq12c444xjafjkgr348h36j16draaa2";
   };
 
+  sourceRoot = "ladspa_sdk_${version}/src";
+
+  strictDeps = true;
+
   patchPhase = ''
-    cd src
     sed -i 's@/usr/@$(out)/@g'  Makefile
-    sed -i 's@-mkdirhier@mkdir -p@g'  Makefile
   '';
+
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "CPP=${stdenv.cc.targetPrefix}c++"
+  ];
+
+  # The default target also runs tests, which we don't want to do in
+  # the build phase as it would break cross.
+  buildFlags = [ "targets" ];
+
+  # Tests try to create and play a sound file.  Playing will fail, but
+  # it's probably still useful to run the part that creates the file.
+  doCheck = true;
 
   meta = {
     description = "The SDK for the LADSPA audio plugin standard";


### PR DESCRIPTION
###### Description of changes

The "mkdirhier" sed is no longer necessary as this string does not appear in the current Makefile.

The default Make target runs tests, so we need to move that to `checkPhase` so it's disabled when cross-compiling.

Might as well take the opportunity to enable `strictDeps`, but it doesn't really matter since there are no dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
