### PR TITLE
emblem: init at 1.1.0

### DIFF
--- a/pkgs/applications/graphics/emblem/default.nix
+++ b/pkgs/applications/graphics/emblem/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, rustPlatform
+, pkg-config
+, meson
+, ninja
+, glib
+, gobject-introspection
+, libadwaita
+, libxml2
+, librsvg
+, wrapGAppsHook4
+, appstream-glib
+, desktop-file-utils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "emblem";
+  version = "1.1.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World/design";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-kNPV1SHkNTBXbMzDJGuDbaGz1WkBqMpVgZKjsh7ejmo=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-yhXxlUOe+mWVpAEB0yN9m5S5yfNRrHnx7XHLXbbf1hc=";
+  };
+
+  nativeBuildInputs = [
+    appstream-glib
+    glib
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    rust.cargo
+    rust.rustc
+  ]);
+
+  buildInputs = [
+    desktop-file-utils
+    libadwaita
+    librsvg
+    libxml2
+  ];
+
+  meta = with lib; {
+    description = "Generate project icons and avatars from a symbolic icon";
+    homepage = "https://gitlab.gnome.org/World/design/emblem";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ foo-dogsquared ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6949,6 +6949,8 @@ with pkgs;
 
   emborg = python3Packages.callPackage ../development/python-modules/emborg { };
 
+  emblem = callPackage ../applications/graphics/emblem { };
+
   emem = callPackage ../applications/misc/emem { };
 
   empty = callPackage ../tools/misc/empty { };


### PR DESCRIPTION
###### Description of changes

Add [Emblem](https://gitlab.gnome.org/World/design/emblem), an application for generating avatar/project icons with a symbolic icon.

Take note this application requires librsvg 2.55.90 but it mostly runs and looks fine with the current version in this branch (which should be librsvg 2.55.1) in my initial testing. 

The basic testing with this package went smoothly (e.g., choosing an icon, choosing the colors, exporting the icon as PNG and SVG).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
