### PR TITLE
meson.setupHook: prefer meson commands over ninja

### DIFF
--- a/doc/hooks/meson.section.md
+++ b/doc/hooks/meson.section.md
@@ -1,16 +1,28 @@
 # Meson {#meson}
 
-Overrides the configure phase to run meson to generate Ninja files. To run these files, you should accompany Meson with ninja. By default, `enableParallelBuilding` is enabled as Meson supports parallel building almost everywhere.
+Overrides the configure, check, and install phases to run `meson setup`, `meson test`, and `meson install`.
+
+Meson is a meta-build system so you will need a secondary build system to run the generated build files in build phase. In Nixpkgs context, you will want to accompany Meson with ninja, which provides a [setup hook](#ninja) registering a ninja-based build phase.
+
+By default, `enableParallelBuilding` is enabled as Meson supports parallel building almost everywhere.
 
 ## Variables controlling Meson {#variables-controlling-meson}
 
 ### `mesonFlags` {#mesonflags}
 
-Controls the flags passed to meson.
+Controls the flags passed to `meson setup`.
+
+##### `mesonCheckFlags` {#mesoncheckflags}
+
+Controls the flags passed to `meson test`.
+
+##### `mesonInstallFlags` {#mesoninstallflags}
+
+Controls the flags passed to `meson install`.
 
 ### `mesonBuildType` {#mesonbuildtype}
 
-Which [`--buildtype`](https://mesonbuild.com/Builtin-options.html#core-options) to pass to Meson. We default to `plain`.
+Which [`--buildtype`](https://mesonbuild.com/Builtin-options.html#core-options) to pass to `meson setup`. We default to `plain`.
 
 ### `mesonAutoFeatures` {#mesonautofeatures}
 
@@ -23,3 +35,11 @@ What value to set [`-Dwrap_mode=`](https://mesonbuild.com/Builtin-options.html#c
 ### `dontUseMesonConfigure` {#dontusemesonconfigure}
 
 Disables using Meson’s `configurePhase`.
+
+##### `dontUseMesonCheck` {#dontusemesoncheck}
+
+Disables using Meson’s `checkPhase`.
+
+##### `dontUseMesonInstall` {#dontusemesoninstall}
+
+Disables using Meson’s `installPhase`.

--- a/doc/hooks/ninja.section.md
+++ b/doc/hooks/ninja.section.md
@@ -1,3 +1,5 @@
 # ninja {#ninja}
 
 Overrides the build, install, and check phase to run ninja instead of make. You can disable this behavior with the `dontUseNinjaBuild`, `dontUseNinjaInstall`, and `dontUseNinjaCheck`, respectively. Parallel building is enabled by default in Ninja.
+
+Note that if the [Meson setup hook](#meson) is also active, Ninja's install and check phases will be disabled in favor of Meson's.

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -28,12 +28,37 @@ mesonConfigurePhase() {
         echo "meson: enabled parallel building"
     fi
 
-    if ! [[ -v enableParallelInstalling ]]; then
-        enableParallelInstalling=1
-        echo "meson: enabled parallel installing"
+    if [[ ${checkPhase-ninjaCheckPhase} = ninjaCheckPhase && -z $dontUseMesonCheck ]]; then
+        checkPhase=mesonCheckPhase
+    fi
+    if [[ ${installPhase-ninjaInstallPhase} = ninjaInstallPhase && -z $dontUseMesonInstall ]]; then
+        installPhase=mesonInstallPhase
     fi
 
     runHook postConfigure
+}
+
+mesonCheckPhase() {
+    runHook preCheck
+
+    local flagsArray=($mesonCheckFlags "${mesonCheckFlagsArray[@]}")
+
+    echoCmd 'check flags' "${flagsArray[@]}"
+    meson test --no-rebuild "${flagsArray[@]}"
+
+    runHook postCheck
+}
+
+mesonInstallPhase() {
+    runHook preInstall
+
+    # shellcheck disable=SC2086
+    local flagsArray=($mesonInstallFlags "${mesonInstallFlagsArray[@]}")
+
+    echoCmd 'install flags' "${flagsArray[@]}"
+    meson install --no-rebuild "${flagsArray[@]}"
+
+    runHook postInstall
 }
 
 if [ -z "${dontUseMesonConfigure-}" -a -z "${configurePhase-}" ]; then


### PR DESCRIPTION
###### Description of changes

Meson now comes with its own set of commands for building, testing, installing etc., that by default wrap around Ninja.  The reason to prefer using the Meson commands is that they take additional options (e.g. setting custom timeouts for tests — my motivation for this change).

Here, I've modified the Meson setup hook so instead of Ninja being run automatically, Meson's equivalent commands will be if Meson is present.  This only happens when Meson is used to configure, to avoid starting to run Meson directly when dealing with custom build systems that wrap around Meson, like QEMU's.

Naturally the Meson commands don't support entirely the same set of options that the Ninja ones did, but I checked through Nixpkgs to find any packages using Meson that used any options that wouldn't be picked up by this new system.  I only found one, and it was just setting `checkTarget = "test"`, which is the default value for Ninja and has no Meson equivalent (because we directly tell Meson to run the tests rather than going through a generic job system like Ninja).

I've tested building all the way to qemu_kvm, which I chose because it has lots of dependencies built with Meson, and also has its own custom Meson-wrapping build system so I could be sure that also still worked.

Fixes, partially: https://github.com/NixOS/nixpkgs/issues/113829

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
