### PR TITLE
linuxPackages.ax99100: fix build on newer kernels

### DIFF
--- a/pkgs/os-specific/linux/ax99100/kernel-5.18-pci_free_consistent-pci_alloc_consistent.patch
+++ b/pkgs/os-specific/linux/ax99100/kernel-5.18-pci_free_consistent-pci_alloc_consistent.patch
@@ -1,0 +1,14 @@
+diff -pNaru5 a/ax99100_sp.h b/ax99100_sp.h
+--- ax99100_sp.h	2022-06-07 16:55:26.621034945 -0400
++++ ax99100_sp.h	2022-06-07 16:58:32.488989767 -0400
+@@ -255,5 +255,10 @@ struct custom_eeprom {
+ #define _INLINE_
+ #endif
+ 
+ #define DEFAULT99100_BAUD 115200
+ #endif
++
++/* #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0) */
++#define pci_alloc_consistent(hwdev,size,dma_handle) dma_alloc_coherent(&hwdev->dev, size, dma_handle, GFP_ATOMIC)
++#define pci_free_consistent(hwdev,size,vaddr,dma_handle) dma_free_coherent(&hwdev->dev, size, vaddr, dma_handle)
++/* #endif */

--- a/pkgs/os-specific/linux/ax99100/kernel-6.1-set_termios-const-ktermios.patch
+++ b/pkgs/os-specific/linux/ax99100/kernel-6.1-set_termios-const-ktermios.patch
@@ -1,0 +1,18 @@
+diff -pNaru5 a/ax99100_sp.c b/ax99100_sp.c
+--- ax99100_sp.c	2023-01-02 23:44:46.707423858 -0500
++++ ax99100_sp.c	2023-01-02 23:44:27.171293092 -0500
+@@ -1915,11 +1915,13 @@ static unsigned int serial99100_get_divi
+ 	DEBUG("In %s quot=%u----baud=%u-----------------------------END\n",__FUNCTION__,quot,baud);
+ 	return quot;	
+ }
+ 
+ //This is a port ops function to set the terminal settings.
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,20)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
++static void serial99100_set_termios(struct uart_port *port, struct ktermios *termios, const struct ktermios *old)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,20)
+ static void serial99100_set_termios(struct uart_port *port, struct ktermios *termios, struct ktermios *old)
+ #else
+ static void serial99100_set_termios(struct uart_port *port, struct termios *termios, struct termios *old)
+ #endif
+ {


### PR DESCRIPTION
###### Description of changes

This PR pulls [some patches](https://aur.archlinux.org/packages/asix-ax99100) from Arch Linux to make the ax99100 serial driver build on newer Linux kernels.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
