### PR TITLE
unvanquished: 0.53.2 -> 0.54.0

### DIFF
--- a/pkgs/games/unvanquished/default.nix
+++ b/pkgs/games/unvanquished/default.nix
@@ -33,15 +33,15 @@
 }:
 
 let
-  version = "0.53.2";
-  binary-deps-version = "6";
+  version = "0.54.0";
+  binary-deps-version = "8";
 
   src = fetchFromGitHub {
     owner = "Unvanquished";
     repo = "Unvanquished";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-VqMhA6GEYh/m+dzOgXS+5Jqo4x7RrQf4qIwstdTTU+E=";
+    sha256 = "sha256-X2c6BHI4W6fOurLiBWIBZzJrZ+7RHMEwN8GJGz6e350=";
   };
 
   unvanquished-binary-deps = stdenv.mkDerivation rec {
@@ -50,8 +50,8 @@ let
     version = binary-deps-version;
 
     src = fetchzip {
-      url = "https://dl.unvanquished.net/deps/linux64-${version}.tar.bz2";
-      sha256 = "sha256-ERfg89oTf9JTtv/qRnTRIzFP+zMpHT8W4WAIxqogy9E=";
+      url = "https://dl.unvanquished.net/deps/linux-amd64-default_${version}.tar.xz ";
+      sha256 = "sha256-6r9j0HRMDC/7i8f4f5bBK4NmwsTpSChHrRWwz0ENAZo=";
     };
 
     dontPatchELF = true;
@@ -119,7 +119,7 @@ let
     pname = "unvanquished-assets";
     inherit version src;
 
-    outputHash = "sha256-MPqyqcZGc5KlkftGCspWhISBJ/h+Os29g7ZK6yWz0cQ=";
+    outputHash = "sha256-ua9Q5E5C4t8z/yNQp6qn1i9NNDAk4ohzvgpMbCBxb8Q=";
     outputHashMode = "recursive";
 
     nativeBuildInputs = [ aria2 cacert ];
@@ -135,9 +135,10 @@ in stdenv.mkDerivation rec {
   inherit version src binary-deps-version;
 
   preConfigure = ''
-    mkdir daemon/external_deps/linux64-${binary-deps-version}/
-    cp -r ${unvanquished-binary-deps}/* daemon/external_deps/linux64-${binary-deps-version}/
-    chmod +w -R daemon/external_deps/linux64-${binary-deps-version}/
+    TARGET="linux-amd64-default_${binary-deps-version}"
+    mkdir daemon/external_deps/"$TARGET"
+    cp -r ${unvanquished-binary-deps}/* daemon/external_deps/"$TARGET"/
+    chmod +w -R daemon/external_deps/"$TARGET"/
   '';
 
   nativeBuildInputs = [
@@ -202,7 +203,7 @@ in stdenv.mkDerivation rec {
     for f in daemon daemon-tty daemonded nacl_loader nacl_helper_bootstrap; do
       install -Dm0755 -t $out/lib/ $f
     done
-    install -Dm0644 -t $out/lib/ irt_core-x86_64.nexe
+    install -Dm0644 -t $out/lib/ irt_core-amd64.nexe
 
     mkdir $out/bin/
     ${wrapBinary "daemon"     "unvanquished"}


### PR DESCRIPTION
###### Description of changes

Release announcement: https://unvanquished.net/unvanquished-0-54-armed-and-dangerous/
Known issues: https://github.com/Unvanquished/Unvanquished/milestone/27, one important one is that [bot have trouble navigating the alien base on chasm and vega](https://github.com/Unvanquished/Unvanquished/issues/2389).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [ ] <del>Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages</del>
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - [x] client
  - [x] server
  - [ ] <del>tty-client</del> (this is mostly a debug tool)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Things that would be nice to do in subsequent PR would be:
* enabling support for arm (I'd like to do it soonish, in another PR)
* enabling unit tests in cmake (they are basically empty now so it's not a high priority)