### PR TITLE
python310Packages.aenum: switch to pytestCheckHook

### DIFF
--- a/pkgs/development/python-modules/aenum/default.nix
+++ b/pkgs/development/python-modules/aenum/default.nix
@@ -1,9 +1,9 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy3k
 , pyparsing
-, python
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -11,26 +11,31 @@ buildPythonPackage rec {
   version = "3.1.11";
   format = "setuptools";
 
+  disabled = pythonOlder "3.7";
+
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-rtLCc1R65yoNXuhpcZwCpkPaFr9QfICVj6rcfgOOP3M=";
+    hash = "sha256-rtLCc1R65yoNXuhpcZwCpkPaFr9QfICVj6rcfgOOP3M=";
   };
 
   nativeCheckInputs = [
     pyparsing
+    pytestCheckHook
   ];
-
-  # py2 likes to reorder tests
-  doCheck = isPy3k;
-
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} aenum/test.py
-    runHook postCheck
-  '';
 
   pythonImportsCheck = [
     "aenum"
+  ];
+
+  disabledTests = [
+    # https://github.com/ethanfurman/aenum/issues/27
+    "test_class_nested_enum_and_pickle_protocol_four"
+    "test_pickle_enum_function_with_qualname"
+    "test_stdlib_inheritence"
+    "test_subclasses_with_getnewargs_ex"
+    "test_arduino_headers"
+    "test_c_header_scanner"
+    "test_extend_flag_backwards_stdlib"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
Fix build (https://hydra.nixos.org/build/205560452)

Switching to `pytestCheckHook` is not the optimal solution but avoids to have to add decorators at multiple places. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
