### PR TITLE
davfs2: 1.6.1 -> 1.7.0

### DIFF
--- a/pkgs/tools/filesystems/davfs2/0002-Make-sure-that-the-setuid-wrapped-umount-is-invoked.patch
+++ b/pkgs/tools/filesystems/davfs2/0002-Make-sure-that-the-setuid-wrapped-umount-is-invoked.patch
@@ -1,42 +1,26 @@
-From 56873cf29974ff0dfc1ba1afb7022ce49e300835 Mon Sep 17 00:00:00 2001
-From: Maximilian Bosch <maximilian@mbosch.me>
-Date: Wed, 11 Nov 2020 11:58:25 +0100
-Subject: [PATCH 2/2] Make sure that the setuid-wrapped `umount` is invoked
-
----
- src/dav_fuse.c     | 2 +-
- src/umount_davfs.c | 4 ++--
- 2 files changed, 3 insertions(+), 3 deletions(-)
-
 diff --git a/src/dav_fuse.c b/src/dav_fuse.c
-index 734bc1f..4501433 100644
+index 6311428..1b1698d 100644
 --- a/src/dav_fuse.c
 +++ b/src/dav_fuse.c
-@@ -187,7 +187,7 @@ dav_fuse_loop(int device, char *mpoint, size_t bufsize, time_t idle_time,
-             unmounting = 1;
+@@ -189,7 +189,7 @@ dav_fuse_loop(int device, char *mpoint, size_t bufsize, time_t idle_time,
              pid_t pid = fork();
              if (pid == 0) {
+ #if defined(__linux__)
 -                execl("/bin/umount", "umount", "-il", mountpoint, NULL);
 +                execl("@wrapperDir@/umount", "umount", "-il", mountpoint, NULL);
-                 _exit(EXIT_FAILURE);
-             }
-         }
+ #elif defined(__FreeBSD__)
+                 execl("/sbin/umount", "umount", "-v", mountpoint, NULL);
+ #endif
 diff --git a/src/umount_davfs.c b/src/umount_davfs.c
-index b7019c3..75e3b4b 100644
+index 6a82fd2..93958be 100644
 --- a/src/umount_davfs.c
 +++ b/src/umount_davfs.c
-@@ -122,9 +122,9 @@ main(int argc, char *argv[])
+@@ -50,7 +50,7 @@
+ #endif
  
-     char *umount_command = NULL;
-     if (mpoint) {
--        umount_command = ne_concat("umount -i '", mpoint, "'", NULL);
-+        umount_command = ne_concat("@wrapperDir@/umount -i '", mpoint, "'", NULL);
-     } else {
--        umount_command = ne_concat("umount -i '", argv[optind], "'", NULL);
-+        umount_command = ne_concat("@wrapperDir@/umount -i '", argv[optind], "'", NULL);
-         error(0, 0,
-               _("\n"
-                 "  can't evaluate PID file name;\n"
--- 
-2.28.0
-
+ #if defined(__linux__)
+-#define UMOUNT_CMD "umount -i"
++#define UMOUNT_CMD "@wrapperDir@/umount -i"
+ #elif defined(__FreeBSD__)
+ #define UMOUNT_CMD "umount"
+ #endif

--- a/pkgs/tools/filesystems/davfs2/default.nix
+++ b/pkgs/tools/filesystems/davfs2/default.nix
@@ -53,5 +53,6 @@ stdenv.mkDerivation rec {
     '';
 
     platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ fgaz ];
   };
 }

--- a/pkgs/tools/filesystems/davfs2/default.nix
+++ b/pkgs/tools/filesystems/davfs2/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , fetchurl
 , fetchpatch
+, autoreconfHook
 , neon
 , procps
 , substituteAll
@@ -10,17 +11,22 @@
 
 stdenv.mkDerivation rec {
   pname = "davfs2";
-  version = "1.6.1";
+  version = "1.7.0";
 
   src = fetchurl {
     url = "mirror://savannah/davfs2/davfs2-${version}.tar.gz";
-    sha256 = "sha256-zj65SOzlgqUck0zLDMcOZZg5FycXyv8XP2ml4q+QxcA=";
+    sha256 = "sha256-JR23Wic4DMoTMLG5cXAMXl3MDJDlpHYiKF8BQO3+Oi8=";
   };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
 
   buildInputs = [ neon zlib ];
 
   patches = [
     ./fix-sysconfdir.patch
+    ./disable-suid.patch
     (substituteAll {
       src = ./0001-umount_davfs-substitute-ps-command.patch;
       ps = "${procps}/bin/ps";
@@ -32,11 +38,6 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [ "--sysconfdir=/etc" ];
-
-  makeFlags = [
-    "sbindir=$(out)/sbin"
-    "ssbindir=$(out)/sbin"
-  ];
 
   meta = {
     homepage = "https://savannah.nongnu.org/projects/davfs2";

--- a/pkgs/tools/filesystems/davfs2/disable-suid.patch
+++ b/pkgs/tools/filesystems/davfs2/disable-suid.patch
@@ -1,0 +1,9 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index bbde353..bcbed04 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -54,4 +54,3 @@ LIBS += @LIBICONV@
+ endif
+ 
+ install-exec-hook:
+-	chmod u+s $(DESTDIR)$(sbindir)/mount.davfs;

--- a/pkgs/tools/filesystems/davfs2/fix-sysconfdir.patch
+++ b/pkgs/tools/filesystems/davfs2/fix-sysconfdir.patch
@@ -1,19 +1,20 @@
-diff -ubr davfs2-1.4.7-orig/etc/Makefile.am davfs2-1.4.7/etc/Makefile.am
---- davfs2-1.4.7-orig/etc/Makefile.am	2013-02-21 11:45:00.185763558 +0100
-+++ davfs2-1.4.7/etc/Makefile.am	2013-02-21 11:53:05.423197775 +0100
-@@ -24,17 +24,17 @@
+diff --git a/etc/Makefile.am b/etc/Makefile.am
+index 5a01282..6a40921 100644
+--- a/etc/Makefile.am
++++ b/etc/Makefile.am
+@@ -24,17 +24,17 @@ pkgsysconfdir = $(sysconfdir)/@PACKAGE@
  
  install-data-local: $(dist_pkgdata_DATA)
  	@$(NORMAL_INSTALL)
 -	$(mkinstalldirs) $(DESTDIR)$(pkgsysconfdir)
--	$(INSTALL_DATA) -b davfs2.conf $(DESTDIR)$(pkgsysconfdir)/davfs2.conf
--	$(INSTALL_DATA) -b -m 600 secrets $(DESTDIR)$(pkgsysconfdir)/secrets
+-	$(INSTALL_DATA) -b $(srcdir)/davfs2.conf $(DESTDIR)$(pkgsysconfdir)/davfs2.conf
+-	$(INSTALL_DATA) -b -m 600 $(srcdir)/secrets $(DESTDIR)$(pkgsysconfdir)/secrets
 -	$(mkinstalldirs) $(DESTDIR)$(pkgsysconfdir)/certs
 -	$(mkinstalldirs) $(DESTDIR)$(pkgsysconfdir)/certs/private
 -	chmod 700 $(DESTDIR)$(pkgsysconfdir)/certs/private
 +	$(mkinstalldirs) $(out)$(pkgsysconfdir)
-+	$(INSTALL_DATA) -b davfs2.conf $(out)$(pkgsysconfdir)/davfs2.conf
-+	$(INSTALL_DATA) -b -m 600 secrets $(out)$(pkgsysconfdir)/secrets
++	$(INSTALL_DATA) -b $(srcdir)/davfs2.conf $(out)$(pkgsysconfdir)/davfs2.conf
++	$(INSTALL_DATA) -b -m 600 $(srcdir)/secrets $(out)$(pkgsysconfdir)/secrets
 +	$(mkinstalldirs) $(out)$(pkgsysconfdir)/certs
 +	$(mkinstalldirs) $(out)$(pkgsysconfdir)/certs/private
 +	chmod 700 $(out)$(pkgsysconfdir)/certs/private
@@ -27,34 +28,3 @@ diff -ubr davfs2-1.4.7-orig/etc/Makefile.am davfs2-1.4.7/etc/Makefile.am
 +	  echo " rm -f $(out)$(pkgsysconfdir)/$$f"; \
 +	  rm -f $(out)$(pkgsysconfdir)/$$f; \
  	done
-diff -ubr davfs2-1.4.7-orig/etc/Makefile.in davfs2-1.4.7/etc/Makefile.in
---- davfs2-1.4.7-orig/etc/Makefile.in	2013-02-21 11:45:00.185763558 +0100
-+++ davfs2-1.4.7/etc/Makefile.in	2013-02-21 11:53:27.241207128 +0100
-@@ -408,19 +408,19 @@
- 
- install-data-local: $(dist_pkgdata_DATA)
- 	@$(NORMAL_INSTALL)
--	$(mkinstalldirs) $(DESTDIR)$(pkgsysconfdir)
--	$(INSTALL_DATA) -b davfs2.conf $(DESTDIR)$(pkgsysconfdir)/davfs2.conf
--	$(INSTALL_DATA) -b -m 600 secrets $(DESTDIR)$(pkgsysconfdir)/secrets
--	$(mkinstalldirs) $(DESTDIR)$(pkgsysconfdir)/certs
--	$(mkinstalldirs) $(DESTDIR)$(pkgsysconfdir)/certs/private
--	chmod 700 $(DESTDIR)$(pkgsysconfdir)/certs/private
-+	$(mkinstalldirs) $(out)$(pkgsysconfdir)
-+	$(INSTALL_DATA) -b davfs2.conf $(out)$(pkgsysconfdir)/davfs2.conf
-+	$(INSTALL_DATA) -b -m 600 secrets $(out)$(pkgsysconfdir)/secrets
-+	$(mkinstalldirs) $(out)$(pkgsysconfdir)/certs
-+	$(mkinstalldirs) $(out)$(pkgsysconfdir)/certs/private
-+	chmod 700 $(out)$(pkgsysconfdir)/certs/private
- 
- uninstall-local:
- 	@$(NORMAL_UNINSTALL)
- 	@list='$(dist_pkgdata_DATA)'; for p in $$list; do \
- 	  f="`echo $$p | sed -e 's|^.*/||'`"; \
--	  echo " rm -f $(DESTDIR)$(pkgsysconfdir)/$$f"; \
--	  rm -f $(DESTDIR)$(pkgsysconfdir)/$$f; \
-+	  echo " rm -f $(out)$(pkgsysconfdir)/$$f"; \
-+	  rm -f $(out)$(pkgsysconfdir)/$$f; \
- 	done
- 
- # Tell versions [3.59,3.63) of GNU make to not export all variables.


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Tested by mounting, using, and unmounting nextcloud

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
