### PR TITLE
init: directx-headers at 1.608.2

### DIFF
--- a/pkgs/os-specific/linux/directx-headers/default.nix
+++ b/pkgs/os-specific/linux/directx-headers/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchFromGitHub, meson, ninja }:
+stdenv.mkDerivation rec {
+  name = "DirectX-Headers";
+  version = "1.608.2";
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "DirectX-Headers";
+    rev = "v${version}";
+    sha256 = "sha256-F0riTDJpydqe4yhE9GKSSvnRI0Sl3oY2sOP+H/vDHG0=";
+  };
+  nativeBuildInputs = [ meson ninja ];
+  mesonFlags = [
+    "-Dbuild-test=false"
+  ];
+  meta = with lib; {
+    maintainers = [ maintainers.cidkidnix ];
+    license = [ licenses.mit ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    description = "Official DirectX-Headers from microsoft for DX12";
+    homepage = "https://github.com/microsoft/DirectX-Headers";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -635,6 +635,8 @@ with pkgs;
 
   dotfiles = callPackage ../applications/misc/dotfiles { };
 
+  directx-headers = callPackage ../os-specific/linux/directx-headers { };
+
   # Dotnet
 
   dotnetCorePackages = recurseIntoAttrs (callPackage ../development/compilers/dotnet {});


### PR DESCRIPTION
###### Description of changes
Add DirectX headers for DX12 from Microsoft, this mostly helps with building mesa with 
`galliumDrivers = [ "d3d12" ]`
`vulkanDrivers = [ "Microsoft-experimental" ]'`
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
