### PR TITLE
treewide: remove global with lib; statements in pkgs/development

### DIFF
--- a/pkgs/development/beam-modules/build-erlang-mk.nix
+++ b/pkgs/development/beam-modules/build-erlang-mk.nix
@@ -17,8 +17,6 @@
 , ...
 }@attrs:
 
-with lib;
-
 let
   debugInfoFlag = lib.optionalString (enableDebugInfo || erlang.debugInfo) "+debug_info";
 
@@ -107,4 +105,4 @@ let
     };
   });
 in
-fix pkg
+lib.fix pkg

--- a/pkgs/development/beam-modules/build-hex.nix
+++ b/pkgs/development/beam-modules/build-hex.nix
@@ -5,8 +5,6 @@
 , hexPkg ? name
 , ... }@attrs:
 
-with lib;
-
 let
   pkg = self: builder (attrs // {
 
@@ -17,4 +15,4 @@ let
     };
   });
 in
-  fix pkg
+  lib.fix pkg

--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -15,7 +15,6 @@
 , ...
 }@attrs:
 
-with lib;
 let
   shell = drv: stdenv.mkDerivation {
     name = "interactive-shell-${drv.name}";
@@ -90,5 +89,5 @@ let
     };
   });
 in
-fix pkg
+lib.fix pkg
 

--- a/pkgs/development/beam-modules/build-rebar3.nix
+++ b/pkgs/development/beam-modules/build-rebar3.nix
@@ -16,8 +16,6 @@
 , ...
 }@attrs:
 
-with lib;
-
 let
   debugInfoFlag = lib.optionalString (enableDebugInfo || erlang.debugInfo) "debug-info";
 
@@ -30,7 +28,7 @@ let
     buildInputs = [ drv ];
   };
 
-  customPhases = filterAttrs
+  customPhases = lib.filterAttrs
     (_: v: v != null)
     { inherit setupHook configurePhase buildPhase installPhase; };
 
@@ -40,7 +38,7 @@ let
     inherit version;
 
     buildInputs = buildInputs ++ [ erlang rebar3 openssl libyaml ];
-    propagatedBuildInputs = unique beamDeps;
+    propagatedBuildInputs = lib.unique beamDeps;
 
     inherit src;
 
@@ -85,4 +83,4 @@ let
     };
   } // customPhases);
 in
-fix pkg
+lib.fix pkg

--- a/pkgs/development/beam-modules/fetch-hex.nix
+++ b/pkgs/development/beam-modules/fetch-hex.nix
@@ -6,8 +6,6 @@
 , meta ? { }
 }:
 
-with lib;
-
 stdenv.mkDerivation ({
   pname = "hex-source-${pkg}";
   inherit version;

--- a/pkgs/development/beam-modules/fetch-rebar-deps.nix
+++ b/pkgs/development/beam-modules/fetch-rebar-deps.nix
@@ -7,8 +7,6 @@
 , meta ? { }
 }:
 
-with lib;
-
 stdenv.mkDerivation ({
   pname = "rebar-deps-${name}";
   inherit version;

--- a/pkgs/development/beam-modules/rebar3-release.nix
+++ b/pkgs/development/beam-modules/rebar3-release.nix
@@ -22,15 +22,13 @@
 , ...
 }@attrs:
 
-with lib;
-
 let
   shell = drv: stdenv.mkDerivation {
     name = "interactive-shell-${drv.pname}";
     buildInputs = [ drv ];
   };
 
-  customPhases = filterAttrs
+  customPhases = lib.filterAttrs
     (_: v: v != null)
     { inherit setupHook configurePhase buildPhase installPhase; };
 
@@ -105,4 +103,4 @@ let
       } // (if attrs ? passthru then attrs.passthru else { }));
     } // customPhases);
 in
-fix pkg
+lib.fix pkg

--- a/pkgs/development/compilers/intercal/default.nix
+++ b/pkgs/development/compilers/intercal/default.nix
@@ -3,7 +3,6 @@
 , bison, flex
 , makeWrapper }:
 
-with lib;
 stdenv.mkDerivation rec {
 
   pname = "intercal";
@@ -31,7 +30,7 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/ick --suffix PATH ':' ${stdenv.cc}/bin
   '';
 
-  meta = {
+  meta = with lib; {
     description = "The original esoteric programming language";
     longDescription = ''
       INTERCAL, an abbreviation for "Compiler Language With No

--- a/pkgs/development/compilers/scala/2.x.nix
+++ b/pkgs/development/compilers/scala/2.x.nix
@@ -1,8 +1,6 @@
 { stdenv, lib, fetchurl, makeWrapper, jre, gnugrep, coreutils, writeScript
 , common-updater-scripts, git, gnused, nix, nixfmt, majorVersion }:
 
-with lib;
-
 let
   repo = "git@github.com:scala/scala.git";
 
@@ -102,7 +100,7 @@ stdenv.mkDerivation rec {
     '';
   };
 
-  meta = {
+  meta = with lib; {
     description = "A general purpose programming language";
     longDescription = ''
       Scala is a general purpose programming language designed to express

--- a/pkgs/development/compilers/sdcc/default.nix
+++ b/pkgs/development/compilers/sdcc/default.nix
@@ -1,11 +1,9 @@
 { lib, stdenv, fetchurl, autoconf, bison, boost, flex, texinfo, zlib, gputils ? null
 , excludePorts ? [] }:
 
-with lib;
-
 let
   # choices: mcs51 z80 z180 r2k r3ka gbz80 tlcs90 ds390 ds400 pic14 pic16 hc08 s08 stm8
-  excludedPorts = excludePorts ++ (optionals (gputils == null) [ "pic14" "pic16" ]);
+  excludedPorts = excludePorts ++ (lib.optionals (gputils == null) [ "pic14" "pic16" ]);
 in
 
 stdenv.mkDerivation rec {
@@ -29,7 +27,7 @@ stdenv.mkDerivation rec {
     fi
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Small Device C Compiler";
     longDescription = ''
       SDCC is a retargettable, optimizing ANSI - C compiler suite that targets

--- a/pkgs/development/interpreters/lolcode/default.nix
+++ b/pkgs/development/interpreters/lolcode/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchFromGitHub, pkg-config, doxygen, cmake, readline }:
 
-with lib;
 stdenv.mkDerivation rec {
 
   pname = "lolcode";
@@ -19,7 +18,7 @@ stdenv.mkDerivation rec {
   # Maybe it clashes with lci scientific logic software package...
   postInstall = "mv $out/bin/lci $out/bin/lolcode-lci";
 
-  meta = {
+  meta = with lib; {
     homepage = "http://lolcode.org";
     description = "An esoteric programming language";
     longDescription = ''

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -12,8 +12,6 @@ assert (enableCrypt -> (libxcrypt != null));
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-with lib;
-
 let
 
   libc = if stdenv.cc.libc or null != null then stdenv.cc.libc else "/usr";
@@ -33,7 +31,7 @@ let
     strictDeps = true;
     # TODO: Add a "dev" output containing the header files.
     outputs = [ "out" "man" "devdoc" ] ++
-      optional crossCompiling "mini";
+      lib.optional crossCompiling "mini";
     setOutputFlags = false;
 
     # On FreeBSD, if Perl is built with threads support, having
@@ -57,9 +55,9 @@ let
         # Enable TLS/SSL verification in HTTP::Tiny by default
         ./http-tiny-verify-ssl-by-default.patch
       ]
-      ++ optional stdenv.isSunOS ./ld-shared.patch
-      ++ optionals stdenv.isDarwin [ ./cpp-precomp.patch ./sw_vers.patch ]
-      ++ optional crossCompiling ./MakeMaker-cross.patch;
+      ++ lib.optional stdenv.isSunOS ./ld-shared.patch
+      ++ lib.optionals stdenv.isDarwin [ ./cpp-precomp.patch ./sw_vers.patch ]
+      ++ lib.optional crossCompiling ./MakeMaker-cross.patch;
 
     # This is not done for native builds because pwd may need to come from
     # bootstrap tools when building bootstrap perl.
@@ -93,18 +91,18 @@ let
         "-Dlocincpth=${libcInc}/include"
         "-Dloclibpth=${libcLib}/lib"
       ]
-      ++ optionals ((builtins.match ''5\.[0-9]*[13579]\..+'' version) != null) [ "-Dusedevel" "-Uversiononly" ]
-      ++ optional stdenv.isSunOS "-Dcc=gcc"
-      ++ optional enableThreading "-Dusethreads"
-      ++ optional (!enableCrypt) "-A clear:d_crypt_r"
-      ++ optional stdenv.hostPlatform.isStatic "--all-static"
-      ++ optionals (!crossCompiling) [
+      ++ lib.optionals ((builtins.match ''5\.[0-9]*[13579]\..+'' version) != null) [ "-Dusedevel" "-Uversiononly" ]
+      ++ lib.optional stdenv.isSunOS "-Dcc=gcc"
+      ++ lib.optional enableThreading "-Dusethreads"
+      ++ lib.optional (!enableCrypt) "-A clear:d_crypt_r"
+      ++ lib.optional stdenv.hostPlatform.isStatic "--all-static"
+      ++ lib.optionals (!crossCompiling) [
         "-Dprefix=${placeholder "out"}"
         "-Dman1dir=${placeholder "out"}/share/man/man1"
         "-Dman3dir=${placeholder "out"}/share/man/man3"
       ];
 
-    configureScript = optionalString (!crossCompiling) "${stdenv.shell} ./Configure";
+    configureScript = lib.optionalString (!crossCompiling) "${stdenv.shell} ./Configure";
 
     dontAddStaticConfigureFlags = true;
 
@@ -138,9 +136,9 @@ let
         OLD_ZLIB     = False
         GZIP_OS_CODE = AUTO_DETECT
         EOF
-      '' + optionalString stdenv.isDarwin ''
+      '' + lib.optionalString stdenv.isDarwin ''
         substituteInPlace hints/darwin.sh --replace "env MACOSX_DEPLOYMENT_TARGET=10.3" ""
-      '' + optionalString (!enableThreading) ''
+      '' + lib.optionalString (!enableThreading) ''
         # We need to do this because the bootstrap doesn't have a static libpthread
         sed -i 's,\(libswanted.*\)pthread,\1,g' Configure
       '';
@@ -183,7 +181,7 @@ let
             }" /no-such-path \
           --replace "${stdenv.cc}" /no-such-path \
           --replace "$man" /no-such-path
-      '' + optionalString crossCompiling
+      '' + lib.optionalString crossCompiling
       ''
         mkdir -p $mini/lib/perl5/cross_perl/${version}
         for dir in cnf/{stub,cpan}; do
@@ -207,7 +205,7 @@ let
           "$mini/lib/perl5/cross_perl/${version}:$out/lib/perl5/${version}:$out/lib/perl5/${version}/$runtimeArch"
       ''; # */
 
-    meta = {
+    meta = with lib; {
       homepage = "https://www.perl.org/";
       description = "The standard implementation of the Perl 5 programmming language";
       license = licenses.artistic1;
@@ -215,7 +213,7 @@ let
       platforms = platforms.all;
       priority = 6; # in `buildEnv' (including the one inside `perl.withPackages') the library files will have priority over files in `perl`
     };
-  } // optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) rec {
+  } // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) rec {
     crossVersion = "c876045741f5159318085d2737b0090f35a842ca"; # June 5, 2022
 
     perl-cross-src = fetchFromGitHub {

--- a/pkgs/development/interpreters/picolisp/default.nix
+++ b/pkgs/development/interpreters/picolisp/default.nix
@@ -1,5 +1,4 @@
 { lib, stdenv, fetchurl, jdk, w3m, openssl, makeWrapper }:
-with lib;
 
 stdenv.mkDerivation rec {
   pname = "picoLisp";
@@ -9,11 +8,11 @@ stdenv.mkDerivation rec {
     sha256 = "0l51x98bn1hh6kv40sdgp0x09pzg5i8yxbcjvm9n5bxsd6bbk5w2";
   };
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [openssl] ++ optional stdenv.is64bit jdk;
+  buildInputs = [openssl] ++ lib.optional stdenv.is64bit jdk;
   patchPhase = ''
     sed -i "s/which java/command -v java/g" mkAsm
 
-    ${optionalString stdenv.isAarch32 ''
+    ${lib.optionalString stdenv.isAarch32 ''
       sed -i s/-m32//g Makefile
       cat >>Makefile <<EOF
       ext.o: ext.c
@@ -23,7 +22,7 @@ stdenv.mkDerivation rec {
       EOF
     ''}
   '';
-  sourceRoot = ''picoLisp/src${optionalString stdenv.is64bit "64"}'';
+  sourceRoot = ''picoLisp/src${lib.optionalString stdenv.is64bit "64"}'';
   postBuild = ''
     cd ../src; make gate
   '';
@@ -49,7 +48,7 @@ stdenv.mkDerivation rec {
     ln -s "$out/lib/picolisp/lib/el" "$out/share/emacs/site-lisp"
   '';
 
-  meta = {
+  meta = with lib; {
     # darwin: build times out
     broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
     description = "A simple Lisp with an integrated database";

--- a/pkgs/development/interpreters/python/wrap-python.nix
+++ b/pkgs/development/interpreters/python/wrap-python.nix
@@ -3,8 +3,6 @@
 , makePythonHook
 , makeWrapper }:
 
-with lib;
-
 makePythonHook {
       deps = makeWrapper;
       substitutions.sitePackages = python.sitePackages;
@@ -19,7 +17,7 @@ makePythonHook {
 
         mkStringSkipper = labelNum: quote: let
           label = "q${toString labelNum}";
-          isSingle = elem quote [ "\"" "'\"'\"'" ];
+          isSingle = lib.elem quote [ "\"" "'\"'\"'" ];
           endQuote = if isSingle then "[^\\\\]${quote}" else quote;
         in ''
           /^[a-z]?${quote}/ {
@@ -45,8 +43,8 @@ makePythonHook {
           :r
           /\\$|,$/{N;br}
           /__future__|^ |^ *(#.*)?$/{n;br}
-          ${concatImapStrings mkStringSkipper quoteVariants}
-          /^[^# ]/i ${replaceStrings ["\n"] [";"] preamble}
+          ${lib.concatImapStrings mkStringSkipper quoteVariants}
+          /^[^# ]/i ${lib.replaceStrings ["\n"] [";"] preamble}
         }
       '';
 } ./wrap.sh

--- a/pkgs/development/interpreters/ruby/ruby-version.nix
+++ b/pkgs/development/interpreters/ruby/ruby-version.nix
@@ -1,6 +1,6 @@
 # Contains the ruby version heuristics
 { lib }:
-with lib;
+
 let
   # The returned set should be immutable
   rubyVersion = major: minor: tiny: tail:
@@ -10,15 +10,15 @@ let
       # Contains the patch number "223" if tail is "p223" or null
       patchLevel =
         let
-          p = removePrefix "p" tail;
+          p = lib.removePrefix "p" tail;
           isPosInt = num:
-            0 == stringLength
-              (replaceStrings
+            0 == lib.stringLength
+              (lib.replaceStrings
               ["0" "1" "2" "3" "4" "5" "6" "7" "8" "9"]
               [""  ""  ""  ""  ""  ""  ""  ""  ""  "" ]
               num);
         in
-          if hasPrefix "p" tail && isPosInt p then p
+          if lib.hasPrefix "p" tail && isPosInt p then p
           else null;
 
       # Shortcuts
@@ -28,11 +28,11 @@ let
       # Ruby separates lib and gem folders by ABI version which isn't very
       # consistent.
       libDir =
-        if versionAtLeast majMinTiny "2.1.0" then
+        if lib.versionAtLeast majMinTiny "2.1.0" then
           "${majMin}.0"
-        else if versionAtLeast majMinTiny "2.0.0" then
+        else if lib.versionAtLeast majMinTiny "2.0.0" then
           "2.0.0"
-        else if versionAtLeast majMinTiny "1.9.1" then
+        else if lib.versionAtLeast majMinTiny "1.9.1" then
           "1.9.1"
         else
           throw "version ${majMinTiny} is not supported";

--- a/pkgs/development/java-modules/maven-minimal.nix
+++ b/pkgs/development/java-modules/maven-minimal.nix
@@ -1,6 +1,5 @@
 { lib, pkgs }:
 
-with lib;
 with pkgs.javaPackages;
 
 let
@@ -10,7 +9,7 @@ let
   poms = import ./poms.nix { inherit fetchMaven; };
 in {
   # Maven needs all of these to function
-  mavenMinimal = flatten
+  mavenMinimal = lib.flatten
     collections.mavenLibs_2_0_6
     ++ collections.mavenLibs_2_0_9
     ++ collections.mavenLibs_2_2_1

--- a/pkgs/development/libraries/SDL/default.nix
+++ b/pkgs/development/libraries/SDL/default.nix
@@ -11,17 +11,15 @@
 # NOTE: When editing this expression see if the same change applies to
 # SDL2 expression too
 
-with lib;
-
 let
   extraPropagatedBuildInputs = [ ]
-    ++ optionals x11Support [ libXext libICE libXrandr ]
-    ++ optionals (openglSupport && stdenv.isLinux) [ libGL libGLU ]
-    ++ optionals (openglSupport && stdenv.isDarwin) [ OpenGL GLUT ]
-    ++ optional alsaSupport alsa-lib
-    ++ optional pulseaudioSupport libpulseaudio
-    ++ optional stdenv.isDarwin Cocoa;
-  rpath = makeLibraryPath extraPropagatedBuildInputs;
+    ++ lib.optionals x11Support [ libXext libICE libXrandr ]
+    ++ lib.optionals (openglSupport && stdenv.isLinux) [ libGL libGLU ]
+    ++ lib.optionals (openglSupport && stdenv.isDarwin) [ OpenGL GLUT ]
+    ++ lib.optional alsaSupport alsa-lib
+    ++ lib.optional pulseaudioSupport libpulseaudio
+    ++ lib.optional stdenv.isDarwin Cocoa;
+  rpath = lib.makeLibraryPath extraPropagatedBuildInputs;
 in
 
 stdenv.mkDerivation rec {
@@ -40,13 +38,13 @@ stdenv.mkDerivation rec {
   outputBin = "dev"; # sdl-config
 
   nativeBuildInputs = [ pkg-config ]
-    ++ optional stdenv.isLinux libcap;
+    ++ lib.optional stdenv.isLinux libcap;
 
   propagatedBuildInputs = [ libiconv ] ++ extraPropagatedBuildInputs;
 
   buildInputs = [ ]
-    ++ optional (!stdenv.hostPlatform.isMinGW && alsaSupport) audiofile
-    ++ optionals stdenv.isDarwin [ AudioUnit CoreAudio CoreServices Kernel OpenGL ];
+    ++ lib.optional (!stdenv.hostPlatform.isMinGW && alsaSupport) audiofile
+    ++ lib.optionals stdenv.isDarwin [ AudioUnit CoreAudio CoreServices Kernel OpenGL ];
 
   configureFlags = [
     "--disable-oss"
@@ -58,9 +56,9 @@ stdenv.mkDerivation rec {
   #   SDL_X11_SYM(int,_XData32,(Display *dpy,register long *data,unsigned len),(dpy,data,len),return)
   #
   # Please try revert the change that introduced this comment when updating SDL.
-  ] ++ optional stdenv.isDarwin "--disable-x11-shared"
-    ++ optional (!x11Support) "--without-x"
-    ++ optional alsaSupport "--with-alsa-prefix=${alsa-lib.out}/lib";
+  ] ++ lib.optional stdenv.isDarwin "--disable-x11-shared"
+    ++ lib.optional (!x11Support) "--without-x"
+    ++ lib.optional alsaSupport "--with-alsa-prefix=${alsa-lib.out}/lib";
 
   patches = [
     ./find-headers.patch

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -55,8 +55,6 @@
 # NOTE: When editing this expression see if the same change applies to
 # SDL expression too
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "SDL2";
   version = "2.24.2";
@@ -88,40 +86,40 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ pkg-config ];
 
-  nativeBuildInputs = [ pkg-config ] ++ optionals waylandSupport [ wayland wayland-scanner ];
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals waylandSupport [ wayland wayland-scanner ];
 
   propagatedBuildInputs = dlopenPropagatedBuildInputs;
 
   dlopenPropagatedBuildInputs = [ ]
     # Propagated for #include <GLES/gl.h> in SDL_opengles.h.
-    ++ optional openglSupport libGL
+    ++ lib.optional openglSupport libGL
     # Propagated for #include <X11/Xlib.h> and <X11/Xatom.h> in SDL_syswm.h.
-    ++ optionals x11Support [ libX11 xorgproto ];
+    ++ lib.optionals x11Support [ libX11 xorgproto ];
 
-  dlopenBuildInputs = optionals alsaSupport [ alsa-lib audiofile ]
-    ++ optional dbusSupport dbus
-    ++ optional libdecorSupport libdecor
-    ++ optional pipewireSupport pipewire
-    ++ optional pulseaudioSupport libpulseaudio
-    ++ optional udevSupport udev
-    ++ optionals waylandSupport [ wayland wayland-protocols libxkbcommon ]
-    ++ optionals x11Support [ libICE libXi libXScrnSaver libXcursor libXinerama libXext libXrandr libXxf86vm ]
-    ++ optionals drmSupport [ libdrm mesa ];
+  dlopenBuildInputs = lib.optionals alsaSupport [ alsa-lib audiofile ]
+    ++ lib.optional dbusSupport dbus
+    ++ lib.optional libdecorSupport libdecor
+    ++ lib.optional pipewireSupport pipewire
+    ++ lib.optional pulseaudioSupport libpulseaudio
+    ++ lib.optional udevSupport udev
+    ++ lib.optionals waylandSupport [ wayland wayland-protocols libxkbcommon ]
+    ++ lib.optionals x11Support [ libICE libXi libXScrnSaver libXcursor libXinerama libXext libXrandr libXxf86vm ]
+    ++ lib.optionals drmSupport [ libdrm mesa ];
 
   buildInputs = [ libiconv ]
     ++ dlopenBuildInputs
-    ++ optional ibusSupport ibus
-    ++ optional fcitxSupport fcitx
-    ++ optionals stdenv.isDarwin [ AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL ];
+    ++ lib.optional ibusSupport ibus
+    ++ lib.optional fcitxSupport fcitx
+    ++ lib.optionals stdenv.isDarwin [ AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL ];
 
   enableParallelBuilding = true;
 
   configureFlags = [
     "--disable-oss"
-  ] ++ optional (!x11Support) "--without-x"
-  ++ optional alsaSupport "--with-alsa-prefix=${alsa-lib.out}/lib"
-  ++ optional stdenv.targetPlatform.isWindows "--disable-video-opengles"
-  ++ optional stdenv.isDarwin "--disable-sdltest";
+  ] ++ lib.optional (!x11Support) "--without-x"
+  ++ lib.optional alsaSupport "--with-alsa-prefix=${alsa-lib.out}/lib"
+  ++ lib.optional stdenv.targetPlatform.isWindows "--disable-video-opengles"
+  ++ lib.optional stdenv.isDarwin "--disable-sdltest";
 
   # We remove libtool .la files when static libs are requested,
   # because they make the builds of downstream libs like `SDL_tff`
@@ -156,9 +154,9 @@ stdenv.mkDerivation rec {
   # list the symbols used in this way.
   postFixup =
     let
-      rpath = makeLibraryPath (dlopenPropagatedBuildInputs ++ dlopenBuildInputs);
+      rpath = lib.makeLibraryPath (dlopenPropagatedBuildInputs ++ dlopenBuildInputs);
     in
-    optionalString (stdenv.hostPlatform.extensions.sharedLibrary == ".so") ''
+    lib.optionalString (stdenv.hostPlatform.extensions.sharedLibrary == ".so") ''
       for lib in $out/lib/*.so* ; do
         if ! [[ -L "$lib" ]]; then
           patchelf --set-rpath "$(patchelf --print-rpath $lib):${rpath}" "$lib"

--- a/pkgs/development/libraries/apr-util/default.nix
+++ b/pkgs/development/libraries/apr-util/default.nix
@@ -10,8 +10,6 @@ assert sslSupport -> openssl != null;
 assert bdbSupport -> db != null;
 assert ldapSupport -> openldap != null;
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "apr-util";
   version = "1.6.1";
@@ -22,21 +20,21 @@ stdenv.mkDerivation rec {
   };
 
   patches = [ ./fix-libxcrypt-build.patch ]
-    ++ optional stdenv.isFreeBSD ./include-static-dependencies.patch;
+    ++ lib.optional stdenv.isFreeBSD ./include-static-dependencies.patch;
 
   NIX_CFLAGS_LINK = [ "-lcrypt" ];
 
   outputs = [ "out" "dev" ];
   outputBin = "dev";
 
-  nativeBuildInputs = [ makeWrapper ] ++ optional stdenv.isFreeBSD autoreconfHook;
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optional stdenv.isFreeBSD autoreconfHook;
 
   configureFlags = [ "--with-apr=${apr.dev}" "--with-expat=${expat.dev}" ]
-    ++ optional (!stdenv.isCygwin) "--with-crypto"
-    ++ optional sslSupport "--with-openssl=${openssl.dev}"
-    ++ optional bdbSupport "--with-berkeley-db=${db.dev}"
-    ++ optional ldapSupport "--with-ldap=ldap"
-    ++ optionals stdenv.isCygwin
+    ++ lib.optional (!stdenv.isCygwin) "--with-crypto"
+    ++ lib.optional sslSupport "--with-openssl=${openssl.dev}"
+    ++ lib.optional bdbSupport "--with-berkeley-db=${db.dev}"
+    ++ lib.optional ldapSupport "--with-ldap=ldap"
+    ++ lib.optionals stdenv.isCygwin
       [ "--without-pgsql" "--without-sqlite2" "--without-sqlite3"
         "--without-freetds" "--without-berkeley-db" "--without-crypto" ]
     ;
@@ -53,10 +51,10 @@ stdenv.mkDerivation rec {
   '';
 
   propagatedBuildInputs = [ apr expat libiconv libxcrypt ]
-    ++ optional sslSupport openssl
-    ++ optional bdbSupport db
-    ++ optional ldapSupport openldap
-    ++ optional stdenv.isFreeBSD cyrus_sasl;
+    ++ lib.optional sslSupport openssl
+    ++ lib.optional bdbSupport db
+    ++ lib.optional ldapSupport openldap
+    ++ lib.optional stdenv.isFreeBSD cyrus_sasl;
 
   postInstall = ''
     for f in $out/lib/*.la $out/lib/apr-util-1/*.la $dev/bin/apu-1-config; do

--- a/pkgs/development/libraries/asio/generic.nix
+++ b/pkgs/development/libraries/asio/generic.nix
@@ -2,8 +2,6 @@
 , version, sha256, ...
 }:
 
-with lib;
-
 stdenv.mkDerivation {
   pname = "asio";
   inherit version;
@@ -17,7 +15,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ openssl ];
 
-  meta = {
+  meta = with lib; {
     homepage = "http://asio.sourceforge.net/";
     description = "Cross-platform C++ library for network and low-level I/O programming";
     license = licenses.boost;

--- a/pkgs/development/libraries/aspell/dictionaries.nix
+++ b/pkgs/development/libraries/aspell/dictionaries.nix
@@ -1,7 +1,5 @@
 {lib, stdenv, fetchurl, aspell, which, writeScript}:
 
-with lib;
-
 /* HOWTO:
 
    * Add some of these to your profile or systemPackages.
@@ -105,7 +103,7 @@ let
         homepage = "http://ftp.gnu.org/gnu/aspell/dict/0index.html";
       } // (args.meta or {});
 
-    } // lib.optionalAttrs (stdenv.isDarwin && elem language [ "is" "nb" ]) {
+    } // lib.optionalAttrs (stdenv.isDarwin && lib.elem language [ "is" "nb" ]) {
       # tar: Cannot open: Illegal byte sequence
       unpackPhase = ''
         runHook preUnpack
@@ -115,7 +113,7 @@ let
         runHook postUnpack
       '';
 
-      postPatch = getAttr language {
+      postPatch = lib.getAttr language {
         is = ''
           cp icelandic.alias íslenska.alias
           sed -i 's/ .slenska\.alias/ íslenska.alias/g' Makefile.pre
@@ -137,7 +135,7 @@ let
       preBuild = ''
         # Aspell can't handle multiple data-dirs
         # Copy everything we might possibly need
-        ${concatMapStringsSep "\n" (p: ''
+        ${lib.concatMapStringsSep "\n" (p: ''
           cp -a ${p}/lib/aspell/* .
         '') ([ aspell ] ++ langInputs)}
         export ASPELL_CONF="data-dir $(pwd)"

--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -2,7 +2,6 @@
 , pam, libxcrypt, fixDarwinDylibNames, autoreconfHook, enableLdap ? false
 , buildPackages, pruneLibtoolFiles, nixosTests }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "cyrus-sasl";
   version = "2.1.28";
@@ -50,7 +49,7 @@ stdenv.mkDerivation rec {
     inherit (nixosTests) parsedmarc postfix;
   };
 
-  meta = {
+  meta = with lib; {
     homepage = "https://www.cyrusimap.org/sasl";
     description = "Library for adding authentication support to connection-based protocols";
     platforms = platforms.unix;

--- a/pkgs/development/libraries/faac/default.nix
+++ b/pkgs/development/libraries/faac/default.nix
@@ -5,7 +5,6 @@
 
 assert mp4v2Support -> (mp4v2 != null);
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "faac";
   version = "1.30";
@@ -16,19 +15,19 @@ stdenv.mkDerivation rec {
   };
 
   configureFlags = [ ]
-    ++ optional mp4v2Support "--with-external-mp4v2"
-    ++ optional drmSupport "--enable-drm";
+    ++ lib.optional mp4v2Support "--with-external-mp4v2"
+    ++ lib.optional drmSupport "--enable-drm";
 
   hardeningDisable = [ "format" ];
 
   nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [ ]
-    ++ optional mp4v2Support mp4v2;
+    ++ lib.optional mp4v2Support mp4v2;
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     description = "Open source MPEG-4 and MPEG-2 AAC encoder";
     license     = licenses.unfreeRedistributable;
     maintainers = with maintainers; [ codyopel ];

--- a/pkgs/development/libraries/faad2/default.nix
+++ b/pkgs/development/libraries/faad2/default.nix
@@ -11,7 +11,6 @@
 , vlc
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "faad2";
   version = "2.10.1";
@@ -24,7 +23,7 @@ stdenv.mkDerivation rec {
   };
 
   configureFlags = []
-    ++ optional drmSupport "--with-drm";
+    ++ lib.optional drmSupport "--with-drm";
 
   nativeBuildInputs = [ autoreconfHook ];
 
@@ -34,7 +33,7 @@ stdenv.mkDerivation rec {
     ocaml-faad = ocamlPackages.faad;
   };
 
-  meta = {
+  meta = with lib; {
     description = "An open source MPEG-4 and MPEG-2 AAC decoder";
     homepage = "https://sourceforge.net/projects/faac/";
     license     = licenses.gpl2Plus;

--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -14,9 +14,7 @@
 , withDoc ? stdenv.cc.isGNU
 }:
 
-with lib;
-
-assert elem precision [ "single" "double" "long-double" "quad-precision" ];
+assert lib.elem precision [ "single" "double" "long-double" "quad-precision" ];
 
 stdenv.mkDerivation rec {
   pname = "fftw-${precision}";
@@ -31,32 +29,32 @@ stdenv.mkDerivation rec {
   };
 
   outputs = [ "out" "dev" "man" ]
-    ++ optional withDoc "info"; # it's dev-doc only
+    ++ lib.optional withDoc "info"; # it's dev-doc only
   outputBin = "dev"; # fftw-wisdom
 
   nativeBuildInputs = [ gfortran ];
 
-  buildInputs = optionals stdenv.cc.isClang [
+  buildInputs = lib.optionals stdenv.cc.isClang [
     # TODO: This may mismatch the LLVM version sin the stdenv, see #79818.
     llvmPackages.openmp
-  ] ++ optional enableMpi mpi;
+  ] ++ lib.optional enableMpi mpi;
 
   configureFlags =
     [ "--enable-shared"
       "--enable-threads"
     ]
-    ++ optional (precision != "double") "--enable-${precision}"
+    ++ lib.optional (precision != "double") "--enable-${precision}"
     # all x86_64 have sse2
     # however, not all float sizes fit
-    ++ optional (stdenv.isx86_64 && (precision == "single" || precision == "double") )  "--enable-sse2"
-    ++ optional enableAvx "--enable-avx"
-    ++ optional enableAvx2 "--enable-avx2"
-    ++ optional enableAvx512 "--enable-avx512"
-    ++ optional enableFma "--enable-fma"
+    ++ lib.optional (stdenv.isx86_64 && (precision == "single" || precision == "double") )  "--enable-sse2"
+    ++ lib.optional enableAvx "--enable-avx"
+    ++ lib.optional enableAvx2 "--enable-avx2"
+    ++ lib.optional enableAvx512 "--enable-avx512"
+    ++ lib.optional enableFma "--enable-fma"
     ++ [ "--enable-openmp" ]
-    ++ optional enableMpi "--enable-mpi"
+    ++ lib.optional enableMpi "--enable-mpi"
     # doc generation causes Fortran wrapper generation which hard-codes gcc
-    ++ optional (!withDoc) "--disable-doc";
+    ++ lib.optional (!withDoc) "--disable-doc";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/geis/default.nix
+++ b/pkgs/development/libraries/geis/default.nix
@@ -15,7 +15,6 @@
 , xorgserver
 }:
 
-with lib;
 
 stdenv.mkDerivation rec {
   pname = "geis";
@@ -48,7 +47,7 @@ stdenv.mkDerivation rec {
     gappsWrapperArgs+=(--set PYTHONPATH "$program_PYTHONPATH")
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A library for input gesture recognition";
     homepage = "https://launchpad.net/geis";
     license = licenses.gpl2;

--- a/pkgs/development/libraries/glew/1.10.nix
+++ b/pkgs/development/libraries/glew/1.10.nix
@@ -2,8 +2,6 @@
 , AGL, OpenGL
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "glew";
   version = "1.10.0";
@@ -20,7 +18,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     sed -i 's|lib64|lib|' config/Makefile.linux
-    ${optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    ${lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     sed -i -e 's/\(INSTALL.*\)-s/\1/' Makefile
     ''}
   '';

--- a/pkgs/development/libraries/gloox/default.nix
+++ b/pkgs/development/libraries/gloox/default.nix
@@ -4,7 +4,6 @@
 , idnSupport ? true, libidn
 }:
 
-with lib;
 
 stdenv.mkDerivation rec{
   pname = "gloox";
@@ -16,11 +15,11 @@ stdenv.mkDerivation rec{
   };
 
   buildInputs = [ ]
-    ++ optional zlibSupport zlib
-    ++ optional sslSupport openssl
-    ++ optional idnSupport libidn;
+    ++ lib.optional zlibSupport zlib
+    ++ lib.optional sslSupport openssl
+    ++ lib.optional idnSupport libidn;
 
-  meta = {
+  meta = with lib; {
     description = "A portable high-level Jabber/XMPP library for C++";
     homepage = "http://camaya.net/gloox";
     license = licenses.gpl3;

--- a/pkgs/development/libraries/gtk/2.x.nix
+++ b/pkgs/development/libraries/gtk/2.x.nix
@@ -7,8 +7,6 @@
 , fetchpatch, buildPackages
 }:
 
-with lib;
-
 let
 
   gtkCleanImmodulesCache = substituteAll {
@@ -44,7 +42,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./patches/2.0-immodules.cache.patch
     ./patches/gtk2-theme-paths.patch
-  ] ++ optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     (fetchpatch {
       url = "https://bug557780.bugzilla-attachments.gnome.org/attachment.cgi?id=306776";
       sha256 = "0sp8f1r5c4j2nlnbqgv7s7nxa4cfwigvm033hvhb1ld652pjag4r";
@@ -54,13 +52,13 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = with xorg;
     [ glib cairo pango gdk-pixbuf atk ]
-    ++ optionals (stdenv.isLinux || stdenv.isDarwin) [
+    ++ lib.optionals (stdenv.isLinux || stdenv.isDarwin) [
          libXrandr libXrender libXcomposite libXi libXcursor
        ]
-    ++ optionals stdenv.isDarwin [ libXdamage ]
-    ++ optional xineramaSupport libXinerama
-    ++ optionals cupsSupport [ cups ]
-    ++ optionals stdenv.isDarwin [ AppKit Cocoa ];
+    ++ lib.optionals stdenv.isDarwin [ libXdamage ]
+    ++ lib.optional xineramaSupport libXinerama
+    ++ lib.optionals cupsSupport [ cups ]
+    ++ lib.optionals stdenv.isDarwin [ AppKit Cocoa ];
 
   preConfigure = if (lib.versionAtLeast stdenv.hostPlatform.darwinMinVersion "11" && stdenv.isDarwin) then ''
     MACOSX_DEPLOYMENT_TARGET=10.16
@@ -69,7 +67,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-gdktarget=${gdktarget}"
     "--with-xinput=yes"
-  ] ++ optionals stdenv.isDarwin [
+  ] ++ lib.optionals stdenv.isDarwin [
     "--disable-glibtest"
     "--disable-introspection"
     "--disable-visibility"
@@ -94,7 +92,7 @@ stdenv.mkDerivation rec {
     inherit gdktarget;
   };
 
-  meta = {
+  meta = with lib; {
     description = "A multi-platform toolkit for creating graphical user interfaces";
     homepage    = "https://www.gtk.org/";
     license     = licenses.lgpl2Plus;

--- a/pkgs/development/libraries/hunspell/wrapper.nix
+++ b/pkgs/development/libraries/hunspell/wrapper.nix
@@ -1,10 +1,9 @@
 { stdenv, lib, hunspell, makeWrapper, dicts ? [] }:
-with lib;
 let
-  searchPath = makeSearchPath "share/hunspell" dicts;
+  searchPath = lib.makeSearchPath "share/hunspell" dicts;
 in
 stdenv.mkDerivation {
-  name = (appendToName "with-dicts" hunspell).name;
+  name = (lib.appendToName "with-dicts" hunspell).name;
   nativeBuildInputs = [ makeWrapper ];
   buildCommand = ''
     makeWrapper ${hunspell.bin}/bin/hunspell $out/bin/hunspell --prefix DICPATH : ${lib.escapeShellArg searchPath}

--- a/pkgs/development/libraries/indicator-application/gtk2.nix
+++ b/pkgs/development/libraries/indicator-application/gtk2.nix
@@ -3,8 +3,6 @@
 , glib, dbus-glib, json-glib
 , gtk2, libindicator-gtk2, libdbusmenu-gtk2, libappindicator-gtk2 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "indicator-application-gtk2";
   version = "12.10.0.1";
@@ -45,7 +43,7 @@ stdenv.mkDerivation rec {
     "localstatedir=\${TMPDIR}"
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Indicator to take menus from applications and place them in the panel (GTK 2 library for Xfce/LXDE)";
     homepage = "https://launchpad.net/indicators-gtk2";
     license = licenses.gpl3;

--- a/pkgs/development/libraries/kerberos/heimdal.nix
+++ b/pkgs/development/libraries/kerberos/heimdal.nix
@@ -4,7 +4,6 @@
 , CoreFoundation, Security, SystemConfiguration
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "heimdal";
   version = "7.8.0";
@@ -22,9 +21,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkg-config python3 perl bison flex texinfo ]
     ++ (with perlPackages; [ JSON ]);
-  buildInputs = optionals (stdenv.isLinux) [ libcap_ng ]
+  buildInputs = lib.optionals (stdenv.isLinux) [ libcap_ng ]
     ++ [ db sqlite openssl libedit openldap pam]
-    ++ optionals (stdenv.isDarwin) [ CoreFoundation Security SystemConfiguration ];
+    ++ lib.optionals (stdenv.isDarwin) [ CoreFoundation Security SystemConfiguration ];
 
   ## ugly, X should be made an option
   configureFlags = [
@@ -42,7 +41,7 @@ stdenv.mkDerivation rec {
     "--with-berkeley-db"
     "--with-berkeley-db-include=${db.dev}/include"
     "--with-openldap=${openldap.dev}"
-  ] ++ optionals (stdenv.isLinux) [
+  ] ++ lib.optionals (stdenv.isLinux) [
     "--with-capng"
   ];
 
@@ -91,7 +90,7 @@ stdenv.mkDerivation rec {
   #  hx_locl.h:67:25: fatal error: pkcs10_asn1.h: No such file or directory
   #enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     description = "An implementation of Kerberos 5 (and some more stuff)";
     license = licenses.bsd3;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/lame/default.nix
+++ b/pkgs/development/libraries/lame/default.nix
@@ -11,7 +11,6 @@
 , debugSupport ? false # Debugging (disables optimizations)
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "lame";
   version = "3.100";
@@ -25,24 +24,24 @@ stdenv.mkDerivation rec {
   outputMan = "out";
 
   nativeBuildInputs = [ ]
-    ++ optional nasmSupport nasm;
+    ++ lib.optional nasmSupport nasm;
 
   buildInputs = [ ]
     #++ optional efenceSupport libefence
     #++ optional mp3xSupport gtk1
-    ++ optional sndfileFileIOSupport libsndfile;
+    ++ lib.optional sndfileFileIOSupport libsndfile;
 
   configureFlags = [
-    (enableFeature nasmSupport "nasm")
-    (enableFeature cpmlSupport "cpml")
+    (lib.enableFeature nasmSupport "nasm")
+    (lib.enableFeature cpmlSupport "cpml")
     #(enableFeature efenceSupport "efence")
     (if sndfileFileIOSupport then "--with-fileio=sndfile" else "--with-fileio=lame")
-    (enableFeature analyzerHooksSupport "analyzer-hooks")
-    (enableFeature decoderSupport "decoder")
-    (enableFeature frontendSupport "frontend")
-    (enableFeature frontendSupport "dynamic-frontends")
+    (lib.enableFeature analyzerHooksSupport "analyzer-hooks")
+    (lib.enableFeature decoderSupport "decoder")
+    (lib.enableFeature frontendSupport "frontend")
+    (lib.enableFeature frontendSupport "dynamic-frontends")
     #(enableFeature mp3xSupport "mp3x")
-    (enableFeature mp3rtpSupport "mp3rtp")
+    (lib.enableFeature mp3rtpSupport "mp3rtp")
     (if debugSupport then "--enable-debug=alot" else "")
   ];
 
@@ -52,7 +51,7 @@ stdenv.mkDerivation rec {
     sed -i '/lame_init_old/d' include/libmp3lame.sym
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A high quality MPEG Audio Layer III (MP3) encoder";
     homepage    = "http://lame.sourceforge.net";
     license     = licenses.lgpl2;

--- a/pkgs/development/libraries/libass/default.nix
+++ b/pkgs/development/libraries/libass/default.nix
@@ -8,7 +8,6 @@
 
 assert fontconfigSupport -> fontconfig != null;
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "libass";
   version = "0.16.0";
@@ -19,18 +18,18 @@ stdenv.mkDerivation rec {
   };
 
   configureFlags = [
-    (enableFeature fontconfigSupport "fontconfig")
-    (enableFeature rasterizerSupport "rasterizer")
-    (enableFeature largeTilesSupport "large-tiles")
+    (lib.enableFeature fontconfigSupport "fontconfig")
+    (lib.enableFeature rasterizerSupport "rasterizer")
+    (lib.enableFeature largeTilesSupport "large-tiles")
   ];
 
   nativeBuildInputs = [ pkg-config yasm ];
 
   buildInputs = [ freetype fribidi harfbuzz ]
-    ++ optional fontconfigSupport fontconfig
-    ++ optional stdenv.isDarwin libiconv;
+    ++ lib.optional fontconfigSupport fontconfig
+    ++ lib.optional stdenv.isDarwin libiconv;
 
-  meta = {
+  meta = with lib; {
     description = "Portable ASS/SSA subtitle renderer";
     homepage    = "https://github.com/libass/libass";
     license     = licenses.isc;

--- a/pkgs/development/libraries/libcollectdclient/default.nix
+++ b/pkgs/development/libraries/libcollectdclient/default.nix
@@ -1,5 +1,4 @@
 { lib, collectd }:
-with lib;
 
 collectd.overrideAttrs (oldAttrs: {
   pname = "libcollectdclient";

--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -5,8 +5,6 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libidn2";
   version = "2.3.2";
@@ -20,14 +18,14 @@ stdenv.mkDerivation rec {
   # Beware: non-bootstrap libidn2 is overridden by ./hack.nix
   outputs = [ "bin" "dev" "out" "info" "devdoc" ];
 
-  patches = optional stdenv.isDarwin ./fix-error-darwin.patch;
+  patches = lib.optional stdenv.isDarwin ./fix-error-darwin.patch;
 
   enableParallelBuilding = true;
 
   # The above patch causes the documentation to be regenerated, so the
   # documentation tools are required.
-  nativeBuildInputs = optionals stdenv.isDarwin [ help2man texinfo ];
-  buildInputs = [ libunistring ] ++ optional stdenv.isDarwin libiconv;
+  nativeBuildInputs = lib.optionals stdenv.isDarwin [ help2man texinfo ];
+  buildInputs = [ libunistring ] ++ lib.optional stdenv.isDarwin libiconv;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   meta = {

--- a/pkgs/development/libraries/libmcrypt/default.nix
+++ b/pkgs/development/libraries/libmcrypt/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl, darwin, disablePosixThreads ? false }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libmcrypt";
   version = "2.5.8";
@@ -11,15 +9,15 @@ stdenv.mkDerivation rec {
     sha256 = "0gipgb939vy9m66d3k8il98rvvwczyaw2ixr8yn6icds9c3nrsz4";
   };
 
-  buildInputs = optional stdenv.isDarwin darwin.cctools;
+  buildInputs = lib.optional stdenv.isDarwin darwin.cctools;
 
-  configureFlags = optionals disablePosixThreads
+  configureFlags = lib.optionals disablePosixThreads
     [ "--disable-posix-threads" ];
 
   meta = {
     description = "Replacement for the old crypt() package and crypt(1) command, with extensions";
     homepage = "http://mcrypt.sourceforge.net";
     license = "GPL";
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/development/libraries/libqtav/default.nix
+++ b/pkgs/development/libraries/libqtav/default.nix
@@ -17,8 +17,6 @@
 , libva
 }:
 
-with lib;
-
 mkDerivation rec {
   pname = "libqtav";
   version = "unstable-2020-09-10";
@@ -64,7 +62,7 @@ mkDerivation rec {
 
   stripDebugList = [ "lib" "libexec" "bin" "qml" ];
 
-  meta = {
+  meta =  with lib; {
     description = "A multimedia playback framework based on Qt + FFmpeg";
     #license = licenses.lgpl21; # For the libraries / headers only.
     license = licenses.gpl3; # With the examples (under bin) and most likely some of the optional dependencies used.

--- a/pkgs/development/libraries/libspf2/default.nix
+++ b/pkgs/development/libraries/libspf2/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, fetchpatch }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libspf2";
   version = "2.2.12";
@@ -35,7 +33,7 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = {
+  meta = with lib; {
     description = "Implementation of the Sender Policy Framework for SMTP " +
                   "authorization (Helsinki Systems fork)";
     homepage = "https://github.com/helsinki-systems/libspf2";

--- a/pkgs/development/libraries/libtap/default.nix
+++ b/pkgs/development/libraries/libtap/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, cmake, perl }:
 
-with lib;
 stdenv.mkDerivation rec {
 
   pname = "libtap";

--- a/pkgs/development/libraries/libunique/3.x.nix
+++ b/pkgs/development/libraries/libunique/3.x.nix
@@ -3,7 +3,6 @@
 , gtk-doc, docbook_xml_dtd_45, docbook_xsl
 , libxslt, libxml2 }:
 
-with lib;
 stdenv.mkDerivation rec {
 
   majorVer = "3.0";
@@ -23,8 +22,8 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://wiki.gnome.org/Attic/LibUnique";
     description = "A library for writing single instance applications";
-    license = licenses.lgpl21;
-    maintainers = [ maintainers.AndersonTorres ];
+    license = lib.licenses.lgpl21;
+    maintainers = [ lib.maintainers.AndersonTorres ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libutempter/default.nix
+++ b/pkgs/development/libraries/libutempter/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchurl, lib, glib }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libutempter";
   version = "1.2.1";
@@ -28,7 +26,7 @@ stdenv.mkDerivation rec {
     "mandir=\${out}/share/man"
   ];
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/altlinux/libutempter";
     description = "Interface for terminal emulators such as screen and xterm to record user sessions to utmp and wtmp files";
     longDescription = ''

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -77,13 +77,11 @@
 , zfs
 }:
 
-with lib;
-
 let
   inherit (stdenv) isDarwin isLinux isx86_64;
-  binPath = makeBinPath ([
+  binPath = lib.makeBinPath ([
     dnsmasq
-  ] ++ optionals isLinux [
+  ] ++ lib.optionals isLinux [
     bridge-utils
     dmidecode
     dnsmasq
@@ -95,10 +93,10 @@ let
     numad
     pmutils
     systemd
-  ] ++ optionals enableIscsi [
+  ] ++ lib.optionals enableIscsi [
     libiscsi
     openiscsi
-  ] ++ optionals enableZfs [
+  ] ++ lib.optionals enableZfs [
     zfs
   ]);
 in
@@ -148,17 +146,17 @@ stdenv.mkDerivation rec {
 
     substituteInPlace meson.build \
       --replace "'dbus-daemon'," "'${lib.getBin dbus}/bin/dbus-daemon',"
-  '' + optionalString isLinux ''
+  '' + lib.optionalString isLinux ''
     sed -i 's,define PARTED "parted",define PARTED "${parted}/bin/parted",' \
       src/storage/storage_backend_disk.c \
       src/storage/storage_util.c
-  '' + optionalString isDarwin ''
+  '' + lib.optionalString isDarwin ''
     sed -i '/qemucapabilitiestest/d' tests/meson.build
     sed -i '/vircryptotest/d' tests/meson.build
     sed -i '/domaincapstest/d' tests/meson.build
     sed -i '/qemufirmwaretest/d' tests/meson.build
     sed -i '/qemuvhostusertest/d' tests/meson.build
-  '' + optionalString (isDarwin && isx86_64) ''
+  '' + lib.optionalString (isDarwin && isx86_64) ''
     sed -i '/qemucaps2xmltest/d' tests/meson.build
     sed -i '/qemuhotplugtest/d' tests/meson.build
     sed -i '/virnetdaemontest/d' tests/meson.build
@@ -178,9 +176,9 @@ stdenv.mkDerivation rec {
     perl
     perlPackages.XMLXPath
   ]
-  ++ optional (!isDarwin) rpcsvc-proto
+  ++ lib.optional (!isDarwin) rpcsvc-proto
   # NOTE: needed for rpcgen
-  ++ optional isDarwin darwin.developer_cmds;
+  ++ lib.optional isDarwin darwin.developer_cmds;
 
   buildInputs = [
     bash
@@ -197,7 +195,7 @@ stdenv.mkDerivation rec {
     readline
     xhtml1
     yajl
-  ] ++ optionals isLinux [
+  ] ++ lib.optionals isLinux [
     acl
     attr
     audit
@@ -213,17 +211,17 @@ stdenv.mkDerivation rec {
     parted
     systemd
     util-linux
-  ] ++ optionals isDarwin [
+  ] ++ lib.optionals isDarwin [
     AppKit
     Carbon
     gmp
     libiconv
   ]
-  ++ optionals enableCeph [ ceph ]
-  ++ optionals enableGlusterfs [ glusterfs ]
-  ++ optionals enableIscsi [ libiscsi openiscsi ]
-  ++ optionals enableXen [ xen ]
-  ++ optionals enableZfs [ zfs ];
+  ++ lib.optionals enableCeph [ ceph ]
+  ++ lib.optionals enableGlusterfs [ glusterfs ]
+  ++ lib.optionals enableIscsi [ libiscsi openiscsi ]
+  ++ lib.optionals enableXen [ xen ]
+  ++ lib.optionals enableZfs [ zfs ];
 
   preConfigure =
     let
@@ -348,7 +346,7 @@ stdenv.mkDerivation rec {
     # Added in nixpkgs:
     gettext() { "${gettext}/bin/gettext" "$@"; }
     '
-  '' + optionalString isLinux ''
+  '' + lib.optionalString isLinux ''
     for f in $out/lib/systemd/system/*.service ; do
       substituteInPlace $f --replace /bin/kill ${coreutils}/bin/kill
     done
@@ -372,7 +370,7 @@ stdenv.mkDerivation rec {
 
   passthru.tests.libvirtd = nixosTests.libvirtd;
 
-  meta = {
+  meta = with lib; {
     description = "A toolkit to interact with the virtualization capabilities of recent versions of Linux and other OSes";
     homepage = "https://libvirt.org/";
     changelog = "https://gitlab.com/libvirt/libvirt/-/raw/v${version}/NEWS.rst";

--- a/pkgs/development/libraries/libvmi/default.nix
+++ b/pkgs/development/libraries/libvmi/default.nix
@@ -10,8 +10,6 @@
   libvirt,
   xenSupport ? true }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libvmi";
   version = "0.12.0";
@@ -24,16 +22,16 @@ stdenv.mkDerivation rec {
     sha256 = "0wbi2nasb1gbci6cq23g6kq7i10rwi1y7r44rl03icr5prqjpdyv";
   };
 
-  buildInputs = [ glib libvirt json_c ] ++ (optional xenSupport xen);
+  buildInputs = [ glib libvirt json_c ] ++ (lib.optional xenSupport xen);
   nativeBuildInputs = [ autoreconfHook bison flex pkg-config ];
 
-  configureFlags = optional (!xenSupport) "--disable-xen";
+  configureFlags = lib.optional (!xenSupport) "--disable-xen";
 
   # libvmi uses dlopen() for the xen libraries, however autoPatchelfHook doesn't work here
-  postFixup = optionalString xenSupport ''
+  postFixup = lib.optionalString xenSupport ''
     libvmi="$out/lib/libvmi.so.${libVersion}"
     oldrpath=$(patchelf --print-rpath "$libvmi")
-    patchelf --set-rpath "$oldrpath:${makeLibraryPath [ xen ]}" "$libvmi"
+    patchelf --set-rpath "$oldrpath:${lib.makeLibraryPath [ xen ]}" "$libvmi"
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/libytnef/default.nix
+++ b/pkgs/development/libraries/libytnef/default.nix
@@ -1,7 +1,5 @@
 { stdenv, lib, fetchFromGitHub, autoreconfHook }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "libytnef";
   version = "2.0";
@@ -15,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  meta = {
+  meta = with lib; {
     inherit (src.meta) homepage;
     description = "Yeraze's TNEF Stream Reader - for winmail.dat files";
     license = licenses.gpl2Plus;

--- a/pkgs/development/libraries/nuspell/wrapper.nix
+++ b/pkgs/development/libraries/nuspell/wrapper.nix
@@ -1,10 +1,10 @@
 { stdenv, lib, nuspell, makeWrapper, dicts ? [] }:
-with lib;
+
 let
-  searchPath = makeSearchPath "share/hunspell" dicts;
+  searchPath = lib.makeSearchPath "share/hunspell" dicts;
 in
 stdenv.mkDerivation {
-  name = (appendToName "with-dicts" nuspell).name;
+  name = (lib.appendToName "with-dicts" nuspell).name;
   nativeBuildInputs = [ makeWrapper ];
   buildCommand = ''
     makeWrapper ${nuspell}/bin/nuspell $out/bin/nuspell --prefix DICPATH : ${lib.escapeShellArg searchPath}

--- a/pkgs/development/libraries/opencascade/default.nix
+++ b/pkgs/development/libraries/opencascade/default.nix
@@ -3,7 +3,6 @@
   OpenCL, Cocoa
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "opencascade-oce";
   version = "0.18.3";
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
     libGL libGLU libXmu freetype fontconfig expat freeimage vtk
     gl2ps tbb
   ]
-    ++ optionals stdenv.isDarwin [OpenCL Cocoa]
+    ++ lib.optionals stdenv.isDarwin [OpenCL Cocoa]
   ;
 
   cmakeFlags = [
@@ -30,7 +29,7 @@ stdenv.mkDerivation rec {
     "-DOCE_WITH_GL2PS=ON"
     "-DOCE_MULTITHREAD_LIBRARY=TBB"
   ]
-  ++ optionals stdenv.isDarwin ["-DOCE_OSX_USE_COCOA=ON" "-DOCE_WITH_OPENCL=ON"];
+  ++ lib.optionals stdenv.isDarwin ["-DOCE_OSX_USE_COCOA=ON" "-DOCE_WITH_OPENCL=ON"];
 
   patches = [
     # Use fontconfig instead of hardcoded directory list
@@ -56,7 +55,7 @@ stdenv.mkDerivation rec {
       --replace FONTCONFIG_LIBRARIES FONTCONFIG_LINK_LIBRARIES
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Open CASCADE Technology, libraries for 3D modeling and numerical simulation";
     homepage = "https://github.com/tpaviot/oce";
     maintainers = [ maintainers.viric ];

--- a/pkgs/development/libraries/pcg-c/default.nix
+++ b/pkgs/development/libraries/pcg-c/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchzip }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   version = "0.94";
   pname = "pcg-c";
@@ -31,8 +29,8 @@ stdenv.mkDerivation rec {
       algorithms for random number generation. Unlike many general-purpose RNGs,
       they are also hard to predict.
     '';
-    platforms = platforms.unix;
-    maintainers = [ maintainers.linus ];
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.linus ];
     broken = stdenv.isi686; # https://github.com/imneme/pcg-c/issues/11
   };
 }

--- a/pkgs/development/libraries/pcre/default.nix
+++ b/pkgs/development/libraries/pcre/default.nix
@@ -3,9 +3,7 @@
 , variant ? null
 }:
 
-with lib;
-
-assert elem variant [ null "cpp" "pcre16" "pcre32" ];
+assert lib.elem variant [ null "cpp" "pcre16" "pcre32" ];
 
 stdenv.mkDerivation rec {
   pname = "pcre"
@@ -21,11 +19,11 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" "doc" "man" ];
 
   # Disable jit on Apple Silicon, https://github.com/zherczeg/sljit/issues/51
-  configureFlags = optional (!(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)) "--enable-jit=auto" ++ [
+  configureFlags = lib.optional (!(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64)) "--enable-jit=auto" ++ [
     "--enable-unicode-properties"
     "--disable-cpp"
   ]
-    ++ optional (variant != null) "--enable-${variant}";
+    ++ lib.optional (variant != null) "--enable-${variant}";
 
   # https://bugs.exim.org/show_bug.cgi?id=2173
   patches = [ ./stacksize-detection.patch ];
@@ -40,7 +38,7 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     moveToOutput bin/pcre-config "$dev"
-  '' + optionalString (variant != null) ''
+  '' + lib.optionalString (variant != null) ''
     ln -sf -t "$out/lib/" '${pcre.out}'/lib/libpcre{,posix}.{so.*.*.*,*dylib,*a}
   '';
 
@@ -57,7 +55,7 @@ stdenv.mkDerivation rec {
       PCRE library is free, even for building proprietary software.
     '';
 
-    platforms = platforms.all;
-    maintainers = with maintainers; [ ];
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/libraries/phonon/backends/gstreamer.nix
+++ b/pkgs/development/libraries/phonon/backends/gstreamer.nix
@@ -3,8 +3,6 @@
 , debug ? false
 }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "phonon-backend-gstreamer";
   version = "4.10.0";

--- a/pkgs/development/libraries/phonon/default.nix
+++ b/pkgs/development/libraries/phonon/default.nix
@@ -12,8 +12,6 @@
 , debug ? false
 }:
 
-with lib;
-
 let
   soname = "phonon4qt5";
   buildsystemdir = "share/cmake/${soname}";

--- a/pkgs/development/libraries/science/math/clmagma/default.nix
+++ b/pkgs/development/libraries/science/math/clmagma/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl, gfortran, opencl-headers, clblas, ocl-icd, mkl, intel-ocl }:
 
-with lib;
-
 let
   incfile = builtins.toFile "make.inc.custom" ''
     CC        = g++

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -32,8 +32,6 @@
 , python3
 }:
 
-with lib;
-
 let blas64_ = blas64; in
 
 let
@@ -121,7 +119,7 @@ let
   blas64 =
     if blas64_ != null
       then blas64_
-      else hasPrefix "x86_64" stdenv.hostPlatform.system;
+      else lib.hasPrefix "x86_64" stdenv.hostPlatform.system;
   # Convert flag values to format OpenBLAS's build expects.
   # `toString` is almost what we need other than bools,
   # which we need to map {true -> 1, false -> 0}
@@ -129,7 +127,7 @@ let
   mkMakeFlagValue = val:
     if !builtins.isBool val then toString val
     else if val then "1" else "0";
-  mkMakeFlagsFromConfig = mapAttrsToList (var: val: "${var}=${mkMakeFlagValue val}");
+  mkMakeFlagsFromConfig = lib.mapAttrsToList (var: val: "${var}=${mkMakeFlagValue val}");
 
   shlibExt = stdenv.hostPlatform.extensions.sharedLibrary;
 

--- a/pkgs/development/libraries/sope/default.nix
+++ b/pkgs/development/libraries/sope/default.nix
@@ -1,6 +1,5 @@
 { gnustep, lib, fetchFromGitHub , libxml2, openssl
 , openldap, mariadb, libmysqlclient, postgresql }:
-with lib;
 
 gnustep.stdenv.mkDerivation rec {
   pname = "sope";
@@ -15,10 +14,10 @@ gnustep.stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
   nativeBuildInputs = [ gnustep.make ];
-  buildInputs = flatten ([ gnustep.base libxml2 openssl ]
-    ++ optional (openldap != null) openldap
-    ++ optionals (mariadb != null) [ libmysqlclient mariadb ]
-    ++ optional (postgresql != null) postgresql);
+  buildInputs = lib.flatten ([ gnustep.base libxml2 openssl ]
+    ++ lib.optional (openldap != null) openldap
+    ++ lib.optionals (mariadb != null) [ libmysqlclient mariadb ]
+    ++ lib.optional (postgresql != null) postgresql);
 
   postPatch = ''
     # Exclude NIX_ variables
@@ -30,9 +29,9 @@ gnustep.stdenv.mkDerivation rec {
   '';
 
   configureFlags = [ "--prefix=" "--disable-debug" "--enable-xml" "--with-ssl=ssl" ]
-    ++ optional (openldap != null) "--enable-openldap"
-    ++ optional (mariadb != null) "--enable-mysql"
-    ++ optional (postgresql != null) "--enable-postgresql";
+    ++ lib.optional (openldap != null) "--enable-openldap"
+    ++ lib.optional (mariadb != null) "--enable-mysql"
+    ++ lib.optional (postgresql != null) "--enable-postgresql";
 
   # Yes, this is ugly.
   preFixup = ''
@@ -40,7 +39,7 @@ gnustep.stdenv.mkDerivation rec {
     rm -rf $out/nix/store
   '';
 
-  meta = {
+  meta = with lib; {
     description = "An extensive set of frameworks which form a complete Web application server environment";
     license = licenses.publicDomain;
     homepage = "https://github.com/inverse-inc/sope";

--- a/pkgs/development/libraries/sqlite/archive-version.nix
+++ b/pkgs/development/libraries/sqlite/archive-version.nix
@@ -1,11 +1,9 @@
 lib: version:
 
-with lib;
-
 let
-  fragments = splitVersion version;
-  major = head fragments;
-  minor = concatMapStrings (fixedWidthNumber 2) (tail fragments);
+  fragments = lib.splitVersion version;
+  major = lib.head fragments;
+  minor = lib.concatMapStrings (lib.fixedWidthNumber 2) (lib.tail fragments);
 in
 
 major + minor + "00"

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -9,14 +9,12 @@
 , enableDeserialize ? false
 }:
 
-with lib;
-
 let
   archiveVersion = import ./archive-version.nix lib;
 in
 
 stdenv.mkDerivation rec {
-  pname = "sqlite${optionalString interactive "-interactive"}";
+  pname = "sqlite${lib.optionalString interactive "-interactive"}";
   version = "3.40.1";
 
   # nixpkgs-update: no auto update
@@ -29,14 +27,14 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" ];
   separateDebugInfo = stdenv.isLinux;
 
-  buildInputs = [ zlib ] ++ optionals interactive [ readline ncurses ];
+  buildInputs = [ zlib ] ++ lib.optionals interactive [ readline ncurses ];
 
   # required for aarch64 but applied for all arches for simplicity
   preConfigure = ''
     patchShebangs configure
   '';
 
-  configureFlags = [ "--enable-threadsafe" ] ++ optional interactive "--enable-readline";
+  configureFlags = [ "--enable-threadsafe" ] ++ lib.optional interactive "--enable-readline";
 
   NIX_CFLAGS_COMPILE = toString ([
     "-DSQLITE_ENABLE_COLUMN_METADATA"
@@ -94,7 +92,7 @@ stdenv.mkDerivation rec {
     inherit sqldiff sqlite-analyzer tracker;
   };
 
-  meta = {
+  meta = with lib; {
     description = "A self-contained, serverless, zero-configuration, transactional SQL database engine";
     downloadPage = "https://sqlite.org/download.html";
     homepage = "https://www.sqlite.org/";

--- a/pkgs/development/libraries/srt/default.nix
+++ b/pkgs/development/libraries/srt/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv, fetchFromGitHub, cmake, openssl
 }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "srt";
   version = "1.5.1";
@@ -28,7 +27,7 @@ stdenv.mkDerivation rec {
     "-UCMAKE_INSTALL_LIBDIR"
   ];
 
-  meta = {
+  meta = with lib; {
     description = "Secure, Reliable, Transport";
     homepage    = "https://github.com/Haivision/srt";
     license     = licenses.mpl20;

--- a/pkgs/development/libraries/unittest-cpp/default.nix
+++ b/pkgs/development/libraries/unittest-cpp/default.nix
@@ -1,7 +1,5 @@
 {lib, stdenv, fetchFromGitHub, cmake}:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "unittest-cpp";
   version = "2.0.0";
@@ -20,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/unittest-cpp/unittest-cpp";
     description = "Lightweight unit testing framework for C++";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/libraries/xvidcore/default.nix
+++ b/pkgs/development/libraries/xvidcore/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchurl, yasm, autoconf, automake, libtool }:
 
-with lib;
 stdenv.mkDerivation rec {
   pname = "xvidcore";
   version = "1.3.7";
@@ -13,7 +12,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     # Configure script is not in the root of the source directory
     cd build/generic
-  '' + optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     # Undocumented darwin hack
     substituteInPlace configure --replace "-no-cpp-precomp" ""
   '';
@@ -21,22 +20,22 @@ stdenv.mkDerivation rec {
   configureFlags = [ ]
     # Undocumented darwin hack (assembly is probably disabled due to an
     # issue with nasm, however yasm is now used)
-    ++ optional stdenv.isDarwin "--enable-macosx_module --disable-assembly";
+    ++ lib.optional stdenv.isDarwin "--enable-macosx_module --disable-assembly";
 
   nativeBuildInputs = [ ]
-    ++ optional (!stdenv.isDarwin) yasm;
+    ++ lib.optional (!stdenv.isDarwin) yasm;
 
   buildInputs = [ ]
     # Undocumented darwin hack
-    ++ optionals stdenv.isDarwin [ autoconf automake libtool ];
+    ++ lib.optionals stdenv.isDarwin [ autoconf automake libtool ];
 
   # Don't remove static libraries (e.g. 'libs/*.a') on darwin.  They're needed to
   # compile ffmpeg (and perhaps other things).
-  postInstall = optionalString (!stdenv.isDarwin) ''
+  postInstall = lib.optionalString (!stdenv.isDarwin) ''
     rm $out/lib/*.a
   '';
 
-  meta = {
+  meta = with lib; {
     description = "MPEG-4 video codec for PC";
     homepage    = "https://www.xvid.com/";
     license     = licenses.gpl2;

--- a/pkgs/development/misc/msp430/mspds/binary.nix
+++ b/pkgs/development/misc/msp430/mspds/binary.nix
@@ -1,9 +1,7 @@
 { stdenv, lib, fetchurl, unzip, autoPatchelfHook }:
 
-with lib;
-
 let
-  archPostfix = optionalString (stdenv.is64bit && !stdenv.isDarwin) "_64";
+  archPostfix = lib.optionalString (stdenv.is64bit && !stdenv.isDarwin) "_64";
 in stdenv.mkDerivation rec {
   pname = "msp-debug-stack-bin";
   version = "3.15.1.1";
@@ -26,7 +24,7 @@ in stdenv.mkDerivation rec {
     install -Dm0644 -t $out/include Inc/*.h
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Unfree binary release of the TI MSP430 FET debug driver";
     homepage = "https://www.ti.com/tool/MSPDS";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/development/misc/msp430/mspds/default.nix
+++ b/pkgs/development/misc/msp430/mspds/default.nix
@@ -6,11 +6,10 @@
 , libusb1 ? null
 }:
 
-with lib;
 assert stdenv.isLinux -> libusb1 != null;
 
 let
-  hidapiDriver = optionalString stdenv.isLinux "-libusb";
+  hidapiDriver = lib.optionalString stdenv.isLinux "-libusb";
 
 in stdenv.mkDerivation {
   pname = "msp-debug-stack";
@@ -33,7 +32,7 @@ in stdenv.mkDerivation {
   preBuild = ''
     rm ThirdParty/src/pugixml.cpp
     rm ThirdParty/include/pugi{config,xml}.hpp
-  '' + optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     makeFlagsArray+=(OUTNAME="-install_name ")
   '';
 
@@ -44,9 +43,9 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ unzip ];
   buildInputs = [ boost hidapi pugixml ]
-    ++ optional stdenv.isLinux libusb1;
+    ++ lib.optional stdenv.isLinux libusb1;
 
-  meta = {
+  meta = with lib; {
     description = "TI MSP430 FET debug driver";
     homepage = "https://www.ti.com/tool/MSPDS";
     license = licenses.bsd3;

--- a/pkgs/development/ocaml-modules/elpi/default.nix
+++ b/pkgs/development/ocaml-modules/elpi/default.nix
@@ -11,7 +11,7 @@
 , version ? if lib.versionAtLeast ocaml.version "4.08" then "1.16.5"
     else if lib.versionAtLeast ocaml.version "4.07" then "1.15.2" else "1.14.1"
 }:
-with lib;
+
 let fetched = coqPackages.metaFetch ({
     release."1.16.5".sha256 = "sha256-tKX5/cVPoBeHiUe+qn7c5FIRYCwY0AAukN7vSd/Nz9A=";
     release."1.15.2".sha256 = "sha256-XgopNP83POFbMNyl2D+gY1rmqGg03o++Ngv3zJfCn2s=";
@@ -31,17 +31,17 @@ buildDunePackage rec {
   pname = "elpi";
   inherit (fetched) version src;
 
-  patches = lib.optional (versionAtLeast version "1.16" || version == "dev")
+  patches = lib.optional (lib.versionAtLeast version "1.16" || version == "dev")
     ./atd_2_10.patch;
 
   minimalOCamlVersion = "4.04";
 
   buildInputs = [ perl ncurses ]
-  ++ optional (versionAtLeast version "1.15" || version == "dev") menhir
-  ++ optional (versionAtLeast version "1.16" || version == "dev") atdgen;
+  ++ lib.optional (lib.versionAtLeast version "1.15" || version == "dev") menhir
+  ++ lib.optional (lib.versionAtLeast version "1.16" || version == "dev") atdgen;
 
   propagatedBuildInputs = [ re stdlib-shims ]
-  ++ (if versionAtLeast version "1.15" || version == "dev"
+  ++ (if lib.versionAtLeast version "1.15" || version == "dev"
      then [ menhirLib ]
      else [ camlp5 ]
   )
@@ -50,7 +50,7 @@ buildDunePackage rec {
      else [ ppxlib_0_15 ppx_deriving_0_15 ]
   );
 
-  meta = {
+  meta = with lib; {
     description = "Embeddable λProlog Interpreter";
     license = licenses.lgpl21Plus;
     maintainers = [ maintainers.vbgl ];

--- a/pkgs/development/ocaml-modules/mtime/default.nix
+++ b/pkgs/development/ocaml-modules/mtime/default.nix
@@ -1,8 +1,6 @@
 { stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg }:
 
-with lib;
-
-throwIfNot (versionAtLeast ocaml.version "4.08")
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.08")
   "mtime is not available for OCaml ${ocaml.version}"
 
 stdenv.mkDerivation rec {
@@ -21,7 +19,7 @@ stdenv.mkDerivation rec {
 
   inherit (topkg) buildPhase installPhase;
 
-  meta = {
+  meta = with lib; {
     description = "Monotonic wall-clock time for OCaml";
     homepage = "https://erratique.ch/software/mtime";
     inherit (ocaml.meta) platforms;

--- a/pkgs/development/ocaml-modules/vg/default.nix
+++ b/pkgs/development/ocaml-modules/vg/default.nix
@@ -5,8 +5,6 @@
   htmlcBackend ? true # depends on js_of_ocaml
 }:
 
-with lib;
-
 let
   inherit (lib) optionals versionOlder;
 
@@ -38,14 +36,14 @@ stdenv.mkDerivation {
   strictDeps = true;
 
   buildPhase = topkg.buildPhase
-    + " --with-uutf ${boolToString pdfBackend}"
-    + " --with-otfm ${boolToString pdfBackend}"
-    + " --with-js_of_ocaml ${boolToString htmlcBackend}"
+    + " --with-uutf ${lib.boolToString pdfBackend}"
+    + " --with-otfm ${lib.boolToString pdfBackend}"
+    + " --with-js_of_ocaml ${lib.boolToString htmlcBackend}"
     + " --with-cairo2 false";
 
   inherit (topkg) installPhase;
 
-  meta = {
+  meta = with lib; {
     description = "Declarative 2D vector graphics for OCaml";
     longDescription = ''
     Vg is an OCaml module for declarative 2D vector graphics. In Vg, images

--- a/pkgs/development/python-modules/mohawk/default.nix
+++ b/pkgs/development/python-modules/mohawk/default.nix
@@ -1,6 +1,5 @@
 { lib, buildPythonPackage, fetchPypi, mock, nose, pytest, six }:
 
-with lib;
 buildPythonPackage rec {
   pname = "mohawk";
   version = "1.1.0";
@@ -21,7 +20,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for Hawk HTTP authorization.";
     homepage = "https://github.com/kumar303/mohawk";
-    license = licenses.mpl20;
+    license = lib.licenses.mpl20;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -1,8 +1,6 @@
 { lib, stdenv, fetchurl, jre, writeScript, common-updater-scripts, git, nixfmt
 , nix, coreutils, gnused, disableRemoteLogging ? true }:
 
-with lib;
-
 let
   repo = "git@github.com:lihaoyi/Ammonite.git";
 
@@ -22,7 +20,7 @@ let
       installPhase = ''
         install -Dm755 $src $out/bin/amm
         sed -i '0,/java/{s|java|${jre}/bin/java|}' $out/bin/amm
-      '' + optionalString (disableRemoteLogging) ''
+      '' + lib.optionalString (disableRemoteLogging) ''
         sed -i "0,/ammonite.Main/{s|ammonite.Main'|ammonite.Main' --no-remote-logging|}" $out/bin/amm
         sed -i '1i #!/bin/sh' $out/bin/amm
       '';
@@ -66,7 +64,7 @@ let
         runHook postInstallCheck
       '';
 
-      meta = {
+      meta = with lib; {
         description = "Improved Scala REPL";
         longDescription = ''
           The Ammonite-REPL is an improved Scala REPL, re-implemented from first principles.

--- a/pkgs/development/tools/butane/default.nix
+++ b/pkgs/development/tools/butane/default.nix
@@ -1,7 +1,5 @@
 { lib, fetchFromGitHub, buildGoModule }:
 
-with lib;
-
 buildGoModule rec {
   pname = "butane";
   version = "0.17.0";
@@ -27,7 +25,7 @@ buildGoModule rec {
     mv $out/bin/{internal,butane}
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Translates human-readable Butane configs into machine-readable Ignition configs";
     license = licenses.asl20;
     homepage = "https://github.com/coreos/butane";

--- a/pkgs/development/tools/eclipse-mat/default.nix
+++ b/pkgs/development/tools/eclipse-mat/default.nix
@@ -18,13 +18,12 @@
 , zlib
 }:
 
-with lib;
 let
   pVersion = "1.13.0.20220615";
-  pVersionTriple = splitVersion pVersion;
-  majorVersion = elemAt pVersionTriple 0;
-  minorVersion = elemAt pVersionTriple 1;
-  patchVersion = elemAt pVersionTriple 2;
+  pVersionTriple = lib.splitVersion pVersion;
+  majorVersion = lib.elemAt pVersionTriple 0;
+  minorVersion = lib.elemAt pVersionTriple 1;
+  patchVersion = lib.elemAt pVersionTriple 2;
   baseVersion = "${majorVersion}.${minorVersion}.${patchVersion}";
   jdk = jdk11;
 in

--- a/pkgs/development/tools/iaca/2.1.nix
+++ b/pkgs/development/tools/iaca/2.1.nix
@@ -1,5 +1,4 @@
 { lib, stdenv, makeWrapper, requireFile, gcc, unzip }:
-with lib;
 
 # v2.1: last version with NHM/WSM arch support
 stdenv.mkDerivation rec {
@@ -17,17 +16,17 @@ stdenv.mkDerivation rec {
     cp bin/iaca $out/bin/
     cp lib/* $out/lib
   '';
-  preFixup = let libPath = makeLibraryPath [ stdenv.cc.cc.lib gcc ]; in ''
+  preFixup = let libPath = lib.makeLibraryPath [ stdenv.cc.cc.lib gcc ]; in ''
     patchelf \
         --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 \
         --set-rpath $out/lib:"${libPath}" \
         $out/bin/iaca
   '';
   postFixup = "wrapProgram $out/bin/iaca --set LD_LIBRARY_PATH $out/lib";
-  meta = {
+  meta = with lib; {
     description = "Intel Architecture Code Analyzer";
     homepage = "https://software.intel.com/en-us/articles/intel-architecture-code-analyzer/";
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ kazcw ];

--- a/pkgs/development/tools/iaca/3.0.nix
+++ b/pkgs/development/tools/iaca/3.0.nix
@@ -1,5 +1,4 @@
 { lib, stdenv, requireFile, unzip }:
-with lib;
 
 stdenv.mkDerivation rec {
   pname = "iaca";
@@ -15,10 +14,10 @@ stdenv.mkDerivation rec {
     cp iaca $out/bin
     patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 $out/bin/iaca
   '';
-  meta = {
+  meta = with lib; {
     description = "Intel Architecture Code Analyzer";
     homepage = "https://software.intel.com/en-us/articles/intel-architecture-code-analyzer/";
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ kazcw ];

--- a/pkgs/development/tools/kind/default.nix
+++ b/pkgs/development/tools/kind/default.nix
@@ -1,7 +1,5 @@
 { lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
-with lib;
-
 buildGoModule rec {
   pname = "kind";
   version = "0.17.0";
@@ -36,11 +34,11 @@ buildGoModule rec {
     done
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Kubernetes IN Docker - local clusters for testing Kubernetes";
     homepage    = "https://github.com/kubernetes-sigs/kind";
     maintainers = with maintainers; [ offline rawkode ];
-    license     = lib.licenses.asl20;
+    license     = licenses.asl20;
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/tools/misc/kibana/7.x.nix
+++ b/pkgs/development/tools/misc/kibana/7.x.nix
@@ -9,11 +9,10 @@
 , which
 }:
 
-with lib;
 let
   nodejs = nodejs-16_x;
   inherit (builtins) elemAt;
-  info = splitString "-" stdenv.hostPlatform.system;
+  info = lib.splitString "-" stdenv.hostPlatform.system;
   arch = elemAt info 0;
   plat = elemAt info 1;
   shas =
@@ -50,7 +49,7 @@ in stdenv.mkDerivation rec {
     sed -i 's@NODE=.*@NODE=${nodejs}/bin/node@' $out/libexec/kibana/bin/kibana
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Visualize logs and time-stamped data";
     homepage = "http://www.elasticsearch.org/overview/kibana";
     license = licenses.elastic;

--- a/pkgs/development/tools/misc/pkg-config/default.nix
+++ b/pkgs/development/tools/misc/pkg-config/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl, libiconv, vanilla ? false }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "pkg-config";
   version = "0.29.2";
@@ -17,20 +15,20 @@ stdenv.mkDerivation rec {
   # Process Requires.private properly, see
   # http://bugs.freedesktop.org/show_bug.cgi?id=4738, migrated to
   # https://gitlab.freedesktop.org/pkg-config/pkg-config/issues/28
-  patches = optional (!vanilla) ./requires-private.patch
-    ++ optional stdenv.isCygwin ./2.36.3-not-win32.patch;
+  patches = lib.optional (!vanilla) ./requires-private.patch
+    ++ lib.optional stdenv.isCygwin ./2.36.3-not-win32.patch;
 
   # These three tests fail due to a (desired) behavior change from our ./requires-private.patch
   postPatch = if vanilla then null else ''
     rm -f check/check-requires-private check/check-gtk check/missing
   '';
 
-  buildInputs = optional (stdenv.isCygwin || stdenv.isDarwin || stdenv.isSunOS) libiconv;
+  buildInputs = lib.optional (stdenv.isCygwin || stdenv.isDarwin || stdenv.isSunOS) libiconv;
 
   configureFlags = [ "--with-internal-glib" ]
-    ++ optionals (stdenv.isSunOS) [ "--with-libiconv=gnu" "--with-system-library-path" "--with-system-include-path" "CFLAGS=-DENABLE_NLS" ]
+    ++ lib.optionals (stdenv.isSunOS) [ "--with-libiconv=gnu" "--with-system-library-path" "--with-system-include-path" "CFLAGS=-DENABLE_NLS" ]
        # Can't run these tests while cross-compiling
-    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform)
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform)
        [ "glib_cv_stack_grows=no"
          "glib_cv_uscore=no"
          "ac_cv_func_posix_getpwuid_r=yes"
@@ -42,7 +40,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''rm -f "$out"/bin/*-pkg-config''; # clean the duplicate file
 
-  meta = {
+  meta = with lib; {
     description = "A tool that allows packages to find out information about other packages";
     homepage = "http://pkg-config.freedesktop.org/wiki/";
     platforms = platforms.all;

--- a/pkgs/development/tools/misc/premake/5.nix
+++ b/pkgs/development/tools/misc/premake/5.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, libuuid, cacert, Foundation, readline }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "premake5";
   version = "5.0.0-beta2";
@@ -13,13 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-2R5gq4jaQsp8Ny1oGuIYkef0kn2UG9jMf20vq0714oY=";
   };
 
-  buildInputs = [ libuuid ] ++ optionals stdenv.isDarwin [ Foundation readline ];
+  buildInputs = [ libuuid ] ++ lib.optionals stdenv.isDarwin [ Foundation readline ];
 
   patches = [ ./no-curl-ca.patch ];
   patchPhase = ''
     substituteInPlace contrib/curl/premake5.lua \
       --replace "ca = nil" "ca = '${cacert}/etc/ssl/certs/ca-bundle.crt'"
-  '' + optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     substituteInPlace premake5.lua \
       --replace -mmacosx-version-min=10.4 -mmacosx-version-min=10.5
   '';
@@ -42,7 +40,7 @@ stdenv.mkDerivation rec {
     homepage = "https://premake.github.io";
     description = "A simple build configuration and project generation tool using lua";
     license = lib.licenses.bsd3;
-    platforms = platforms.darwin ++ platforms.linux;
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
     broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }

--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -3,8 +3,6 @@
 , withDocumentation ? false, withClangPlugins ? true
 }:
 
-with lib;
-
 let
   # Fetch clang from qt vendor, this contains submodules like this:
   # clang<-clang-tools-extra<-clazy.
@@ -31,7 +29,7 @@ mkDerivation rec {
   };
 
   buildInputs = [ qtbase qtscript qtquickcontrols qtdeclarative elfutils.dev ] ++
-    optionals withClangPlugins [ llvmPackages_8.libclang
+    lib.optionals withClangPlugins [ llvmPackages_8.libclang
                                  clang_qt_vendor
                                  llvmPackages_8.llvm ];
 
@@ -47,9 +45,9 @@ mkDerivation rec {
 
   doCheck = true;
 
-  buildFlags = optional withDocumentation "docs";
+  buildFlags = lib.optional withDocumentation "docs";
 
-  installFlags = [ "INSTALL_ROOT=$(out)" ] ++ optional withDocumentation "install_docs";
+  installFlags = [ "INSTALL_ROOT=$(out)" ] ++ lib.optional withDocumentation "install_docs";
 
   qtWrapperArgs = [ "--set-default PERFPROFILER_PARSER_FILEPATH ${lib.getBin perf}/bin" ];
 
@@ -58,7 +56,7 @@ mkDerivation rec {
       --replace '$$[QT_INSTALL_QML]/QtQuick/Controls' '${qtquickcontrols}/${qtbase.qtQmlPrefix}/QtQuick/Controls'
     substituteInPlace src/libs/libs.pro \
       --replace '$$[QT_INSTALL_QML]/QtQuick/Controls' '${qtquickcontrols}/${qtbase.qtQmlPrefix}/QtQuick/Controls'
-    '' + optionalString withClangPlugins ''
+    '' + lib.optionalString withClangPlugins ''
     # Fix paths for llvm/clang includes directories.
     substituteInPlace src/shared/clang/clang_defines.pri \
       --replace '$$clean_path($${LLVM_LIBDIR}/clang/$${LLVM_VERSION}/include)' '${clang_qt_vendor}/lib/clang/8.0.0/include' \
@@ -72,8 +70,8 @@ mkDerivation rec {
       --replace 'LLVM_CXXFLAGS ~= s,-gsplit-dwarf,' '${lib.concatStringsSep "\n" ["LLVM_CXXFLAGS ~= s,-gsplit-dwarf," "    LLVM_CXXFLAGS += -fno-rtti"]}'
   '';
 
-  preBuild = optionalString withDocumentation ''
-    ln -s ${getLib qtbase}/$qtDocPrefix $NIX_QT5_TMP/share
+  preBuild = lib.optionalString withDocumentation ''
+    ln -s ${lib.getLib qtbase}/$qtDocPrefix $NIX_QT5_TMP/share
   '';
 
   postInstall = ''
@@ -92,7 +90,7 @@ mkDerivation rec {
     '';
     homepage = "https://wiki.qt.io/Category:Tools::QtCreator";
     license = "LGPL";
-    maintainers = [ maintainers.akaWolf ];
+    maintainers = [ lib.maintainers.akaWolf ];
     platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" ];
   };
 }

--- a/pkgs/development/tools/sauce-connect/default.nix
+++ b/pkgs/development/tools/sauce-connect/default.nix
@@ -1,7 +1,5 @@
 { stdenv, lib, fetchurl, zlib, unzip }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "sauce-connect";
   version = "4.5.4";
@@ -24,7 +22,7 @@ stdenv.mkDerivation rec {
   patchPhase = lib.optionalString stdenv.isLinux ''
     patchelf \
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "$out/lib:${makeLibraryPath [zlib]}" \
+      --set-rpath "$out/lib:${lib.makeLibraryPath [zlib]}" \
       bin/sc
   '';
 
@@ -35,7 +33,7 @@ stdenv.mkDerivation rec {
 
   dontStrip = true;
 
-  meta = {
+  meta = with lib; {
     description = "A secure tunneling app for executing tests securely when testing behind firewalls";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;

--- a/pkgs/development/tools/selenium/htmlunit-driver/default.nix
+++ b/pkgs/development/tools/selenium/htmlunit-driver/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchurl }:
 
-with lib;
-
 stdenv.mkDerivation rec {
   pname = "htmlunit-driver-standalone";
   version = "2.27";
@@ -15,7 +13,7 @@ stdenv.mkDerivation rec {
 
   installPhase = "install -D $src $out/share/lib/${pname}-${version}/${pname}-${version}.jar";
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/SeleniumHQ/htmlunit-driver";
     description = "A WebDriver server for running Selenium tests on the HtmlUnit headless browser";
     maintainers = with maintainers; [ coconnor offline ];

--- a/pkgs/development/tools/selenium/selendroid/default.nix
+++ b/pkgs/development/tools/selenium/selendroid/default.nix
@@ -1,6 +1,5 @@
 { lib, stdenv, fetchurl, makeWrapper, jdk, selenium-server-standalone }:
 
-with lib;
 let
     pname = "selendroid-standalone";
     pluginName = "selendroid-grid-plugin-${version}";
@@ -39,7 +38,7 @@ stdenv.mkDerivation {
       --add-flags "-capabilityMatcher io.selendroid.grid.SelendroidCapabilityMatcher"
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "http://selendroid.io/";
     description = "Test automation for native or hybrid Android apps and the mobile web";
     maintainers = with maintainers; [ offline ];

--- a/pkgs/development/tools/selenium/server/default.nix
+++ b/pkgs/development/tools/selenium/server/default.nix
@@ -1,8 +1,6 @@
 { lib, stdenv, fetchurl, makeWrapper, jre
 , htmlunit-driver, chromedriver, chromeSupport ? true }:
 
-with lib;
-
 let
   minorVersion = "3.141";
   patchVersion = "59";
@@ -26,11 +24,11 @@ in stdenv.mkDerivation rec {
     cp $src $out/share/lib/${pname}-${version}/${pname}-${version}.jar
     makeWrapper ${jre}/bin/java $out/bin/selenium-server \
       --add-flags "-cp $out/share/lib/${pname}-${version}/${pname}-${version}.jar:${htmlunit-driver}/share/lib/${htmlunit-driver.name}/${htmlunit-driver.name}.jar" \
-      ${optionalString chromeSupport "--add-flags -Dwebdriver.chrome.driver=${chromedriver}/bin/chromedriver"} \
+      ${lib.optionalString chromeSupport "--add-flags -Dwebdriver.chrome.driver=${chromedriver}/bin/chromedriver"} \
       --add-flags "org.openqa.grid.selenium.GridLauncherV3"
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "http://www.seleniumhq.org/";
     description = "Selenium Server for remote WebDriver";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];

--- a/pkgs/development/tools/summon/default.nix
+++ b/pkgs/development/tools/summon/default.nix
@@ -1,7 +1,5 @@
 { buildGoModule, fetchFromGitHub, lib, patchResolver ? true }:
 
-with lib;
-
 buildGoModule rec {
   pname = "summon";
   version = "0.8.2";
@@ -19,7 +17,7 @@ buildGoModule rec {
 
   # Patches provider resolver to support resolving unqualified names
   # from $PATH, e.g. `summon -p gopass` instead of `summon -p $(which gopass)`
-  patches = optionals patchResolver [ ./resolve-paths.patch ];
+  patches = lib.optionals patchResolver [ ./resolve-paths.patch ];
 
   postInstall = ''
     mv $out/bin/cmd $out/bin/summon


### PR DESCRIPTION
###### Description of changes

I am trying to split #211241 into smaller changes to get it into a reviewable bulk and try to approach that in smaller groups by pkgs category.

This PR removes the global `with lib;` statements of `pkgs/development`.
 
I tried to follow the rule to replace all with lib; with lib. but if its for the meta attr. For meta i replaced it with  `meta = with lib; {` if there was no other scoping before that. It there was other scoping i tried to follow that.

Some packages like gcc i have skipped as it does not look super trival for me (it also imports builtins globally).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
