### PR TITLE
parquet-tools: 0.2.9 -> 0.2.12

### DIFF
--- a/pkgs/tools/misc/parquet-tools/default.nix
+++ b/pkgs/tools/misc/parquet-tools/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchFromGitHub
-, fetchpatch
 , python3Packages
 }:
 
@@ -8,36 +7,34 @@ with python3Packages;
 
 buildPythonApplication rec {
   pname = "parquet-tools";
-  version = "0.2.9";
-  disabled = pythonOlder "3.8";
+  version = "0.2.12";
 
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "ktrueda";
     repo = "parquet-tools";
-    rev = version;
-    sha256 = "0aw0x7lhagp4dwis09fsizr7zbhdpliav0ns5ll5qny7x4m6rkfy";
+    rev = "refs/tags/${version}";
+    hash = "sha256-5bK+kW550DgBhcH5INozwGKKjM+xXblmFg2Tu2rnos4=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/ktrueda/parquet-tools/commit/1c70a07e1c9f17c8890d23aad3ded5dd6c706cb3.patch";
-      sha256 = "08j1prdqj8ksw8gwiyj7ivshk82ahmywbzmywclw52nlnniig0sa";
-    })
-  ];
-
   postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'thrift = "^0.13.0"' 'thrift = "*"' \
-      --replace 'halo = "^0.0.29"' 'halo = "*"'
     substituteInPlace tests/test_inspect.py \
       --replace "parquet-cpp-arrow version 5.0.0" "parquet-cpp-arrow version ${pyarrow.version}" \
       --replace "serialized_size: 2222" "serialized_size: 2221" \
       --replace "format_version: 1.0" "format_version: 2.6"
   '';
 
-  nativeBuildInputs = [ poetry-core ];
+  pythonRelaxDeps = [
+    "halo"
+    "tabulate"
+    "thrift"
+  ];
+
+  nativeBuildInputs = [
+    poetry-core
+    pythonRelaxDepsHook
+  ];
 
   propagatedBuildInputs = [
     boto3
@@ -50,20 +47,25 @@ buildPythonApplication rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
     moto
     pytest-mock
+    pytestCheckHook
   ];
 
   disabledTests = [
-    # these tests try to read python code as parquet and fail
+    # These tests try to read Python code as parquet and fail
     "test_local_wildcard"
     "test_local_and_s3_wildcard_files"
+  ];
+
+  pythonImportsCheck = [
+    "parquet_tools"
   ];
 
   meta = with lib; {
     description = "A CLI tool for parquet files";
     homepage = "https://github.com/ktrueda/parquet-tools";
+    changelog = "https://github.com/ktrueda/parquet-tools/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ cpcloud ];
   };


### PR DESCRIPTION
Diff: https://github.com/ktrueda/parquet-tools/compare/refs/tags/0.2.9...0.2.12

Changelog: https://github.com/ktrueda/parquet-tools/releases/tag/0.2.12

###### Description of changes
Fix build (https://hydra.nixos.org/build/206967962)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
