### PR TITLE
haskellPackages: ignore maintainers without email

### DIFF
--- a/maintainers/scripts/haskell/maintainer-handles.nix
+++ b/maintainers/scripts/haskell/maintainer-handles.nix
@@ -1,7 +1,21 @@
 # Nix script to lookup maintainer github handles from their email address. Used by ./hydra-report.hs.
+#
+# This script produces an attr set mapping of email addresses to GitHub handles:
+#
+# ```nix
+# > import ./maintainer-handles.nix
+# { "cdep.illabout@gmail.com" = "cdepillabout"; "john@smith.com" = "johnsmith"; ... }
+# ```
+#
+# This mapping contains all maintainers in ../../mainatainer-list.nix, but it
+# ignores maintainers who don't have a GitHub account or an email address.
 let
   pkgs = import ../../.. {};
   maintainers = import ../../maintainer-list.nix;
   inherit (pkgs) lib;
-  mkMailGithubPair = _: maintainer: if maintainer ? github then { "${maintainer.email}" = maintainer.github; } else {};
+  mkMailGithubPair = _: maintainer:
+    if (maintainer ? email) && (maintainer ? github) then
+      { "${maintainer.email}" = maintainer.github; }
+    else
+      {};
 in lib.zipAttrsWith (_: builtins.head) (lib.mapAttrsToList mkMailGithubPair maintainers)


### PR DESCRIPTION
###### Description of changes

The Hydra report generator was failing in https://github.com/cdepillabout/nix-haskell-updates-status/actions/runs/4036712903/jobs/6939513150 because there was a user recently(?) added that does not have an email address:

![image](https://user-images.githubusercontent.com/64804/215363322-d5c539f6-cb16-41c0-8dae-5261ead44b56.png)

The Haskell Hydra report generator (`maintainers/scripts/haskell/hydra-report.hs`) uses the `maintainer-handles.nix` script for generating a mapping of email addresses to GitHub handles.

This `maintainer-handles.nix` script is necessary because the Haskell Hydra report generator gets Hydra job status info as input, but needs to ping users on GitHub.  Hydra job status info only contains user emails (not GitHub handles).  So the `maintainer-handles.nix` script is necessary for looking up GitHub handles from email addresses.

This PR fixes the `maintainers-handles.nix` code to ignore maintainers that don't have email addresses.  The code was originally assuming that all maintainers have email addresses, but there was recently a maintainer added without an email address.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
