### PR TITLE
python310Packages.scooby: 0.7.0 -> 0.7.1

### DIFF
--- a/pkgs/development/python-modules/scooby/default.nix
+++ b/pkgs/development/python-modules/scooby/default.nix
@@ -1,28 +1,65 @@
 { lib
+, beautifulsoup4
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, numpy
+, pytest-console-scripts
+, pytestCheckHook
+, pythonOlder
+, pyvips
+, scipy
 , setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "scooby";
   version = "0.7.1";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-UgFPRoG8wylZMuDz2Utp5A5hlaaWWzTmiUExLOa2Nt4=";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "banesullivan";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-wKbCIA6Xp+VYhcQ5ZpHo5usB+ksnMAJyv5naBvl4Cxo=";
   };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [
     setuptools-scm
   ];
 
-  pythonImportsCheck = [ "scooby" ];
+  nativeCheckInputs = [
+    beautifulsoup4
+    numpy
+    pytest-console-scripts
+    pytestCheckHook
+    pyvips
+    scipy
+  ];
+
+  preCheck = ''
+    export PATH="$PATH:$out/bin";
+  '';
+
+  pythonImportsCheck = [
+    "scooby"
+  ];
+
+  disabledTests = [
+    # Tests have additions requirements (e.g., time and module)
+    "test_get_version"
+    "test_tracking"
+    "test_import_os_error"
+    "test_import_time"
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/banesullivan/scooby";
-    description = "A lightweight tool for reporting Python package versions and hardware resources";
     changelog = "https://github.com/banesullivan/scooby/releases/tag/v${version}";
+    description = "A lightweight tool for reporting Python package versions and hardware resources";
+    homepage = "https://github.com/banesullivan/scooby";
     license = licenses.mit;
     maintainers = with maintainers; [ wegank ];
   };

--- a/pkgs/development/python-modules/scooby/default.nix
+++ b/pkgs/development/python-modules/scooby/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "scooby";
-  version = "0.7.0";
+  version = "0.7.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-scD/uuAtepatt8Yn7b6PJMfSj9AT7iOy0HuVHyVvEhk=";
+    hash = "sha256-UgFPRoG8wylZMuDz2Utp5A5hlaaWWzTmiUExLOa2Nt4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/scooby/default.nix
+++ b/pkgs/development/python-modules/scooby/default.nix
@@ -22,6 +22,7 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = "https://github.com/banesullivan/scooby";
     description = "A lightweight tool for reporting Python package versions and hardware resources";
+    changelog = "https://github.com/banesullivan/scooby/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ wegank ];
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
