### PR TITLE
ddnet: 16.5 -> 16.7.2

### DIFF
--- a/pkgs/games/ddnet/default.nix
+++ b/pkgs/games/ddnet/default.nix
@@ -4,6 +4,7 @@
 , cmake
 , ninja
 , pkg-config
+, rustPlatform
 , curl
 , freetype
 , libGLU
@@ -22,6 +23,7 @@
 , vulkan-loader
 , glslang
 , spirv-tools
+, gtest
 , Carbon
 , Cocoa
 , OpenGL
@@ -30,16 +32,33 @@
 
 stdenv.mkDerivation rec {
   pname = "ddnet";
-  version = "16.5";
+  version = "16.7.2";
 
   src = fetchFromGitHub {
     owner = "ddnet";
     repo = pname;
     rev = version;
-    sha256 = "sha256-fHe72ew+qoSyOqXU9Hs9EyecrYDjEqTm+Ii9Zja9up4=";
+    hash = "sha256-dK46ubcq/sYSXLeZwAeomj9+jpSNpgHsTmXKdrllLTc=";
   };
 
-  nativeBuildInputs = [ cmake ninja pkg-config ];
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    name = "${pname}-${version}";
+    inherit src;
+    hash = "sha256-jLR/XriiKXmpHGBHtPa1vpE5ms3Dw1wrNt/4KARyM74=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    rustPlatform.rust.rustc
+    rustPlatform.rust.cargo
+    rustPlatform.cargoSetupHook
+  ];
+
+  nativeCheckInputs = [
+    gtest
+  ];
 
   buildInputs = [
     curl
@@ -62,14 +81,17 @@ stdenv.mkDerivation rec {
     spirv-tools
   ] ++ lib.optionals stdenv.isDarwin [ Carbon Cocoa OpenGL Security ];
 
-  cmakeFlags = [
-    "-DAUTOUPDATE=OFF"
-  ];
-
   postPatch = ''
     substituteInPlace src/engine/shared/storage.cpp \
       --replace /usr/ $out/
   '';
+
+  cmakeFlags = [
+    "-DAUTOUPDATE=OFF"
+  ];
+
+  doCheck = true;
+  checkTarget = "run_tests";
 
   meta = with lib; {
     description = "A Teeworlds modification with a unique cooperative gameplay.";
@@ -82,9 +104,10 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://ddnet.org";
     license = licenses.asl20;
-    maintainers = with maintainers; [ sirseruju lom ];
+    maintainers = with maintainers; [ sirseruju lom ncfavier ];
     mainProgram = "DDNet";
     # error: use of undeclared identifier 'pthread_attr_set_qos_class_np'
+    # https://github.com/ddnet/ddnet/pull/5913
     broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/games/ddnet/default.nix
+++ b/pkgs/games/ddnet/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , ninja
 , pkg-config
@@ -81,6 +82,15 @@ stdenv.mkDerivation rec {
     spirv-tools
   ] ++ lib.optionals stdenv.isDarwin [ Carbon Cocoa OpenGL Security ];
 
+  patches = [
+    (fetchpatch {
+      # error: use of undeclared identifier 'pthread_attr_set_qos_class_np'
+      # https://github.com/ddnet/ddnet/pull/5913
+      url = "https://github.com/ddnet/ddnet/pull/5913/commits/ccc6cd59de58905dce3a3bd5d8461a03b1adb249.patch";
+      hash = "sha256-CkHckE+bOMKDcoijNYDo+zEQ9Eq9ePDV18LybzCMPYs=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace src/engine/shared/storage.cpp \
       --replace /usr/ $out/
@@ -106,8 +116,5 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ sirseruju lom ncfavier ];
     mainProgram = "DDNet";
-    # error: use of undeclared identifier 'pthread_attr_set_qos_class_np'
-    # https://github.com/ddnet/ddnet/pull/5913
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
Adds a build dependency on Rust.

Also enable the tests and add me as maintainer.

Let's see if it's still broken on darwin. EDIT: if so, I'll try applying [ddnet/ddnet@`97b9349` (#5913)](https://github.com/ddnet/ddnet/pull/5913/commits/97b9349e9b3ecd7263ed3abd6f58fe52c9f9b05d)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
