### PR TITLE
build-support/cc-wrapper: revert "pass in non-existent --sysroot= to …

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -343,18 +343,11 @@ stdenv.mkDerivation {
     # compile, because it uses "#include_next <limits.h>" to find the
     # limits.h file in ../includes-fixed. To remedy the problem,
     # another -idirafter is necessary to add that directory again.
-    #
-    # We use --sysroot=/nix/store/does/not/exist to drop embedded default
-    # path to glibc headers gcc was built against. Without it -idirafter
-    # only appends to the list and outdated glibc headers end up being
-    # used. 'cc-cflags-before' is used to allow user's --sysroot= option
-    # to override our default.
     + optionalString (libc != null) (''
       touch "$out/nix-support/libc-cflags"
       touch "$out/nix-support/libc-ldflags"
       echo "-B${libc_lib}${libc.libdir or "/lib/"}" >> $out/nix-support/libc-crt1-cflags
     '' + optionalString (!(cc.langD or false)) ''
-      echo "--sysroot=/nix/store/does/not/exist" >> $out/nix-support/cc-cflags-before
       echo "-idirafter ${libc_dev}${libc.incdir or "/include"}" >> $out/nix-support/libc-cflags
     '' + optionalString (isGNU && (!(cc.langD or false))) ''
       for dir in "${cc}"/lib/gcc/*/*/include-fixed; do

--- a/pkgs/development/compilers/dmd/generic.nix
+++ b/pkgs/development/compilers/dmd/generic.nix
@@ -151,13 +151,6 @@ stdenv.mkDerivation rec {
     git
   ];
 
-  # Workaround cc-wrapper's --sysroot= value for `staging-next`: it
-  # breaks library lookup via RUNPATH:
-  #   ld: warning: libm.so.6, needed by ./generated/linux/release/64/lib.so, not found (try using -rpath or -rpath-link)
-  #   ld: /build/druntime/generated/linux/release/64/libdruntime.so: undefined reference to `log10@GLIBC_2.2.5'
-  # TODO(trofi): remove the workaround once cc-wrapper is fixed.
-  NIX_CFLAGS_COMPILE = [ "--sysroot=/" ];
-
   buildInputs = [
     curl
     tzdata

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -322,10 +322,6 @@ self = stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = lib.optionals stdenv.isDarwin [ "-fno-common" ] ++ lib.optionals enableOpenCL [
     "-UPIPE_SEARCH_DIR"
     "-DPIPE_SEARCH_DIR=\"${placeholder "opencl"}/lib/gallium-pipe\""
-
-    # Work around regression from https://github.com/NixOS/nixpkgs/pull/210004
-    # TODO(trofi): remove
-    "--sysroot=/"
   ];
 
   passthru = {

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -92,16 +92,6 @@ let
 
     passAsFile = [ "extraConfig" ];
 
-    # Workaround '-idirafter' ordering bug in staging-next:
-    #   https://github.com/NixOS/nixpkgs/pull/210004
-    # where libc '-idirafter' gets added after user's idirafter and
-    # breaks.
-    # TODO(trofi): remove it in staging once fixed in cc-wrapper.
-    preConfigure = ''
-      export NIX_CFLAGS_COMPILE_BEFORE_${lib.replaceStrings ["-" "."] ["_" "_"] buildPackages.stdenv.hostPlatform.config}=$(< ${buildPackages.stdenv.cc}/nix-support/libc-cflags)
-      export NIX_CFLAGS_COMPILE_BEFORE_${lib.replaceStrings ["-" "."] ["_" "_"]               stdenv.hostPlatform.config}=$(<               ${stdenv.cc}/nix-support/libc-cflags)
-    '';
-
     configurePhase = ''
       runHook preConfigure
 

--- a/pkgs/tools/misc/ipxe/default.nix
+++ b/pkgs/tools/misc/ipxe/default.nix
@@ -48,16 +48,6 @@ stdenv.mkDerivation rec {
     substituteInPlace src/util/genfsimg --replace "	syslinux " "	true "
   ''; # calling syslinux on a FAT image isn't going to work
 
-  # Workaround '-idirafter' ordering bug in staging-next:
-  #   https://github.com/NixOS/nixpkgs/pull/210004
-  # where libc '-idirafter' gets added after user's idirafter and
-  # breaks.
-  # TODO(trofi): remove it in staging once fixed in cc-wrapper.
-  preConfigure = ''
-    export NIX_CFLAGS_COMPILE_BEFORE_${lib.replaceStrings ["-" "."] ["_" "_"] buildPackages.stdenv.hostPlatform.config}=$(< ${buildPackages.stdenv.cc}/nix-support/libc-cflags)
-    export NIX_CFLAGS_COMPILE_BEFORE_${lib.replaceStrings ["-" "."] ["_" "_"]               stdenv.hostPlatform.config}=$(<               ${stdenv.cc}/nix-support/libc-cflags)
-  '';
-
   # not possible due to assembler code
   hardeningDisable = [ "pic" "stackprotector" ];
 

--- a/pkgs/tools/misc/wimboot/default.nix
+++ b/pkgs/tools/misc/wimboot/default.nix
@@ -13,15 +13,6 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "source/src";
 
-  # Workaround '-idirafter' ordering bug in staging-next:
-  #   https://github.com/NixOS/nixpkgs/pull/210004
-  # where libc '-idirafter' gets added after user's idirafter and
-  # breaks.
-  # TODO(trofi): remove it in staging once fixed in cc-wrapper.
-  preConfigure = ''
-    export NIX_CFLAGS_COMPILE_BEFORE_${lib.replaceStrings ["-" "."] ["_" "_"] stdenv.hostPlatform.config}=$(< ${stdenv.cc}/nix-support/libc-cflags)
-  '';
-
   buildInputs = [ libbfd zlib libiberty ];
   makeFlags = [ "wimboot.x86_64.efi" ];
 


### PR DESCRIPTION
…untangle from libc"

This reverts commit 8c80bd08b7e39229947d55104d1871f5066437d9 ("build-support/cc-wrapper: pass in non-existent --sysroot= to untangle from libc").

This change was good in spirit: we caught a few genuine problems with `scons` based packages (`godot`, `fluxus`) and unexpected `-idirafter` includes in various boot loadres (`ipxe`, wimboot`):

    https://github.com/NixOS/nixpkgs/pull/210004#issuecomment-1407162693

Unfortunately `--sysroot=` also has a negative impact on libary search order for DT_NEEDED libraries and RUNPATHs of linked libraries. This unexpectedly broke `dmd`, `d-seams`, `llvmPackages_rocm.compiler-rt`).

An interesting case of unexpected breakage is `usbmuxd2` where the bug exposed incomplete library move on `libstdc++fs` in `gcc`.

The library breakage is very non-intuitive (on top of already unusual layout of `cc-wrapper` driver). Let's revert this change for now.

Once it lands we can undo `--sysroot=/` workarounds merged for `staging-next`.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
