### PR TITLE
bitwarden: build from source

### DIFF
--- a/pkgs/desktops/gnome/core/gnome-keyring/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-keyring/default.nix
@@ -19,6 +19,7 @@
 , docbook-xsl-nons
 , docbook_xml_dtd_43
 , gnome
+, useWrappedDaemon ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -78,7 +79,7 @@ stdenv.mkDerivation rec {
   '';
 
   # Use wrapped gnome-keyring-daemon with cap_ipc_lock=ep
-  postFixup = ''
+  postFixup = lib.optionalString useWrappedDaemon ''
     files=($out/etc/xdg/autostart/* $out/share/dbus-1/services/*)
 
     for file in ''${files[*]}; do

--- a/pkgs/tools/security/bitwarden/default.nix
+++ b/pkgs/tools/security/bitwarden/default.nix
@@ -1,73 +1,154 @@
-{ atomEnv
-, autoPatchelfHook
-, dpkg
-, fetchurl
-, lib
+{ lib
+, buildNpmPackage
+, dbus
+, electron
+, fetchFromGitHub
+, glib
+, gnome
+, gtk3
+, jq
 , libsecret
-, libxshmfence
 , makeDesktopItem
 , makeWrapper
-, stdenv
-, udev
+, moreutils
+, nodejs-16_x
+, pkg-config
+, python3
+, rustPlatform
 , wrapGAppsHook
 }:
 
-stdenv.mkDerivation rec {
-  pname = "bitwarden";
-  version = "2023.1.1";
+let
+  description = "A secure and free password manager for all of your devices";
+  icon = "bitwarden";
 
-  src = fetchurl {
-    url = "https://github.com/bitwarden/clients/releases/download/desktop-v${version}/Bitwarden-${version}-amd64.deb";
-    sha256 = "sha256-bL3ybErpY5jeCixF8qtU/DQ35xU+43K9aXreHsoCF7Q=";
+  buildNpmPackage' = buildNpmPackage.override { nodejs = nodejs-16_x; };
+
+  version = "2023.1.1";
+  src = fetchFromGitHub {
+    owner = "bitwarden";
+    repo = "clients";
+    rev = "desktop-v${version}";
+    sha256 = "YEHPDUa0BK8dtaIeWv2kICj6IZIOXUG13mCRzRk80ZY=";
+  };
+
+  desktop-native = rustPlatform.buildRustPackage rec {
+    pname = "bitwarden-desktop-native";
+    inherit src version;
+    sourceRoot = "source/apps/desktop/desktop_native";
+    cargoSha256 = "qSpLMYwFtE7BDVcUm7ycpKnfJSvlAUGL2KFoaSjREBM=";
+
+    patchFlags = [ "-p4" ];
+
+    nativeBuildInputs = [
+      pkg-config
+      wrapGAppsHook
+    ];
+
+    buildInputs = [
+      glib
+      gtk3
+      libsecret
+    ];
+
+    nativeCheckInputs = [
+      dbus
+      (gnome.gnome-keyring.override { useWrappedDaemon = false; })
+    ];
+
+    checkFlags = [
+      "--skip=password::password::tests::test"
+    ];
+
+    checkPhase = ''
+      runHook preCheck
+
+      export HOME=$(mktemp -d)
+      export -f cargoCheckHook runHook _eval _callImplicitHook
+      dbus-run-session \
+        --config-file=${dbus}/share/dbus-1/session.conf \
+        -- bash -e -c cargoCheckHook
+      runHook postCheck
+    '';
   };
 
   desktopItem = makeDesktopItem {
     name = "bitwarden";
     exec = "bitwarden %U";
-    icon = "bitwarden";
-    comment = "A secure and free password manager for all of your devices";
+    inherit icon;
+    comment = description;
     desktopName = "Bitwarden";
     categories = [ "Utility" ];
   };
 
-  dontBuild = true;
-  dontConfigure = true;
-  dontPatchELF = true;
-  dontWrapGApps = true;
+in
 
-  nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook wrapGAppsHook ];
+buildNpmPackage' {
+  pname = "bitwarden";
+  inherit src version;
 
-  buildInputs = [ libsecret libxshmfence ] ++ atomEnv.packages;
+  makeCacheWritable = true;
+  npmBuildFlags = [
+    "--workspace apps/desktop"
+  ];
+  npmDepsHash = "sha256-qDKs0P593cLnbBGPb3VCuAw0fCjVusF1dt4xCxh6BRo=";
 
-  unpackPhase = "dpkg-deb -x $src .";
+  ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-  installPhase = ''
-    mkdir -p "$out/bin"
-    cp -R "opt" "$out"
-    cp -R "usr/share" "$out/share"
-    chmod -R g-w "$out"
-
-    # Desktop file
-    mkdir -p "$out/share/applications"
-    cp "${desktopItem}/share/applications/"* "$out/share/applications"
-  '';
-
-  runtimeDependencies = [
-    (lib.getLib udev)
+  nativeBuildInputs = [
+    jq
+    makeWrapper
+    moreutils
   ];
 
-  postFixup = ''
-    makeWrapper $out/opt/Bitwarden/bitwarden $out/bin/bitwarden \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libsecret stdenv.cc.cc ] }" \
-      "''${gappsWrapperArgs[@]}"
+  preBuild = ''
+    jq 'del(.scripts.postinstall)' apps/desktop/package.json | sponge apps/desktop/package.json
+    jq '.scripts.build = ""' apps/desktop/desktop_native/package.json | sponge apps/desktop/desktop_native/package.json
+    cp ${desktop-native}/lib/libdesktop_native.so apps/desktop/desktop_native/desktop_native.linux-x64-musl.node
+  '';
+
+  postBuild = ''
+    pushd apps/desktop
+
+    "$(npm bin)"/electron-builder \
+      --dir \
+      -c.electronDist=${electron}/lib/electron \
+      -c.electronVersion=${electron.version}
+
+    popd
+  '';
+
+  installPhase = ''
+    mkdir $out
+
+    pushd apps/desktop/dist/linux-unpacked
+    mkdir -p $out/opt/Bitwarden
+    cp -r locales resources{,.pak} $out/opt/Bitwarden
+    popd
+
+    makeWrapper '${electron}/bin/electron' "$out/bin/bitwarden" \
+      --add-flags $out/opt/Bitwarden/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
+
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/* $out/share/applications
+
+    pushd apps/desktop/resources/icons
+    for icon in *.png; do
+      dir=$out/share/icons/hicolor/"''${icon%.png}"/apps
+      mkdir -p "$dir"
+      cp "$icon" "$dir"/${icon}.png
+    done
+    popd
   '';
 
   meta = with lib; {
-    description = "A secure and free password manager for all of your devices";
+    inherit description;
     homepage = "https://bitwarden.com";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ kiwi ];
+    license = lib.licenses.gpl3;
+    maintainers = with maintainers; [ amarshall kiwi ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/tools/security/bitwarden/default.nix
+++ b/pkgs/tools/security/bitwarden/default.nix
@@ -24,19 +24,19 @@ let
 
   buildNpmPackage' = buildNpmPackage.override { nodejs = nodejs-16_x; };
 
-  version = "2023.1.1";
+  version = "2023.2.0";
   src = fetchFromGitHub {
     owner = "bitwarden";
     repo = "clients";
     rev = "desktop-v${version}";
-    sha256 = "YEHPDUa0BK8dtaIeWv2kICj6IZIOXUG13mCRzRk80ZY=";
+    sha256 = "/k2r+TikxVGlz8cnOq5zF3oUYw4zj31vDAD7OQFQlC4=";
   };
 
   desktop-native = rustPlatform.buildRustPackage rec {
     pname = "bitwarden-desktop-native";
     inherit src version;
     sourceRoot = "source/apps/desktop/desktop_native";
-    cargoSha256 = "qSpLMYwFtE7BDVcUm7ycpKnfJSvlAUGL2KFoaSjREBM=";
+    cargoSha256 = "sha256-zLftfmWYYUAaMvIT21qhVsHzxnNdQhFBH0fRBwVduAc=";
 
     patchFlags = [ "-p4" ];
 
@@ -91,7 +91,7 @@ buildNpmPackage' {
   npmBuildFlags = [
     "--workspace apps/desktop"
   ];
-  npmDepsHash = "sha256-qDKs0P593cLnbBGPb3VCuAw0fCjVusF1dt4xCxh6BRo=";
+  npmDepsHash = "sha256-aFjN1S0+lhHjK3VSYfx0F5X8wSJwRRr6zQpPGt2VpxE=";
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
@@ -99,6 +99,7 @@ buildNpmPackage' {
     jq
     makeWrapper
     moreutils
+    python3
   ];
 
   preBuild = ''


### PR DESCRIPTION
###### Description of changes

Bitwarden package is now built from source.

I’ve been running the source build for 11+ days now without any problems for my usage. In particular, though, testing of the functionality of the “desktop_native” feature would be appreciated, as that seems most likely to have gone awry—afaik I don’t use anything it does and it’s not clear to me how to exercise it manually.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x]  x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
