### PR TITLE
umockdev: 0.17.13 -> 0.17.15

### DIFF
--- a/pkgs/development/libraries/umockdev/default.nix
+++ b/pkgs/development/libraries/umockdev/default.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "umockdev";
-  version = "0.17.13";
+  version = "0.17.15";
 
   outputs = [ "bin" "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "https://github.com/martinpitt/umockdev/releases/download/${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-bG6/bmIJtqSXRuDZGkSNAntUJxurgu1woTLs8pTKE88=";
+    sha256 = "7UGO4rv7B4H0skuXKe8nCtg83czWaln/lEsFnvE2j+8=";
   };
 
   patches = [

--- a/pkgs/development/libraries/umockdev/hardcode-paths.patch
+++ b/pkgs/development/libraries/umockdev/hardcode-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 2ed9027..1f6bbf2 100644
+index 15d9e5d..a1906dd 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -38,6 +38,7 @@ g_ir_compiler = find_program('g-ir-compiler', required: false)
+@@ -44,6 +44,7 @@ g_ir_compiler = find_program('g-ir-compiler', required: false)
  
  conf.set('PACKAGE_NAME', meson.project_name())
  conf.set_quoted('VERSION', meson.project_version())
@@ -10,7 +10,7 @@ index 2ed9027..1f6bbf2 100644
  
  # glibc versions somewhere between 2.28 and 2.34
  if cc.has_function('__fxstatat', prefix: '#include <sys/stat.h>')
-@@ -148,7 +149,7 @@ hacked_gir = custom_target('UMockdev-1.0 hacked gir',
+@@ -156,7 +157,7 @@ hacked_gir = custom_target('UMockdev-1.0 hacked gir',
  
  if g_ir_compiler.found()
  umockdev_typelib = custom_target('UMockdev-1.0 typelib',
@@ -31,28 +31,28 @@ index 5269dd0..a2ec46d 100644
  }
  
 diff --git a/src/umockdev-record.vala b/src/umockdev-record.vala
-index 8434d32..68c7f8e 100644
+index bf0e644..ff5ea59 100644
 --- a/src/umockdev-record.vala
 +++ b/src/umockdev-record.vala
-@@ -435,7 +435,7 @@ main (string[] args)
+@@ -444,7 +444,7 @@ main (string[] args)
          preload = "";
      else
          preload = preload + ":";
--    Environment.set_variable("LD_PRELOAD", preload + "libumockdev-preload.so.0", true);
-+    Environment.set_variable("LD_PRELOAD", preload + Config.LIBDIR + "/libumockdev-preload.so.0", true);
+-    checked_setenv("LD_PRELOAD", preload + "libumockdev-preload.so.0");
++    checked_setenv("LD_PRELOAD", preload + Config.LIBDIR + "/libumockdev-preload.so.0");
  
      try {
          root_dir = DirUtils.make_tmp("umockdev.XXXXXX");
 diff --git a/src/umockdev-run.vala b/src/umockdev-run.vala
-index 9a1ba10..6df2522 100644
+index 7b0753e..66b778b 100644
 --- a/src/umockdev-run.vala
 +++ b/src/umockdev-run.vala
 @@ -95,7 +95,7 @@ main (string[] args)
          preload = "";
      else
          preload = preload + ":";
--    Environment.set_variable ("LD_PRELOAD", preload + "libumockdev-preload.so.0", true);
-+    Environment.set_variable ("LD_PRELOAD", preload + Config.LIBDIR + "/libumockdev-preload.so.0", true);
+-    checked_setenv ("LD_PRELOAD", preload + "libumockdev-preload.so.0");
++    checked_setenv ("LD_PRELOAD", preload + Config.LIBDIR + "/libumockdev-preload.so.0");
  
      var testbed = new UMockdev.Testbed ();
  


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
