### PR TITLE
prosody: add cloud_notify_encrypted module

### DIFF
--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -99,6 +99,15 @@ let
       description = "Push notifications to inform users of new messages or other pertinent information even when they have no XMPP clients online";
     };
 
+    cloud_notify_encrypted = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Include encrypted text within cloud notifications for message preview with Siskin IM.
+        See <https://xeps.tigase.net/docs/push-notifications/encrypt/> for details.
+      '';
+    };
+
     pep = mkOption {
       type = types.bool;
       default = true;

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -108,6 +108,24 @@ let
       '';
     };
 
+    cloud_notify_priority_tag = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Include a priority tag within cloud notifications for e.g. calls with Sisikin IM.
+        See <https://xeps.tigase.net/docs/push-notifications/priority/> for details.
+      '';
+    };
+
+    cloud_notify_filters = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Allow filtering cloud notifications so e.g. unknown senders will not trigger a cloud message on Siskin IM.
+        See <https://xeps.tigase.net/docs/push-notifications/filters/unknown-senders/> for details.
+      '';
+    };
+
     pep = mkOption {
       type = types.bool;
       default = true;

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -30,6 +30,7 @@ let
       luabitop
       luadbi-sqlite3
       luaunbound
+      luaossl
     ]
     ++ lib.optional withDBI p.luadbi
     ++ withExtraLuaPackages p
@@ -43,6 +44,7 @@ stdenv.mkDerivation rec {
   # default setup.
   nixosModuleDeps = [
     "cloud_notify"
+    "cloud_notify_encrypted"
     "vcard_muc"
     "http_upload"
   ];

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -45,6 +45,8 @@ stdenv.mkDerivation rec {
   nixosModuleDeps = [
     "cloud_notify"
     "cloud_notify_encrypted"
+    "cloud_notify_priority_tag"
+    "cloud_notify_filters"
     "vcard_muc"
     "http_upload"
   ];


### PR DESCRIPTION
###### Description of changes

I've been pointed out in https://github.com/tigase/siskin-im/issues/177 that this module exists: [modules.prosody.im/mod_cloud_notify_encrypted](https://modules.prosody.im/mod_cloud_notify_encrypted)
regardless of my success with the actual issue linked I think the module would be useful in general.

I'm not sure what to do with new modules, should I add it with default enable=false for a while first?
Alternatively I'd be open to just do this in my configuration, but I wouldn't know how to add `luaossl` to the luaEnv cleanly from there.

This is take 2 of https://github.com/NixOS/nixpkgs/pull/162491 -- can't re-open that PR after rebasing the branch...

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
