### PR TITLE
python310Packages.packaging: 21.3 -> 23.0, add SuperSandro2000 as mai…

### DIFF
--- a/pkgs/development/python-modules/packaging/default.nix
+++ b/pkgs/development/python-modules/packaging/default.nix
@@ -1,39 +1,38 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pyparsing
+, flit-core
+, pretend
 , pytestCheckHook
 , pythonOlder
-, pretend
-, setuptools
 }:
 
 let
   packaging = buildPythonPackage rec {
     pname = "packaging";
-    version = "21.3";
+    version = "23.0";
     format = "pyproject";
 
-    disabled = pythonOlder "3.6";
+    disabled = pythonOlder "3.7";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "sha256-3UfEKSfYmrkR5gZRiQfMLTofOLvQJjhZcGQ/nFuOz+s=";
+      sha256 = "sha256-tq0pf4kH3g+i/hzL0m/a84f19Hxydf7fjM6J+ZRGz5c=";
     };
 
     nativeBuildInputs = [
-      setuptools
+      flit-core
     ];
-
-    propagatedBuildInputs = [ pyparsing ];
 
     nativeCheckInputs = [
       pytestCheckHook
       pretend
     ];
 
-    # Prevent circular dependency
+    # Prevent circular dependency with pytest
     doCheck = false;
+
+    pythonImportsCheck = [ "packaging" ];
 
     passthru.tests = packaging.overridePythonAttrs (_: { doCheck = true; });
 
@@ -41,7 +40,7 @@ let
       description = "Core utilities for Python packages";
       homepage = "https://github.com/pypa/packaging";
       license = with licenses; [ bsd2 asl20 ];
-      maintainers = with maintainers; [ bennofs ];
+      maintainers = with maintainers; [ bennofs SuperSandro2000 ];
     };
   };
 in


### PR DESCRIPTION
…ntainer

Removes pyparsing dependency which was already with 22.0 no longer a requiremnt.

https://github.com/pypa/packaging/releases

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
