### PR TITLE
python3.pkgs: fix splice through unsupported hosts 

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -36,7 +36,7 @@
             stdenv
           ];
           providesSetupHook = lib.attrByPath [ "provides" "setupHook"] false;
-          valid = value: !((lib.isDerivation value) && !((pythonPackages.hasPythonModule value) || (providesSetupHook value))) || (lib.elem value exceptions);
+          valid = value: !lib.isDerivation value || pythonPackages.hasPythonModule value || providesSetupHook value || lib.elem value exceptions;
           func = name: value: if (valid value) then value else throw "${name} should use `buildPythonPackage` or `toPythonModule` if it is to be part of the Python packages set.";
         in lib.mapAttrs func items;
       in ensurePythonModules (callPackage

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -36,8 +36,12 @@
             stdenv
           ];
           providesSetupHook = lib.attrByPath [ "provides" "setupHook"] false;
-          valid = value: !lib.isDerivation value || pythonPackages.hasPythonModule value || providesSetupHook value || lib.elem value exceptions;
-          func = name: value: if (valid value) then value else throw "${name} should use `buildPythonPackage` or `toPythonModule` if it is to be part of the Python packages set.";
+          valid = value: pythonPackages.hasPythonModule value || providesSetupHook value || lib.elem value exceptions;
+          func = name: value:
+            if lib.isDerivation value then
+              lib.extendDerivation (valid value || throw "${name} should use `buildPythonPackage` or `toPythonModule` if it is to be part of the Python packages set.") {} value
+            else
+              value;
         in lib.mapAttrs func items;
       in ensurePythonModules (callPackage
         # Function that when called


### PR DESCRIPTION
###### Description of changes

Previously, unless unsupported platforms were allowed, the following would fail to evaluate (from an "x86_64-linux" system):

```nix
pkgsCross.x86_64-freebsd.__splicedPackages.docutils.__spliced.buildHost
```

It shouldn't have, because the `buildHost` package ends up being for Linux.  This broke evaluation of e.g. `pkgsCross.x86_64-freebsd.libdrm`, because it has `docutils` in `nativeBuildInputs`.  `mkDerivation` would try to go through `__spliced.buildHost` on docutils to get to the Linux version, but the check in `ensurePythonModules` would kick in first, triggering the meta check because of the equality check in the implementation of `hasPythonModule`, which would fail because Python is not marked as supported on FreeBSD in Nixpkgs at the moment.  Thus, even though they're not supposed to be, the meta checks would be triggered even though the only attribute being accessed on the unsupported derivation was `__spliced`.

We can fix this by using the same mechanism used to implement the meta checks themselves: `lib.extendDerivation`.  Now, attempting to access `drvPath` or `outPath` on an attribute that fails the validity check will produce the same error as before, but other accesses will be allowed through, fixing splicing.

I've tested evaluation of packages that pass and fail the validity check, and confirmed that the behaviour is still correct.

While I was here, I also simplified the logic in the validity check.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
