### PR TITLE
craftos-pc: init plugins compatibility

### DIFF
--- a/pkgs/applications/emulators/craftos-pc/wrapper.nix
+++ b/pkgs/applications/emulators/craftos-pc/wrapper.nix
@@ -1,0 +1,63 @@
+# Shamelessly stolen and modified from mpv/wrapper.nix
+# Arguments that this derivation gets when it is created with `callPackage`
+{ stdenv
+, lib
+, makeWrapper
+, symlinkJoin
+}:
+
+# the unwrapped CraftOS-PC derivation - 1st argument to `wrapCraftos`
+craftos-pc:
+
+let
+  # arguments to the function (exposed as `wrapMpv` in all-packages.nix)
+  wrapper = {
+    extraMakeWrapperArgs ? [],
+    # a set of derivations (probably from `craftosPlugins`) where each is
+    # expected to have a `pluginName` passthru attribute that points to the
+    # name of the script that would reside in the script's derivation's
+    # `$out/share/craftos/plugins/`.
+    plugins ? [],
+  }:
+  let
+    # All arguments besides the input and output binaries (${craftos-pc}/bin/craftos and
+    # $out/bin/craftos). These are used by the darwin specific makeWrapper call
+    # used to wrap $out/Applications/CraftOS-PC.app/Contents/MacOS/craftos as well.
+    mostMakeWrapperArgs = lib.strings.escapeShellArgs ([ "--inherit-argv0"
+    ] ++ (lib.lists.flatten (map
+      # For every script in the `scripts` argument, add the necessary flags to the wrapper
+      (plugin:
+        [
+          # Here we rely on the existence of the `pluginName` passthru
+          # attribute of the script derivation from the `scripts`
+          "--plugin ${plugin}/share/craftos/plugins/${plugin.pluginName}${stdenv.hostPlatform.extensions.sharedLibrary}"
+        ]
+      ) plugins
+    )) ++ extraMakeWrapperArgs)
+    ;
+  in
+    symlinkJoin {
+      name = "craftos-pc-with-plugins-${craftos-pc.version}";
+
+      paths = craftos-pc.all;
+
+      nativeBuildInputs = [ makeWrapper ];
+
+      passthru.unwrapped = craftos-pc;
+
+      postBuild = ''
+        # wrapProgram can't operate on symlinks
+        rm "$out/bin/${craftos-pc.meta.mainProgram}"
+        makeWrapper "${craftos-pc}/bin/${craftos-pc.meta.mainProgram}" "$out/bin/${craftos-pc.meta.mainProgram}" ${mostMakeWrapperArgs}
+      '' + lib.optionalString stdenv.isDarwin ''
+        # wrapProgram can't operate on symlinks
+        rm "$out/Applications/CraftOS-PC.app/Contents/MacOS/craftos"
+        makeWrapper "${craftos-pc}/Applications/CraftOS-PC.app/Contents/MacOS/craftos" "$out/Applications/CraftOS-PC.app/Contents/MacOS/${craftos-pc.meta.mainProgram}" ${mostMakeWrapperArgs}
+      '';
+
+      meta = {
+        inherit (craftos-pc.meta) mainProgram homepage description maintainers;
+      };
+    };
+in
+  lib.makeOverridable wrapper

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2020,13 +2020,11 @@ with pkgs;
 
   collapseos-cvm = callPackage ../applications/emulators/collapseos-cvm { };
 
-  craftos-pc = callPackage ../applications/emulators/craftos-pc { };
+  craftos-pc-unwrapped = callPackage ../applications/emulators/craftos-pc { };
 
-  darcnes = callPackage ../applications/emulators/darcnes { };
-
-  desmume = callPackage ../applications/emulators/desmume { };
-
-  dgen-sdl = callPackage ../applications/emulators/dgen-sdl { };
+  # Wraps without trigerring a rebuild
+  wrapCraftosPC = callPackage ../applications/emulators/craftos-pc/wrapper.nix { };
+  craftos-pc = wrapCraftosPC craftos-pc-unwrapped { };
 
   dlx = callPackage ../applications/emulators/dlx { };
 


### PR DESCRIPTION
###### Description of changes

This PR adds a wrapper for the `craftos-pc` plugins which allows the user to add custom plugins to CraftOS-PC in a similar fashion to `mpv`.

This PR will also add the plugins from the [official plugins repository](); it will most likely make them available in the `craftosPlugins` attrset.

Non-technical description: This allows users to enable plugins with CraftOS-PC via Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
