### PR TITLE
criu: support cross-compile for armv7l and aarch64

### DIFF
--- a/pkgs/os-specific/linux/criu/default.nix
+++ b/pkgs/os-specific/linux/criu/default.nix
@@ -1,6 +1,8 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, protobuf, protobufc, asciidoc, iptables
 , xmlto, docbook_xsl, libpaper, libnl, libcap, libnet, pkg-config, iproute2
-, which, python3, makeWrapper, docbook_xml_dtd_45, perl, nftables, libbsd }:
+, which, python3, makeWrapper, docbook_xml_dtd_45, perl, nftables, libbsd
+, buildPackages
+}:
 
 stdenv.mkDerivation rec {
   pname = "criu";
@@ -22,9 +24,34 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
-  nativeBuildInputs = [ pkg-config docbook_xsl which makeWrapper docbook_xml_dtd_45 python3 python3.pkgs.wrapPython perl ];
-  buildInputs = [ protobuf asciidoc xmlto libpaper libnl libcap libnet nftables libbsd ];
-  propagatedBuildInputs = [ protobufc ] ++ (with python3.pkgs; [ python python3.pkgs.protobuf ]);
+  depsBuildBuild = [ protobufc buildPackages.stdenv.cc ];
+  nativeBuildInputs = [
+    pkg-config
+    asciidoc
+    xmlto
+    libpaper
+    docbook_xsl
+    which
+    makeWrapper
+    docbook_xml_dtd_45
+    python3
+    python3.pkgs.wrapPython
+    perl
+  ];
+  buildInputs = [
+    protobuf
+    libnl
+    libcap
+    libnet
+    nftables
+    libbsd
+  ];
+  propagatedBuildInputs = [
+    protobufc
+  ] ++ (with python3.pkgs; [
+    python
+    python3.pkgs.protobuf
+  ]);
 
   postPatch = ''
     substituteInPlace ./Documentation/Makefile \
@@ -34,7 +61,27 @@ stdenv.mkDerivation rec {
     ln -sf ${protobuf}/include/google/protobuf/descriptor.proto ./images/google/protobuf/descriptor.proto
   '';
 
-  makeFlags = [ "PREFIX=$(out)" "ASCIIDOC=${asciidoc}/bin/asciidoc" "XMLTO=${xmlto}/bin/xmlto" ];
+  makeFlags = let
+    # criu's Makefile infrastructure expects to be passed a target architecture
+    # which neither matches the config-tuple's first part, nor the
+    # targetPlatform.linuxArch attribute. Thus we take the latter and map it
+    # onto the expected string:
+    linuxArchMapping = {
+      "x86_64" = "x86";
+      "arm" = "arm";
+      "arm64" = "aarch64";
+      "powerpc" = "ppc64";
+      "s390" = "s390";
+      "mips" = "mips";
+    };
+  in [
+    "PREFIX=$(out)"
+    "ASCIIDOC=${buildPackages.asciidoc}/bin/asciidoc"
+    "XMLTO=${buildPackages.xmlto}/bin/xmlto"
+  ] ++ (lib.optionals (stdenv.buildPlatform != stdenv.targetPlatform) [
+    "ARCH=${linuxArchMapping."${stdenv.targetPlatform.linuxArch}"}"
+    "CROSS_COMPILE=${stdenv.targetPlatform.config}-"
+  ]);
 
   outputs = [ "out" "dev" "man" ];
 
@@ -58,7 +105,7 @@ stdenv.mkDerivation rec {
     description = "Userspace checkpoint/restore for Linux";
     homepage    = "https://criu.org";
     license     = licenses.gpl2;
-    platforms   = [ "x86_64-linux" "aarch64-linux" ];
+    platforms   = [ "x86_64-linux" "aarch64-linux" "armv7l-linux" ];
     maintainers = [ maintainers.thoughtpolice ];
   };
 }


### PR DESCRIPTION
###### Description of changes

This fixes the `criu` package to support cross-compilation to armv7l and aarch64 architectures (tested on an x86 build host). `criu` requires some additional flags to be passed to its Makefile infrastructure to hint at the target architecture. It further requires a few dependencies to be executed on the build host, hence moving them to `depsBuildBuild`.

The package has been tested by building the following attributes on an x86 build host:
- `pkgs.criu`
- `pkgsCross.armv7l-hf-multiplatform.criu`
- `pkgsCross.aarch64-multiplatform.criu`
- `pkgsCross.ppc64.criu`: fails because of an undefined preprocessor macro specifying the target system's endianness
- `pkgsCross.s390.criu`: fails because target system is unsupported in protobuf dependency
- `pkgsCross.mips.criu`: fails because target system is unsupported in protobuf dependency

These are all architectures which are supported by `criu`, as can be seen in its Makefile. In accordance with the above, I've only added `armv7l-linux` to the supported systems set.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [N/A] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
