### PR TITLE
ocamlPackages.pyml: fix test on darwin

### DIFF
--- a/pkgs/development/ocaml-modules/pyml/default.nix
+++ b/pkgs/development/ocaml-modules/pyml/default.nix
@@ -28,6 +28,10 @@ buildDunePackage rec {
         "CHANGES.md"
       ];
     })
+    (fetchpatch {
+      url = "https://github.com/thierry-martinez/pyml/commit/97407473800b3f6215190643c1e6b9bd25d5caeb.patch";
+      hash = "sha256-7CrVuV4JT7fyi/ktWz4nNOG/BbqsQVCoJwCAhE2y4YU=";
+    })
   ];
 
   buildInputs = [
@@ -40,7 +44,7 @@ buildDunePackage rec {
   ];
 
   nativeCheckInputs = [
-    python3.pkgs.numpy
+    python3.pkgs.numpy python3.pkgs.ipython
   ];
 
   strictDeps = true;


### PR DESCRIPTION
###### Description of changes

Caught while reviewing https://github.com/NixOS/nixpkgs/pull/162385

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

While building I saw:

```
building
       clang pyml_arch.ml.sharp
clang-11: warning: argument unused during compilation: '-fno-strict-overflow' [-Wunused-command-line-argument]
       clang numpy_stubs.o
clang-11: warning: argument unused during compilation: '-fno-strict-overflow' [-Wunused-command-line-argument]
       clang pyml_stubs.o
clang-11: warning: argument unused during compilation: '-fno-strict-overflow' [-Wunused-command-line-argument]
```
it seem that clang doesn't handle this argument where should I change it ? in cc-wrapper ?

I also added IPython because some test where skipped.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
