### PR TITLE
ttfb: init at 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11254,6 +11254,12 @@
     githubId = 3737;
     name = "Peter Jones";
   };
+  phip1611 = {
+    email = "phip1611@gmail.com";
+    github = "phip1611";
+    githubId = 5737016;
+    name = "Philipp Schuster";
+  };
   pkharvey = {
     email = "kayharvey@protonmail.com";
     github = "pkharvey";

--- a/pkgs/development/tools/ttfb/default.nix
+++ b/pkgs/development/tools/ttfb/default.nix
@@ -1,0 +1,45 @@
+{ darwin
+, fetchCrate
+, lib
+, openssl
+, pkg-config
+, rustPlatform
+, stdenv
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ttfb";
+  version = "1.6.0";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-o7kzQ8jtAqDwTUPtjeNqgotxREeWl7jQG+EDrYWJL/Q=";
+  };
+
+  cargoSha256 = "sha256-ayyYrrFDVOYVjVo5TLaRn2mvmywe5BjQ7kRVV2r0iK8=";
+
+  # The bin feature activates all dependencies of the binary. Otherwise,
+  # only the library is build.
+  buildFeatures = [ "bin" ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  meta = with lib; {
+    description = "CLI-Tool to measure the TTFB (time to first byte) of HTTP(S) requests";
+    longDescription = ''
+      This crate measures the times of DNS lookup, TCP connect, TLS handshake, and HTTP's TTFB
+      for a given IP or domain.
+    '';
+    homepage = "https://github.com/phip1611/ttfb";
+    changelog = "https://github.com/phip1611/ttfb/blob/v${version}/CHANGELOG.md";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ phip1611 ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12648,6 +12648,8 @@ with pkgs;
 
   oysttyer = callPackage ../applications/networking/instant-messengers/oysttyer { };
 
+  ttfb = callPackage ../development/tools/ttfb { };
+
   twilight = callPackage ../tools/graphics/twilight {
     libX11 = xorg.libX11;
   };


### PR DESCRIPTION
This adds ttfb to nixpkgs.

This is my first-ever upstreamed package.
I don't know what to set in the maintainers attribute.

###### Description of changes

Adds the CLI utility <https://github.com/phip1611/ttfb> to to nixpkgs.
It works on Linux and MacOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
