### PR TITLE
rmlint: fix NIX_* environment propagations to scons

### DIFF
--- a/pkgs/tools/misc/rmlint/default.nix
+++ b/pkgs/tools/misc/rmlint/default.nix
@@ -31,6 +31,11 @@ stdenv.mkDerivation rec {
     sha256 = "15xfkcw1bkfyf3z8kl23k3rlv702m0h7ghqxvhniynvlwbgh6j2x";
   };
 
+  patches = [
+    # pass through NIX_* environment variables to scons.
+    ./scons-nix-env.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     sphinx
@@ -56,9 +61,6 @@ stdenv.mkDerivation rec {
   ];
 
   prePatch = ''
-    export CFLAGS="$NIX_CFLAGS_COMPILE"
-    export LDFLAGS="''${NIX_LDFLAGS//-rpath /-Wl,-rpath=}"
-
     # remove sources of nondeterminism
     substituteInPlace lib/cmdline.c \
       --replace "__DATE__" "\"Jan  1 1970\"" \
@@ -67,6 +69,7 @@ stdenv.mkDerivation rec {
       --replace "gzip -c " "gzip -cn "
   '';
 
+  # Otherwise tries to access /usr.
   prefixKey = "--prefix=";
 
   sconsFlags = lib.optionals (!withGui) [ "--without-gui" ];

--- a/pkgs/tools/misc/rmlint/scons-nix-env.patch
+++ b/pkgs/tools/misc/rmlint/scons-nix-env.patch
@@ -1,0 +1,19 @@
+scons does not use os environment by default:
+  https://scons.org/doc/2.1.0/HTML/scons-user/x1750.html
+
+nixpkgs' cc-wrapper on the other hand relies on various NIX_* variables
+to be passed through like NIX_CFLAGS_COMPILE_BEFORE.
+--- a/SConstruct
++++ b/SConstruct
+@@ -559,10 +559,7 @@ options = dict(
+     SHLINKCOMSTR=link_shared_library_message,
+     LINKCOMSTR=link_program_message,
+     PREFIX=GetOption('prefix'),
+-    ENV = dict([ (key, os.environ[key])
+-                 for key in os.environ
+-                 if key in ['PATH', 'TERM', 'HOME', 'PKG_CONFIG_PATH']
+-              ])
++    ENV = os.environ,
+ )
+ 
+ if ARGUMENTS.get('VERBOSE') == "1":


### PR DESCRIPTION
scons build system does not work by default in nixpkgs envoironment as it filters system environment and throws away NIX_* flags:

    https://scons.org/doc/2.1.0/HTML/scons-user/x1750.html

Fix build system to always propagate os.environment. Drop the workarounds that pass subset of the variables through.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
