### PR TITLE
[22.11] rustc: 1.64.0 -> 1.66.1

### DIFF
--- a/pkgs/applications/editors/zee/default.nix
+++ b/pkgs/applications/editors/zee/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub, pkg-config, openssl, stdenv, Security }:
+{ lib, rustPlatform, fetchFromGitHub, fetchpatch, pkg-config, openssl, stdenv, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "zee";
@@ -11,6 +11,11 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-/9SogKOaXdFDB+e0//lrenTTbfmXqNFGr23L+6Pnm8w=";
   };
 
+  cargoPatches = [
+    # fixed upstream but unreleased
+    ./update-ropey-for-rust-1.65.diff
+  ];
+
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ openssl ] ++ lib.optional stdenv.isDarwin Security;
@@ -20,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   # see https://github.com/zee-editor/zee#syntax-highlighting
   ZEE_DISABLE_GRAMMAR_BUILD=1;
 
-  cargoSha256 = "sha256-mbqI1csnU95VWgax4GjIxB+nhMtmpaeJ8QQ3qb0hY4c=";
+  cargoHash = "sha256-fBBjtjM7AnyAL6EOFstL4h6yS+UoLgxck6Mc0tJcXaI=";
 
   meta = with lib; {
     description = "A modern text editor for the terminal written in Rust";

--- a/pkgs/applications/editors/zee/update-ropey-for-rust-1.65.diff
+++ b/pkgs/applications/editors/zee/update-ropey-for-rust-1.65.diff
@@ -1,0 +1,28 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 7159c28..0fa43c2 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1248,9 +1248,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "ropey"
+-version = "1.4.1"
++version = "1.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "fa0dd9b26e2a102b33d400b7b7d196c81a4014eb96eda90b1c5b48d7215d9633"
++checksum = "bbd22239fafefc42138ca5da064f3c17726a80d2379d817a3521240e78dd0064"
+ dependencies = [
+  "smallvec",
+  "str_indices",
+@@ -1408,9 +1408,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+ 
+ [[package]]
+ name = "str_indices"
+-version = "0.3.2"
++version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "adfad63a1b47951101cd667a85b2959a62910cf03f814fff25df89c460b873f8"
++checksum = "9d9199fa80c817e074620be84374a520062ebac833f358d74b37060ce4a0f2c0"
+ 
+ [[package]]
+ name = "strsim"

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -474,6 +474,8 @@ buildStdenv.mkDerivation ({
   separateDebugInfo = enableDebugSymbols;
   enableParallelBuilding = true;
 
+  NIX_LDFLAGS = if (with stdenv; isAarch64 && isLinux) then [ "-lgcc" ] else null;
+
   # tests were disabled in configureFlags
   doCheck = false;
 

--- a/pkgs/applications/networking/remote/rustdesk/default.nix
+++ b/pkgs/applications/networking/remote/rustdesk/default.nix
@@ -38,6 +38,11 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-IlrfqwNyaSHE9Ct0mn7MUxEg7p1Ku34eOMYelEAYFW8=";
   };
 
+  patches = [
+    # based on https://github.com/rustdesk/rustdesk/pull/1900
+    ./fix-for-rust-1.65.diff
+  ];
+
   cargoSha256 = "sha256-1OMWEk+DerltF7kwdo4d04rbgIFLHBRq3vZaL7jtrdE=";
 
   LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";

--- a/pkgs/applications/networking/remote/rustdesk/fix-for-rust-1.65.diff
+++ b/pkgs/applications/networking/remote/rustdesk/fix-for-rust-1.65.diff
@@ -1,0 +1,31 @@
+diff --git a/libs/hbb_common/src/config.rs b/libs/hbb_common/src/config.rs
+index 74982de5..308bcf80 100644
+--- a/libs/hbb_common/src/config.rs
++++ b/libs/hbb_common/src/config.rs
+@@ -656,7 +656,7 @@ const PEERS: &str = "peers";
+ 
+ impl PeerConfig {
+     pub fn load(id: &str) -> PeerConfig {
+-        let _ = CONFIG.read().unwrap(); // for lock
++        let _lock = CONFIG.read().unwrap();
+         match confy::load_path(&Self::path(id)) {
+             Ok(config) => config,
+             Err(err) => {
+@@ -667,7 +667,7 @@ impl PeerConfig {
+     }
+ 
+     pub fn store(&self, id: &str) {
+-        let _ = CONFIG.read().unwrap(); // for lock
++        let _lock = CONFIG.read().unwrap();
+         if let Err(err) = confy::store_path(Self::path(id), self) {
+             log::error!("Failed to store config: {}", err);
+         }
+@@ -808,7 +808,7 @@ pub struct LanPeers {
+ 
+ impl LanPeers {
+     pub fn load() -> LanPeers {
+-        let _ = CONFIG.read().unwrap(); // for lock
++        let _lock = CONFIG.read().unwrap();
+         match confy::load_path(&Config::file_("_lan_peers")) {
+             Ok(peers) => peers,
+             Err(err) => {

--- a/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
@@ -1,6 +1,8 @@
 cargoSetupPostUnpackHook() {
     echo "Executing cargoSetupPostUnpackHook"
 
+    export NIX_LDFLAGS+=" @aarch64LinuxGccWorkaround@"
+
     # Some cargo builds include build hooks that modify their own vendor
     # dependencies. This copies the vendor directory into the build tree and makes
     # it writable. If we're using a tarball, the unpackFile hook already handles

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -98,6 +98,9 @@ in {
           host-config = true
           target-applies-to-host = true
         '';
+
+        # https://github.com/NixOS/nixpkgs/issues/201254
+        aarch64LinuxGccWorkaround = lib.optionalString (stdenv.isLinux && stdenv.isAarch64 && stdenv.cc.isGNU) "-lgcc";
       };
     } ./cargo-setup-hook.sh) {};
 

--- a/pkgs/development/compilers/rust/1_65.nix
+++ b/pkgs/development/compilers/rust/1_65.nix
@@ -20,8 +20,8 @@
 } @ args:
 
 import ./default.nix {
-  rustcVersion = "1.64.0";
-  rustcSha256 = "sha256-s82fSB4aKQG/bzgI0wxpzE6oDZPEzE4u1SJYsYA4EgU=";
+  rustcVersion = "1.65.0";
+  rustcSha256 = "sha256-WCi7Z/Z36r+MOEAgWCsM56+IThyEOJSE9/jQDdgsADg=";
 
   llvmSharedForBuild = pkgsBuildBuild.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };
   llvmSharedForHost = pkgsBuildHost.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };
@@ -37,25 +37,25 @@ import ./default.nix {
 
   # Note: the version MUST be one version prior to the version we're
   # building
-  bootstrapVersion = "1.63.0";
+  bootstrapVersion = "1.64.0";
 
   # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
   bootstrapHashes = {
-    i686-unknown-linux-gnu = "6ac6ca18f119e099749d67c6dc25ce3f70542b43cc05062d5138fc1052e44c54";
-    x86_64-unknown-linux-gnu = "536bcf16807a4ff49b7b29af6e573a2f1821055bfad72c275c60e56edc693984";
-    x86_64-unknown-linux-musl = "4516f1fa2a0d9ec9176cc734e5faaa0a3d439bd49f75553a484b6c3c6d7905ab";
-    arm-unknown-linux-gnueabihf = "8847d8482e1d5ec962e092a63c95618dc7e17a079a9bf58bec1da39cac0ba4ce";
-    armv7-unknown-linux-gnueabihf = "d9227bf6d93f49889c698d35adc7ab3e042988740b9d9d9c81fb54fc0f854474";
-    aarch64-unknown-linux-gnu = "26745b57500da293a8147122a5998926301350a610c164f053107cbe026d3a51";
-    aarch64-unknown-linux-musl = "8fee65f2bd7e010259763939cbef8ed0794773ec8959c5ef90273cf39dcba180";
-    x86_64-apple-darwin = "37f76a45b8616e764c2663850758ce822c730e96af60168a46b818f528c1467d";
-    aarch64-apple-darwin = "25c3f43459da9b8683292999c3522d88980b0ca3244fe830f5a87a8092aac5a6";
-    powerpc64le-unknown-linux-gnu = "781662048caa48b78540c2fb22f0aa7c06d6d8e81aede0f6ef900c11428056cf";
-    riscv64gc-unknown-linux-gnu = "a7f398b45229c5cca833f75421c32897174e365fbbdf78e19b87612736c918aa";
-    mips64el-unknown-linux-gnuabi64 = "19f04c576c9d6b171acba65cfe44edcbcf6134a75a853d2f1538fdb2128ec654";
+    i686-unknown-linux-gnu = "177b4f95c8cdaa34bb29e69950cbfe236e123757078af4792779c43ee3818199";
+    x86_64-unknown-linux-gnu = "a893977f238291370ab96726a74b6b9ae854dc75fbf5730954d901a93843bf9b";
+    x86_64-unknown-linux-musl = "d5c4293a8fe1b34d857bec4124229c39711f8759aa2f6108c8b6c22a308f96bb";
+    arm-unknown-linux-gnueabihf = "0d7c9c746f7b98f1f99e4cf720f9a32b2f5cdf22cb1d9f677b41c1dca62f14f8";
+    armv7-unknown-linux-gnueabihf = "0be29740f565ca8835ba260691274585733a7f4130ec872bfa37654a08013828";
+    aarch64-unknown-linux-gnu = "7d8860572431bd4ee1b9cd0cd77cf7ff29fdd5b91ed7c92a820f872de6ced558";
+    aarch64-unknown-linux-musl = "9e7cfd960fb8ad3e1f51ef667c56032d3d4d9d9f573a06bbcf65a7c7a96ab430";
+    x86_64-apple-darwin = "b6003d49fb857ff8dc105a3ccba98b851cd3e7d874005acb92284fd1113adc0d";
+    aarch64-apple-darwin = "e1a37dc5991304716e260144311fd291d8fb514042e45c244c582b3454477038";
+    powerpc64le-unknown-linux-gnu = "9d4591033eac22093d107991a68fffccea087b26bb54115d46cc544fbf5ef66c";
+    riscv64gc-unknown-linux-gnu = "f63981d9c1057cb20cf30871757d42475a1cd0c187b3dcce5fabb0cce0f80c5b";
+    mips64el-unknown-linux-gnuabi64 = "47488e4c53cca5c99b5837474a880f6c2368a7fe8368560dd8077bddb94959b5";
   };
 
-  selectRustPackage = pkgs: pkgs.rust_1_64;
+  selectRustPackage = pkgs: pkgs.rust_1_65;
 
   rustcPatches = [
   ];

--- a/pkgs/development/compilers/rust/1_66.nix
+++ b/pkgs/development/compilers/rust/1_66.nix
@@ -20,8 +20,8 @@
 } @ args:
 
 import ./default.nix {
-  rustcVersion = "1.66.0";
-  rustcSha256 = "sha256-OzzT6lqCombnXQs18LVMFgIVdtnreNOEBSF1p3KTWkg=";
+  rustcVersion = "1.66.1";
+  rustcSha256 = "sha256-WzyTOpTHIYdwXU7ikxmLq/3QlEL1k3+9aF2zqB9JWbo=";
 
   llvmSharedForBuild = pkgsBuildBuild.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };
   llvmSharedForHost = pkgsBuildHost.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };

--- a/pkgs/development/compilers/rust/1_66.nix
+++ b/pkgs/development/compilers/rust/1_66.nix
@@ -20,8 +20,8 @@
 } @ args:
 
 import ./default.nix {
-  rustcVersion = "1.65.0";
-  rustcSha256 = "sha256-WCi7Z/Z36r+MOEAgWCsM56+IThyEOJSE9/jQDdgsADg=";
+  rustcVersion = "1.66.0";
+  rustcSha256 = "sha256-OzzT6lqCombnXQs18LVMFgIVdtnreNOEBSF1p3KTWkg=";
 
   llvmSharedForBuild = pkgsBuildBuild.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };
   llvmSharedForHost = pkgsBuildHost.llvmPackages_14.libllvm.override { enableSharedLibraries = true; };
@@ -37,25 +37,25 @@ import ./default.nix {
 
   # Note: the version MUST be one version prior to the version we're
   # building
-  bootstrapVersion = "1.64.0";
+  bootstrapVersion = "1.65.0";
 
   # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
   bootstrapHashes = {
-    i686-unknown-linux-gnu = "177b4f95c8cdaa34bb29e69950cbfe236e123757078af4792779c43ee3818199";
-    x86_64-unknown-linux-gnu = "a893977f238291370ab96726a74b6b9ae854dc75fbf5730954d901a93843bf9b";
-    x86_64-unknown-linux-musl = "d5c4293a8fe1b34d857bec4124229c39711f8759aa2f6108c8b6c22a308f96bb";
-    arm-unknown-linux-gnueabihf = "0d7c9c746f7b98f1f99e4cf720f9a32b2f5cdf22cb1d9f677b41c1dca62f14f8";
-    armv7-unknown-linux-gnueabihf = "0be29740f565ca8835ba260691274585733a7f4130ec872bfa37654a08013828";
-    aarch64-unknown-linux-gnu = "7d8860572431bd4ee1b9cd0cd77cf7ff29fdd5b91ed7c92a820f872de6ced558";
-    aarch64-unknown-linux-musl = "9e7cfd960fb8ad3e1f51ef667c56032d3d4d9d9f573a06bbcf65a7c7a96ab430";
-    x86_64-apple-darwin = "b6003d49fb857ff8dc105a3ccba98b851cd3e7d874005acb92284fd1113adc0d";
-    aarch64-apple-darwin = "e1a37dc5991304716e260144311fd291d8fb514042e45c244c582b3454477038";
-    powerpc64le-unknown-linux-gnu = "9d4591033eac22093d107991a68fffccea087b26bb54115d46cc544fbf5ef66c";
-    riscv64gc-unknown-linux-gnu = "f63981d9c1057cb20cf30871757d42475a1cd0c187b3dcce5fabb0cce0f80c5b";
-    mips64el-unknown-linux-gnuabi64 = "47488e4c53cca5c99b5837474a880f6c2368a7fe8368560dd8077bddb94959b5";
+    i686-unknown-linux-gnu = "b29869f8e2c7029150a929b2c4e26843f363846ad99253a25be6abcfa8e84f46";
+    x86_64-unknown-linux-gnu = "8f754fdd5af783fe9020978c64e414cb45f3ad0a6f44d045219bbf2210ca3cb9";
+    x86_64-unknown-linux-musl = "716984def5509a844c2dde1c7be42bfadeb179f751d5c1a30c9c7198c8c089cd";
+    arm-unknown-linux-gnueabihf = "e27f835c16bfcb66ad022a17d5c4602899e021e483a432ca4cc2cb4ecd39e938";
+    armv7-unknown-linux-gnueabihf = "5376d467a29b32cacb771e0c76dc280bd623852709e7ffd92caabab076d5475f";
+    aarch64-unknown-linux-gnu = "f406136010e6a1cdce3fb6573506f00d23858af49dd20a46723c3fa5257b7796";
+    aarch64-unknown-linux-musl = "4b701dc3cbac04ebf0e336cff2f4ce5fc1a1984c183226863c9ed911eb00b07e";
+    x86_64-apple-darwin = "139087a3937799415fd829e5a88162a69a32c23725a44457f9c96b98e4d64a7c";
+    aarch64-apple-darwin = "7ddc335bd10fc32d3039ef36248a5d0c4865db2437c8aad20a2428a6cf41df09";
+    powerpc64le-unknown-linux-gnu = "3f1d0d5bb13213348dc65e373f8c412fc0a12ee55abc1c864f7e0300932fc687";
+    riscv64gc-unknown-linux-gnu = "aac7067348d218faa452b4bdc735778a51570a310ad645313ec767b5d7c88492";
+    mips64el-unknown-linux-gnuabi64 = "d91ed3857c5256720da890f6533684b684e880bf9006dc4e4f4181213a5c4a09";
   };
 
-  selectRustPackage = pkgs: pkgs.rust_1_65;
+  selectRustPackage = pkgs: pkgs.rust_1_66;
 
   rustcPatches = [
   ];

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -52,7 +52,9 @@ in stdenv.mkDerivation rec {
        # when linking stage1 libstd: cc: undefined reference to `__cxa_begin_catch'
        optional (stdenv.isLinux && !withBundledLLVM) "--push-state --as-needed -lstdc++ --pop-state"
     ++ optional (stdenv.isDarwin && !withBundledLLVM) "-lc++"
-    ++ optional stdenv.isDarwin "-rpath ${llvmSharedForHost}/lib");
+    ++ optional stdenv.isDarwin "-rpath ${llvmSharedForHost}/lib"
+       # https://github.com/NixOS/nixpkgs/issues/201254
+    ++ optional (stdenv.isLinux && stdenv.isAarch64 && stdenv.cc.isGNU) "-lgcc");
 
   # Increase codegen units to introduce parallelism within the compiler.
   RUSTFLAGS = "-Ccodegen-units=10";

--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -149,6 +149,8 @@ stdenv.mkDerivation (finalAttrs: rec {
   # while we have a double-float toolchain
   NIX_CFLAGS_COMPILE = lib.optionalString (with stdenv.hostPlatform; isRiscV && is64bit && lib.versionOlder version "91") "-mabi=lp64d";
 
+  NIX_LDFLAGS = if (with stdenv; isAarch64 && isLinux) then [ "-lgcc" ] else null;
+
   postPatch = lib.optionalString (lib.versionOlder version "102") ''
     # This patch is a manually applied fix of
     #   https://bugzilla.mozilla.org/show_bug.cgi?id=1644600

--- a/pkgs/development/tools/rust/sqlx-cli/default.nix
+++ b/pkgs/development/tools/rust/sqlx-cli/default.nix
@@ -1,4 +1,17 @@
-{ stdenv, lib, rustPlatform, fetchFromGitHub, pkg-config, openssl, SystemConfiguration, CoreFoundation, Security, libiconv, testers, sqlx-cli }:
+{ stdenv
+, lib
+, rustPlatform
+, fetchFromGitHub
+, fetchpatch
+, pkg-config
+, openssl
+, SystemConfiguration
+, CoreFoundation
+, Security
+, libiconv
+, testers
+, sqlx-cli
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "sqlx-cli";
@@ -10,6 +23,15 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     sha256 = "sha256-pQlrKjhOJfjNEmLxqnFmmBY1naheZUsaq2tGdLKGxjg=";
   };
+
+  patches = [
+    # https://github.com/launchbadge/sqlx/pull/2228
+    (fetchpatch {
+      name = "fix-rust-1.65-compile.patch";
+      url = "https://github.com/launchbadge/sqlx/commit/2fdf85b212332647dc4ac47e087df946151feedf.patch";
+      hash = "sha256-5BCuIwmECe9qQrdYll7T+UOGwuTBolWEhKNE7GcZqJw=";
+    })
+  ];
 
   cargoSha256 = "sha256-AbA8L7rkyZfKW0vvjyrcW5eU6jGD+zAqIcEUOJmeqJs=";
 

--- a/pkgs/os-specific/linux/catfs/default.nix
+++ b/pkgs/os-specific/linux/catfs/default.nix
@@ -15,6 +15,11 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0zca0c4n2p9s5kn8c9f9lyxdf3df88a63nmhprpgflj86bh8wgf5";
   };
 
+  patches = [
+    # monitor https://github.com/kahing/catfs/issues/71
+    ./fix-for-rust-1.65.diff
+  ];
+
   cargoSha256 = "1agcwq409s40kyij487wjrp8mj7942r9l2nqwks4xqlfb0bvaimf";
 
   cargoPatches = [

--- a/pkgs/os-specific/linux/catfs/fix-for-rust-1.65.diff
+++ b/pkgs/os-specific/linux/catfs/fix-for-rust-1.65.diff
@@ -1,0 +1,13 @@
+diff --git a/src/catfs/file.rs b/src/catfs/file.rs
+index 6e781eb..92fdd80 100644
+--- a/src/catfs/file.rs
++++ b/src/catfs/file.rs
+@@ -569,7 +569,7 @@ impl Handle {
+         path: &dyn AsRef<Path>,
+         create: bool,
+     ) -> error::Result<()> {
+-        let _ = self.page_in_res.0.lock().unwrap();
++        drop(self.page_in_res.0.lock().unwrap());
+ 
+         let mut buf = [0u8; 0];
+         let mut flags = rlibc::O_RDWR;

--- a/pkgs/tools/misc/rpm-ostree/default.nix
+++ b/pkgs/tools/misc/rpm-ostree/default.nix
@@ -114,6 +114,9 @@ stdenv.mkDerivation rec {
     env NOCONFIGURE=1 ./autogen.sh
   '';
 
+  # https://github.com/NixOS/nixpkgs/issues/201254
+  NIX_LDFLAGS = lib.optionalString (stdenv.isLinux && stdenv.isAarch64 && stdenv.cc.isGNU) "-lgcc";
+
   meta = with lib; {
     description = "A hybrid image/package system. It uses OSTree as an image format, and uses RPM as a component model";
     homepage = "https://coreos.github.io/rpm-ostree/";

--- a/pkgs/tools/misc/synth/default.nix
+++ b/pkgs/tools/misc/synth/default.nix
@@ -1,6 +1,7 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
+, fetchpatch
 , stdenv
 , AppKit
 , Security
@@ -18,6 +19,15 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoSha256 = "sha256-COy8szsYKEzjtRBH8063ug5BkMv3qpc3i2RNb+n4I04=";
+
+  patches = [
+    # https://github.com/shuttle-hq/synth/pull/391
+    (fetchpatch {
+      name = "fix-for-rust-1.65.patch";
+      url = "https://github.com/shuttle-hq/synth/commit/c69b9b5c72441a51d09fc977de16b09a60eeecd3.patch";
+      hash = "sha256-uRCf+rEYTRgYPyrAbcXNEwpB92tzN8oYgv+/TyJaoHo=";
+    })
+  ];
 
   buildInputs = lib.optionals stdenv.isDarwin [
     AppKit

--- a/pkgs/tools/misc/vector/default.nix
+++ b/pkgs/tools/misc/vector/default.nix
@@ -44,6 +44,11 @@ rustPlatform.buildRustPackage {
     hash = "sha256-7iYiSO966o0M9M0ijGCpuRVRgus+tURLBN9S5lPDRb8=";
   };
 
+  patches = [
+    # replace with https://github.com/vectordotdev/vector/pull/15093 when ready
+    ./fix-for-rust-1.66.diff
+  ];
+
   cargoHash = "sha256-EqK6r/pFFKmnpPPUhqdC3bztYQZ+2w7u7V8Rj+9oWII=";
   nativeBuildInputs = [ pkg-config cmake perl ];
   buildInputs = [ oniguruma openssl protobuf rdkafka zstd ]

--- a/pkgs/tools/misc/vector/fix-for-rust-1.66.diff
+++ b/pkgs/tools/misc/vector/fix-for-rust-1.66.diff
@@ -1,0 +1,13 @@
+diff --git a/src/sources/aws_kinesis_firehose/filters.rs b/src/sources/aws_kinesis_firehose/filters.rs
+index ac33682..fe65ed4 100644
+--- a/src/sources/aws_kinesis_firehose/filters.rs
++++ b/src/sources/aws_kinesis_firehose/filters.rs
+@@ -28,7 +28,7 @@ pub fn firehose(
+     acknowledgements: bool,
+     out: SourceSender,
+     log_namespace: LogNamespace,
+-) -> impl Filter<Extract = impl warp::Reply, Error = Infallible> + Clone {
++) -> impl Filter<Extract = (impl warp::Reply,), Error = Infallible> + Clone {
+     let bytes_received = register!(BytesReceived::from(Protocol::HTTP));
+     let context = handlers::Context {
+         compression: record_compression,

--- a/pkgs/tools/networking/httplz/default.nix
+++ b/pkgs/tools/networking/httplz/default.nix
@@ -1,6 +1,7 @@
 { lib
 , rustPlatform
 , fetchCrate
+, fetchpatch
 , installShellFiles
 , makeWrapper
 , pkg-config
@@ -20,6 +21,15 @@ rustPlatform.buildRustPackage rec {
     pname = "https";
     sha256 = "sha256-+nCqMTLrBYNQvoKo1PzkyzRCkKdlE88+NYoJcIlAJts=";
   };
+
+  patches = [
+    # https://github.com/thecoshman/http/pull/151
+    (fetchpatch {
+      name = "fix-rust-1.65-compile.patch";
+      url = "https://github.com/thecoshman/http/commit/6e4c8e97cce09d0d18d4936f90aa643659d813fc.patch";
+      hash = "sha256-mXclXfp2Nzq6Pr9VFmxiOzECGZEQRNOAcXoKhiOyuFs=";
+    })
+  ];
 
   cargoSha256 = "sha256-odiVIfNJPpagoASnYvdOosHXa37gbQM8Zmvtnao0pAs=";
 

--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -79,6 +79,9 @@ replace-with = "vendored-sources"' >> ./zeroidc/.cargo/config.toml
 
   outputs = [ "out" "man" ];
 
+  # https://github.com/NixOS/nixpkgs/issues/201254
+  NIX_LDFLAGS = lib.optionalString (stdenv.isLinux && stdenv.isAarch64 && stdenv.cc.isGNU) "-lgcc";
+
   meta = with lib; {
     description = "Create flat virtual Ethernet networks of almost unlimited size";
     homepage = "https://www.zerotier.com";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15009,11 +15009,11 @@ with pkgs;
     inherit (darwin) apple_sdk;
   };
 
-  rust_1_65 = callPackage ../development/compilers/rust/1_65.nix {
+  rust_1_66 = callPackage ../development/compilers/rust/1_66.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_14 = llvmPackages_14.libllvm;
   };
-  rust = rust_1_65;
+  rust = rust_1_66;
 
   mrustc = callPackage ../development/compilers/mrustc { };
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
@@ -15022,8 +15022,8 @@ with pkgs;
     openssl = openssl_1_1;
   };
 
-  rustPackages_1_65 = rust_1_65.packages.stable;
-  rustPackages = rustPackages_1_65;
+  rustPackages_1_66 = rust_1_66.packages.stable;
+  rustPackages = rustPackages_1_66;
 
   inherit (rustPackages) cargo clippy rustc rustPlatform;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15009,11 +15009,11 @@ with pkgs;
     inherit (darwin) apple_sdk;
   };
 
-  rust_1_64 = callPackage ../development/compilers/rust/1_64.nix {
+  rust_1_65 = callPackage ../development/compilers/rust/1_65.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_14 = llvmPackages_14.libllvm;
   };
-  rust = rust_1_64;
+  rust = rust_1_65;
 
   mrustc = callPackage ../development/compilers/mrustc { };
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
@@ -15022,8 +15022,8 @@ with pkgs;
     openssl = openssl_1_1;
   };
 
-  rustPackages_1_64 = rust_1_64.packages.stable;
-  rustPackages = rustPackages_1_64;
+  rustPackages_1_65 = rust_1_65.packages.stable;
+  rustPackages = rustPackages_1_65;
 
   inherit (rustPackages) cargo clippy rustc rustPlatform;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11106,6 +11106,8 @@ with pkgs;
 
   rpm-ostree = callPackage ../tools/misc/rpm-ostree {
     gperf = gperf_3_0;
+    # https://github.com/NixOS/nixpkgs/issues/201254
+    stdenv = if stdenv.isLinux && stdenv.isAarch64 && stdenv.cc.isGNU then gcc11Stdenv else stdenv;
   };
 
   rpm2targz = callPackage ../tools/archivers/rpm2targz { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15012,6 +15012,8 @@ with pkgs;
   rust_1_66 = callPackage ../development/compilers/rust/1_66.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_14 = llvmPackages_14.libllvm;
+    # https://github.com/NixOS/nixpkgs/issues/201254
+    stdenv = if stdenv.isLinux && stdenv.isAarch64 && stdenv.cc.isGNU then gcc11Stdenv else stdenv;
   };
   rust = rust_1_66;
 


### PR DESCRIPTION
###### Description of changes

https://github.com/rust-lang/rust/releases/tag/1.65.0
https://github.com/rust-lang/rust/releases/tag/1.66.0
https://github.com/rust-lang/rust/releases/tag/1.66.1

Fixes CVE-2022-46176.

This is the path of least resistence, sadly; see the discussion in #210139.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin, `nix-build -A fd -A synth -A sqlx-cli -A zee -A httplz`
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
