### PR TITLE
ocamlPackages.decompress: 1.5.1 → 1.5.2

### DIFF
--- a/pkgs/development/ocaml-modules/carton/default.nix
+++ b/pkgs/development/ocaml-modules/carton/default.nix
@@ -11,10 +11,11 @@ buildDunePackage rec {
   version = "0.6.0";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-git/releases/download/${pname}-v${version}/git-${pname}-v${version}.tbz";
-    sha256 = "sha256-NAm4Xq7L0Dgynr8cKZQ356M4GR6D19LbCRxvnSlIf1U=";
+    hash = "sha256-NAm4Xq7L0Dgynr8cKZQ356M4GR6D19LbCRxvnSlIf1U=";
   };
 
   patches = [

--- a/pkgs/development/ocaml-modules/carton/git.nix
+++ b/pkgs/development/ocaml-modules/carton/git.nix
@@ -9,6 +9,7 @@ buildDunePackage {
   pname = "carton-git";
 
   inherit (carton) version src postPatch;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     carton

--- a/pkgs/development/ocaml-modules/carton/lwt.nix
+++ b/pkgs/development/ocaml-modules/carton/lwt.nix
@@ -11,6 +11,7 @@ buildDunePackage {
   pname = "carton-lwt";
 
   inherit (carton) version src postPatch;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     carton

--- a/pkgs/development/ocaml-modules/decompress/default.nix
+++ b/pkgs/development/ocaml-modules/decompress/default.nix
@@ -1,22 +1,24 @@
 { lib, fetchurl, buildDunePackage
 , checkseum, optint, cmdliner
 , bigstringaf, alcotest, camlzip, base64, ctypes, fmt, crowbar, rresult
+, astring, bos
 }:
 
 buildDunePackage rec {
   pname = "decompress";
-  version = "1.5.1";
+  version = "1.5.2";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/decompress/releases/download/v${version}/decompress-${version}.tbz";
-    sha256 = "sha256-y/OVojFxhksJQQvvtS38SF7ZnMEQhAtwDey0ISwypP4=";
+    hash = "sha256-qMmmuhMlFNVq02JvvV55EkhEg2AQNQ7hYdQ7spv1di4=";
   };
 
   buildInputs = [ cmdliner ];
   propagatedBuildInputs = [ optint checkseum ];
-  nativeCheckInputs = [ alcotest bigstringaf ctypes fmt camlzip base64 crowbar rresult ];
+  nativeCheckInputs = [ alcotest astring bigstringaf bos ctypes fmt camlzip base64 crowbar rresult ];
   doCheck = true;
 
   meta = {

--- a/pkgs/development/ocaml-modules/pbkdf/default.nix
+++ b/pkgs/development/ocaml-modules/pbkdf/default.nix
@@ -10,12 +10,14 @@ buildDunePackage rec {
   pname = "pbkdf";
   version = "1.2.0";
 
+  duneVersion = "3";
+
   src = fetchzip {
     url = "https://github.com/abeaumont/ocaml-pbkdf/archive/${version}.tar.gz";
     sha256 = "sha256-dGi4Vw+7VBpK/NpJ6zdpogm+E6G/oJovXCksJBSmqjI=";
   };
 
-  minimalOCamlVersion = "4.07";
+  minimalOCamlVersion = "4.08";
   propagatedBuildInputs = [ cstruct mirage-crypto ];
   nativeCheckInputs = [ alcotest ];
   doCheck = true;


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/decompress/blob/v1.5.2/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
