### PR TITLE
treewide: convert 43 fonts to stdenvNoCC.mkDerivation

### DIFF
--- a/pkgs/data/fonts/atkinson-hyperlegible/default.nix
+++ b/pkgs/data/fonts/atkinson-hyperlegible/default.nix
@@ -1,21 +1,22 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation {
   pname = "atkinson-hyperlegible";
   version = "unstable-2021-04-29";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "googlefonts";
-  repo = "atkinson-hyperlegible";
-  rev = "1cb311624b2ddf88e9e37873999d165a8cd28b46";
-  sha256 = "sha256-urSTqC3rfDRM8IMG+edwKEe7NPiTuDZph3heGHzLDks=";
+  src = fetchFromGitHub {
+    owner = "googlefonts";
+    repo = "atkinson-hyperlegible";
+    rev = "1cb311624b2ddf88e9e37873999d165a8cd28b46";
+    hash = "sha256-RN4m5gyY2OiPzRXgFVQ3pq6JdkPcMxV4fRlX2EK+gOM=";
+  };
 
-  postFetch = ''
-    install -Dm644 -t $out/share/fonts/opentype $out/fonts/otf/*
-    shopt -s extglob dotglob
-    rm -rf $out/!(share)
-    shopt -u extglob dotglob
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 -t $out/share/fonts/opentype fonts/otf/*
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/aurulent-sans/default.nix
+++ b/pkgs/data/fonts/aurulent-sans/default.nix
@@ -1,15 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  name = "aurulent-sans-0.1";
-  owner = "deepfire";
-  repo = "hartke-aurulent-sans";
-  rev = name;
-  postFetch = ''
-    mkdir -p $out/share/fonts
-    tar xf $downloadedFile -C $out/share/fonts --strip=1
+stdenvNoCC.mkDerivation rec {
+  pname = "aurulent-sans";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "deepfire";
+    repo = "hartke-aurulent-sans";
+    rev = "${pname}-${version}";
+    hash = "sha256-M/duhgqxXZJq5su9FrsGjZdm+wtO5B5meoDomde+GwY=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.otf -t $out/share/fonts
+
+    runHook postInstall
   '';
-  sha256 = "1l60psfv9x0x9qx9vp1qnhmck7a7kks385m5ycrd3d91irz1j5li";
 
   meta = {
     description = "Aurulent Sans";

--- a/pkgs/data/fonts/b612/default.nix
+++ b/pkgs/data/fonts/b612/default.nix
@@ -1,24 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-fetchFromGitHub rec {
+stdenvNoCC.mkDerivation rec {
   pname = "b612";
   version = "1.008";
 
-  owner = "polarsys";
-  repo = "b612";
-  rev = version;
+  src = fetchFromGitHub {
+    owner = "polarsys";
+    repo = "b612";
+    rev = version;
+    hash = "sha256-uyBC8UNOwztCHXhR9XZuWDwrty0eClbo0E+gI1PmjEg=";
+  };
 
-  postFetch = ''
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
+    mv fonts/ttf/*.ttf $out/share/fonts/truetype
 
-    mv $out/fonts/ttf/*.ttf $out/share/fonts/truetype
-
-    shopt -s extglob dotglob
-    rm -rf $out/!(share)
-    shopt -u extglob dotglob
+    runHook postInstall
   '';
-
-  hash = "sha256-aJ3XzWQauPsWwEDAHT2rD9a8RvLv1kqU3krFXprmypk=";
 
   meta = with lib; {
     homepage = "https://b612-font.com/";
@@ -36,8 +36,8 @@ fetchFromGitHub rec {
       variants of the font. This one, baptized B612 in reference to the
       imaginary asteroid of the aviator Saint‑Exupéry, benefited from a complete
       hinting on all the characters.
-      '';
-    license = with licenses; [ ofl epl10 bsd3 ] ;
+    '';
+    license = with licenses; [ ofl epl10 bsd3 ];
     maintainers = with maintainers; [ leenaars ];
     platforms = platforms.all;
   };

--- a/pkgs/data/fonts/behdad-fonts/default.nix
+++ b/pkgs/data/fonts/behdad-fonts/default.nix
@@ -1,19 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "behdad-fonts";
   version = "0.0.3";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "font-store";
-  repo = "BehdadFont";
-  rev = "v${version}";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  src = fetchFromGitHub {
+    owner = "font-store";
+    repo = "BehdadFont";
+    rev = "v${version}";
+    hash = "sha256-gKfzxo3/bCMKXl2d6SP07ahIiNrUyrk/SN5XLND2lWY=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
     find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/behrad-fonts {} \;
+
+    runHook postInstall
   '';
-  sha256 = "0c57232462cv1jrfn0m2bl7jzcfkacirrdd2qimrc8iqhkz0ajfz";
 
   meta = with lib; {
     homepage = "https://github.com/font-store/BehdadFont";

--- a/pkgs/data/fonts/cabin/default.nix
+++ b/pkgs/data/fonts/cabin/default.nix
@@ -1,19 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  name = "cabin-1.005";
+stdenvNoCC.mkDerivation rec {
+  pname = "cabin";
+  version = "1.005";
 
-  owner = "impallari";
-  repo = "Cabin";
-  rev = "982839c790e9dc57c343972aa34c51ed3b3677fd";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Cabin";
+    rev = "982839c790e9dc57c343972aa34c51ed3b3677fd";
+    hash = "sha256-9l4QcwCot340Bq41ER68HSZGQ9h0opyzgG3DG/fVZ5s=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts/opentype fonts/OTF/*.otf
-    install -m444 -Dt $out/share/doc/${name}    README.md FONTLOG.txt
-  '';
+    install -m444 -Dt $out/share/doc/${pname}-${version} README.md FONTLOG.txt
 
-  sha256 = "1bl7h217m695jn4rbniialfk573aa44fslp2rjxnhkicakpcm44h";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A humanist sans with 4 weights and true italics";

--- a/pkgs/data/fonts/comic-mono/default.nix
+++ b/pkgs/data/fonts/comic-mono/default.nix
@@ -1,23 +1,27 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation {
+  pname = "comic-mono-font";
   version = "2020-12-28";
-in fetchFromGitHub {
-  name = "comic-mono-font-${version}";
 
-  owner = "dtinth";
-  repo = "comic-mono-font";
-  rev = "9a96d04cdd2919964169192e7d9de5012ef66de4";
+  src = fetchFromGitHub {
+    owner = "dtinth";
+    repo = "comic-mono-font";
+    rev = "9a96d04cdd2919964169192e7d9de5012ef66de4";
+    hash = "sha256-q8NxrluWuH23FfRlntIS0MDdl3TkkGE7umcU2plS6eU=";
+  };
 
-  postFetch = ''
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts
-    tar -z -f $downloadedFile --wildcards -x \*.ttf --one-top-level=$out/share/fonts
+    cp *.ttf $out/share/fonts
 
     mkdir -p $out/etc/fonts/conf.d
     ln -s ${./comic-mono-weight.conf} $out/etc/fonts/conf.d/30-comic-mono.conf
-  '';
 
-  hash = "sha256-poMU+WfDZcsyWyFiiXKJ284X22CJlxQIzcJtApnIdAY=";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A legible monospace font that looks like Comic Sans";

--- a/pkgs/data/fonts/dancing-script/default.nix
+++ b/pkgs/data/fonts/dancing-script/default.nix
@@ -1,19 +1,22 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation {
   pname = "dancing-script";
   version = "2.0";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "impallari";
-  repo = "DancingScript";
-  rev = "f7f54bc1b8836601dae8696666bfacd306f77e34";
-  sha256 = "dfFvh8h+oMhAQL9XKMrNr07VUkdQdxAsA8+q27KWWCA=";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "DancingScript";
+    rev = "f7f54bc1b8836601dae8696666bfacd306f77e34";
+    hash = "sha256-B9oAZFPH3dG/Nt5FfKfFVJYtfUKGK0AXNkQHRC7IgdU=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts/truetype fonts/ttf/*.ttf
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/dosis/default.nix
+++ b/pkgs/data/fonts/dosis/default.nix
@@ -1,19 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  name = "dosis-1.007";
+stdenvNoCC.mkDerivation rec {
+  pname = "dosis";
+  version = "1.007";
 
-  owner = "impallari";
-  repo = "Dosis";
-  rev = "12df1e13e58768f20e0d48ff15651b703f9dd9dc";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Dosis";
+    rev = "12df1e13e58768f20e0d48ff15651b703f9dd9dc";
+    hash = "sha256-rZ49uNBlI+NWkiZykpyXzOonXlbVB6Vf6a/8A56Plj4=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     find . -name '*.otf' -exec install -m444 -Dt $out/share/fonts/opentype {} \;
-    install -m444 -Dt $out/share/doc/${name} README.md FONTLOG.txt
-  '';
+    install -m444 -Dt $out/share/doc/${pname}-${version} README.md FONTLOG.txt
 
-  sha256 = "0vz25w45i8flfvppymr5h83pa2n1r37da20v7691p44018fdsdny";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A very simple, rounded, sans serif family";

--- a/pkgs/data/fonts/et-book/default.nix
+++ b/pkgs/data/fonts/et-book/default.nix
@@ -1,16 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  rev = "7e8f02dadcc23ba42b491b39e5bdf16e7b383031";
-  name = "et-book-${builtins.substring 0 6 rev}";
-  owner = "edwardtufte";
-  repo = "et-book";
-  sha256 = "1bfb1l8k7fzgk2l8cikiyfn5x9m0fiwrnsbc1483p8w3qp58s5n2";
+stdenvNoCC.mkDerivation rec {
+  pname = "et-book";
+  version = "unstable-2015-10-05";
 
-  postFetch = ''
-    tar -xzf $downloadedFile
+  src = fetchFromGitHub {
+    owner = "edwardtufte";
+    repo = pname;
+    rev = "7e8f02dadcc23ba42b491b39e5bdf16e7b383031";
+    hash = "sha256-B6ryC9ibNop08TJC/w9LSHHwqV/81EezXsTUJFq8xpo=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
-    cp -t $out/share/fonts/truetype et-book-${rev}/source/4-ttf/*.ttf
+    cp -t $out/share/fonts/truetype source/4-ttf/*.ttf
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/fira/default.nix
+++ b/pkgs/data/fonts/fira/default.nix
@@ -1,21 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "fira";
   version = "4.202";
-in fetchFromGitHub {
-  name = "fira-${version}";
 
-  owner = "mozilla";
-  repo = "Fira";
-  rev = version;
+  src = fetchFromGitHub {
+    owner = "mozilla";
+    repo = "Fira";
+    rev = version;
+    hash = "sha256-HLReqgL0PXF5vOpwLN0GiRwnzkjGkEVEyOEV2Z4R0oQ=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/opentype
     cp otf/*.otf $out/share/fonts/opentype
-  '';
 
-  sha256 = "1iwxbp7kw5kghh5nbycb05zby7p2ib61mywva3h6giv2wd4lpxnz";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://mozilla.github.io/Fira/";

--- a/pkgs/data/fonts/gandom-fonts/default.nix
+++ b/pkgs/data/fonts/gandom-fonts/default.nix
@@ -1,19 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "gandom-fonts";
   version = "0.8";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "rastikerdar";
-  repo = "gandom-font";
-  rev = "v${version}";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "gandom-font";
+    rev = "v${version}";
+    hash = "sha256-nez8T0TtRLyXxIIR69LrVGde5ThCvA0fLXkYLyYQRV8=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
     find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/gandom-fonts {} \;
+
+    runHook postInstall
   '';
-  sha256 = "sha256-EDS3wwKwe2BIcOCxu7DxkVLCoEoTPP31k5ID51lqn3M=";
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/gandom-font";

--- a/pkgs/data/fonts/gelasio/default.nix
+++ b/pkgs/data/fonts/gelasio/default.nix
@@ -1,18 +1,25 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
-  version = "unstable-2018-08-12";
-in fetchFromGitHub {
-  name = "gelasio-${version}";
-  owner = "SorkinType";
-  repo = "Gelasio";
-  rev = "5bced461d54bcf8e900bb3ba69455af35b0d2ff1";
-  sha256 = "0dfskz2vpwsmd88rxqsxf0f01g4f2hm6073afcm424x5gc297n39";
+stdenvNoCC.mkDerivation {
+  pname = "gelasio";
+  version = "unstable-2022-06-09";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  src = fetchFromGitHub {
+    owner = "SorkinType";
+    repo = "Gelasio";
+    rev = "a75c6d30a35f74cdbaea1813bdbcdb64bb11d3d5";
+    hash = "sha256-ncm0lSDPPPREdxTx3dGl6OGBn4FGAjFTlQpA6oDCdMI=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
-    cp *.ttf $out/share/fonts/truetype/
+    cp fonts/ttf/*.ttf $out/share/fonts/truetype/
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/ia-writer-duospace/default.nix
+++ b/pkgs/data/fonts/ia-writer-duospace/default.nix
@@ -1,19 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
-  version = "20180721";
-in fetchFromGitHub {
-  name = "ia-writer-duospace-${version}";
+stdenvNoCC.mkDerivation {
+  pname = "ia-writer-duospace";
+  version = "unstable-2018-07-21";
 
-  owner = "iaolo";
-  repo = "iA-Fonts";
-  rev = "55edf60f544078ab1e14987bc67e9029a200e0eb";
-  sha256 = "0932lcxf861vb3hz52z1xj8r99ag9sdyqsnq9brv7gc4kp2l339c";
+  src = fetchFromGitHub {
+    owner = "iaolo";
+    repo = "iA-Fonts";
+    rev = "55edf60f544078ab1e14987bc67e9029a200e0eb";
+    hash = "sha256-/ifzOScILLuFkjFIgpy0ArCcelgealbpypKvZ46xApU=";
+  };
 
-  postFetch = ''
-    tar --strip-components=1 -xzvf $downloadedFile
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/opentype
     cp "iA Writer Duospace/OTF (Mac)/"*.otf $out/share/fonts/opentype/
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/inriafonts/default.nix
+++ b/pkgs/data/fonts/inriafonts/default.nix
@@ -1,20 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "inriafonts";
   version = "1.200";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "BlackFoundry";
-  repo = "InriaFonts";
-  rev = "v${version}";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  src = fetchFromGitHub {
+    owner = "BlackFoundry";
+    repo = "InriaFonts";
+    rev = "v${version}";
+    hash = "sha256-CMKkwGuUEVYavnFi15FCk7Xloyk97w+LhAZ6mpIv5xg=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts/truetype fonts/*/TTF/*.ttf
     install -m444 -Dt $out/share/fonts/opentype fonts/*/OTF/*.otf
+
+    runHook postInstall
   '';
-  sha256 = "0wrwcyycyzvgvgnlmwi1ncdvwb8f6bbclynd1105rsyxgrz5dd70";
 
   meta = with lib; {
     homepage = "https://black-foundry.com/work/inria";

--- a/pkgs/data/fonts/ir-standard-fonts/default.nix
+++ b/pkgs/data/fonts/ir-standard-fonts/default.nix
@@ -1,19 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "ir-standard-fonts";
-  version = "unstable-2017-01-21";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "morealaz";
-  repo = pname;
-  rev = "d36727d6c38c23c01b3074565667a2fe231fe18f";
+  version = "20170121";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  src = fetchFromGitHub {
+    owner = "molaeiali";
+    repo = pname;
+    rev = version;
+    hash = "sha256-o1d8SBX3nf7g6Gh4OP+JRS+LNrHTQOIiHhW3VNCkDV0=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
     find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/ir-standard-fonts {} \;
+
+    runHook postInstall
   '';
-  sha256 = "0i2vzhwk77pm6fx5z5gxl026z9f35rhh3cvl003mry2lcg1x5rhp";
 
   meta = with lib; {
     homepage = "https://github.com/morealaz/ir-standard-fonts";

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -1,23 +1,25 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation {
   pname = "junicode";
   version = "1.003";
-in
-fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "psb1558";
-  repo = "Junicode-font";
-  rev = "55d816d91a5e19795d9b66edec478379ee2b9ddb";
+  src = fetchFromGitHub {
+    owner = "psb1558";
+    repo = "Junicode-font";
+    rev = "55d816d91a5e19795d9b66edec478379ee2b9ddb";
+    hash = "sha256-eTiMgI8prnpR4H6sqKRaB3Gcnt4C5QWZalRajWW49G4=";
+  };
 
-  postFetch = ''
+  installPhase = ''
+    runHook preInstall
+
     local out_ttf=$out/share/fonts/junicode-ttf
     mkdir -p $out_ttf
-    tar -f $downloadedFile -C $out_ttf --wildcards -x '*.ttf' --strip=2
-  '';
+    cp legacy/*.ttf $out_ttf
 
-  sha256 = "1v334gljmidh58kmrarz5pf348b0ac7vh25f1xs3gyvn78khh5nw";
+    runHook postInstall
+  '';
 
   meta = {
     homepage = "https://github.com/psb1558/Junicode-font";

--- a/pkgs/data/fonts/kreative-square-fonts/default.nix
+++ b/pkgs/data/fonts/kreative-square-fonts/default.nix
@@ -1,22 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation {
   pname = "kreative-square-fonts";
   version = "unstable-2021-01-29";
-in
-fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "kreativekorp";
-  repo = "open-relay";
-  rev = "084f05af3602307499981651eca56851bec01fca";
+  src = fetchFromGitHub {
+    owner = "kreativekorp";
+    repo = "open-relay";
+    rev = "084f05af3602307499981651eca56851bec01fca";
+    hash = "sha256-+ihosENczaGal3BGDIaJ/de0pf8txdtelSYMxPok6ww=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     install -Dm444 -t $out/share/fonts/truetype/ KreativeSquare/KreativeSquare.ttf
     install -Dm444 -t $out/share/fonts/truetype/ KreativeSquare/KreativeSquareSM.ttf
+
+    runHook postInstall
   '';
-  sha256 = "15vvbbzv6b3jh7lxg77viycdd7yf3y8lxy54vs3rsrsxwncg0pak";
 
   meta = with lib; {
     description = "Fullwidth scalable monospace font designed specifically to support pseudographics, semigraphics, and private use characters";

--- a/pkgs/data/fonts/lalezar-fonts/default.nix
+++ b/pkgs/data/fonts/lalezar-fonts/default.nix
@@ -1,20 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation {
   pname = "lalezar-fonts";
   version = "unstable-2017-02-28";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "BornaIz";
-  repo = "Lalezar";
-  rev = "238701c4241f207e92515f845a199be9131c1109";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  src = fetchFromGitHub {
+    owner = "BornaIz";
+    repo = "Lalezar";
+    rev = "238701c4241f207e92515f845a199be9131c1109";
+    hash = "sha256-95z58ABTx53aREXRpj9xgclX9kuGiQiiKBwqwnF6f8g=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/lalezar-fonts
     cp -v $( find . -name '*.ttf') $out/share/fonts/lalezar-fonts
+
+    runHook postInstall
   '';
-  sha256 = "0jmwhr2dqgj3vn0v26jh6c0id6n3wd6as3bq39xa870zlk7v307b";
 
   meta = with lib; {
     homepage = "https://github.com/BornaIz/Lalezar";

--- a/pkgs/data/fonts/libre-baskerville/default.nix
+++ b/pkgs/data/fonts/libre-baskerville/default.nix
@@ -1,19 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  name = "libre-baskerville-1.000";
+stdenvNoCC.mkDerivation rec {
+  pname = "libre-baskerville";
+  version = "1.000";
 
-  owner = "impallari";
-  repo = "Libre-Baskerville";
-  rev = "2fba7c8e0a8f53f86efd3d81bc4c63674b0c613f";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Libre-Baskerville";
+    rev = "2fba7c8e0a8f53f86efd3d81bc4c63674b0c613f";
+    hash = "sha256-1EXi1hxFpc7pFsLbEj1xs9LqjeIf3XBol/8HdKNROUU=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts/truetype *.ttf
-    install -m444 -Dt $out/share/doc/${name}    README.md FONTLOG.txt
-  '';
+    install -m444 -Dt $out/share/doc/${pname}-${version} README.md FONTLOG.txt
 
-  sha256 = "1kpji85d1mgwq8b4fh1isznrhsrv32la3wf058rwjmhx5a3l7yaj";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A webfont family optimized for body text";

--- a/pkgs/data/fonts/libre-bodoni/default.nix
+++ b/pkgs/data/fonts/libre-bodoni/default.nix
@@ -1,19 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  name = "libre-bodoni-2.000";
+stdenvNoCC.mkDerivation rec {
+  pname = "libre-bodoni";
+  version = "2.000";
 
-  owner = "impallari";
-  repo = "Libre-Bodoni";
-  rev = "995a40e8d6b95411d660cbc5bb3f726ffd080c7d";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Libre-Bodoni";
+    rev = "995a40e8d6b95411d660cbc5bb3f726ffd080c7d";
+    hash = "sha256-yfqVeT/JiAT+fsqkXUxqlz4sEEFwEJUdvFTAzuqejtk=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts/opentype */v2000\ -\ initial\ glyphs\ migration/OTF/*.otf
-    install -m444 -Dt $out/share/doc/${name}    README.md FONTLOG.txt
-  '';
+    install -m444 -Dt $out/share/doc/${pname}-${version} README.md FONTLOG.txt
 
-  sha256 = "0my0i5a7f0d27m6dcdirjmlcnswqqfp8gl3ccxa5f2wkn3qlzkvz";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Bodoni fonts adapted for today's web requirements";

--- a/pkgs/data/fonts/libre-franklin/default.nix
+++ b/pkgs/data/fonts/libre-franklin/default.nix
@@ -1,19 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-fetchFromGitHub rec {
-  name = "libre-franklin-1.014";
+stdenvNoCC.mkDerivation rec {
+  pname = "libre-franklin";
+  version = "1.014";
 
-  owner = "impallari";
-  repo = "Libre-Franklin";
-  rev = "006293f34c47bd752fdcf91807510bc3f91a0bd3";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Libre-Franklin";
+    rev = "006293f34c47bd752fdcf91807510bc3f91a0bd3";
+    hash = "sha256-GR1KHiQ1lTOmU8eAPR2pxUlMpWiW2EDMG78VDjELxDU=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts/opentype */OTF/*.otf
-    install -m444 -Dt $out/share/doc/${name}    README.md FONTLOG.txt
-  '';
+    install -m444 -Dt $out/share/doc/${pname}-${version} README.md FONTLOG.txt
 
-  sha256 = "0aq280m01pbirkzga432340aknf2m5ggalw0yddf40sqz7falykf";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "A reinterpretation and expansion based on the 1912 Morris Fuller Benton’s classic.";

--- a/pkgs/data/fonts/manrope/default.nix
+++ b/pkgs/data/fonts/manrope/default.nix
@@ -1,18 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "manrope";
   version = "3";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "sharanda";
-  repo = pname;
-  rev = "3bd68c0c325861e32704470a90dfc1868a5c37e9";
-  sha256 = "1h4chkfbp75hrrqqarf28ld4yb7hfrr7q4w5yz96ivg94lbwlnld";
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+
+  src = fetchFromGitHub {
+    owner = "sharanda";
+    repo = pname;
+    rev = "3bd68c0c325861e32704470a90dfc1868a5c37e9";
+    hash = "sha256-Gm7mUD/Ud2Rf8mA3jwUL7RE8clCmb6SETOskuj6r1sw=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
     install -Dm644 -t $out/share/fonts/opentype "desktop font"/*
+
+    runHook postInstall
   '';
+
   meta = with lib; {
     description = "Open-source modern sans-serif font family";
     homepage = "https://github.com/sharanda/manrope";

--- a/pkgs/data/fonts/material-icons/default.nix
+++ b/pkgs/data/fonts/material-icons/default.nix
@@ -1,20 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "material-icons";
   version = "3.0.1";
-in fetchFromGitHub {
-  name = "material-icons-${version}";
 
-  owner  = "google";
-  repo   = "material-design-icons";
-  rev    = version;
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "material-design-icons";
+    rev = version;
+    hash = "sha256-4FphNJCsaLWzlVR4TmXnDBid0EVj39fkeoh5j1leBZ8=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
     cp iconfont/*.ttf $out/share/fonts/truetype
+
+    runHook postInstall
   '';
-  sha256 = "1syy6v941lb8nqxhdf7mfx28v05lwrfnq53r3c1ym13x05l9kchp";
 
   meta = with lib; {
     description = "System status icons by Google, featuring material design";

--- a/pkgs/data/fonts/montserrat/default.nix
+++ b/pkgs/data/fonts/montserrat/default.nix
@@ -1,25 +1,27 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-fetchFromGitHub rec {
+stdenvNoCC.mkDerivation rec {
   pname = "montserrat";
   version = "7.222";
 
-  owner = "JulietaUla";
-  repo = pname;
-  rev = "v${version}";
-  sha256 = "sha256-MeNnc1e5X5f0JyaLY6fX22rytHkvL++eM2ygsdlGMv0=";
+  src = fetchFromGitHub {
+    owner = "JulietaUla";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-eVCRn2OtNI5NuYZBQy06HKnMMXhPPnFxI8m8kguZjg0=";
+  };
 
-  postFetch = ''
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/{otf,ttf,woff,woff2}
 
-    mv $out/fonts/otf/*.otf $out/share/fonts/otf
-    mv $out/fonts/ttf/*.ttf $out/share/fonts/ttf
-    mv $out/fonts/webfonts/*.woff $out/share/fonts/woff
-    mv $out/fonts/webfonts/*.woff2 $out/share/fonts/woff2
+    mv fonts/otf/*.otf $out/share/fonts/otf
+    mv fonts/ttf/*.ttf $out/share/fonts/ttf
+    mv fonts/webfonts/*.woff $out/share/fonts/woff
+    mv fonts/webfonts/*.woff2 $out/share/fonts/woff2
 
-    shopt -s extglob dotglob
-    rm -rf $out/!(share)
-    shopt -u extglob dotglob
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/myrica/default.nix
+++ b/pkgs/data/fonts/myrica/default.nix
@@ -1,18 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-fetchFromGitHub {
-  name = "myrica-2.011.20160403";
+stdenvNoCC.mkDerivation {
+  pname = "myrica";
+  version = "2.011.20160403";
 
-  owner = "tomokuni";
-  repo = "Myrica";
-  # commit does not exist on any branch on the target repository
-  rev = "b737107723bfddd917210f979ccc32ab3eb6dc20";
-  sha256 = "187rklcibbkai6m08173ca99qn8v7xpdfdv0izpymmavj85axm12";
+  src = fetchFromGitHub {
+    owner = "tomokuni";
+    repo = "Myrica";
+    # commit does not exist on any branch on the target repository
+    rev = "b737107723bfddd917210f979ccc32ab3eb6dc20";
+    hash = "sha256-kx+adbN2DsO81KJFt+FGAPZN+1NpE9xiagKZ4KyaJV0=";
+  };
 
-  postFetch = ''
-    tar --strip-components=1 -xzvf $downloadedFile
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
     cp product/*.TTC $out/share/fonts/truetype
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/nahid-fonts/default.nix
+++ b/pkgs/data/fonts/nahid-fonts/default.nix
@@ -1,19 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "nahid-fonts";
   version = "0.3.0";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "rastikerdar";
-  repo = "nahid-font";
-  rev = "v${version}";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "nahid-font";
+    rev = "v${version}";
+    hash = "sha256-r8/W0/pJV6OX954spIITvW7M6lIbZRpbsvEHErnXglg=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
     find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/nahid-fonts {} \;
+
+    runHook postInstall
   '';
-  sha256 = "0df169sibq14j2mj727sq86c00jm1nz8565v85hkvh4zgz2plb7c";
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/nahid-font";

--- a/pkgs/data/fonts/nika-fonts/default.nix
+++ b/pkgs/data/fonts/nika-fonts/default.nix
@@ -1,19 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "nika-fonts";
   version = "1.0.0";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "font-store";
-  repo = "NikaFont";
-  rev = "v${version}";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  src = fetchFromGitHub {
+    owner = "font-store";
+    repo = "NikaFont";
+    rev = "v${version}";
+    hash = "sha256-jDemm8IyjhoCOg4Bfsp0tzUR7m+JaswL5d7Kug+asJk=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
     find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/nika-fonts {} \;
+
+    runHook postInstall
   '';
-  sha256 = "1x34b2dqn1dymi1vmj5vrjcy2z8s0f3rr6cniyrz85plvid6x40i";
 
   meta = with lib; {
     homepage = "https://github.com/font-store/NikaFont/";

--- a/pkgs/data/fonts/office-code-pro/default.nix
+++ b/pkgs/data/fonts/office-code-pro/default.nix
@@ -1,21 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "office-code-pro";
   version = "1.004";
-in fetchFromGitHub rec {
-  name = "${pname}-${version}";
 
-  owner = "nathco";
-  repo = "Office-Code-Pro";
-  rev = version;
+  src = fetchFromGitHub {
+    owner = "nathco";
+    repo = "Office-Code-Pro";
+    rev = version;
+    hash = "sha256-qzKTXYswkithZUJT0a3IifCq4RJFeKciZAPhYr2U1X4=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
-    install -m644 -Dt $out/share/doc/${name} README.md
+  installPhase = ''
+    runHook preInstall
+
+    install -m644 -Dt $out/share/doc/${pname}-${version} README.md
     install -m444 -Dt $out/share/fonts/opentype 'Fonts/Office Code Pro/OTF/'*.otf 'Fonts/Office Code Pro D/OTF/'*.otf
+
+    runHook postInstall
   '';
-  sha256 = "1bagwcaicn6q8qkqazz6wb3x30y4apmkga0mkv8fh6890hfhywr9";
 
   meta = with lib; {
     description = "A customized version of Source Code Pro";

--- a/pkgs/data/fonts/orbitron/default.nix
+++ b/pkgs/data/fonts/orbitron/default.nix
@@ -1,42 +1,45 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation {
+  pname = "orbitron";
   version = "20110526";
-in fetchFromGitHub {
-  name = "orbitron-${version}";
 
-  owner = "theleagueof";
-  repo = "orbitron";
-  rev = "13e6a52";
+  src = fetchFromGitHub {
+    owner = "theleagueof";
+    repo = "orbitron";
+    rev = "13e6a52";
+    hash = "sha256-zjNPVrDUxcQbrsg1/8fFa6Wenu1yuG/XDfKA7NVZ0rA=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     install -m444 -Dt $out/share/fonts/opentype/orbitron *.otf
     install -m444 -Dt $out/share/fonts/ttf/orbitron      *.ttf
-  '';
 
-  sha256 = "1y9yzvpqs2v3ssnqk2iiglrh8amgsscnk8vmfgnqgqi9f4dhdvnv";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://www.theleagueofmoveabletype.com/orbitron";
     downloadPage = "https://www.theleagueofmoveabletype.com/orbitron/download";
     description = "Geometric sans-serif for display purposes by Matt McInerney";
     longDescription = ''
-     Orbitron is a geometric sans-serif typeface intended for display
-     purposes. It features four weights (light, medium, bold, and
-     black), a stylistic alternative, small caps, and a ton of
-     alternate glyphs.
+      Orbitron is a geometric sans-serif typeface intended for display
+      purposes. It features four weights (light, medium, bold, and
+      black), a stylistic alternative, small caps, and a ton of
+      alternate glyphs.
 
-     Orbitron was designed so that graphic designers in the future
-     will have some alternative to typefaces like Eurostile or Bank
-     Gothic. If you’ve ever seen a futuristic sci-fi movie, you have
-     may noticed that all other fonts have been lost or destroyed in
-     the apocalypse that led humans to flee earth. Only those very few
-     geometric typefaces have survived to be used on spaceship
-     exteriors, space station signage, monopolistic corporate
-     branding, uniforms featuring aerodynamic shoulder pads, etc. Of
-     course Orbitron could also be used on the posters for the movies
-     portraying this inevitable future.
+      Orbitron was designed so that graphic designers in the future
+      will have some alternative to typefaces like Eurostile or Bank
+      Gothic. If you’ve ever seen a futuristic sci-fi movie, you have
+      may noticed that all other fonts have been lost or destroyed in
+      the apocalypse that led humans to flee earth. Only those very few
+      geometric typefaces have survived to be used on spaceship
+      exteriors, space station signage, monopolistic corporate
+      branding, uniforms featuring aerodynamic shoulder pads, etc. Of
+      course Orbitron could also be used on the posters for the movies
+      portraying this inevitable future.
     '';
     license = licenses.ofl;
     platforms = platforms.all;

--- a/pkgs/data/fonts/oxygenfonts/default.nix
+++ b/pkgs/data/fonts/oxygenfonts/default.nix
@@ -1,19 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-fetchFromGitHub {
-  name = "oxygenfonts-20160824";
+stdenvNoCC.mkDerivation rec {
+  pname = "oxygenfonts";
+  version = "20160824";
 
-  owner = "vernnobile";
-  repo = "oxygenFont";
-  rev = "62db0ebe3488c936406685485071a54e3d18473b";
+  src = fetchFromGitHub {
+    owner = "vernnobile";
+    repo = "oxygenFont";
+    rev = "62db0ebe3488c936406685485071a54e3d18473b";
+    hash = "sha256-0LKq8nChkDAb6U1sOUyga/DvzpDmIjoRn+2PB9rok4w=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
     cp */Oxygen-Sans.ttf */Oxygen-Sans-Bold.ttf */OxygenMono-Regular.ttf $out/share/fonts/truetype
-  '';
 
-  sha256 = "17m86p1s7a7d90zqjsr46h5bpmas4vxsgj7kd0j5c8cb7lw92jyf";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Desktop/gui font for integrated use with the KDE desktop";

--- a/pkgs/data/fonts/parastoo-fonts/default.nix
+++ b/pkgs/data/fonts/parastoo-fonts/default.nix
@@ -1,20 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "parastoo-fonts";
   version = "2.0.1";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "rastikerdar";
-  repo = "parastoo-font";
-  rev = "v${version}";
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "parastoo-font";
+    rev = "v${version}";
+    hash = "sha256-E94B9R2h227D49dscCBsprmb7w0GrQ+2tWOWRf8FH30=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/parastoo-fonts {} \;
+
+    runHook postInstall
   '';
-  sha256 = "sha256-4smobLS43DB7ISmbWDWX0IrtaeiyXpi1QpAiL8NyXoQ=";
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/parastoo-font";

--- a/pkgs/data/fonts/powerline-fonts/default.nix
+++ b/pkgs/data/fonts/powerline-fonts/default.nix
@@ -1,22 +1,27 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-fetchFromGitHub {
-  name = "powerline-fonts-2018-11-11";
+stdenvNoCC.mkDerivation {
+  pname = "powerline-fonts";
+  version = "unstable-2018-11-11";
 
-  owner = "powerline";
-  repo = "fonts";
-  rev = "e80e3eba9091dac0655a0a77472e10f53e754bb0";
+  src = fetchFromGitHub {
+    owner = "powerline";
+    repo = "fonts";
+    rev = "e80e3eba9091dac0655a0a77472e10f53e754bb0";
+    hash = "sha256-GGfON6Z/0czCUAGxnqtndgDnaZGONFTU9/Hu4BGDHlk=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     find . -name '*.otf'    -exec install -Dt $out/share/fonts/opentype {} \;
     find . -name '*.ttf'    -exec install -Dt $out/share/fonts/truetype {} \;
     find . -name '*.bdf'    -exec install -Dt $out/share/fonts/bdf      {} \;
     find . -name '*.pcf.gz' -exec install -Dt $out/share/fonts/pcf      {} \;
     find . -name '*.psf.gz' -exec install -Dt $out/share/consolefonts   {} \;
-  '';
 
-  sha256 = "0r8p4z3db17f5p8jr7sv80nglmjxhg83ncfvwg1dszldswr0dhvr";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/powerline/fonts";

--- a/pkgs/data/fonts/raleway/default.nix
+++ b/pkgs/data/fonts/raleway/default.nix
@@ -1,21 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation {
+  pname = "raleway";
   version = "2016-08-30";
-in fetchFromGitHub {
-  name = "raleway-${version}";
 
-  owner = "impallari";
-  repo = "Raleway";
-  rev = "fa27f47b087fc093c6ae11cfdeb3999ac602929a";
+  src = fetchFromGitHub {
+    owner = "impallari";
+    repo = "Raleway";
+    rev = "fa27f47b087fc093c6ae11cfdeb3999ac602929a";
+    hash = "sha256-mcIpE+iqG6M43I5TT95oV+5kNgphunmyxC+Jaj0JysQ=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     find . -name "*-Original.otf" -exec install -Dt $out/share/fonts/opentype {} \;
-    cp *.txt *.md -d $out
-  '';
 
-  sha256 = "16jr7drqg2wib2q48ajlsa7rh1jxjibl1wd4rjndi49vfl463j60";
+    runHook postInstall
+  '';
 
   meta = {
     description = "Raleway is an elegant sans-serif typeface family";

--- a/pkgs/data/fonts/redhat-official/default.nix
+++ b/pkgs/data/fonts/redhat-official/default.nix
@@ -1,23 +1,26 @@
-{ lib, fetchFromGitHub }:
-let
+{ lib, stdenvNoCC, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "redhat-official";
   version = "4.0.2";
-in
-fetchFromGitHub {
-  name = "redhat-official-${version}";
 
-  owner = "RedHatOfficial";
-  repo = "RedHatFont";
-  rev = version;
+  src = fetchFromGitHub {
+    owner = "RedHatOfficial";
+    repo = "RedHatFont";
+    rev = version;
+    hash = "sha256-p5RS/57CDApwnRDwMi0gIEJYTDAtibIyyU2w/pnbHJI=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     for kind in mono proportional; do
       install -m444 -Dt $out/share/fonts/opentype fonts/$kind/static/otf/*.otf
       install -m444 -Dt $out/share/fonts/truetype fonts/$kind/static/ttf/*.ttf
     done
-  '';
 
-  sha256 = "sha256-904uQtbAdLx9MJudLk/vVk/+uK0nsPbWbAeXrWxTHm8=";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/RedHatOfficial/RedHatFont";

--- a/pkgs/data/fonts/rhodium-libre/default.nix
+++ b/pkgs/data/fonts/rhodium-libre/default.nix
@@ -1,22 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "RhodiumLibre";
   version = "1.2.0";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "DunwichType";
-  repo = pname;
-  rev = version;
+  src = fetchFromGitHub {
+    owner = "DunwichType";
+    repo = pname;
+    rev = version;
+    hash = "sha256-YCQvUdjEAj4G71WCRCM0+NwiqRqwt1Ggeg9jb/oWEsY=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     install -Dm444 -t $out/share/fonts/opentype/ RhodiumLibre-Regular.otf
     install -Dm444 -t $out/share/fonts/truetype/ RhodiumLibre-Regular.ttf
-  '';
 
-  sha256 = "04ax6bri5vsji465806p8d7zbdf12r5bpvcm9nb8isfqm81ggj0r";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "F/OSS/Libre font for Latin and Devanagari";

--- a/pkgs/data/fonts/sahel-fonts/default.nix
+++ b/pkgs/data/fonts/sahel-fonts/default.nix
@@ -1,20 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "sahel-fonts";
   version = "3.4.0";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "rastikerdar";
-  repo = "sahel-font";
-  rev = "v${version}";
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "sahel-font";
+    rev = "v${version}";
+    hash = "sha256-U4tIICXZFK9pk7zdzRwBPIPYFUlYXPSebnItUJUgGJY=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/sahel-fonts {} \;
+
+    runHook postInstall
   '';
-  sha256 = "sha256-MrKSgz9WpVgLS37uH/7S0LPBD/n3GLXeUCMBD7x5CG8=";
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/sahel-font";

--- a/pkgs/data/fonts/samim-fonts/default.nix
+++ b/pkgs/data/fonts/samim-fonts/default.nix
@@ -1,20 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "samim-fonts";
   version = "4.0.4";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "rastikerdar";
-  repo = "samim-font";
-  rev = "v${version}";
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "samim-font";
+    rev = "v${version}";
+    hash = "sha256-erT8iV5YHbEN47nEE5p5CbQYUgm8daOjymLAWF4fpVk=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/samim-fonts {} \;
+
+    runHook postInstall
   '';
-  sha256 = "sha256-WYSJ2mAzAe5H0EaMYU3qNVcQ0lRuHsjZ11YmLnZ2FCo=";
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/samim-font";

--- a/pkgs/data/fonts/shabnam-fonts/default.nix
+++ b/pkgs/data/fonts/shabnam-fonts/default.nix
@@ -1,20 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "shabnam-fonts";
   version = "5.0.1";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "rastikerdar";
-  repo = "shabnam-font";
-  rev = "v${version}";
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "shabnam-font";
+    rev = "v${version}";
+    hash = "sha256-H03GTKRVPiwU4edkr4x5upW4JCy6320Lo+cKK9FRMQs=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/shabnam-fonts {} \;
+
+    runHook postInstall
   '';
-  sha256 = "sha256-m4G4UtW/0S9CsvaSF7QfthfIxGQ02E7SucdDm5s3G7A=";
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/shabnam-font";

--- a/pkgs/data/fonts/tt2020/default.nix
+++ b/pkgs/data/fonts/tt2020/default.nix
@@ -1,20 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "TT2020";
-  version = "2020-01-05";
-in
-fetchFromGitHub {
-  name = "${pname}-${version}";
-  owner = "ctrlcctrlv";
-  repo = pname;
-  rev = "2b418fab5f99f72a18b3b2e7e2745ac4e03aa612";
-  sha256 = "1z0nizvs0gp0xl7pn6xcjvsysxhnfm7aqfamplkyvya3fxvhncds";
+  version = "0.2.1";
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  src = fetchFromGitHub {
+    owner = "ctrlcctrlv";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-eAJzaookHcQ/7QNq/HUKA/O2liyKynJNdo6QuZ1Bv6k=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
     install -Dm644 -t $out/share/fonts/truetype dist/*.ttf
     install -Dm644 -t $out/share/fonts/woff2 dist/*.woff2
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/vazir-code-font/default.nix
+++ b/pkgs/data/fonts/vazir-code-font/default.nix
@@ -1,20 +1,23 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "vazir-code-font";
   version = "1.1.2";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "rastikerdar";
-  repo = "vazir-code-font";
-  rev = "v${version}";
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "vazir-code-font";
+    rev = "v${version}";
+    hash = "sha256-iBojse3eHr4ucZtPfpkN+mmO6sEExY8WcAallyPgMsI=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/truetype {} \;
+
+    runHook postInstall
   '';
-  sha256 = "0ivwpn9xm2zwhwgg9mghyiy5v66cn4786w9j6rkff5cmzshv279r";
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/vazir-code-font";

--- a/pkgs/data/fonts/vazir-fonts/default.nix
+++ b/pkgs/data/fonts/vazir-fonts/default.nix
@@ -1,20 +1,25 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "vazir-fonts";
   version = "32.0.0";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "rastikerdar";
-  repo = "vazir-font";
-  rev = "v${version}";
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "vazir-font";
+    rev = "v${version}";
+    hash = "sha256-lkjlSW3Sfr1bJ9/IOsZl9yOVh9mYKhoV5XcLkqcQ71g=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/truetype {} \;
+
+    runHook postInstall
   '';
-  sha256 = "sha256-Uy8hgBtCcTLwXu9FkLN1WavUfP74Jf53ChxVGS3UBVM=";
 
   meta = with lib; {
     homepage = "https://github.com/rastikerdar/vazir-font";

--- a/pkgs/data/fonts/xkcd-font/default.nix
+++ b/pkgs/data/fonts/xkcd-font/default.nix
@@ -1,24 +1,24 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "xkcd-font";
   version = "unstable-2017-08-24";
-in fetchFromGitHub {
-  name = "${pname}-${version}";
 
-  owner = "ipython";
-  repo = pname;
-  rev = "5632fde618845dba5c22f14adc7b52bf6c52d46d";
+  src = fetchFromGitHub {
+    owner = "ipython";
+    repo = pname;
+    rev = "5632fde618845dba5c22f14adc7b52bf6c52d46d";
+    hash = "sha256-1DgSx2L+OpXuPVSXbbl/hcZUyBK9ikPyGWuk6wNzlwc=";
+  };
 
-  postFetch = ''
-    install -Dm444 -t $out/share/fonts/opentype/ $out/xkcd/build/xkcd.otf
-    install -Dm444 -t $out/share/fonts/truetype/ $out/xkcd-script/font/xkcd-script.ttf
+  installPhase = ''
+    runHook preInstall
 
-    shopt -s extglob dotglob
-    rm -rf $out/!(share)
-    shopt -u extglob dotglob
+    install -Dm444 -t $out/share/fonts/opentype/ xkcd/build/xkcd.otf
+    install -Dm444 -t $out/share/fonts/truetype/ xkcd-script/font/xkcd-script.ttf
+
+    runHook postInstall
   '';
-  sha256 = "sha256-ITsJPs+ZXwUWYe2AmwyVZib8RV7bpiWHOUD8qEZRHHY=";
 
   meta = with lib; {
     description = "The xkcd font";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
