### PR TITLE
vulkan-caps-viewer: 3.27 -> 3.28

### DIFF
--- a/pkgs/tools/graphics/vulkan-caps-viewer/default.nix
+++ b/pkgs/tools/graphics/vulkan-caps-viewer/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   qmakeFlags = [
     "DEFINES+=wayland"
     "CONFIG+=release"
-  ]  ++ lib.lists.optionals withX11 [ "DEFINES+=X11" ];
+  ] ++ lib.lists.optionals withX11 [ "DEFINES+=X11" ];
 
   installFlags = [ "INSTALL_ROOT=$(out)" ];
 
@@ -51,10 +51,11 @@ stdenv.mkDerivation rec {
       Client application to display hardware implementation details for GPUs supporting the Vulkan API by Khronos.
       The hardware reports can be submitted to a public online database that allows comparing different devices, browsing available features, extensions, formats, etc.
     '';
-    homepage    = "https://vulkan.gpuinfo.org/";
-    platforms   = platforms.unix;
-    license     = licenses.gpl2Only;
+    homepage = "https://vulkan.gpuinfo.org/";
+    platforms = platforms.unix;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ pedrohlc ];
+    changelog = "https://github.com/SaschaWillems/VulkanCapsViewer/releases/tag/${version}";
     # never built on aarch64-darwin, x86_64-darwin since first introduction in nixpkgs
     broken = stdenv.isDarwin;
   };

--- a/pkgs/tools/graphics/vulkan-caps-viewer/default.nix
+++ b/pkgs/tools/graphics/vulkan-caps-viewer/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-caps-viewer";
-  version = "3.27";
+  version = "3.28";
 
   src = fetchFromGitHub {
     owner = "SaschaWillems";
     repo = "VulkanCapsViewer";
     rev = version;
-    hash = "sha256-B/FBX63JnBdshNLVMPA0qGnm0c/RGilIahX3VjJnpkI=";
+    hash = "sha256-gy0gFbPZAwQJHqJvk7WrbZ5y2I+9BGv9VaCoOW1QPek=";
     # Note: this derivation strictly requires vulkan-header to be the same it was developed against.
     # To help us, they've put it in a git-submodule.
     # The result will work with any vulkan-loader version.


### PR DESCRIPTION
###### Description of changes

Changelog: https://github.com/SaschaWillems/VulkanCapsViewer/releases/tag/3.28
Actually, full changes: https://github.com/SaschaWillems/VulkanCapsViewer/compare/3.27...3.28

###### Things done

Tested building and running.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

