### PR TITLE
stm32cubemx: 6.6.1 -> 6.7.0

### DIFF
--- a/pkgs/development/embedded/stm32/stm32cubemx/default.nix
+++ b/pkgs/development/embedded/stm32/stm32cubemx/default.nix
@@ -1,19 +1,21 @@
 { lib, stdenv, makeDesktopItem, copyDesktopItems, icoutils, fdupes, imagemagick, jdk11, fetchzip }:
-# TODO: JDK16 causes STM32CubeMX to crash right now, so we fixed the version to JDK11
-# This may be fixed in a future version of STM32CubeMX. This issue has been reported to ST:
+# TODO: Since be1392dbd9debfe1d9a72b6aeb01a7a3c625623f, this package uses JDK11 because there have
+# been issues with JDK16 at that time. The issue that caused the program to crash at startup:
 # https://community.st.com/s/question/0D53W00000jnOzPSAU/stm32cubemx-crashes-on-launch-with-openjdk16
-# If you're updating this derivation, check the link above to see if it's been fixed upstream
-# and try replacing all occurrences of jdk11 with jre and test whether it works.
+# This seems to have been resolved but code generation to EWARM and MDK-ARM failed with JDK19 which
+# was the newest JDK then..Therefore, JDK11 was kept.
+# If you're updating this derivation, check if all issues with the newest JDK have been resolved by
+# replacing all occurrences of jdk11 with jdk. If so, keep that change.
 let
   iconame = "STM32CubeMX";
 in
 stdenv.mkDerivation rec {
   pname = "stm32cubemx";
-  version = "6.6.1";
+  version = "6.7.0";
 
   src = fetchzip {
     url = "https://sw-center.st.com/packs/resource/library/stm32cube_mx_v${builtins.replaceStrings ["."] [""] version}-lin.zip";
-    sha256 = "sha256-NfJMXHQ7JXzRSdOAYfx2t0xsi/w2S5FK3NovcsDOi+E=";
+    sha256 = "sha256-PX8Fw8XK4WXAs9oRDYS5exUTP74Bdkt7dA9sP8VpLzM=";
     stripRoot = false;
   };
 


### PR DESCRIPTION
###### Description of changes / Commit message

Release notes available at https://community.st.com/s/feed/0D53W00001yFCKTSA4

The jdk11 note has been updated to inform that the initial issue seems to be resolved but at least one other issue has been found with JDK19.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
