### PR TITLE
`mpy-utils`: Init at 0.1.13

### DIFF
--- a/pkgs/tools/misc/mpy-utils/default.nix
+++ b/pkgs/tools/misc/mpy-utils/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, lib, python3, buildPythonApplication, fetchPypi, fusepy, pyserial }:
+
+buildPythonApplication rec {
+  pname = "mpy-utils";
+  version = "0.1.13";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-die8hseaidhs9X7mfFvV8C8zn0uyw08gcHNqmjl+2Z4=";
+  };
+
+  propagatedBuildInputs = [ fusepy pyserial ];
+
+  meta = with lib; {
+    description = "MicroPython development utility programs";
+    homepage = "https://github.com/nickzoic/mpy-utils";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aciceri ];
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1469,6 +1469,8 @@ with pkgs;
 
   mprocs = callPackage ../tools/misc/mprocs { };
 
+  mpy-utils = python3Packages.callPackage ../tools/misc/mpy-utils { };
+
   nominatim = callPackage ../servers/nominatim { };
 
   ocs-url = libsForQt5.callPackage ../tools/misc/ocs-url { };


### PR DESCRIPTION
###### Description of changes

Adding [mpy-utils](https://github.com/nickzoic/mpy-utils), it includes several CLI tools:

- `mpy-download`
- `mpy-fuse`
- `mpy-reset`
- `mpy-sync`
- `mpy-upload`
- `mpy-watch`

I've only tested `mpy-fuse` (and it seems to work) but I think everything else should also work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html)) **I've tested it only on Linux**
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages **Not applicable**
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) **There aren't**
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`) **Commands help pages show up and `mpy-fuse` correctly works**
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
  - [X] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
  **I don't think this change is significant**
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
