### PR TITLE
ipu6  webcam support

### DIFF
--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -25,5 +25,7 @@
 
   gst-vaapi = callPackage ./vaapi { };
 
+  icamerasrc = callPackage ./icamerasrc { };
+
   # note: gst-python is in ./python/default.nix - called under pythonPackages
 }

--- a/pkgs/development/libraries/gstreamer/icamerasrc/default.nix
+++ b/pkgs/development/libraries/gstreamer/icamerasrc/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, gst_all_1
+, ipu6-camera-hal
+, libdrm
+}:
+
+stdenv.mkDerivation rec {
+  pname = "icamerasrc";
+  version = "20221209";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "icamerasrc";
+    rev = "refs/tags/rpl_plat_${version}_pv";
+    hash = "sha256-qlV363l4tUjUAa1LiZQq55byKpz1tLESKAXEmgiYHVo=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  preConfigure = ''
+    # https://github.com/intel/ipu6-camera-hal/issues/1
+    export CHROME_SLIM_CAMHAL=ON
+    # https://github.com/intel/icamerasrc/issues/22
+    export STRIP_VIRTUAL_CHANNEL_CAMHAL=ON
+  '';
+
+  buildInputs = [
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    ipu6-camera-hal
+    libdrm
+  ];
+
+  NIX_CFLAGS_COMPILE = [
+    # gstcameradeinterlace.cpp:55:10: fatal error: gst/video/video.h: No such file or directory
+    "-I${gst_all_1.gst-plugins-base.dev}/include/gstreamer-1.0"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "GStreamer Plugin for MIPI camera support through the IPU6/IPU6EP/IPU6SE on Intel Tigerlake/Alderlake/Jasperlake platforms";
+    homepage = "https://github.com/intel/icamerasrc/tree/icamerasrc_slim_api";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ hexa ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/libraries/ipu6-camera-hal/default.nix
+++ b/pkgs/development/libraries/ipu6-camera-hal/default.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+
+# build
+, cmake
+, pkg-config
+
+# runtime
+, expat
+, ipu6-camera-bin
+, libtool
+, gst_all_1
+}:
+
+stdenv.mkDerivation {
+  pname = "ipu6-camera-hal";
+  version = "unstable-2023-01-09";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "ipu6-camera-hal";
+    rev = "37292891c73367d22ba1fc96ea9b6e4546903037";
+    hash = "sha256-dJvTZt85rt5/v2JXOsfbSY933qffyXW74L0nWdIlqug=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  cmakeFlags = [
+    "-DIPU_VER=${ipu6-camera-bin.ipuVersion}"
+    # missing libiacss
+    "-DUSE_PG_LITE_PIPE=ON"
+    # missing libipu4
+    "-DENABLE_VIRTUAL_IPU_PIPE=OFF"
+  ];
+
+  NIX_CFLAGS_COMPILE = [
+    "-I${lib.getDev ipu6-camera-bin}/include/ia_imaging"
+    "-I${lib.getDev ipu6-camera-bin}/include/ia_camera"
+  ];
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    expat
+    ipu6-camera-bin
+    libtool
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+  ];
+
+  preFixup = ''
+    ls -lah $out/lib/pkgconfig/
+    sed -Ei \
+      -e "s,^prefix=.*,prefix=$out," \
+      -e "s,^exec_prefix=.*,exec_prefix=''${prefix}," \
+      -e "s,^libdir=.*,libdir=''${prefix}/lib," \
+      -e "s,^includedir=.*,includedir=''${prefix}/include/libcamhal," \
+      $out/lib/pkgconfig/libcamhal.pc
+  '';
+
+  meta = with lib; {
+    description = "HAL for processing of images in userspace";
+    homepage = "https://github.com/intel/ipu6-camera-hal";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hexa ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
+++ b/pkgs/os-specific/linux/firmware/ipu6-camera-bins/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+
+# Pick one of
+# - ipu6 (Tiger Lake)
+# - ipu6ep (Alder Lake)
+, ipuVersion ? "ipu6"
+}:
+
+stdenv.mkDerivation {
+  pname = "${ipuVersion}-camera-bin";
+  version = "unstable-2022-11-12";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "ipu6-camera-bins";
+    rev = "4694ba7ee51652d29ef41e7fde846b83a2a1c53b";
+    hash = "sha256-XPT3dbV6Kl1/TEeiQESF4Q4s95hjtiv4VLlqlahQXqE=";
+  };
+
+  sourceRoot = "source/${ipuVersion}";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp --no-preserve=mode --recursive \
+      lib \
+      include \
+      $out/
+
+    install -D ../LICENSE $out/share/doc
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    for pcfile in $out/lib/pkgconfig/*.pc; do
+      substituteInPlace $pcfile \
+        --replace 'exec_prefix=/usr' 'exec_prefix=''${prefix}' \
+        --replace 'prefix=/usr' "prefix=$out" \
+        --replace 'libdir=/usr/lib' 'libdir=''${prefix}/lib' \
+        --replace 'includedir=/usr/include' 'includedir=''${prefix}/include'
+    done
+  '';
+
+  passthru = {
+    inherit ipuVersion;
+  };
+
+  meta = let
+    generation = {
+      ipu6 = "Tiger Lake";
+      ipu6ep = "Alder Lake";
+    }.${ipuVersion};
+  in with lib; {
+    description = "${generation} IPU firmware and proprietary image processing libraries";
+    homepage = "https://github.com/intel/ipu6-camera-bins";
+    license = licenses.issl;
+    sourceProvenance = with sourceTypes; [
+      binaryFirmware
+    ];
+    maintainers = with maintainers; [
+      hexa
+    ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/os-specific/linux/firmware/ivsc-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/ivsc-firmware/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation {
+  pname = "ivsc-firmware";
+  version = "unstable-2022-11-02";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "ivsc-firmware";
+    rev = "29c5eff4cdaf83e90ef2dcd2035a9cdff6343430";
+    hash = "sha256-GuD1oTnDEs0HslJjXx26DkVQIe0eS+js4UoaTDa77ME=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/firmware/vsc
+    cp --no-preserve=mode --recursive ./firmware/* $out/lib/firmware/vsc/
+    install -D ./LICENSE $out/share/doc
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Firmware binaries for the Intel Vision Sensing Controller";
+    homepage = "https://github.com/intel/ivsc-firmware";
+    license = licenses.issl;
+    sourceProvenance = with sourceTypes; [
+      binaryFirmware
+    ];
+    maintainers = with maintainers; [
+      hexa
+    ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/os-specific/linux/ipu6-drivers/default.nix
+++ b/pkgs/os-specific/linux/ipu6-drivers/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, kernel
+}:
+
+let
+  ivsc-driver = fetchFromGitHub {
+    owner = "intel";
+    repo = "ivsc-driver";
+    rev = "94ecb88b3ac238d9145ac16230d6e0779bb4fd32";
+    hash = "sha256-Q7iyKw4WFSX42E4AtoW/zYRKpknWZSU66V5VPAx6AjA=";
+  };
+in
+
+stdenv.mkDerivation rec {
+  pname = "ipu6-drivers";
+  version = "unstable-2023-01-17";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = pname;
+    rev = "f83b0747b297cc42325668aaf69471d89253b88e";
+    hash = "sha256-yl2ZtJUTh1/qmTA8USd+FBCUAY5qNdh4bSvFRPImQNI=";
+  };
+
+  postPatch = ''
+    cp --no-preserve=mode --recursive --verbose \
+      ${ivsc-driver}/backport-include \
+      ${ivsc-driver}/drivers \
+      ${ivsc-driver}/include \
+      .
+  '';
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernel.makeFlags ++ [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  enableParallelBuilding = true;
+
+  preInstall = ''
+    sed -i -e "s,INSTALL_MOD_DIR=,INSTALL_MOD_PATH=$out INSTALL_MOD_DIR=," Makefile
+  '';
+
+  installTargets = [
+    "modules_install"
+  ];
+
+  meta = {
+    homepage = "https://github.com/intel/ipu6-drivers";
+    description = "IPU6 kernel driver";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ hexa ];
+    platforms = [ "x86_64-linux" ];
+    broken = kernel.kernelOlder "5.15";
+  };
+}

--- a/pkgs/os-specific/linux/ipu6-drivers/default.nix
+++ b/pkgs/os-specific/linux/ipu6-drivers/default.nix
@@ -1,17 +1,9 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, ivsc-driver
 , kernel
 }:
-
-let
-  ivsc-driver = fetchFromGitHub {
-    owner = "intel";
-    repo = "ivsc-driver";
-    rev = "94ecb88b3ac238d9145ac16230d6e0779bb4fd32";
-    hash = "sha256-Q7iyKw4WFSX42E4AtoW/zYRKpknWZSU66V5VPAx6AjA=";
-  };
-in
 
 stdenv.mkDerivation rec {
   pname = "ipu6-drivers";
@@ -26,9 +18,9 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     cp --no-preserve=mode --recursive --verbose \
-      ${ivsc-driver}/backport-include \
-      ${ivsc-driver}/drivers \
-      ${ivsc-driver}/include \
+      ${ivsc-driver.src}/backport-include \
+      ${ivsc-driver.src}/drivers \
+      ${ivsc-driver.src}/include \
       .
   '';
 

--- a/pkgs/os-specific/linux/ivsc-driver/default.nix
+++ b/pkgs/os-specific/linux/ivsc-driver/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, kernel
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ivsc-drivers";
+  version = "unstable-2023-01-06";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "ivsc-driver";
+    rev = "94ecb88b3ac238d9145ac16230d6e0779bb4fd32";
+    hash = "sha256-Q7iyKw4WFSX42E4AtoW/zYRKpknWZSU66V5VPAx6AjA=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernel.makeFlags ++ [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  enableParallelBuilding = true;
+
+  preInstall = ''
+    sed -i -e "s,INSTALL_MOD_DIR=,INSTALL_MOD_PATH=$out INSTALL_MOD_DIR=," Makefile
+  '';
+
+  installTargets = [
+    "modules_install"
+  ];
+
+  meta = {
+    homepage = "https://github.com/intel/ivsc-drivers";
+    description = "Intel Vision Sensing Controller kernel driver";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ hexa ];
+    platforms = [ "x86_64-linux" ];
+    broken = kernel.kernelOlder "5.15";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25877,6 +25877,8 @@ with pkgs;
     ipu6-camera-bin = ipu6ep-camera-bin;
   };
 
+  ivsc-firmware = callPackage ../os-specific/linux/firmware/ivsc-firmware { };
+
   iputils = hiPrio (callPackage ../os-specific/linux/iputils { });
   # hiPrio for collisions with inetutils (ping)
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25865,6 +25865,12 @@ with pkgs;
 
   iproute2 = callPackage ../os-specific/linux/iproute { };
 
+  ipu6-camera-bin = callPackage ../os-specific/linux/firmware/ipu6-camera-bins {};
+
+  ipu6ep-camera-bin = callPackage ../os-specific/linux/firmware/ipu6-camera-bins {
+    ipuVersion = "ipu6ep";
+  };
+
   iputils = hiPrio (callPackage ../os-specific/linux/iputils { });
   # hiPrio for collisions with inetutils (ping)
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25867,8 +25867,14 @@ with pkgs;
 
   ipu6-camera-bin = callPackage ../os-specific/linux/firmware/ipu6-camera-bins {};
 
+  ipu6-camera-hal = callPackage ../development/libraries/ipu6-camera-hal {};
+
   ipu6ep-camera-bin = callPackage ../os-specific/linux/firmware/ipu6-camera-bins {
     ipuVersion = "ipu6ep";
+  };
+
+  ipu6ep-camera-hal = callPackage ../development/libraries/ipu6-camera-hal {
+    ipu6-camera-bin = ipu6ep-camera-bin;
   };
 
   iputils = hiPrio (callPackage ../os-specific/linux/iputils { });

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -332,6 +332,8 @@ in {
 
     ipu6-drivers = callPackage ../os-specific/linux/ipu6-drivers {};
 
+    ivsc-driver = callPackage ../os-specific/linux/ivsc-driver {};
+
     ixgbevf = callPackage ../os-specific/linux/ixgbevf {};
 
     it87 = callPackage ../os-specific/linux/it87 {};

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -330,6 +330,8 @@ in {
 
     intel-speed-select = if lib.versionAtLeast kernel.version "5.3" then callPackage ../os-specific/linux/intel-speed-select { } else null;
 
+    ipu6-drivers = callPackage ../os-specific/linux/ipu6-drivers {};
+
     ixgbevf = callPackage ../os-specific/linux/ixgbevf {};
 
     it87 = callPackage ../os-specific/linux/it87 {};


### PR DESCRIPTION
###### Description of changes

Playing around with ipu6 stack to get the webcam on my 12th gen laptop going.

The overall versioning of things is pretty odd, so I went off of the latest commits.

- [x] kernel driver `linuxPackages.ipu6-drivers`
  - https://github.com/intel/ipu6-drivers
  - [x] can hopefully reuse the `ivsc-driver` source?
- [x] firmware `ipu6-camera-bin`, `ipu6ep-camera-bin`
  - https://github.com/intel/ipu6-camera-bins
  - top-level attributes for tiger lake (11th gen: `ipu6-camera-bin`) and alder lake (12th gen: `ipu6ep-camera-bin`)
- [x] userspace hal `ipu6-camera-hal`, `ipu6ep-camera-hal`
  - https://github.com/intel/ipu6-camera-ha
- [x] gstreamer plugin `gst_all_1.istreamersrc`
  - https://github.com/intel/icamerasrc/tree/icamerasrc_slim_api
  - [x] fails to build: `gstcamerawfovinterface.h:159:70: error: 'camera_view_rotation_t' has not been declared`
    - https://github.com/intel/ipu6-camera-hal/issues/1
    - not sure if putting it below `gst_all_1` is correct
 - [x] kernel driver `ivsc-driver`
   - https://github.com/intel/ivsc-driver
 - [x] firmware `ivsc-firmare`
   - https://github.com/intel/ivsc-firmware

I still need to understand how to install the individual bits and pieces. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

