### PR TITLE
python310Packages.airtouch4pyapi: 1.0.5 -> 1.0.8

### DIFF
--- a/pkgs/development/python-modules/airtouch4pyapi/default.nix
+++ b/pkgs/development/python-modules/airtouch4pyapi/default.nix
@@ -1,14 +1,13 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , numpy
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "airtouch4pyapi";
-  version = "1.0.5";
+  version = "1.0.8";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -16,18 +15,9 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "LonePurpleWolf";
     repo = pname;
-    # https://github.com/LonePurpleWolf/airtouch4pyapi/issues/5
-    rev = "34783888846783c058fe79cec16feda45504f701";
-    sha256 = "17c7fm72p085pg9msvsfdggbskvm12a6jlb5bw1cndrqsqcrxywx";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-RiRwebumidn0nijL/e9J74ZYx0DASi1up5BTNxYoGEA=";
   };
-
-  patches = [
-    # https://github.com/LonePurpleWolf/airtouch4pyapi/pull/10
-    (fetchpatch {
-      url = "https://github.com/LonePurpleWolf/airtouch4pyapi/commit/5b5d91fad63495c83422e7a850897946ac95b25d.patch";
-      hash = "sha256-tVlCLXuOJSqjbs0jj0iHCIXWZE8wmMV3ChzmE6uq3SM=";
-    })
-  ];
 
   propagatedBuildInputs = [
     numpy


### PR DESCRIPTION

###### Description of changes
Diff: https://github.com/LonePurpleWolf/airtouch4pyapi/compare/3478388...v1.0.8

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
