### PR TITLE
cassandra: fix python reference

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24083,9 +24083,11 @@ with pkgs;
 
   cassandra_3_0 = callPackage ../servers/nosql/cassandra/3.0.nix {
     jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
+    python = python2;
   };
   cassandra_3_11 = callPackage ../servers/nosql/cassandra/3.11.nix {
     jre = jre8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
+    python = python2;
   };
   cassandra_4 = callPackage ../servers/nosql/cassandra/4.nix {
     # Effective Cassandra 4.0.2 there is full Java 11 support


### PR DESCRIPTION
cassandra: fix python reference

* `cassandra` package builds fine with Python 3. BUT:
  - `cassandra.passthru.tests.nixos` fails as:
    - `Unable to lock JVM memory (ENOMEM). This can result in part of the JVM being swapped out, especially with mmapped I/O enabled. Increase RLIMIT_MEMLOCK or run Cassandra as root.`
    - Also fails with Python2. This PR is not causing it!
      - Python 2 logs: https://termbin.com/aztg
      - Python 3 logs: https://termbin.com/frmnj

* The reason I went for this PR is `nixpkgs-review` gifted me this error:
   - `error: Function called without required argument "python" at /nixpkgs/pkgs/servers/nosql/cassandra/generic.nix:4, did you mean "jython", "python2" or "python3"?`