### PR TITLE
libde265: 1.0.9 -> 1.0.10

### DIFF
--- a/pkgs/development/libraries/libde265/default.nix
+++ b/pkgs/development/libraries/libde265/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , autoreconfHook
 , pkg-config
 
@@ -13,15 +14,24 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.9";
+  version = "1.0.10";
   pname = "libde265";
 
   src = fetchFromGitHub {
     owner = "strukturag";
     repo = "libde265";
     rev = "v${version}";
-    sha256 = "sha256-OpiQapppuKCR27tIG5OW+KiNMP9ysv7CaobiBOW6VUI=";
+    sha256 = "sha256-d2TJKPvOAqLe+ZO1+Rd/yRIn3W1u1q62ZH20/9N2Shw=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "revert-cmake-change-pkg-config.patch";
+      url = "https://github.com/strukturag/libde265/commit/388b61459c2abe2b949114ab54e83fb4dbfa8ba0.patch";
+      sha256 = "sha256-b6wwSvZpK7lIu0uD1SqK2zGBUjb/25+JW1Pf1fvHc0I=";
+      revert = true;
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 


### PR DESCRIPTION
###### Description of changes

Fixes:
* CVE-2020-21594
* CVE-2020-21595
* CVE-2020-21596
* CVE-2020-21597
* CVE-2020-21598
* CVE-2020-21599
* CVE-2020-21600
* CVE-2020-21601
* CVE-2020-21602
* CVE-2020-21603
* CVE-2020-21604
* CVE-2020-21605
* CVE-2020-21606
* CVE-2022-1253
* CVE-2022-43236
* CVE-2022-43237
* CVE-2022-43238
* CVE-2022-43239
* CVE-2022-43240
* CVE-2022-43241
* CVE-2022-43242
* CVE-2022-43243
* CVE-2022-43244
* CVE-2022-43245
* CVE-2022-43248
* CVE-2022-43249
* CVE-2022-43250
* CVE-2022-43252
* CVE-2022-43253
* CVE-2022-47655

https://github.com/strukturag/libde265/releases/tag/v1.0.10

`libheif` now uses [cmake as recommended by the project](https://github.com/strukturag/libheif/blob/v1.14.2/README.md?plain=1#L122), building with the autotools breaks with libde265.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
I built `libde265.passthru.tests` with those changes on top of master.