### PR TITLE
libredirect: add more wrappers

### DIFF
--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -201,6 +201,37 @@ WRAPPER(int, __xstat64)(int ver, const char * path, struct stat64 * st)
 WRAPPER_DEF(__xstat64)
 #endif
 
+#ifdef __linux__
+WRAPPER(int, statx)(int dirfd, const char * restrict pathname, int flags,
+    unsigned int mask, struct statx * restrict statxbuf)
+{
+    int (*statx_real) (int, const char * restrict, int,
+        unsigned int, struct statx * restrict) = LOOKUP_REAL(statx);
+    char buf[PATH_MAX];
+    return statx_real(dirfd, rewrite(pathname, buf), flags, mask, statxbuf);
+}
+WRAPPER_DEF(statx)
+#endif
+
+WRAPPER(int, fstatat)(int dirfd, const char * pathname, struct stat * statbuf, int flags)
+{
+    int (*fstatat_real) (int, const char *, struct stat *, int) = LOOKUP_REAL(fstatat);
+    char buf[PATH_MAX];
+    return fstatat_real(dirfd, rewrite(pathname, buf), statbuf, flags);
+}
+WRAPPER_DEF(fstatat);
+
+// In musl libc, fstatat64 is simply a macro for fstatat
+#if !defined(__APPLE__) && !defined(fstatat64)
+WRAPPER(int, fstatat64)(int dirfd, const char * pathname, struct stat64 * statbuf, int flags)
+{
+    int (*fstatat64_real) (int, const char *, struct stat64 *, int) = LOOKUP_REAL(fstatat64);
+    char buf[PATH_MAX];
+    return fstatat64_real(dirfd, rewrite(pathname, buf), statbuf, flags);
+}
+WRAPPER_DEF(fstatat64);
+#endif
+
 WRAPPER(int, stat)(const char * path, struct stat * st)
 {
     int (*__stat_real) (const char *, struct stat *) = LOOKUP_REAL(stat);
@@ -208,6 +239,17 @@ WRAPPER(int, stat)(const char * path, struct stat * st)
     return __stat_real(rewrite(path, buf), st);
 }
 WRAPPER_DEF(stat)
+
+// In musl libc, stat64 is simply a macro for stat
+#if !defined(__APPLE__) && !defined(stat64)
+WRAPPER(int, stat64)(const char * path, struct stat64 * st)
+{
+    int (*stat64_real) (const char *, struct stat64 *) = LOOKUP_REAL(stat64);
+    char buf[PATH_MAX];
+    return stat64_real(rewrite(path, buf), st);
+}
+WRAPPER_DEF(stat64)
+#endif
 
 WRAPPER(int, access)(const char * path, int mode)
 {
@@ -345,6 +387,14 @@ WRAPPER(int, system)(const char *command)
     return _system(newCommand);
 }
 WRAPPER_DEF(system)
+
+WRAPPER(int, chdir)(const char *path)
+{
+    int (*chdir_real) (const char *) = LOOKUP_REAL(chdir);
+    char buf[PATH_MAX];
+    return chdir_real(rewrite(path, buf));
+}
+WRAPPER_DEF(chdir);
 
 WRAPPER(int, mkdir)(const char *path, mode_t mode)
 {

--- a/pkgs/build-support/libredirect/test.c
+++ b/pkgs/build-support/libredirect/test.c
@@ -63,6 +63,12 @@ int main(int argc, char *argv[])
     FILE *testfp;
     int testfd;
     struct stat testsb;
+#ifndef __APPLE__
+    struct stat64 testsb64;
+#endif
+#ifdef __linux__
+    struct statx testsbx;
+#endif
     char buf[PATH_MAX];
 
     testfp = fopen(TESTPATH, "r");
@@ -76,6 +82,20 @@ int main(int argc, char *argv[])
     assert(access(TESTPATH, X_OK) == 0);
 
     assert(stat(TESTPATH, &testsb) != -1);
+#ifndef __APPLE__
+    assert(stat64(TESTPATH, &testsb64) != -1);
+#endif
+    assert(fstatat(123, TESTPATH, &testsb, 0) != -1);
+#ifndef __APPLE__
+    assert(fstatat64(123, TESTPATH, &testsb64, 0) != -1);
+#endif
+#ifdef __linux__
+    assert(statx(123, TESTPATH, 0, STATX_ALL, &testsbx) != -1);
+#endif
+
+    assert(getcwd(buf, PATH_MAX) != NULL);
+    assert(chdir(TESTDIR) == 0);
+    assert(chdir(buf) == 0);
 
     assert(mkdir(TESTDIR "/dir-mkdir", 0777) == 0);
     assert(unlink(TESTDIR "/dir-mkdir") == -1); // it's a directory!


### PR DESCRIPTION
###### Description of changes

This appears to satisfy the JVM and most coreutils programs like mkdir, etc., as used in self-contained installers like Revenera InstallAnywhere.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
