### PR TITLE
android-studio: fix default JAVA_HOME path

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -79,7 +79,7 @@ let
     installPhase = ''
       cp -r . $out
       wrapProgram $out/bin/studio.sh \
-        --set-default JAVA_HOME "$out/jre" \
+        --set-default JAVA_HOME "$out/jbr" \
         --set ANDROID_EMULATOR_USE_SYSTEM_LIBS 1 \
         --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb" \
         ${lib.optionalString tiling_wm "--set _JAVA_AWT_WM_NONREPARENTING 1"} \


### PR DESCRIPTION
###### Description of changes

In all `android-studio` versions starting with `2022.`, which is all currently packaged versions, the bundled Java runtime folder has been renamed from `jre` to `jbr`. This makes Gradle fail with a `NoSuchFileException`.

```
$ ls -l $(NIXPKGS_ALLOW_UNFREE=1 nix build --print-out-paths -f . 'androidStudioPackages.stable.unwrapped')
insgesamt 48
-r--r--r--  1 root root  1852  1. Jan 1970  Install-Linux-tar.txt
-r--r--r--  1 root root 11352  1. Jan 1970  LICENSE.txt
-r--r--r--  1 root root   396  1. Jan 1970  NOTICE.txt
dr-xr-xr-x  5 root root  4096  1. Jan 1970  bin
-r--r--r--  1 root root    27  1. Jan 1970  build.txt
dr-xr-xr-x  6 root root    68  1. Jan 1970  jbr
dr-xr-xr-x  5 root root  4096  1. Jan 1970  lib
dr-xr-xr-x  2 root root  4096  1. Jan 1970  license
dr-xr-xr-x 65 root root  4096  1. Jan 1970  plugins
-r--r--r--  1 root root   436  1. Jan 1970  product-info.json
```

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'element-android'.
> Failed to notify project evaluation listener.
   > /nix/store/z41ql5r60im8qgbdyi1jlxaw7lpy5hkk-android-studio-stable-2022.1.1.19-unwrapped/jre

...

Caused by: java.nio.file.NoSuchFileException: /nix/store/z41ql5r60im8qgbdyi1jlxaw7lpy5hkk-android-studio-stable-2022.1.1.19-unwrapped/jre
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
