### PR TITLE
tmux: apply patch for CVE-2022-47016

### DIFF
--- a/pkgs/tools/misc/tmux/CVE-2022-47016.patch
+++ b/pkgs/tools/misc/tmux/CVE-2022-47016.patch
@@ -1,0 +1,72 @@
+From 01f753df5dc269cf054b94c3f210aa880872d602 Mon Sep 17 00:00:00 2001
+From: nicm <nicm>
+Date: Wed, 24 Aug 2022 07:22:30 +0000
+Subject: [PATCH] Check for NULL returns from bufferevent_new.
+
+(cherry picked from commit e86752820993a00e3d28350cbe46878ba95d9012)
+---
+ control.c | 4 ++++
+ file.c    | 4 ++++
+ window.c  | 2 ++
+ 3 files changed, 10 insertions(+)
+
+diff --git a/control.c b/control.c
+index 73286e00..6183a006 100644
+--- a/control.c
++++ b/control.c
+@@ -775,6 +775,8 @@ control_start(struct client *c)
+ 
+ 	cs->read_event = bufferevent_new(c->fd, control_read_callback,
+ 	    control_write_callback, control_error_callback, c);
++	if (cs->read_event == NULL)
++		fatalx("out of memory");
+ 	bufferevent_enable(cs->read_event, EV_READ);
+ 
+ 	if (c->flags & CLIENT_CONTROLCONTROL)
+@@ -782,6 +784,8 @@ control_start(struct client *c)
+ 	else {
+ 		cs->write_event = bufferevent_new(c->out_fd, NULL,
+ 		    control_write_callback, control_error_callback, c);
++		if (cs->write_event == NULL)
++			fatalx("out of memory");
+ 	}
+ 	bufferevent_setwatermark(cs->write_event, EV_WRITE, CONTROL_BUFFER_LOW,
+ 	    0);
+diff --git a/file.c b/file.c
+index b2f155fe..04a907bf 100644
+--- a/file.c
++++ b/file.c
+@@ -585,6 +585,8 @@ file_write_open(struct client_files *files, struct tmuxpeer *peer,
+ 
+ 	cf->event = bufferevent_new(cf->fd, NULL, file_write_callback,
+ 	    file_write_error_callback, cf);
++	if (cf->event == NULL)
++		fatalx("out of memory");
+ 	bufferevent_enable(cf->event, EV_WRITE);
+ 	goto reply;
+ 
+@@ -744,6 +746,8 @@ file_read_open(struct client_files *files, struct tmuxpeer *peer,
+ 
+ 	cf->event = bufferevent_new(cf->fd, file_read_callback, NULL,
+ 	    file_read_error_callback, cf);
++	if (cf->event == NULL)
++		fatalx("out of memory");
+ 	bufferevent_enable(cf->event, EV_READ);
+ 	return;
+ 
+diff --git a/window.c b/window.c
+index c0cd9bdc..294a1f08 100644
+--- a/window.c
++++ b/window.c
+@@ -1042,6 +1042,8 @@ window_pane_set_event(struct window_pane *wp)
+ 
+ 	wp->event = bufferevent_new(wp->fd, window_pane_read_callback,
+ 	    NULL, window_pane_error_callback, wp);
++	if (wp->event == NULL)
++		fatalx("out of memory");
+ 	wp->ictx = input_init(wp, wp->event, &wp->palette);
+ 
+ 	bufferevent_enable(wp->event, EV_READ|EV_WRITE);
+-- 
+2.39.1
+

--- a/pkgs/tools/misc/tmux/default.nix
+++ b/pkgs/tools/misc/tmux/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , autoreconfHook
 , bison
 , libevent
@@ -34,6 +35,10 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-SygHxTe7N4y7SdzKixPFQvqRRL57Fm8zWYHfTpW+yVY=";
   };
+
+  patches = [
+    ./CVE-2022-47016.patch
+  ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
###### Description of changes

Upstream issues:
https://github.com/tmux/tmux/issues/3312
https://github.com/tmux/tmux/issues/3447

Upstream patch does not apply cleanly on top of 3.3a.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
