### PR TITLE
honeymarker, honeyvent, honeytail: uses fetchFromGitHub

### DIFF
--- a/pkgs/servers/tracing/honeycomb/honeymarker/default.nix
+++ b/pkgs/servers/tracing/honeycomb/honeymarker/default.nix
@@ -1,13 +1,15 @@
-{ lib, buildGoModule, fetchurl }:
+{ lib, buildGoModule, fetchFromGitHub }:
 import ./versions.nix ({version, sha256}:
   buildGoModule {
   pname = "honeymarker";
   inherit version;
   vendorSha256 = "sha256-ZuDobjC/nizZ7G0o/zVTQmDfDjcdBhfPcmkhgwFc7VU=";
 
-  src = fetchurl {
-    url = "https://github.com/honeycombio/honeymarker/archive/refs/tags/v${version}.tar.gz";
-    inherit sha256;
+  src = fetchFromGitHub {
+    owner = "honeycombio";
+    repo = "honeymarker";
+    rev = "v${version}";
+    hash = sha256;
   };
   inherit (buildGoModule.go) GOOS GOARCH;
 

--- a/pkgs/servers/tracing/honeycomb/honeymarker/versions.nix
+++ b/pkgs/servers/tracing/honeycomb/honeymarker/versions.nix
@@ -1,6 +1,6 @@
 generic: {
   v0_2_1 = generic {
     version = "0.2.1";
-    sha256 = "0gp427bsc1y7k6j1sqgl8r3kng5b0qhmqd4bpfb9139ivmp2sykk";
+    sha256 = "sha256-tiwX94CRvXnUYpiux94XhOj2abn1Uc+wjcDOmw79ab4=";
   };
 }

--- a/pkgs/servers/tracing/honeycomb/honeytail/default.nix
+++ b/pkgs/servers/tracing/honeycomb/honeytail/default.nix
@@ -1,13 +1,15 @@
-{ lib, buildGoModule, fetchurl }:
+{ lib, buildGoModule, fetchFromGitHub }:
 import ./versions.nix ({version, sha256}:
   buildGoModule {
   pname = "honeytail";
   inherit version;
   vendorSha256 = "sha256-LtiiLGLjhbfT49A6Fw5CbSbnmTHMxtcUssr+ayCVrvY=";
 
-  src = fetchurl {
-    url = "https://github.com/honeycombio/honeytail/archive/refs/tags/v${version}.tar.gz";
-    inherit sha256;
+  src = fetchFromGitHub {
+    owner = "honeycombio";
+    repo = "honeytail";
+    rev = "v${version}";
+    hash = sha256;
   };
   inherit (buildGoModule.go) GOOS GOARCH;
 

--- a/pkgs/servers/tracing/honeycomb/honeytail/versions.nix
+++ b/pkgs/servers/tracing/honeycomb/honeytail/versions.nix
@@ -1,6 +1,6 @@
 generic: {
   v1_6_0 = generic {
     version = "1.6.0";
-    sha256 = "039svpvqjck7s3rq86s29xgcyxl1wr0zj90s3jsyp058zk1dgwdy";
+    sha256 = "sha256-S0hIgNNzF1eNe+XJs+PT7EUIl5oJCXu+B/zQago4sf8=";
   };
 }

--- a/pkgs/servers/tracing/honeycomb/honeyvent/default.nix
+++ b/pkgs/servers/tracing/honeycomb/honeyvent/default.nix
@@ -1,13 +1,15 @@
-{ lib, buildGoModule, fetchurl }:
+{ lib, buildGoModule, fetchFromGitHub }:
 import ./versions.nix ({version, sha256}:
   buildGoModule {
   pname = "honeyvent";
   inherit version;
   vendorSha256 = null;
 
-  src = fetchurl {
-    url = "https://github.com/honeycombio/honeyvent/archive/refs/tags/v${version}.tar.gz";
-    inherit sha256;
+  src = fetchFromGitHub {
+    owner = "honeycombio";
+    repo = "honeyvent";
+    rev = "v${version}";
+    hash = sha256;
   };
   inherit (buildGoModule.go) GOOS GOARCH;
 

--- a/pkgs/servers/tracing/honeycomb/honeyvent/versions.nix
+++ b/pkgs/servers/tracing/honeycomb/honeyvent/versions.nix
@@ -1,6 +1,6 @@
 generic: {
   v1_1_0 = generic {
     version = "1.1.0";
-    sha256 = "0ar2m25ngdd1wk7d70j2781wbrvhjhf9cj9qvp24jjrhqng6hvn7";
+    sha256 = "sha256-yFQEOshjaH6fRCQ7IZChANI9guZlTXk35p1NzQvxUdI=";
   };
 }


### PR DESCRIPTION
###### Description of changes

The archive hashes has changed.
See https://github.blog/changelog/2023-01-30-git-archive-checksums-may-change/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
