### PR TITLE
yarn: add bash completion

### DIFF
--- a/pkgs/development/tools/yarn/default.nix
+++ b/pkgs/development/tools/yarn/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, nodejs, fetchFromGitHub, fetchzip, testers, yarn }:
+{ lib, fetchFromGitHub, fetchzip, nodejs, stdenvNoCC, testers }:
 
 let
   completion = fetchFromGitHub {
@@ -8,12 +8,12 @@ let
     hash = "sha256-z7KPXeYPPRuaEPxgY6YqsLt9n8cSsW3n2FhOzVde1HU=";
   };
 in
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "yarn";
   version = "1.22.19";
 
   src = fetchzip {
-    url = "https://github.com/yarnpkg/yarn/releases/download/v${version}/yarn-v${version}.tar.gz";
+    url = "https://github.com/yarnpkg/yarn/releases/download/v${finalAttrs.version}/yarn-v${finalAttrs.version}.tar.gz";
     sha256 = "sha256-12wUuWH+kkqxAgVYkyhIYVtexjv8DFP9kLpFLWg+h0o=";
   };
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     ln -s ${completion}/yarn-completion.bash $out/share/bash-completion/completions/yarn.bash
   '';
 
-  passthru.tests = testers.testVersion { package = yarn; };
+  passthru.tests = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = with lib; {
     homepage = "https://yarnpkg.com/";
@@ -36,4 +36,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ offline screendriver ];
     platforms = platforms.linux ++ platforms.darwin;
   };
-}
+})

--- a/pkgs/development/tools/yarn/default.nix
+++ b/pkgs/development/tools/yarn/default.nix
@@ -30,10 +30,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   passthru.tests = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = with lib; {
-    homepage = "https://yarnpkg.com/";
     description = "Fast, reliable, and secure dependency management for javascript";
+    homepage = "https://classic.yarnpkg.com/";
+    changelog = "https://github.com/yarnpkg/yarn/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = licenses.bsd2;
     maintainers = with maintainers; [ offline screendriver ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = nodejs.meta.platforms;
   };
 })

--- a/pkgs/development/tools/yarn/default.nix
+++ b/pkgs/development/tools/yarn/default.nix
@@ -34,7 +34,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://classic.yarnpkg.com/";
     changelog = "https://github.com/yarnpkg/yarn/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ offline screendriver ];
+    maintainers = with maintainers; [ offline screendriver marsam ];
     platforms = nodejs.meta.platforms;
   };
 })

--- a/pkgs/development/tools/yarn/default.nix
+++ b/pkgs/development/tools/yarn/default.nix
@@ -1,5 +1,13 @@
-{ lib, stdenv, nodejs, fetchzip, testers, yarn }:
+{ lib, stdenv, nodejs, fetchFromGitHub, fetchzip, testers, yarn }:
 
+let
+  completion = fetchFromGitHub {
+    owner = "dsifford";
+    repo = "yarn-completion";
+    rev = "v0.17.0";
+    hash = "sha256-z7KPXeYPPRuaEPxgY6YqsLt9n8cSsW3n2FhOzVde1HU=";
+  };
+in
 stdenv.mkDerivation rec {
   pname = "yarn";
   version = "1.22.19";
@@ -12,10 +20,11 @@ stdenv.mkDerivation rec {
   buildInputs = [ nodejs ];
 
   installPhase = ''
-    mkdir -p $out/{bin,libexec/yarn/}
+    mkdir -p $out/{bin,libexec/yarn/,share/bash-completion/completions/}
     cp -R . $out/libexec/yarn
     ln -s $out/libexec/yarn/bin/yarn.js $out/bin/yarn
     ln -s $out/libexec/yarn/bin/yarn.js $out/bin/yarnpkg
+    ln -s ${completion}/yarn-completion.bash $out/share/bash-completion/completions/yarn.bash
   '';
 
   passthru.tests = testers.testVersion { package = yarn; };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
