### PR TITLE
argp-standalone: 1.3 -> 1.5.0; broaden platforms

### DIFF
--- a/pkgs/development/libraries/argp-standalone/default.nix
+++ b/pkgs/development/libraries/argp-standalone/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/argp-standalone/argp-standalone";
     description = "Standalone version of arguments parsing functions from Glibc";
-    platforms = with platforms; darwin ++ linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ amar1729 ];
     license = licenses.lgpl21Plus;
   };

--- a/pkgs/development/libraries/argp-standalone/default.nix
+++ b/pkgs/development/libraries/argp-standalone/default.nix
@@ -1,62 +1,25 @@
-{ lib, stdenv, fetchurl, fetchpatch }:
+{ lib, stdenv, fetchFromGitHub, meson, ninja }:
 
-let
-  patch-argp-fmtstream = fetchpatch {
-    name = "patch-argp-fmtstream.h";
-    url = "https://raw.githubusercontent.com/Homebrew/formula-patches/b5f0ad3/argp-standalone/patch-argp-fmtstream.h";
-    sha256 = "5656273f622fdb7ca7cf1f98c0c9529bed461d23718bc2a6a85986e4f8ed1cb8";
-  };
-
-  patch-throw-in-funcdef = fetchpatch {
-    name = "argp-standalone-1.3-throw-in-funcdef.patch";
-    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-libs/argp-standalone/files/argp-standalone-1.3-throw-in-funcdef.patch?id=409d0e2a9c9c899fb1fb04cc808fe0aff3f745ca";
-    sha256 = "0b2b4l1jkvmnffl22jcn4ydzxy2i7fnmmnfim12f0yg5pb8fs43c";
-  };
-
-  patch-shared = fetchpatch {
-    name = "argp-standalone-1.3-shared.patch";
-    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-libs/argp-standalone/files/argp-standalone-1.3-shared.patch?id=409d0e2a9c9c899fb1fb04cc808fe0aff3f745ca";
-    sha256 = "1xx2zdc187a1m2x6c1qs62vcrycbycw7n0q3ks2zkxpaqzx2dgkw";
-  };
-in
 stdenv.mkDerivation rec {
   pname = "argp-standalone";
-  version = "1.3";
+  version = "1.5.0";
 
-  src = fetchurl {
-    url = "https://www.lysator.liu.se/~nisse/misc/argp-standalone-${version}.tar.gz";
-    sha256 = "dec79694da1319acd2238ce95df57f3680fea2482096e483323fddf3d818d8be";
+  src = fetchFromGitHub {
+    owner = "argp-standalone";
+    repo = "argp-standalone";
+    rev = version;
+    sha256 = "jWnoWVnUVDQlsC9ru7oB9PdtZuyCCNqGnMqF/f2m0ZY=";
   };
 
-  patches =
-       lib.optionals stdenv.hostPlatform.isDarwin [ patch-argp-fmtstream ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ patch-throw-in-funcdef patch-shared ];
-
-  patchFlags = lib.optional stdenv.hostPlatform.isDarwin "-p0";
-
-  # For currently unknown reason, `-fPIC` has to be passed explicitly, otherwise
-  # downstream software like `elfutils` will get `recompile errors like:
-  #     libargp.a(argp-help.o): relocation R_X86_64_PC32 against symbol `program_invocation_short_name' can not be used when making a shared object; recompile with -fPIC
-  # It seems that nixpkgs's on-by-default `-fPIC` is not in effect here.
-  preConfigure = lib.optionalString stdenv.hostPlatform.isLinux "export CFLAGS='-fgnu89-inline -fPIC'";
-
-  postInstall = ''
-    mkdir -p $out/lib $out/include
-    cp libargp.a $out/lib
-    cp argp.h $out/include
-  '';
+  nativeBuildInputs = [ meson ninja ];
 
   doCheck = true;
 
-  makeFlags = [ "AR:=$(AR)" ];
-
-  enableParallelBuilding = true;
-
   meta = with lib; {
-    homepage = "https://www.lysator.liu.se/~nisse/misc/";
-    description = "Standalone version of arguments parsing functions from GLIBC";
+    homepage = "https://github.com/argp-standalone/argp-standalone";
+    description = "Standalone version of arguments parsing functions from Glibc";
     platforms = with platforms; darwin ++ linux;
     maintainers = with maintainers; [ amar1729 ];
-    license = licenses.gpl2;
+    license = licenses.lgpl21Plus;
   };
 }


### PR DESCRIPTION
###### Description of changes

Switch to maintained fork also used by Alpine, DPorts, FreeBSD Ports,
Gentoo, LiGurOS, and OpenBSD Ports.

All the issues we had hacks for seem to have been fixed.

Builds fine for FreeBSD and NetBSD.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
