### PR TITLE
libfabric: revert to 1.15.1

### DIFF
--- a/pkgs/development/libraries/libfabric/default.nix
+++ b/pkgs/development/libraries/libfabric/default.nix
@@ -3,11 +3,11 @@
 , fetchFromGitHub
 , pkg-config
 , autoreconfHook
-, enablePsm2 ? (stdenv.isx86_64 && stdenv.isLinux)
 , libpsm2
-, enableOpx ? (stdenv.isx86_64 && stdenv.isLinux)
 , libuuid
 , numactl
+, enablePsm2 ? (stdenv.isx86_64 && stdenv.isLinux)
+, enableOpx ? (stdenv.isx86_64 && stdenv.isLinux)
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/libfabric/default.nix
+++ b/pkgs/development/libraries/libfabric/default.nix
@@ -1,18 +1,9 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, pkg-config
-, autoreconfHook
-, libpsm2
-, libuuid
-, numactl
-, enablePsm2 ? (stdenv.isx86_64 && stdenv.isLinux)
-, enableOpx ? (stdenv.isx86_64 && stdenv.isLinux)
-}:
+{ lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook, libpsm2
+, enablePsm2 ? (stdenv.isx86_64 && stdenv.isLinux) }:
 
 stdenv.mkDerivation rec {
   pname = "libfabric";
-  version = "1.17.0";
+  version = "1.15.1";
 
   enableParallelBuilding = true;
 
@@ -20,17 +11,14 @@ stdenv.mkDerivation rec {
     owner = "ofiwg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-tXfAn8hkasA2UuA4/8dOE3EcORyJo/A33TtSNdzDXD8=";
+    sha256 = "sha256-uL3L9k9yqdZXQmR1zi8OEIGLAZ8cf7EBnlDhetaMA08=";
   };
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];
 
-  buildInputs = lib.optionals enableOpx [ libuuid numactl ] ++ lib.optional enablePsm2 [ libpsm2 ];
+  buildInputs = lib.optional enablePsm2 libpsm2;
 
-  configureFlags = [
-    (if enablePsm2 then "--enable-psm2=${libpsm2}" else "--disable-psm2")
-    (if enableOpx then "--enable-opx" else "--disable-opx")
-  ];
+  configureFlags = [ (if enablePsm2 then "--enable-psm2=${libpsm2}" else "--disable-psm2") ];
 
   meta = with lib; {
     homepage = "https://ofiwg.github.io/libfabric/";


### PR DESCRIPTION
###### Description of changes
Libfabric seems to introduce subtle errors, which are picked up by the test phase of `python3Packges.mpi4py`.
This may, however, also affect other packages, but is not detected during the build (i.e. any test). 
Since there is no patch or solution at moment, I suggest reverting to the latest known working version until a fix is available.

Closes https://github.com/NixOS/nixpkgs/issues/212220


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
