### PR TITLE
go-musicfox: init at 3.6.1

### DIFF
--- a/pkgs/applications/audio/go-musicfox/default.nix
+++ b/pkgs/applications/audio/go-musicfox/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, clangStdenv
+, pkg-config
+, alsa-lib
+, flac
+}:
+
+# gcc only supports objc on darwin
+buildGoModule.override { stdenv = clangStdenv; } rec {
+  pname = "go-musicfox";
+  version = "3.6.1";
+
+  src = fetchFromGitHub {
+    owner = "anhoder";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-iinEo+HrcNM3gx1iUqe1duRd45PrYgVybRt9NKphwuY=";
+  };
+
+  deleteVendor = true;
+
+  vendorHash = "sha256-DbdAEvcspTYMYMvc5IBEUtQAJMW8JZpNi0UA/DvzGFo=";
+
+  subPackages = [ "cmd/musicfox.go" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X go-musicfox/pkg/constants.AppVersion=${version}"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    flac
+  ];
+
+  meta = with lib; {
+    description = "Terminal netease cloud music client written in Go";
+    homepage = "https://github.com/anhoder/go-musicfox";
+    license = licenses.mit;
+    mainProgram = "musicfox";
+    maintainers = with maintainers; [ zendo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28977,6 +28977,8 @@ with pkgs;
 
   go-motion = callPackage ../development/tools/go-motion { };
 
+  go-musicfox = callPackage ../applications/audio/go-musicfox { };
+
   gpg-mdp = callPackage ../applications/misc/gpg-mdp { };
 
   greenfoot = callPackage ../applications/editors/greenfoot {


### PR DESCRIPTION
###### Description of changes

https://github.com/anhoder/go-musicfox

Terminal netease cloud music client written in Go.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
