### PR TITLE
frink: init at 2023-01-05

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13840,6 +13840,12 @@
     githubId = 1699155;
     name = "Steve Elliott";
   };
+  stefanfehrenbach = {
+    email = "stefan.fehrenbach@gmail.com";
+    github = "fehrenbach";
+    githubId = 203168;
+    name = "Stefan Fehrenbach";
+  };
   stehessel = {
     email = "stephan@stehessel.de";
     github = "stehessel";

--- a/pkgs/development/tools/frink/default.nix
+++ b/pkgs/development/tools/frink/default.nix
@@ -1,0 +1,54 @@
+{ fetchurl
+, frink
+, jdk
+, lib
+, rlwrap
+, stdenv
+, testers
+}:
+stdenv.mkDerivation rec {
+  pname = "frink";
+  version = "2023-01-31";
+
+  src = fetchurl {
+    # Upstream does not provide versioned download links
+    url = "https://web.archive.org/web/20230202134810/https://frinklang.org/frinkjar/frink.jar";
+    sha256 = "sha256-xs1FQvFPgeAxscAiwBBP8N8aYe0OlsYbH/vbzzCbYZc=";
+  };
+
+  dontUnpack = true;
+
+  buildInputs = [ jdk rlwrap ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib
+
+    cp ${src} $out/lib/frink.jar
+
+    cat > "$out/bin/frink" << EOF
+    #!${stdenv.shell}
+    exec ${rlwrap}/bin/rlwrap ${jdk}/bin/java -classpath "$out/lib/frink.jar" frink.gui.FrinkStarter "\$@"
+    EOF
+
+    chmod a+x "$out/bin/frink"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A practical calculating tool and programming language";
+    homepage = "https://frinklang.org/";
+    license = licenses.unfree;
+    sourceProvenance = [ sourceTypes.binaryBytecode ];
+    maintainers = [ maintainers.stefanfehrenbach ];
+  };
+
+  passthru.tests = {
+    callFrinkVersion = testers.testVersion {
+      package = frink;
+      command = "frink -e 'FrinkVersion[]'";
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -508,6 +508,8 @@ with pkgs;
 
   frece = callPackage ../development/tools/frece { };
 
+  frink = callPackage ../development/tools/frink { };
+
   frugal = callPackage ../development/tools/frugal { };
 
   glade = callPackage ../development/tools/glade { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The Frink programming language and calculator

https://frinklang.org/

I'd quite like this in 22.11, but I can't add the backport label myself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->