### PR TITLE
colima: use lima-bin on darwin for native macOS virtualization support

### DIFF
--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -9,12 +9,11 @@
 , qemu
 , testers
 , colima
+  # use lima-bin on darwin to support native macOS virtualization
+  # https://github.com/NixOS/nixpkgs/pull/209171
+, lima-drv ? if stdenv.isDarwin then lima-bin else lima
 }:
 
-# use lima-bin on darwin to support native macOS virtualization
-# https://github.com/NixOS/nixpkgs/pull/209171
-let lima-drv = if stdenv.isDarwin then lima-bin else lima;
-in
 buildGoModule rec {
   pname = "colima";
   version = "0.5.2";

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -11,6 +11,8 @@
 , colima
 }:
 
+# use lima-bin on darwin to support native macOS virtualization
+# https://github.com/NixOS/nixpkgs/pull/209171
 let lima-drv = if stdenv.isDarwin then lima-bin else lima;
 in
 buildGoModule rec {

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -1,14 +1,18 @@
 { lib
+, stdenv
 , buildGoModule
 , fetchFromGitHub
 , installShellFiles
 , lima
+, lima-bin
 , makeWrapper
 , qemu
 , testers
 , colima
 }:
 
+let lima-drv = if stdenv.isDarwin then lima-bin else lima;
+in
 buildGoModule rec {
   pname = "colima";
   version = "0.5.2";
@@ -41,7 +45,7 @@ buildGoModule rec {
 
   postInstall = ''
     wrapProgram $out/bin/colima \
-      --prefix PATH : ${lib.makeBinPath [ lima qemu ]}
+      --prefix PATH : ${lib.makeBinPath [ lima-drv qemu ]}
 
     installShellCompletion --cmd colima \
       --bash <($out/bin/colima completion bash) \


### PR DESCRIPTION
###### Description of changes

Tested with `result/bin/colima start --vm-type vz`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
