### PR TITLE
mbusd: init at 0.5.1

### DIFF
--- a/pkgs/servers/mbusd/default.nix
+++ b/pkgs/servers/mbusd/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "mbusd";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "3cky";
+    repo = "mbusd";
+    rev = "v${version}";
+    hash = "sha256-vYYaJKcnREng+2UsDIZ28hvANkQCHVixQIxo82m7MQs=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  meta = with lib; {
+    description = "Modbus TCP to Modbus RTU (RS-232/485) gateway";
+    homepage = "https://github.com/3cky/mbusd";
+    changelog = "https://github.com/3cky/mbusd/blob/v${version}/CHANGELOG.md";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24386,6 +24386,8 @@ with pkgs;
 
   mattermost-desktop = callPackage ../applications/networking/instant-messengers/mattermost-desktop { };
 
+  mbusd = callPackage ../servers/mbusd { };
+
   memcached = callPackage ../servers/memcached {};
 
   merecat = callPackage ../servers/http/merecat { };


### PR DESCRIPTION
###### Description of changes
**[mbusd](https://github.com/3cky/mbusd)** is open-source [Modbus TCP to Modbus RTU (RS-232/485)](https://en.wikipedia.org/wiki/Modbus) gateway.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
