### PR TITLE
inferno: 0.11.7 -> 0.11.14

### DIFF
--- a/pkgs/development/tools/inferno/default.nix
+++ b/pkgs/development/tools/inferno/default.nix
@@ -1,26 +1,23 @@
-{ fetchCrate, lib, rustPlatform }:
+{ lib, rustPlatform, fetchFromGitHub }:
 
 rustPlatform.buildRustPackage rec {
   pname = "inferno";
-  version = "0.11.7";
+  version = "0.11.14";
 
-  # github version doesn't have a Cargo.lock
-  src = fetchCrate {
-    inherit pname version;
-    sha256 = "sha256-HZBCLgWC9yEo3lY7If18SILKZV3rwHv7FBVdumiTbJg=";
+  src = fetchFromGitHub {
+    owner = "jonhoo";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-0H+h4BM4x3vlI6EMeXNzcCQpW2S4czJR2GaviZ0nhEM=";
+    fetchSubmodules = true;
   };
 
-  cargoSha256 = "sha256-upO+G9569NXFuc2vpxR6E4nxJqCjg+RMlxV7oKb7v1E=";
+  cargoHash = "sha256-5VQNgZUgakQUczKs7T+c305c3I1DDSaVMO3tFXqIdIc=";
 
-  # these tests depend on a patched version of flamegraph which is included in
-  # the github repository as a submodule, but absent from the crates version
+  # skip flaky tests
   checkFlags = [
-    "--skip=collapse::dtrace::tests::test_collapse_multi_dtrace"
-    "--skip=collapse::dtrace::tests::test_collapse_multi_dtrace_simple"
-    "--skip=collapse::perf::tests::test_collapse_multi_perf"
-    "--skip=collapse::perf::tests::test_collapse_multi_perf_simple"
-    "--skip=collapse::perf::tests::test_multiple_skip_after"
-    "--skip=collapse::perf::tests::test_one_skip_after"
+    "--skip=flamegraph_base_symbol"
+    "--skip=flamegraph_multiple_base_symbol"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Diff: https://github.com/jonhoo/inferno/compare/v0.11.7...v0.11.14

Changelog: https://github.com/jonhoo/inferno/blob/v0.11.14/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
