### PR TITLE
Revert "mdds: 2.0.3 -> 2.1.0"

### DIFF
--- a/pkgs/development/libraries/mdds/default.nix
+++ b/pkgs/development/libraries/mdds/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mdds";
-  version = "2.1.0";
+  version = "2.0.3";
 
   src = fetchFromGitLab {
     owner = "mdds";
     repo = "mdds";
     rev = finalAttrs.version;
-    hash = "sha256-RZ2wGwle4raWlogc5X+VEeriPGS0Nqs7CWGENFEotvs=";
+    hash = "sha256-Y9uBJKM34UTEj/3c1w69QHhvwFcMNlAohEco0O0B+xI=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
> Result of nixpkgs-review run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
> 12 packages failed to build: libreoffice, ...
> 1 package built:

Is #212261 really good to merge?

Closes #212556.