### PR TITLE
scholarly: init at 1.7.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11238,6 +11238,12 @@
     githubId = 610615;
     name = "Chih-Mao Chen";
   };
+  pkosel = {
+    name = "pkosel";
+    email = "philipp.kosel@gmail.com";
+    github = "pkosel";
+    githubId = 170943;
+  };
   plabadens = {
     name = "Pierre Labadens";
     email = "labadens.pierre+nixpkgs@gmail.com";

--- a/pkgs/development/python-modules/scholarly/default.nix
+++ b/pkgs/development/python-modules/scholarly/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, unittestCheckHook
+
+, arrow
+, beautifulsoup4
+, bibtexparser
+, deprecated
+, fake-useragent
+, free-proxy
+, httpx
+, python-dotenv
+, selenium
+, sphinx-rtd-theme
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "scholarly";
+  version = "1.7.11";
+
+  # Pypi does not contain tests
+  src = fetchFromGitHub {
+    owner = "scholarly-python-package";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = lib.fakeHash;
+  };
+
+  propagatedBuildInputs = [
+    arrow
+    beautifulsoup4
+    bibtexparser
+    deprecated
+    fake-useragent
+    free-proxy
+    httpx
+    python-dotenv
+    selenium
+    sphinx-rtd-theme
+    typing-extensions
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    python test_module.py
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/scholarly-python-package/scholarly";
+    description = "Simple access to Google Scholar authors and citations";
+    license = with licenses; [ unlicense ];
+    maintainers = with maintainers; [ pkosel ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10211,6 +10211,8 @@ self: super: with self; {
 
   schiene = callPackage ../development/python-modules/schiene { };
 
+  scholarly = callPackage ../development/python-modules/scholarly { };
+
   schwifty = callPackage ../development/python-modules/schwifty { };
 
   scim2-filter-parser = callPackage ../development/python-modules/scim2-filter-parser { };


### PR DESCRIPTION
###### Description of changes

Add [scholarly](https://github.com/scholarly-python-package/scholarly), which provides simple access to Google Scholar authors and citations. Depends on #211693.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
