### PR TITLE
llvmPackages_latest: 14 -> 15

### DIFF
--- a/pkgs/development/compilers/llvm/15/default.nix
+++ b/pkgs/development/compilers/llvm/15/default.nix
@@ -306,6 +306,10 @@ in let
 
     libcxxStdenv = overrideCC stdenv buildLlvmTools.libcxxClang;
 
+    libclc = callPackage ./libclc {
+      inherit llvm_meta targetLlvm;
+    };
+
     libcxxabi = let
       # CMake will "require" a compiler capable of compiling C++ programs
       # cxx-header's build does not actually use one so it doesn't really matter

--- a/pkgs/development/compilers/llvm/git/default.nix
+++ b/pkgs/development/compilers/llvm/git/default.nix
@@ -6,6 +6,7 @@
 # This is the default binutils, but with *this* version of LLD rather
 # than the default LLVM verion's, if LLD is the choice. We use these for
 # the `useLLVM` bootstrapping below.
+, targetLlvm
 , bootBintoolsNoLibc ?
     if stdenv.targetPlatform.linker == "lld"
     then null
@@ -296,7 +297,7 @@ let
     };
 
     openmp = callPackage ./openmp {
-      inherit llvm_meta;
+      inherit llvm_meta targetLlvm;
     };
   });
 

--- a/pkgs/development/compilers/llvm/git/default.nix
+++ b/pkgs/development/compilers/llvm/git/default.nix
@@ -258,6 +258,10 @@ let
 
     libcxxStdenv = overrideCC stdenv buildLlvmTools.libcxxClang;
 
+    libclc = callPackage ./libclc {
+      inherit llvm_meta targetLlvm;
+    };
+
     libcxxabi = let
       # CMake will "require" a compiler capable of compiling C++ programs
       # cxx-header's build does not actually use one so it doesn't really matter

--- a/pkgs/development/compilers/llvm/git/libclc/default.nix
+++ b/pkgs/development/compilers/llvm/git/libclc/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, llvm_meta
+, monorepoSrc
+, runCommand
+, cmake
+, ninja
+, python3
+, llvm
+, targetLlvm
+, clang-unwrapped
+, spirv-llvm-translator
+, version
+} @ args:
+
+let
+  llvm = if stdenv.buildPlatform == stdenv.hostPlatform then args.llvm else targetLlvm;
+  spirv = spirv-llvm-translator.override {
+    llvm = args.llvm; # use LLVM for the build platform here, not targetLlvm
+  };
+in
+
+stdenv.mkDerivation rec {
+  pname = "libclc";
+  inherit version;
+
+  src = runCommand "${pname}-src-${version}" {} ''
+    mkdir -p "$out"
+    cp -r ${monorepoSrc}/cmake "$out"
+    cp -r ${monorepoSrc}/${pname} "$out"
+  '';
+  sourceRoot = "${src.name}/${pname}";
+
+  # cmake expects all required binaries to be in the same place, so it will not be able to find clang without the patch
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace 'find_program( LLVM_CLANG clang PATHS ''${LLVM_BINDIR} NO_DEFAULT_PATH )' \
+                'find_program( LLVM_CLANG clang PATHS "${clang-unwrapped}/bin" NO_DEFAULT_PATH )' \
+      --replace 'find_program( LLVM_SPIRV llvm-spirv PATHS ''${LLVM_BINDIR} NO_DEFAULT_PATH )' \
+                'find_program( LLVM_SPIRV llvm-spirv PATHS "${spirv}/bin" NO_DEFAULT_PATH )'
+  '';
+
+  nativeBuildInputs = [ cmake ninja python3 spirv ];
+  buildInputs = [ llvm clang-unwrapped ];
+  strictDeps = true;
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ];
+
+  meta = llvm_meta // {
+    homepage = "http://libclc.llvm.org/";
+    description = "Implementation of the library requirements of the OpenCL C programming language";
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/development/compilers/llvm/git/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/git/openmp/default.nix
@@ -6,6 +6,7 @@
 , cmake
 , ninja
 , llvm
+, targetLlvm
 , lit
 , clang-unwrapped
 , perl
@@ -34,7 +35,9 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [ cmake ninja perl pkg-config lit ];
-  buildInputs = [ llvm ];
+  buildInputs = [
+    (if stdenv.buildPlatform == stdenv.hostPlatform then llvm else targetLlvm)
+  ];
 
   # Unsup:Pass:XFail:Fail
   # 26:267:16:8

--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -9,6 +9,8 @@
 }:
 
 let
+   # TODO(rrbutani): use release-version instead of version to support
+   # `llvmPackages_git`.
   llvmMajor = lib.versions.major llvm.version;
   isROCm = lib.hasPrefix "rocm" llvm.pname;
 

--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -66,6 +66,15 @@ stdenv.mkDerivation {
     install -D tools/llvm-spirv/llvm-spirv $out/bin/llvm-spirv
   '';
 
+  # On macOS the produced binaries' rpath references the build dir and is *not*
+  # rewritten to the install dir by cmake during installation (when
+  # `CMAKE_SKIP_BUILD_RPATH` is set to `Off`). So, we set rpath ourselves.
+  preFixup = lib.optional stdenv.hostPlatform.isDarwin ''
+    for exe in "$out/bin/"* ; do
+      ${stdenv.cc.targetPrefix}install_name_tool -add_rpath "$out/lib" "$exe"
+    done
+  '';
+
   meta = with lib; {
     homepage    = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator";
     description = "A tool and a library for bi-directional translation between SPIR-V and LLVM IR";

--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -6,6 +6,7 @@
 , llvm
 , spirv-headers
 , spirv-tools
+, testers
 }:
 
 let
@@ -30,7 +31,7 @@ let
       hash = "sha256-NoIoa20+2sH41rEnr8lsMhtfesrtdPINiXtUnxYVm8s=";
     } else throw "Incompatible LLVM version.";
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "SPIRV-LLVM-Translator";
   inherit (branch) version;
 
@@ -75,11 +76,17 @@ stdenv.mkDerivation {
     done
   '';
 
+  passthru.tests.version = with finalAttrs; testers.testVersion {
+    package = finalPackage;
+    version = llvm.version;
+  };
+
   meta = with lib; {
     homepage    = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator";
     description = "A tool and a library for bi-directional translation between SPIR-V and LLVM IR";
     license     = licenses.ncsa;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ gloaming ];
+    mainProgram = "llvm-spirv";
   };
-}
+})

--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -307,6 +307,17 @@ in stdenv.mkDerivation {
       sha256 = "1rma1al0rbm3s3ql6bnvbcighp74lri1lcrwbyacgdqp80fgw1b6";
     }}
 
+    ${lib.optionalString (!stdenv.isDarwin) ''
+    # Needed to build with clang 15+ without disabling warnings; can drop this
+    # once we update to 5.8.x.
+    patch -p1 -d swift-corelibs-libdispatch -i ${fetchpatch {
+      name = "swift-corelibs-libdispatch-fix-unused-but-set-warning";
+      url = "https://github.com/apple/swift-corelibs-libdispatch/commit/915f25141a7c57b6a2a3bc8697572644af181ec5.patch";
+      sha256 = "sha256-gxhMwSlE/y4LkOvmCaDMPjd7EcoX6xaacK4MLa3mOUM=";
+      includes = ["src/shims/yield.c"];
+    }}
+    ''}
+
     ${lib.optionalString stdenv.isLinux ''
     substituteInPlace llvm-project/clang/lib/Driver/ToolChains/Linux.cpp \
       --replace 'SysRoot + "/lib' '"${glibc}/lib" "' \

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -2,7 +2,8 @@
 , pkgs
 , newScope
 , darwin
-, llvmPackages_latest
+# See: https://github.com/NixOS/nixpkgs/pull/213202#issuecomment-1483644798
+, llvmPackages_14
 , overrideCC
 }:
 
@@ -23,12 +24,12 @@ let
     # currently closest to the official Swift builds.
     clang = if pkgs.stdenv.isDarwin
       then
-        llvmPackages_latest.clang.override rec {
+        llvmPackages_14.clang.override rec {
           libc = apple_sdk.Libsystem;
           bintools = pkgs.bintools.override { inherit libc; };
         }
       else
-        llvmPackages_latest.clang;
+        llvmPackages_14.clang;
 
     # Overrides that create a useful environment for swift packages, allowing
     # packaging with `swiftPackages.callPackage`. These are similar to

--- a/pkgs/development/compilers/swift/libdispatch/default.nix
+++ b/pkgs/development/compilers/swift/libdispatch/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , callPackage
+, fetchpatch
 , cmake
 , ninja
 , useSwift ? true, swift
@@ -19,7 +20,18 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ cmake ]
     ++ lib.optionals useSwift [ ninja swift ];
 
-  patches = [ ./disable-swift-overlay.patch ];
+  patches = [
+    ./disable-swift-overlay.patch
+
+    # Needed to build with clang 15+ without disabling warnings; can drop this
+    # once we update to 5.8.x.
+    (fetchpatch {
+      name = "swift-corelibs-libdispatch-fix-unused-but-set-warning";
+      url = "https://github.com/apple/swift-corelibs-libdispatch/commit/915f25141a7c57b6a2a3bc8697572644af181ec5.patch";
+      sha256 = "sha256-gxhMwSlE/y4LkOvmCaDMPjd7EcoX6xaacK4MLa3mOUM=";
+      includes = ["src/shims/yield.c"];
+    })
+  ];
 
   cmakeFlags = lib.optional useSwift "-DENABLE_SWIFT=ON";
 

--- a/pkgs/development/libraries/libclc/default.nix
+++ b/pkgs/development/libraries/libclc/default.nix
@@ -3,6 +3,7 @@
 let
   llvm = llvmPackages.llvm;
   clang-unwrapped = llvmPackages.clang-unwrapped;
+  spirv = spirv-llvm-translator.override { inherit llvm; };
 in
 
 stdenv.mkDerivation rec {
@@ -23,10 +24,10 @@ stdenv.mkDerivation rec {
       --replace 'find_program( LLVM_CLANG clang PATHS ''${LLVM_BINDIR} NO_DEFAULT_PATH )' \
                 'find_program( LLVM_CLANG clang PATHS "${clang-unwrapped}/bin" NO_DEFAULT_PATH )' \
       --replace 'find_program( LLVM_SPIRV llvm-spirv PATHS ''${LLVM_BINDIR} NO_DEFAULT_PATH )' \
-                'find_program( LLVM_SPIRV llvm-spirv PATHS "${spirv-llvm-translator}/bin" NO_DEFAULT_PATH )'
+                'find_program( LLVM_SPIRV llvm-spirv PATHS "${spirv}/bin" NO_DEFAULT_PATH )'
   '';
 
-  nativeBuildInputs = [ cmake ninja python3 spirv-llvm-translator ];
+  nativeBuildInputs = [ cmake ninja python3 spirv ];
   buildInputs = [ llvm clang-unwrapped ];
   strictDeps = true;
   cmakeFlags = [

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1871,6 +1871,7 @@ mapAliases ({
     inherit (stdenvAdapters) overrideCC;
     buildLlvmTools = buildPackages.llvmPackages_git.tools;
     targetLlvmLibraries = targetPackages.llvmPackages_git.libraries or llvmPackages_git.libraries;
+    targetLlvm = targetPackages.llvmPackages_git.llvm or llvmPackages_git.llvm;
   });
 
   # Added 2022-01-28

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15554,7 +15554,7 @@ with pkgs;
     targetLlvm = targetPackages.llvmPackages_15.llvm or llvmPackages_15.llvm;
   }));
 
-  llvmPackages_latest = llvmPackages_14;
+  llvmPackages_latest = llvmPackages_15;
 
   llvmPackages_rocm = recurseIntoAttrs (callPackage ../development/compilers/llvm/rocm { });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21192,9 +21192,7 @@ with pkgs;
 
   libcint = callPackage ../development/libraries/libcint { };
 
-  libclc = callPackage ../development/libraries/libclc {
-    llvmPackages = llvmPackages_latest;
-  };
+  libclc  = llvmPackages_latest.libclc;
 
   libcli = callPackage ../development/libraries/libcli { };
 


### PR DESCRIPTION
###### Description of changes

Follow up to #194634 that targets `staging` and bumps `llvmPackages_latest`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).