### PR TITLE
lab: fix zsh completion, suffix all programs to be consistent 

### DIFF
--- a/pkgs/applications/version-management/lab/default.nix
+++ b/pkgs/applications/version-management/lab/default.nix
@@ -22,14 +22,16 @@ buildGoModule rec {
   ldflags = [ "-s" "-w" "-X main.version=${version}" ];
 
   postInstall = ''
-    # make xdg-open overrideable at runtime
-    wrapProgram $out/bin/lab \
-      --prefix PATH ":" "${lib.makeBinPath [ git ]}" \
-      --suffix PATH ":" "${lib.makeBinPath [ xdg-utils ]}"
+    # create shell completions before wrapProgram so that lab detects the right
+    # path for itself
     installShellCompletion --cmd lab \
       --bash <($out/bin/lab completion bash) \
       --fish <($out/bin/lab completion fish) \
       --zsh <($out/bin/lab completion zsh)
+    # make xdg-open overrideable at runtime
+    wrapProgram $out/bin/lab \
+      --prefix PATH ":" "${lib.makeBinPath [ git ]}" \
+      --suffix PATH ":" "${lib.makeBinPath [ xdg-utils ]}"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/version-management/lab/default.nix
+++ b/pkgs/applications/version-management/lab/default.nix
@@ -22,16 +22,14 @@ buildGoModule rec {
   ldflags = [ "-s" "-w" "-X main.version=${version}" ];
 
   postInstall = ''
-    # create shell completions before wrapProgram so that lab detects the right
-    # path for itself
+    # create shell completions before wrapProgram so that lab detects the right path for itself
     installShellCompletion --cmd lab \
       --bash <($out/bin/lab completion bash) \
       --fish <($out/bin/lab completion fish) \
       --zsh <($out/bin/lab completion zsh)
     # make xdg-open overrideable at runtime
     wrapProgram $out/bin/lab \
-      --prefix PATH ":" "${lib.makeBinPath [ git ]}" \
-      --suffix PATH ":" "${lib.makeBinPath [ xdg-utils ]}"
+      --suffix PATH ":" "${lib.makeBinPath [ git xdg-utils ]}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Fixes #209115 by generating completions before we wrap the binary, so that `lab completions` detects the correct path for itself.

To test:
- `nix shell .#lab .#zsh -c zsh`
- in zsh: `source $(nix build --no-out-link --print-out-paths)/share/zsh/site-functions/_lab`
- enter `lab ` and press tab

If `lab` is not set up, tab completion will cause another error <TODO>. It's an issue with upstream though:
- https://github.com/zaquestion/lab/pull/846

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
