### PR TITLE
grub2_pvgrub_image: fix evaluation on armv7l-linux and riscv{32,64}-linux

### DIFF
--- a/pkgs/tools/misc/grub/pvgrub_image/default.nix
+++ b/pkgs/tools/misc/grub/pvgrub_image/default.nix
@@ -4,7 +4,10 @@ let
   efiSystemsBuild = {
     i686-linux.target = "i386";
     x86_64-linux.target = "x86_64";
+    armv7l-linux.target = "arm";
     aarch64-linux.target = "aarch64";
+    riscv32-linux.target = "riscv32";
+    riscv64-linux.target = "riscv64";
   };
 
 in (


### PR DESCRIPTION
###### Description of changes
Fix nixpkgs evaluation error when using nixpkgs-review on armv7l-linux:
```
$ nix-env --option system armv7l-linux -f /home/misuzu/nixpkgs -qaP --xml --out-path --show-trace --no-allow-import-from-derivation > /dev/null
error: attribute 'armv7l-linux' missing

       at /home/misuzu/nixpkgs/pkgs/tools/misc/grub/pvgrub_image/default.nix:24:24:

           23|     # if we include it.
           24|     grub-mkimage -O "${efiSystemsBuild.${stdenv.hostPlatform.system}.target}-xen" -c grub-bootstrap.cfg \
             |                        ^
           25|       -m memdisk.tar -o "grub-${efiSystemsBuild.${stdenv.hostPlatform.system}.target}-xen.bin" \

       … while evaluating the attribute 'buildCommand' of the derivation 'pvgrub-image'

       at /home/misuzu/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:286:7:

          285|     // (lib.optionalAttrs (attrs ? name || (attrs ? pname && attrs ? version)) {
          286|       name =
             |       ^
          287|         let

       … while querying the derivation named 'pvgrub-image'
```
Copied from https://github.com/NixOS/nixpkgs/blob/2c257a212e26cb9d81d70640aed733afc716aee6/pkgs/tools/misc/grub/2.0x.nix#L22

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [X] armv7l-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
