### PR TITLE
linuxPackages.it87: unstable-2022-02-26 -> unstable-2023-01-28, refactor

### DIFF
--- a/pkgs/os-specific/linux/it87/default.nix
+++ b/pkgs/os-specific/linux/it87/default.nix
@@ -2,15 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "it87-${version}-${kernel.version}";
-  version = "unstable-2022-02-26";
+  version = "unstable-2023-01-28";
 
-  # Original is no longer maintained.
-  # This is the same upstream as the AUR uses.
   src = fetchFromGitHub {
     owner = "frankcrawford";
     repo = "it87";
-    rev = "c93d61adadecb009c92f3258cd3ff14a66efb193";
-    sha256 = "sha256-wVhs//iwZUUGRTk1DpV/SnA7NZ7cFyYbsUbtazlxb6Q=";
+    sha256 = "sha256-YIdr9NQuwv6LE0MXtVp+cSOz60w2c+br9mLqMIrGuAc=";
+    rev = "49975da600368d57333a0b7e44301a578590b1d3";
   };
 
   hardeningDisable = [ "pic" ];
@@ -18,18 +16,21 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   preConfigure = ''
-    sed -i 's|depmod|#depmod|' Makefile
+    sed -i -e 's|depmod|#depmod|' Makefile
+  '' + lib.optionalString (kernel.kernelOlder "5") ''
+    sed -i -e '/^[[:space:]]*fallthrough;/s|^|//|' it87.c
   '';
 
   makeFlags = [
     "TARGET=${kernel.modDirVersion}"
     "KERNEL_MODULES=${kernel.dev}/lib/modules/${kernel.modDirVersion}"
-    "MODDESTDIR=$(out)/lib/modules/${kernel.modDirVersion}/kernel/drivers/hwmon"
+    "MODDESTDIR=$(out)/lib/modules/${kernel.modDirVersion}/updates/drivers/hwmon"
+    "COMPRESS_XZ=y"
   ];
 
   meta = with lib; {
     description = "Patched module for IT87xx superio chip sensors support";
-    homepage = "https://github.com/hannesha/it87";
+    homepage = "https://github.com/frankcrawford/it87";
     license = licenses.gpl2Plus;
     platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = teams.lumiguide.members;


### PR DESCRIPTION
###### Description of changes

- Update to current commit
- Install to `updates/...` instead of `kernel/...` to avoid filename conflicts and make modprobe prefer it over in-tree it87.ko.xz
- Compress module
- Update homepage to point at the actual source of the module
- Make it build with 4.x kernel (comment out the `fallthrough;` no-op)

Package was originally installing uncompressed `kernel/drivers/hwmon/it87.ko` next to the in-tree `kernel/drivers/hwmon/it87.ko.xz`. The `modprobe` command was preferring the in-tree module and it was necessary to use plain `insmod` to load it. I'm not sure if it there was a way to add it to `boot.kernelModules`.

As per `depmod.d(5)`, `depmod`'s default search order is `"updates built-in"` (`updates/` directory has preference over built-in modules). Installing the module in `updates/drivers/hwmon/` makes `depmod`/`modprobe` prefer it over the in-tree one. It also makes it possible to compress the module with `xz` (compressing in `kernel/` resulted in file conflict errors when building the kernel-modules bundle).

Tests with `nixpkgs-review` showed that the module doesn't build with kernel 4.x because of undefined `fallthrough;` no-op function. Commenting it out for older kernels makes it build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] i686-linux
  - [ ] aarch64-linux (N/A)
  - [ ] x86_64-darwin (N/A)
  - [ ] aarch64-darwin (N/A)
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tagging maintainers: @roelvandijk @Lucus16 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
