### PR TITLE
cmocka: enable tests and set broken for static

### DIFF
--- a/pkgs/development/libraries/cmocka/default.nix
+++ b/pkgs/development/libraries/cmocka/default.nix
@@ -20,38 +20,44 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+  ] ++ lib.optional doCheck "-DUNIT_TESTING=ON"
+    ++ lib.optional stdenv.hostPlatform.isStatic "-DBUILD_SHARED_LIBS=OFF";
+
+  doCheck = true;
+
   meta = with lib; {
     description = "Lightweight library to simplify and generalize unit tests for C";
+    longDescription = ''
+      There are a variety of C unit testing frameworks available however
+      many of them are fairly complex and require the latest compiler
+      technology.  Some development requires the use of old compilers which
+      makes it difficult to use some unit testing frameworks. In addition
+      many unit testing frameworks assume the code being tested is an
+      application or module that is targeted to the same platform that will
+      ultimately execute the test.  Because of this assumption many
+      frameworks require the inclusion of standard C library headers in the
+      code module being tested which may collide with the custom or
+      incomplete implementation of the C library utilized by the code under
+      test.
 
-    longDescription =
-      ''There are a variety of C unit testing frameworks available however
-        many of them are fairly complex and require the latest compiler
-        technology.  Some development requires the use of old compilers which
-        makes it difficult to use some unit testing frameworks. In addition
-        many unit testing frameworks assume the code being tested is an
-        application or module that is targeted to the same platform that will
-        ultimately execute the test.  Because of this assumption many
-        frameworks require the inclusion of standard C library headers in the
-        code module being tested which may collide with the custom or
-        incomplete implementation of the C library utilized by the code under
-        test.
+      Cmocka only requires a test application is linked with the standard C
+      library which minimizes conflicts with standard C library headers.
+      Also, CMocka tries to avoid the use of some of the newer features of
+      C compilers.
 
-        Cmocka only requires a test application is linked with the standard C
-        library which minimizes conflicts with standard C library headers.
-        Also, CMocka tries to avoid the use of some of the newer features of
-        C compilers.
+      This results in CMocka being a relatively small library that can be
+      used to test a variety of exotic code. If a developer wishes to
+      simply test an application with the latest compiler then other unit
+      testing frameworks may be preferable.
 
-        This results in CMocka being a relatively small library that can be
-        used to test a variety of exotic code. If a developer wishes to
-        simply test an application with the latest compiler then other unit
-        testing frameworks may be preferable.
-
-        This is the successor of Google's Cmockery.'';
-
+      This is the successor of Google's Cmockery.
+    '';
     homepage = "https://cmocka.org/";
-
     license = licenses.asl20;
     platforms = platforms.all;
     maintainers = with maintainers; [ kragniz rasendubi ];
+    broken = stdenv.hostPlatform.isStatic; # See https://github.com/NixOS/nixpkgs/issues/213623
   };
 }


### PR DESCRIPTION
cmocka
  - enable tests
  - set broken for static
  - add static flag (according to upstream's `DefineOptions.cmake`)
  - cleanup

Note: Static solution will be tracked at issue #213623


Sadly will have to restart PR because of that old/known problem when changing from master to staging... Yeah.. :(