### PR TITLE
fwupd: 1.8.9 -> 1.8.10

### DIFF
--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -333,7 +333,6 @@ let
         "fwupd/remotes.d/lvfs.conf"
         "fwupd/remotes.d/vendor.conf"
         "fwupd/remotes.d/vendor-directory.conf"
-        "fwupd/thunderbolt.conf"
         "fwupd/uefi_capsule.conf"
         "pki/fwupd/GPG-KEY-Linux-Foundation-Firmware"
         "pki/fwupd/GPG-KEY-Linux-Vendor-Firmware-Service"
@@ -348,6 +347,8 @@ let
         "fwupd/redfish.conf"
       ] ++ lib.optionals haveMSR [
         "fwupd/msr.conf"
+      ] ++ lib.optionals isx86 [
+        "fwupd/thunderbolt.conf"
       ];
 
       # DisabledPlugins key in fwupd/daemon.conf

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -54,6 +54,7 @@
 , libmbim
 , libcbor
 , xz
+, enableFlashrom ? false
 }:
 
 let
@@ -76,7 +77,7 @@ let
   # # Currently broken on Aarch64
   # haveFlashrom = isx86;
   # Experimental
-  haveFlashrom = false;
+  haveFlashrom = isx86 && enableFlashrom;
 
   runPythonCommand = name: buildCommandPython: runCommand name {
     nativeBuildInputs = [ python3 ];
@@ -116,7 +117,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "fwupd";
-    version = "1.8.9";
+    version = "1.8.10";
 
     # libfwupd goes to lib
     # daemon, plug-ins and libfwupdplugin go to out
@@ -125,7 +126,7 @@ let
 
     src = fetchurl {
       url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-      hash = "sha256-cZp5GsS6WYiuuT7EJ3i9ZdM8sHXQwJO1wE5eFoK+Uoo=";
+      hash = "sha256-vvNUidNdhW9xeksjEVnkIR7CZ4oBQizZJRMFtZUq6Ow=";
     };
 
     patches = [


### PR DESCRIPTION
###### Description of changes

[Changelog](https://github.com/fwupd/fwupd/releases/tag/1.8.10)

Ping: @jtojnar 

I also included an extra argument to make it possible to enable flashrom using an override, but we keep it disabled by default.
It is not possible to build fwupd currently with the flashrom package from nixpkgs, as it does not expose a pkg-config file, but allowing to enable flashrom with an override, allows to build fwupd with a custom flashrom package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
