### PR TITLE
mbuffer: add gcc to LD_LIBRARY_PATH

### DIFF
--- a/pkgs/tools/misc/mbuffer/default.nix
+++ b/pkgs/tools/misc/mbuffer/default.nix
@@ -2,7 +2,9 @@
 , stdenv
 , fetchurl
 , openssl
+, makeWrapper
 , which
+, gcc-unwrapped
 }:
 
 stdenv.mkDerivation rec {
@@ -18,8 +20,15 @@ stdenv.mkDerivation rec {
     openssl
   ];
   nativeBuildInputs = [
+    makeWrapper
     which
   ];
+
+  postFixup = ''
+    # Fix missing libgcc_s.so.1 (needed for cross-compiled binaries).
+    wrapProgram "$out/bin/mbuffer" \
+      --prefix LD_LIBRARY_PATH ":" "${lib.makeLibraryPath [ gcc-unwrapped ]}"
+  '';
 
   doCheck = true;
 


### PR DESCRIPTION
###### Description of changes

Fixes #213453. `mbuffer` needs `libgcc_s.so.1` when it's cross-compiled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] armv7l-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
