### PR TITLE
concord: init at 2.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9968,6 +9968,12 @@
     github = "MrTarantoga";
     githubId = 53876219;
   };
+  mrtuxa = {
+    email = "mrtuxa@leipzig.freifunk.net";
+    name = "mrtuxa";
+    github = "mrtuxa";
+    githubId = 69870860;
+  };
   mrVanDalo = {
     email = "contact@ingolf-wagner.de";
     github = "mrVanDalo";

--- a/pkgs/development/libraries/concord/default.nix
+++ b/pkgs/development/libraries/concord/default.nix
@@ -11,13 +11,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-+nuVyqA/V/J6DWAeIs9Pv90ry3px1gJsF460qvfSEH8=";
   };
 
-buildInputs = [ 
- curl 
-];
+  buildInputs = [ curl ];
 
-installFlags = [ 
- "PREFIX=${"out"}" 
-];
+  installFlags = [ "PREFIX=${"out"}" ];
 
   meta = with lib; {
     description = "A Discord API wrapper library made in C";

--- a/pkgs/development/libraries/concord/default.nix
+++ b/pkgs/development/libraries/concord/default.nix
@@ -12,11 +12,11 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ 
-     curl 
+    curl 
   ];
 
   installFlags = [ 
-     "PREFIX=${"out"}" 
+    "PREFIX=${"out"}" 
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/concord/default.nix
+++ b/pkgs/development/libraries/concord/default.nix
@@ -8,13 +8,16 @@ stdenv.mkDerivation rec {
     owner = "Cogmasters";
     repo = "concord";
     rev = "v${version}";
-    hash =
-      "sha256-+nuVyqA/V/J6DWAeIs9Pv90ry3px1gJsF460qvfSEH8=";
+    hash = "sha256-+nuVyqA/V/J6DWAeIs9Pv90ry3px1gJsF460qvfSEH8=";
   };
 
-  buildInputs = [ curl ];
+  buildInputs = [ 
+     curl 
+  ];
 
-  installFlags = [ "PREFIX=${"out"}" ];
+  installFlags = [ 
+     "PREFIX=${"out"}" 
+  ];
 
   meta = with lib; {
     description = "A Discord API wrapper library made in C";

--- a/pkgs/development/libraries/concord/default.nix
+++ b/pkgs/development/libraries/concord/default.nix
@@ -1,8 +1,4 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, curl
-}:
+{ stdenv, lib, fetchFromGitHub, curl }:
 
 stdenv.mkDerivation rec {
   pname = "concord";
@@ -12,16 +8,13 @@ stdenv.mkDerivation rec {
     owner = "Cogmasters";
     repo = "concord";
     rev = "v${version}";
-    hash = "sha256-+nuVyqA/V/J6DWAeIs9Pv90ry3px1gJsF460qvfSEH8="; # Fill this in based on the fetch error
+    hash =
+      "sha256-+nuVyqA/V/J6DWAeIs9Pv90ry3px1gJsF460qvfSEH8=";
   };
 
-  buildInputs = [
-    curl
-  ];
+  buildInputs = [ curl ];
 
-  installFlags = [
-  	"PREFIX=${"out"}"
-  ];
+  installFlags = [ "PREFIX=${"out"}" ];
 
   meta = with lib; {
     description = "A Discord API wrapper library made in C";

--- a/pkgs/development/libraries/concord/default.nix
+++ b/pkgs/development/libraries/concord/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, curl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "concord";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "Cogmasters";
+    repo = "concord";
+    rev = "v${version}";
+    hash = "sha256-+nuVyqA/V/J6DWAeIs9Pv90ry3px1gJsF460qvfSEH8="; # Fill this in based on the fetch error
+  };
+
+  buildInputs = [
+    curl
+  ];
+
+  installFlags = [
+  	"PREFIX=${"out"}"
+  ];
+
+  meta = with lib; {
+    description = "A Discord API wrapper library made in C";
+    homepage = "https://github.com/Cogmasters/concord";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ mrtuxa ];
+  };
+}

--- a/pkgs/development/libraries/concord/default.nix
+++ b/pkgs/development/libraries/concord/default.nix
@@ -11,13 +11,13 @@ stdenv.mkDerivation rec {
     hash = "sha256-+nuVyqA/V/J6DWAeIs9Pv90ry3px1gJsF460qvfSEH8=";
   };
 
-  buildInputs = [ 
-    curl 
-  ];
+buildInputs = [ 
+ curl 
+];
 
-  installFlags = [ 
-    "PREFIX=${"out"}" 
-  ];
+installFlags = [ 
+ "PREFIX=${"out"}" 
+];
 
   meta = with lib; {
     description = "A Discord API wrapper library made in C";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38886,4 +38886,6 @@ with pkgs;
   resgate = callPackage ../servers/resgate { };
 
   oversteer = callPackage ../applications/misc/oversteer { };
+
+  concord = callPackage ../development/development/concord { };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38887,5 +38887,5 @@ with pkgs;
 
   oversteer = callPackage ../applications/misc/oversteer { };
 
-  concord = callPackage ../development/development/concord { };
+  concord = callPackage ../development/libraries/concord { };
 }


### PR DESCRIPTION
###### Description of changes

I made it compatible with Nix

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
