### PR TITLE
treewide: convert 9 fonts to stdenvNoCC.mkDerivation

### DIFF
--- a/pkgs/data/fonts/source-code-pro/default.nix
+++ b/pkgs/data/fonts/source-code-pro/default.nix
@@ -1,14 +1,22 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "source-code-pro";
   version = "2.038";
-in (fetchzip {
-  name = "source-code-pro-${version}";
 
-  url = "https://github.com/adobe-fonts/source-code-pro/releases/download/${version}R-ro%2F1.058R-it%2F1.018R-VAR/OTF-source-code-pro-${version}R-ro-1.058R-it.zip";
+  src = fetchzip {
+    url = "https://github.com/adobe-fonts/source-code-pro/releases/download/${version}R-ro%2F1.058R-it%2F1.018R-VAR/OTF-source-code-pro-${version}R-ro-1.058R-it.zip";
+    stripRoot = false;
+    hash = "sha256-ijeTLka131jf6B9xj/eNWK1T5r7r3aBXBgnVyRAxmuY=";
+  };
 
-  sha256 = "027cf62zj27q7l3d4sqzdfgz423lzysihdg8cvmkk6z910a1v368";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.otf -t $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = {
     description = "Monospaced font family for user interface and coding environments";
@@ -17,9 +25,4 @@ in (fetchzip {
     homepage = "https://adobe-fonts.github.io/source-code-pro/";
     license = lib.licenses.ofl;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
-})
+}

--- a/pkgs/data/fonts/source-han-code-jp/default.nix
+++ b/pkgs/data/fonts/source-han-code-jp/default.nix
@@ -1,15 +1,21 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "source-han-code-jp";
-  version = "2.012R";
-in (fetchzip {
-  name = "${pname}-${version}";
+  version = "2.012";
 
-  url = "https://github.com/adobe-fonts/${pname}/archive/${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/adobe-fonts/${pname}/archive/${version}R.zip";
+    hash = "sha256-ljO/1/CaE9Yj+AN5xxlIr30/nV/axGQPO0fGACAZGCQ=";
+  };
 
-  sha256 = "16y5as1k864ghy3vzp8svr3q0sw57rv53za3f48700ksvxz5pwry";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 OTF/*.otf -t $out/share/fonts/opentype
+
+    runHook postInstall
+  '';
 
   meta = {
     description = "A monospaced Latin font suitable for coding";
@@ -18,9 +24,4 @@ in (fetchzip {
     homepage = "https://blogs.adobe.com/CCJKType/2015/06/source-han-code-jp.html";
     license = lib.licenses.ofl;
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
-  '';
-})
+}

--- a/pkgs/data/fonts/source-sans-pro/default.nix
+++ b/pkgs/data/fonts/source-sans-pro/default.nix
@@ -1,18 +1,28 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
 # Source Sans Pro got renamed to Source Sans 3 (see
 # https://github.com/adobe-fonts/source-sans/issues/192). This is the
 # last version named "Pro". It is useful for backward compatibility
 # with older documents/templates/etc.
-let
-  version = "3.006";
-in (fetchzip {
+
+stdenvNoCC.mkDerivation rec {
   name = "source-sans-pro-${version}";
+  version = "3.006";
 
-  url = "https://github.com/adobe-fonts/source-sans/archive/${version}R.zip";
+  src = fetchzip {
+    url = "https://github.com/adobe-fonts/source-sans/archive/${version}R.zip";
+    hash = "sha256-1Savijgq3INuUN89MR0t748HOuGseXVw5Kd4hYwuVas=";
+  };
 
-  sha256 = "sha256-uWr/dFyLF65v0o6+oN/3RQoe4ziPspzGB1rgiBkoTYY=";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 OTF/*.otf -t $out/share/fonts/opentype
+    install -Dm444 TTF/*.ttf -t $out/share/fonts/truetype
+    install -Dm444 VAR/*.otf -t $out/share/fonts/variable
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://adobe-fonts.github.io/source-sans/";
@@ -21,11 +31,4 @@ in (fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ ttuegel ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/{opentype,truetype,variable}
-    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
-    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
-    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
-  '';
-})
+}

--- a/pkgs/data/fonts/source-sans/default.nix
+++ b/pkgs/data/fonts/source-sans/default.nix
@@ -1,14 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "source-sans";
   version = "3.046";
-in (fetchzip {
-  name = "source-sans-${version}";
 
-  url = "https://github.com/adobe-fonts/source-sans/archive/${version}R.zip";
+  src = fetchzip {
+    url = "https://github.com/adobe-fonts/source-sans/archive/${version}R.zip";
+    hash = "sha256-nBLEK+T5n1CdZK2zvCWIhF2MxPmiAwL9l55a55yHtgU=";
+  };
 
-  sha256 = "1wxdinnliq0xqbjrs0sqykwaggkmyqawfq862d9xn05g1pnxda94";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 OTF/*.otf -t $out/share/fonts/opentype
+    install -Dm444 TTF/*.ttf -t $out/share/fonts/truetype
+    install -Dm444 VAR/*.otf -t $out/share/fonts/variable
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://adobe-fonts.github.io/source-sans/";
@@ -17,11 +26,4 @@ in (fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ ttuegel ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/{opentype,truetype,variable}
-    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
-    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
-    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
-  '';
-})
+}

--- a/pkgs/data/fonts/source-serif-pro/default.nix
+++ b/pkgs/data/fonts/source-serif-pro/default.nix
@@ -1,18 +1,28 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
 # Source Serif Pro got renamed to Source Serif 4 (see
 # https://github.com/adobe-fonts/source-serif/issues/77). This is the
 # last version named "Pro". It is useful for backward compatibility
 # with older documents/templates/etc.
-let
+
+stdenvNoCC.mkDerivation rec {
+  pname = "source-serif-pro";
   version = "3.001";
-in (fetchzip {
-  name = "source-serif-pro-${version}";
 
-  url = "https://github.com/adobe-fonts/source-serif/releases/download/${version}R/source-serif-pro-${version}R.zip";
+  src = fetchzip {
+    url = "https://github.com/adobe-fonts/source-serif/releases/download/${version}R/source-serif-pro-${version}R.zip";
+    hash = "sha256-chXoaPOACtQ7wz/etElXuIJH/yvUsP03WlxeCfqWF/w=";
+  };
 
-  sha256 = "sha256-rYWk8D41QMuuSP+cQMk8ttT7uX3a7gBk4OqjA7K9udk=";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 OTF/*.otf -t $out/share/fonts/opentype
+    install -Dm444 TTF/*.ttf -t $out/share/fonts/truetype
+    install -Dm444 VAR/*.otf -t $out/share/fonts/variable
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://adobe-fonts.github.io/source-serif/";
@@ -21,11 +31,4 @@ in (fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ ttuegel ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/{opentype,truetype,variable}
-    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
-    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
-    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
-  '';
-})
+}

--- a/pkgs/data/fonts/source-serif/default.nix
+++ b/pkgs/data/fonts/source-serif/default.nix
@@ -1,14 +1,23 @@
-# when changing this expression convert it from 'fetchzip' to 'stdenvNoCC.mkDerivation'
-{ lib, fetchzip }:
+{ lib, stdenvNoCC, fetchzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "source-serif";
   version = "4.004";
-in (fetchzip {
-  name = "source-serif-${version}";
 
-  url = "https://github.com/adobe-fonts/source-serif/releases/download/${version}R/source-serif-${version}.zip";
+  src = fetchzip {
+    url = "https://github.com/adobe-fonts/source-serif/releases/download/${version}R/source-serif-${version}.zip";
+    hash = "sha256-tGSMOwYBEZat7MI78wkPr6lgJdsOdOaIZb+IAOoOlq4=";
+  };
 
-  sha256 = "06814hcp20abca6p0ii61f23g6h1ibqyhq30lsva59wbwx5iha0h";
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 OTF/*.otf -t $out/share/fonts/opentype
+    install -Dm444 TTF/*.ttf -t $out/share/fonts/truetype
+    install -Dm444 VAR/*.otf -t $out/share/fonts/variable
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://adobe-fonts.github.io/source-serif/";
@@ -17,11 +26,4 @@ in (fetchzip {
     platforms = platforms.all;
     maintainers = with maintainers; [ ttuegel ];
   };
-}).overrideAttrs (_: {
-  postFetch = ''
-    mkdir -p $out/share/fonts/{opentype,truetype,variable}
-    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
-    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
-    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
-  '';
-})
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
