### PR TITLE
paperless-ngx: 1.11.3 -> 1.12.2

### DIFF
--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -17,13 +17,13 @@
 }:
 
 let
-  version = "1.11.3";
+  version = "1.12.2";
 
   src = fetchFromGitHub {
     owner = "paperless-ngx";
     repo = "paperless-ngx";
     rev = "refs/tags/v${version}";
-    hash = "sha256-d1O8bAXB7NPymibagWUgMDZ9LAZ6QpawmT5D5yw4j+w=";
+    hash = "sha256-1QufnRD2Nbc4twRZ4Yrf3ae1BRGves8tJ/M7coWnRPI=";
   };
 
   # Use specific package versions required by paperless-ngx
@@ -93,7 +93,7 @@ let
     pname = "paperless-ngx-frontend";
     inherit version src;
 
-    npmDepsHash = "sha256-ZjIWU8i2Riz4KmC1Woi0uaJ+uNyuU27XwFqvo4bCC5k=";
+    npmDepsHash = "sha256-fp0Gy3018u2y6jaUM9bmXU0SVjyEJdsvkBqbmb8S10Y=";
 
     nativeBuildInputs = [
       python3
@@ -130,21 +130,25 @@ python.pkgs.buildPythonApplication rec {
 
   propagatedBuildInputs = with python.pkgs; [
     aioredis
-    arrow
+    amqp
+    anyio
     asgiref
     async-timeout
     attrs
     autobahn
     automat
+    billiard
     bleach
-    blessed
     celery
     certifi
     cffi
     channels-redis
     channels
-    chardet
+    charset-normalizer
     click
+    click-didyoumean
+    click-plugins
+    click-repl
     coloredlogs
     concurrent-log-handler
     constantly
@@ -155,18 +159,16 @@ python.pkgs.buildPythonApplication rec {
     django-cors-headers
     django-extensions
     django-filter
-    django-picklefield
     django
     djangorestframework
     filelock
-    fuzzywuzzy
     gunicorn
     h11
     hiredis
     httptools
     humanfriendly
+    humanize
     hyperlink
-    imagehash
     idna
     imap-tools
     img2pdf
@@ -177,9 +179,11 @@ python.pkgs.buildPythonApplication rec {
     langdetect
     lxml
     msgpack
+    mysqlclient
     nltk
     numpy
     ocrmypdf
+    packaging
     pathvalidate
     pdf2image
     pdfminer-six
@@ -187,6 +191,7 @@ python.pkgs.buildPythonApplication rec {
     pillow
     pluggy
     portalocker
+    prompt-toolkit
     psycopg2
     pyasn1-modules
     pyasn1
@@ -195,7 +200,6 @@ python.pkgs.buildPythonApplication rec {
     python-dateutil
     python-dotenv
     python-gnupg
-    levenshtein
     python-magic
     pytz
     pyyaml
@@ -208,27 +212,34 @@ python.pkgs.buildPythonApplication rec {
     scikit-learn
     scipy
     service-identity
-    six
-    sortedcontainers
+    setproctitle
+    sniffio
     sqlparse
     threadpoolctl
     tika
+    tornado
     tqdm
-    twisted.optional-dependencies.tls
+    twisted
     txaio
+    tzdata
     tzlocal
     urllib3
     uvicorn
     uvloop
+    vine
     watchdog
-    watchgod
+    watchfiles
     wcwidth
+    webencodings
     websockets
     whitenoise
     whoosh
+    zipp
     zope_interface
-  ];
-
+  ]
+  ++ redis.optional-dependencies.hiredis
+  ++ twisted.optional-dependencies.tls
+  ++ uvicorn.optional-dependencies.standard;
 
   postBuild = ''
     # Compile manually because `pythonRecompileBytecodeHook` only works
@@ -255,12 +266,12 @@ python.pkgs.buildPythonApplication rec {
       --prefix PATH : "${path}"
   '';
 
-  nativeCheckInputs = with python.pkgs.pythonPackages; [
+  nativeCheckInputs = with python.pkgs; [
+    factory_boy
+    imagehash
     pytest-django
     pytest-env
-    pytest-sugar
     pytest-xdist
-    factory_boy
     pytestCheckHook
   ];
 
@@ -302,6 +313,7 @@ python.pkgs.buildPythonApplication rec {
   meta = with lib; {
     description = "Tool to scan, index, and archive all of your physical documents";
     homepage = "https://paperless-ngx.readthedocs.io/";
+    changelog = "https://github.com/paperless-ngx/paperless-ngx/releases/tag/v${version}";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ lukegb gador erikarvstedt ];
   };

--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -266,6 +266,11 @@ python.pkgs.buildPythonApplication rec {
       --prefix PATH : "${path}"
   '';
 
+  postFixup = ''
+    # Remove tests with samples (~14M)
+    find $out/lib/paperless-ngx -type d -name tests -exec rm -rv {} +
+  '';
+
   nativeCheckInputs = with python.pkgs; [
     factory_boy
     imagehash

--- a/pkgs/development/python-modules/redis/default.nix
+++ b/pkgs/development/python-modules/redis/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   ];
 
   passthru.optional-dependencies = {
-    hidredis = [
+    hiredis = [
       hiredis
     ];
     ocsp = [


### PR DESCRIPTION
https://github.com/paperless-ngx/paperless-ngx/releases/tag/v1.12.0
https://github.com/paperless-ngx/paperless-ngx/releases/tag/v1.12.1
https://github.com/paperless-ngx/paperless-ngx/releases/tag/v1.12.2

Ok, rundown of what I did.

- The frontend is now available in a separate derivation through `paperless-ngx.frontend`
- Started to selectively copy content into `$out`, specifically left out
  - `docs` (probably needs to be built using mkdocs, but then into a dedicated output)
  - `docker`
  - `scripts` (systemd units and docker startup script)
- Dropped the tests and its samples from the final package to save 14 MB, we're now at ~90.4 MB down from 187 MB
  - 82 MB Frontend
  - 8.4 MB Backend
- Updated to 1.12.2
- Added a migration, so we're reindexing documents as recommended in the 1.12.1 release notes

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
