### PR TITLE
fetch-hex: produce output acceptable to mix lock check `.hex` file

### DIFF
--- a/pkgs/development/beam-modules/fetch-hex.nix
+++ b/pkgs/development/beam-modules/fetch-hex.nix
@@ -19,9 +19,18 @@ stdenv.mkDerivation ({
   };
 
   unpackCmd = ''
-    tar -xf $curSrc contents.tar.gz
+    tar -xf $curSrc contents.tar.gz CHECKSUM metadata.config
     mkdir contents
     tar -C contents -xzf contents.tar.gz
+    mv metadata.config contents/hex_metadata.config
+
+    # To make the extracted hex tarballs appear legitimate to mix, we need to
+    # make sure they contain not just the contents of contents.tar.gz but also
+    # a .hex file with some lock metadata.
+    # We use an old version of .hex file per hex's mix_task_test.exs since it
+    # is just plain-text instead of an encoded format.
+    # See: https://github.com/hexpm/hex/blob/main/test/hex/mix_task_test.exs#L410
+    echo -n "${pkg},${version},$(cat CHECKSUM | tr '[:upper:]' '[:lower:]'),hexpm" > contents/.hex
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Description of changes

Add .hex and hex_metadata.config to extracted hex tarballs during fetchHex.

This makes the extracted folder look more like what mix deps.get what produce. Currently, mix will reject the extracted tar produced by fetchHex because it is missing a proper `.hex` file

Notably, it'd allow something like:

```nix
let
  nixified = pkgs.runCommand "nixified-mix" { } "${pkgs.mix2nix}/bin/mix2nix ${./mix.lock} > $out";
  mixNixDeps = with pkgs; import nixified { inherit lib beamPackages; };
  # Formatter & dialyzr require the deps/ folder to be present to recursively get format requirements, so
  # consolidate all of them here:
  consolidatedDeps = pkgs.runCommand "deps" { } ''
    mkdir $out
    cd $out
    ${toString(pkgs.lib.mapAttrsToList (name: value: "cp -r ${value.src} ${name}\n") mixNixDeps)}
  '';
```
Now `consolidatedDeps` can be copied in and used by mix -- much like `mixFodDeps`, except no
FoD is required since https://github.com/ydlr/mix2nix/pull/13 allows nix2mix to be used as an IFD.

(I don't think `hex_metadata.config` is strictly necessary but I put it in because it's also there in mix deps).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
