### PR TITLE
binutils: symlink libraries and headers for "target" to lib/ and include/

### DIFF
--- a/pkgs/development/compilers/llvm/10/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/10/llvm/default.nix
@@ -5,7 +5,7 @@
 , cmake
 , python3
 , libffi
-, enableGoldPlugin ? (!stdenv.isDarwin && !stdenv.targetPlatform.isWasi)
+, enableGoldPlugin ? libbfd.hasPluginAPI
 , libbfd
 , libpfm
 , libxml2

--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -5,7 +5,7 @@
 , cmake
 , python3
 , libffi
-, enableGoldPlugin ? (!stdenv.isDarwin && !stdenv.targetPlatform.isWasi)
+, enableGoldPlugin ? libbfd.hasPluginAPI
 , libbfd
 , libpfm
 , libxml2

--- a/pkgs/development/compilers/llvm/12/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/12/llvm/default.nix
@@ -5,7 +5,7 @@
 , cmake
 , python3
 , libffi
-, enableGoldPlugin ? (!stdenv.isDarwin && !stdenv.targetPlatform.isWasi)
+, enableGoldPlugin ? libbfd.hasPluginAPI
 , libbfd
 , libpfm
 , libxml2

--- a/pkgs/development/compilers/llvm/13/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/13/llvm/default.nix
@@ -5,6 +5,7 @@
 , cmake
 , python3
 , libffi
+, enableGoldPlugin ? libbfd.hasPluginAPI
 , libbfd
 , libpfm
 , libxml2
@@ -153,7 +154,7 @@ in stdenv.mkDerivation (rec {
     "-DSPHINX_OUTPUT_MAN=ON"
     "-DSPHINX_OUTPUT_HTML=OFF"
     "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
-  ] ++ optionals (!isDarwin) [
+  ] ++ optionals (enableGoldPlugin) [
     "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
   ] ++ optionals isDarwin [
     "-DLLVM_ENABLE_LIBCXX=ON"

--- a/pkgs/development/compilers/llvm/14/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/14/llvm/default.nix
@@ -6,6 +6,7 @@
 , cmake
 , python3
 , libffi
+, enableGoldPlugin ? libbfd.hasPluginAPI
 , libbfd
 , libpfm
 , libxml2
@@ -165,7 +166,7 @@ in stdenv.mkDerivation (rec {
     "-DSPHINX_OUTPUT_MAN=ON"
     "-DSPHINX_OUTPUT_HTML=OFF"
     "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
-  ] ++ optionals (!isDarwin) [
+  ] ++ optionals (enableGoldPlugin) [
     "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
   ] ++ optionals isDarwin [
     "-DLLVM_ENABLE_LIBCXX=ON"

--- a/pkgs/development/compilers/llvm/15/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/15/llvm/default.nix
@@ -9,6 +9,7 @@
 , python3
 , python3Packages
 , libffi
+, enableGoldPlugin ? libbfd.hasPluginAPI
 , libbfd
 , libpfm
 , libxml2
@@ -327,7 +328,7 @@ in stdenv.mkDerivation (rec {
     "-DSPHINX_OUTPUT_MAN=ON"
     "-DSPHINX_OUTPUT_HTML=OFF"
     "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
-  ] ++ optionals (!isDarwin) [
+  ] ++ optionals (enableGoldPlugin) [
     "-DLLVM_BINUTILS_INCDIR=${libbfd.dev}/include"
   ] ++ optionals isDarwin [
     "-DLLVM_ENABLE_LIBCXX=ON"

--- a/pkgs/development/compilers/llvm/5/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/5/llvm/default.nix
@@ -5,7 +5,7 @@
 , cmake
 , python3
 , libffi
-, enableGoldPlugin ? (!stdenv.isDarwin && !stdenv.targetPlatform.isWasi)
+, enableGoldPlugin ? libbfd.hasPluginAPI
 , libbfd
 , libxml2
 , ncurses

--- a/pkgs/development/compilers/llvm/6/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/6/llvm/default.nix
@@ -4,7 +4,7 @@
 , cmake
 , python3
 , libffi
-, enableGoldPlugin ? (!stdenv.isDarwin && !stdenv.targetPlatform.isWasi)
+, enableGoldPlugin ? libbfd.hasPluginAPI
 , libbfd
 , libxml2
 , ncurses

--- a/pkgs/development/compilers/llvm/7/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/7/llvm/default.nix
@@ -5,7 +5,7 @@
 , cmake
 , python3
 , libffi
-, enableGoldPlugin ? (!stdenv.isDarwin && !stdenv.targetPlatform.isWasi)
+, enableGoldPlugin ? libbfd.hasPluginAPI
 , libbfd
 , libpfm
 , libxml2

--- a/pkgs/development/compilers/llvm/8/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/8/llvm/default.nix
@@ -5,7 +5,7 @@
 , cmake
 , python3
 , libffi
-, enableGoldPlugin ? (!stdenv.isDarwin && !stdenv.targetPlatform.isWasi)
+, enableGoldPlugin ? libbfd.hasPluginAPI
 , libbfd
 , libpfm
 , libxml2

--- a/pkgs/development/compilers/llvm/9/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/9/llvm/default.nix
@@ -5,7 +5,7 @@
 , cmake
 , python3
 , libffi
-, enableGoldPlugin ? (!stdenv.isDarwin && !stdenv.targetPlatform.isWasi)
+, enableGoldPlugin ? libbfd.hasPluginAPI
 , libbfd
 , libpfm
 , libxml2

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -243,8 +243,10 @@ stdenv.mkDerivation (finalAttrs: {
     inherit targetPrefix;
     hasGold = enableGold;
     isGNU = true;
-    # Having --enable-plugins is not enough, system has to support dlopen()
-    hasPluginAPI = enableGold && !stdenv.isDarwin && !stdenv.targetPlatform.isWasi;
+    # Having --enable-plugins is not enough, system has to support
+    # dlopen() or equivalent. See config/plugins.m4 and configure.ac
+    # (around PLUGINS) for cases that support or not support plugins.
+    hasPluginAPI = enableGold && !stdenv.isDarwin;
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -246,7 +246,8 @@ stdenv.mkDerivation (finalAttrs: {
     # Having --enable-plugins is not enough, system has to support
     # dlopen() or equivalent. See config/plugins.m4 and configure.ac
     # (around PLUGINS) for cases that support or not support plugins.
-    hasPluginAPI = enableGold && !stdenv.isDarwin;
+    # No platform specific filters yet here.
+    hasPluginAPI = enableGold;
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -228,6 +228,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  # For the same reason we don't split "lib" output we undo the $target/
+  # prefix for installed headers and libraries we link:
+  #   $out/$host/$target/lib/*     to $out/lib/
+  #   $out/$host/$target/include/* to $dev/include/*
+  # TODO(trofi): fix installation paths upstream so we could remove this
+  # code and have "lib" output unconditionally.
+  postInstall = lib.optionalString (hostPlatform != targetPlatform) ''
+    ln -s $out/${hostPlatform.config}/${targetPlatform.config}/lib/*     $out/lib/
+    ln -s $out/${hostPlatform.config}/${targetPlatform.config}/include/* $dev/include/
+  '';
+
   passthru = {
     inherit targetPrefix;
     hasGold = enableGold;

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -232,6 +232,8 @@ stdenv.mkDerivation (finalAttrs: {
     inherit targetPrefix;
     hasGold = enableGold;
     isGNU = true;
+    # Having --enable-plugins is not enough, system has to support dlopen()
+    hasPluginAPI = enableGold && !stdenv.isDarwin && !stdenv.targetPlatform.isWasi;
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/binutils/libbfd.nix
+++ b/pkgs/development/tools/misc/binutils/libbfd.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   ];
 
   passthru = {
-    dev = binutils-unwrapped-all-targets.dev;
+    inherit (binutils-unwrapped-all-targets) dev hasPluginAPI;
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/misc/binutils/libopcodes.nix
+++ b/pkgs/development/tools/misc/binutils/libopcodes.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   ];
 
   passthru = {
-    dev = binutils-unwrapped-all-targets.dev;
+    inherit (binutils-unwrapped-all-targets) dev hasPluginAPI;
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

`binutils` is inconsistent at installing it's headers to

    $dev/include

Instead it installs headers into two locations:

    $out/$host/$target/include
    $dev/include

There is no distinction between these two. Both headers are for HOST
libraries. Expetially for multitarget binutils builds.

This change fixes build of the following packages that build `binutils`
as a cross-compiler:

    pkgsCross.x86_64-freebsd.buildPackages.llvm_12
    pkgsCross.aarch64-multiplatform.buildPackages.llvm_12

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
