### PR TITLE
mailman: 3.3.5 -> 3.3.8

### DIFF
--- a/pkgs/servers/mail/mailman/package.nix
+++ b/pkgs/servers/mail/mailman/package.nix
@@ -1,16 +1,22 @@
-{ lib, fetchpatch, python3, postfix, lynx
+{ lib
+, fetchpatch
+, python3
+, docutils
+, sphinx
+, postfix
+, lynx
 }:
 
 with python3.pkgs;
 
 buildPythonPackage rec {
   pname = "mailman";
-  version = "3.3.5";
+  version = "3.3.8";
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "12mgxs1ndhdjjkydx48b95na9k9h0disfqgrr6wxx7vda6dqvcwz";
+    hash = "sha256-g6wH7lXqK0yJ8AxO1HFxMvBicBJ9NGWlPePFyxl9Qc4=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
@@ -31,6 +37,11 @@ buildPythonPackage rec {
     sqlalchemy
     zope_component
     zope_configuration
+  ];
+
+  checkInputs = [
+    docutils
+    sphinx
   ];
 
   patches = [
@@ -63,9 +74,6 @@ buildPythonPackage rec {
   # has all the necessary search paths to execute unwrapped 'master' and
   # 'runner' scripts.
   dontWrapPythonPrograms = true;
-
-  # requires flufl.testing, which the upstream has archived
-  doCheck = false;
 
   meta = {
     homepage = "https://www.gnu.org/software/mailman/";

--- a/pkgs/servers/mail/mailman/python.nix
+++ b/pkgs/servers/mail/mailman/python.nix
@@ -3,18 +3,7 @@
 python3.override {
   packageOverrides = self: super: {
     # does not find tests
-    alembic = super.alembic.overridePythonAttrs (oldAttrs:  {
-      doCheck = false;
-    });
-    # Needed by mailman, see https://gitlab.com/mailman/mailman/-/issues/964
-    sqlalchemy = super.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
-      version = "1.3.24";
-      src = super.fetchPypi {
-        inherit version;
-        inherit (oldAttrs) pname;
-        sha256 = "06bmxzssc66cblk1hamskyv5q3xf1nh1py3vi6dka4lkpxy7gfzb";
-      };
-      # does not find tests
+    alembic = super.alembic.overridePythonAttrs (oldAttrs: {
       doCheck = false;
     });
     # Fixes `AssertionError: database connection isn't set to UTC`


### PR DESCRIPTION
###### Description of changes

recent version of mailman supports 1.4+ sqlalchemy https://gitlab.com/mailman/mailman/-/merge_requests/1035

I am not familiar enough with mailman to test it, but at least it builds, and hopefully a starting point for someone who finds this

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
fixes https://github.com/NixOS/nixpkgs/issues/213150 cc @mdorman 