### PR TITLE
rhvoice: fix NIX_* environment propagations to scons

### DIFF
--- a/pkgs/applications/audio/rhvoice/honor_nix_environment.patch
+++ b/pkgs/applications/audio/rhvoice/honor_nix_environment.patch
@@ -1,5 +1,3 @@
-diff --git a/SConstruct b/SConstruct
-index 3ad4d9a..fb02365 100644
 --- a/SConstruct
 +++ b/SConstruct
 @@ -94,11 +94,8 @@ def CheckWiX(context):
@@ -16,13 +14,15 @@ index 3ad4d9a..fb02365 100644
  
  def validate_spd_version(key,val,env):
      m=re.match(r"^\d+\.\d+",val)
-@@ -208,9 +205,9 @@ def create_base_env(user_vars):
+@@ -207,10 +204,10 @@ def create_base_env(user_vars):
+     env_args["LIBS"]=[]
      env_args["package_name"]="RHVoice"
      env_args["CPPDEFINES"]=[("RHVOICE","1")]
-     env=Environment(**env_args)
+-    env=Environment(**env_args)
 -    if env["dev"]:
 -        env["prefix"]=os.path.abspath("local")
 -        env["RPATH"]=env.Dir("$libdir").abspath
++    env=Environment(ENV = os.environ, **env_args)
 +    env.PrependENVPath("PATH", os.environ["PATH"])
 +    env["ENV"]["PKG_CONFIG_PATH"]=os.environ["PKG_CONFIG_PATH"]
 +    env["RPATH"]=env.Dir("$libdir").abspath


### PR DESCRIPTION
scons build system does not work by default in nixpkgs envoironment as it filters system environment and throws away NIX_* flags:

    https://scons.org/doc/2.1.0/HTML/scons-user/x1750.html

Fix build system to always propagate os.environment.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
