### PR TITLE
crabz: 0.7.10 -> 0.8.1

### DIFF
--- a/pkgs/tools/compression/crabz/default.nix
+++ b/pkgs/tools/compression/crabz/default.nix
@@ -2,41 +2,22 @@
 , rustPlatform
 , fetchFromGitHub
 , cmake
-, stdenv
-, libiconv
-, CoreFoundation
-, Security
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "crabz";
-  version = "0.7.10";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "sstadick";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-A1mjnGnFKgCdwr2J0MBUzpL/UI9nOHDxbrZ9UazqZik=";
+    sha256 = "sha256-w/e0NFmBsYNEECT+2zHEm/UUpp5LxPYr0BdKikT2o1M=";
   };
 
-  cargoSha256 = "sha256-YxO0YPY82Q6dXOBs2ZoSAv14p67kNsmhGOiwt+voD5I=";
+  cargoSha256 = "sha256-9VOJeRvyudZSCaUZ1J9gHMEoWXEnEhCZPxvfYGRKzj0=";
 
   nativeBuildInputs = [ cmake ];
-
-  buildInputs = lib.optionals stdenv.isDarwin [
-    libiconv
-    CoreFoundation
-    Security
-  ];
-
-  # link System as a dylib instead of a framework on macos
-  postPatch = lib.optionalString stdenv.isDarwin ''
-    core_affinity=../$(stripHash $cargoDeps)/core_affinity
-    oldHash=$(sha256sum $core_affinity/src/lib.rs | cut -d " " -f 1)
-    substituteInPlace $core_affinity/src/lib.rs --replace framework dylib
-    substituteInPlace $core_affinity/.cargo-checksum.json \
-      --replace $oldHash $(sha256sum $core_affinity/src/lib.rs | cut -d " " -f 1)
-  '';
 
   meta = with lib; {
     description = "A cross platform, fast, compression and decompression tool";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5936,9 +5936,7 @@ with pkgs;
 
   cpuminer = callPackage ../tools/misc/cpuminer { };
 
-  crabz = callPackage ../tools/compression/crabz {
-    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
-  };
+  crabz = callPackage ../tools/compression/crabz { };
 
   ethash = callPackage ../development/libraries/ethash { };
 


### PR DESCRIPTION
Diff: https://github.com/sstadick/crabz/compare/v0.7.10...v0.8.1

Changelog: https://github.com/sstadick/crabz/blob/v0.8.1/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
