### PR TITLE
ecwolf: remove obsolete build steps & fix executable not being added to `PATH`

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6638,6 +6638,12 @@
     github = "jayeshbhoot";
     githubId = 1915507;
   };
+  jayman2000 = {
+    email = "jason@jasonyundt.email";
+    github = "Jayman2000";
+    githubId = 5579359;
+    name = "Jason Yundt";
+  };
   jb55 = {
     email = "jb55@jb55.com";
     github = "jb55";

--- a/pkgs/games/ecwolf/default.nix
+++ b/pkgs/games/ecwolf/default.nix
@@ -33,6 +33,12 @@ stdenv.mkDerivation rec {
     sed -i -e "s|include(\''${CMAKE_CURRENT_SOURCE_DIR}/macosx/install.txt)||" src/CMakeLists.txt
   '';
 
+  # ECWolf installs its binary to the games/ directory, but Nix only adds bin/
+  # directories to the PATH.
+  postInstall = ''
+    mv "$out/games" "$out/bin"
+  '';
+
   meta = with lib; {
     description = "Enhanched SDL-based port of Wolfenstein 3D for various platforms";
     homepage = "https://maniacsvault.net/ecwolf/";

--- a/pkgs/games/ecwolf/default.nix
+++ b/pkgs/games/ecwolf/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     description = "Enhanched SDL-based port of Wolfenstein 3D for various platforms";
     homepage = "https://maniacsvault.net/ecwolf/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ sander ];
+    maintainers = with maintainers; [ jayman2000 sander ];
     platforms = platforms.all;
     # On Darwin, the linker fails to find a bunch of symbols.
     broken = stdenv.isDarwin;

--- a/pkgs/games/ecwolf/default.nix
+++ b/pkgs/games/ecwolf/default.nix
@@ -28,36 +28,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake copyDesktopItems pkg-config ];
   buildInputs = [ zlib bzip2 libjpeg SDL2 SDL2_net SDL2_mixer gtk3 ];
 
-  desktopItems = [
-    (makeDesktopItem {
-      name = "ecwolf";
-      exec = "ecwolf";
-      comment = "Enhanced Wolfenstein 3D port";
-      desktopName = "Wolfenstein 3D";
-      categories = [ "Game" ];
-    })
-  ];
-
-  # Change the location where the ecwolf executable looks for the ecwolf.pk3
-  # file.
-  #
-  # By default, it expects the PK3 file to reside in the same directory as the
-  # executable, which is not desirable.
-  # We will adjust the code so that it can be retrieved from the share/
-  # directory.
-
-  preConfigure = ''
-    sed -i -e "s|ecwolf.pk3|$out/share/ecwolf/ecwolf.pk3|" src/version.h
-  ''
   # Disable app bundle creation on Darwin. It fails, and it is not needed to run it from the Nix store
-  + lib.optionalString stdenv.isDarwin ''
+  preConfigure = lib.optionalString stdenv.isDarwin ''
     sed -i -e "s|include(\''${CMAKE_CURRENT_SOURCE_DIR}/macosx/install.txt)||" src/CMakeLists.txt
-  '';
-
-  # Install the required PK3 file in the required data directory
-  postInstall = ''
-    mkdir -p $out/share/ecwolf
-    cp ecwolf.pk3 $out/share/ecwolf
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[ECWolf 1.4.0 made several changes that make it easier for Linux distros to create packages for ECWolf.](https://bitbucket.org/ecwolf/ecwolf/commits/55a28ec7e141b6ea1833aa3604e8e03236f873f4) ECWolf now generates its own desktop shortcut, so we no longer need to use `makeDesktopItem`. ECWolf now also will look in the `CMAKE_INSTALL_PREFIX/share/ecwolf` directory for `ecwolf.pk3`, so we no longer need to patch `src/version.h` or copy `ecwolf.pk3` manually.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
