### PR TITLE
coreboot-toolchain: 4.16 -> 4.19

### DIFF
--- a/pkgs/development/tools/misc/coreboot-toolchain/default.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/default.nix
@@ -19,12 +19,12 @@ let
 
     stdenvNoCC.mkDerivation rec {
       pname = "coreboot-toolchain-${arch}";
-      version = "4.16";
+      version = "4.19";
 
       src = fetchgit {
         url = "https://review.coreboot.org/coreboot";
         rev = version;
-        sha256 = "sha256-PCum+IvJ136eZQLovUi9u4xTLLs17MkMP5Oc0/2mMY4=";
+        sha256 = "sha256-pGS+bfX2k/ot7sHL9aiaQpA0wtbHHZEObJ/h2JGF5/4=";
         fetchSubmodules = false;
         leaveDotGit = true;
         postFetch = ''
@@ -70,7 +70,7 @@ let
   );
 in
 
-lib.listToAttrs (map (arch: lib.nameValuePair arch (common arch {})) [
+lib.listToAttrs (map (arch: lib.nameValuePair arch (common arch { })) [
   "i386"
   "x64"
   "arm"

--- a/pkgs/development/tools/misc/coreboot-toolchain/stable.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/stable.nix
@@ -7,10 +7,10 @@
     };
   }
   {
-    name = "mpfr-4.1.0.tar.xz";
+    name = "mpfr-4.1.1.tar.xz";
     archive = fetchurl {
-      sha256 = "0zwaanakrqjf84lfr5hfsdr7hncwv9wj0mchlr7cmxigfgqs760c";
-      url = "mirror://gnu/mpfr/mpfr-4.1.0.tar.xz";
+      sha256 = "0gf3ibi7kzz39zj72qc9r607clyhm80gs8wbp71zzfkxasyrblgz";
+      url = "mirror://gnu/mpfr/mpfr-4.1.1.tar.xz";
     };
   }
   {
@@ -35,10 +35,10 @@
     };
   }
   {
-    name = "acpica-unix2-20211217.tar.gz";
+    name = "R10_20_22.tar.gz";
     archive = fetchurl {
-      sha256 = "0521hmaw2zhi0mpgnaf2i83dykfgql4bx98cg7xqy8wmj649z194";
-      url = "https://acpica.org/sites/acpica/files/acpica-unix2-20211217.tar.gz";
+      sha256 = "11iv3jrz27g7bv7ffyxsrgm4cq60cld2gkkl008p3lcwfyqpx88s";
+      url = "https://github.com/acpica/acpica/archive/refs/tags//R10_20_22.tar.gz";
     };
   }
   {

--- a/pkgs/development/tools/misc/coreboot-toolchain/update.sh
+++ b/pkgs/development/tools/misc/coreboot-toolchain/update.sh
@@ -1,24 +1,26 @@
 #!/usr/bin/env nix-shell
 #!nix-shell --pure -i bash -p nix cacert git getopt
 
+# shellcheck shell=bash
+
 if [ ! -d .git ]; then
-  echo "This script needs to be run from the root directory of nixpkgs. Exiting."
-  exit 1
+    echo "This script needs to be run from the root directory of nixpkgs. Exiting."
+    exit 1
 fi
 
 pkg_dir="$(dirname "$0")"
 
 src="$(nix-build . --no-out-link -A coreboot-toolchain.i386.src)"
-urls=$($src/util/crossgcc/buildgcc -u)
+urls=$("${src}/util/crossgcc/buildgcc" -u)
 
 tmp=$(mktemp)
-echo '{ fetchurl }: [' > $tmp
+echo '{ fetchurl }: [' >"$tmp"
 
 for url in $urls; do
-  name="$(basename $url)"
-  hash="$(nix-prefetch-url "$url")"
+    name="$(basename "$url")"
+    hash="$(nix-prefetch-url "$url")"
 
-  cat << EOF >> $tmp
+    cat <<EOF >>"$tmp"
   {
     name = "$name";
     archive = fetchurl {
@@ -29,8 +31,8 @@ for url in $urls; do
 EOF
 done
 
-echo ']' >> $tmp
+echo ']' >>"$tmp"
 
-sed -ie 's/https\:\/\/ftpmirror\.gnu\.org/mirror\:\/\/gnu/g' $tmp
+sed -ie 's/https\:\/\/ftpmirror\.gnu\.org/mirror\:\/\/gnu/g' "$tmp"
 
-mv $tmp $pkg_dir/sources.nix
+mv "$tmp" "${pkg_dir}/sources.nix"


### PR DESCRIPTION
###### Description of changes

https://doc.coreboot.org/releases/coreboot-4.19-relnotes.html#toolchain-updates

Supersedes #206449

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
