### PR TITLE
python3Packages.tensorflow-io : init at 0.30.0

### DIFF
--- a/pkgs/development/python-modules/tensorflow-io/default.nix
+++ b/pkgs/development/python-modules/tensorflow-io/default.nix
@@ -23,6 +23,7 @@ let
     postPatch =
       let
         rulesPython.oldRef = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161";
+        # Cf. https://github.com/bazelbuild/rules_python/blob/82c8f0a084c35dafc381725c195597910cbab218/.github/workflows/workspace_snippet.sh#L9
         rulesPython.newRef = "8c15896f6686beb5c631a4459a3aa8392daccaab805ea899c9d14215074b60ef";
         rulesPython.oldUrl = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz";
         rulesPython.newUrl = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.17.3.tar.gz";

--- a/pkgs/development/python-modules/tensorflow-io/default.nix
+++ b/pkgs/development/python-modules/tensorflow-io/default.nix
@@ -20,15 +20,41 @@ let
       rev = "v${version}";
       hash = "sha256-SeXw9MES7tyMQ34jR9NHtO3S+y6nsvU6z0JCjj0r6Mk=";
     };
+    patches = [
+      ./remove-lint_dependencies.patch
+    ];
     postPatch =
       let
-        rulesPython.oldRef = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161";
         # Cf. https://github.com/bazelbuild/rules_python/blob/82c8f0a084c35dafc381725c195597910cbab218/.github/workflows/workspace_snippet.sh#L9
-        rulesPython.newRef = "8c15896f6686beb5c631a4459a3aa8392daccaab805ea899c9d14215074b60ef";
+        rulesPython.tags = {
+          "0.1.0" = "48f7e716f4098b85296ad93f5a133baf712968c13fbc2fdf3a6136158fe86eac";
+          "0.2.0" = "0d25ab1c7b18b3f48d1bff97bfa70c1625438b40c5f661946fb43eca4ba9d9dd";
+          "0.3.0" = "4feecd37ec6e9941a455a19e7392bed65003eab0aa6ea347ca431bce2640e530";
+          "0.4.0" = "45f22030b4c3475d5beb74ee9a9b86df6e83d5e18c6f23c7ec1a43cea7a31b93";
+          "0.5.0" = "a2fd4c2a8bcf897b718e5643040b03d9528ac6179f6990774b7c19b2dc6cd96b";
+          "0.6.0" = "a30abdfc7126d497a7698c29c46ea9901c6392d6ed315171a6df5ce433aa4502";
+          "0.7.0" = "15f84594af9da06750ceb878abbf129241421e3abbd6e36893041188db67f2fb";
+          "0.8.0" = "9fcf91dbcc31fde6d1edb15f117246d912c33c36f44cf681976bd886538deba6";
+          "0.9.0" = "5fa3c738d33acca3b97622a13a741129f67ef43f5fdfcec63b29374cc0574c29";
+          "0.10.0" = "56dc7569e5dd149e576941bdb67a57e19cd2a7a63cc352b62ac047732008d7e1";
+          "0.11.0" = "c03246c11efd49266e8e41e12931090b613e12a59e6f55ba2efd29a7cb8b4258";
+          "0.12.0" = "b593d13bb43c94ce94b483c2858e53a9b811f6f10e1e0eedc61073bd90e58d9c";
+          "0.13.0" = "8c8fe44ef0a9afc256d1e75ad5f448bb59b81aba149b8958f02f7b3a98f5d9b4";
+          "0.14.0" = "a868059c8c6dd6ad45a205cca04084c652cfe1852e6df2d5aca036f6e5438380";
+          "0.15.0" = "fda23c37fbacf7579f94d5e8f342d3a831140e9471b770782e83846117dd6596";
+          "0.16.0" = "815e666b1e9560c959ca79f2e2c62dd138c73bd8e7d85551e00e136cfd9b6278";
+          "0.17.0" = "6dd4f396a48ecdeea6f70fb97be6568d291a8cba9a763d2b880e1c523ea0c997";
+          "0.17.3" = "8c15896f6686beb5c631a4459a3aa8392daccaab805ea899c9d14215074b60ef";
+        };
+        rulesPython.oldTag = "0.1.0";
+        rulesPython.newTag = "0.6.0";
+        # rulesPython.oldRef = rulesPython.tags.${rulesPython.oldTag};
+        rulesPython.oldRef = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161";
+        rulesPython.newRef = rulesPython.tags.${rulesPython.newTag};
         rulesPython.oldUrl = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz";
-        rulesPython.newUrl = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.17.3.tar.gz";
+        rulesPython.newUrl = "https://github.com/bazelbuild/rules_python/archive/refs/tags/${rulesPython.newTag}.tar.gz";
         rulesPython.insertAfter = ''name = "rules_python"'';
-        rulesPython.insertStripPrefix = ''strip_prefix = "rules_python-0.17.3",'';
+        rulesPython.insertStripPrefix = ''strip_prefix = "rules_python-${rulesPython.newTag}",'';
       in
       ''
         # Pins 5.1.1, we've got 5.4.0
@@ -37,8 +63,8 @@ let
         substituteInPlace WORKSPACE \
           --replace "${rulesPython.oldRef}" "${rulesPython.newRef}" \
           --replace "${rulesPython.oldUrl}" "${rulesPython.newUrl}"
-        sed -i '/${rulesPython.insertAfter}/a ${rulesPython.insertStripPrefix}' WORKSPACE 
         sed -i 's/^.*rules_python-0.0.1.*$//' WORKSPACE
+        sed -i '/${rulesPython.insertAfter}/a ${rulesPython.insertStripPrefix}' WORKSPACE 
       '';
 
     nativeBuildInputs = [

--- a/pkgs/development/python-modules/tensorflow-io/default.nix
+++ b/pkgs/development/python-modules/tensorflow-io/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, buildBazelPackage
+, bazel_5
+, python
+, absl-py
+, setuptools
+, wheel
+}:
+
+let
+  pname = "tensorflow-io";
+  version = "0.30.0";
+  bazel-wheel = buildBazelPackage {
+    name = "${pname}-${version}-py2.py3-none-any.whl";
+    src = fetchFromGitHub {
+      owner = "tensorflow";
+      repo = "io";
+      rev = "v${version}";
+      hash = "sha256-SeXw9MES7tyMQ34jR9NHtO3S+y6nsvU6z0JCjj0r6Mk=";
+    };
+    postPatch = ''
+      # Pins 5.1.1, we've got 5.4.0
+      rm -f .bazelversion
+    '';
+
+    nativeBuildInputs = [
+      setuptools
+      wheel
+      absl-py
+    ];
+    bazel = bazel_5;
+
+    # why does it not take a list?
+    bazelTarget = "//tensorflow_io/... //tensorflow_io_gcs_filesystem/...";
+
+    fetchAttrs = {
+      sha256 = "";
+    };
+
+    buildAttrs = {
+      preBuild = ''
+        patchShebangs .
+      '';
+      installPhase = ''
+        # TODO: cf. tf-probability or something
+        # ...
+        mv *.whl "$out"
+      '';
+    };
+  };
+in
+buildPythonPackage {
+  inherit pname version;
+
+  src = bazel-wheel;
+
+  meta = with lib; {
+    description = "Dataset, streaming, and file system extensions maintained by TensorFlow SIG-IO";
+    homepage = "https://www.tensorflow.org/io";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/tensorflow-io/default.nix
+++ b/pkgs/development/python-modules/tensorflow-io/default.nix
@@ -20,10 +20,25 @@ let
       rev = "v${version}";
       hash = "sha256-SeXw9MES7tyMQ34jR9NHtO3S+y6nsvU6z0JCjj0r6Mk=";
     };
-    postPatch = ''
-      # Pins 5.1.1, we've got 5.4.0
-      rm -f .bazelversion
-    '';
+    postPatch =
+      let
+        rulesPython.oldRef = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161";
+        rulesPython.newRef = "8c15896f6686beb5c631a4459a3aa8392daccaab805ea899c9d14215074b60ef";
+        rulesPython.oldUrl = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz";
+        rulesPython.newUrl = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.17.3.tar.gz";
+        rulesPython.insertAfter = ''name = "rules_python"'';
+        rulesPython.insertStripPrefix = ''strip_prefix = "rules_python-0.17.3",'';
+      in
+      ''
+        # Pins 5.1.1, we've got 5.4.0
+        rm -f .bazelversion
+
+        substituteInPlace WORKSPACE \
+          --replace "${rulesPython.oldRef}" "${rulesPython.newRef}" \
+          --replace "${rulesPython.oldUrl}" "${rulesPython.newUrl}"
+        sed -i '/${rulesPython.insertAfter}/a ${rulesPython.insertStripPrefix}' WORKSPACE 
+        sed -i 's/^.*rules_python-0.0.1.*$//' WORKSPACE
+      '';
 
     nativeBuildInputs = [
       setuptools

--- a/pkgs/development/python-modules/tensorflow-io/remove-lint_dependencies.patch
+++ b/pkgs/development/python-modules/tensorflow-io/remove-lint_dependencies.patch
@@ -1,0 +1,24 @@
+diff --git a/WORKSPACE b/WORKSPACE
+index 66edd1c1..bcaa0cde 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -102,17 +102,12 @@ http_archive(
+     ],
+ )
+ 
+-load("@rules_python//python:pip.bzl", "pip_import")
++load("@rules_python//python:pip.bzl", "pip_install")
+ 
+-pip_import(
+-    name = "lint_dependencies",
++pip_install(
+     requirements = "//tools/lint:requirements.txt",
+ )
+ 
+-load("@lint_dependencies//:requirements.bzl", "pip_install")
+-
+-pip_install()
+-
+ http_archive(
+     name = "org_tensorflow",
+     sha256 = "99c732b92b1b37fc243a559e02f9aef5671771e272758aa4aec7f34dc92dac48",

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11214,6 +11214,8 @@ self: super: with self; {
 
   tensorflow-estimator = callPackage ../development/python-modules/tensorflow-estimator { };
 
+  tensorflow-io = callPackage ../development/python-modules/tensorflow-io { };
+
   tensorflow-metadata = callPackage ../development/python-modules/tensorflow-metadata { };
 
   tensorflow-probability = callPackage ../development/python-modules/tensorflow-probability { };


### PR DESCRIPTION
###### Description of changes

(A failing attempt to) Introduce `tensorflow-io` and its `tensorflow-io-gcs-filesystem` variant. Since recently, `tensorflow-io-gcs-filesystem` appears to have been declared a dependency for `tensorflow`:
- https://github.com/tensorflow/tensorflow/pull/53442
- https://github.com/tensorflow/tensorflow/commit/ef8f805801092c9b453d8450cf1398b5f5330c43
- https://github.com/tensorflow/io/issues/1591

At the moment of writing `tensorflow-io` is a blocker for https://github.com/NixOS/nixpkgs/pull/211173



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Steps before switching from DRAFT to PULL REQUEST
  - [x] Workaround the `rules_python` issue. Until https://github.com/tensorflow/io/issues/1763 has been addressed, we'll be, ourselves, patching `WORKSPACE` to use different `rules_python` release
  - [x] CUDA variables
  - [ ] `TF_HEADER_DIR` error (cannot reach it anymore, getting a new error): https://gist.github.com/e6c87938b92cce9e88b46a95f491106e
  - [ ] `go_sdk` error: https://gist.github.com/SomeoneSerge/9b77706f2ca7cec0f584f6c79a984765

- Built on platform(s)
  - [ ] x86_64-linux