### PR TITLE
tts: 0.9.0 -> 0.10.2

### DIFF
--- a/pkgs/tools/audio/tts/default.nix
+++ b/pkgs/tools/audio/tts/default.nix
@@ -1,6 +1,7 @@
 { lib
 , python3
 , fetchFromGitHub
+, fetchpatch
 , espeak-ng
 }:
 
@@ -24,7 +25,7 @@ let
         src = super.fetchPypi {
           pname = "librosa";
           inherit version;
-          sha256 = "c53d05e768ae4a3e553ae21c2e5015293e5efbfd5c12d497f1104cb519cca6b3";
+          hash = "sha256-xT0F52iuSj5VOuIcLlAVKT5e+/1cEtSX8RBMtRnMprM=";
         };
       });
     };
@@ -32,15 +33,28 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "tts";
-  version = "0.9.0";
+  version = "0.10.2";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "coqui-ai";
     repo = "TTS";
-    rev = "v${version}";
-    sha256 = "sha256-p4I583Rs/4eig7cnOcJjri2ugOLAeF2nvPIvMZrN1Ss=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-IcuRhsURgEYIuS7ldZtxAy4Z/XNDehTGsOfYW+DhScg=";
   };
+
+  patches = [
+    # Use packaging.version for version comparisons
+    (fetchpatch {
+      url = "https://github.com/coqui-ai/TTS/commit/77a9ef8ac97ea1b0f7f8d8287dba69a74fdf22ce.patch";
+      hash = "sha256-zWJmINyxw2efhR9KIVkDPHao5703zlpCKwdzOh/1APY=";
+    })
+    # Fix espeak version detection logic
+    (fetchpatch {
+      url = "https://github.com/coqui-ai/TTS/commit/0031df0143b069d7db59ba04d1adfafcc1a92f47.patch";
+      hash = "sha256-6cL9YqWrB+0QomINpA9BxdYmEDpXF03udGEchydQmBA=";
+    })
+  ];
 
   postPatch = let
     relaxedConstraints = [
@@ -64,6 +78,7 @@ python.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = with python.pkgs; [
     cython
+    packaging
   ];
 
   propagatedBuildInputs = with python.pkgs; [
@@ -82,6 +97,7 @@ python.pkgs.buildPythonApplication rec {
     mecab-python3
     nltk
     numba
+    packaging
     pandas
     pypinyin
     pysbd
@@ -134,6 +150,8 @@ python.pkgs.buildPythonApplication rec {
     "test_run_all_models"
     "test_synthesize"
     "test_voice_conversion"
+    "test_multi_speaker_multi_lingual_model"
+    "test_single_speaker_model"
     # Mismatch between phonemes
     "test_text_to_ids_phonemes_with_eos_bos_and_blank"
     # Takes too long
@@ -151,6 +169,7 @@ python.pkgs.buildPythonApplication rec {
     "tests/tts_tests/test_glow_tts_d-vectors_train.py"
     "tests/tts_tests/test_glow_tts_speaker_emb_train.py"
     "tests/tts_tests/test_glow_tts_train.py"
+    "tests/tts_tests/test_overflow_train.py"
     "tests/tts_tests/test_speedy_speech_train.py"
     "tests/tts_tests/test_tacotron2_d-vectors_train.py"
     "tests/tts_tests/test_tacotron2_speaker_emb_train.py"


### PR DESCRIPTION
https://github.com/coqui-ai/TTS/releases/tag/v0.10.2
https://github.com/coqui-ai/TTS/releases/tag/v0.10.1
https://github.com/coqui-ai/TTS/releases/tag/v0.10.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
