### PR TITLE
treewide: convert 30 fonts

### DIFF
--- a/pkgs/data/fonts/gdouros/default.nix
+++ b/pkgs/data/fonts/gdouros/default.nix
@@ -1,32 +1,36 @@
-{ fetchzip, lib }:
+{ lib, stdenvNoCC, fetchzip }:
 
 let
   fonts = {
-    aegan     = { version = "13.00"; file = "Aegean.zip";       sha256 = "sha256-1DnbfL6bKn8Upht/ZYfKIp9kuDHq7y9E+jkt2Yhr38A="; description = "Aegean"; };
-    aegyptus  = { version = "13.00"; file = "Aegyptus.zip";     sha256 = "sha256-tObgHlhaquq6Akn/HdYKNfnKHHJP42yAT7lIn5qdCzY="; description = "Egyptian Hieroglyphs, Coptic, Meroitic"; };
-    akkadian  = { version = "13.00"; file = "Akkadian.zip";     sha256 = "sha256-iHiXfxMS9FIlrRgT23MfxzCqYJMQrKuKYDShrqB74vU="; description = "Sumero-Akkadian Cuneiform"; };
-    assyrian  = { version = "13.00"; file = "Assyrian.zip";     sha256 = "sha256-YjTQjv1Vybr14Sn9pUdbGYVf4ZIjGT+cpB1qCIg1NNQ="; description = "Neo-Assyrian in Unicode with OpenType"; };
-    eemusic   = { version = "13.00"; file = "EEMusic.zip";      sha256 = "sha256-PaYBJOV+dmRV1ehY7TwDNL9dz1jPo58I3N8lWX1Vmy8="; description = "Byzantine Musical Notation in Unicode with OpenType"; };
-    maya      = { version = "13.00"; file = "Maya%20Hieroglyphs.zip"; sha256 = "sha256-9uqGo4hweV1ydI+pEp76IqmHslWvxr87rTvziQs35bQ="; description = "Maya Hieroglyphs"; };
-    symbola   = { version = "13.00"; file = "Symbola.zip";      sha256 = "sha256-C9HmforXr/Hqopb3go+bzqRFcWPv+0rz0JZsXc3mcxw="; description = "Basic Latin, Greek, Cyrillic and many Symbol blocks of Unicode"; };
-    textfonts = { version = "13.00"; file = "Textfonts.zip";    sha256 = "sha256-1bDi5mwrT2I8gx6QdhnWjXATFdNAU9nt77BiFIci6C8="; description = "Aroania, Anaktoria, Alexander, Avdira and Asea"; };
-    unidings  = { version = "13.00"; file = "Unidings.zip";     sha256 = "sha256-6lSkDb603XIrBGy4fZhY7xYDd3x0qA0PRQOlQ9Roig0="; description = "Glyphs and Icons for blocks of The Unicode Standard"; };
+    aegan     = { version = "13.00"; file = "Aegean.zip";       hash = "sha256-3HmCqCMZLN6zF1N/EirQOPnHKTGHoc4aHKoZxFYTB34="; description = "Aegean"; };
+    aegyptus  = { version = "13.00"; file = "Aegyptus.zip";     hash = "sha256-SSAK707xhpsUTq8tSBcrzNGunCYad58amtCqAWuevnY="; description = "Egyptian Hieroglyphs, Coptic, Meroitic"; };
+    akkadian  = { version = "13.00"; file = "Akkadian.zip";     hash = "sha256-wXiDYyfujAs6fklOCqXq7Ms7wP5RbPlpNVwkUy7CV4k="; description = "Sumero-Akkadian Cuneiform"; };
+    assyrian  = { version = "13.00"; file = "Assyrian.zip";     hash = "sha256-CZj1sc89OexQ0INb7pbEu5GfE/w2E5JmhjT8cosoLSg="; description = "Neo-Assyrian in Unicode with OpenType"; };
+    eemusic   = { version = "13.00"; file = "EEMusic.zip";      hash = "sha256-LxOcQOPEImw0wosxJotbOJRbe0qlK5dR+kazuhm99Kg="; description = "Byzantine Musical Notation in Unicode with OpenType"; };
+    maya      = { version = "13.00"; file = "Maya%20Hieroglyphs.zip"; hash = "sha256-PAwF1lGqm6XVf4NQCA8AFLGU40N0Xsn5Q8x9ikHJDhY="; description = "Maya Hieroglyphs"; };
+    symbola   = { version = "13.00"; file = "Symbola.zip";      hash = "sha256-TsHWmzkEyMa8JOZDyjvk7PDhm239oH/FNllizNFf398="; description = "Basic Latin, Greek, Cyrillic and many Symbol blocks of Unicode"; };
+    textfonts = { version = "13.00"; file = "Textfonts.zip";    hash = "sha256-7S3NiiyDvyYoDrLPt2z3P9bEEFOEZACv2sIHG1Tn6yI="; description = "Aroania, Anaktoria, Alexander, Avdira and Asea"; };
+    unidings  = { version = "13.00"; file = "Unidings.zip";     hash = "sha256-WUY+Ylphep6WuzqLQ3Owv+vK5Yuu/aAkn4GOFXL0uQY="; description = "Glyphs and Icons for blocks of The Unicode Standard"; };
   };
 
-  mkpkg = name_: {version, file, sha256, description}: fetchzip rec {
-    name = "${name_}-${version}";
-    url = "https://dn-works.com/wp-content/uploads/2020/UFAS-Fonts/${file}";
-    stripRoot = false;
-    postFetch = ''
-      mkdir -p $out/share/{fonts/opentype,doc/${name_}}
-      mv $out/*.otf                -t "$out/share/fonts/opentype"
-      mv $out/*.{odt,ods,pdf,xlsx}       -t "$out/share/doc/${name_}"  || true  # install docs if any
-      find $out -type d -empty -delete
-      shopt -s extglob dotglob
-      rm -rf $out/!(share)
-      shopt -u extglob dotglob
+  mkpkg = pname: { version, file, hash, description }: stdenvNoCC.mkDerivation rec {
+    inherit pname version;
+
+    src = fetchzip {
+      url = "https://dn-works.com/wp-content/uploads/2020/UFAS-Fonts/${file}";
+      stripRoot = false;
+      inherit hash;
+    };
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/{fonts/opentype,doc/${pname}}
+      mv *.otf                -t "$out/share/fonts/opentype"
+      mv *.{odt,ods,pdf,xlsx}       -t "$out/share/doc/${pname}"  || true  # install docs if any
+
+      runHook postInstall
     '';
-    inherit sha256;
 
     meta = {
       inherit description;
@@ -39,4 +43,4 @@ let
     };
   };
 in
-  lib.mapAttrs mkpkg fonts
+lib.mapAttrs mkpkg fonts

--- a/pkgs/data/fonts/hanazono/default.nix
+++ b/pkgs/data/fonts/hanazono/default.nix
@@ -1,19 +1,24 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "hanazono";
   version = "20170904";
-in fetchzip {
-  name = "hanazono-${version}";
 
-  url = "mirror://osdn/hanazono-font/68253/hanazono-${version}.zip";
+  src = fetchzip {
+    url = "mirror://osdn/hanazono-font/68253/hanazono-${version}.zip";
+    stripRoot = false;
+    hash = "sha256-qd0q4wQnHBGLT7C+UQIiOHnxCnRCscMZcj3P5RRxD1U=";
+  };
 
-  postFetch = ''
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.txt -d $out/share/doc/hanazono
-  '';
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 *.txt -t $out/share/doc/hanazono
 
-  sha256 = "0qiyd1vk3w8kqmwc6xi5d390wdr4ln8xhfbx3n8r1hhad9iz14p6";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Japanese Mincho-typeface TrueType font";

--- a/pkgs/data/fonts/kochi-substitute-naga10/default.nix
+++ b/pkgs/data/fonts/kochi-substitute-naga10/default.nix
@@ -1,24 +1,24 @@
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let version = "20030809";
-in
-fetchzip {
-  name = "kochi-substitute-naga10-${version}";
+stdenvNoCC.mkDerivation rec {
+  pname = "kochi-substitute-naga10";
+  version = "20030809";
 
-  url = "mirror://osdn/efont/5411/kochi-substitute-${version}.tar.bz2";
+  src = fetchzip {
+    url = "mirror://osdn/efont/5411/kochi-substitute-${version}.tar.bz2";
+    stripRoot = false;
+    hash = "sha256-dRJAxeVGYcNjLWqJJ+9Z2FW3BHrgyGRzlgM2x5YG3AM=";
+  };
 
-  stripRoot = false;
+  installPhase = ''
+    runHook preInstall
 
-  postFetch = ''
     mkdir -p $out/share/fonts/truetype
-    mv $out/*/kochi-gothic-subst.ttf $out/share/fonts/truetype/kochi-gothic-subst-naga10.ttf
-    mv $out/*/kochi-mincho-subst.ttf $out/share/fonts/truetype/kochi-mincho-subst-naga10.ttf
-    shopt -s extglob dotglob
-    rm -rf $out/!(share)
-    shopt -u extglob dotglob
-  '';
+    mv */kochi-gothic-subst.ttf $out/share/fonts/truetype/kochi-gothic-subst-naga10.ttf
+    mv */kochi-mincho-subst.ttf $out/share/fonts/truetype/kochi-mincho-subst-naga10.ttf
 
-  sha256 = "sha256-SZ7ZJYuCYU0NxWHlEszbvFmyZxWeBtmPL204PjIrS64=";
+    runHook postInstall
+  '';
 
   meta = {
     description = "Japanese font, non-free replacement for MS Gothic and MS Mincho";

--- a/pkgs/data/fonts/lohit-fonts/default.nix
+++ b/pkgs/data/fonts/lohit-fonts/default.nix
@@ -1,35 +1,38 @@
-{ fetchzip, lib }:
+{ lib, stdenvNoCC, fetchurl }:
 let
   fonts = {
-    assamese        = { label = "Assamese";          version = "2.91.5"; sha256 = "06cw416kgw0m6883n5ixmpniinsd747rdmacf06z83w1hqwj2js6"; };
-    bengali         = { label = "Bengali";           version = "2.91.5"; sha256 = "1j7gfmkzzyk9mivy09a9yfqxpidw52hw48dyh4qkci304mspcbvr"; };
-    devanagari      = { label = "Devanagari script"; version = "2.95.4"; sha256 = "1c17xirzx5rf7xpmkrm94jf9xrzckyagwnqn3pyag28lyj8x67m5"; };
-    gujarati        = { label = "Gujarati";          version = "2.92.4"; sha256 = "0xdgmkikz532zxj239wr73l24qnzxhra88f52146x7fsb7gpvfb1"; };
-    gurmukhi        = { label = "Gurmukhi script";   version = "2.91.2"; sha256 = "1xk1qvc0xwcmjcavj9zmy4bbphffdlv7sldmqlk30ch5fy5r0ypb"; }; # renamed from Punjabi
-    kannada         = { label = "Kannada";           version = "2.5.4" ; sha256 = "0sax56xg98p2nf0nsvba42hhz946cs7q0gidiz9zfpb6pbgwxdgg"; };
-    malayalam       = { label = "Malayalam";         version = "2.92.2"; sha256 = "18sca59fj9zvqhagbix35i4ld2n4mwv57q04pijl5gvpyfb1abs8"; };
-    marathi         = { label = "Marathi";           version = "2.94.2"; sha256 = "0cjjxxlhqmdmhr35s4ak0ma89456daik5rqrn6pdzj39098lmci7"; };
-    nepali          = { label = "Nepali";            version = "2.94.2"; sha256 = "1p7lif136xakfqkbv6p1lb56rs391b25vn4bxrjdfvsk0r0h0ry3"; };
-    odia            = { label = "Odia";              version = "2.91.2"; sha256 = "0z5rc4f9vfrfm8h2flzf5yx44x50jqdmmzifkmjwczib3hpg2ila"; }; # renamed from Oriya
-    tamil-classical = { label = "Classical Tamil";   version = "2.5.4" ; sha256 = "0svmj3dhk0195mhdwjhi3qgwa83223irb32fp12782sj9njdvyi2"; };
-    tamil           = { label = "Tamil";             version = "2.91.3"; sha256 = "0qyw9p8alyvjryyw8a25q3gfyrhby49mjb0ydgggf5ckd07kblcm"; };
-    telugu          = { label = "Telugu";            version = "2.5.5" ; sha256 = "07p41686ypmclj9d3njp01lvrgssqxa4s5hsbrqfjrnwd3rjspzr"; };
+    assamese        = { label = "Assamese";          version = "2.91.5"; hash = "sha256-Oo/hHHFg/Nu3eaZLMdBclY90lKU2AMFUclyXHxGaAgg="; };
+    bengali         = { label = "Bengali";           version = "2.91.5"; hash = "sha256-QGf94TdQS2c9+wSSDK4Mknw5ubCGTuvg0xoNaJdirBc="; };
+    devanagari      = { label = "Devanagari script"; version = "2.95.4"; hash = "sha256-6CbOCqOei5eO1zwNQZvB+fFDkqxvJnK82z+zmClhRAE="; };
+    gujarati        = { label = "Gujarati";          version = "2.92.4"; hash = "sha256-BpwibF0/HXDvXpDEek0fj73cxo2QC1hSfQ49Q/ZOZg8="; };
+    gurmukhi        = { label = "Gurmukhi script";   version = "2.91.2"; hash = "sha256-5iLFW2FEE5LBqoALi+3sUjwC0ADntsp259TP+bYwR9g="; }; # renamed from Punjabi
+    kannada         = { label = "Kannada";           version = "2.5.4" ; hash = "sha256-7y2u0tBdNYCeY7Y+aqhxXP7Qv6GglJeVO1wvM9CzyIQ="; };
+    malayalam       = { label = "Malayalam";         version = "2.92.2"; hash = "sha256-SzM38vuAlP9OMC8kUuHQylmH8TUjCeg1y/Zcu2I2bjA="; };
+    marathi         = { label = "Marathi";           version = "2.94.2"; hash = "sha256-jK1Gwcr5gqzRNkbIxs4V/OYgUlUEpU0OYzKDTkiMlqM="; };
+    nepali          = { label = "Nepali";            version = "2.94.2"; hash = "sha256-OX1ekxeSbVGOrdbZ3Jvu4nii0zkgbuij10JIzqRcFx4="; };
+    odia            = { label = "Odia";              version = "2.91.2"; hash = "sha256-3/eczBGGZj4QPs7KY0as9zk5HaBfhgz6YgU0qmwpVcA="; }; # renamed from Oriya
+    tamil-classical = { label = "Classical Tamil";   version = "2.5.4" ; hash = "sha256-6SsddTCEUHMoF7X4+i7eXimmMuktfFAl8uz95RwM+yg="; };
+    tamil           = { label = "Tamil";             version = "2.91.3"; hash = "sha256-8lcNw87o9lhQsKwCqwBSfx7rhcrH/eEqac7EsA9/w/E="; };
+    telugu          = { label = "Telugu";            version = "2.5.5" ; hash = "sha256-cZh93NfEB+5S1JeEowtBMJ0nbZsFGpbEp2WAtzxrA8A="; };
   };
   gplfonts = {
     # GPL fonts removed from later releases
-    kashmiri        = { label = "Kashmiri";          version = "2.4.3" ; sha256 = "0c6whklad9bscymrlcbxj4fdvh4cdf40vb61ykbp6mapg6dqxwhn"; };
-    konkani         = { label = "Konkani";           version = "2.4.3" ; sha256 = "0pcb5089dabac1k6ymqnbnlyk7svy2wnb5glvhsd8glycjhrcp70"; };
-    maithili        = { label = "Maithili";          version = "2.4.3" ; sha256 = "1yfwv7pcj7k4jryz0s6mb56bq7fs15g56y7pi5yd89q1f8idk6bc"; };
-    sindhi          = { label = "Sindhi";            version = "2.4.3" ; sha256 = "1iywzyy185bvfsfi5pp11c8bzrp40kni2cpwcmxqwha7c9v8brlc"; };
+    kashmiri        = { label = "Kashmiri";          version = "2.4.3" ; hash = "sha256-6T2QaWnt3+e5nr4vbk44FouqmeWKzia1lSf8S/bvqCs="; };
+    konkani         = { label = "Konkani";           version = "2.4.3" ; hash = "sha256-hVy2rxrUTPDeNnugi3Bk7z0JqGmk4/yeUsAoI/4R7A8="; };
+    maithili        = { label = "Maithili";          version = "2.4.3" ; hash = "sha256-ikDcpJqdizAYRpgoebzqxOEeodJ6C3fO2rsqGzC0HCs="; };
+    sindhi          = { label = "Sindhi";            version = "2.4.3" ; hash = "sha256-wU3B9fh+8E1bFBMnakzmajY7eNKzed9+eYL5AOxyNQI="; };
   };
 
-  mkpkg = license: name: {label, version, sha256}: fetchzip {
-    name = "lohit-${name}-${version}";
+  mkpkg = license: pname: {label, version, hash}: stdenvNoCC.mkDerivation {
+    inherit pname version;
 
-    url = "https://releases.pagure.org/lohit/lohit-${name}-ttf-${version}.tar.gz";
+    src = fetchurl {
+      url = "https://releases.pagure.org/lohit/lohit-${pname}-ttf-${version}.tar.gz";
+      inherit hash;
+    };
 
-    postFetch = ''
-      tar -xzf $downloadedFile --strip-components=1
+    installPhase = ''
+      runHook preInstall
 
       mkdir -p $out/share/fonts/truetype
       cp -v *.ttf $out/share/fonts/truetype/
@@ -37,11 +40,11 @@ let
       mkdir -p $out/etc/fonts/conf.d
       cp -v *.conf $out/etc/fonts/conf.d
 
-      mkdir -p "$out/share/doc/lohit-${name}"
-      cp -v ChangeLog* COPYRIGHT* "$out/share/doc/lohit-${name}/"
-    '';
+      mkdir -p "$out/share/doc/lohit-${pname}"
+      cp -v ChangeLog* COPYRIGHT* "$out/share/doc/lohit-${pname}/"
 
-    inherit sha256;
+      runHook postInstall
+    '';
 
     meta = {
       inherit license;

--- a/pkgs/data/fonts/mplus-outline-fonts/default.nix
+++ b/pkgs/data/fonts/mplus-outline-fonts/default.nix
@@ -1,16 +1,23 @@
-{ lib, fetchzip, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchurl, fetchFromGitHub }:
 
 let pname = "mplus-outline-fonts";
-in {
-  osdnRelease = fetchzip {
-    name = "${pname}-osdn";
-    url = "mirror://osdn/mplus-fonts/62344/mplus-TESTFLIGHT-063a.tar.xz";
-    sha256 = "sha256-+VN+aFx5hMlWwtk+FM+vL6G07+yEi9kYYsoQLSfMUZo=";
-    postFetch = ''
-      install -m444 -Dt $out/share/fonts/truetype/${pname} $out/*.ttf
-      shopt -s extglob dotglob
-      rm -rf $out/!(share)
-      shopt -u extglob dotglob
+in
+{
+  osdnRelease = stdenvNoCC.mkDerivation {
+    pname = "${pname}-osdn";
+    version = "063a";
+
+    src = fetchurl {
+      url = "mirror://osdn/mplus-fonts/62344/mplus-TESTFLIGHT-063a.tar.xz";
+      hash = "sha256-ROuXO0tq/1dN5FTbEF3cI+Z0nCKUc0vZyx4Nc05M3Xk=";
+    };
+
+    installPhase = ''
+      runHook preInstall
+
+      install -m444 -Dt $out/share/fonts/truetype/${pname} *.ttf
+
+      runHook postInstall
     '';
 
     meta = with lib; {
@@ -22,19 +29,25 @@ in {
     };
   };
 
-  githubRelease = fetchFromGitHub {
-    name = "${pname}-github";
-    owner = "coz-m";
-    repo = "MPLUS_FONTS";
-    rev = "336fec4e9e7c1e61bd22b82e6364686121cf3932";
-    sha256 = "sha256-LSIyrstJOszll72mxXIC7EW4KEMTFCaQwWs59j0UScE=";
-    postFetch = ''
+  githubRelease = stdenvNoCC.mkDerivation {
+    pname = "${pname}-github";
+    version = "unstable-2022-05-19";
+
+    src = fetchFromGitHub {
+      owner = "coz-m";
+      repo = "MPLUS_FONTS";
+      rev = "336fec4e9e7c1e61bd22b82e6364686121cf3932";
+      hash = "sha256-jzDDUs1dKjqNjsMeTA2/4vm+akIisnOuE2mPQS7IDSA=";
+    };
+
+    installPhase = ''
+      runHook preInstall
+
       mkdir -p $out/share/fonts/{truetype,opentype}/${pname}
-      mv $out/fonts/ttf/* $out/share/fonts/truetype/${pname}
-      mv $out/fonts/otf/* $out/share/fonts/opentype/${pname}
-      shopt -s extglob dotglob
-      rm -rf $out/!(share)
-      shopt -u extglob dotglob
+      mv fonts/ttf/* $out/share/fonts/truetype/${pname}
+      mv fonts/otf/* $out/share/fonts/opentype/${pname}
+
+      runHook postInstall
     '';
 
     meta = with lib; {

--- a/pkgs/data/fonts/rounded-mgenplus/default.nix
+++ b/pkgs/data/fonts/rounded-mgenplus/default.nix
@@ -1,17 +1,25 @@
-{ lib, fetchzip, p7zip }:
+{ lib, stdenvNoCC, fetchurl, p7zip }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "rounded-mgenplus";
   version = "20150602";
-in fetchzip rec {
-  name = "${pname}-${version}";
 
-  url = "https://osdn.jp/downloads/users/8/8598/${name}.7z";
-  postFetch = ''
-    ${p7zip}/bin/7z x $downloadedFile
+  src = fetchurl {
+    url = "https://osdn.jp/downloads/users/8/8598/${pname}-${version}.7z";
+    hash = "sha256-7OpnZJc9k5NiOPHAbtJGMQvsMg9j81DCvbfo0f7uJcw=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ p7zip ];
+
+  installPhase = ''
+    runHook preInstall
+
     install -m 444 -D -t $out/share/fonts/${pname} ${pname}-*.ttf
+
+    runHook postInstall
   '';
-  sha256 = "0vwdknagdrl5dqwpb1x5lxkbfgvbx8dpg7cb6yamgz71831l05v1";
 
   meta = with lib; {
     description = "A Japanese font based on Rounded M+ and Noto Sans Japanese";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
