### PR TITLE
treewide: convert 21 fonts to stdenvNoCC.mkDerivation

### DIFF
--- a/pkgs/data/fonts/andagii/default.nix
+++ b/pkgs/data/fonts/andagii/default.nix
@@ -1,14 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "andagii";
   version = "1.0.2";
-in (fetchzip {
-  name = "andagii-${version}";
 
-  url = "http://www.i18nguy.com/unicode/andagii.zip";
-  curlOpts = "--user-agent 'Mozilla/5.0'";
-  sha256 = "0j5kf2fmyqgnf5ji6h0h79lq9n9d85hkfrr4ya8hqj4gwvc0smb2";
+  src = fetchzip {
+    url = "http://www.i18nguy.com/unicode/andagii.zip";
+    curlOpts = "--user-agent 'Mozilla/5.0'";
+    hash = "sha256-U7wC55G8jIvMMyPcEiJQ700A7nkWdgWK1LM0F/wgDCg=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    cp -v ANDAGII_.TTF $out/share/fonts/truetype/andagii.ttf
+
+    runHook postInstall
+  '';
 
   # There are multiple claims that the font is GPL, so I include the
   # package; but I cannot find the original source, so use it on your
@@ -20,10 +29,4 @@ in (fetchzip {
     license = "unknown";
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    unzip $downloadedFile
-    mkdir -p $out/share/fonts/truetype
-    cp -v ANDAGII_.TTF $out/share/fonts/truetype/andagii.ttf
-  '';
-})
+}

--- a/pkgs/data/fonts/andika/default.nix
+++ b/pkgs/data/fonts/andika/default.nix
@@ -1,33 +1,33 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "andika";
   version = "6.101";
-  name = "andika-${version}";
-in
-  (fetchzip rec {
-    inherit name;
 
+  src = fetchzip {
     url = "https://software.sil.org/downloads/r/andika/Andika-${version}.zip";
+    hash = "sha256-LghkGd/cjuXghzsU9X/YneNIdBeDEnu0ARszipANm8w=";
+  };
 
-    sha256 = "sha256-J/Ad+fmCMOxLoo+691LE6Bgi/l3ovIfWScwwVWtqACI=";
+  installPhase = ''
+    runHook preInstall
 
-    meta = with lib; {
-      homepage = "https://software.sil.org/andika";
-      description = "A family designed especially for literacy use taking into account the needs of beginning readers";
-      longDescription = ''
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 *OFL.txt *OFL-FAQ.txt *README.txt *FONTLOG.txt -t $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://software.sil.org/andika";
+    description = "A family designed especially for literacy use taking into account the needs of beginning readers";
+    longDescription = ''
       Andika is a sans serif, Unicode-compliant font designed especially for literacy use, taking into account the needs of beginning readers. The focus is on clear, easy-to-perceive letterforms that will not be readily confused with one another.
 
       A sans serif font is preferred by some literacy personnel for teaching people to read. Its forms are simpler and less cluttered than those of most serif fonts. For years, literacy workers have had to make do with fonts that were not really suitable for beginning readers and writers. In some cases, literacy specialists have had to tediously assemble letters from a variety of fonts in order to get all of the characters they need for their particular language project, resulting in confusing and unattractive publications. Andika addresses those issues.
-      '';
-      license = licenses.ofl;
-      platforms = platforms.all;
-      maintainers = [ maintainers.f--t ];
-    };
-  }).overrideAttrs (_: {
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
     '';
-  })
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.f--t ];
+  };
+}

--- a/pkgs/data/fonts/ankacoder/default.nix
+++ b/pkgs/data/fonts/ankacoder/default.nix
@@ -1,12 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let version = "1.100"; in
-(fetchzip {
-  name = "ankacoder-${version}";
-  url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/anka-coder-fonts/AnkaCoder.${version}.zip";
+stdenvNoCC.mkDerivation rec {
+  pname = "ankacoder";
+  version = "1.100";
 
-  sha256 = "1jqx9micfmiarqh9xp330gl96v3vxbwzz9cmg2vi845n9md4im85";
+  src = fetchzip {
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/anka-coder-fonts/AnkaCoder.${version}.zip";
+    stripRoot = false;
+    hash = "sha256-14ItaSQ/fO/WDq0O4SXGWnZgiM0kayJrWQgsKb7bsyY=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Anka/Coder fonts";
@@ -15,10 +26,4 @@ let version = "1.100"; in
     maintainers = with maintainers; [ dtzWill ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    unzip $downloadedFile
-    mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype
-  '';
-})
+}

--- a/pkgs/data/fonts/annapurna-sil/default.nix
+++ b/pkgs/data/fonts/annapurna-sil/default.nix
@@ -1,31 +1,31 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "annapurna-sil";
   version = "1.204";
-  name = "annapurna-sil-${version}";
-in
-  (fetchzip rec {
-    inherit name;
 
+  src = fetchzip {
     url = "https://software.sil.org/downloads/r/annapurna/AnnapurnaSIL-${version}.zip";
+    hash = "sha256-4ya3Iydrz5Pvol9sTDIe9ZW5k3+XQp8GB2LAnRpeiXs=";
+  };
 
-    sha256 = "sha256-kVeP9ZX8H+Wn6jzmH1UQvUKY6vJjadMTdEusS7LodFM=";
+  installPhase = ''
+    runHook preInstall
 
-    meta = with lib; {
-      homepage = "https://software.sil.org/annapurna";
-      description = "Unicode-based font family with broad support for writing systems that use the Devanagari script";
-      longDescription = ''
-        Annapurna SIL is a Unicode-based font family with broad support for writing systems that use the Devanagari script. Inspired by traditional calligraphic forms, the design is intended to be highly readable, reasonably compact, and visually attractive.
-      '';
-      license = licenses.ofl;
-      platforms = platforms.all;
-      maintainers = [ maintainers.kmein ];
-    };
-  }).overrideAttrs (_: {
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 *OFL.txt *OFL-FAQ.txt *README.txt *FONTLOG.txt -t $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://software.sil.org/annapurna";
+    description = "Unicode-based font family with broad support for writing systems that use the Devanagari script";
+    longDescription = ''
+      Annapurna SIL is a Unicode-based font family with broad support for writing systems that use the Devanagari script. Inspired by traditional calligraphic forms, the design is intended to be highly readable, reasonably compact, and visually attractive.
     '';
-  })
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.kmein ];
+  };
+}

--- a/pkgs/data/fonts/babelstone-han/default.nix
+++ b/pkgs/data/fonts/babelstone-han/default.nix
@@ -1,14 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation {
+  pname = "babelstone-han";
   version = "13.0.3";
-in (fetchzip {
-  name = "babelstone-han-${version}";
 
-  # upstream download links are unversioned, so hash changes
-  url = "https://web.archive.org/web/20200210125314/https://www.babelstone.co.uk/Fonts/Download/BabelStoneHan.zip";
-  sha256 = "018isk3hbzsihzrxavgjbn485ngzvlm96npqx9y7zpkxsssslc4w";
+  src = fetchzip {
+    # upstream download links are unversioned, so hash changes
+    url = "https://web.archive.org/web/20200210125314/https://www.babelstone.co.uk/Fonts/Download/BabelStoneHan.zip";
+    hash = "sha256-LLhNtHu2hh5DY2XVSrLuVzzR6OtMdSSHetyA0k1IFs0=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    cp *.ttf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Unicode CJK font with over 36000 Han characters";
@@ -18,9 +27,4 @@ in (fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ emily ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/truetype
-    unzip $downloadedFile '*.ttf' -d $out/share/fonts/truetype
-  '';
-})
+}

--- a/pkgs/data/fonts/barlow/default.nix
+++ b/pkgs/data/fonts/barlow/default.nix
@@ -1,14 +1,26 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
-let
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "barlow";
   version = "1.422";
-in
-(fetchzip rec {
-  name = "barlow-${version}";
 
-  url = "https://tribby.com/fonts/barlow/download/barlow-${version}.zip";
+  src = fetchzip {
+    url = "https://tribby.com/fonts/barlow/download/barlow-${version}.zip";
+    stripRoot = false;
+    hash = "sha256-aHAGPEgBkH41r7HR0D74OGCa7ta7Uo8Mgq4YVtYOwU8=";
+  };
 
-  sha256 = "08ld4c3zq4d1px07lc64i7l8848zsc61ddy3654w2sh0hx5sm5ld";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 fonts/otf/*.otf -t $out/share/fonts/opentype
+    install -Dm644 fonts/ttf/*.ttf fonts/gx/*.ttf -t $out/share/fonts/truetype
+    install -Dm644 fonts/eot/*.eot -t $out/share/fonts/eot
+    install -Dm644 fonts/woff/*.woff -t $out/share/fonts/woff
+    install -Dm644 fonts/woff2/*.woff2 -t $out/share/fonts/woff2
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A grotesk variable font superfamily";
@@ -17,13 +29,4 @@ in
     maintainers = [ maintainers.marsam ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.eot -d $out/share/fonts/eot
-    unzip -j $downloadedFile \*.woff -d $out/share/fonts/woff
-    unzip -j $downloadedFile \*.woff2 -d $out/share/fonts/woff2
-  '';
-})
+}

--- a/pkgs/data/fonts/borg-sans-mono/default.nix
+++ b/pkgs/data/fonts/borg-sans-mono/default.nix
@@ -1,16 +1,22 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation {
   pname = "borg-sans-mono";
   version = "0.2.0";
-in
-(fetchzip {
-  name = "${pname}-${version}";
 
-  # https://github.com/marnen/borg-sans-mono/issues/19
-  url = "https://github.com/marnen/borg-sans-mono/files/107663/BorgSansMono.ttf.zip";
-  sha256 = "1gz4ab0smw76ih5cs2l3n92c77nv7ld5zghq42avjsfhxrc2n5ri";
+  src = fetchzip {
+    # https://github.com/marnen/borg-sans-mono/issues/19
+    url = "https://github.com/marnen/borg-sans-mono/files/107663/BorgSansMono.ttf.zip";
+    hash = "sha256-nn7TGeVm45t7QI8+eEREBTFg9aShYYKtdEYEwQwO2fQ=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Droid Sans Mono Slashed + Hasklig-style ligatures";
@@ -19,9 +25,4 @@ in
     platforms = platforms.all;
     maintainers = with maintainers; [ atila ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
-})
+}

--- a/pkgs/data/fonts/cascadia-code/default.nix
+++ b/pkgs/data/fonts/cascadia-code/default.nix
@@ -1,14 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
-let
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "cascadia-code";
   version = "2111.01";
-in
-(fetchzip {
-  name = "cascadia-code-${version}";
 
-  url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/CascadiaCode-${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/microsoft/cascadia-code/releases/download/v${version}/CascadiaCode-${version}.zip";
+    stripRoot = false;
+    hash = "sha256-v9Vm5X80wEvorMhIlRw3MnyuSOdBpTl9ibBPpmm1vig=";
+  };
 
-  sha256 = "sha256-kUVTQ/oMZztNf22sDbQBpQW0luSc5nr5sxWU5etLDec=";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 otf/static/*.otf -t $out/share/fonts/opentype
+    install -Dm644 ttf/static/*.ttf -t $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Monospaced font that includes programming ligatures and is designed to enhance the modern look and feel of the Windows Terminal";
@@ -18,10 +27,4 @@ in
     maintainers = [ maintainers.marsam ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
-})
+}

--- a/pkgs/data/fonts/charis-sil/default.nix
+++ b/pkgs/data/fonts/charis-sil/default.nix
@@ -1,33 +1,33 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "charis-sil";
   version = "6.101";
-  name = "charis-sil-${version}";
-in
-  (fetchzip rec {
-    inherit name;
 
+  src = fetchzip {
     url = "https://software.sil.org/downloads/r/charis/CharisSIL-${version}.zip";
+    hash = "sha256-Rf5eKQVZw7zgTv6KkJUdNdd4sSJPdvjy/GDLusvlgzE=";
+  };
 
-    sha256 = "sha256-b1ms9hJ6IPe7W6O9KgzHZvwT4/nAoLOhdydcUrwNfnU=";
+  installPhase = ''
+    runHook preInstall
 
-    meta = with lib; {
-      homepage = "https://software.sil.org/charis";
-      description = "A family of highly readable fonts for broad multilingual use";
-      longDescription = ''
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 *OFL.txt *OFL-FAQ.txt *README.txt *FONTLOG.txt -t $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://software.sil.org/charis";
+    description = "A family of highly readable fonts for broad multilingual use";
+    longDescription = ''
       This Charis SIL font is essentially the same design as the SIL Charis font first released by SIL in 1997. Charis is similar to Bitstream Charter, one of the first fonts designed specifically for laser printers. It is highly readable and holds up well in less-than-ideal reproduction environments. It also has a full set of styles – regular, italic, bold, bold italic. Charis is a serif, proportionally-spaced font optimized for readability in long printed documents.
 
       The goal for this product was to provide a single Unicode-based font family that would contain a comprehensive inventory of glyphs needed for almost any Roman- or Cyrillic-based writing system, whether used for phonetic or orthographic needs. In addition, there is provision for other characters and symbols useful to linguists. This font makes use of state-of-the-art font technologies to support complex typographic issues, such as the need to position arbitrary combinations of base glyphs and diacritics optimally.
-      '';
-      license = licenses.ofl;
-      platforms = platforms.all;
-      maintainers = [ maintainers.f--t ];
-    };
-  }).overrideAttrs (_: {
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
     '';
-  })
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.f--t ];
+  };
+}

--- a/pkgs/data/fonts/comic-relief/default.nix
+++ b/pkgs/data/fonts/comic-relief/default.nix
@@ -1,15 +1,27 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "comic-relief";
   version = "1.1";
-  name = "comic-relief-${version}";
-in (fetchzip rec {
-  inherit name;
 
-  url = "https://fontlibrary.org/assets/downloads/comic-relief/45c456b6db2aaf2f7f69ac66b5ac7239/comic-relief.zip";
+  src = fetchzip {
+    url = "https://fontlibrary.org/assets/downloads/comic-relief/45c456b6db2aaf2f7f69ac66b5ac7239/comic-relief.zip";
+    stripRoot = false;
+    hash = "sha256-lvkMfaQvLMZ8F0Q5JnpmMsIAkR+XfihoHIoS4z5QEvA=";
+  };
 
-  sha256 = "0dz0y7w6mq4hcmmxv6fn4mp6jkln9mzr4s96vsg68wrl5b7k9yff";
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/etc/fonts/conf.d
+    mkdir -p $out/share/doc/${pname}-${version}
+    mkdir -p $out/share/fonts/truetype
+    cp -v ${./comic-sans-ms-alias.conf}     $out/etc/fonts/conf.d/30-comic-sans-ms.conf
+    cp *.ttf      -d $out/share/fonts/truetype
+    cp FONTLOG.txt -d $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://fontlibrary.org/en/font/comic-relief";
@@ -23,20 +35,11 @@ in (fetchzip rec {
     '';
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = [maintainers.rycee];
+    maintainers = [ maintainers.rycee ];
 
     # Reduce the priority of this package. The intent is that if you
     # also install the `corefonts` package, then you probably will not
     # want to install the font alias of this package.
     priority = 10;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/etc/fonts/conf.d
-    mkdir -p $out/share/doc/${name}
-    mkdir -p $out/share/fonts/truetype
-    cp -v ${./comic-sans-ms-alias.conf}     $out/etc/fonts/conf.d/30-comic-sans-ms.conf
-    unzip -j $downloadedFile \*.ttf      -d $out/share/fonts/truetype
-    unzip -j $downloadedFile FONTLOG.txt -d $out/share/doc/${name}
-  '';
-})
+}

--- a/pkgs/data/fonts/courier-prime/default.nix
+++ b/pkgs/data/fonts/courier-prime/default.nix
@@ -1,14 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "courier-prime";
   version = "unstable-2019-12-05";
-  repo = "CourierPrime";
-  rev = "7f6d46a766acd9391d899090de467c53fd9c9cb0";
-in (fetchzip rec {
-  name = "courier-prime-${version}";
-  url = "https://github.com/quoteunquoteapps/${repo}/archive/${rev}/${name}.zip";
-  sha256 = "1xh4pkksm6zrafhb69q4lq093q6pl245zi9qhqw3x6c1ab718704";
+
+  src = fetchzip {
+    url = "https://github.com/quoteunquoteapps/CourierPrime/archive/7f6d46a766acd9391d899090de467c53fd9c9cb0/${pname}-${version}.zip";
+    hash = "sha256-pMFZpytNtgoZrBj2Gj8SgJ0Lab8uVY5aQtcO2lFbHj4=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m444 -Dt $out/share/fonts/truetype fonts/ttf/*.ttf
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Monospaced font designed specifically for screenplays";
@@ -17,9 +24,4 @@ in (fetchzip rec {
     maintainers = [ maintainers.austinbutler ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    unzip $downloadedFile
-    install -m444 -Dt $out/share/fonts/truetype ${repo}-${rev}/fonts/ttf/*.ttf
-  '';
-})
+}

--- a/pkgs/data/fonts/cozette/default.nix
+++ b/pkgs/data/fonts/cozette/default.nix
@@ -1,15 +1,25 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "cozette";
   version = "1.13.0";
-in
-(fetchzip rec {
-  name = "Cozette-${version}";
 
-  url = "https://github.com/slavfox/Cozette/releases/download/v.${version}/CozetteFonts.zip";
+  src = fetchzip {
+    url = "https://github.com/slavfox/Cozette/releases/download/v.${version}/CozetteFonts.zip";
+    hash = "sha256-bMgjNnm84vk7jT2UvgCeQwmjZ+9X1GzGLXIEukhaWGw=";
+  };
 
-  sha256 = "sha256-xp3BCYfNUxCNewg4FfzmJnKp0PARvvnViMVwT25nWdM=";
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 *.otf -t $out/share/fonts/opentype
+    install -Dm644 *.bdf -t $out/share/fonts/misc
+    install -Dm644 *.otb -t $out/share/fonts/misc
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A bitmap programming font optimized for coziness";
@@ -18,12 +28,4 @@ in
     platforms = platforms.all;
     maintainers = with maintainers; [ brettlyons marsam ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.bdf -d $out/share/fonts/misc
-    unzip -j $downloadedFile \*.otb -d $out/share/fonts/misc
-  '';
-})
+}

--- a/pkgs/data/fonts/d2coding/default.nix
+++ b/pkgs/data/fonts/d2coding/default.nix
@@ -1,15 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
-  version = "1.3.2";
+stdenvNoCC.mkDerivation rec {
   pname = "d2codingfont";
+  version = "1.3.2";
 
-in (fetchzip {
-  name = "${pname}-${version}";
-  url = "https://github.com/naver/${pname}/releases/download/VER${version}/D2Coding-Ver${version}-20180524.zip";
+  src = fetchzip {
+    url = "https://github.com/naver/${pname}/releases/download/VER${version}/D2Coding-Ver${version}-20180524.zip";
+    stripRoot = false;
+    hash = "sha256-iC6iaUSVg4zt3wVFJUU4HEeswuKDOTFsAxq/0gRiOCA=";
+  };
 
-  sha256 = "1812r82530wzfki7k9cm35fy6k2lvis7j6w0w8svc784949m1wwj";
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts
+    install -Dm644 */*-all.ttc -t $out/share/fonts/truetype/
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Monospace font with support for Korean and latin characters";
@@ -25,9 +33,4 @@ in (fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ dtzWill ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*-all.ttc -d $out/share/fonts/truetype/
-  '';
-})
+}

--- a/pkgs/data/fonts/doulos-sil/default.nix
+++ b/pkgs/data/fonts/doulos-sil/default.nix
@@ -1,33 +1,33 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "doulos-sil";
   version = "6.101";
-  name = "doulos-sil-${version}";
-in
-  (fetchzip rec {
-    inherit name;
 
+  src = fetchzip {
     url = "https://software.sil.org/downloads/r/doulos/DoulosSIL-${version}.zip";
+    hash = "sha256-CPjk6SLgsDYjachZZ1hanp6Q+cxTxfHOkoeU59Om5b8=";
+  };
 
-    sha256 = "sha256-vYdnudMkkWz6r8pwq98fyO0zcfFBRPmrqlmWxHCOIcc=";
+  installPhase = ''
+    runHook preInstall
 
-    meta = with lib; {
-      homepage = "https://software.sil.org/doulos";
-      description = "A font that provides complete support for the International Phonetic Alphabet";
-      longDescription = ''
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 *OFL.txt *OFL-FAQ.txt *README.txt *FONTLOG.txt -t $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://software.sil.org/doulos";
+    description = "A font that provides complete support for the International Phonetic Alphabet";
+    longDescription = ''
       This Doulos SIL font is essentially the same design as the SIL Doulos font first released by SIL in 1992. The design has been changed from the original in that it has been scaled down to be a better match with contemporary digital fonts, such as Times New Roman®. This current release is a regular typeface, with no bold or italic version available or planned. It is intended for use alongside other Times-like fonts where a range of styles (italic, bold) are not needed. Therefore, just one font is included in the Doulos SIL release: Doulos SIL Regular.
 
       The goal for this product was to provide a single Unicode-based font family that would contain a comprehensive inventory of glyphs needed for almost any Roman- or Cyrillic-based writing system, whether used for phonetic or orthographic needs. In addition, there is provision for other characters and symbols useful to linguists. This font makes use of state-of-the-art font technologies to support complex typographic issues, such as the need to position arbitrary combinations of base glyphs and diacritics optimally.
-      '';
-      license = licenses.ofl;
-      platforms = platforms.all;
-      maintainers = [ maintainers.f--t ];
-    };
-  }).overrideAttrs (_: {
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
     '';
-  })
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.f--t ];
+  };
+}

--- a/pkgs/data/fonts/eb-garamond/default.nix
+++ b/pkgs/data/fonts/eb-garamond/default.nix
@@ -1,15 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "eb-garamond";
   version = "0.016";
-  name = "eb-garamond-${version}";
-in (fetchzip rec {
-  inherit name;
 
-  url = "https://bitbucket.org/georgd/eb-garamond/downloads/EBGaramond-${version}.zip";
+  src = fetchzip {
+    url = "https://bitbucket.org/georgd/eb-garamond/downloads/EBGaramond-${version}.zip";
+    hash = "sha256-P2VCLcqcMBBoTDJyRLP9vlHI+jE0EqPjPziN2MJbgEg=";
+  };
 
-  sha256 = "04jq4mpln85zzbla8ybsjw7vn9qr3r0snmk5zykrm24imq7ripv3";
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/{doc,fonts}
+    install -Dm644 otf/*.otf                                    -t $out/share/fonts/opentype
+    install -Dm644 *Changes *README.markdown *README.xelualatex -t $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "http://www.georgduffner.at/ebgaramond/";
@@ -18,10 +26,4 @@ in (fetchzip rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.otf                                          -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*Changes \*README.markdown \*README.xelualatex -d "$out/share/doc/${name}"
-  '';
-})
+}

--- a/pkgs/data/fonts/emacs-all-the-icons-fonts/default.nix
+++ b/pkgs/data/fonts/emacs-all-the-icons-fonts/default.nix
@@ -1,14 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "emacs-all-the-icons-fonts";
   version = "5.0.0";
-in (fetchzip {
-  name = "emacs-all-the-icons-fonts-${version}";
 
-  url = "https://github.com/domtronn/all-the-icons.el/archive/${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/domtronn/all-the-icons.el/archive/${version}.zip";
+    hash = "sha256-70ysVxOey6NLlCwhEYhxpxO6uuarMFDpg3Efh+3bj1M=";
+  };
 
-  sha256 = "0vc9bkm4pcc05llcd2c9zr3d88h3zmci0izla5wnw8hg1n0rsrii";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 fonts/*.ttf -t $out/share/fonts/all-the-icons
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Icon fonts for emacs all-the-icons";
@@ -20,17 +27,12 @@ in (fetchzip {
     homepage = "https://github.com/domtronn/all-the-icons.el";
 
     /*
-    The fonts come under a mixture of licenses - the MIT license,
-    SIL OFL license, and Apache license v2.0. See the GitHub page
-    for further information.
+      The fonts come under a mixture of licenses - the MIT license,
+      SIL OFL license, and Apache license v2.0. See the GitHub page
+      for further information.
     */
     license = licenses.free;
     platforms = platforms.all;
     maintainers = with maintainers; [ rlupton20 ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/all-the-icons
-  '';
-})
+}

--- a/pkgs/data/fonts/encode-sans/default.nix
+++ b/pkgs/data/fonts/encode-sans/default.nix
@@ -1,12 +1,22 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
-let name = "encode-sans-1.002";
-in (fetchzip rec {
-  inherit name;
+{ lib, stdenvNoCC, fetchzip }:
 
-  url = "https://github.com/impallari/Encode-Sans/archive/11162b46892d20f55bd42a00b48cbf06b5871f75.zip";
+stdenvNoCC.mkDerivation rec {
+  pname = "encode-sans";
+  version = "1.002";
 
-  sha256 = "16mx894zqlwrhnp4rflgayxhxppmsj6k7haxdngajhb30rlwf08p";
+  src = fetchzip {
+    url = "https://github.com/impallari/Encode-Sans/archive/11162b46892d20f55bd42a00b48cbf06b5871f75.zip";
+    hash = "sha256-TPAUc5msAUgJZHibjgYaS2TOuzKFy0rje9ZQTXE6s+w=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf                   -t $out/share/fonts/truetype
+    install -Dm644 *README.md *FONTLOG.txt -t $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A versatile sans serif font family";
@@ -23,10 +33,4 @@ in (fetchzip rec {
     maintainers = with maintainers; [ cmfwyp ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf                    -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*README.md \*FONTLOG.txt -d "$out/share/doc/${name}"
-  '';
-})
+}

--- a/pkgs/data/fonts/ezra-sil/default.nix
+++ b/pkgs/data/fonts/ezra-sil/default.nix
@@ -1,28 +1,28 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "ezra-sil";
   version = "2.51";
-  name = "ezra-sil-${version}";
-in
-  (fetchzip rec {
-    inherit name;
 
+  src = fetchzip {
     url = "https://software.sil.org/downloads/r/ezra/EzraSIL-${version}.zip";
+    hash = "sha256-hGOHjvFVFLwyVkcoUz+7rQekCdn4oEOB+L16XRpthJM=";
+  };
 
-    sha256 = "sha256-1LGw/RPFeNtEvcBWFWZf8+dABvWye2RfZ/jt8rwQewM=";
+  installPhase = ''
+    runHook preInstall
 
-    meta = with lib; {
-      homepage = "https://software.sil.org/ezra";
-      description = "Typeface fashioned after the square letter forms of the typography of the Biblia Hebraica Stuttgartensia (BHS)";
-      license = licenses.ofl;
-      platforms = platforms.all;
-      maintainers = [ maintainers.kmein ];
-    };
-  }).overrideAttrs (_: {
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL-FAQ.txt \*README.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
-    '';
-  })
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 *OFL-FAQ.txt *README.txt *FONTLOG.txt -t $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://software.sil.org/ezra";
+    description = "Typeface fashioned after the square letter forms of the typography of the Biblia Hebraica Stuttgartensia (BHS)";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.kmein ];
+  };
+}

--- a/pkgs/data/fonts/fira-code/default.nix
+++ b/pkgs/data/fonts/fira-code/default.nix
@@ -1,14 +1,24 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "fira-code";
   version = "6.2";
-in (fetchzip {
-  name = "fira-code-${version}";
 
-  url = "https://github.com/tonsky/FiraCode/releases/download/${version}/Fira_Code_v${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/tonsky/FiraCode/releases/download/${version}/Fira_Code_v${version}.zip";
+    stripRoot = false;
+    hash = "sha256-UHOwZL9WpCHk6vZaqI/XfkZogKgycs5lWg1p0XdQt0A=";
+  };
 
-  sha256 = "0l02ivxz3jbk0rhgaq83cqarqxr07xgp7n27l0fh8fbgxwi52djl";
+  # only extract the variable font because everything else is a duplicate
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts
+    cp variable_ttf/*-VF.ttf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/tonsky/FiraCode";
@@ -22,10 +32,4 @@ in (fetchzip {
     maintainers = [ maintainers.rycee ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  # only extract the variable font because everything else is a duplicate
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile '*-VF.ttf' -d $out/share/fonts/truetype
-  '';
-})
+}

--- a/pkgs/data/fonts/fira-code/symbols.nix
+++ b/pkgs/data/fonts/fira-code/symbols.nix
@@ -1,12 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-(fetchzip {
-  name = "fira-code-symbols-20160811";
+stdenvNoCC.mkDerivation {
+  pname = "fira-code-symbols";
+  version = "20160811";
 
-  url = "https://github.com/tonsky/FiraCode/files/412440/FiraCode-Regular-Symbol.zip";
+  src = fetchzip {
+    url = "https://github.com/tonsky/FiraCode/files/412440/FiraCode-Regular-Symbol.zip";
+    hash = "sha256-7y51blEn0Osf8azytK08zJgtfVX/CIWQkiOoRzYKIa4=";
+  };
 
-  sha256 = "19krsp22rin74ix0i19v4bh1c965g18xkmz1n55h6n6qimisnbkm";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.otf -t $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "FiraCode unicode ligature glyphs in private use area";
@@ -19,9 +28,4 @@
     maintainers = [ maintainers.Profpatsch ];
     homepage = "https://github.com/tonsky/FiraCode/issues/211#issuecomment-239058632";
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile -d $out/share/fonts/opentype
-  '';
-})
+}

--- a/pkgs/data/fonts/fira-mono/default.nix
+++ b/pkgs/data/fonts/fira-mono/default.nix
@@ -1,13 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let version = "4.202";
-in (fetchzip {
-  name = "fira-mono-${version}";
+stdenvNoCC.mkDerivation rec {
+  pname = "fira-mono";
+  version = "4.202";
 
-  url = "https://github.com/mozilla/Fira/archive/${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/mozilla/Fira/archive/${version}.zip";
+    hash = "sha256-HLReqgL0PXF5vOpwLN0GiRwnzkjGkEVEyOEV2Z4R0oQ=";
+  };
 
-  sha256 = "1ci3fxhdwabvfj4nl16pwcgqnh7s2slp8vblribk8zkpx8cbp1dj";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 otf/FiraMono*.otf -t $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://mozilla.github.io/Fira/";
@@ -22,9 +30,4 @@ in (fetchzip {
     maintainers = [ maintainers.rycee ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile Fira-${version}/otf/FiraMono\*.otf -d $out/share/fonts/opentype
-  '';
-})
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
