### PR TITLE
Run the defaultPkgConfigPackages tests on hydra

### DIFF
--- a/maintainers/scripts/eval-release.nix
+++ b/maintainers/scripts/eval-release.nix
@@ -17,6 +17,7 @@ let
         if (builtins.tryEval attrs.drvPath).success
         then { inherit (attrs) name drvPath; }
         else { failed = true; }
+      else if attrs == null then {}
       else { recurseForDerivations = true; } //
            mapAttrs (n: v: let path' = path ++ [n]; in trace path' (recurse path' v)) attrs
     else { };

--- a/pkgs/top-level/pkg-config/test-defaultPkgConfigPackages.nix
+++ b/pkgs/top-level/pkg-config/test-defaultPkgConfigPackages.nix
@@ -42,4 +42,4 @@ let
     else testers.hasPkgConfigModule { inherit moduleName; package = pkg; };
 
 in
-  allTests // { inherit tests-combined; }
+  lib.recurseIntoAttrs allTests // { inherit tests-combined; }


### PR DESCRIPTION
###### Description of changes

 - fixes the tarball job broken in #212282 
 - reverts #213615 
 - tested with `nix-build nixos/release-small.nix -A nixpkgs.tarball`
    - (the tests themselves do not run in that jobset, but the tarball job does evaluate them)

Commit message:

This will allow tests.pkg-config.defaultPkgConfigPackages to run on
hydra without breaking the tarball job.

Regarding the use of null, I'll quote 473ac96 which does lib.hydraJob.

By allowing null, we allow code to avoid filterAttrs, improving
laziness in real world use cases.
Specifically, this strategy prevents infinite recursion errors,
performance issues and possibly other errors that are unrelated to
the user's code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
