### PR TITLE
linuxPackages.apfs: unstable-2022-10-20 -> 0.3.0

### DIFF
--- a/nixos/tests/apfs.nix
+++ b/nixos/tests/apfs.nix
@@ -21,9 +21,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     with subtest("Enable case sensitivity and normalization sensitivity"):
       machine.succeed(
           "mkapfs -s -z /dev/vdb",
-          # Triggers a bug, see https://github.com/linux-apfs/linux-apfs-rw/issues/15
-          # "mount -o cknodes,readwrite /dev/vdb /tmp/mnt",
-          "mount -o readwrite /dev/vdb /tmp/mnt",
+          "mount -o cknodes,readwrite /dev/vdb /tmp/mnt",
           "echo 'Hello World 1' > /tmp/mnt/test.txt",
           "[ ! -f /tmp/mnt/TeSt.TxT ] || false", # Test case sensitivity
           "echo 'Hello World 1' | diff - /tmp/mnt/test.txt",
@@ -36,13 +34,13 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     with subtest("Disable case sensitivity and normalization sensitivity"):
       machine.succeed(
           "mkapfs /dev/vdb",
-          "mount -o readwrite /dev/vdb /tmp/mnt",
+          "mount -o cknodes,readwrite /dev/vdb /tmp/mnt",
           "echo 'bla bla bla' > /tmp/mnt/Test.txt",
           "echo -n 'Hello World' > /tmp/mnt/test.txt",
           "echo ' 1' >> /tmp/mnt/TEST.TXT",
           "umount /tmp/mnt",
           "apfsck /dev/vdb",
-          "mount -o readwrite /dev/vdb /tmp/mnt",
+          "mount -o cknodes,readwrite /dev/vdb /tmp/mnt",
           "echo 'Hello World 1' | diff - /tmp/mnt/TeSt.TxT", # Test case insensitivity
           "echo 'Hello World 2' > /tmp/mnt/\u0061\u0301.txt",
           "echo 'Hello World 2' | diff - /tmp/mnt/\u0061\u0301.txt",

--- a/pkgs/os-specific/linux/apfs/default.nix
+++ b/pkgs/os-specific/linux/apfs/default.nix
@@ -5,15 +5,18 @@
 , nixosTests
 }:
 
+let
+  tag = "0.3.0";
+in
 stdenv.mkDerivation {
   pname = "apfs";
-  version = "unstable-2022-10-20-${kernel.version}";
+  version = "${tag}-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "linux-apfs";
     repo = "linux-apfs-rw";
-    rev = "e6eb67c92d425d395eac1c4403629391bdd5064d";
-    sha256 = "sha256-6rv5qZCjOqt0FaNFhA3tYg6/SdssvoT8kPVhalajgOo=";
+    rev = "v${tag}";
+    sha256 = "sha256-ABFqkiIJuFapFsUIFHfw8+TujePZm7ZX/qHuFO2KdnQ=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -29,6 +32,15 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "APFS module for linux";
+    longDescription = ''
+      The Apple File System (APFS) is the copy-on-write filesystem currently
+      used on all Apple devices. This module provides a degree of experimental
+      support on Linux.
+      If you make use of the write support, expect data corruption.
+      Read-only support is somewhat more complete, with sealed volumes,
+      snapshots, and all the missing compression algorithms recently added.
+      Encryption is still not in the works though.
+    '';
     homepage = "https://github.com/linux-apfs/linux-apfs-rw";
     license = licenses.gpl2Only;
     platforms = platforms.linux;


### PR DESCRIPTION
###### Description of changes
https://github.com/linux-apfs/linux-apfs-rw/releases/tag/v0.3.0

I also added a `longDescription` and modified the test to verify the checksum on all metadata nodes now that it works.

`linuxKernel.packages.linux_testing_bcachefs.apfs` also fails without this PR.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).