### PR TITLE
Pantheon 7 updates 2023-01-26

### DIFF
--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/0001-Remove-Install-Unlisted-Engines-function.patch
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/0001-Remove-Install-Unlisted-Engines-function.patch
@@ -263,7 +263,7 @@ deleted file mode 100644
 index 275c302..0000000
 --- a/src/InputMethod/Installer/InstallList.vala
 +++ /dev/null
-@@ -1,73 +0,0 @@
+@@ -1,75 +0,0 @@
 -/*
 -* 2019-2020 elementary, Inc. (https://elementary.io)
 -*
@@ -306,7 +306,7 @@ index 275c302..0000000
 -            case KO:
 -                return { "ibus-hangul" };
 -            case ZH:
--                return { "ibus-cangjie", "ibus-chewing", "ibus-pinyin" };
+-                return { "ibus-cangjie", "ibus-chewing", "ibus-pinyin", "ibus-rime" };
 -            default:
 -                assert_not_reached ();
 -        }
@@ -327,6 +327,8 @@ index 275c302..0000000
 -            case "ibus-chewing":
 -                return ZH;
 -            case "ibus-pinyin":
+-                return ZH;
+-            case "ibus-rime":
 -                return ZH;
 -            default:
 -                assert_not_reached ();

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , substituteAll
 , meson
@@ -23,20 +24,33 @@
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-keyboard";
-  version = "2.7.0";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-ge87rctbd7iR9x9Xq4sMIC09DiPHbpbWBgMZUuJNWbw=";
+    sha256 = "sha256-DofAOv7sCe7RAJpgz9PEYm+C8RAl0a1KgFm9jToMsEY=";
   };
 
   patches = [
     ./0001-Remove-Install-Unlisted-Engines-function.patch
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit ibus onboard;
+      inherit ibus onboard libgnomekbd;
+    })
+
+    # Revert schema key change that requires new GSD and Gala.
+    # TODO(@bobby285271): drop these in #196511.
+    (fetchpatch {
+      url = "https://github.com/elementary/switchboard-plug-keyboard/commit/555e9650bb8f74a7664e2393c589fe6664954a88.patch";
+      sha256 = "sha256-koSTYLPRh9rOyxmJPtrj/fPuu2jb1SKZu6BwKsMvAmc=";
+      revert = true;
+    })
+    (fetchpatch {
+      url = "https://github.com/elementary/switchboard-plug-keyboard/commit/6ebd57673b45cc64e1caf895134efc0d5f6cf2be.patch";
+      sha256 = "sha256-Ezsh0t1/909MHCB2EJEnl4kcnXngshNYgrmqUQsfsaY=";
+      revert = true;
     })
   ];
 
@@ -55,7 +69,6 @@ stdenv.mkDerivation rec {
     gtk3
     ibus
     libgee
-    libgnomekbd
     libhandy
     libxklavier
     switchboard

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/fix-paths.patch
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/fix-paths.patch
@@ -24,3 +24,16 @@ index 75d2d805..b86252a4 100644
                      appinfo.launch (null, null);
                  } catch (Error e) {
                      warning ("Unable to launch onboard-settings: %s", e.message);
+diff --git a/src/Dialogs/AddLayoutDialog.vala b/src/Dialogs/AddLayoutDialog.vala
+index 7c2efda3..de77094f 100644
+--- a/src/Dialogs/AddLayoutDialog.vala
++++ b/src/Dialogs/AddLayoutDialog.vala
+@@ -197,7 +197,7 @@ public class Pantheon.Keyboard.LayoutPage.AddLayoutDialog : Granite.Dialog {
+         });
+ 
+         keyboard_map_button.clicked.connect (() => {
+-            string command = "gkbd-keyboard-display \"--layout=" + layout_id + "\"";
++            string command = "@libgnomekbd@/bin/gkbd-keyboard-display \"--layout=" + layout_id + "\"";
+             try {
+                 AppInfo.create_from_commandline (command, null, AppInfoCreateFlags.NONE).launch (null, null);
+             } catch (Error e) {

--- a/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
@@ -13,13 +13,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "elementary-icon-theme";
-  version = "7.1.0";
+  version = "7.2.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "icons";
     rev = version;
-    sha256 = "sha256-SMeVu4RbXodbxtVkQE2tvv6LaVWzrq7UBlwmi30ns2Q=";
+    sha256 = "sha256-Hh7RiD85N48IpO2sfWSybhS7kJYXH4VOhQ6PVIP9IS8=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

https://github.com/NixOS/nixpkgs/issues/170361
https://github.com/bobby285271/what-changed/issues/17

I am doing two updates together specifically for

- https://github.com/elementary/icons/commit/5c0694cd72db1218ad56e66930fa2ef32457596e 
- https://github.com/elementary/switchboard-plug-keyboard/commit/7b72d850c4659484027f9d4d4eb863ddafb28fcb

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
