### PR TITLE
agdsn-zsh-config: init at 0.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5105,6 +5105,12 @@
     githubId = 36706276;
     name = "Fufezan Mihai";
   };
+  fugi = {
+    email = "me@fugi.dev";
+    github = "FugiMuffi";
+    githubId = 21362942;
+    name = "Fugi";
+  };
   fusion809 = {
     email = "brentonhorne77@gmail.com";
     github = "fusion809";

--- a/pkgs/shells/zsh/agdsn-zsh-config/default.nix
+++ b/pkgs/shells/zsh/agdsn-zsh-config/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenvNoCC, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "agdsn-zsh-config";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "agdsn";
+    repo = "agdsn-zsh-config";
+    rev = "v${version}";
+    sha256 = "sha256-/l2fE4ZsZ6f89fYG9sTEV1mrXZ3MLXx6K3CTUQHiAsc=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m644 zshrc-base-hw.zsh "$out/etc/zsh/zshrc"
+    install -D -m644 zshrc-home.zsh "$out/etc/skel/.zshrc"
+    install -D -m644 zshrc-home.zsh "$out/etc/zsh/newuser.zshrc.recommended"
+    install -D -m644 profile-d-agdsn-zsh-config.sh "$out/etc/profile.d/agdsn-zsh-config.sh"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A modified version of the Grml Zsh configuration specialised for the needs of system administration";
+    homepage = "https://github.com/agdsn/agdsn-zsh-config";
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ fugi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13793,6 +13793,8 @@ with pkgs;
   runtimeShell = "${runtimeShellPackage}${runtimeShellPackage.shellPath}";
   runtimeShellPackage = bash;
 
+  agdsn-zsh-config = callPackage ../shells/zsh/agdsn-zsh-config { };
+
   any-nix-shell = callPackage ../shells/any-nix-shell { };
 
   bash = lowPrio (callPackage ../shells/bash/5.nix {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

AG DSN Zsh Config is a modified version of the Grml Zsh configuration specialised for the needs of system administration and developed for the residential network Arbeitsgemeinschaft Dresdner Studentennetz (AG DSN).

Notably adds many useful aliases and support for `ip netns` to the prompt.

Upstream repo: https://github.com/agdsn/agdsn-zsh-config

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
