### PR TITLE
deepin(go-packages): init at 20.8

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -3,6 +3,15 @@ let
   packages = self:
   let
     inherit (self) callPackage;
+
+    replaceAll = x: y: ''
+      echo Replacing "${x}" to "${y}":
+      for file in $(grep -rl "${x}"); do
+        echo -- $file
+        substituteInPlace $file \
+          --replace "${x}" "${y}"
+      done
+    '';
   in {
     #### LIBRARIES
     dtkcommon = callPackage ./library/dtkcommon { };
@@ -24,6 +33,9 @@ let
     deepin-calculator = callPackage ./apps/deepin-calculator { };
     deepin-editor = callPackage ./apps/deepin-editor { };
     deepin-terminal = callPackage ./apps/deepin-terminal { };
+
+    #### Go Packages
+    go-lib = callPackage ./go-package/go-lib { inherit replaceAll; };
 
     #### ARTWORK
     dde-account-faces = callPackage ./artwork/dde-account-faces { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -37,6 +37,7 @@ let
     #### Go Packages
     go-lib = callPackage ./go-package/go-lib { inherit replaceAll; };
     go-gir-generator = callPackage ./go-package/go-gir-generator { };
+    go-dbus-factory = callPackage ./go-package/go-dbus-factory { };
 
     #### ARTWORK
     dde-account-faces = callPackage ./artwork/dde-account-faces { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -39,6 +39,9 @@ let
     go-gir-generator = callPackage ./go-package/go-gir-generator { };
     go-dbus-factory = callPackage ./go-package/go-dbus-factory { };
 
+    #### TOOLS
+    deepin-gettext-tools = callPackage ./tools/deepin-gettext-tools { };
+
     #### ARTWORK
     dde-account-faces = callPackage ./artwork/dde-account-faces { };
     deepin-icon-theme = callPackage ./artwork/deepin-icon-theme { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -38,6 +38,7 @@ let
     go-lib = callPackage ./go-package/go-lib { inherit replaceAll; };
     go-gir-generator = callPackage ./go-package/go-gir-generator { };
     go-dbus-factory = callPackage ./go-package/go-dbus-factory { };
+    deepin-pw-check = callPackage ./go-package/deepin-pw-check { };
 
     #### TOOLS
     deepin-gettext-tools = callPackage ./tools/deepin-gettext-tools { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -36,6 +36,7 @@ let
 
     #### Go Packages
     go-lib = callPackage ./go-package/go-lib { inherit replaceAll; };
+    go-gir-generator = callPackage ./go-package/go-gir-generator { };
 
     #### ARTWORK
     dde-account-faces = callPackage ./artwork/dde-account-faces { };

--- a/pkgs/desktops/deepin/go-package/deepin-pw-check/default.nix
+++ b/pkgs/desktops/deepin/go-package/deepin-pw-check/default.nix
@@ -1,0 +1,84 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, buildGoPackage
+, pkg-config
+, deepin-gettext-tools
+, go-dbus-factory
+, go-gir-generator
+, go-lib
+, gtk3
+, glib
+, libxcrypt
+, gettext
+, iniparser
+, cracklib
+, linux-pam
+}:
+
+buildGoPackage rec {
+  pname = "deepin-pw-check";
+  version = "5.1.18";
+
+  goPackagePath = "github.com/linuxdeepin/deepin-pw-check";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-v1Z4ArkrejjOCO1vD+BhfEl9pTfuvKgLM6Ont0IUCQk=";
+  };
+
+  goDeps = ./deps.nix;
+
+  nativeBuildInputs = [
+    pkg-config
+    gettext
+    deepin-gettext-tools
+  ];
+
+  buildInputs = [
+    go-dbus-factory
+    go-gir-generator
+    go-lib
+    glib
+    libxcrypt
+    gtk3
+    iniparser
+    cracklib
+    linux-pam
+  ];
+
+  postPatch = ''
+    sed -i 's|iniparser/||' */*.c
+    substituteInPlace misc/pkgconfig/libdeepin_pw_check.pc \
+      --replace "/usr" "$out"
+    substituteInPlace misc/system-services/com.deepin.daemon.PasswdConf.service \
+      --replace "/usr/lib/deepin-pw-check/deepin-pw-check" "$out/lib/deepin-pw-check/deepin-pw-check"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    GOPATH="$GOPATH:${go-dbus-factory}/share/gocode"
+    GOPATH="$GOPATH:${go-gir-generator}/share/gocode"
+    GOPATH="$GOPATH:${go-lib}/share/gocode"
+    make -C go/src/${goPackagePath}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    make install PREFIX="$out" PKG_FILE_DIR=$out/lib/pkg-config PAM_MODULE_DIR=$out/etc/pam.d -C go/src/${goPackagePath}
+    # https://github.com/linuxdeepin/deepin-pw-check/blob/d5597482678a489077a506a87f06d2b6c4e7e4ed/debian/rules#L21
+    ln -s $out/lib/libdeepin_pw_check.so $out/lib/libdeepin_pw_check.so.1
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Tool to verify the validity of the password";
+    homepage = "https://github.com/linuxdeepin/deepin-pw-check";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/go-package/deepin-pw-check/deps.nix
+++ b/pkgs/desktops/deepin/go-package/deepin-pw-check/deps.nix
@@ -1,0 +1,75 @@
+[
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "v1.5.1";
+      sha256 = "sha256-B8kZ8yiWgallT7R2j1kSRJcJkSGFVf9ise+TpXa+7XY=";
+    };
+  }
+  {
+    goPackagePath = "github.com/godbus/dbus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/godbus/dbus";
+      rev = "v5.1.0";
+      sha256 = "sha256-JSPtmkGEStBEVrKGszeLCb7P38SzQKgMiDC3eDppXs0=";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.7.1";
+      sha256 = "sha256-disUVIHiIDSj/go3APtJH8awSl8QwKRRFLKI7LRnl0w=";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/sys";
+      rev = "289d7a0edf712062d9f1484b07bdf2383f48802f";
+      sha256 = "sha256-AzS/J3OocI7mA0xsIfQzyskNKVija7F2yvuts+EFJBs=";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev = "496545a6307b2a7d7a710fd516e5e16e8ab62dbc";
+      sha256 = "sha256-j8yDji+vqsitpRZirpb4w/Em8nstgf28wpwkcrOlxBk=";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "sha256-nhzSUrE1fCkN0+RL04N4h8jWmRFPPPWbCuDc7Ss0akI=";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.3.0";
+      sha256 = "sha256-T753/EiD5Cpk6H2JFhd+s1gFvpNptG2XlEHxZF6dQaw=";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "5d4384ee4fb2527b0a1256a821ebfc92f91efefc";
+      sha256 = "sha256-XA4Oj1gdmdV/F/+8kMI+DBxKPthZ768hbKsO3d9Gx90=";
+    };
+  }
+]
+

--- a/pkgs/desktops/deepin/go-package/go-dbus-factory/default.nix
+++ b/pkgs/desktops/deepin/go-package/go-dbus-factory/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "go-dbus-factory";
+  version = "1.10.23";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-6u9Bpoa80j/K1MipncfM378/qmSSMZAlx88jE4hHYBk=";
+  };
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  meta = with lib; {
+    description = "Generate go binding of D-Bus interfaces";
+    homepage = "https://github.com/linuxdeepin/go-dbus-factory";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/go-package/go-gir-generator/default.nix
+++ b/pkgs/desktops/deepin/go-package/go-gir-generator/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, go
+, pkg-config
+, libgudev
+, gobject-introspection
+}:
+
+stdenv.mkDerivation rec {
+  pname = "go-gir-generator";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-lFseui/M3+TyfYoa+rnS0cGhN6gdLrgpzgOwqzYcyPk=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    go
+  ];
+
+  buildInputs = [
+    libgudev
+    gobject-introspection
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "GOCACHE=$(TMPDIR)/go-cache"
+  ];
+
+  meta = with lib; {
+    description = "Generate static golang bindings for GObject";
+    homepage = "https://github.com/linuxdeepin/go-gir-generator";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/go-package/go-lib/default.nix
+++ b/pkgs/desktops/deepin/go-package/go-lib/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, replaceAll
+, runtimeShell
+}:
+
+stdenv.mkDerivation rec {
+  pname = "go-lib";
+  version = "5.8.27";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-ZV5zWu7UvNKVcVo79/iKMhF4H09rGyDCvEL61H05lZc=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "fix_IsDir_for_symlink";
+      url = "https://github.com/linuxdeepin/go-lib/commit/79239904679dc70a11e1ac8e65670afcfdd7c122.patch";
+      sha256 = "sha256-RsN9hK26i/W6P/+e1l1spCLdlgIEWTehhIW6POBOvW4=";
+    })
+  ];
+
+  postPatch = replaceAll "/bin/sh" "${runtimeShell}";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/gocode/src/github.com/linuxdeepin/go-lib
+    cp -a * $out/share/gocode/src/github.com/linuxdeepin/go-lib
+    rm -r $out/share/gocode/src/github.com/linuxdeepin/go-lib/debian
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Library containing many useful go routines for things such as glib, gettext, archive, graphic, etc";
+    homepage = "https://github.com/linuxdeepin/go-lib";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/tools/deepin-gettext-tools/default.nix
+++ b/pkgs/desktops/deepin/tools/deepin-gettext-tools/default.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gettext
+, python3Packages
+, perlPackages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "deepin-gettext-tools";
+  version = "1.0.10";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-5Dd2QU6JYwuktusssNDfA7IHa6HbFcWo9sZf5PS7NtI=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/generate_mo.py --replace "sudo cp" "cp"
+  '';
+
+  nativeBuildInputs = [ python3Packages.wrapPython ];
+
+  buildInputs = [
+    gettext
+    perlPackages.perl
+    perlPackages.ConfigTiny
+    perlPackages.XMLLibXML
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  postFixup = ''
+    wrapPythonPrograms
+    wrapPythonProgramsIn "$out/lib/${pname}"
+    wrapProgram $out/bin/deepin-desktop-ts-convert --set PERL5LIB $PERL5LIB
+  '';
+
+  meta = with lib; {
+    description = "Translation file processing utils for DDE development";
+    homepage = "https://github.com/linuxdeepin/deepin-gettext-tools";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Part of https://github.com/linuxdeepin/dde-nixos/issues/9

go-lib: Library containing many useful go routines for things such as glib, gettext, archive, graphic, etc
go-dbus-factory : Generate go binding of D-Bus interfaces
go-gir-generator: Generate static golang bindings for GObject
deepin-pw-check: Tool to verify the validity of the password
deepin-gettext-tools(python/perl):  Translation file processing utils for DDE development 

dde-api / dde-daemon  don't packaged in this pr

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
