### PR TITLE
scriv: init at 1.2.0

### DIFF
--- a/pkgs/applications/version-management/scriv/default.nix
+++ b/pkgs/applications/version-management/scriv/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, python3
+, fetchPypi
+, pandoc
+, git
+, scriv
+, testers
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "scriv";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-u2HDD+pzFYpNGMKLu1eCHDCCRWg++w2Je9ReSnhWtHI=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    attrs
+    click
+    click-log
+    jinja2
+    requests
+  ] ++ lib.optionals (python3.pythonOlder "3.11") [
+    tomli
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+    coverage
+    freezegun
+    pudb
+    pytest-mock
+    responses
+    pyyaml
+
+    pandoc
+    git
+  ];
+  disabledTests = [
+    # assumes we have checked out the full repo (including remotes)
+    "test_real_get_github_repos"
+  ];
+
+  passthru.tests = {
+    version = testers.testVersion { package = scriv; };
+  };
+
+  meta = {
+    description = "Command-line tool for helping developers maintain useful changelogs.";
+    homepage = "https://github.com/nedbat/scriv";
+    changelog = "https://github.com/nedbat/scriv/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ amesgen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2424,6 +2424,8 @@ with pkgs;
 
   sakura = callPackage ../applications/terminal-emulators/sakura { };
 
+  scriv = callPackage ../applications/version-management/scriv { };
+
   st = callPackage ../applications/terminal-emulators/st {
     conf = config.st.conf or null;
     patches = config.st.patches or [];


### PR DESCRIPTION
###### Description of changes

https://github.com/nedbat/scriv

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
