### PR TITLE
resholve: 0.8.5 -> 0.9.0

### DIFF
--- a/pkgs/development/misc/resholve/README.md
+++ b/pkgs/development/misc/resholve/README.md
@@ -252,8 +252,23 @@ with some rules (internal to resholve) for locating sub-executions in
 some of the more common commands.
 
 - "execer" lore identifies whether an executable can, cannot,
-  or might execute its arguments. Every "can" or "might" verdict requires
-  either built-in rules for finding the executable, or human triage.
+  or might execute its arguments. Every "can" or "might" verdict requires:
+  - an update to the matching rules in [binlore](https://github.com/abathur/binlore)
+    if there's absolutely no exec in the executable and binlore just lacks
+    rules for understanding this
+  - an override in [binlore](https://github.com/abathur/binlore) if there is
+    exec but it isn't actually under user control
+  - a parser in [resholve](https://github.com/abathur/resholve) capable of
+    isolating the exec'd words if the command does have exec under user
+    control
+  - overriding the execer lore for the executable if manual triage indicates
+    that all of the invocations in the current package don't include any
+    commands that the executable would exec
+  - if manual triage turns up any commands that would be exec'd, use some
+    non-resholve tool to patch/substitute/replace them before or after you
+    run resholve on them (if before, you may need to also add keep directives
+    for these absolute paths)
+
 - "wrapper" lore maps shell exec wrappers to the programs they exec so
   that resholve can substitute an executable's verdict for its wrapper's.
 

--- a/pkgs/development/misc/resholve/oildev.nix
+++ b/pkgs/development/misc/resholve/oildev.nix
@@ -9,8 +9,7 @@
 , # py-yajl deps
   git
 , # oil deps
-  readline
-, cmark
+  cmark
 , file
 , glibcLocales
 , six
@@ -36,12 +35,12 @@ rec {
 
   py-yajl = python27.pkgs.buildPythonPackage rec {
     pname = "oil-pyyajl-unstable";
-    version = "2019-12-05";
+    version = "2022-09-01";
     src = fetchFromGitHub {
       owner = "oilshell";
       repo = "py-yajl";
-      rev = "eb561e9aea6e88095d66abcc3990f2ee1f5339df";
-      sha256 = "17hcgb7r7cy8r1pwbdh8di0nvykdswlqj73c85k6z8m0filj3hbh";
+      rev = "72686b0e2e9d13d3ce5fefe47ecd607c540c90a3";
+      hash = "sha256-H3GKN0Pq1VFD5+SWxm8CXUVO7zAyj/ngKVmDaG/aRT4=";
       fetchSubmodules = true;
     };
     # just for submodule IIRC
@@ -60,9 +59,9 @@ rec {
     src = fetchFromGitHub {
       owner = "oilshell";
       repo = "oil";
-      # rev == present HEAD of release/0.8.12
-      rev = "799c0703d1da86cb80d1f5b163edf9369ad77cf1";
-      hash = "sha256-QNSISr719ycZ1Z0quxHWzCb3IvHGj9TpogaYz20hDM4=";
+      # rev == present HEAD of release/0.14.0
+      rev = "3d0427e222f7e42ae7be90c706d7fde555efca2e";
+      hash = "sha256-XMoNkBEEmD6AwNSu1uSh3OcWLfy4/ADtRckn/Pj2cP4=";
 
       /*
         It's not critical to drop most of these; the primary target is
@@ -73,16 +72,16 @@ rec {
         hash on rev updates. Command will fail w/o and not print hash.
       */
       postFetch = ''
-        rm -rf Python-2.7.13 benchmarks metrics py-yajl rfc gold web testdata services demo devtools cpp
+        rm -rf $out/{Python-2.7.13,metrics,py-yajl,rfc,gold,web,testdata,services,demo,devtools}
       '';
     };
 
-    # patch to support a python package, pass tests on macOS, etc.
+    # patch to support a python package, pass tests on macOS, drop deps, etc.
     patchSrc = fetchFromGitHub {
       owner = "abathur";
       repo = "nix-py-dev-oil";
-      rev = "v0.8.12.2";
-      hash = "sha256-+dVxzPKMGNKFE+7Ggzx9iWjjvwW2Ow3UqmjjUud9Mqo=";
+      rev = "v0.14.0.0";
+      hash = "sha256-U6uR8G6yB2xwuDE/fznco23mVFSVdCxPUNdCRYz4Mj8=";
     };
     patches = [
       "${patchSrc}/0001-add_setup_py.patch"
@@ -91,13 +90,18 @@ rec {
       "${patchSrc}/0006-disable_failing_libc_tests.patch"
       "${patchSrc}/0007-namespace_via_init.patch"
       "${patchSrc}/0009-avoid_nix_arch64_darwin_toolchain_bug.patch"
+      "${patchSrc}/0010-disable-line-input.patch"
+      "${patchSrc}/0011-disable-fanos.patch"
+      "${patchSrc}/0012-disable-doc-cmark.patch"
     ];
 
-    buildInputs = [ readline cmark py-yajl ];
+    configureFlags = [
+      "--without-readline"
+    ];
 
     nativeBuildInputs = [ re2c file makeWrapper ];
 
-    propagatedBuildInputs = [ six typing ];
+    propagatedBuildInputs = [ six typing py-yajl ];
 
     doCheck = true;
 
@@ -106,7 +110,12 @@ rec {
     '';
 
     postPatch = ''
-      patchShebangs asdl build core doctools frontend native oil_lang
+      patchShebangs asdl build core doctools frontend pyext oil_lang
+      substituteInPlace pyext/fastlex.c --replace '_gen/frontend' '../_gen/frontend'
+      substituteInPlace core/main_loop.py --replace 'import fanos' '# import fanos'
+      rm cpp/stdlib.h # keep modules from finding the wrong stdlib?
+      # work around hard parse failure documented in oilshell/oil#1468
+      substituteInPlace osh/cmd_parse.py --replace 'elif self.c_id == Id.Op_LParen' 'elif False'
     '';
 
     /*
@@ -120,8 +129,17 @@ rec {
     # See earlier note on glibcLocales TODO: verify needed?
     LOCALE_ARCHIVE = lib.optionalString (stdenv.buildPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive";
 
-    # not exhaustive; just a spot-check for now
-    pythonImportsCheck = [ "oil" "oil._devbuild" ];
+    # not exhaustive; sample what resholve uses as a sanity check
+    pythonImportsCheck = [
+      "oil"
+      "oil.asdl"
+      "oil.core"
+      "oil.frontend"
+      "oil._devbuild"
+      "oil._devbuild.gen.id_kind_asdl"
+      "oil._devbuild.gen.syntax_asdl"
+      "oil.tools.osh2oil"
+    ];
 
     meta = {
       license = with lib.licenses; [

--- a/pkgs/development/misc/resholve/source.nix
+++ b/pkgs/development/misc/resholve/source.nix
@@ -3,7 +3,7 @@
 }:
 
 rec {
-  version = "0.8.5";
+  version = "0.9.0";
   rSrc =
     # local build -> `make ci`; `make clean` to restore
     # return to remote source
@@ -14,6 +14,6 @@ rec {
         owner = "abathur";
         repo = "resholve";
         rev = "v${version}";
-        hash = "sha256-DX1xe3YC0PlhwbjsvbmUzNjrwhxFpbZW87WWbKcD0us=";
+        hash = "sha256-FRdCeeC2c3bMEXekEyilgW0PwFfUWGstZ5mXdmRPM5w=";
       };
 }


### PR DESCRIPTION
This release gets resholve caught up to the latest release of oil/osh. Since the update was already somewhat involved, I used the opportunity to also figure out how to patch out some C extensions and external dependencies that shouldn't be necessary just to use the parser.

- update README.md
- https://github.com/abathur/resholve/blob/master/CHANGELOG.md#v090-jan-29-2023
- https://github.com/abathur/nix-py-dev-oil/compare/v0.8.12.3...v0.14.0.0

Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>14 packages built:</summary>
  <ul>
    <li>aaxtomp3</li>
    <li>bash-preexec</li>
    <li>bashup-events32</li>
    <li>bashup-events44</li>
    <li>bats</li>
    <li>git-ftp</li>
    <li>ix</li>
    <li>locate-dominating-file</li>
    <li>mons</li>
    <li>msmtp</li>
    <li>packcc</li>
    <li>pdf2odt</li>
    <li>shunit2</li>
    <li>yadm</li>
  </ul>
</details>

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>19 packages built:</summary>
  <ul>
    <li>aaxtomp3</li>
    <li>arch-install-scripts</li>
    <li>bash-preexec</li>
    <li>bashup-events32</li>
    <li>bashup-events44</li>
    <li>bats</li>
    <li>dgoss</li>
    <li>git-ftp</li>
    <li>ix</li>
    <li>locate-dominating-file</li>
    <li>mons</li>
    <li>msmtp</li>
    <li>packcc</li>
    <li>pdf2odt</li>
    <li>pdfmm</li>
    <li>shunit2</li>
    <li>wgnord</li>
    <li>yadm</li>
    <li>zxfer</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
