### PR TITLE
discord-gamesdk: init at 3.2.1

### DIFF
--- a/pkgs/development/libraries/discord-gamesdk/default.nix
+++ b/pkgs/development/libraries/discord-gamesdk/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchzip
+, autoPatchelfHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "discord-gamesdk";
+  version = "3.2.1";
+
+  src = fetchzip {
+    url = "https://dl-game-sdk.discordapp.net/${version}/discord_game_sdk.zip";
+    sha256 = "sha256-83DgL9y3lHLLJ8vgL3EOVk2Tjcue64N+iuDj/UpSdLc=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  installPhase =
+    let
+      processor = stdenv.hostPlatform.uname.processor;
+      sharedLibrary = stdenv.hostPlatform.extensions.sharedLibrary;
+    in
+    ''
+      runHook preInstall
+
+      install -Dm555 lib/${processor}/discord_game_sdk${sharedLibrary} $out/lib/discord_game_sdk${sharedLibrary}
+
+      runHook postInstall
+    '';
+
+  meta = with lib; {
+    homepage = "https://discord.com/developers/docs/game-sdk/sdk-starter-guide";
+    description = "Library to allow other programs to interact with the Discord desktop application";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ tomodachi94 ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "x86_64-windows" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19242,6 +19242,8 @@ with pkgs;
 
   discordchatexporter-cli = callPackage ../tools/backup/discordchatexporter-cli { };
 
+  discord-gamesdk = callPackage ../development/libraries/discord-gamesdk { };
+
   discord-rpc = callPackage ../development/libraries/discord-rpc {
     inherit (darwin.apple_sdk.frameworks) AppKit;
   };


### PR DESCRIPTION
###### Description of changes
A library that allows programs to interface with Discord.

Note: Some games or applications might have this library vendored; I'm not sure how to discover those, just something to be aware of.

(I'm not aware of a better homepage URL; if there's a better one, please link me to it!)

This is a duplicate of #213233, as I was not careful with a shallow clone.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] ~~aarch64-linux~~ Not applicable
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
