### PR TITLE
python3Packages.wandb: 0.13.7 -> 0.13.9

### DIFF
--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, appdirs
 , azure-core
 , bokeh
 , buildPythonPackage
@@ -39,7 +40,7 @@
 
 buildPythonPackage rec {
   pname = "wandb";
-  version = "0.13.7";
+  version = "0.13.9";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -48,7 +49,7 @@ buildPythonPackage rec {
     owner = pname;
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-o9mIGSILztnHY3Eyb0MlznUEdMbCfA1BT6ux0UlesBc=";
+    hash = "sha256-BpFLN4WLT+fm5+50NDOU4bM73WjeGEhD6P8XKE9n9cI=";
   };
 
   patches = [
@@ -65,6 +66,7 @@ buildPythonPackage rec {
 
   # setuptools is necessary since pkg_resources is required at runtime.
   propagatedBuildInputs = [
+    appdirs
     click
     docker_pycreds
     gitpython
@@ -99,8 +101,10 @@ buildPythonPackage rec {
     tqdm
   ];
 
+  # Set BOKEH_CDN_VERSION to stop bokeh throwing an exception in tests
   preCheck = ''
     export HOME=$(mktemp -d)
+    export BOKEH_CDN_VERSION=3.0.3
   '';
 
   pythonRelaxDeps = [ "protobuf" ];
@@ -117,7 +121,6 @@ buildPythonPackage rec {
     "tests/unit_tests_old/test_logging.py"
     "tests/unit_tests_old/test_metric_internal.py"
     "tests/unit_tests_old/test_public_api.py"
-    "tests/unit_tests_old/test_report_api.py"
     "tests/unit_tests_old/test_runtime.py"
     "tests/unit_tests_old/test_sender.py"
     "tests/unit_tests_old/test_tb_watcher.py"


### PR DESCRIPTION
###### Description of changes

- Update to 0.13.9
- Disable some tests that attempt network access
- Explictly set `BOKEH_CDN_VERSION` for tests to prevent hitting a NRE when bokeh loads

These changes were encountered when reviewing #207070.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
