### PR TITLE
[22.11] bind: 9.18.9 -> 9.18.11

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "bind";
-  version = "9.18.10";
+  version = "9.18.11";
 
   src = fetchurl {
     url = "https://downloads.isc.org/isc/bind9/${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-9BWpL+tiVotQhUoGPLIx4lc1H4ZyGG0KsDGkmz3iysY=";
+    sha256 = "sha256-j/M1KBIjDLy9pC34fK2WH5QWPT2kV8XkvvgFf9XfIVg=";
   };
 
   outputs = [ "out" "lib" "dev" "man" "dnsutils" "host" ];

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "bind";
-  version = "9.18.9";
+  version = "9.18.10";
 
   src = fetchurl {
     url = "https://downloads.isc.org/isc/bind9/${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-apZlmY1WhgRGDfCRj8jM+tfSk4jU2EJWDAVswhHLskM=";
+    sha256 = "sha256-9BWpL+tiVotQhUoGPLIx4lc1H4ZyGG0KsDGkmz3iysY=";
   };
 
   outputs = [ "out" "lib" "dev" "man" "dnsutils" "host" ];


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2022-3094, CVE-2022-3736 and CVE-2022-3924.
    
Security advisories:
* https://kb.isc.org/docs/cve-2022-3094
* https://kb.isc.org/docs/cve-2022-3736
* https://kb.isc.org/docs/cve-2022-3924
    
Changelog:
https://downloads.isc.org/isc/bind9/9.18.11/CHANGES

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review pr 213189` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>37 packages built:</summary>
  <ul>
    <li>acme-sh</li>
    <li>asn</li>
    <li>autofs5</li>
    <li>bashSnippets</li>
    <li>bind</li>
    <li>blueberry</li>
    <li>check-wmiplus</li>
    <li>cinnamon.cinnamon-common</li>
    <li>cinnamon.cinnamon-gsettings-overrides</li>
    <li>cinnamon.cinnamon-screensaver</li>
    <li>cinnamon.cinnamon-session</li>
    <li>cinnamon.nemo</li>
    <li>cinnamon.pix</li>
    <li>cinnamon.warpinator</li>
    <li>cinnamon.xapp</li>
    <li>cinnamon.xreader</li>
    <li>cinnamon.xviewer</li>
    <li>dig</li>
    <li>dwm-status</li>
    <li>gnome.gnome-nettool</li>
    <li>host</li>
    <li>hw-probe</li>
    <li>hypnotix</li>
    <li>inxi</li>
    <li>monitoring-plugins</li>
    <li>nmapsi4</li>
    <li>python310Packages.xapp</li>
    <li>python39Packages.xapp</li>
    <li>sssd</li>
    <li>sticky</li>
    <li>testssl</li>
    <li>timeshift</li>
    <li>timeshift-minimal</li>
    <li>timeshift-unwrapped</li>
    <li>twa</li>
    <li>xed-editor</li>
    <li>xplayer</li>
  </ul>
</details>
