### PR TITLE
treewide: convert 17 fonts to stdenvNoCC.mkDerivation

### DIFF
--- a/pkgs/data/fonts/arkpandora/default.nix
+++ b/pkgs/data/fonts/arkpandora/default.nix
@@ -1,23 +1,26 @@
-{ lib, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "arkpandora";
   version = "2.04";
-in fetchurl {
-  name = "arkpandora-${version}";
 
-  urls = [
-    "http://distcache.FreeBSD.org/ports-distfiles/ttf-arkpandora-${version}.tgz"
-    "ftp://ftp.FreeBSD.org/pub/FreeBSD/ports/distfiles/ttf-arkpandora-${version}.tgz"
-    "http://www.users.bigpond.net.au/gavindi/ttf-arkpandora-${version}.tgz"
-  ];
-  downloadToTemp = true;
-  recursiveHash = true;
-  postFetch = ''
-    tar -xzvf $downloadedFile --strip-components=1
+  src = fetchurl {
+    urls = [
+      "http://distcache.FreeBSD.org/ports-distfiles/ttf-arkpandora-${version}.tgz"
+      "ftp://ftp.FreeBSD.org/pub/FreeBSD/ports/distfiles/ttf-arkpandora-${version}.tgz"
+      "http://www.users.bigpond.net.au/gavindi/ttf-arkpandora-${version}.tgz"
+    ];
+    hash = "sha256-ofyVPJjQD8w+8WgETF2UcJlfbSsKQgBsH3ob+yjvrpo=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
     cp *.ttf $out/share/fonts/truetype
+
+    runHook postInstall
   '';
-  sha256 = "177k0fbs0787al0snkl8w68d2qkg7snnnq6qp28j9s98vaabs04k";
 
   meta = {
     description = "Font, metrically identical to Arial and Times New Roman";

--- a/pkgs/data/fonts/ccsymbols/default.nix
+++ b/pkgs/data/fonts/ccsymbols/default.nix
@@ -1,23 +1,24 @@
-{ lib, fetchurl, unzip }:
+{ lib, stdenvNoCC, fetchurl, unzip }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "ccsymbols";
   version = "2020-04-19";
-in
 
-fetchurl rec {
-  name = "${pname}-${version}";
+  src = fetchurl {
+    url = "https://www.ctrl.blog/file/${version}_cc-symbols.zip";
+    hash = "sha256-hkARhb8T6VgGAybYkVuPuebjhuk1dwiBJ1bZMwvYpMY=";
+  };
 
-  url = "https://www.ctrl.blog/file/${version}_cc-symbols.zip";
-  sha256 = "sha256-mrNgTS6BAVJrIz9fHOjf8pkSbZtZ55UjyoL9tQ1fiA8=";
-  recursiveHash = true;
+  sourceRoot = ".";
 
   nativeBuildInputs = [ unzip ];
 
-  downloadToTemp = true;
-  postFetch = ''
-    mkdir -p "$out/share/fonts/ccsymbols"
-    unzip -d "$out/share/fonts/ccsymbols" "$downloadedFile"
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 CCSymbols.* -t $out/share/fonts/ccsymbols
+
+    runHook postInstall
   '';
 
   passthru = { inherit pname version; };

--- a/pkgs/data/fonts/cnstrokeorder/default.nix
+++ b/pkgs/data/fonts/cnstrokeorder/default.nix
@@ -1,20 +1,23 @@
-{ lib, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "cnstrokeorder";
   version = "0.0.4.7";
-in fetchurl {
-  name = "cnstrokeorder-${version}";
 
-  url = "http://rtega.be/chmn/CNstrokeorder-${version}.ttf";
+  src = fetchurl {
+    url = "http://rtega.be/chmn/CNstrokeorder-${version}.ttf";
+    hash = "sha256-YYtOcUvt1V0DwAs/vf9KltcmYCFJNirvwjGyOK4JpIY=";
+  };
 
-  recursiveHash = true;
-  downloadToTemp = true;
+  dontUnpack = true;
 
-  postFetch = ''
-    install -D $downloadedFile $out/share/fonts/truetype/CNstrokeorder-${version}.ttf
+  installPhase = ''
+    runHook preInstall
+
+    install -D $src $out/share/fonts/truetype/CNstrokeorder-${version}.ttf
+
+    runHook postInstall
   '';
-
-  sha256 = "0cizgfdgbq9av5c8234mysr2q54iw9pkxrmq5ga8gv32hxhl5bx4";
 
   meta = with lib; {
     description = "Chinese font that shows stroke order for HSK 1-4";

--- a/pkgs/data/fonts/curie/default.nix
+++ b/pkgs/data/fonts/curie/default.nix
@@ -1,22 +1,23 @@
-{ lib, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "curie";
   version = "1.0";
-in fetchurl rec {
-  name = "curie-${version}";
 
-  url = "https://github.com/NerdyPepper/curie/releases/download/v${version}/curie-v${version}.tar.gz";
+  src = fetchurl {
+    url = "https://github.com/NerdyPepper/curie/releases/download/v${version}/curie-v${version}.tar.gz";
+    hash = "sha256-B89GNbOmm3lY/cRWQJEFu/5morCM/WrRQb/m6covbt8=";
+  };
 
-  downloadToTemp = true;
+  sourceRoot = ".";
 
-  recursiveHash = true;
+  installPhase = ''
+    runHook preInstall
 
-  sha256 = "sha256-twPAzsbTveYW0rQd7FYZz5AMZgvPbNmn5c7Nfzn7B0A=";
-
-  postFetch = ''
-    tar xzf $downloadedFile
     mkdir -p $out/share/fonts/misc
     install *.otb $out/share/fonts/misc
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/edwin/default.nix
+++ b/pkgs/data/fonts/edwin/default.nix
@@ -1,22 +1,21 @@
-{ lib, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "edwin";
   version = "0.52";
-in fetchurl {
-  name = "edwin-${version}";
 
-  url = "https://github.com/MuseScoreFonts/Edwin/archive/refs/tags/v${version}.tar.gz";
+  src = fetchurl {
+    url = "https://github.com/MuseScoreFonts/Edwin/archive/refs/tags/v${version}.tar.gz";
+    hash = "sha256-7yQUiLZupGc+RCZdhyO08JWqhROYqMOZ9wRdGJ6uixU=";
+  };
 
-  downloadToTemp = true;
+  installPhase = ''
+    runHook preInstall
 
-  recursiveHash = true;
-
-  sha256 = "sha256-e0ADK72ECl+QMvLWtFJfeHBmuEwzr9M+Kqvkd5Z2mmo=";
-
-  postFetch = ''
-    tar xzf $downloadedFile
     mkdir -p $out/share/fonts/opentype
-    install Edwin-${version}/*.otf $out/share/fonts/opentype
+    install *.otf $out/share/fonts/opentype
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/fixedsys-excelsior/default.nix
+++ b/pkgs/data/fonts/fixedsys-excelsior/default.nix
@@ -1,19 +1,23 @@
-{ lib, fetchurl } :
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "fixedsys-excelsior";
   version = "3.00";
-in fetchurl rec {
-  name = "fixedsys-excelsior-${version}";
 
-  url = "https://raw.githubusercontent.com/chrissimpkins/codeface/master/fonts/fixed-sys-excelsior/FSEX300.ttf";
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/chrissimpkins/codeface/master/fonts/fixed-sys-excelsior/FSEX300.ttf";
+    hash = "sha256-buDzVzvF4z6TthbvYoL0m8DiJ6Map1Osdu0uPz0CBW0=";
+  };
 
-  downloadToTemp = true;
-  recursiveHash = true;
-  postFetch = ''
-    install -m444 -D $downloadedFile $out/share/fonts/truetype/${name}.ttf
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m444 -D $src $out/share/fonts/truetype/${pname}-${version}.ttf
+
+    runHook postInstall
   '';
-
-  sha256 = "32d6f07f1ff08c764357f8478892b2ba5ade23427af99759f34a0ba24bcd2e37";
 
   meta = {
     homepage = "http://www.fixedsysexcelsior.com/";

--- a/pkgs/data/fonts/i-dot-ming/default.nix
+++ b/pkgs/data/fonts/i-dot-ming/default.nix
@@ -1,17 +1,22 @@
-{ lib, fetchurl, writeScript }:
+{ lib, stdenvNoCC, fetchurl, writeScript }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "i.ming";
   version = "8.00";
-in
-fetchurl {
-  name = "i.ming-${version}";
-  url = "https://raw.githubusercontent.com/ichitenfont/I.Ming/${version}/${version}/I.Ming-${version}.ttf";
-  hash = "sha256-JGu9H0+IdJL6QQtLwvqlFLEaJdq1JVRiqLm5zptwjyE=";
 
-  recursiveHash = true;
-  downloadToTemp = true;
-  postFetch = ''
-    install -DT -m444 $downloadedFile $out/share/fonts/truetype/I.Ming/I.Ming.ttf
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/ichitenfont/I.Ming/${version}/${version}/I.Ming-${version}.ttf";
+    hash = "sha256-6345629OdKz6lTnD3Vjtp6DzsYy0ojaL0naXGrtdZvw=";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -DT -m444 $src $out/share/fonts/truetype/I.Ming/I.Ming.ttf
+
+    runHook postInstall
   '';
 
   passthru = {

--- a/pkgs/data/fonts/last-resort/default.nix
+++ b/pkgs/data/fonts/last-resort/default.nix
@@ -1,19 +1,23 @@
-{ lib, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "last-resort";
   version = "15.000";
-in fetchurl {
-  name = "last-resort-${version}";
 
-  url = "https://github.com/unicode-org/last-resort-font/releases/download/${version}/LastResortHE-Regular.ttf";
-  downloadToTemp = true;
+  src = fetchurl {
+    url = "https://github.com/unicode-org/last-resort-font/releases/download/${version}/LastResortHE-Regular.ttf";
+    hash = "sha256-Qyo/tuBvBHnG/LW8sUAy62xpeqlXfyfwjUCbr4vJEag=";
+  };
 
-  postFetch = ''
-    install -D -m 0644 $downloadedFile $out/share/fonts/truetype/LastResortHE-Regular.ttf
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m 0644 $src $out/share/fonts/truetype/LastResortHE-Regular.ttf
+
+    runHook postInstall
   '';
-
-  recursiveHash = true;
-  sha256 = "sha256-mkRIA6Hajl5e9j/qb3WSKaIaHmekjl5wGUSszWMfmjw=";
 
   meta = with lib; {
     description = "Fallback font of last resort";

--- a/pkgs/data/fonts/libertinus/default.nix
+++ b/pkgs/data/fonts/libertinus/default.nix
@@ -1,18 +1,20 @@
-{ lib, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "libertinus";
   version = "7.040";
-in fetchurl rec {
-  name = "libertinus-${version}";
-  url = "https://github.com/alerque/libertinus/releases/download/v${version}/Libertinus-${version}.tar.xz";
-  sha256 = "0z658r88p52dyrcslv0wlccw0sw7m5jz8nbqizv95nf7bfw96iyk";
 
-  downloadToTemp = true;
-  recursiveHash = true;
+  src = fetchurl {
+    url = "https://github.com/alerque/libertinus/releases/download/v${version}/Libertinus-${version}.tar.xz";
+    hash = "sha256-f+nwInItHBzGfcLCihELO7VbrjV1GWFg0kIsiTM7OFA=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile --strip=1
+  installPhase = ''
+    runHook preInstall
+
     install -m644 -Dt $out/share/fonts/opentype static/OTF/*.otf
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/linja-pi-pu-lukin/default.nix
+++ b/pkgs/data/fonts/linja-pi-pu-lukin/default.nix
@@ -1,16 +1,22 @@
-{ lib, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-fetchurl {
+stdenvNoCC.mkDerivation {
   pname = "linja-pi-pu-lukin";
   version = "unstable-2021-10-29";
 
-  url = "https://web.archive.org/web/20211029000000/https://jansa-tp.github.io/linja-pi-pu-lukin/PuLukin.otf";
-  hash = "sha256-VPdrMHWpiokFYON4S8zT+pSs4TsB17S8TZRtkjqIqU8=";
+  src = fetchurl {
+    url = "https://web.archive.org/web/20211029000000/https://jansa-tp.github.io/linja-pi-pu-lukin/PuLukin.otf";
+    hash = "sha256-Mf7P9fLGiG7L555Q3wRaI/PRv/TIs0njLq2IzIbc5Wo=";
+  };
 
-  downloadToTemp = true;
-  recursiveHash = true;
-  postFetch = ''
-    install -D $downloadedFile $out/share/fonts/opentype/linja-pi-pu-lukin.otf
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D $src $out/share/fonts/opentype/linja-pi-pu-lukin.otf
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -230,15 +230,22 @@ rec {
       pname = "noto-fonts-emoji-blob-bin";
       version = "14.0.1";
     in
-    fetchurl {
-      name = "${pname}-${version}";
-      url = "https://github.com/C1710/blobmoji/releases/download/v${version}/Blobmoji.ttf";
-      sha256 = "sha256-wSH9kRJ8y2i5ZDqzeT96dJcEJnHDSpU8bOhmxaT+UCg=";
+    stdenvNoCC.mkDerivation {
+      inherit pname version;
 
-      downloadToTemp = true;
-      recursiveHash = true;
-      postFetch = ''
-        install -Dm 444 $downloadedFile $out/share/fonts/blobmoji/Blobmoji.ttf
+      src = fetchurl {
+        url = "https://github.com/C1710/blobmoji/releases/download/v${version}/Blobmoji.ttf";
+        hash = "sha256-w9s7uF6E6nomdDmeKB4ATcGB/5A4sTwDvwHT3YGXz8g=";
+      };
+
+      dontUnpack = true;
+
+      installPhase = ''
+        runHook preInstall
+
+        install -Dm 444 $src $out/share/fonts/blobmoji/Blobmoji.ttf
+
+        runHook postInstall
       '';
 
       meta = with lib; {

--- a/pkgs/data/fonts/open-fonts/default.nix
+++ b/pkgs/data/fonts/open-fonts/default.nix
@@ -1,21 +1,21 @@
-{ lib, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "open-fonts";
   version = "0.7.0";
-in
-fetchurl {
-  name = "${pname}-${version}";
 
-  url = "https://github.com/kiwi0fruit/open-fonts/releases/download/${version}/open-fonts.tar.xz";
-  downloadToTemp = true;
-  recursiveHash = true;
-  sha256 = "sha256-bSP9Flotoo3E5vRU3eKOUAPD2fmkWseWYWG4y0S07+4=";
+  src = fetchurl {
+    url = "https://github.com/kiwi0fruit/open-fonts/releases/download/${version}/open-fonts.tar.xz";
+    hash = "sha256-NJKbdrvgZz9G7mjAJYzN7rU/fo2xRFZA2BbQ+A56iPw=";
+  };
 
-  postFetch = ''
-    tar xf $downloadedFile
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
-    install open-fonts/*.ttf $out/share/fonts/truetype
+    install *.ttf $out/share/fonts/truetype
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/pecita/default.nix
+++ b/pkgs/data/fonts/pecita/default.nix
@@ -1,29 +1,30 @@
-{ lib, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation {
+  pname = "pecita";
   version = "5.4";
-in
 
-fetchurl {
-  name = "pecita-${version}";
+  src = fetchurl {
+    url = "http://pecita.eu/b/Pecita.otf";
+    hash = "sha256-D9IZ+p4UFHUNt9me7D4vv0x6rMK9IaViKPliCEyX6t4=";
+  };
 
-  url = "http://pecita.eu/b/Pecita.otf";
+  dontUnpack = true;
 
-  downloadToTemp = true;
+  installPhase = ''
+    runHook preInstall
 
-  postFetch = ''
     mkdir -p $out/share/fonts/opentype
-    cp -v $downloadedFile $out/share/fonts/opentype/Pecita.otf
-  '';
+    cp -v $src $out/share/fonts/opentype/Pecita.otf
 
-  recursiveHash = true;
-  sha256 = "0pwm20f38lcbfkdqkpa2ydpc9kvmdg0ifc4h2dmipsnwbcb5rfwm";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "http://pecita.eu/police-en.php";
     description = "Handwritten font with connected glyphs";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = [maintainers.rycee];
+    maintainers = [ maintainers.rycee ];
   };
 }

--- a/pkgs/data/fonts/sarasa-gothic/default.nix
+++ b/pkgs/data/fonts/sarasa-gothic/default.nix
@@ -1,21 +1,27 @@
-{ lib, fetchurl, libarchive }:
+{ lib, stdenvNoCC, fetchurl, p7zip }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "sarasa-gothic";
   version = "0.38.0";
-in fetchurl {
-  name = "sarasa-gothic-${version}";
 
-  # Use the 'ttc' files here for a smaller closure size.
-  # (Using 'ttf' files gives a closure size about 15x larger, as of November 2021.)
-  url = "https://github.com/be5invis/Sarasa-Gothic/releases/download/v${version}/sarasa-gothic-ttc-${version}.7z";
-  sha256 = "sha256-lGkb3e2EFHkDLm+/KArfOQ50qBFRThlpcID06g0t4aI=";
+  src = fetchurl {
+    # Use the 'ttc' files here for a smaller closure size.
+    # (Using 'ttf' files gives a closure size about 15x larger, as of November 2021.)
+    url = "https://github.com/be5invis/Sarasa-Gothic/releases/download/v${version}/sarasa-gothic-ttc-${version}.7z";
+    hash = "sha256-UXWstk1vIoaFqa8nVxfJcAtN7BzWevzgfMx1gyXu0k8=";
+  };
 
-  recursiveHash = true;
-  downloadToTemp = true;
+  sourceRoot = ".";
 
-  postFetch = ''
+  nativeBuildInputs = [ p7zip ];
+
+  installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/fonts/truetype
-    ${libarchive}/bin/bsdtar -xf $downloadedFile -C $out/share/fonts/truetype
+    cp *.ttc $out/share/fonts/truetype
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/scientifica/default.nix
+++ b/pkgs/data/fonts/scientifica/default.nix
@@ -1,25 +1,24 @@
-{ lib, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "scientifica";
   version = "2.3";
-in fetchurl rec {
-  name = "scientifica-${version}";
 
-  url = "https://github.com/NerdyPepper/scientifica/releases/download/v${version}/scientifica.tar";
+  src = fetchurl {
+    url = "https://github.com/NerdyPepper/scientifica/releases/download/v${version}/scientifica.tar";
+    hash = "sha256-8IV4aaDoRsbxddy4U90fEZ6henUhjmO38HNtWo4ein8=";
+  };
 
-  downloadToTemp = true;
+  installPhase = ''
+    runHook preInstall
 
-  recursiveHash = true;
-
-  sha256 = "sha256-pVWkj/2lFpmWk0PPDrIMU4Gey7/m/9tzUsuD3ZDUAdc=";
-
-  postFetch = ''
-    tar xf $downloadedFile
     mkdir -p $out/share/fonts/truetype
     mkdir -p $out/share/fonts/misc
-    install scientifica/ttf/*.ttf $out/share/fonts/truetype
-    install scientifica/otb/*.otb $out/share/fonts/misc
-    install scientifica/bdf/*.bdf $out/share/fonts/misc
+    install ttf/*.ttf $out/share/fonts/truetype
+    install otb/*.otb $out/share/fonts/misc
+    install bdf/*.bdf $out/share/fonts/misc
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/fonts/spleen/default.nix
+++ b/pkgs/data/fonts/spleen/default.nix
@@ -1,25 +1,31 @@
-{ lib, fetchurl, xorg }:
+{ lib, stdenvNoCC, fetchurl, xorg }:
 
-let
+stdenvNoCC.mkDerivation rec {
   pname = "spleen";
   version = "1.9.1";
-in fetchurl {
-  name = "${pname}-${version}";
-  url = "https://github.com/fcambus/spleen/releases/download/${version}/spleen-${version}.tar.gz";
 
-  downloadToTemp = true;
-  recursiveHash = true;
-  postFetch = ''
-    tar xvf $downloadedFile --strip=1
+  src = fetchurl {
+    url = "https://github.com/fcambus/spleen/releases/download/${version}/spleen-${version}.tar.gz";
+    hash = "sha256-fvWcTgKkXp3e1ryhi1Oc3w8OtJ5svLJXhY2lasXapiI=";
+  };
+
+  nativeBuildInputs = [ xorg.mkfontscale ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
     d="$out/share/fonts/misc"
     install -D -m 644 *.{pcf,bdf,otf} -t "$d"
     install -D -m 644 *.psfu -t "$out/share/consolefonts"
     install -m644 fonts.alias-spleen $d/fonts.alias
 
     # create fonts.dir so NixOS xorg module adds to fp
-    ${xorg.mkfontscale}/bin/mkfontdir "$d"
+    mkfontdir "$d"
+
+    runHook postInstall
   '';
-  sha256 = "sha256-6Imsa0ku8On63di0DOo0QxBa0t+tbtPRxM531EIiG94=";
 
   meta = with lib; {
     description = "Monospaced bitmap fonts";

--- a/pkgs/data/fonts/unifont_upper/default.nix
+++ b/pkgs/data/fonts/unifont_upper/default.nix
@@ -1,19 +1,23 @@
-{ lib, fetchurl }:
+{ lib, stdenvNoCC, fetchurl }:
 
-let
+stdenvNoCC.mkDerivation rec {
+  pname = "unifont_upper";
   version = "15.0.01";
-in fetchurl rec {
-  name = "unifont_upper-${version}";
 
-  url = "mirror://gnu/unifont/unifont-${version}/${name}.ttf";
+  src = fetchurl {
+    url = "mirror://gnu/unifont/unifont-${version}/${pname}-${version}.ttf";
+    hash = "sha256-o6ItW9fME+f4t2cvhj96r3ZG9nKLAUznn/pdukFYnxw=";
+  };
 
-  downloadToTemp = true;
+  dontUnpack = true;
 
-  recursiveHash = true;
+  installPhase = ''
+    runHook preInstall
 
-  postFetch = "install -Dm644 $downloadedFile $out/share/fonts/truetype/unifont_upper.ttf";
+    install -Dm644 $src $out/share/fonts/truetype/unifont_upper.ttf
 
-  hash = "sha256-cGX9umTGRfrQT3gwPgNqxPHB7Un3ZT3b7hPy4IP45Fk=";
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Unicode font for glyphs above the Unicode Basic Multilingual Plane";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
