### PR TITLE
fetchFromBittorrent: init

### DIFF
--- a/doc/builders/fetchers.chapter.md
+++ b/doc/builders/fetchers.chapter.md
@@ -243,3 +243,26 @@ or
 
 ***
 ```
+## `fetchFromBittorrent` {#fetchfrombittorrent}
+
+`fetchFromBittorrent` expects two arguments. `url` which can either be a Magnet URI (Magnet Link) such as `magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c` or an HTTP URL pointing to a `.torrent` file. It can also take a `config` argument which will craft a `settings.json` configuration file and give it to `transmission`, the underlying program that is performing the fetch. The available config options for `transmission` can be found [here](https://github.com/transmission/transmission/blob/main/docs/Editing-Configuration-Files.md#options)
+
+```
+{ fetchFromBittorrent }:
+
+fetchFromBittorrent {
+  config = { peer-limit-global = 100; };
+  url = "magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c";
+  sha256 = "";
+}
+```
+
+### Parameters {#fetchfrombittorrent-parameters}
+
+- `url`: Magnet URI (Magnet Link) such as `magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c` or an HTTP URL pointing to a `.torrent` file.
+
+- `backend`: Which bittorrent program to use. Default: `"transmission"`. Valid values are `"rqbit"` or `"transmission"`. These are the two most suitable torrent clients for fetching in a fixed-output derivation at the time of writing, as they can be easily exited after usage. `rqbit` is written in Rust and has a smaller closure size than `transmission`, and the performance and peer discovery properties differs between these clients, requiring experimentation to decide upon which is the best.
+
+- `config`: When using `transmission` as the `backend`, a json configuration can
+  be supplied to transmission. Refer to the [upstream documentation](https://github.com/transmission/transmission/blob/main/docs/Editing-Configuration-Files.md) for information on how to configure.
+

--- a/pkgs/build-support/fetchbittorrent/default.nix
+++ b/pkgs/build-support/fetchbittorrent/default.nix
@@ -1,0 +1,60 @@
+{ lib, runCommand, transmission_noSystemd, rqbit, writeShellScript, formats, cacert, rsync }:
+let
+  urlRegexp = ''.*xt=urn:bt[im]h:([^&]{64}|[^&]{40}).*'';
+in
+{ url
+, name ?
+  if (builtins.match urlRegexp url) == null then
+    "bittorrent"
+  else
+    "bittorrent-" + builtins.head (builtins.match urlRegexp url)
+, config ? if (backend == "transmission") then { } else throw "json config for configuring fetchFromBitorrent only works with the transmission backend"
+, hash
+, backend ? "transmission"
+, recursiveHash ? true
+, postFetch ? ""
+, postUnpack ? ""
+}:
+let
+  afterSuccess = writeShellScript "fetch-bittorrent-done.sh" ''
+    ${postUnpack}
+    # Flatten the directory, so that only the torrent contents are in $out, not
+    # the folder name
+    shopt -s dotglob
+    mv -v $downloadedDirectory/*/* $out
+    rm -v -rf $downloadedDirectory
+    unset downloadedDirectory
+    ${postFetch}
+    kill $PPID
+  '';
+  jsonConfig = (formats.json {}).generate "jsonConfig" config;
+in
+runCommand name {
+  nativeBuildInputs = [ cacert ] ++ (if (backend == "transmission" ) then [ transmission_noSystemd ] else if (backend == "rqbit") then [ rqbit ] else throw "rqbit or transmission are the only available backends for fetchbittorrent");
+  outputHashAlgo = if hash != "" then null else "sha256";
+  outputHash = hash;
+  outputHashMode = if recursiveHash then "recursive" else "flat";
+
+  # url will be written to the derivation, meaning it can be parsed and utilized
+  # by external tools, such as tools that may want to seed fetchBittorrent calls
+  # in nixpkgs
+  inherit url;
+}
+(if (backend == "transmission") then ''
+  export HOME=$TMP
+  export downloadedDirectory=$out/downloadedDirectory
+  mkdir -p $downloadedDirectory
+  mkdir -p $HOME/.config/transmission
+  cp ${jsonConfig} $HOME/.config/transmission/settings.json
+  function handleChild {
+    # This detects failures and logs the contents of the transmission fetch
+    find $out
+    exit 0
+  }
+  trap handleChild CHLD
+  transmission-cli --port $(shuf -n 1 -i 49152-65535) --portmap --finish ${afterSuccess} --download-dir $downloadedDirectory --config-dir "$HOME"/.config/transmission "$url"
+'' else
+''
+  export HOME=$TMP
+  rqbit --disable-dht-persistence --http-api-listen-addr "127.0.0.1:$(shuf -n 1 -i 49152-65535)" download -o $out --exit-on-finish "$url"
+'')

--- a/pkgs/build-support/fetchbittorrent/tests.nix
+++ b/pkgs/build-support/fetchbittorrent/tests.nix
@@ -1,0 +1,25 @@
+{ testers, fetchFromBittorrent, ... }:
+
+{
+  http-link = testers.invalidateFetcherByDrvHash fetchFromBittorrent {
+    url = "https://webtorrent.io/torrents/wired-cd.torrent";
+    hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
+    backend = "transmission";
+  };
+  magnet-link = testers.invalidateFetcherByDrvHash fetchFromBittorrent {
+    url = "magnet:?xt=urn:btih:a88fda5954e89178c372716a6a78b8180ed4dad3&dn=The+WIRED+CD+-+Rip.+Sample.+Mash.+Share&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fwired-cd.torrent";
+    hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
+    backend = "transmission";
+  };
+  http-link-rqbit = testers.invalidateFetcherByDrvHash fetchFromBittorrent {
+    url = "https://webtorrent.io/torrents/wired-cd.torrent";
+    hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
+    backend = "rqbit";
+  };
+  magnet-link-rqbit = testers.invalidateFetcherByDrvHash fetchFromBittorrent {
+    url = "magnet:?xt=urn:btih:a88fda5954e89178c372716a6a78b8180ed4dad3&dn=The+WIRED+CD+-+Rip.+Sample.+Mash.+Share&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fwired-cd.torrent";
+    hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
+    backend = "rqbit";
+  };
+}
+

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -104,6 +104,7 @@ with pkgs;
   cc-multilib-clang = callPackage ./cc-wrapper/multilib.nix { stdenv = clangMultiStdenv; };
 
   fetchurl = callPackages ../build-support/fetchurl/tests.nix { };
+  fetchFromBittorrent = callPackages ../build-support/fetchbittorrent/tests.nix { };
   fetchpatch = callPackages ../build-support/fetchpatch/tests.nix { };
   fetchpatch2 = callPackages ../build-support/fetchpatch/tests.nix { fetchpatch = fetchpatch2; };
   fetchDebianPatch = callPackages ../build-support/fetchdebianpatch/tests.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36177,6 +36177,7 @@ with pkgs;
   };
   transmission-gtk = transmission.override { enableGTK3 = true; };
   transmission-qt = transmission.override { enableQt = true; };
+  transmission_noSystemd = transmission.override { enableSystemd = false; };
 
   transmission_4 = callPackage ../applications/networking/p2p/transmission/4.nix {
     fmt = fmt_9;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1099,6 +1099,8 @@ with pkgs;
 
   fetchs3 = callPackage ../build-support/fetchs3 { };
 
+  fetchFromBittorrent = callPackage ../build-support/fetchbittorrent { };
+
   fetchsvn = if stdenv.buildPlatform != stdenv.hostPlatform
     # hack around splicing being crummy with things that (correctly) don't eval.
     then buildPackages.fetchsvn


### PR DESCRIPTION
Adds and documents a basic FOD Fetcher for Bittorrent that uses Transmission as a client, which has the additional benefit of being able to fully configure this fetcher using `builtins.toJSON`, since Transmission uses a JSON configuration, as shown in the example below.

```
{ fetchFromBittorrent }:

fetchFromBittorrent {
  config = { peer-limit-global = 100; }; # Optional
  url = "magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c";
  sha256 = "";
}
```

If a magnet url is provided, the derivation `name` is derived from the sha1 bittorrent info hash or the sha256 variant for bittorrent v2, which is also supported. This name can be reversed to download the torrent in most clients.

Thanks to @ursi for helping me with the regexp for parsing the Magnet URIs

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
