### PR TITLE
ninja: limit CPU load to $NIX_BUILD_CORES

### DIFF
--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -10,6 +10,7 @@ ninjaBuildPhase() {
 
     local flagsArray=(
         -j$buildCores
+        -l$buildCores
         $ninjaFlags "${ninjaFlagsArray[@]}"
     )
 
@@ -39,6 +40,7 @@ ninjaCheckPhase() {
 
         local flagsArray=(
             -j$buildCores
+            -l$buildCores
             $ninjaFlags "${ninjaFlagsArray[@]}"
             $checkTarget
         )


### PR DESCRIPTION
###### Description of changes

`-j$buildCores` is not sufficient to limit CPU load
for example, clang loads multiple cores per process, as seen in #212328

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Maintainers

@thoughtpolice @bjornfor @orivej