### PR TITLE
nix-init: init at 0.1.0

### DIFF
--- a/pkgs/tools/nix/nix-init/default.nix
+++ b/pkgs/tools/nix/nix-init/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, installShellFiles
+, makeWrapper
+, pkg-config
+, zstd
+, stdenv
+, darwin
+, nix
+, nurl
+, callPackage
+, spdx-license-list-data
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nix-init";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = "nix-init";
+    rev = "v${version}";
+    hash = "sha256-97aAlH03H8xTVhp45FwecNb7i/ZUtJG9OOYBx8Sf+YI=";
+  };
+
+  cargoHash = "sha256-uvn1cP6aIxfPKG/QLtHBd6fHjl7JNRtkZ4gIG2tpHVg=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    zstd
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/nix-init \
+      --prefix PATH : ${lib.makeBinPath [ nix nurl ]}
+    installManPage artifacts/nix-init.1
+    installShellCompletion artifacts/nix-init.{bash,fish} --zsh artifacts/_nix-init
+  '';
+
+  GEN_ARTIFACTS = "artifacts";
+  NIX_LICENSES = callPackage ./license.nix { };
+  SPDX_LICENSE_LIST_DATA = "${spdx-license-list-data.json}/json/details";
+  ZSTD_SYS_USE_PKG_CONFIG = true;
+
+  meta = with lib; {
+    description = "Command line tool to generate Nix packages from URLs";
+    homepage = "https://github.com/nix-community/nix-init";
+    changelog = "https://github.com/nix-community/nix-init/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/tools/nix/nix-init/license.nix
+++ b/pkgs/tools/nix/nix-init/license.nix
@@ -1,0 +1,23 @@
+# vendored from src/licenses.nix
+
+{ lib, writeText }:
+
+let
+  inherit (builtins) concatLists concatStringsSep length;
+  inherit (lib) flip licenses mapAttrsToList optional;
+
+  inserts = concatLists
+    (flip mapAttrsToList licenses
+      (k: v: optional (v ? spdxId) ''  xs.insert("${v.spdxId}", "${k}");''));
+in
+
+writeText "license.rs" ''
+  fn get_nix_licenses() -> rustc_hash::FxHashMap<&'static str, &'static str> {
+      let mut xs = std::collections::HashMap::with_capacity_and_hasher(
+          ${toString (length inserts)},
+          Default::default(),
+      );
+      ${concatStringsSep "\n    " inserts}
+      xs
+  }
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37644,6 +37644,8 @@ with pkgs;
   nix-info = callPackage ../tools/nix/info { };
   nix-info-tested = nix-info.override { doCheck = true; };
 
+  nix-init = callPackage ../tools/nix/nix-init { };
+
   nix-index-unwrapped = callPackage ../tools/package-management/nix-index {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

[Annoucement](https://discourse.nixos.org/t/nix-init-generate-nix-packages-from-urls-with-hash-prefetching-dependency-inference-license-detection-and-more/25035)
https://github.com/nix-community/nix-init

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
