### PR TITLE
python310Packages.python-lsp-server: 1.7.0 -> 1.7.1

### DIFF
--- a/pkgs/development/python-modules/autopep8/default.nix
+++ b/pkgs/development/python-modules/autopep8/default.nix
@@ -1,17 +1,20 @@
 { lib
+, buildPythonPackage
 , fetchFromGitHub
 , fetchpatch
-, buildPythonPackage
-, pythonOlder
-, pycodestyle
 , glibcLocales
-, tomli
+, pycodestyle
 , pytestCheckHook
+, pythonOlder
+, tomli
 }:
 
 buildPythonPackage rec {
   pname = "autopep8";
   version = "2.0.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "hhatto";
@@ -19,6 +22,15 @@ buildPythonPackage rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-YEPSsUzJG4MPiiloVAf9m/UiChkhkN0+lK6spycpSvo=";
   };
+
+  patches = [
+    # Ignore DeprecationWarnings to fix tests on Python 3.11, https://github.com/hhatto/autopep8/pull/665
+    (fetchpatch {
+      name = "ignore-deprecation-warnings.patch";
+      url = "https://github.com/hhatto/autopep8/commit/75b444d7cf510307ef67dc2b757d384b8a241348.patch";
+      hash = "sha256-5hcJ2yAuscvGyI7zyo4Cl3NEFG/fZItQ8URstxhzwzE=";
+    })
+  ];
 
   propagatedBuildInputs = [
     pycodestyle

--- a/pkgs/development/python-modules/python-lsp-server/default.nix
+++ b/pkgs/development/python-modules/python-lsp-server/default.nix
@@ -18,6 +18,7 @@
 , pylint
 , pyqt5
 , pytestCheckHook
+, pythonRelaxDepsHook
 , python-lsp-jsonrpc
 , pythonOlder
 , rope
@@ -49,15 +50,20 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace "--cov-report html --cov-report term --junitxml=pytest.xml" "" \
-      --replace "--cov pylsp --cov test" "" \
-      --replace "autopep8>=1.6.0,<1.7.1" "autopep8" \
-      --replace "flake8>=5.0.0,<7" "flake8" \
-      --replace "mccabe>=0.7.0,<0.8.0" "mccabe" \
-      --replace "pycodestyle>=2.9.0,<2.11.0" "pycodestyle" \
-      --replace "pyflakes>=2.5.0,<3.1.0" "pyflakes"
+      --replace "--cov pylsp --cov test" ""
   '';
 
+  pythonRelaxDeps = [
+    "autopep8"
+    "flake8"
+    "mccabe"
+    "pycodestyle"
+    "pydocstyle"
+    "pyflakes"
+  ];
+
   nativeBuildInputs = [
+    pythonRelaxDepsHook
     setuptools-scm
   ];
 

--- a/pkgs/development/python-modules/python-lsp-server/default.nix
+++ b/pkgs/development/python-modules/python-lsp-server/default.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage rec {
   pname = "python-lsp-server";
-  version = "1.7.0";
+  version = "1.7.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     owner = "python-lsp";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-9cyzJxyCris7FsVni5IZCCL6IAcsN8tMakNoKPeWv7s=";
+    hash = "sha256-Rx8mHBmJw4gh0FtQBVMmOlQklODplrhnWwzsEhQm4NE=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     substituteInPlace pyproject.toml \
       --replace "--cov-report html --cov-report term --junitxml=pytest.xml" "" \
       --replace "--cov pylsp --cov test" "" \
-      --replace "autopep8>=1.6.0,<1.7.0" "autopep8" \
+      --replace "autopep8>=1.6.0,<1.7.1" "autopep8" \
       --replace "flake8>=5.0.0,<7" "flake8" \
       --replace "mccabe>=0.7.0,<0.8.0" "mccabe" \
       --replace "pycodestyle>=2.9.0,<2.11.0" "pycodestyle" \
@@ -130,6 +130,8 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
+    # Don't run lint tests
+    "test_pydocstyle"
     # https://github.com/python-lsp/python-lsp-server/issues/243
     "test_numpy_completions"
     "test_workspace_loads_pycodestyle_config"


### PR DESCRIPTION
Diff: https://github.com/python-lsp/python-lsp-server/compare/refs/tags/v1.7.0...v1.7.1

Changelog: https://github.com/python-lsp/python-lsp-server/blob/v1.7.1/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
