### PR TITLE
obs-gstreamer: 0.3.5 -> 0.4.0; obs-vaapi: init at 0.1.0

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -30,6 +30,8 @@
 
   obs-source-record = callPackage ./obs-source-record.nix { };
 
+  obs-vaapi = callPackage ./obs-vaapi { };
+
   obs-vkcapture = callPackage ./obs-vkcapture.nix {
     obs-vkcapture32 = pkgsi686Linux.obs-studio-plugins.obs-vkcapture;
   };

--- a/pkgs/applications/video/obs-studio/plugins/obs-gstreamer.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-gstreamer.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "obs-gstreamer";
-  version = "0.3.5";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "fzwoch";
-    repo = "obs-gstreamer";
+    repo = pname;
     rev = "v${version}";
-    hash = "sha256-zP1MMoXLp+gp0fjVbWi/Wse6I8u9/K2IeSew3OjkCkE=";
+    hash = "sha256-C4yee7hzkSOjIeaacLaTGPzZ1qYdYtHK5a3m9gz2pPI=";
   };
 
   nativeBuildInputs = [ pkg-config meson ninja ];
@@ -25,7 +25,6 @@ stdenv.mkDerivation rec {
   # - We need "getLib" instead of default derivation, otherwise it brings gstreamer-bin;
   # - without gst-plugins-base it won't even show proper errors in logs;
   # - Without gst-plugins-bad it won't find element "h264parse";
-  # - gst-vaapi adds "VA-API" to "Encoder type";
   # - gst-plugins-ugly adds "x264" to "Encoder type";
   # Tip: "could not link appsrc to videoconvert1" can mean a lot of things, enable GST_DEBUG=2 for help.
   passthru.obsWrapperArguments =
@@ -36,10 +35,14 @@ stdenv.mkDerivation rec {
       gstreamer
       gst-plugins-base
       gst-plugins-bad
-
       gst-plugins-ugly
-      gst-vaapi
     ];
+
+  # Fix output directory
+  postInstall = ''
+    mkdir $out/lib/obs-plugins
+    mv $out/lib/obs-gstreamer.so $out/lib/obs-plugins/
+  '';
 
   meta = with lib; {
     description = "An OBS Studio source, encoder and video filter plugin to use GStreamer elements/pipelines in OBS Studio";

--- a/pkgs/applications/video/obs-studio/plugins/obs-vaapi/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-vaapi/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gst_all_1
+, pciutils
+, pkg-config
+, meson
+, ninja
+, obs-studio
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-vaapi";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "fzwoch";
+    repo = pname;
+    rev = version;
+    hash = "sha256-qA4xVVShkp40QHp2HmmRzVxQaBwskRpUNEULKetVMu8=";
+  };
+
+  nativeBuildInputs = [ pkg-config meson ninja ];
+  buildInputs = with gst_all_1; [ gstreamer gst-plugins-base obs-studio pciutils ];
+
+  # - We need "getLib" instead of default derivation, otherwise it brings gstreamer-bin;
+  # - without gst-plugins-base it won't even show proper errors in logs;
+  # - Without gst-plugins-bad it won't find element "vapostproc";
+  # - gst-vaapi adds "VA-API" to "Encoder type";
+  # Tip: "could not link appsrc to videoconvert1" can mean a lot of things, enable GST_DEBUG=2 for help.
+  passthru.obsWrapperArguments =
+    let
+      gstreamerHook = package: "--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : ${lib.getLib package}/lib/gstreamer-1.0";
+    in
+    with gst_all_1; builtins.map gstreamerHook [
+      gstreamer
+      gst-plugins-base
+      gst-plugins-bad
+      gst-vaapi
+    ];
+
+  meta = with lib; {
+    description = "OBS Studio VAAPI support via GStreamer";
+    homepage = "https://github.com/fzwoch/obs-vaapi";
+    maintainers = with maintainers; [ ahuzik pedrohlc ];
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/applications/video/obs-studio/wrapper.nix
+++ b/pkgs/applications/video/obs-studio/wrapper.nix
@@ -24,7 +24,7 @@ symlinkJoin {
           "$out/bin/obs"
           ''--set OBS_PLUGINS_PATH "${pluginsJoined}/lib/obs-plugins"''
           ''--set OBS_PLUGINS_DATA_PATH "${pluginsJoined}/share/obs/obs-plugins"''
-        ] ++ pluginArguments;
+        ] ++ lists.unique pluginArguments;
     in ''
     ${concatStringsSep " " wrapCommandLine}
 


### PR DESCRIPTION
###### Description of changes

The VA-API portions of `obs-gstreamer` were split to their own `obs-vaapi` plugin.

Remaining changelog can be seen at: https://github.com/fzwoch/obs-gstreamer/releases/tag/v0.4.0

###### Things done

Tested each plugin individually, and both of them, screenshots at the end.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Screenshots

- Without these plugins:
![without-plugins](https://user-images.githubusercontent.com/1368952/214947464-1b271673-d376-4471-be51-670cb6c16f7f.png)

- Only vaapi:
![obs-vaapi](https://user-images.githubusercontent.com/1368952/214947332-efbd8a3a-c60e-4f88-944d-4ff0be19190e.png)

- Only gstreamer:
![obs-gstreamer](https://user-images.githubusercontent.com/1368952/214947823-ad652c89-cff6-4ae3-91e7-8926b531beff.png)

- Both plugins:
![both](https://user-images.githubusercontent.com/1368952/214947864-d0a7c4ea-7a09-4bc1-8756-e1577bdeb080.png)
