### PR TITLE
libvirt-glib: fix cross

### DIFF
--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -5,21 +5,23 @@
 , meson
 , ninja
 , pkg-config
-, gobject-introspection
 , gettext
-, gtk-doc
-, docbook-xsl-nons
 , vala
 , libcap_ng
 , libvirt
 , libxml2
+, withIntrospection ? stdenv.hostPlatform == stdenv.buildPlatform
+, gobject-introspection
+, withDocs ? stdenv.hostPlatform == stdenv.buildPlatform
+, gtk-doc
+, docbook-xsl-nons
 }:
 
 stdenv.mkDerivation rec {
   pname = "libvirt-glib";
   version = "4.0.0";
 
-  outputs = [ "out" "dev" "devdoc" ];
+  outputs = [ "out" "dev" ] ++ lib.optional withDocs "devdoc";
 
   src = fetchurl {
     url = "https://libvirt.org/sources/glib/${pname}-${version}.tar.xz";
@@ -39,21 +41,34 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     gettext
-    gtk-doc
-    docbook-xsl-nons
     vala
     gobject-introspection
+  ] ++ lib.optionals withIntrospection [
+    gobject-introspection
+  ] ++ lib.optionals withDocs [
+    gtk-doc
+    docbook-xsl-nons
   ];
 
-  buildInputs = (lib.optionals stdenv.isLinux [
-    libcap_ng
-  ]) ++ [
+  buildInputs = [
     libvirt
     libxml2
+  ] ++ lib.optionals stdenv.isLinux [
+    libcap_ng
+  ] ++ lib.optionals withIntrospection [
     gobject-introspection
   ];
 
   strictDeps = true;
+
+  # The build system won't let us build with docs or introspection
+  # unless we're building natively, but will still do a mandatory
+  # check for the dependencies for those things unless we explicitly
+  # disable the options.
+  mesonFlags = [
+    (lib.mesonEnable "docs" withDocs)
+    (lib.mesonEnable "introspection" withIntrospection)
+  ];
 
   # https://gitlab.com/libvirt/libvirt-glib/-/issues/4
   NIX_CFLAGS_COMPILE = [ "-Wno-error=pointer-sign" ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
