### PR TITLE
ocamlPackages.javalib: 3.2.1 → 3.2.2; sawja: 1.5.11 → 1.5.12

### DIFF
--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -8,19 +8,18 @@
 , extlib
 }:
 
-if lib.versionOlder ocaml.version "4.04"
-then throw "javalib is not available for OCaml ${ocaml.version}"
-else
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.08")
+  "javalib is not available for OCaml ${ocaml.version}"
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-javalib";
-  version = "3.2.1";
+  version = "3.2.2";
 
   src = fetchFromGitHub {
     owner = "javalib-team";
     repo = "javalib";
-    rev = "v${version}";
-    sha256 = "sha256-du1h+S+A7CetMXofsYxdGeSsobCgspDB9oUE9WNUbbo=";
+    rev = version;
+    hash = "sha256-XaI7GTU/O5UEWuYX4yqaIRmEoH7FuvCg/+gtKbE/P1s=";
   };
 
   nativeBuildInputs = [ which ocaml findlib ];

--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -2,12 +2,11 @@
 
 let
   pname = "sawja";
-  version = "1.5.11";
+  version = "1.5.12";
 in
 
-if lib.versionOlder ocaml.version "4.07"
-then throw "${pname} is not available for OCaml ${ocaml.version}"
-else
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.08")
+  "${pname} is not available for OCaml ${ocaml.version}"
 
 stdenv.mkDerivation {
 
@@ -19,7 +18,7 @@ stdenv.mkDerivation {
     owner = "javalib-team";
     repo = pname;
     rev = version;
-    sha256 = "sha256-1aKkRZDuLJLmDhUC1FXnn4QrgXaTyAbnXfTOAdnKgs8=";
+    hash = "sha256-G1W8/G0TEcldnFnH/NAb9a6ZSGGP2fWTM47lI8bBHnw=";
   };
 
   nativeBuildInputs = [ which ocaml findlib ];


### PR DESCRIPTION
###### Description of changes

 - https://github.com/javalib-team/javalib/blob/3.2.2/CHANGELOG
 - https://github.com/javalib-team/sawja/blob/1.5.12/CHANGELOG

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
