### PR TITLE
python3Packages.dasbus: 1.7 -> unstable-11-10-2022

### DIFF
--- a/pkgs/development/python-modules/dasbus/default.nix
+++ b/pkgs/development/python-modules/dasbus/default.nix
@@ -1,16 +1,20 @@
-{ lib, buildPythonPackage, fetchPypi, pygobject3, dbus }:
+{ lib, buildPythonPackage, fetchFromGitHub, pygobject3, dbus, hatchling, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "dasbus";
-  version = "1.7";
+  version = "unstable-11-10-2022";
+  format = "pyproject";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-qIUNhBrf6O5fe7n4LPRJq5tJUNwGM4lwcXGODQA2tvY=";
+  src = fetchFromGitHub {
+    owner = "rhinstaller";
+    repo = pname;
+    rev = "64b6b4d9e37cd7e0cbf4a7bf75faa7cdbd01086d";
+    hash = "sha256-TmhhDrfpP+nUErAd7dUb+RtGBRtWwn3bYOoIqa0VRoc=";
   };
 
+  nativeBuildInputs = [ hatchling ];
   propagatedBuildInputs = [ pygobject3 ];
-  nativeCheckInputs = [ dbus ];
+  nativeCheckInputs = [ dbus pytestCheckHook ];
 
   meta = with lib; {
     homepage = "https://github.com/rhinstaller/dasbus";


### PR DESCRIPTION
change format to pyproject
add hatchling as a build time dep

fix #212879 and https://github.com/NixOS/nixpkgs/commit/6ad9cb0b5f4645a45eee094721de30b547021218#commitcomment-97674867

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
