### PR TITLE
yarn2nix: support https://github.com dependencies

### DIFF
--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
@@ -136,7 +136,7 @@ function fetchLockedDep(builtinFetchGit) {
         fileName,
         `${githubUrl}.git`,
         githubRev,
-        branch || "master",
+        branch || "HEAD",
         builtinFetchGit
       );
     }

--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/generateNix.js
@@ -115,7 +115,7 @@ function fetchLockedDep(builtinFetchGit) {
       const githubUrl = `https://github.com/${s[3]}/${s[4]}.git`;
       const githubRev = s[6];
 
-      const [_, branch] = nameWithVersion.split("#");
+      const [, branch] = nameWithVersion.split("#");
 
       return fetchgit(
         fileName,
@@ -126,10 +126,25 @@ function fetchLockedDep(builtinFetchGit) {
       );
     }
 
+    if (resolved.startsWith("https://github.com/")) {
+      const s = resolved.split("/");
+
+      const [githubUrl, githubRev] = resolved.split("#");
+      const [, branch] = nameWithVersion.split("#");
+
+      return fetchgit(
+        fileName,
+        `${githubUrl}.git`,
+        githubRev,
+        branch || "master",
+        builtinFetchGit
+      );
+    }
+
     if (url.startsWith("git+") || url.startsWith("git:")) {
       const rev = sha1OrRev;
 
-      const [_, branch] = nameWithVersion.split("#");
+      const [, branch] = nameWithVersion.split("#");
 
       const urlForGit = url.replace(/^git\+/, "");
 

--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/urlToName.js
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/lib/urlToName.js
@@ -8,6 +8,7 @@ const path = require("path");
 // - git+https://github.com/srghma/node-shell-quote.git
 // - git+https://1234user:1234pass@git.graphile.com/git/users/1234user/postgraphile-supporter.git
 // - https://codeload.github.com/Gargron/emoji-mart/tar.gz/934f314fd8322276765066e8a2a6be5bac61b1cf
+// - https://github.com/Gargron/emoji-mart#934f314fd8322276765066e8a2a6be5bac61b1cf
 
 function urlToName(url) {
   // Yarn generates `codeload.github.com` tarball URLs, where the final
@@ -20,9 +21,15 @@ function urlToName(url) {
     return path.basename(url);
   }
 
-  return url
+  let name = url
     .replace(/https:\/\/(.)*(.com)\//g, "") // prevents having long directory names
     .replace(/[@/%:-]/g, "_"); // replace @ and : and - and % characters with underscore
+
+  if (!(name.endsWith(".tar.gz") || name.endsWith(".tgz"))) {
+    name = name + ".tgz";
+  }
+
+  return name;
 }
 
 module.exports = urlToName;


### PR DESCRIPTION
###### Description of changes

Yarn supports `https://github.com/org/repo#rev` dependencies. This makes sure these get parsed and translated correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
