### PR TITLE
python310Packages.systemd: 234 -> 235, adopt, run tests

### DIFF
--- a/pkgs/development/python-modules/systemd/default.nix
+++ b/pkgs/development/python-modules/systemd/default.nix
@@ -1,30 +1,23 @@
 { lib
 , buildPythonPackage
-, fetchpatch
 , fetchFromGitHub
+, libredirect
 , systemd
 , pkg-config
+, pytest
+, python
 }:
 
 buildPythonPackage rec {
   pname = "systemd";
-  version = "234";
+  version = "235";
 
   src = fetchFromGitHub {
     owner = "systemd";
     repo = "python-systemd";
     rev = "v${version}";
-    sha256 = "1fakw7qln44mfd6pj4kqsgyrhkc6cyr653id34kv0rdnb1bvysrz";
+    sha256 = "sha256-8p4m4iM/z4o6PHRQIpuSXb64tPTWGlujEYCDVLiIt2o=";
   };
-
-  patches = [
-    # Fix runtime issues on Python 3.10
-    # https://github.com/systemd/python-systemd/issues/107
-    (fetchpatch {
-      url = "https://github.com/systemd/python-systemd/commit/c71bbac357f0ac722e1bcb2edfa925b68cca23c9.patch";
-      sha256 = "22s72Wa/BCwNNvwbxEUh58jhHlbA00SNwNVchVDovcc=";
-    })
-  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -34,8 +27,17 @@ buildPythonPackage rec {
     systemd
   ];
 
-  # No module named 'systemd._journal
-  doCheck = false;
+  nativeCheckInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    echo "12345678901234567890123456789012" > machine-id
+    export NIX_REDIRECTS=/etc/machine-id=$(realpath machine-id) \
+    LD_PRELOAD=${libredirect}/lib/libredirect.so
+
+    pytest $out/${python.sitePackages}/systemd
+  '';
 
   pythonImportsCheck = [
     "systemd.journal"
@@ -46,7 +48,9 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python module for native access to the systemd facilities";
-    homepage = "http://www.freedesktop.org/software/systemd/python-systemd/";
+    homepage = "https://www.freedesktop.org/software/systemd/python-systemd/";
+    changelog = "https://github.com/systemd/python-systemd/blob/v${version}/NEWS";
     license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
