### PR TITLE
esphome: 2022.12.4 -> 2022.12.6

### DIFF
--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -16,14 +16,14 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "esphome";
-  version = "2022.12.4";
+  version = "2022.12.8";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-HU4S6U5v0r93z4T6JpclEF6Cw6vy0VoprVyI4Z2Ti7s=";
+    hash = "sha256-VKxCdejQGWLYeNOxa1PCwhdrLilnsYD9UBqj8Sen+OM=";
   };
 
   postPatch = ''
@@ -77,7 +77,6 @@ python.pkgs.buildPythonApplication rec {
     mock
     pytest-asyncio
     pytest-mock
-    pytest-sugar
     pytestCheckHook
   ];
 

--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -1,4 +1,5 @@
 { lib
+, callPackage
 , python3
 , fetchFromGitHub
 , platformio
@@ -13,7 +14,7 @@ let
     };
   };
 in
-with python.pkgs; buildPythonApplication rec {
+python.pkgs.buildPythonApplication rec {
   pname = "esphome";
   version = "2022.12.4";
   format = "setuptools";
@@ -42,7 +43,7 @@ with python.pkgs; buildPythonApplication rec {
   # They have validation functions like:
   # - validate_cryptography_installed
   # - validate_pillow_installed
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with python.pkgs; [
     aioesphomeapi
     click
     colorama
@@ -71,7 +72,7 @@ with python.pkgs; buildPythonApplication rec {
     "--set ESPHOME_USE_SUBPROCESS ''"
   ];
 
-  nativeCheckInputs = [
+  nativeCheckInputs = with python.pkgs; [
     hypothesis
     mock
     pytest-asyncio
@@ -92,7 +93,7 @@ with python.pkgs; buildPythonApplication rec {
   '';
 
   passthru = {
-    dashboard = esphome-dashboard;
+    dashboard = python.pkgs.esphome-dashboard;
     updateScript = callPackage ./update.nix {};
   };
 

--- a/pkgs/tools/misc/esphome/update.nix
+++ b/pkgs/tools/misc/esphome/update.nix
@@ -1,12 +1,23 @@
 { writeShellScript
 , lib
+, curl
+, jq
 , git
+, gnugrep
+, gnused
 , nix-update
 }:
 
 writeShellScript "update-esphome" ''
-  PATH=${lib.makeBinPath [ git nix-update ]}
+  PATH=${lib.makeBinPath [ curl gnugrep gnused jq git nix-update ]}
 
-  nix-update esphome.dashboard
-  nix-update esphome
+  LATEST=$(curl https://api.github.com/repos/esphome/esphome/releases/latest | jq -r '.name')
+  echo "Latest version: $LATEST"
+
+  DASHBOARD_VERSION=$(curl https://raw.githubusercontent.com/esphome/esphome/$LATEST/requirements.txt | \
+    grep "esphome-dashboard==" | sed "s/.*=//")
+  echo "Dashboard version: $DASHBOARD_VERSION"
+
+  nix-update esphome.dashboard --version $DASHBOARD_VERSION
+  nix-update esphome --version $LATEST
 ''


### PR DESCRIPTION
Implementing matching dashboard version retrieval.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
