### PR TITLE
pythonPackages.notify-py: 0.3.39 -> 0.3.42

### DIFF
--- a/pkgs/development/python-modules/loguru/default.nix
+++ b/pkgs/development/python-modules/loguru/default.nix
@@ -4,30 +4,28 @@
 , buildPythonPackage
 , colorama
 , fetchpatch
-, fetchPypi
+, fetchFromGitHub
+, freezegun
+, mypy
 , pytestCheckHook
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "loguru";
-  version = "0.6.0";
+  # No release since Jan 2022, only master is compatible with Python 3.11
+  # https://github.com/Delgan/loguru/issues/740
+  version = "unstable-2023-01-20";
   format = "setuptools";
 
   disabled = pythonOlder "3.5";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-BmvQZ1jQpRPpg2/ZxrWnW/s/02hB9LmWvGC1R6MJ1Bw=";
+  src = fetchFromGitHub {
+    owner = "Delgan";
+    repo = pname;
+    rev = "07f94f3c8373733119f85aa8b9ca05ace3325a4b";
+    hash = "sha256-lMGyQbBX3z6186ojs/iew7JMrG91ivPA679T9r+7xYw=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-test-repr-infinite-recursion.patch";
-      url = "https://github.com/Delgan/loguru/commit/4fe21f66991abeb1905e24c3bc3c634543d959a2.patch";
-      hash = "sha256-NUOkgUS28TOazO0txMinFtaKwsi/J1Y7kqjjvMRCnR8=";
-    })
-  ];
 
   propagatedBuildInputs = lib.optionals (pythonOlder "3.7") [
     aiocontextvars
@@ -36,19 +34,15 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     colorama
+    freezegun
+    mypy
   ];
 
   disabledTestPaths = lib.optionals stdenv.isDarwin [
     "tests/test_multiprocessing.py"
   ];
 
-  disabledTests = [
-    "test_time_rotation_reopening"
-    "test_file_buffering"
-    # Tests are failing with Python 3.10
-    "test_exception_others"
-    ""
-  ] ++ lib.optionals stdenv.isDarwin [
+  disabledTests = lib.optionals stdenv.isDarwin [
     "test_rotation_and_retention"
     "test_rotation_and_retention_timed_file"
     "test_renaming"

--- a/pkgs/development/python-modules/notify-py/default.nix
+++ b/pkgs/development/python-modules/notify-py/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "notify-py";
-  version = "0.3.39";
+  version = "0.3.42";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "ms7m";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-QIK5MCCOsD8SStoh7TRw+l9k28SjChwV2J/T7gMKnAs=";
+    hash = "sha256-XtjJImH9UwPPZS/Yqs8S5xGXOLBRmJRawzxWXoPWvrM=";
   };
 
   patches = lib.optionals stdenv.isLinux [


### PR DESCRIPTION
###### Description of changes

Updates `loguru` to current master since there hasn't been a release in a long time, but they have fixed Python 3.11 on master. This in turn fixes a number of dependent builds, such as `notify-py`.

https://github.com/Delgan/loguru/compare/0.6.0...master
https://github.com/ms7m/notify-py/compare/refs/tags/v0.3.39...v0.3.41

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).