### PR TITLE
 globalprotect-openconnect: 1.4.8 -> 1.4.9

### DIFF
--- a/pkgs/tools/networking/globalprotect-openconnect/default.nix
+++ b/pkgs/tools/networking/globalprotect-openconnect/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub
+{ stdenv, lib, fetchurl
 , cmake, qtwebsockets, qtwebengine, qtkeychain, wrapQtAppsHook, openconnect
 }:
 
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/yuezk/GlobalProtect-openconnect/releases/download/v${version}/globalprotect-openconnect-${version}.tar.gz";
-    sha256 = "0b7s3gf0gznlpmf9dxfq77254zlxmpajhzzn3scrdrvf413sjl0f";
+    hash = "sha256-vhvVKESLbqHx3XumxbIWOXIreDkW3yONDMXMHxhjsvk=";
   };
 
   nativeBuildInputs = [ cmake wrapQtAppsHook ];

--- a/pkgs/tools/networking/globalprotect-openconnect/default.nix
+++ b/pkgs/tools/networking/globalprotect-openconnect/default.nix
@@ -1,22 +1,19 @@
 { stdenv, lib, fetchFromGitHub
-, cmake, qtwebsockets, qtwebengine, wrapQtAppsHook, openconnect
+, cmake, qtwebsockets, qtwebengine, qtkeychain, wrapQtAppsHook, openconnect
 }:
 
 stdenv.mkDerivation rec {
   pname = "globalprotect-openconnect";
-  version = "1.4.8";
+  version = "1.4.9";
 
-  src = fetchFromGitHub {
-    owner = "yuezk";
-    repo = "GlobalProtect-openconnect";
-    fetchSubmodules = true;
-    rev = "v${version}";
-    sha256 = "sha256-PQAlGeHVayImKalCNv2SwPcxD0ts4BVSqeo1hKYmnMA=";
+  src = builtins.fetchTarball {
+    url = "https://github.com/yuezk/GlobalProtect-openconnect/releases/download/v${version}/globalprotect-openconnect-${version}.tar.gz";
+    sha256 = "0b7s3gf0gznlpmf9dxfq77254zlxmpajhzzn3scrdrvf413sjl0f";
   };
 
   nativeBuildInputs = [ cmake wrapQtAppsHook ];
 
-  buildInputs = [ openconnect qtwebsockets qtwebengine ];
+  buildInputs = [ openconnect qtwebsockets qtwebengine qtkeychain ];
 
   patchPhase = ''
     substituteInPlace GPService/gpservice.h \

--- a/pkgs/tools/networking/globalprotect-openconnect/default.nix
+++ b/pkgs/tools/networking/globalprotect-openconnect/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   pname = "globalprotect-openconnect";
   version = "1.4.9";
 
-  src = builtins.fetchTarball {
+  src = fetchurl {
     url = "https://github.com/yuezk/GlobalProtect-openconnect/releases/download/v${version}/globalprotect-openconnect-${version}.tar.gz";
     sha256 = "0b7s3gf0gznlpmf9dxfq77254zlxmpajhzzn3scrdrvf413sjl0f";
   };


### PR DESCRIPTION
###### Description of changes

https://github.com/yuezk/GlobalProtect-openconnect/releases/tag/v1.4.9

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->