### PR TITLE
platformio: fix udev path

### DIFF
--- a/pkgs/development/embedded/platformio/chrootenv.nix
+++ b/pkgs/development/embedded/platformio/chrootenv.nix
@@ -38,7 +38,7 @@ buildFHSUserEnv {
     mkdir -p $out/lib/udev/rules.d
 
     ln -s $out/bin/platformio $out/bin/pio
-    ln -s ${src}/scripts/99-platformio-udev.rules $out/lib/udev/rules.d/99-platformio-udev.rules
+    ln -s ${src}/platformio/assets/system/99-platformio-udev.rules $out/lib/udev/rules.d/99-platformio-udev.rules
   '';
 
   runScript = "platformio";


### PR DESCRIPTION
###### Description of changes

My system build failed because of this line:

```
services.udev.packages = [ pkgs.platformio ];
```

the error was:

```
error: builder for '/nix/store/by6bnr5qwz4hbgiiar3bx9kf9dycf8q9-udev-rules.drv' failed with exit code 1;
       last 5 log lines:
       > Adding rules for package /nix/store/2gkyfm0iknhya91g992yfdl693ss7d78-logitech-wheel-udev-rules
       > Copying /nix/store/2gkyfm0iknhya91g992yfdl693ss7d78-logitech-wheel-udev-rules/lib/udev/rules.d/99-logitech-wheel.rules to /nix/store/m745a54gv3achgwjk30y6rmfz8in7vb3-udev-rules/99-logitech-wheel.rules
       > Adding rules for package /nix/store/b42fi4zl9qa7dxqc447vmsp3fr11hc5p-platformio
       > Copying /nix/store/b42fi4zl9qa7dxqc447vmsp3fr11hc5p-platformio/lib/udev/rules.d/99-platformio-udev.rules to /nix/store/m745a54gv3achgwjk30y6rmfz8in7vb3-udev-rules/99-platformio-udev.rules
       > cat: /nix/store/b42fi4zl9qa7dxqc447vmsp3fr11hc5p-platformio/lib/udev/rules.d/99-platformio-udev.rules: No such file or directory
       For full logs, run 'nix log /nix/store/by6bnr5qwz4hbgiiar3bx9kf9dycf8q9-udev-rules.drv'.
```

this was caused by a missing symlink:

```
> ls -la /nix/store/b42fi4zl9qa7dxqc447vmsp3fr11hc5p-platformio/lib/udev/rules.d/99-platformio-udev.rules
lrwxrwxrwx 2 root root 83 Jan  1  1970 /nix/store/b42fi4zl9qa7dxqc447vmsp3fr11hc5p-platformio/lib/udev/rules.d/99-platformio-udev.rules -> /nix/store/sg3q28q6m1k4q9g436ccpn0q7kr1d468-source/scripts/99-platformio-udev.rules
> ls -la /nix/store/sg3q28q6m1k4q9g436ccpn0q7kr1d468-source/scripts/99-platformio-udev.rules
ls: cannot access '/nix/store/sg3q28q6m1k4q9g436ccpn0q7kr1d468-source/scripts/99-platformio-udev.rules': No such file or directory
```

It seems the udev file has changed location in the platformio repository:

https://github.com/platformio/platformio-core/blob/61ba8afee6117810972083a1d300c587ff728bec/platformio/assets/system/99-platformio-udev.rules

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
