### PR TITLE
radare2.plugins.r2ghidra: init at 5.8.2

### DIFF
--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -124,6 +124,7 @@ stdenv.mkDerivation rec {
   # TODO better?
   passthru = {
     plugins = {
+      r2ghidra = callPackage ./plugins/r2ghidra { };
     };
     # nix-build -E "with import ./. {}; pkgs.radare2.withPlugins [\"r2ghidra\"]"
     # TODO better?

--- a/pkgs/development/tools/analysis/radare2/plugins/r2ghidra/default.nix
+++ b/pkgs/development/tools/analysis/radare2/plugins/r2ghidra/default.nix
@@ -1,0 +1,131 @@
+# see also
+# https://github.com/radareorg/radare2-pm/blob/master/db/r2ghidra
+# https://github.com/radareorg/radare2-pm/blob/master/db/r2ghidra-sleigh
+
+{ lib
+, clangStdenv
+, fetchFromGitHub
+, buildPackages
+, pkg-config
+, meson
+, ninja
+, radare2
+}:
+
+clangStdenv.mkDerivation rec {
+  pname = "r2ghidra";
+  version = "5.8.2";
+
+  src = fetchFromGitHub {
+    owner = "radareorg";
+    repo = "r2ghidra";
+    rev = version;
+    sha256 = "sha256-vAccsANhMoAMWgsYSK7DI1OmJQeQRPazOMJlAxRsa+g=";
+    fetchSubmodules = true;
+  };
+
+  # https://github.com/radareorg/r2ghidra/blob/master/ghidra/Makefile
+  # GHIDRA_NATIVE_COMMIT
+  # https://github.com/radareorg/r2ghidra/blob/5.8.2/Makefile
+  # https://github.com/radareorg/ghidra-native
+  # https://github.com/radareorg/r2ghidra/issues/100
+  ghidra-native-src = fetchFromGitHub {
+    owner = "radareorg";
+    repo = "ghidra-native";
+    rev = "0.2.5";
+    sha256 = "sha256-dycOFz0ZBXbPAuFobvxJkdFWzSETilcBdMf1KLtl5JY=";
+  };
+
+  # https://github.com/NationalSecurityAgency/ghidra/tree/master/Ghidra/Processors
+  ghidra-processors-src = fetchFromGitHub {
+    owner = "NationalSecurityAgency";
+    repo = "ghidra";
+    rev = "Ghidra_10.2.2_build";
+    # 6 of 240 MB
+    sparseCheckout = ''
+      Ghidra/Processors
+    '';
+    sha256 = "sha256-g1efLVLoFQYqoaFAYGy/lfrPx2ZfXEhp0ZsJH9ew7XE=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ];
+
+  buildInputs = [
+    radare2
+  ];
+
+  # need write-access for patch + build
+  postUnpack = ''
+    cp -r ${ghidra-native-src} source/ghidra-native
+    chmod -R +w source/ghidra-native
+    cp -r ${ghidra-processors-src}/Ghidra source/ghidra/src
+    chmod -R +w source/ghidra/src
+  '';
+
+  NIX_CFLAGS_COMPILE = [
+    "-O1" # fortify
+    # hide warnings
+    "-Wno-return-stack-address"
+    "-Wno-unused-variable"
+    "-Wno-unused-function"
+    "-Wno-reorder-ctor"
+    "-Wno-switch"
+    "-Wno-pessimizing-move"
+    "-Wno-unneeded-internal-declaration"
+    "-Wno-mismatched-tags"
+    "-Wno-unused-result"
+    "-Wno-macro-redefined"
+  ];
+
+  # https://github.com/radareorg/r2ghidra/blob/master/preconfigure
+  postPatch = ''
+    echo "Patching install prefix in meson.build"
+    sed -i.bak "s|^  r2_plugdir = res.stdout().strip()$|&.replace('${radare2.out}', '$out')|" meson.build
+    diff -u meson.build{.bak,} || true
+    rm meson.build.bak
+
+    echo "Patching radare2 library path"
+    substituteInPlace src/SleighAsm.cpp \
+      --replace \
+        'path = strdup (R2_PREFIX "/lib/radare2/" R2_VERSION "/r2ghidra_sleigh");' \
+        'path = strdup ("'$out'" "/lib/radare2/" R2_VERSION "/r2ghidra_sleigh");'
+
+    echo "Patching ghidra-native"
+    make -C ghidra-native patch
+  '';
+
+  # workround for https://github.com/radareorg/r2ghidra/issues/93
+  # https://github.com/radareorg/r2ghidra/blob/master/ghidra/Makefile
+  postBuild = ''
+    GHIDRA_SLEIGH_HOME=../ghidra/src/Processors
+    cp -v ../ghidra-processors.txt.default ../ghidra-processors.txt
+    echo "Compiling processor files"
+    ./sleighc -a $GHIDRA_SLEIGH_HOME/DATA
+    cat ../ghidra-processors.txt | sed "s|^|$GHIDRA_SLEIGH_HOME/|" | xargs -n1 -P$NIX_BUILD_CORES ./sleighc -a 2>/dev/null
+  '';
+
+  # TODO use radare2.abiVersion https://github.com/radareorg/radare2/pull/20545
+  postInstall = ''
+    echo "Installing processor files to $out/lib/radare2/${radare2.version}/r2ghidra_sleigh"
+    mkdir $out/lib/radare2/${radare2.version}/r2ghidra_sleigh
+    for a in DATA $(cat ../ghidra-processors.txt); do
+      for b in $GHIDRA_SLEIGH_HOME/$a/*/*/*.{cspec,ldefs,pspec,sla}; do
+        cp $b $out/lib/radare2/${radare2.version}/r2ghidra_sleigh
+      done
+    done
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Native Ghidra Decompiler for radare2";
+    homepage = "https://github.com/radareorg/r2ghidra";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ milahu ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
###### Description of changes

add ghidra plugin for radare2

fix #86448

###### TODO

- [ ] radare2.withPlugins probably should accept a list of packages, not a list of strings
- [x] make it work with `iaito`
- [ ] make it work with `rizin`
- [ ] make it work with `cutter`
- [ ] add more radare2 plugins from https://github.com/radareorg/radare2-pm

###### Testing

```sh
# build
nix-build -E 'with import ./. {}; (radare2.withPlugins ["r2ghidra"])'

# shell
nix-shell -E 'with import ./. {}; mkShell { buildInputs = [ (radare2.withPlugins ["r2ghidra"]) hello ]; }'
r2 $(which hello)
# aa
# s main
# pdg
```

result

<details>

```c
void entry0(ulong noname_0, ulong noname_1, ulong arg3)

{
    ulong unaff_retaddr;
    uchar auStack8 [8];
    
    (*_reloc.__libc_start_main)
              (main, unaff_retaddr, &stack0x00000008, sym.__libc_csu_init, sym.__libc_csu_fini, arg3, auStack8);
    do {
    // WARNING: Do nothing block with infinite loop
    } while( true );
}
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### maintainers

radare2 maintainers @raskin @makefu @mic92 @arkivm