### PR TITLE
python310Packages.opensearch-py: init at 2.1.1

### DIFF
--- a/pkgs/development/python-modules/opensearch-py/default.nix
+++ b/pkgs/development/python-modules/opensearch-py/default.nix
@@ -1,0 +1,59 @@
+{ aiohttp
+, botocore
+, buildPythonPackage
+, certifi
+, fetchFromGitHub
+, lib
+, mock
+, pytest-asyncio
+, pytestCheckHook
+, pyyaml
+, requests
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "opensearch-py";
+  version = "2.1.1";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "opensearch-project";
+    repo = "opensearch-py";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-uJ6fdRPDK76qKHE4E6dI01vKgvfqbc6A1RCwnOtuOTY=";
+  };
+
+  propagatedBuildInputs = [
+    botocore
+    certifi
+    requests
+    urllib3
+  ];
+
+  nativeCheckInputs = [
+    mock
+    pytest-asyncio
+    pytestCheckHook
+    pyyaml
+  ] ++ passthru.optional-dependencies.async;
+
+  disabledTestPaths = [
+    # require network
+    "test_opensearchpy/test_async/test_connection.py"
+    "test_opensearchpy/test_async/test_server"
+    "test_opensearchpy/test_connection.py"
+    "test_opensearchpy/test_server"
+    "test_opensearchpy/test_server_secured"
+  ];
+
+  passthru.optional-dependencies.async = [ aiohttp ];
+
+  meta = {
+    description = "Python low-level client for OpenSearch";
+    homepage = "https://github.com/opensearch-project/opensearch-py";
+    changelog = "https://github.com/opensearch-project/opensearch-py/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mcwitt ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6645,6 +6645,8 @@ self: super: with self; {
 
   openrouteservice = callPackage ../development/python-modules/openrouteservice { };
 
+  opensearch-py = callPackage ../development/python-modules/opensearch-py { };
+
   opensensemap-api = callPackage ../development/python-modules/opensensemap-api { };
 
   opensfm = callPackage ../development/python-modules/opensfm { };


### PR DESCRIPTION
###### Description of changes

Adds opensearch-py, a community-maintained, open-source fork of elasticsearch-py.

- https://github.com/opensearch-project/opensearch-py
- https://pypi.org/project/opensearch-py/

Resolves https://github.com/NixOS/nixpkgs/issues/173418.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
