### PR TITLE
Revert "libdatrie: depend on libiconv unconditionally"

### DIFF
--- a/pkgs/development/libraries/libdatrie/default.nix
+++ b/pkgs/development/libraries/libdatrie/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     installShellFiles
   ];
 
-  buildInputs = [ libiconv ];
+  buildInputs = lib.optional stdenv.isDarwin libiconv;
 
   preAutoreconf = let
     reports = "https://github.com/tlwg/libdatrie/issues";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#212669

It caused too large rebuild; needs to go to `staging` instead (or change).