### PR TITLE
nixos/kubo: unmount on stop

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -332,6 +332,8 @@ In addition to numerous new and upgraded packages, this release has the followin
     [headscale's example configuration](https://github.com/juanfont/headscale/blob/main/config-example.yaml)
     can be directly written as attribute-set in Nix within this option.
 
+- `services.kubo` unmounts `ipfsMountDir` and `ipnsMountDir` even if it is killed uncleanly, when 'autoMount` is enabled.
+
 - `nixos/lib/make-disk-image.nix` can now mutate EFI variables, run user-provided EFI firmware or variable templates. This is now extensively documented in the NixOS manual.
 
 - `services.grafana` listens only on localhost by default again. This was changed to upstreams default of `0.0.0.0` by accident in the freeform setting conversion.

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -332,7 +332,7 @@ In addition to numerous new and upgraded packages, this release has the followin
     [headscale's example configuration](https://github.com/juanfont/headscale/blob/main/config-example.yaml)
     can be directly written as attribute-set in Nix within this option.
 
-- `services.kubo` unmounts `ipfsMountDir` and `ipnsMountDir` even if it is killed uncleanly, when 'autoMount` is enabled.
+- `services.kubo` now unmounts `ipfsMountDir` and `ipnsMountDir` even if it is killed unexpectedly when 'autoMount` is enabled.
 
 - `nixos/lib/make-disk-image.nix` can now mutate EFI variables, run user-provided EFI firmware or variable templates. This is now extensively documented in the NixOS manual.
 

--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -319,6 +319,10 @@ in
           # change when the changes are applied. Whyyyyyy.....
           ipfs --offline config replace -
       '';
+      postStop = mkIf cfg.autoMount ''
+        # After an unclean shutdown the fuse mounts at ${cfg.ipnsMountDir} and ${cfg.ipfsMountDir} are locked
+        umount --quiet '${cfg.ipnsMountDir}' '${cfg.ipfsMountDir}' || true
+      '';
       serviceConfig = {
         ExecStart = [ "" "${cfg.package}/bin/ipfs daemon ${kuboFlags}" ];
         User = cfg.user;

--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -320,7 +320,7 @@ in
           ipfs --offline config replace -
       '';
       postStop = mkIf cfg.autoMount ''
-        # After an unclean shutdown the fuse mounts at ${cfg.ipnsMountDir} and ${cfg.ipfsMountDir} are locked
+        # After an unclean shutdown the fuse mounts at cfg.ipnsMountDir and cfg.ipfsMountDir are locked
         umount --quiet '${cfg.ipnsMountDir}' '${cfg.ipfsMountDir}' || true
       '';
       serviceConfig = {

--- a/nixos/tests/kubo.nix
+++ b/nixos/tests/kubo.nix
@@ -55,8 +55,15 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     # Workaround: using CID Version 1 avoids that.
     ipfs_hash = fuse.succeed(
         "echo fnord3 | ipfs --api /ip4/127.0.0.1/tcp/2324 add --quieter --cid-version=1"
-    )
+    ).strip()
 
-    fuse.succeed(f"cat /ipfs/{ipfs_hash.strip()} | grep fnord3")
+    fuse.succeed(f"cat /ipfs/{ipfs_hash} | grep fnord3")
+
+    # Force Kubo to crash and wait for it to restart
+    # Tests the unmounting of /ipns and /ipfs
+    fuse.systemctl("kill --signal=SIGKILL ipfs.service")
+    fuse.wait_for_unit("ipfs.service", timeout = 30)
+
+    fuse.succeed(f"cat /ipfs/{ipfs_hash} | grep fnord3")
   '';
 })

--- a/nixos/tests/kubo.nix
+++ b/nixos/tests/kubo.nix
@@ -50,12 +50,13 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     machine.succeed("test ! -e /var/lib/ipfs/")
 
     # Test FUSE mountpoint
+    # The FUSE mount functionality is broken as of v0.13.0 and v0.17.0.
+    # See https://github.com/ipfs/kubo/issues/9044.
+    # Workaround: using CID Version 1 avoids that.
     ipfs_hash = fuse.succeed(
-        "echo fnord3 | ipfs --api /ip4/127.0.0.1/tcp/2324 add --quieter"
+        "echo fnord3 | ipfs --api /ip4/127.0.0.1/tcp/2324 add --quieter --cid-version=1"
     )
 
-    # The FUSE mount functionality is broken as of v0.13.0.
-    # See https://github.com/ipfs/kubo/issues/9044.
-    # fuse.succeed(f"cat /ipfs/{ipfs_hash.strip()} | grep fnord3")
+    fuse.succeed(f"cat /ipfs/{ipfs_hash.strip()} | grep fnord3")
   '';
 })


### PR DESCRIPTION
###### Description of changes
When kubo is force killed with `pkill -KILL ipfs` or by systemd-oomd, it doesn't unmount /ipfs and /ipns. Those locked directories prevent it from starting up the next time. So, this change unmounts those directories on systemd postStop.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
I am running the same change on my server with
```nix
systemd.services.ipfs.postStop = mkIf config.services.kubo.autoMount ''
    # After an unclean shutdown the fuse mounts at ${config.services.kubo.ipnsMountDir} and ${config.services.kubo.ipfsMountDir} are locked
    umount ${config.services.kubo.ipnsMountDir} || true
    umount ${config.services.kubo.ipfsMountDir} || true
'';
```

Is the release note fine?
 
---
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
