### PR TITLE
wiimms-iso-tools: 3.02a -> 3.05a

### DIFF
--- a/pkgs/tools/filesystems/wiimms-iso-tools/default.nix
+++ b/pkgs/tools/filesystems/wiimms-iso-tools/default.nix
@@ -25,9 +25,7 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    patchShebangs setup.sh
-    patchShebangs gen-template.sh
-    patchShebangs gen-text-file.sh
+    patchShebangs setup.sh gen-template.sh gen-text-file.sh
     substituteInPlace setup.sh --replace gcc "$CC"
     substituteInPlace Makefile --replace gcc "$CC"
   '';

--- a/pkgs/tools/filesystems/wiimms-iso-tools/default.nix
+++ b/pkgs/tools/filesystems/wiimms-iso-tools/default.nix
@@ -1,12 +1,12 @@
-{lib, stdenv, fetchurl, fetchpatch, zlib, ncurses, fuse}:
+{ lib, stdenv, fetchurl, fetchpatch, zlib, ncurses, fuse }:
 
 stdenv.mkDerivation rec {
   pname = "wiimms-iso-tools";
-  version = "3.02a";
+  version = "3.05a";
 
   src = fetchurl {
-    url = "https://download.wiimm.de/source/wiimms-iso-tools/wiimms-iso-tools.source-${version}.tar.bz2";
-    sha256 = "074cvcaqz23xyihslc6n64wwxwcnl6xp7l0750yb9pc0wrqxmj69";
+    url = "https://download.wiimm.de/source/wiimms-iso-tools/wiimms-iso-tools.source-${version}.txz";
+    hash = "sha256-5aikiPJkZf9OwD8QmQ7ijhBOtFQpkIErvb6gOvEu2L0=";
   };
 
   buildInputs = [ zlib ncurses fuse ];
@@ -28,10 +28,10 @@ stdenv.mkDerivation rec {
     patchShebangs setup.sh
     patchShebangs gen-template.sh
     patchShebangs gen-text-file.sh
+    substituteInPlace setup.sh --replace gcc "$CC"
+    substituteInPlace Makefile --replace gcc "$CC"
   '';
 
-  # Workaround build failure on -fno-common toolchains like upstream gcc-10.
-  NIX_CFLAGS_COMPILE = "-Wno-error=format-security -fcommon";
   INSTALL_PATH = "$out";
 
   installPhase = ''
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     homepage = "https://wit.wiimm.de";
     description = "A set of command line tools to manipulate Wii and GameCube ISO images and WBFS containers";
     license = licenses.gpl2;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ nilp0inter ];
   };
 }


### PR DESCRIPTION
###### Description of changes

https://wit.wiimm.de/changelog.html#r8245
https://wit.wiimm.de/changelog.html#r8427
https://wit.wiimm.de/changelog.html#r8638

This also adds Clang (and, by extension, macOS) support.

May fix #213181.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
