### PR TITLE
papis: enable tests

### DIFF
--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -27,7 +27,6 @@
 , tqdm
 , typing-extensions
 , whoosh
-, xdg-utils
 }:
 
 buildPythonPackage rec {
@@ -76,13 +75,8 @@ buildPythonPackage rec {
       --replace "--cov=papis" ""
   '';
 
-  # Tests are failing on Python > 3.9
-  doCheck = !stdenv.isDarwin && !(pythonAtLeast "3.10");
-
-  nativeCheckInputs = ([
+  checkInputs = [
     pytestCheckHook
-  ]) ++ [
-    xdg-utils
   ];
 
   preCheck = ''
@@ -106,6 +100,8 @@ buildPythonPackage rec {
     "test_get_data"
     "test_validate_arxivid"
     "test_yaml"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "test_default_opener"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -112,6 +112,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Powerful command-line document and bibliography manager";
     homepage = "https://papis.readthedocs.io/";
+    changelog = "https://github.com/papis/papis/blob/v${version}/CHANGELOG.md";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ nico202 teto ];
   };

--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -69,8 +69,9 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
+    # Remove when https://github.com/papis/papis/pull/478 lands in upstream
     substituteInPlace setup.py \
-      --replace "isbnlib>=3.9.1,<3.10" "isbnlib>=3.9"
+      --replace "etc/bash_completion.d/" "share/bash-completion/completions/"
     substituteInPlace setup.cfg \
       --replace "--cov=papis" ""
   '';

--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -114,6 +114,6 @@ buildPythonPackage rec {
     homepage = "https://papis.readthedocs.io/";
     changelog = "https://github.com/papis/papis/blob/v${version}/CHANGELOG.md";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ nico202 teto ];
+    maintainers = with maintainers; [ nico202 teto marsam ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
