### PR TITLE
python3Packages.pythran: remove unused dependencies

### DIFF
--- a/pkgs/development/python-modules/pythran/default.nix
+++ b/pkgs/development/python-modules/pythran/default.nix
@@ -7,7 +7,7 @@
 , gast
 , numpy
 , beniget
-, isPy3k
+, pythonOlder
 , substituteAll
 }:
 
@@ -17,12 +17,15 @@ let
 in buildPythonPackage rec {
   pname = "pythran";
   version = "0.11.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "serge-sans-paille";
     repo = "pythran";
     rev = version;
-    sha256 = "sha256-F9gUZOTSuiqvfGoN4yQqwUg9mnCeBntw5eHO7ZnjpzI=";
+    hash = "sha256-F9gUZOTSuiqvfGoN4yQqwUg9mnCeBntw5eHO7ZnjpzI=";
   };
 
   patches = [
@@ -52,11 +55,11 @@ in buildPythonPackage rec {
   # Test suite is huge and has a circular dependency on scipy.
   doCheck = false;
 
-  disabled = !isPy3k;
-
-  meta = {
+  meta = with lib; {
     description = "Ahead of Time compiler for numeric kernels";
     homepage = "https://github.com/serge-sans-paille/pythran";
-    license = lib.licenses.bsd3;
+    changelog = "https://github.com/serge-sans-paille/pythran/blob/${version}/Changelog";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pythran/default.nix
+++ b/pkgs/development/python-modules/pythran/default.nix
@@ -4,10 +4,7 @@
 , fetchFromGitHub
 , openmp
 , ply
-, networkx
-, decorator
 , gast
-, six
 , numpy
 , beniget
 , isPy3k
@@ -38,10 +35,7 @@ in buildPythonPackage rec {
 
   propagatedBuildInputs = [
     ply
-    networkx
-    decorator
     gast
-    six
     numpy
     beniget
   ];


### PR DESCRIPTION
networkx, six and decorator are no longer necessary as of version 0.9.12. See changelog at https://github.com/serge-sans-paille/pythran/blob/0.9.12/Changelog

###### Description of changes

Removed netwrokx, six and decorator inputs to pythran

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).