### PR TITLE
fluxus: fix NIX_* environment propagations to scons

### DIFF
--- a/pkgs/applications/graphics/fluxus/default.nix
+++ b/pkgs/applications/graphics/fluxus/default.nix
@@ -22,26 +22,6 @@
 , zlib
 }:
 let
-  libs = [
-    alsa-lib
-    bzip2
-    fftw
-    freeglut
-    freetype
-    glew
-    libjack2
-    libGL
-    libGLU
-    libjpeg
-    liblo
-    libpng
-    libsndfile
-    libtiff
-    ode
-    openal
-    openssl
-    zlib
-  ];
   racket = racket_7_9;
 in
 stdenv.mkDerivation rec {
@@ -77,7 +57,6 @@ stdenv.mkDerivation rec {
     "RacketPrefix=${racket}"
     "RacketInclude=${racket}/include/racket"
     "RacketLib=${racket}/lib/racket"
-    "LIBPATH=${lib.makeLibraryPath libs}"
     "DESTDIR=build"
   ];
   configurePhase = ''

--- a/pkgs/applications/graphics/fluxus/fix-build.patch
+++ b/pkgs/applications/graphics/fluxus/fix-build.patch
@@ -1,5 +1,10 @@
-diff --git a/SConstruct b/SConstruct
-index 32cb644..650333a 100644
+scons does not use os environment by default:
+  https://scons.org/doc/2.1.0/HTML/scons-user/x1750.html
+
+nixpkgs' cc-wrapper on the other hand relies on various NIX_* variables
+to be passed through like NIX_CFLAGS_COMPILE_BEFORE.
+
+While at it ported to python3-style print().
 --- a/SConstruct
 +++ b/SConstruct
 @@ -6,7 +6,7 @@
@@ -11,16 +16,15 @@ index 32cb644..650333a 100644
  
  MajorVersion = "0"
  MinorVersion = "19"
-@@ -225,13 +225,18 @@ if env['PLATFORM'] == 'posix':
-                     ["asound", "alsa/asoundlib.h"],
-                     ["openal", "AL/al.h"]]
+@@ -100,6 +100,7 @@ IncludePaths = [
+ paranoid = ' -W -Wcast-qual -Wwrite-strings -Wcast-align -Wpointer-arith -Wconversion -Wredundant-decls -Wunreachable-code -Winline -Wlarger-than-256'
  
-+env.Append(ENV={'PATH': ' ' + os.environ['PATH'], })
-+env.Append(LIBPATH=ARGUMENTS.get('LIBPATH', '').split(':'))
-+env.Append(CCFLAGS=' ' + os.environ.get('NIX_CFLAGS_COMPILE',''))
-+env.Append(CCFLAGS=' -DNULL=0')
-+
- ################################################################################
+ env = Environment(CCFLAGS = '-ggdb -pipe -Wall -O3 -ffast-math -Wno-unused -fPIC -pthread',
++                  ENV = os.environ,
+                   VERSION_NUM = FluxusVersion)
+ env.MergeFlags(ARGUMENTS.get('CCFLAGS', '').split())
+ env.MergeFlags(ARGUMENTS.get('LDFLAGS', '').split())
+@@ -229,9 +230,9 @@ if env['PLATFORM'] == 'posix':
  # Make sure we have these libraries availible
  
  if not GetOption('clean'):
@@ -33,7 +37,7 @@ index 32cb644..650333a 100644
          # detect ode precision
          if not GetOption('clean'):
            try:
-@@ -240,27 +245,27 @@ if not GetOption('clean'):
+@@ -240,27 +241,27 @@ if not GetOption('clean'):
              if isinstance(ode_str[0], str):
                env.MergeFlags(ode_str[0])
            except:
@@ -65,7 +69,7 @@ index 32cb644..650333a 100644
                          Exit(1)
  
          if not conf.CheckFunc("dInitODE2"):
-@@ -334,7 +339,7 @@ if not GetOption('clean'):
+@@ -334,7 +335,7 @@ if not GetOption('clean'):
  			])
  
  	if raco_status != 0:
@@ -74,7 +78,7 @@ index 32cb644..650333a 100644
  		Exit(1)
  
  
-@@ -377,8 +382,8 @@ if not GetOption('clean') and static_modules:
+@@ -377,8 +378,8 @@ if not GetOption('clean') and static_modules:
  
  		app_env['LIBS'].remove("pthread")
  		app_env['LIBS'].remove("dl")
@@ -85,7 +89,7 @@ index 32cb644..650333a 100644
  
  		# now go through the rest of the libs, removing them from
  		# the environment at the same time
-@@ -425,7 +430,7 @@ SConscript(dirs = build_dirs,
+@@ -425,7 +426,7 @@ SConscript(dirs = build_dirs,
  if not GetOption('clean'):
      helpmap_status = subprocess.call(["racket", "makehelpmap.scm"], cwd="docs/helpmap")
      if helpmap_status != 0:


### PR DESCRIPTION
scons build system does not work by default in nixpkgs envoironment as it filters system environment and throws away NIX_* flags:

    https://scons.org/doc/2.1.0/HTML/scons-user/x1750.html

Fix build system to always propagate os.environment.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
