### PR TITLE
diffutils: 3.8 -> 3.9

### DIFF
--- a/pkgs/tools/text/diffutils/default.nix
+++ b/pkgs/tools/text/diffutils/default.nix
@@ -7,12 +7,24 @@
 
 stdenv.mkDerivation rec {
   pname = "diffutils";
-  version = "3.8";
+  version = "3.9";
 
   src = fetchurl {
     url = "mirror://gnu/diffutils/diffutils-${version}.tar.xz";
-    sha256 = "sha256-pr3X0bMSZtEcT03mwbdI1GB6sCMa9RiPwlM9CuJDj+w=";
+    hash = "sha256-2A076QogGGjeg9eNrTQTrYgWDMU7zDbrnq98INvwI/E=";
   };
+
+  patches = [
+    # Backport of a fix for 'diff -D' output.
+    # TODO: remove when updating to 3.10.
+    ./fix-diff-D.patch
+  ];
+
+  postPatch = ''
+    # avoid the need for help2man
+    # TODO: can be removed when fix-diff-D.patch is removed.
+    touch man/diff.1
+  '';
 
   outputs = [ "out" "info" ];
 

--- a/pkgs/tools/text/diffutils/fix-diff-D.patch
+++ b/pkgs/tools/text/diffutils/fix-diff-D.patch
@@ -1,0 +1,15 @@
+https://git.savannah.gnu.org/cgit/diffutils.git/patch/?id=ba08fbbb0ca5da455bf695236c57bc50e7faed50
+https://github.com/NixOS/nixpkgs/pull/213421#issuecomment-1407749912
+
+Fix 'diff -D' regression
+--- a/src/diff.c
++++ b/src/diff.c
+@@ -416,7 +416,7 @@ main (int argc, char **argv)
+ 	    char *base = b;
+ 	    int changes = 0;
+ 
+-	    for (i = 0; i < sizeof sizeof C_ifdef_group_formats; i++)
++	    for (i = 0; i < sizeof C_ifdef_group_formats; i++)
+ 	      {
+ 		char ch = C_ifdef_group_formats[i];
+ 		switch (ch)


### PR DESCRIPTION
Changes: https://savannah.gnu.org/forum/forum.php?forum_id=10282

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
