### PR TITLE
treewide: use more secure and proxy friendly https protocol to fetch …

### DIFF
--- a/pkgs/development/tools/ofono-phonesim/default.nix
+++ b/pkgs/development/tools/ofono-phonesim/default.nix
@@ -11,7 +11,7 @@ mkDerivation {
   version = "unstable-2019-11-18";
 
   src = fetchgit {
-    url = "git://git.kernel.org/pub/scm/network/ofono/phonesim.git";
+    url = "https://git.kernel.org/pub/scm/network/ofono/phonesim.git";
     rev = "adf231a84cd3708b825dc82c56e841dd7e3b4541";
     sha256 = "1840914sz46l8h2jwa0lymw6dvgj72wq9bhp3k4v4rk6masbf6hp";
   };

--- a/pkgs/os-specific/linux/blktrace/default.nix
+++ b/pkgs/os-specific/linux/blktrace/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.3.0";
 
   # Official source
-  # "git://git.kernel.org/pub/scm/linux/kernel/git/axboe/blktrace.git"
+  # "https://git.kernel.org/pub/scm/linux/kernel/git/axboe/blktrace.git"
   src = fetchurl {
     url = "https://brick.kernel.dk/snaps/blktrace-${version}.tar.bz2";
     sha256 = "sha256-1t7aA4Yt4r0bG5+6cpu7hi2bynleaqf3yoa2VoEacNY=";

--- a/pkgs/os-specific/linux/error-inject/default.nix
+++ b/pkgs/os-specific/linux/error-inject/default.nix
@@ -10,7 +10,7 @@
     version = "4cbe46321b4a81365ff3aafafe63967264dbfec5";
 
     src = fetchgit {
-      url = "git://git.kernel.org/pub/scm/utils/cpu/mce/mce-inject.git";
+      url = "https://git.kernel.org/pub/scm/utils/cpu/mce/mce-inject.git";
       rev = version;
       sha256 = "0gjapg2hrlxp8ssrnhvc19i3r1xpcnql7xv0zjgbv09zyha08g6z";
     };
@@ -40,7 +40,7 @@
     version = "9bd5e2c7886fca72f139cd8402488a2235957d41";
 
     src = fetchgit {
-      url = "git://git.kernel.org/pub/scm/linux/kernel/git/gong.chen/aer-inject.git";
+      url = "https://git.kernel.org/pub/scm/linux/kernel/git/gong.chen/aer-inject.git";
       rev = version;
       sha256 = "0bh6mzpk2mr4xidkammmkfk21b4dbq793qjg25ryyxd1qv0c6cg4";
     };

--- a/pkgs/os-specific/linux/libtraceevent/default.nix
+++ b/pkgs/os-specific/linux/libtraceevent/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.6.2";
 
   src = fetchgit {
-    url = "git://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git";
+    url = "https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git";
     rev = "libtraceevent-${version}";
     sha256 = "sha256-iLy2rEKn0UJguRcY/W8RvUq7uX+snQojb/cXOmMsjwc=";
   };

--- a/pkgs/os-specific/linux/libtracefs/default.nix
+++ b/pkgs/os-specific/linux/libtracefs/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   version = "1.6.4";
 
   src = fetchgit {
-    url = "git://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git";
+    url = "https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git";
     rev = "libtracefs-${version}";
     sha256 = "sha256-fWop0EMkoVulLBzU7q8x1IhMtdnEJ89wMz0cz964F6s=";
   };

--- a/pkgs/os-specific/linux/trace-cmd/default.nix
+++ b/pkgs/os-specific/linux/trace-cmd/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   version = "3.1.6";
 
   src = fetchgit {
-    url    = "git://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/";
+    url    = "https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/";
     rev    = "trace-cmd-v${version}";
     sha256 = "sha256-qjfeomeExjsx/6XrUaGm5szbL7XVlekGd4Hsuncv8NY=";
   };

--- a/pkgs/tools/misc/xfstests/default.nix
+++ b/pkgs/tools/misc/xfstests/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   version = "2022.09.04";
 
   src = fetchgit {
-    url = "git://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git";
+    url = "https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git";
     rev = "v${version}";
     sha256 = "sha256-hPFoqNmB8pewvBN1nzVMkTrMHCo0xc8tmmIODaiDeRw=";
   };

--- a/pkgs/tools/networking/mmsd/default.nix
+++ b/pkgs/tools/networking/mmsd/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   version = "unstable-2019-07-15";
 
   src = fetchgit {
-    url = "git://git.kernel.org/pub/scm/network/ofono/mmsd.git";
+    url = "https://git.kernel.org/pub/scm/network/ofono/mmsd.git";
     rev = "f4b8b32477a411180be1823fdc460b4f7e1e3c9c";
     sha256 = "0hcnpyhsi7b5m825dhnwbp65yi0961wi8mipzdvaw5nc693xv15b";
   };

--- a/pkgs/tools/networking/ofono/default.nix
+++ b/pkgs/tools/networking/ofono/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   src = fetchgit {
-    url = "git://git.kernel.org/pub/scm/network/ofono/ofono.git";
+    url = "https://git.kernel.org/pub/scm/network/ofono/ofono.git";
     rev = version;
     sha256 = "sha256-T8rfReruvHGQCN9IDGIrFCoNjFKKMnUGPKzxo2HTZFQ=";
   };

--- a/pkgs/tools/security/efitools/default.nix
+++ b/pkgs/tools/security/efitools/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchgit {
-    url = "git://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git";
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git";
     rev = "v${version}";
     sha256 = "0jabgl2pxvfl780yvghq131ylpf82k7banjz0ksjhlm66ik8gb1i";
   };


### PR DESCRIPTION
…from git.kernel.org

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
