### PR TITLE
python310Packages.awswrangler: init at 2.19.0

### DIFF
--- a/pkgs/development/python-modules/awswrangler/default.nix
+++ b/pkgs/development/python-modules/awswrangler/default.nix
@@ -1,0 +1,88 @@
+{ backoff
+, SPARQLWrapper
+, boto3
+, buildPythonPackage
+, fetchFromGitHub
+, gremlinpython
+, jsonpath-ng
+, lib
+, moto
+, openpyxl
+, opensearch-py
+, pandas
+, pg8000
+, poetry-core
+, progressbar2
+, pyarrow
+, pymysql
+, pyodbc
+, pytestCheckHook
+, pythonOlder
+, pythonRelaxDepsHook
+, redshift-connector
+, requests-aws4auth
+}:
+
+buildPythonPackage rec {
+  pname = "awswrangler";
+  version = "2.19.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7.1";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "aws-sdk-pandas";
+    rev = "refs/tags/${version}";
+    hash = "sha256-xUEytEgr/djfnoOowLxAZmbPkMS+vU0fuPY7JxZXEe0=";
+  };
+
+  nativeBuildInputs = [ poetry-core pythonRelaxDepsHook ];
+
+  propagatedBuildInputs = [
+    backoff
+    boto3
+    gremlinpython
+    jsonpath-ng
+    openpyxl
+    opensearch-py
+    pandas
+    pg8000
+    progressbar2
+    pyarrow
+    pymysql
+    redshift-connector
+    requests-aws4auth
+  ];
+
+  pythonRelaxDeps = [
+    "gremlinpython"
+    "numpy"
+    "pandas"
+    "pg8000"
+  ];
+
+  nativeCheckInputs = [ moto pytestCheckHook ];
+
+  pytestFlagsArray = [
+    # Subset of tests that run in upstream CI (many others require credentials)
+    # https://github.com/aws/aws-sdk-pandas/blob/2b7c62ac0762b1303149bb3c03979791479ba4f9/.github/workflows/minimal-tests.yml
+    "tests/test_metadata.py"
+    "tests/test_session.py"
+    "tests/test_utils.py"
+    "tests/test_moto.py"
+  ];
+
+  passthru.optional-dependencies = {
+    sqlserver = [ pyodbc ];
+    sparql = [ SPARQLWrapper ];
+  };
+
+  meta = {
+    description = "Pandas on AWS";
+    homepage = "https://github.com/aws/aws-sdk-pandas";
+    changelog = "https://github.com/aws/aws-sdk-pandas/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mcwitt ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -841,6 +841,8 @@ self: super: with self; {
 
   awslambdaric = callPackage ../development/python-modules/awslambdaric { };
 
+  awswrangler = callPackage ../development/python-modules/awswrangler { };
+
   axis = callPackage ../development/python-modules/axis { };
 
   azure-appconfiguration = callPackage ../development/python-modules/azure-appconfiguration { };


### PR DESCRIPTION
###### Description of changes

~This depends on #213053 and #213054.~

Adds AWS SDK for Pandas (awswrangler on PyPI):

- https://github.com/aws/aws-sdk-pandas
- https://pypi.org/project/awswrangler/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
