### PR TITLE
font-awesome: convert to stdenvNoCC.mkDerivation

### DIFF
--- a/pkgs/data/fonts/font-awesome/default.nix
+++ b/pkgs/data/fonts/font-awesome/default.nix
@@ -1,21 +1,22 @@
-{ lib, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 let
-  font-awesome = { version, sha256, rev ? version }: fetchFromGitHub {
-    name = "font-awesome-${version}";
+  font-awesome = { version, hash, rev ? version }: stdenvNoCC.mkDerivation {
+    pname = "font-awesome";
+    inherit version;
 
+    src = fetchFromGitHub {
+      owner = "FortAwesome";
+      repo = "Font-Awesome";
+      inherit rev hash;
+    };
 
-    owner = "FortAwesome";
-    repo = "Font-Awesome";
-    inherit rev;
+    installPhase = ''
+      runHook preInstall
 
-    postFetch = ''
-      install -m444 -Dt $out/share/fonts/opentype $out/{fonts,otfs}/*.otf
-      shopt -s extglob dotglob
-      rm -rf $out/!(share)
-      shopt -u extglob dotglob
+      install -m444 -Dt $out/share/fonts/opentype {fonts,otfs}/*.otf
+
+      runHook postInstall
     '';
-
-    inherit sha256;
 
     meta = with lib; {
       description = "Font Awesome - OTF font";
@@ -40,14 +41,14 @@ in
   v4 = font-awesome {
     version = "4.7.0";
     rev = "v4.7.0";
-    sha256 = "sha256-qdrIwxAB+z+4PXrKrj6bBuiJY0DYQuHm2DRng5sYEck=";
+    hash = "sha256-LL9zWFC+76wH74nqKszPQf2ZDfXq8BiH6tuiK43wYHA=";
   };
   v5 = font-awesome {
     version = "5.15.3";
-    sha256 = "sha256-EDxk/yO3nMmtM/ytrAEgPYSBbep3rA3NrKkiqf3OsU0=";
+    hash = "sha256-CFXGsl70o/gXUCEKu8Wkv4EBRhrrcMIq8NpfWzcxEus=";
   };
   v6 = font-awesome {
     version = "6.1.1";
-    sha256 = "sha256-BjK1PJQFWtKDvfQ2Vh7BoOPqYucyvOG+2Pu/Kh+JpAA=";
+    hash = "sha256-rujqhKI33Pi2xugMKGoTJDkPkCDK407+Da6yNJP2yAc=";
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
