### PR TITLE
pw-volume: init at 0.4.0

### DIFF
--- a/pkgs/tools/audio/pw-volume/default.nix
+++ b/pkgs/tools/audio/pw-volume/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, fetchFromGitHub
+, fetchurl
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pw-volume";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "smasher164";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-u7Ct9Kfwld/h3b6hUZdfHNuDGE4NA3MwrmgUj4g64lw=";
+  };
+
+  cargoPatches = [
+    (fetchurl {
+      # update Cargo.lock
+      url = "https://github.com/smasher164/pw-volume/commit/be104eaaeb84def26b392cc44bb1e7b880bef0fc.patch";
+      sha256 = "sha256-gssRcKpqxSAvW+2kJzIAR/soIQ3xg6LDZ7OeXds4ulY=";
+    })
+  ];
+
+  cargoSha256 = "sha256-Vzd5ZbbzJh2QqiOrBOszsNqLwxM+mm2lbGd5JtKZzEM=";
+
+  meta = with lib; {
+    description = "Basic interface to PipeWire volume controls";
+    homepage = "https://github.com/smasher164/pw-volume";
+    license = licenses.mit;
+    maintainers = with maintainers; [ astro ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16479,6 +16479,8 @@ with pkgs;
   pipewire_0_2 = callPackage ../development/libraries/pipewire/0.2.nix {};
   wireplumber = callPackage ../development/libraries/pipewire/wireplumber.nix {};
 
+  pw-volume = callPackage ../tools/audio/pw-volume {};
+
   pyradio = callPackage ../applications/audio/pyradio {};
 
   racket = callPackage ../development/interpreters/racket {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
