### PR TITLE
ruby: remove invalid paths from RbConfig::CONFIG

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -181,8 +181,10 @@ let
               ${removeReferencesTo}/bin/remove-references-to \
                 -t ${stdenv.cc} \
                 $out/lib/libruby*
-              ${removeReferencesTo}/bin/remove-references-to \
-                -t ${stdenv.cc} \
+              # Get rid of the CC runtime dependency without adding bogus
+              # paths.
+              sed -i -e '/^  CONFIG\["MJIT_CC"\]/d' \
+                -e '/^  CONFIG\["LDFLAGS"\]/s|-L${stdenv.cc}/resource-root/lib ||' \
                 $rbConfig
               sed -i '/CC_VERSION_MESSAGE/d' $rbConfig
             ''
@@ -230,6 +232,7 @@ let
           cp ${./rbconfig.rb} $devdoc/lib/ruby/site_ruby/rbconfig.rb
         '' + opString useBaseRuby ''
           # Prevent the baseruby from being included in the closure.
+          sed -i '/^  CONFIG\["LDFLAGS"]/s|-L${baseRuby}/lib ||' $rbConfig
           ${removeReferencesTo}/bin/remove-references-to \
             -t ${baseRuby} \
             $rbConfig $out/lib/libruby*


### PR DESCRIPTION
Ruby gems are build using the `LDFLAGS` from
`RbConfig::CONFIG['LDFLAGS']` and this string contains paths from `$baseRuby` which have been modified by `remove-references-to` so that they are invalid.

Building gems or using `Makefile`s generated by `mkmf` in any capacity leads to linker warnings like
```
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-ruby-2.7.6/lib'
```

This commit removes the corresponding `-L` options from `rbconfig.rb`, fixing these warnings.

Fixes: #177130

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
