### PR TITLE
looking-glass-client: B5.0.1 -> B6

### DIFF
--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, makeDesktopItem, cmake, pkg-config
 , freefont_ttf, spice-protocol, nettle, libbfd, fontconfig, libffi, expat
 , libxkbcommon, libGL, libXext, libXrandr, libXi, libXScrnSaver, libXinerama
-, libXcursor, libXpresent, wayland, wayland-protocols
+, libXcursor, libXpresent, libpulseaudio, libsamplerate, pipewire, wayland, wayland-protocols
 }:
 
 let
@@ -16,13 +16,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "looking-glass-client";
-  version = "B5.0.1";
+  version = "B6";
 
   src = fetchFromGitHub {
     owner = "gnif";
     repo = "LookingGlass";
     rev = version;
-    sha256 = "sha256-UzZQU5SzJ2mo9QBweQB0VJSnKfzgTG5QaKpIQN/6LCE=";
+    sha256 = "sha256-6vYbNmNJBCoU23nVculac24tHqH7F4AZVftIjL93WJU=";
     fetchSubmodules = true;
   };
 
@@ -45,6 +45,9 @@ stdenv.mkDerivation rec {
     libXpresent
     libXext
     libXrandr
+    libpulseaudio
+    libsamplerate
+    pipewire
     wayland
     wayland-protocols
   ];

--- a/pkgs/os-specific/linux/kvmfr/default.nix
+++ b/pkgs/os-specific/linux/kvmfr/default.nix
@@ -9,19 +9,6 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "pic" "format" ];
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  patches = lib.optional (kernel.kernelAtLeast "5.16") (fetchpatch {
-    name = "kvmfr-5.16.patch";
-    url = "https://github.com/gnif/LookingGlass/commit/a9b5302a517e19d7a2da114acf71ef1e69cfb497.patch";
-    sha256 = "017nxlk2f7kyjp6llwa74dbczdb1jk8v791qld81dxhzkm9dyqqx";
-    stripLen = 1;
-  })
-  ++ lib.optional (kernel.kernelAtLeast "5.18") (fetchpatch {
-    name = "kvmfr-5.18.patch";
-    url = "https://github.com/gnif/LookingGlass/commit/c7029f95042fe902843cb6acbfc75889e93dc210.patch";
-    sha256 = "sha256-6DpL17XWj8BKpiBdKdCPC51MWKLIo6PixQ9UaygT2Zg=";
-    stripLen = 1;
-  });
-
   makeFlags = [
     "KVER=${kernel.modDirVersion}"
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"


### PR DESCRIPTION
###### Description of changes
looking-glass-client: B5.0.1 -> B6

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
