### PR TITLE
Setuptools rust hook for cross compilation

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -160,6 +160,20 @@ in {
       };
     } ./setuptools-check-hook.sh) {};
 
+    setuptoolsRustBuildHook = callPackage ({ makePythonHook, setuptools-rust, rust }:
+      makePythonHook {
+        name = "setuptools-rust-setup-hook";
+        propagatedBuildInputs = [ setuptools-rust ];
+        substitutions = {
+          pyLibDir = "${python}/lib/${python.libPrefix}";
+          cargoBuildTarget = rust.toRustTargetSpec stdenv.hostPlatform;
+          cargoLinkerVar = lib.toUpper (
+              builtins.replaceStrings ["-"] ["_"] (
+                rust.toRustTarget stdenv.hostPlatform));
+          targetLinker = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc";
+        };
+      } ./setuptools-rust-hook.sh) {};
+
   unittestCheckHook = callPackage ({ makePythonHook }:
     makePythonHook {
       name = "unittest-check-hook";

--- a/pkgs/development/interpreters/python/hooks/setuptools-rust-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-rust-hook.sh
@@ -1,0 +1,18 @@
+echo "Sourcing setuptools-rust-hook"
+
+setuptoolsRustSetup() {
+    # This can work only if rustPlatform.cargoSetupHook is also included
+    if ! command -v cargoSetupPostPatchHook >/dev/null; then
+        echo "ERROR: setuptools-rust has to be used alongside with rustPlatform.cargoSetupHook!"
+        exit 1
+    fi
+
+    export PYO3_CROSS_LIB_DIR="@pyLibDir@"
+    export CARGO_BUILD_TARGET=@cargoBuildTarget@
+    # TODO theoretically setting linker should not be required because it is
+    # already set in pkgs/build-support/rust/hooks/default.nix but build fails
+    # on missing linker without this.
+    export CARGO_TARGET_@cargoLinkerVar@_LINKER=@targetLinker@
+}
+
+preConfigureHooks+=(setuptoolsRustSetup)

--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -6,7 +6,7 @@
 , rustPlatform
 , cargo
 , rustc
-, setuptools-rust
+, setuptoolsRustBuildHook
 , openssl
 , Security
 , isPyPy
@@ -54,7 +54,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     rustPlatform.cargoSetupHook
-    setuptools-rust
+    setuptoolsRustBuildHook
     cargo
     rustc
     pkg-config


### PR DESCRIPTION
###### Description of changes
Introduces setup hook for setuptools-rust that provides environment variables to really perform cross compilation of Rust code when using setuptools-rust.

This is a followup of https://github.com/NixOS/nixpkgs/pull/208401 and https://github.com/NixOS/nixpkgs/issues/205807.

###### Things done

Added setup hook. I also added `rustc` and `cargo` to the propagated dependencies and removed them from packages using `setuptools-rust`. This is for sure optional and thus can be dropped if you disagree with it.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
