### PR TITLE
vulkan-sdk: 1.3.236.0 -> 1.3.239.0

### DIFF
--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -10,13 +10,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "glslang";
-  version = "1.3.236.0";
+  version = "1.3.239.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
     rev = "sdk-${version}";
-    hash = "sha256-iVcx1j7OMJEU4cPydNwQSFufTUiqq7GKp69Y6pEt7Wc=";
+    hash = "sha256-P2HG/oJXdB5nvU3zVnj2vSLJGQuDcZiQBfBBvuR66Kk=";
   };
 
   # These get set at all-packages, keep onto them for child drvs

--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -33,6 +33,14 @@ stdenv.mkDerivation rec {
       url = "https://github.com/KhronosGroup/glslang/commit/7627bd89583c5aafb8b38c81c15494019271fabf.patch";
       hash = "sha256-1Dwhn78PG4gAGgEwTXpC+mkZRyvy8sTIsEvihXFeNaQ=";
     })
+    # Upstream tries to detect the Darwin linker by checking for AppleClang, but it’s just Clang in nixpkgs.
+    # Revert the commit to allow the build to work on Darwin with the nixpkg Darwin Clang toolchain.
+    (fetchpatch {
+      name = "Fix-Darwin-linker-error.patch";
+      url = "https://github.com/KhronosGroup/glslang/commit/586baa35a47b3aa6ad3fa829a27f0f4206400668.patch";
+      hash = "sha256-paAl4E8GzogcxDEzn/XuhNH6XObp+i7WfArqAiuH4Mk=";
+      revert = true;
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/spirv-headers/default.nix
+++ b/pkgs/development/libraries/spirv-headers/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "spirv-headers";
-  version = "1.3.236.0";
+  version = "1.3.239.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
     rev = "sdk-${version}";
-    hash = "sha256-eWI1MyIWxcg1JepRsnHBmitehDigDa+dR8kXvIkYejY=";
+    hash = "sha256-bjiWGSmpEbydXtCLP8fRZfPBvdCzBoJxKXTx3BroQbg=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/vk-bootstrap/default.nix
+++ b/pkgs/development/libraries/vk-bootstrap/default.nix
@@ -9,14 +9,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vk-bootstrap";
-  version = "0.6";
+  version = "0.7";
   outputs = [ "out" "dev" ];
 
   src = fetchFromGitHub {
     owner = "charles-lunarg";
     repo = "vk-bootstrap";
     rev = "v${version}";
-    sha256 = "sha256-T24SCJSGta4yuK58NcQnMeiO3sg9P9/O3kaFJFO/eOE=";
+    hash = "sha256-X3ANqfplrCF1R494+H5/plcwMH7rbW6zpLA4MZrYaoE=";
   };
 
   postPatch = ''

--- a/pkgs/development/libraries/vulkan-headers/default.nix
+++ b/pkgs/development/libraries/vulkan-headers/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, cmake }:
 stdenv.mkDerivation rec {
   pname = "vulkan-headers";
-  version = "1.3.236.0";
+  version = "1.3.239.0";
 
   nativeBuildInputs = [ cmake ];
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "KhronosGroup";
     repo = "Vulkan-Headers";
     rev = "sdk-${version}";
-    hash = "sha256-b1q9QugFH4lieS8CTOyZ3uoQ7bd44G8NPEwRtUPD+24=";
+    hash = "sha256-mzxT6s4ZHShB9tGyyf8jDtVWVEclHPYW+9oKy7v0bC4=";
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -3,14 +3,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-loader";
-  version = "1.3.236.0";
+  version = "1.3.239.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "Vulkan-Loader";
       rev = "sdk-${version}";
-      hash = "sha256-Y6OakowZlb40ZatITQCFBK/qSZqSdgTNew1XUFD/jMo=";
+      hash = "sha256-4oxynsbFLmsrpI5NEs7gI50g0XVcaUWuZRn6JKB/+hA=";
     });
 
   patches = [ ./fix-pkgconfig.patch ];

--- a/pkgs/development/libraries/vulkan-loader/fix-pkgconfig.patch
+++ b/pkgs/development/libraries/vulkan-loader/fix-pkgconfig.patch
@@ -5,10 +5,10 @@ index 153815577..584b15273 100644
 @@ -1,7 +1,5 @@
 -prefix=@CMAKE_INSTALL_PREFIX@
 -exec_prefix=${prefix}
--libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
--includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+-libdir=${exec_prefix}/@CMAKE_INSTALL_REL_LIBDIR_PC@
+-includedir=${prefix}/@CMAKE_INSTALL_REL_INCLUDEDIR_PC@
 +libdir=@CMAKE_INSTALL_LIBDIR@
 +includedir=@CMAKE_INSTALL_INCLUDEDIR@
- 
+
  Name: @CMAKE_PROJECT_NAME@
  Description: Vulkan Loader

--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "spirv-tools";
-  version = "1.3.236.0";
+  version = "1.3.239.0";
 
   src = (assert version == spirv-headers.version;
     fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "SPIRV-Tools";
       rev = "sdk-${version}";
-      hash = "sha256-BV7V/jS782zdvtuw/wNY5fyAdx8Z2niWSocNaW0Atho=";
+      hash = "sha256-xLYykbCHb6OH5wUSgheAfReXhxZtI3RqBJ+PxDZx58s=";
     }
   );
 

--- a/pkgs/development/tools/vulkan-validation-layers/default.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/default.nix
@@ -22,7 +22,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "vulkan-validation-layers";
-  version = "1.3.236.0";
+  version = "1.3.239.0";
 
   # If we were to use "dev" here instead of headers, the setupHook would be
   # placed in that output instead of "out".
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
       owner = "KhronosGroup";
       repo = "Vulkan-ValidationLayers";
       rev = "sdk-${version}";
-      hash = "sha256-+VbiXtxzYaF5o+wIrJ+09LmgBdaLv/0VJGFDnBkrXms=";
+      hash = "sha256-k/A0TaERQAHSM0Fal2IOaRvTz3FV2Go/17P12FSBG1s=";
     });
 
   # Include absolute paths to layer libraries in their associated

--- a/pkgs/tools/graphics/spirv-cross/default.nix
+++ b/pkgs/tools/graphics/spirv-cross/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "spirv-cross";
-  version = "1.3.236.0";
+  version = "1.3.239.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Cross";
     rev = "sdk-${finalAttrs.version}";
-    hash = "sha256-zx/fjDKgteWizC3O1bL4WSwwPNw2/2m0xCnCiOttgAo=";
+    hash = "sha256-Awtsz4iMuS3JuvaYHRxjo56EnnZPjo9YGfeYAi7lmJY=";
   };
 
   nativeBuildInputs = [ cmake python3 ];

--- a/pkgs/tools/graphics/vulkan-extension-layer/default.nix
+++ b/pkgs/tools/graphics/vulkan-extension-layer/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-extension-layer";
-  version = "1.3.236.0";
+  version = "1.3.239.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "Vulkan-ExtensionLayer";
       rev = "sdk-${version}";
-      hash = "sha256-NlBS7UuV2AZPY5VyoqTnTf63M7fHIPQDZRtMZ4XwMzA=";
+      hash = "sha256-0t9HGyiYk3twYQLFCcWsrPiXY1dqjdCadjP4yMLoFwA=";
     });
 
   nativeBuildInputs = [ cmake jq ];

--- a/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools-lunarg/default.nix
@@ -10,6 +10,7 @@
 , libXrandr
 , libffi
 , libxcb
+, pkg-config
 , wayland
 , which
 , xcbutilkeysyms
@@ -24,18 +25,18 @@
 stdenv.mkDerivation rec {
   pname = "vulkan-tools-lunarg";
   # The version must match that in vulkan-headers
-  version = "1.3.236.0";
+  version = "1.3.239.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "LunarG";
       repo = "VulkanTools";
       rev = "sdk-${version}";
-      hash = "sha256-0dGD3InmEd9hO8+uVGMqBHXXfyX8tswyuOaZCftudz0=";
+      hash = "sha256-zgkuTy9ccg8D/riA1CM/PnbXW1R0jWEINtcEVilETwk=";
       fetchSubmodules = true;
     });
 
-  nativeBuildInputs = [ cmake python3 jq which ];
+  nativeBuildInputs = [ cmake python3 jq which pkg-config ];
 
   buildInputs = [
     expat

--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -21,7 +21,7 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-tools";
-  version = "1.3.236.0";
+  version = "1.3.239.0";
 
   # It's not strictly necessary to have matching versions here, however
   # since we're using the SDK version we may as well be consistent with
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
       owner = "KhronosGroup";
       repo = "Vulkan-Tools";
       rev = "sdk-${version}";
-      hash = "sha256-PmNTpdAkXJkARLohRtUOuKTZPoKgeVF4DAo1wsAq5xE=";
+      hash = "sha256-DQGwxTZzS0eATKodMpeJaQdXADvomiqPOspDYoPFZjI=";
     });
 
   nativeBuildInputs = [

--- a/pkgs/tools/graphics/vulkan-tools/use-nix-moltenvk.patch
+++ b/pkgs/tools/graphics/vulkan-tools/use-nix-moltenvk.patch
@@ -1,8 +1,8 @@
 diff --git a/cube/CMakeLists.txt b/cube/CMakeLists.txt
-index 616fbc96..d2811c8d 100644
+index a2f026e7..327f5dba 100644
 --- a/cube/CMakeLists.txt
 +++ b/cube/CMakeLists.txt
-@@ -262,14 +262,7 @@ else()
+@@ -257,14 +257,7 @@ else()
  endif()
  
  if(APPLE)
@@ -18,7 +18,7 @@ index 616fbc96..d2811c8d 100644
  else()
      install(TARGETS vkcube RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
  endif()
-@@ -309,14 +302,7 @@ else()
+@@ -302,14 +295,7 @@ else()
  endif()
  
  if(APPLE)
@@ -35,10 +35,10 @@ index 616fbc96..d2811c8d 100644
      install(TARGETS vkcubepp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
  endif()
 diff --git a/cube/macOS/cube/cube.cmake b/cube/macOS/cube/cube.cmake
-index 9b823f95..238c3e67 100644
+index 9b823f95..0c43a2c9 100644
 --- a/cube/macOS/cube/cube.cmake
 +++ b/cube/macOS/cube/cube.cmake
-@@ -72,12 +69,14 @@ set_source_files_properties("${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json"
+@@ -72,12 +72,14 @@ set_source_files_properties("${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json"
  # Copy the MoltenVK lib into the bundle.
  if(${CMAKE_GENERATOR} MATCHES "^Xcode.*")
      add_custom_command(TARGET vkcube POST_BUILD
@@ -56,10 +56,10 @@ index 9b823f95..238c3e67 100644
                         DEPENDS vulkan)
  endif()
 diff --git a/cube/macOS/cubepp/cubepp.cmake b/cube/macOS/cubepp/cubepp.cmake
-index eae4de3c..0acd18f9 100644
+index eae4de3c..e528ae26 100644
 --- a/cube/macOS/cubepp/cubepp.cmake
 +++ b/cube/macOS/cubepp/cubepp.cmake
-@@ -74,12 +71,14 @@ set_source_files_properties("${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json"
+@@ -74,12 +74,14 @@ set_source_files_properties("${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json"
  # Copy the MoltenVK lib into the bundle.
  if(${CMAKE_GENERATOR} MATCHES "^Xcode.*")
      add_custom_command(TARGET vkcubepp POST_BUILD
@@ -107,10 +107,10 @@ index bad3c414..b498906d 100644
  
  find_library(COCOA NAMES Cocoa)
 diff --git a/vulkaninfo/CMakeLists.txt b/vulkaninfo/CMakeLists.txt
-index fb236a5b..3c8270d4 100644
+index d23dcf89..32aa0ebb 100644
 --- a/vulkaninfo/CMakeLists.txt
 +++ b/vulkaninfo/CMakeLists.txt
-@@ -139,9 +139,4 @@ elseif(APPLE)
+@@ -136,9 +136,5 @@ elseif(APPLE)
      add_definitions(-DVK_USE_PLATFORM_MACOS_MVK -DVK_USE_PLATFORM_METAL_EXT)
  endif()
  
@@ -119,37 +119,5 @@ index fb236a5b..3c8270d4 100644
 -else()
 -    install(TARGETS vulkaninfo RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 -endif()
--
 +install(TARGETS vulkaninfo RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-diff --git a/vulkaninfo/macOS/vulkaninfo.cmake b/vulkaninfo/macOS/vulkaninfo.cmake
-index 9614530e..56af3b89 100644
---- a/vulkaninfo/macOS/vulkaninfo.cmake
-+++ b/vulkaninfo/macOS/vulkaninfo.cmake
-@@ -48,26 +48,4 @@ set_source_files_properties(${CMAKE_BINARY_DIR}/staging-json/MoltenVK_icd.json
-                             MACOSX_PACKAGE_LOCATION
-                             "Resources/vulkan/icd.d")
  
--# Xcode projects need some extra help with what would be install steps.
--if(${CMAKE_GENERATOR} MATCHES "^Xcode.*")
--    add_custom_command(TARGET vulkaninfo-bundle POST_BUILD
--                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/MoltenVK/dylib/macOS/libMoltenVK.dylib"
--                               ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/vulkaninfo.app/Contents/Frameworks/libMoltenVK.dylib
--                       DEPENDS vulkan)
--else()
--    add_custom_command(TARGET vulkaninfo-bundle POST_BUILD
--                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/MoltenVK/dylib/macOS/libMoltenVK.dylib"
--                               ${CMAKE_CURRENT_BINARY_DIR}/vulkaninfo.app/Contents/Frameworks/libMoltenVK.dylib
--                       DEPENDS vulkan)
--endif()
--
--# Keep RPATH so fixup_bundle can use it to find libraries
--set_target_properties(vulkaninfo-bundle PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
--install(TARGETS vulkaninfo-bundle BUNDLE DESTINATION "vulkaninfo")
--# Fix up the library search path in the executable to find (loader) libraries in the bundle. When fixup_bundle() is passed a bundle
--# in the first argument, it looks at the Info.plist file to determine the BundleExecutable. In this case, the executable is a
--# script, which can't be fixed up. Instead pass it the explicit name of the executable.
--install(CODE "
--    include(BundleUtilities)
--    fixup_bundle(\${CMAKE_INSTALL_PREFIX}/vulkaninfo/vulkaninfo.app/Contents/MacOS/vulkaninfo \"\" \"${Vulkan_LIBRARY_DIR}\")
--    ")
-+install(TARGETS vulkaninfo-bundle BUNDLE DESTINATION "Applications")


### PR DESCRIPTION
###### Description of changes

- Bumps to latest tags, check changelog: https://vulkan.lunarg.com/doc/sdk/1.3.239.0/linux/release_notes.html

- Rebased current patches

- Bumps vk-bootstrap to use Vulkan 1.1+ compatible headers.

###### Things done

Tested building `vulkan-tools`, which built `vulkan-headers`, `vulkan-loader`, and `glslang`. Building `vulkan-tools-lunarg` builds `vulkan-validation-layers`, that builds the spirv stack. I've built `vulkan-extension-layer` and `spirv-cross` and that closed the testing. All of this in `x86-64-linux`.
