### PR TITLE
slrn: build slrnpull

### DIFF
--- a/pkgs/applications/networking/newsreaders/slrn/default.nix
+++ b/pkgs/applications/networking/newsreaders/slrn/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-slang=${slang.dev}"
     "--with-ssl=${openssl.dev}"
+    "--with-slrnpull"
   ];
 
   buildInputs = [ slang ncurses openssl ];


### PR DESCRIPTION
###### Description of changes

As explained in its documentation, also build slrnpull when building slrn: https://github.com/jedsoft/slrn/blob/master/doc/slrnpull/SETUP
slrnpull can be used to pull newsgroups so they can later be read offline by other programs, like slrn itself or, for example, notmuch: https://notmuchmail.org/software/

This seems to increase the size of the closure by 0.1M (the binary and its man page) so I'm not quite sure there would be any benefit in making it configurable?

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
