### PR TITLE
treewide: convert 17 fonts to stdenvNoCC.mkDerivation

### DIFF
--- a/pkgs/data/fonts/public-sans/default.nix
+++ b/pkgs/data/fonts/public-sans/default.nix
@@ -1,14 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "public-sans";
   version = "2.001";
-in (fetchzip {
-  name = "public-sans-${version}";
 
-  url = "https://github.com/uswds/public-sans/releases/download/v${version}/public-sans-v${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/uswds/public-sans/releases/download/v${version}/public-sans-v${version}.zip";
+    stripRoot = false;
+    hash = "sha256-XFs/UMXI/kdrW+53t8Mj26+Rn5p+LQ6KW2K2/ShoIag=";
+  };
 
-  sha256 = "sha256-Ba7D4J72GZQsGn0KINRib9BmHsAnoEsAwAOC+M3CkMU=";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 */*/*.otf -t $out/share/fonts/opentype
+    install -Dm644 */*/*.ttf -t $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A strong, neutral, principles-driven, open source typeface for text or display";
@@ -18,10 +27,4 @@ in (fetchzip {
     maintainers = with maintainers; [ dtzWill ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
-})
+}

--- a/pkgs/data/fonts/quattrocento-sans/default.nix
+++ b/pkgs/data/fonts/quattrocento-sans/default.nix
@@ -1,27 +1,29 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "quattrocento-sans";
   version = "2.0";
-  name = "quattrocento-sans-${version}";
-in (fetchzip rec {
-  inherit name;
 
-  url = "https://web.archive.org/web/20170709124317/http://www.impallari.com/media/releases/quattrocento-sans-v${version}.zip";
+  src = fetchzip {
+    url = "https://web.archive.org/web/20170709124317/http://www.impallari.com/media/releases/quattrocento-sans-v${version}.zip";
+    stripRoot = false;
+    hash = "sha256-L3aFZmaA94B9APxsp8bSBpocIlK3Ehvj/RFXVcW2nso=";
+  };
 
-  sha256 = "0g8hnn92ks4y0jbizwj7yfa097lk887wqkqpqjdmc09sd2n44343";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 */*/QuattrocentoSans*.otf -t $out/share/fonts/opentype
+    install -Dm644 */FONTLOG.txt             -t $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "http://www.impallari.com/quattrocentosans/";
     description = "A classic, elegant and sober sans-serif typeface";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = [maintainers.rycee];
+    maintainers = [ maintainers.rycee ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/{fonts,doc}
-    unzip -j $downloadedFile '*/QuattrocentoSans*.otf' -d $out/share/fonts/opentype
-    unzip -j $downloadedFile '*/FONTLOG.txt'           -d $out/share/doc/${name}
-  '';
-})
+}

--- a/pkgs/data/fonts/quattrocento/default.nix
+++ b/pkgs/data/fonts/quattrocento/default.nix
@@ -1,27 +1,28 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "quattrocento";
   version = "1.1";
-  name = "quattrocento-${version}";
-in (fetchzip rec {
-  inherit name;
 
-  url = "https://web.archive.org/web/20170707001804/http://www.impallari.com/media/releases/quattrocento-v${version}.zip";
+  src = fetchzip {
+    url = "https://web.archive.org/web/20170707001804/http://www.impallari.com/media/releases/quattrocento-v${version}.zip";
+    hash = "sha256-ntY6Wl6TI8F7SShMyD8mdOxVg4oz9kvJ7vKTyGdPLtE=";
+  };
 
-  sha256 = "0f8l19y61y20sszn8ni8h9kgl0zy1gyzychg22z5k93ip4h7kfd0";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 */*.otf     -t $out/share/fonts/opentype
+    install -Dm644 FONTLOG.txt -t $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "http://www.impallari.com/quattrocento/";
     description = "A classic, elegant, sober and strong serif typeface";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = [maintainers.rycee];
+    maintainers = [ maintainers.rycee ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/{fonts,doc}
-    unzip -j $downloadedFile \*.otf        -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*FONTLOG.txt -d $out/share/doc/${name}
-  '';
-})
+}

--- a/pkgs/data/fonts/roboto/default.nix
+++ b/pkgs/data/fonts/roboto/default.nix
@@ -1,14 +1,22 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "roboto";
   version = "2.138";
-in (fetchzip {
-  name = "roboto-${version}";
 
-  url = "https://github.com/google/roboto/releases/download/v${version}/roboto-unhinted.zip";
+  src = fetchzip {
+    url = "https://github.com/google/roboto/releases/download/v${version}/roboto-unhinted.zip";
+    stripRoot = false;
+    hash = "sha256-ue3PUZinBpcYgSho1Zrw1KHl7gc/GlN1GhWFk6g5QXE=";
+  };
 
-  sha256 = "1s3c48wwvvwd3p4w3hfkri5v2c54j2bdxmd3bjv54klc5mrlh6z3";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
 
   meta = {
     homepage = "https://github.com/google/roboto";
@@ -22,9 +30,4 @@ in (fetchzip {
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.romildo ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.ttf -x __MACOSX/\* -d $out/share/fonts/truetype
-  '';
-})
+}

--- a/pkgs/data/fonts/stix-two/default.nix
+++ b/pkgs/data/fonts/stix-two/default.nix
@@ -1,14 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
-let
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "stix-two";
   version = "2.13";
-in
-(fetchzip {
-  name = "stix-two-${version}";
 
-  url = "https://github.com/stipub/stixfonts/raw/v${version}/zipfiles/STIX${builtins.replaceStrings [ "." ] [ "_" ] version}-all.zip";
+  src = fetchzip {
+    url = "https://github.com/stipub/stixfonts/raw/v${version}/zipfiles/STIX${builtins.replaceStrings [ "." ] [ "_" ] version}-all.zip";
+    stripRoot = false;
+    hash = "sha256-hfQmrw7HjlhQSA0rVTs84i3j3iMVR0k7tCRBcB6hEpU=";
+  };
 
-  sha256 = "sha256-cBtZe/oq4bQCscSAhJ4YuTSghDleD9O/+3MHOJyI50o=";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 */*.otf -t $out/share/fonts/opentype
+    install -Dm644 */*.ttf -t $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://www.stixfonts.org/";
@@ -17,10 +26,4 @@ in
     platforms = platforms.all;
     maintainers = [ maintainers.rycee ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
-})
+}

--- a/pkgs/data/fonts/sudo/default.nix
+++ b/pkgs/data/fonts/sudo/default.nix
@@ -1,12 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "sudo-font";
   version = "0.64";
-in (fetchzip {
-  name = "sudo-font-${version}";
-  url = "https://github.com/jenskutilek/sudo-font/releases/download/v${version}/sudo.zip";
-  sha256 = "sha256-ewLTeIVY76eq5mHTnjIsJ5Q2CMuBqXJzxvjZTONPsr8=";
+
+  src = fetchzip {
+    url = "https://github.com/jenskutilek/sudo-font/releases/download/v${version}/sudo.zip";
+    hash = "sha256-Y99YPoNpe55Wrj5epiqqQ6ddUBTj9uI4oj4M5ARTzJo=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype/
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Font for programmers and command line users";
@@ -16,9 +25,4 @@ in (fetchzip {
     maintainers = with maintainers; [ dtzWill ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/
-  '';
-})
+}

--- a/pkgs/data/fonts/terminus-font-ttf/default.nix
+++ b/pkgs/data/fonts/terminus-font-ttf/default.nix
@@ -1,14 +1,26 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "terminus-font-ttf";
   version = "4.49.1";
-in (fetchzip {
-  name = "terminus-font-ttf-${version}";
 
-  url = "https://files.ax86.net/terminus-ttf/files/${version}/terminus-ttf-${version}.zip";
+  src = fetchzip {
+    url = "https://files.ax86.net/terminus-ttf/files/${version}/terminus-ttf-${version}.zip";
+    hash = "sha256-NKswkZR05V21mszT56S2x85k//qhfzRShhepYaAybDc=";
+  };
 
-  sha256 = "sha256-UaTnCamIRN/3xZsYt5nYzvykXQ3ri94a047sWOJ2RfU=";
+  installPhase = ''
+    runHook preInstall
+
+    for i in *.ttf; do
+      local destname="$(echo "$i" | sed -E 's|-[[:digit:].]+\.ttf$|.ttf|')"
+      install -Dm 644 "$i" "$out/share/fonts/truetype/$destname"
+    done
+
+    install -Dm 644 COPYING "$out/share/doc/terminus-font-ttf/COPYING"
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A clean fixed width TTF font";
@@ -20,15 +32,4 @@ in (fetchzip {
     license = licenses.ofl;
     maintainers = with maintainers; [ ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    unzip -j $downloadedFile
-
-    for i in *.ttf; do
-      local destname="$(echo "$i" | sed -E 's|-[[:digit:].]+\.ttf$|.ttf|')"
-      install -Dm 644 "$i" "$out/share/fonts/truetype/$destname"
-    done
-
-    install -Dm 644 COPYING "$out/share/doc/terminus-font-ttf/COPYING"
-  '';
-})
+}

--- a/pkgs/data/fonts/theano/default.nix
+++ b/pkgs/data/fonts/theano/default.nix
@@ -1,15 +1,25 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "theano";
   version = "2.0";
-  name = "theano-${version}";
-in (fetchzip rec {
-  inherit name;
 
-  url = "https://github.com/akryukov/theano/releases/download/v${version}/theano-${version}.otf.zip";
+  src = fetchzip {
+    url = "https://github.com/akryukov/theano/releases/download/v${version}/theano-${version}.otf.zip";
+    stripRoot = false;
+    hash = "sha256-9wnwHcRHB+AToOvGwZSXvHkQ8hqMd7Sdl26Ty/IwbPw=";
+  };
 
-  sha256 = "1my1symb7k80ys33iphsxvmf6432wx6vjdnxhzhkgrang1rhx1h8";
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/opentype
+    mkdir -p $out/share/doc/${pname}-${version}
+    cp *.otf $out/share/fonts/opentype
+    cp *.txt $out/share/doc/${pname}-${version}
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/akryukov/theano";
@@ -18,11 +28,4 @@ in (fetchzip rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    mkdir -p $out/share/doc/${name}
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.txt -d "$out/share/doc/${name}"
-  '';
-})
+}

--- a/pkgs/data/fonts/times-newer-roman/default.nix
+++ b/pkgs/data/fonts/times-newer-roman/default.nix
@@ -1,15 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation {
+  pname = "times-newer-roman";
   version = "unstable-2018-09-11";
-in
-(fetchzip {
-  name = "times-newer-roman-${version}";
 
-  url = "https://web.archive.org/web/20210609022835/https://timesnewerroman.com/assets/TimesNewerRoman.zip";
+  src = fetchzip {
+    url = "https://web.archive.org/web/20210609022835/https://timesnewerroman.com/assets/TimesNewerRoman.zip";
+    stripRoot = false;
+    hash = "sha256-wO4rxyJNQyhRLpswCYKXdeiXy5G+iWyxulYCHZb60QM=";
+  };
 
-  hash = "sha256-Hx59RYLLwfimEQjEEes0lCpg6iql46DFwhQ7kVGiEzc=";
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/opentype
+    cp *.otf $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A font that looks just like Times New Roman, except each character is 5-10% wider";
@@ -18,9 +26,4 @@ in
     maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
-})
+}

--- a/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
+++ b/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
@@ -1,13 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "ultimate-oldschool-pc-font-pack";
   version = "2.2";
-in
-(fetchzip {
-  name = "ultimate-oldschool-pc-font-pack-${version}";
-  url = "https://int10h.org/oldschool-pc-fonts/download/oldschool_pc_font_pack_v${version}_linux.zip";
-  sha256 = "sha256-BOA2fMa2KT3Bkpvj/0DzrzuZbl3RARvNn4qbI/+dApU=";
+
+  src = fetchzip {
+    url = "https://int10h.org/oldschool-pc-fonts/download/oldschool_pc_font_pack_v${version}_linux.zip";
+    stripRoot = false;
+    hash = "sha256-54U8tZzvivTSOgmGesj9QbIgkSTm9w4quMhsuEc0Xy4=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    cp */*.ttf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "The Ultimate Oldschool PC Font Pack (TTF Fonts)";
@@ -16,9 +26,4 @@ in
     license = licenses.cc-by-sa-40;
     maintainers = [ maintainers.endgame ];
   };
-}).overrideAttrs (_: {
-  postFetch= ''
-    mkdir -p $out/share/fonts/truetype
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
-  '';
-})
+}

--- a/pkgs/data/fonts/undefined-medium/default.nix
+++ b/pkgs/data/fonts/undefined-medium/default.nix
@@ -1,12 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
-let name = "undefined-medium-1.0";
-in (fetchzip rec {
-  inherit name;
+{ lib, stdenvNoCC, fetchzip }:
 
-  url = "https://github.com/andirueckel/undefined-medium/archive/v1.0.zip";
+stdenvNoCC.mkDerivation rec {
+  pname = "undefined-medium";
+  version = "1.0";
 
-  sha256 = "1wa04jzbffshwcxm705yb5wja8wakn8j7fvim1mlih2z1sqw0njk";
+  src = fetchzip {
+    url = "https://github.com/andirueckel/undefined-medium/archive/v1.0.zip";
+    hash = "sha256-HG+V7jR7dDI6LeoiCg/8F38lW8Zdo6CyLj2DXy/ff64=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 fonts/otf/*.otf -t $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://undefined-medium.com/";
@@ -19,9 +28,4 @@ in (fetchzip rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile ${name}/fonts/otf/\*.otf -d $out/share/fonts/opentype
-  '';
-})
+}

--- a/pkgs/data/fonts/vollkorn/default.nix
+++ b/pkgs/data/fonts/vollkorn/default.nix
@@ -1,14 +1,27 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, stdenv, fetchzip }:
-let
+{ lib, stdenvNoCC, fetchzip }:
+
+stdenvNoCC.mkDerivation rec {
   pname = "vollkorn";
   version = "4.105";
-in
-(fetchzip {
-  name = "${pname}-${version}";
-  url = "http://vollkorn-typeface.com/download/vollkorn-${builtins.replaceStrings ["."] ["-"] version}.zip";
-  sha256 = "0srff2nqs7353mqcpmvaq156lamfh621py4h1771n0l9ix2c8mss";
-  stripRoot = false;
+
+  src = fetchzip {
+    url = "http://vollkorn-typeface.com/download/vollkorn-${builtins.replaceStrings ["."] ["-"] version}.zip";
+    stripRoot = false;
+    hash = "sha256-oG79GgCwCavbMFAPakza08IPmt13Gwujrkc/NKTai7g=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -pv $out/share/{doc/${pname}-${version},fonts/{opentype,truetype,WOFF,WOFF2}}
+    cp -v {Fontlog,OFL-FAQ,OFL}.txt $out/share/doc/${pname}-${version}/
+    cp -v PS-OTF/*.otf $out/share/fonts/opentype
+    cp -v TTF/*.ttf $out/share/fonts/truetype
+    cp -v WOFF/*.woff $out/share/fonts/WOFF
+    cp -v WOFF2/*.woff2 $out/share/fonts/WOFF2
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "http://vollkorn-typeface.com/";
@@ -17,14 +30,4 @@ in
     platforms = platforms.all;
     maintainers = [ maintainers.schmittlauch ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -pv $out/share/{doc/${pname}-${version},fonts/{opentype,truetype,WOFF,WOFF2}}
-    unzip $downloadedFile
-    cp -v {Fontlog,OFL-FAQ,OFL}.txt $out/share/doc/${pname}-${version}/
-    cp -v PS-OTF/*.otf $out/share/fonts/opentype
-    cp -v TTF/*.ttf $out/share/fonts/truetype
-    cp -v WOFF/*.woff $out/share/fonts/WOFF
-    cp -v WOFF2/*.woff2 $out/share/fonts/WOFF2
-  '';
-})
+}

--- a/pkgs/data/fonts/weather-icons/default.nix
+++ b/pkgs/data/fonts/weather-icons/default.nix
@@ -1,13 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "weather-icons";
   version = "2.0.12";
-in (fetchzip {
-  name = "weather-icons-${version}";
 
-  url = "https://github.com/erikflowers/weather-icons/archive/refs/tags/${version}.zip";
-  sha256 = "sha256-NGPzAloeZa1nCazb+mjAbYw7ZYYDoKpLwcvzg1Ly9oM=";
+  src = fetchzip {
+    url = "https://github.com/erikflowers/weather-icons/archive/refs/tags/${version}.zip";
+    hash = "sha256-0ZFH2awUo4BkTpK1OsWZ4YKczJHo+HHM6ezGBJAmT+U=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 _docs/font-source/weathericons-regular.otf -t $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Weather Icons";
@@ -21,9 +29,4 @@ in (fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ pnelson ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile weather-icons-${version}/_docs/font-source/weathericons-regular.otf -d $out/share/fonts/opentype
-  '';
-})
+}

--- a/pkgs/data/fonts/work-sans/default.nix
+++ b/pkgs/data/fonts/work-sans/default.nix
@@ -1,15 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "work-sans";
   version = "2.010";
-in
-(fetchzip {
-  name = "work-sans-${version}";
 
-  url = "https://github.com/weiweihuanghuang/Work-Sans/archive/refs/tags/v${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/weiweihuanghuang/Work-Sans/archive/refs/tags/v${version}.zip";
+    hash = "sha256-cedcx3CpcPZk3jxxIs5Bz78dxZNtOemvXnUBO6zl2dw=";
+  };
 
-  sha256 = "sha256-S4O5EoKY4w/p+MHeHRCmPyQRAOUfEwNiETxMgNcsrws=";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 fonts/variable/*.ttf fonts/static/TTF/*.ttf -t $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A grotesque sans";
@@ -18,9 +24,4 @@ in
     maintainers = [ maintainers.marsam ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile "*/fonts/*.ttf" -d $out/share/fonts/opentype
-  '';
-})
+}

--- a/pkgs/data/fonts/yanone-kaffeesatz/default.nix
+++ b/pkgs/data/fonts/yanone-kaffeesatz/default.nix
@@ -1,12 +1,22 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-(fetchzip {
-  name = "yanone-kaffeesatz-2004";
+stdenvNoCC.mkDerivation rec {
+  pname = "yanone-kaffeesatz";
+  version = "2004";
 
-  url = "https://yanone.de/2015/data/UIdownloads/Yanone%20Kaffeesatz.zip";
+  src = fetchzip {
+    url = "https://yanone.de/2015/data/UIdownloads/Yanone%20Kaffeesatz.zip";
+    stripRoot = false;
+    hash = "sha256-8yAB73UJ77/c8/VLqiFeT1KtoBQzOh+vWrI+JA2dCoY=";
+  };
 
-  sha256 = "190c4wx7avy3kp98lsyml7kc0jw7csf5n79af2ypbkhsadfsy8di";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.otf -t $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = {
     description = "The free font classic";
@@ -15,9 +25,4 @@
     homepage = "https://yanone.de/fonts/kaffeesatz/";
     license = lib.licenses.ofl;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
-})
+}

--- a/pkgs/data/fonts/zilla-slab/default.nix
+++ b/pkgs/data/fonts/zilla-slab/default.nix
@@ -1,13 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "zilla-slab";
   version = "1.002";
-in (fetchzip {
-  name = "zilla-slab-${version}";
 
-  url = "https://github.com/mozilla/zilla-slab/releases/download/v${version}/Zilla-Slab-Fonts-v${version}.zip";
-  sha256 = "1b1ys28hyjcl4qwbnsyi6527nj01g3d6id9jl23fv6f8fjm4ph0f";
+  src = fetchzip {
+    url = "https://github.com/mozilla/zilla-slab/releases/download/v${version}/Zilla-Slab-Fonts-v${version}.zip";
+    stripRoot = false;
+    hash = "sha256-yOHu+dSWlyI7w1N1teED9R1Fphso2bKAlYDC1KdqBCc=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    cp -v zilla-slab/ttf/*.ttf $out/share/fonts/truetype/
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/mozilla/zilla-slab";
@@ -26,10 +36,4 @@ in (fetchzip {
     maintainers = with maintainers; [ caugner ];
     platforms = platforms.all;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    unzip $downloadedFile
-    mkdir -p $out/share/fonts/truetype
-    cp -v zilla-slab/ttf/*.ttf $out/share/fonts/truetype/
-  '';
-})
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
