### PR TITLE
Revert #178290: nixos/virtualisation: add option

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -766,15 +766,6 @@
           been fixed to allow more than one plugin in the path.
         </para>
       </listitem>
-      <listitem>
-        <para>
-          A new option was added to the virtualisation module that
-          enables specifying explicitly named network interfaces in QEMU
-          VMs. The existing <literal>virtualisation.vlans</literal> is
-          still supported for cases where the name of the network
-          interface is irrelevant.
-        </para>
-      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -191,5 +191,3 @@ In addition to numerous new and upgraded packages, this release has the followin
 - `nixos-version` now accepts `--configuration-revision` to display more information about the current generation revision
 
 - The option `services.nomad.extraSettingsPlugins` has been fixed to allow more than one plugin in the path.
-
-- A new option was added to the virtualisation module that enables specifying explicitly named network interfaces in QEMU VMs. The existing `virtualisation.vlans` is still supported for cases where the name of the network interface is irrelevant.

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -12,9 +12,7 @@ let
   };
 
 
-  vlans = map (m: (
-    m.virtualisation.vlans ++
-    (lib.mapAttrsToList (_: v: v.vlan) m.virtualisation.interfaces))) (lib.attrValues config.nodes);
+  vlans = map (m: m.virtualisation.vlans) (lib.attrValues config.nodes);
   vms = map (m: m.system.build.vm) (lib.attrValues config.nodes);
 
   nodeHostNames =

--- a/nixos/lib/testing/network.nix
+++ b/nixos/lib/testing/network.nix
@@ -18,40 +18,24 @@ let
 
   networkModule = { config, nodes, pkgs, ... }:
     let
-      qemu-common = import ../qemu-common.nix { inherit lib pkgs; };
-
-      # Convert legacy VLANs to named interfaces and merge with explicit interfaces.
-      vlansNumbered = forEach (zipLists config.virtualisation.vlans (range 1 255)) (v: {
-        name = "eth${toString v.snd}";
-        vlan = v.fst;
-        assignIP = true;
-      });
-      explicitInterfaces = lib.mapAttrsToList (n: v: v // { name = n; }) config.virtualisation.interfaces;
-      interfaces = vlansNumbered ++ explicitInterfaces;
-      interfacesNumbered = zipLists interfaces (range 1 255);
-
-      # Automatically assign IP addresses to requested interfaces.
-      assignIPs = lib.filter (i: i.assignIP) interfaces;
-      ipInterfaces = forEach assignIPs (i:
-        nameValuePair i.name { ipv4.addresses =
-          [ { address = "192.168.${toString i.vlan}.${toString config.virtualisation.test.nodeNumber}";
+      interfacesNumbered = zipLists config.virtualisation.vlans (range 1 255);
+      interfaces = forEach interfacesNumbered ({ fst, snd }:
+        nameValuePair "eth${toString snd}" {
+          ipv4.addresses =
+            [{
+              address = "192.168.${toString fst}.${toString config.virtualisation.test.nodeNumber}";
               prefixLength = 24;
             }];
         });
-
-      qemuOptions = lib.flatten (forEach interfacesNumbered ({ fst, snd }:
-        qemu-common.qemuNICFlags snd fst.vlan config.virtualisation.test.nodeNumber));
-      udevRules = forEach interfacesNumbered ({ fst, snd }:
-        "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"${qemu-common.qemuNicMac fst.vlan config.virtualisation.test.nodeNumber}\",NAME=\"${fst.name}\"");
 
       networkConfig =
         {
           networking.hostName = mkDefault config.virtualisation.test.nodeName;
 
-          networking.interfaces = listToAttrs ipInterfaces;
+          networking.interfaces = listToAttrs interfaces;
 
           networking.primaryIPAddress =
-            optionalString (ipInterfaces != [ ]) (head (head ipInterfaces).value.ipv4.addresses).address;
+            optionalString (interfaces != [ ]) (head (head interfaces).value.ipv4.addresses).address;
 
           # Put the IP addresses of all VMs in this machine's
           # /etc/hosts file.  If a machine has multiple
@@ -67,13 +51,16 @@ let
                     "${config.networking.hostName}.${config.networking.domain} " +
                   "${config.networking.hostName}\n"));
 
-          virtualisation.qemu.options = qemuOptions;
-          boot.initrd.services.udev.rules = concatMapStrings (x: x + "\n") udevRules;
+          virtualisation.qemu.options =
+            let qemu-common = import ../qemu-common.nix { inherit lib pkgs; };
+            in
+            flip concatMap interfacesNumbered
+              ({ fst, snd }: qemu-common.qemuNICFlags snd fst config.virtualisation.test.nodeNumber);
         };
 
     in
     {
-      key = "network-interfaces";
+      key = "ip-address";
       config = networkConfig // {
         # Expose the networkConfig items for tests like nixops
         # that need to recreate the network config.

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -545,8 +545,7 @@ in
     virtualisation.vlans =
       mkOption {
         type = types.listOf types.ints.unsigned;
-        default = if config.virtualisation.interfaces == {} then [ 1 ] else [ ];
-        defaultText = lib.literalExpression ''if config.virtualisation.interfaces == {} then [ 1 ] else [ ]'';
+        default = [ 1 ];
         example = [ 1 2 ];
         description =
           lib.mdDoc ''
@@ -560,35 +559,6 @@ in
             in the list of VMs.
           '';
       };
-
-    virtualisation.interfaces = mkOption {
-      default = {};
-      example = {
-        enp1s0.vlan = 1;
-      };
-      description = lib.mdDoc ''
-        Network interfaces to add to the VM.
-      '';
-      type = with types; attrsOf (submodule {
-        options = {
-          vlan = mkOption {
-            type = types.ints.unsigned;
-            description = lib.mdDoc ''
-              VLAN to which the network interface is connected.
-            '';
-          };
-
-          assignIP = mkOption {
-            type = types.bool;
-            default = false;
-            description = lib.mdDoc ''
-              Automatically assign an IP address to the network interface using the same scheme as
-              virtualisation.vlans.
-            '';
-          };
-        };
-      });
-    };
 
     virtualisation.writableStore =
       mkOption {


### PR DESCRIPTION
...for explicitly named network interfaces

This reverts commit 6ae3e7695e27a4f7afb1d2017f5967d5e82f4c00. (and evaluation fixups 08d26bbb726 7aed90a969c)
Some of the tests fail or time out after the merge.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
