### PR TITLE
coqPackages_8_16.coq-lsp: init at 0.1.6+8.16

### DIFF
--- a/pkgs/development/coq-modules/coq-lsp/default.nix
+++ b/pkgs/development/coq-modules/coq-lsp/default.nix
@@ -1,0 +1,36 @@
+{ lib, mkCoqDerivation, coq, serapi, makeWrapper, version ? null }:
+
+mkCoqDerivation rec {
+  pname = "coq-lsp";
+  owner = "ejgallego";
+  namePrefix = [ ];
+
+  useDune = true;
+
+  release."0.1.6.1+8.16".sha256 = "sha256-aX8/pN4fVYaF7ZEPYfvYpEZLiQM++ZG1fAhiLftQ9Aw=";
+
+  inherit version;
+  defaultVersion = with lib.versions; lib.switch coq.coq-version [
+    { case = isEq "8.16"; out = "0.1.6.1+8.16"; }
+  ] null;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    dune install ${pname} --prefix=$out
+    wrapProgram $out/bin/coq-lsp --prefix OCAMLPATH : $OCAMLPATH
+    runHook postInstall
+  '';
+
+  propagatedBuildInputs = [ serapi ]
+    ++ (with coq.ocamlPackages; [ camlp-streams dune-build-info menhir uri yojson ]);
+
+  meta = with lib; {
+    description = "Language Server Protocol and VS Code Extension for Coq";
+    homepage = "https://github.com/ejgallego/coq-lsp";
+    changelog = "https://github.com/ejgallego/coq-lsp/blob/${defaultVersion}/CHANGES.md";
+    maintainers = with maintainers; [ marsam ];
+    license = licenses.lgpl21Only;
+  };
+}

--- a/pkgs/development/coq-modules/serapi/default.nix
+++ b/pkgs/development/coq-modules/serapi/default.nix
@@ -2,7 +2,7 @@
 
 let
   release = {
-    "8.16.0+0.16.0".sha256 = "sha256-Of5vO6wvqGyxagjGuuY3qCiLKbBr3VzLHiIn9U2R21E=";
+    "8.16.0+0.16.3".sha256 = "sha256-22Kawp8jAsgyBTppwN5vmN7zEaB1QfPs0qKxd6x/7Uc=";
     "8.15.0+0.15.0".sha256 = "1vh99ya2dq6a8xl2jrilgs0rpj4j227qx8zvzd2v5xylx0p4bbrp";
     "8.14.0+0.14.0".sha256 = "1kh80yb791yl771qbqkvwhbhydfii23a7lql0jgifvllm2k8hd8d";
     "8.13.0+0.13.0".sha256 = "0k69907xn4k61w4mkhwf8kh8drw9pijk9ynijsppihw98j8w38fy";
@@ -18,7 +18,7 @@ in
 
   defaultVersion =  with versions;
     lib.switch coq.version [
-      { case = isEq "8.16"; out = "8.16.0+0.16.0"; }
+      { case = isEq "8.16"; out = "8.16.0+0.16.3"; }
       { case = isEq "8.15"; out = "8.15.0+0.15.0"; }
       { case = isEq "8.14"; out = "8.14.0+0.14.0"; }
       { case = isEq "8.13"; out = "8.13.0+0.13.0"; }
@@ -88,7 +88,7 @@ in
     ];
 
     propagatedBuildInputs = o.propagatedBuildInputs ++
-      lib.optional (version == "8.16.0+0.16.0" || version == "dev") coq.ocamlPackages.ppx_hash
+      lib.optional (version == "8.16.0+0.16.3" || version == "dev") coq.ocamlPackages.ppx_hash
     ;
 
 })

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -34,6 +34,7 @@ let
       coq-elpi = callPackage ../development/coq-modules/coq-elpi {};
       coq-ext-lib = callPackage ../development/coq-modules/coq-ext-lib {};
       coq-haskell = callPackage ../development/coq-modules/coq-haskell { };
+      coq-lsp = callPackage ../development/coq-modules/coq-lsp {};
       coq-record-update = callPackage ../development/coq-modules/coq-record-update { };
       coqeal = callPackage ../development/coq-modules/coqeal {};
       coqhammer = callPackage ../development/coq-modules/coqhammer {};


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add https://github.com/ejgallego/coq-lsp

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
