### PR TITLE
python3Packages.uptime-kuma-api: init at 0.9.0

### DIFF
--- a/pkgs/development/python-modules/uptime-kuma-api/default.nix
+++ b/pkgs/development/python-modules/uptime-kuma-api/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python-socketio
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "uptime-kuma-api";
+  version = "0.9.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    pname = "uptime_kuma_api";
+    inherit version;
+    hash = "sha256-nbRBsG4Mietd6kcrvpbTbWUP0SMRXbW4mWme1G5n3ks=";
+  };
+
+  propagatedBuildInputs = [
+    python-socketio
+    python-socketio.optional-dependencies.client
+  ];
+
+  pythonImportsCheck = [
+    "uptime_kuma_api"
+  ];
+
+  # Tests need an uptime-kuma instance to run
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A Python wrapper for the Uptime Kuma Socket.IO API";
+    homepage = "https://github.com/lucasheld/uptime-kuma-api";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ julienmalka ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11868,6 +11868,8 @@ self: super: with self; {
 
   uptime = callPackage ../development/python-modules/uptime { };
 
+  uptime-kuma-api = callPackage ../development/python-modules/uptime-kuma-api { };
+
   uptime-kuma-monitor = callPackage ../development/python-modules/uptime-kuma-monitor { };
 
   uranium = callPackage ../development/python-modules/uranium { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
