### PR TITLE
python3Packages.riscof: init 1.25.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5263,6 +5263,15 @@
     githubId = 313929;
     name = "Gabriel Ebner";
   };
+  genericnerdyusername = {
+    name = "GenericNerdyUsername";
+    email = "genericnerdyusername@proton.me";
+    github = "GenericNerdyUsername";
+    githubId = 111183546;
+    keys = [{
+      fingerprint = "58CE D4BE 6B10 149E DA80  A990 2F48 6356 A4CB 30F3";
+    }];
+  };
   genofire = {
     name = "genofire";
     email = "geno+dev@fireorbit.de";

--- a/pkgs/applications/virtualization/sail-riscv/default.nix
+++ b/pkgs/applications/virtualization/sail-riscv/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, arch
+, ocamlPackages
+, ocaml
+, zlib
+, z3
+}:
+
+
+stdenv.mkDerivation rec {
+  pname = "sail-riscv";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "riscv";
+    repo = pname;
+    rev = version;
+    hash = "sha256-7PZNNUMaCZEBf0lOCqkquewRgZPooBOjIbGF7JlLnEo=";
+  };
+
+  nativeBuildInputs = with ocamlPackages; [ ocamlbuild findlib ocaml z3 sail ];
+  buildInputs = with ocamlPackages; [ zlib linksem ];
+  strictDeps = true;
+
+  postPatch = ''
+    rm -r prover_snapshots
+  '';
+
+  makeFlags = [
+    "SAIL=sail"
+    "ARCH=${arch}"
+    "SAIL_DIR=${ocamlPackages.sail}/share/sail"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp c_emulator/riscv_sim_${arch} $out/bin
+    mkdir $out/share/
+    cp -r generated_definitions/{coq,hol4,isabelle} $out/share/
+
+    runHook postInstall
+  '';
+
+
+  meta = with lib; {
+    homepage = "https://github.com/riscv/sail-riscv";
+    description = "A formal specification of the RISC-V architecture, written in Sail";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/development/ocaml-modules/lem/default.nix
+++ b/pkgs/development/ocaml-modules/lem/default.nix
@@ -1,0 +1,45 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, ncurses
+, makeWrapper
+, ocamlbuild
+, findlib
+, ocaml
+, num
+, zarith
+}:
+
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.07")
+  "lem is not available for OCaml ${ocaml.version}"
+
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-lem";
+  version = "2022-12-10";
+
+  src = fetchFromGitHub {
+    owner = "rems-project";
+    repo = "lem";
+    rev = version;
+    hash = "sha256-ZQgcuIVRkJS0KtpzjbO4OPHGg6B0TadWA6XpRir30y8=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ocamlbuild findlib ocaml ];
+  propagatedBuildInputs = [ zarith num ];
+
+  installFlags = [ "INSTALL_DIR=$(out)" ];
+
+  createFindlibDestdir = true;
+
+  postInstall = ''
+    wrapProgram $out/bin/lem --set LEMLIB $out/share/lem/library
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/rems-project/lem";
+    description = "A tool for lightweight executable mathematics";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = with licenses; [ bsd3 gpl2 ];
+    platforms = ocaml.meta.platforms;
+  };
+}

--- a/pkgs/development/ocaml-modules/linksem/default.nix
+++ b/pkgs/development/ocaml-modules/linksem/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+, findlib
+, ocaml
+, lem
+}:
+
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.07")
+  "linksem is not available for OCaml ${ocaml.version}"
+
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-linksem";
+  version = "0.8";
+
+  src = fetchFromGitHub {
+    owner = "rems-project";
+    repo = "linksem";
+    rev = version;
+    hash = "sha256-7/YfDK3TruKCckMzAPLRrwBkHRJcX1S+AzXHWRxkZPA=";
+  };
+
+  nativeBuildInputs = [ findlib ocaml ];
+
+  propagatedBuildInputs = [ lem ];
+
+  createFindlibDestdir = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/rems-project/linksem";
+    description = "A formalisation of substantial parts of ELF linking and DWARF debug information";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.bsd2;
+    platforms = ocaml.meta.platforms;
+  };
+}

--- a/pkgs/development/ocaml-modules/sail/default.nix
+++ b/pkgs/development/ocaml-modules/sail/default.nix
@@ -1,0 +1,79 @@
+{ lib
+, fetchFromGitHub
+, buildDunePackage
+, base64
+, omd
+, menhir
+, ott
+, linenoise
+, dune-site
+, pprint
+, makeWrapper
+, lem
+, z3
+, linksem
+, num
+}:
+
+buildDunePackage rec {
+  pname = "sail";
+  version = "0.15";
+
+  src = fetchFromGitHub {
+    owner = "rems-project";
+    repo = "sail";
+    rev = version;
+    hash = "sha256-eNdFOSzkniNvSCZeORRJ/IYAu+9P4HSouwmhd4BQLPk=";
+  };
+
+  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
+
+  nativeBuildInputs = [
+    makeWrapper
+    ott
+    menhir
+    lem
+  ];
+
+  propagatedBuildInputs = [
+    base64
+    omd
+    dune-site
+    linenoise
+    pprint
+    linksem
+  ];
+
+  preBuild = ''
+    rm -r aarch*  # Remove code derived from non-bsd2 arm spec
+    rm -r snapshots  # Some of this might be derived from stuff in the aarch dir, it builds fine without it
+  '';
+  # `buildDunePackage` only builds the [pname] package
+  # This doesnt work in this case, as sail includes multiple packages in the same source tree
+  buildPhase = ''
+    runHook preBuild
+    dune build --release ''${enableParallelBuild:+-j $NIX_BUILD_CORES}
+    runHook postBuild
+  '';
+  checkPhase = ''
+    runHook preCheck
+    dune runtest ''${enableParallelBuild:+-j $NIX_BUILD_CORES}
+    runHook postCheck
+  '';
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix $out --libdir $OCAMLFIND_DESTDIR
+    runHook postInstall
+  '';
+  postInstall = ''
+    wrapProgram $out/bin/sail --set SAIL_DIR $out/share/sail
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/rems-project/sail";
+    description = "A language for describing the instruction-set architecture (ISA) semantics of processors";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/development/python-modules/dataproperty/default.nix
+++ b/pkgs/development/python-modules/dataproperty/default.nix
@@ -1,0 +1,39 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, mbstrdecoder
+, typepy
+, pytestCheckHook
+, termcolor
+}:
+
+buildPythonPackage rec {
+  pname = "dataproperty";
+  version = "0.55.0";
+
+  src = fetchFromGitHub {
+    owner = "thombashi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-ODSrKZ8M/ni9r2gkVIKWaKkdr+3AVi4INkEKJ+cmb44=";
+  };
+
+  propagatedBuildInputs = [ mbstrdecoder typepy ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  checkInputs = [ termcolor ];
+
+  # Tests fail, even on non-nixos
+  pytestFlagsArray = [
+    "--deselect test/test_dataproperty.py::Test_DataPeroperty_len::test_normal_ascii_escape_sequence"
+    "--deselect test/test_dataproperty.py::Test_DataPeroperty_is_include_ansi_escape::test_normal"
+    "--deselect test/test_dataproperty.py::Test_DataPeroperty_repr::test_normal"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/thombashi/dataproperty";
+    description = "A library for extracting properties from data";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/mbstrdecoder/default.nix
+++ b/pkgs/development/python-modules/mbstrdecoder/default.nix
@@ -1,0 +1,31 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, chardet
+, pytestCheckHook
+, faker
+}:
+
+buildPythonPackage rec {
+  pname = "mbstrdecoder";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "thombashi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-U8F+mWKDulIRvvhswmdGnxKjM2qONQybViQ5TLZbLDY=";
+  };
+
+  propagatedBuildInputs = [ chardet ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  checkInputs = [ faker ];
+
+  meta = with lib; {
+    homepage = "https://github.com/thombashi/mbstrdecoder";
+    description = "A library for decoding multi-byte character strings";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/pytablewriter/default.nix
+++ b/pkgs/development/python-modules/pytablewriter/default.nix
@@ -1,0 +1,57 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, dataproperty
+, mbstrdecoder
+, pathvalidate
+, setuptools
+, tabledata
+, tcolorpy
+, typepy
+, pytestCheckHook
+, pyyaml
+, toml
+, elasticsearch
+, dominate
+}:
+
+buildPythonPackage rec {
+  pname = "pytablewriter";
+  version = "0.64.2";
+
+  src = fetchFromGitHub {
+    owner = "thombashi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-+IOHnmdd9g3SoHyITJJtbJ0/SAAmwWmwX5XeqsO34EM=";
+  };
+
+  propagatedBuildInputs = [
+    dataproperty
+    mbstrdecoder
+    pathvalidate
+    tabledata
+    tcolorpy
+    typepy
+  ];
+
+  checkInputs = [ pyyaml toml elasticsearch dominate ];
+  nativeCheckInputs = [ pytestCheckHook ];
+  # Circular dependency
+  disabledTests = [
+    "test_normal_from_file"
+    "test_normal_from_text"
+    "test_normal_clear_theme"
+  ];
+  disabledTestPaths = [
+    "test/writer/binary/test_excel_writer.py"
+    "test/writer/binary/test_sqlite_writer.py"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/thombashi/pytablewriter";
+    description = "A library to write a table in various formats";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/riscof/default.nix
+++ b/pkgs/development/python-modules/riscof/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, git
+, riscv-isac
+, riscv-config
+, jinja2
+}:
+
+buildPythonPackage rec {
+  pname = "riscof";
+  version = "1.25.2";
+
+  src = fetchFromGitHub {
+    owner = "riscv-software-src";
+    repo = pname;
+    rev = "1.25.2";
+    hash = "sha256-6jiKBGj4NN038/qq3ze+L0MYpQEEaN5xt4CTWu0i4qs=";
+  };
+
+  postPatch = "substituteInPlace riscof/requirements.txt --replace 'GitPython==3.1.17' GitPython";
+
+  propagatedBuildInputs = [ riscv-isac riscv-config jinja2 ];
+
+  patches = [
+    # riscof copies a template directory from the store, but breaks because it doesn't change permissions and expects it to be writeable
+    ./make_writeable.patch
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/riscv-software-src/riscof";
+    description = "RISC-V Architectural Test Framework";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/riscof/make_writeable.patch
+++ b/pkgs/development/python-modules/riscof/make_writeable.patch
@@ -1,0 +1,25 @@
+diff --git a/riscof/cli.py b/riscof/cli.py
+index 26af62e..9d0ddbf 100644
+--- a/riscof/cli.py
++++ b/riscof/cli.py
+@@ -502,6 +502,7 @@ def setup(dutname,refname,work_dir):
+         src = os.path.join(constants.root, "Templates/setup/model/")
+         dest = os.path.join(cwd, dutname)
+         distutils.dir_util.copy_tree(src, dest)
++        os.system(f"chmod +w -R '{dest}'")
+ 
+         os.rename(cwd+'/'+dutname+'/model_isa.yaml',
+                 cwd+'/'+dutname+'/'+dutname+'_isa.yaml')
+@@ -525,10 +526,12 @@ def setup(dutname,refname,work_dir):
+             src = os.path.join(constants.root, "Templates/setup/sail_cSim/")
+             dest = os.path.join(cwd, refname)
+             distutils.dir_util.copy_tree(src, dest)
++            os.system(f"chmod +w -R '{dest}'")
+         else:
+             src = os.path.join(constants.root, "Templates/setup/reference/")
+             dest = os.path.join(cwd, refname)
+             distutils.dir_util.copy_tree(src, dest)
++            os.system(f"chmod +w -R '{dest}'")
+             os.rename(cwd+'/'+refname+'/riscof_model.py',
+                 cwd+'/'+refname+'/riscof_'+refname+'.py')
+             with open(cwd+'/'+refname+'/riscof_'+refname+'.py', 'r') as file :

--- a/pkgs/development/python-modules/riscv-config/default.nix
+++ b/pkgs/development/python-modules/riscv-config/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, cerberus
+, pyyaml
+, ruamel-yaml
+}:
+
+buildPythonPackage rec {
+  pname = "riscv-config";
+  version = "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = "riscv-software-src";
+    repo = pname;
+    rev = version;
+    hash = "sha256-HKmHrvOF4OOzoILrBJG46UOKow5gRxMcXXiI6f34dPc=";
+  };
+
+  propagatedBuildInputs = [ cerberus pyyaml ruamel-yaml ];
+
+  meta = with lib; {
+    homepage = "https://github.com/riscv/riscv-config";
+    description = "RISC-V configuration validator";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/riscv-isac/default.nix
+++ b/pkgs/development/python-modules/riscv-isac/default.nix
@@ -1,0 +1,44 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, click
+, colorlog
+, gitpython
+, pyelftools
+, pytablewriter
+, pytest
+, pyyaml
+, ruamel-yaml
+}:
+
+buildPythonPackage rec {
+  pname = "riscv-isac";
+  version = "0.16.1";
+
+  src = fetchFromGitHub {
+    owner = "riscv-software-src";
+    repo = pname;
+    rev = version;
+    hash = "sha256-Krjr9bvpoOeNfMbYj/QbJ+Y+AVLjwrzj8KKMUXCfnMA=";
+  };
+
+  postPatch = "substituteInPlace riscv_isac/requirements.txt --replace 'pyelftools==0.26' pyelftools";
+
+  propagatedBuildInputs = [
+    click
+    colorlog
+    gitpython
+    pyelftools
+    pytablewriter
+    pytest
+    pyyaml
+    ruamel-yaml
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/riscv/riscv-isac";
+    description = "An ISA coverage extraction tool";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/tabledata/default.nix
+++ b/pkgs/development/python-modules/tabledata/default.nix
@@ -1,0 +1,30 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, dataproperty
+, typepy
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "tabledata";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "thombashi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-6Nkdc32cp9wbmw7cnBn5VAJKfqxNunyxExuZ9b+qWNY=";
+  };
+
+  propagatedBuildInputs = [ dataproperty typepy ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    homepage = "https://github.com/thombashi/tabledata";
+    description = "A library to represent tabular data";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/tcolorpy/default.nix
+++ b/pkgs/development/python-modules/tcolorpy/default.nix
@@ -1,0 +1,26 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "tcolorpy";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "thombashi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-duMbeKygEuGVcg4+gQRfClww3rs5AsmJR1VQBo7KWFY=";
+  };
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    homepage = "https://github.com/thombashi/tcolorpy";
+    description = "A library to apply true color for terminal text";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/typepy/default.nix
+++ b/pkgs/development/python-modules/typepy/default.nix
@@ -1,0 +1,34 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, mbstrdecoder
+, python-dateutil
+, pytz
+, packaging
+, pytestCheckHook
+, tcolorpy
+}:
+
+buildPythonPackage rec {
+  pname = "typepy";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "thombashi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-J6SgVd2m0wOVr2ZV/pryRcJrn+BYTGstAUQO349c2lE=";
+  };
+
+  propagatedBuildInputs = [ mbstrdecoder python-dateutil pytz packaging ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  checkInputs = [ tcolorpy ];
+
+  meta = with lib; {
+    homepage = "https://github.com/thombashi/typepy";
+    description = "A library for variable type checker/validator/converter at a run time";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38112,6 +38112,14 @@ with pkgs;
 
   sailsd = callPackage ../misc/sailsd { };
 
+  sail-riscv-rv32 = callPackage ../applications/virtualization/sail-riscv {
+    arch = "RV32";
+  };
+
+  sail-riscv-rv64 = callPackage ../applications/virtualization/sail-riscv {
+    arch = "RV64";
+  };
+
   shc = callPackage ../tools/security/shc { };
 
   shellz = callPackage ../tools/security/shellz { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -759,6 +759,8 @@ let
 
     linenoise = callPackage ../development/ocaml-modules/linenoise { };
 
+    linksem = callPackage ../development/ocaml-modules/linksem { };
+
     llvm = callPackage ../development/ocaml-modules/llvm {
       libllvm = pkgs.llvmPackages_10.libllvm;
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -743,6 +743,8 @@ let
 
     lastfm = callPackage ../development/ocaml-modules/lastfm { };
 
+    lem = callPackage ../development/ocaml-modules/lem { };
+
     lens = callPackage ../development/ocaml-modules/lens { };
 
     letsencrypt = callPackage ../development/ocaml-modules/letsencrypt { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1244,6 +1244,8 @@ let
 
     rusage = callPackage ../development/ocaml-modules/rusage { };
 
+    sail = callPackage ../development/ocaml-modules/sail { };
+
     samplerate = callPackage ../development/ocaml-modules/samplerate { };
 
     secp256k1 = callPackage ../development/ocaml-modules/secp256k1 {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8941,6 +8941,8 @@ self: super: with self; {
 
   pytabix = callPackage ../development/python-modules/pytabix { };
 
+  pytablewriter = callPackage ../development/python-modules/pytablewriter { };
+
   pytado = callPackage ../development/python-modules/pytado { };
 
   pytaglib = callPackage ../development/python-modules/pytaglib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11200,6 +11200,8 @@ self: super: with self; {
 
   tableaudocumentapi = callPackage ../development/python-modules/tableaudocumentapi { };
 
+  tabledata = callPackage ../development/python-modules/tabledata { };
+
   tables = callPackage ../development/python-modules/tables { };
 
   tablib = callPackage ../development/python-modules/tablib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11764,6 +11764,8 @@ self: super: with self; {
 
   typeguard = callPackage ../development/python-modules/typeguard { };
 
+  typepy = callPackage ../development/python-modules/typepy { };
+
   typer = callPackage ../development/python-modules/typer { };
 
   types-colorama = callPackage ../development/python-modules/types-colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10057,6 +10057,8 @@ self: super: with self; {
 
   ripser = callPackage ../development/python-modules/ripser { };
 
+  riscv-config = callPackage ../development/python-modules/riscv-config { };
+
   riscv-isac = callPackage ../development/python-modules/riscv-isac { };
 
   rising = callPackage ../development/python-modules/rising { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11234,6 +11234,8 @@ self: super: with self; {
 
   tbm-utils = callPackage ../development/python-modules/tbm-utils { };
 
+  tcolorpy = callPackage ../development/python-modules/tcolorpy { };
+
   tcxparser = callPackage ../development/python-modules/tcxparser { };
 
   tcxreader = callPackage ../development/python-modules/tcxreader { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5770,6 +5770,8 @@ self: super: with self; {
 
   mbddns = callPackage ../development/python-modules/mbddns { };
 
+  mbstrdecoder = callPackage ../development/python-modules/mbstrdecoder { };
+
   mccabe = callPackage ../development/python-modules/mccabe { };
 
   mcstatus = callPackage ../development/python-modules/mcstatus { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2241,6 +2241,8 @@ self: super: with self; {
 
   datapoint = callPackage ../development/python-modules/datapoint { };
 
+  dataproperty = callPackage ../development/python-modules/dataproperty { };
+
   dataset = callPackage ../development/python-modules/dataset { };
 
   datasets = callPackage ../development/python-modules/datasets { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10057,6 +10057,8 @@ self: super: with self; {
 
   ripser = callPackage ../development/python-modules/ripser { };
 
+  riscv-isac = callPackage ../development/python-modules/riscv-isac { };
+
   rising = callPackage ../development/python-modules/rising { };
 
   ritassist = callPackage ../development/python-modules/ritassist { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10057,6 +10057,8 @@ self: super: with self; {
 
   ripser = callPackage ../development/python-modules/ripser { };
 
+  riscof = callPackage ../development/python-modules/riscof { };
+
   riscv-config = callPackage ../development/python-modules/riscv-config { };
 
   riscv-isac = callPackage ../development/python-modules/riscv-isac { };


### PR DESCRIPTION
###### Description of changes

Add riscof (and dependencies)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Relevant: #213222 