### PR TITLE
dejagnu: fix target passing for 'runtest' wrapper

### DIFF
--- a/pkgs/development/tools/misc/dejagnu/default.nix
+++ b/pkgs/development/tools/misc/dejagnu/default.nix
@@ -36,8 +36,11 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    wrapProgram "$out/bin/runtest" \
-      --prefix PATH ":" "${expect}/bin"
+    # 'runtest' and 'dejagnu' look up 'expect' in their 'bin' path
+    # first. We avoid use of 'wrapProgram' here because  wrapping
+    # of shell scripts does not preserve argv[0] for schell scripts:
+    #   https://sourceware.org/PR30052#c5
+    ln -s ${expect}/bin/expect $out/bin/expect
   '';
 
   meta = with lib; {


### PR DESCRIPTION
The problem was initially noticed in https://sourceware.org/PR30052#c5 where 'runtest' was passing bogus target name when ran without parameters:

    $ ./result/bin/runtest
    ...
    Target is .runtest-wrapped
    Host   is x86_64-pc-linux-gnu

Note that runtest switches to non-native mode and uses wrapper name as a target name. Mechanics of it is a bit involved: 'runtest' itself detects targets passing via ${0} parameter:

    # somewhere in runtest:
    mypath=${0-.}
    ...
    if [ "$target" != runtest ] ; then
        target="--target ${target}"
    else
        target=""
    fi

which would be fine if we ran 'runtest'.

In `nixpkgs` `runtest` is a shell wrapper:

    $ cat /<<NIX>>/dejagnu-1.6.3/bin/runtest
    #! /<<NIX>>/bash-5.2-p15/bin/bash -e
    ...
    exec -a "$0" "/<<NIX>>/dejagnu-1.6.3/bin/.runtest-wrapped"  "$@"

You would expect that `.runtest-wrapped` would get `$0` as an `argv[0]` here, but no. If both are `bash` scripts `bash` peeks original `argv[0]` and breaks `runtest`:

    https://lists.gnu.org/archive/html/bug-bash/2023-01/msg00082.html

The workaround here is to drop the wrapper and place `expect` symlink into a place where `dejagnu` and `runtest` expect it to be without a wrapper creation.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
