### PR TITLE
treewide: convert 26 fonts to stdenvNoCC.mkDerivation

### DIFF
--- a/pkgs/data/fonts/fraunces/default.nix
+++ b/pkgs/data/fonts/fraunces/default.nix
@@ -1,14 +1,22 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
-let
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "fraunces";
   version = "1.000";
-in
-(fetchzip {
-  name = "fraunces-${version}";
 
-  url = "https://github.com/undercasetype/Fraunces/releases/download/${version}/UnderCaseType_Fraunces_${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/undercasetype/Fraunces/releases/download/${version}/UnderCaseType_Fraunces_${version}.zip";
+    hash = "sha256-hu2G4Fs2I3TMEy/EBFnc88Pv3c8Mpc5rm3OwVvol7gQ=";
+  };
 
-  sha256 = "0qgl140qkn9p87x7pk60fd3lj206y5h0fq2xkcj2qiv3sxbqxwqb";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *Desktop/static/otf/*.otf -t $out/share/fonts/opentype
+    install -Dm644 *Desktop/static/ttf/*.ttf *Desktop/*.ttf -t $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A display, “Old Style” soft-serif typeface inspired by early 20th century typefaces";
@@ -17,10 +25,4 @@ in
     maintainers = [ maintainers.marsam ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
-})
+}

--- a/pkgs/data/fonts/galatia-sil/default.nix
+++ b/pkgs/data/fonts/galatia-sil/default.nix
@@ -1,31 +1,31 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "galatia-sil";
   version = "2.1";
-  name = "galatia-sil-${version}";
-in
-  (fetchzip rec {
-    inherit name;
 
+  src = fetchzip {
     url = "https://software.sil.org/downloads/r/galatia/GalatiaSIL-${version}.zip";
+    hash = "sha256-7kXnTC5vpUOjcT40oNW6e32zFGejlWJq1J+p+5DiAos=";
+  };
 
-    sha256 = "sha256-zLL/7LMcJul2LilhEafpvm+tiYlgv1y1jj85VvG+wiI=";
+  installPhase = ''
+    runHook preInstall
 
-    meta = with lib; {
-      homepage = "https://software.sil.org/galatia";
-      description = "Font designed to support Biblical Polytonic Greek";
-      longDescription = ''
-        Galatia SIL, designed to support Biblical Polytonic Greek, is a Unicode 3.1 font released under the SIL Open Font License. The font supports precomposed characters rather than decomposed characters. Thus, you must use a keyboard that outputs NFC encoding (precomposed).
-      '';
-      license = licenses.ofl;
-      platforms = platforms.all;
-      maintainers = [ maintainers.kmein ];
-    };
-  }).overrideAttrs (_: {
-    postFetch = ''
-      mkdir -p $out/share/{doc,fonts}
-      unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-      unzip -j $downloadedFile \*OFL.txt \*OFL-FAQ.txt \*FONTLOG.txt -d "$out/share/doc/${name}"
+    install -Dm644 $downloadedFile *.ttf -t $out/share/fonts/truetype
+    install -Dm644 $downloadedFile OFL.txt OFL-FAQ.txt FONTLOG.txt -t $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://software.sil.org/galatia";
+    description = "Font designed to support Biblical Polytonic Greek";
+    longDescription = ''
+      Galatia SIL, designed to support Biblical Polytonic Greek, is a Unicode 3.1 font released under the SIL Open Font License. The font supports precomposed characters rather than decomposed characters. Thus, you must use a keyboard that outputs NFC encoding (precomposed).
     '';
-  })
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.kmein ];
+  };
+}

--- a/pkgs/data/fonts/gentium-book-basic/default.nix
+++ b/pkgs/data/fonts/gentium-book-basic/default.nix
@@ -1,17 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
-  major = "1";
-  minor = "102";
-  version = "${major}.${minor}";
-  name = "gentium-book-basic-${version}";
-in (fetchzip rec {
-  inherit name;
+stdenvNoCC.mkDerivation rec {
+  pname = "gentium-book-basic";
+  version = "1.102";
 
-  url = "http://software.sil.org/downloads/r/gentium/GentiumBasic_${major}${minor}.zip";
+  src = fetchzip {
+    url = "http://software.sil.org/downloads/r/gentium/GentiumBasic_${lib.versions.major version}${lib.versions.minor version}.zip";
+    hash = "sha256-oCmpl95MJRfCV25cg/4cf8AwQWnoymXasSss1ziOPoE=";
+  };
 
-  sha256 = "0598zr5f7d6ll48pbfbmmkrybhhdks9b2g3m2g67wm40070ffzmd";
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/{doc,fonts}
+    install -Dm644 *.ttf                       -t $out/share/fonts/truetype
+    install -Dm644 FONTLOG.txt GENTIUM-FAQ.txt -t $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://software.sil.org/gentium/";
@@ -20,10 +26,4 @@ in (fetchzip rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf                            -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*/FONTLOG.txt \*/GENTIUM-FAQ.txt -d $out/share/doc/${name}
-  '';
-})
+}

--- a/pkgs/data/fonts/gentium/default.nix
+++ b/pkgs/data/fonts/gentium/default.nix
@@ -1,15 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "gentium";
   version = "6.101";
-  name = "gentium-${version}";
-in (fetchzip rec {
-  inherit name;
 
-  url = "http://software.sil.org/downloads/r/gentium/GentiumPlus-${version}.zip";
+  src = fetchzip {
+    url = "http://software.sil.org/downloads/r/gentium/GentiumPlus-${version}.zip";
+    hash = "sha256-iKD1Q7/lsbZCuJQoJqySQHwplrHv8yzmph+QwKpYgMU=";
+  };
 
-  sha256 = "sha256-+T5aUlqQYDWRp4/4AZzsREHgjAnOeUB6qn1GAI0A5hE=";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 FONTLOG.txt README.txt -t $out/share/doc/${pname}-${version}
+    cp -r documentation $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://software.sil.org/gentium/";
@@ -34,20 +42,4 @@ in (fetchzip rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -l $downloadedFile
-    unzip -j $downloadedFile \*.ttf \
-      -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \
-      \*/FONTLOG.txt \
-      \*/README.txt \
-      -d $out/share/doc/${name}
-    unzip -j $downloadedFile \
-      \*/documentation/\*.html \
-      \*/documentation/\*.txt \
-      -x \*/documentation/source/\* \
-      -d $out/share/doc/${name}/documentation
-  '';
-})
+}

--- a/pkgs/data/fonts/hack/default.nix
+++ b/pkgs/data/fonts/hack/default.nix
@@ -1,14 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "hack-font";
   version = "3.003";
-in (fetchzip {
-  name = "hack-font-${version}";
 
-  url = "https://github.com/chrissimpkins/Hack/releases/download/v${version}/Hack-v${version}-ttf.zip";
+  src = fetchzip {
+    url = "https://github.com/chrissimpkins/Hack/releases/download/v${version}/Hack-v${version}-ttf.zip";
+    hash = "sha256-SxF4kYp9aL/9L9EUniquFadzWt/+PcvhUQOIOvCrFRM=";
+  };
 
-  sha256 = "1l6ih6v7dqali5c7zh6z2xnbf9h2wz0ag6fdgszmqd5lnhw39v6s";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/hack
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A typeface designed for source code";
@@ -22,7 +29,7 @@ in (fetchzip {
     homepage = "https://sourcefoundry.org/hack/";
 
     /*
-     "The font binaries are released under a license that permits unlimited
+      "The font binaries are released under a license that permits unlimited
       print, desktop, and web use for commercial and non-commercial
       applications. It may be embedded and distributed in documents and
       applications. The source is released in the widely supported UFO format
@@ -33,9 +40,4 @@ in (fetchzip {
     maintainers = with maintainers; [ dywedir ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/hack
-  '';
-})
+}

--- a/pkgs/data/fonts/hasklig/default.nix
+++ b/pkgs/data/fonts/hasklig/default.nix
@@ -1,14 +1,22 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "hasklig";
   version = "1.1";
-in (fetchzip {
-  name = "hasklig-${version}";
 
-  url = "https://github.com/i-tu/Hasklig/releases/download/${version}/Hasklig-${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/i-tu/Hasklig/releases/download/${version}/Hasklig-${version}.zip";
+    stripRoot = false;
+    hash = "sha256-jsPQtjuegMePt4tB1dZ9mq15LSxXBYwtakbq4od/sko=";
+  };
 
-  sha256 = "0xxyx0nkapviqaqmf3b610nq17k20afirvc72l32pfspsbxz8ybq";
+  installPhase = ''
+    runHook preInstall
+
+    install -m444 -Dt $out/share/fonts/opentype *.otf
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/i-tu/Hasklig";
@@ -17,9 +25,4 @@ in (fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ davidrusu Profpatsch ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    unzip $downloadedFile
-    install -m444 -Dt $out/share/fonts/opentype *.otf
-  '';
-})
+}

--- a/pkgs/data/fonts/hyperscrypt/default.nix
+++ b/pkgs/data/fonts/hyperscrypt/default.nix
@@ -1,15 +1,22 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ fetchzip, lib }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "hyperscrypt";
   version = "1.1";
-  pname = "HyperScrypt";
-in
 
-(fetchzip {
-  name = "${lib.toLower pname}-font-${version}";
-  url = "https://gitlab.com/StudioTriple/Hyper-Scrypt/-/archive/${version}/Hyper-Scrypt-${version}.zip";
-  sha256 = "01pf5p2scmw02s0gxnibiwxbpzczphaaapv0v4s7svk9aw2gmc0m";
+  src = fetchzip {
+    url = "https://gitlab.com/StudioTriple/Hyper-Scrypt/-/archive/${version}/Hyper-Scrypt-${version}.zip";
+    hash = "sha256-ONlAB9C/GYK6KmOaiHCYErkS6OlQ3TUnoumNDHGZnes=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 fonts/HyperScrypt_Web/*.ttf -t $out/share/fonts/truetype/
+    install -Dm644 fonts/HyperScrypt_Web/*.otf fonts/*.otf -t $out/share/fonts/opentype/
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://velvetyne.fr/fonts/hyper-scrypt/";
@@ -28,15 +35,9 @@ in
       molted metal, Hyper Scrypt is based upon a rigorous grid,
       allowing some neat alignements between shapes in multi lines
       layouts.
-      '';
+    '';
     license = licenses.ofl;
     maintainers = with maintainers; [ leenaars ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/{truetype,opentype}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/${pname}.ttf
-    unzip -j $downloadedFile \*${pname}.otf -d $out/share/fonts/opentype/${pname}.otf
-  '';
-})
+}

--- a/pkgs/data/fonts/ibm-plex/default.nix
+++ b/pkgs/data/fonts/ibm-plex/default.nix
@@ -1,15 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "ibm-plex";
   version = "6.0.1";
 
-in (fetchzip {
-  name = "ibm-plex-${version}";
+  src = fetchzip {
+    url = "https://github.com/IBM/plex/releases/download/v${version}/OpenType.zip";
+    hash = "sha256-n13NuKrZUc0JGvDf2PLZkxogefDkEHaOZk4JN42/C74=";
+  };
 
-  url = "https://github.com/IBM/plex/releases/download/v${version}/OpenType.zip";
+  installPhase = ''
+    runHook preInstall
 
-  sha256 = "sha256-HxO0L5Q6WJQBqtg64cczzuRcSYi4jEqbOzEWxDmqFp8=";
+    install -Dm644 */*.otf IBM-Plex-Sans-JP/unhinted/* -t $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "IBM Plex Typeface";
@@ -19,9 +25,4 @@ in (fetchzip {
     platforms = platforms.all;
     maintainers = [ maintainers.romildo ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile "OpenType/*/*.otf" -x "OpenType/IBM-Plex-Sans-JP/unhinted/*" -d $out/share/fonts/opentype
-  '';
-})
+}

--- a/pkgs/data/fonts/inter/default.nix
+++ b/pkgs/data/fonts/inter/default.nix
@@ -1,14 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "inter";
   version = "3.19";
-in (fetchzip {
-  name = "inter-${version}";
 
-  url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-${version}.zip";
+    stripRoot = false;
+    hash = "sha256-6kUQUTFtxiJEU6sYC6HzMwm1H4wvaKIoxoY3F6GJJa8=";
+  };
 
-  sha256 = "sha256-8p15thg3xyvCA/8dH2jGQoc54nzESFDyv5m47FgWrSI=";
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/opentype
+    cp */*.otf $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://rsms.me/inter/";
@@ -17,10 +26,4 @@ in (fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ demize dtzWill ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
-})
-
+}

--- a/pkgs/data/fonts/ipaexfont/default.nix
+++ b/pkgs/data/fonts/ipaexfont/default.nix
@@ -1,12 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-(fetchzip {
-  name = "ipaexfont-004.01";
+stdenvNoCC.mkDerivation {
+  pname = "ipaexfont";
+  version = "004.01";
 
-  url = "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip";
+  src = fetchzip {
+    url = "https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip";
+    hash = "sha256-/87qJIb+v4qrtDy+ApfXxh59reOk+6RhGqFN98mc+8Q=";
+  };
 
-  sha256 = "0wp369kri33kb1mmiq4lpl9i4xnacw9fj63ycmkmlkq64s8qnjnx";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Japanese font package with Mincho and Gothic fonts";
@@ -21,9 +30,4 @@
     license = licenses.ipa;
     maintainers = with maintainers; [ gebner ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/opentype
-  '';
-})
+}

--- a/pkgs/data/fonts/ipafont/default.nix
+++ b/pkgs/data/fonts/ipafont/default.nix
@@ -1,12 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-(fetchzip {
-  name = "ipafont-003.03";
+stdenvNoCC.mkDerivation {
+  pname = "ipafont";
+  version = "003.03";
 
-  url = "https://moji.or.jp/wp-content/ipafont/IPAfont/IPAfont00303.zip";
+  src = fetchzip {
+    url = "https://moji.or.jp/wp-content/ipafont/IPAfont/IPAfont00303.zip";
+    hash = "sha256-EzUNKuDNHr0NIXiqX09w99wtz1r2pZurR/izdgzTcAs=";
+  };
 
-  sha256 = "0lrjd0bfy36f9j85m12afg5nvr5id3sig2nmzs5qifskbd7mqv9h";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = {
     description = "Japanese font package with Mincho and Gothic fonts";
@@ -19,9 +28,4 @@
     license = lib.licenses.ipa;
     maintainers = [ lib.maintainers.auntie ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/opentype
-  '';
-})
+}

--- a/pkgs/data/fonts/jost/default.nix
+++ b/pkgs/data/fonts/jost/default.nix
@@ -1,13 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{lib, fetchzip}:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "jost";
   version = "3.5";
-in (fetchzip {
-  name = "jost-${version}";
-  url = "https://github.com/indestructible-type/Jost/releases/download/${version}/Jost.zip";
 
-  sha256="0l78vhmbsyfmrva5wc76pskhxqryyg8q5xddpj9g5wqsddy525dq";
+  src = fetchzip {
+    url = "https://github.com/indestructible-type/Jost/releases/download/${version}/Jost.zip";
+    hash = "sha256-ne81bMhmTzNZ/GGIzb7nCYh19vNLK+hJ3cP/zDxtiGM=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 fonts/otf/*.otf -t $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/indestructible-type/Jost";
@@ -15,9 +23,4 @@ in (fetchzip {
     license = licenses.ofl;
     maintainers = [ maintainers.ar1a ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
-})
+}

--- a/pkgs/data/fonts/kawkab-mono/default.nix
+++ b/pkgs/data/fonts/kawkab-mono/default.nix
@@ -1,21 +1,26 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-(fetchzip {
-  name = "kawkab-mono-20151015";
+stdenvNoCC.mkDerivation {
+  pname = "kawkab-mono";
+  version = "20151015";
 
-  url = "http://makkuk.com/kawkab-mono/downloads/kawkab-mono-0.1.zip";
+  src = fetchzip {
+    url = "http://makkuk.com/kawkab-mono/downloads/kawkab-mono-0.1.zip";
+    stripRoot = false;
+    hash = "sha256-arZTzXj7Ba5G4WF3eZVGNaONhOsYVPih9iBgsN/lg14=";
+  };
 
-  sha256 = "1vfrb7xs817najplncg7zl9j5yxj8qnwb7aqm2v9p9xwafa4d2yd";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
 
   meta = {
     description = "An arab fixed-width font";
     homepage = "https://makkuk.com/kawkab-mono/";
     license = lib.licenses.ofl;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
-})
+}

--- a/pkgs/data/fonts/lato/default.nix
+++ b/pkgs/data/fonts/lato/default.nix
@@ -1,12 +1,22 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-(fetchzip {
-  name = "lato-2.0";
+stdenvNoCC.mkDerivation {
+  pname = "lato";
+  version = "2.0";
 
-  url = "https://www.latofonts.com/download/Lato2OFL.zip";
+  src = fetchzip {
+    url = "https://www.latofonts.com/download/Lato2OFL.zip";
+    stripRoot = false;
+    hash = "sha256-n1TsqigCQIGqyGLGTjLtjHuBf/iCwRlnqh21IHfAuXI=";
+  };
 
-  sha256 = "1amwn6vcaggxrd2s4zw21s2pr47zmzdf2xfy4x9lxa2cd9bkhvg5";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 Lato2OFL/*.ttf -t $out/share/fonts/lato
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://www.latofonts.com/";
@@ -32,9 +42,4 @@
     platforms = platforms.all;
     maintainers = with maintainers; [ chris-martin ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/lato
-  '';
-})
+}

--- a/pkgs/data/fonts/lmmath/default.nix
+++ b/pkgs/data/fonts/lmmath/default.nix
@@ -1,13 +1,24 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "lmmath";
   version = "1.959";
-in (fetchzip rec {
-  name = "lmmath-${version}";
 
-  url = "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip";
-  sha256 = "05k145bxgxjh7i9gx1ahigxfpc2v2vwzsy2mc41jvvg51kjr8fnn";
+  src = fetchzip {
+    url = "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip";
+    hash = "sha256-et/WMhfZZYgP0S7ZmI6MZK5owv9bSoMBXFX6yGSng5Y=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/opentype/
+    mkdir -p $out/share/doc/latinmodern-math-${version}/
+    cp otf/*.otf $out/share/fonts/opentype/
+    cp doc/*.txt $out/share/doc/latinmodern-math-${version}/
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "The Latin Modern Math (LM Math) font completes the modernization of the Computer Modern family of typefaces designed and programmed by Donald E. Knuth";
@@ -19,11 +30,4 @@ in (fetchzip rec {
     maintainers = with maintainers; [ siddharthist ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype/
-    mkdir -p $out/share/doc/latinmodern-math-${version}/
-    unzip -j $downloadedFile "*/otf/*.otf" -d $out/share/fonts/opentype/
-    unzip -j $downloadedFile "*/doc/*.txt" -d $out/share/doc/latinmodern-math-${version}/
-  '';
-})
+}

--- a/pkgs/data/fonts/mno16/default.nix
+++ b/pkgs/data/fonts/mno16/default.nix
@@ -1,22 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "mno16";
   version = "1.0";
-in (fetchzip rec {
-  name = "${pname}-${version}";
-  url = "https://github.com/sevmeyer/${pname}/releases/download/${version}/${name}.zip";
-  sha256 = "1x06nl281fcjk6g1p4cgrgxakmwcci6vvasskaygsqlzxd8ig87w";
+
+  src = fetchzip {
+    url = "https://github.com/sevmeyer/${pname}/releases/download/${version}/${pname}-${version}.zip";
+    stripRoot = false;
+    hash = "sha256-xJQ9V7GlGUTEeYhqYFl/SemS6iqV0eW85YOn/tLgA+M=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp fonts/*.ttf $out/share/fonts/truetype/
+  '';
 
   meta = with lib; {
     description = "minimalist monospaced font";
     homepage = "https://sev.dev/fonts/mno16";
     license = licenses.cc0;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/
-  '';
-})
+}

--- a/pkgs/data/fonts/mononoki/default.nix
+++ b/pkgs/data/fonts/mononoki/default.nix
@@ -1,14 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "mononoki";
   version = "1.3";
-in (fetchzip {
-  name = "mononoki-${version}";
 
-  url = "https://github.com/madmalik/mononoki/releases/download/${version}/mononoki.zip";
+  src = fetchzip {
+    url = "https://github.com/madmalik/mononoki/releases/download/${version}/mononoki.zip";
+    stripRoot = false;
+    hash = "sha256-bZYBRdmbQVs4i6UzMIHwJnoLWggX4CW8ZogNFYiX/9w=";
+  };
 
-  sha256 = "sha256-K2uOpJRmQ1NcDZfh6rorCF0MvGHFCsSW8J7Ue9OC/OY=";
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/mononoki
+    cp webfont/* $out/share/fonts/mononoki
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/madmalik/mononoki";
@@ -16,9 +25,4 @@ in (fetchzip {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/mononoki
-    unzip -j $downloadedFile -d $out/share/fonts/mononoki
-  '';
-})
+}

--- a/pkgs/data/fonts/nanum-gothic-coding/default.nix
+++ b/pkgs/data/fonts/nanum-gothic-coding/default.nix
@@ -1,15 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
-  version = "VER2.5";
-  fullName = "NanumGothicCoding-2.5";
+stdenvNoCC.mkDerivation rec {
+  pname = "nanum-gothic-coding";
+  version = "2.5";
 
-in (fetchzip {
-  name = "nanum-gothic-coding";
-  url = "https://github.com/naver/nanumfont/releases/download/${version}/${fullName}.zip";
+  src = fetchzip {
+    url = "https://github.com/naver/nanumfont/releases/download/VER${version}/NanumGothicCoding-${version}.zip";
+    stripRoot = false;
+    hash = "sha256-jHbbCMUxn54iQMKdAWI3r8CDxi+5LLJh8ucQzq2Ukdc=";
+  };
 
-  sha256 = "0b3pkhd6xn6393zi0dhj3ah08w1y1ji9fl6584bi0c8lanamf2pc";
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/NanumGothicCoding
+    cp *.ttf $out/share/fonts/NanumGothicCoding
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A contemporary monospaced sans-serif typeface with a warm touch";
@@ -18,9 +26,4 @@ in (fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/NanumGothicCoding
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/NanumGothicCoding
-  '';
-})
+}

--- a/pkgs/data/fonts/national-park/default.nix
+++ b/pkgs/data/fonts/national-park/default.nix
@@ -1,14 +1,22 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "national-park-typeface";
   version = "206464";
-in (fetchzip {
-  name = "${pname}-${version}";
-  url = "https://files.cargocollective.com/c${version}/NationalPark.zip";
 
-  sha256 = "044gh4xcasp8i9ny6z4nmns1am2pk5krc4ann2afq35v9bnl2q5d";
+  src = fetchzip {
+    url = "https://files.cargocollective.com/c${version}/NationalPark.zip";
+    stripRoot = false;
+    hash = "sha256-VUboZZVJfKupnoHXo3RxetEEYimrr1DxghVZaaWnnw4=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.otf -t $out/share/fonts/opentype/
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = ''Typeface designed to mimic the national park service
@@ -17,9 +25,4 @@ in (fetchzip {
     license = licenses.ofl;
     maintainers = with maintainers; [ dtzWill ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile National\*.otf -d $out/share/fonts/opentype/
-  '';
-})
+}

--- a/pkgs/data/fonts/norwester/default.nix
+++ b/pkgs/data/fonts/norwester/default.nix
@@ -1,15 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
-  version = "1.2";
+stdenvNoCC.mkDerivation rec {
   pname = "norwester";
-in (fetchzip {
-  name = "${pname}-${version}";
+  version = "1.2";
 
-  url = "http://jamiewilson.io/norwester/assets/norwester.zip";
+  src = fetchzip {
+    url = "http://jamiewilson.io/norwester/assets/norwester.zip";
+    stripRoot = false;
+    hash = "sha256-Ak/nobrQE/XYGWs/IhlZlTp74ff+s4adUR6Sht5Yf8g=";
+  };
 
-  sha256 = "1npsaiiz9g5z6315lnmynwcnrfl37fyxc7w1mhkw1xbzcnv74z4r";
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/opentype
+    cp ${pname}-v${version}/${pname}.otf $out/share/fonts/opentype/
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "http://jamiewilson.io/norwester";
@@ -18,9 +26,4 @@ in (fetchzip {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -D -j $downloadedFile ${pname}-v${version}/${pname}.otf -d $out/share/fonts/opentype/
-  '';
-})
+}

--- a/pkgs/data/fonts/oldstandard/default.nix
+++ b/pkgs/data/fonts/oldstandard/default.nix
@@ -1,15 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "oldstandard";
   version = "2.2";
-  name = "oldstandard-${version}";
-in (fetchzip rec {
-  inherit name;
 
-  url = "https://github.com/akryukov/oldstand/releases/download/v${version}/${name}.otf.zip";
+  src = fetchzip {
+    url = "https://github.com/akryukov/oldstand/releases/download/v${version}/${pname}-${version}.otf.zip";
+    stripRoot = false;
+    hash = "sha256-cDB5KJm87DK+GczZ3Nmn4l5ejqViswVbwrJ9XbhEh8I=";
+  };
 
-  sha256 = "1qwfsyp51grr56jcnkkmnrnl3r20pmhp9zh9g88kp64m026cah6n";
+  installPhase = ''
+    runHook preInstall
+
+    install -m444 -Dt $out/share/fonts/opentype *.otf
+    install -m444 -Dt $out/share/doc/${pname}-${version}    FONTLOG.txt
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/akryukov/oldstand";
@@ -18,10 +26,4 @@ in (fetchzip rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    unzip $downloadedFile
-    install -m444 -Dt $out/share/fonts/opentype *.otf
-    install -m444 -Dt $out/share/doc/${name}    FONTLOG.txt
-  '';
-})
+}

--- a/pkgs/data/fonts/open-dyslexic/default.nix
+++ b/pkgs/data/fonts/open-dyslexic/default.nix
@@ -1,26 +1,28 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation {
+  pname = "open-dyslexic";
   version = "2016-06-23";
-in (fetchzip {
-  name = "open-dyslexic-${version}";
 
-  url = "https://github.com/antijingoist/open-dyslexic/archive/20160623-Stable.zip";
+  src = fetchzip {
+    url = "https://github.com/antijingoist/open-dyslexic/archive/20160623-Stable.zip";
+    hash = "sha256-f/uavR3n0qHyqumZDw7r8Zy0om2RlJAKyWuGaUXSJ1s=";
+  };
 
-  sha256 = "1vl8z5rknh2hpr2f0v4b2qgs5kclx5pzyk8al7243k5db82a2cyi";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 otf/*.otf -t $out/share/fonts/opentype
+    install -Dm644 README.md -t $out/share/doc/open-dyslexic
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://opendyslexic.org/";
     description = "Font created to increase readability for readers with dyslexia";
     license = "Bitstream Vera License (https://www.gnome.org/fonts/#Final_Bitstream_Vera_Fonts)";
     platforms = platforms.all;
-    maintainers = [maintainers.rycee];
+    maintainers = [ maintainers.rycee ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.otf       -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*/README.md -d $out/share/doc/open-dyslexic
-  '';
-})
+}

--- a/pkgs/data/fonts/overpass/default.nix
+++ b/pkgs/data/fonts/overpass/default.nix
@@ -1,15 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "overpass";
   version = "3.0.5";
-  name = "overpass-${version}";
-in (fetchzip rec {
-  inherit name;
 
-  url = "https://github.com/RedHatOfficial/Overpass/releases/download/v${version}/overpass-${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/RedHatOfficial/Overpass/releases/download/v${version}/overpass-${version}.zip";
+    hash = "sha256-8AWT0/DELfNWXtZOejC90DbUSOtyGt9tSkcSuO7HP2o=";
+  };
 
-  sha256 = "1fpyhd6x3i3g0xxjmyfnjsri1kkvci15fv7jp1bnza7k0hz0bnha";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 */*/*.otf -t $out/share/fonts/opentype
+    install -Dm644 */*/*.ttf -t $out/share/fonts/truetype
+    install -Dm644 *.md  -t $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://overpassfont.org/";
@@ -18,11 +26,4 @@ in (fetchzip rec {
     platforms = platforms.all;
     maintainers = [ maintainers.rycee ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts $out/share/doc
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.md  -d $out/share/doc/${name}
-  '';
-})
+}

--- a/pkgs/data/fonts/paratype-pt/mono.nix
+++ b/pkgs/data/fonts/paratype-pt/mono.nix
@@ -1,15 +1,26 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-(fetchzip {
-  name = "paratype-pt-mono";
+stdenvNoCC.mkDerivation rec {
+  pname = "paratype-pt-mono";
+  version = "2.005";
 
-  urls = [
-    "https://company.paratype.com/system/attachments/631/original/ptmono.zip"
-    "http://rus.paratype.ru/system/attachments/631/original/ptmono.zip"
-  ];
+  src = fetchzip {
+    urls = [
+      "https://company.paratype.com/system/attachments/631/original/ptmono.zip"
+      "http://rus.paratype.ru/system/attachments/631/original/ptmono.zip"
+    ];
+    stripRoot = false;
+    hash = "sha256-mfDAu/KGelC6wZpUCrUrLVZKo+XiKNBqcpMI8tH2tMw=";
+  };
 
-  sha256 = "07kl82ngby55khvzsvn831ddpc0q8djgz2y6gsjixkyjfdk2xjjm";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 *.txt -t $out/share/doc/paratype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "http://www.paratype.ru/public/";
@@ -23,10 +34,4 @@
     platforms = platforms.all;
     maintainers = with maintainers; [ raskin ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.txt -d $out/share/doc/paratype
-  '';
-})
+}

--- a/pkgs/data/fonts/paratype-pt/sans.nix
+++ b/pkgs/data/fonts/paratype-pt/sans.nix
@@ -1,15 +1,26 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-(fetchzip {
-  name = "paratype-pt-sans";
+stdenvNoCC.mkDerivation rec {
+  pname = "paratype-pt-sans";
+  version = "2.005";
 
-  urls = [
-    "https://company.paratype.com/system/attachments/629/original/ptsans.zip"
-    "http://rus.paratype.ru/system/attachments/629/original/ptsans.zip"
-  ];
+  src = fetchzip {
+    urls = [
+      "https://company.paratype.com/system/attachments/629/original/ptsans.zip"
+      "http://rus.paratype.ru/system/attachments/629/original/ptsans.zip"
+    ];
+    stripRoot = false;
+    hash = "sha256-34TqYXtWzkAstaGQBhJy+/hVk5tg6ZvHZ/kvUroWVLs=";
+  };
 
-  sha256 = "01fkd417gv98jf3a6zyfi9w2dkqsbddy1vacga2672yf0kh1z1r0";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 *.txt -t $out/share/doc/paratype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "http://www.paratype.ru/public/";
@@ -23,10 +34,4 @@
     platforms = platforms.all;
     maintainers = with maintainers; [ raskin ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.txt -d $out/share/doc/paratype
-  '';
-})
+}

--- a/pkgs/data/fonts/paratype-pt/serif.nix
+++ b/pkgs/data/fonts/paratype-pt/serif.nix
@@ -1,15 +1,26 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-(fetchzip {
-  name = "paratype-pt-serif";
+stdenvNoCC.mkDerivation rec {
+  pname = "paratype-pt-serif";
+  version = "2.005";
 
-  urls = [
-    "https://company.paratype.com/system/attachments/634/original/ptserif.zip"
-    "http://rus.paratype.ru/system/attachments/634/original/ptserif.zip"
-  ];
+  src = fetchzip {
+    urls = [
+      "https://company.paratype.com/system/attachments/634/original/ptserif.zip"
+      "http://rus.paratype.ru/system/attachments/634/original/ptserif.zip"
+    ];
+    stripRoot = false;
+    hash = "sha256-4L3t5NEHmj975fn8eBAkRUO1OL0xseNp9g7k7tt/O2c=";
+  };
 
-  sha256 = "1iw5qi4ag3yp1lwmi91lb18gr768bqwl46xskaqnkhr9i9qp0v6d";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 *.txt -t $out/share/doc/paratype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "http://www.paratype.ru/public/";
@@ -23,10 +34,4 @@
     platforms = platforms.all;
     maintainers = with maintainers; [ raskin ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.txt -d $out/share/doc/paratype
-  '';
-})
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
