### PR TITLE
rotp: init at 1.04

### DIFF
--- a/pkgs/games/rotp/0001-store-config-and-saves-in-XDG_CONFIG_HOME.patch
+++ b/pkgs/games/rotp/0001-store-config-and-saves-in-XDG_CONFIG_HOME.patch
@@ -1,0 +1,106 @@
+From 0b49ad87d24193b819dfaf706b4f9f62256863ac Mon Sep 17 00:00:00 2001
+From: Joshua Trees <me@jtrees.io>
+Date: Tue, 31 Jan 2023 22:59:55 +0100
+Subject: [PATCH] store config and saves in XDG_CONFIG_HOME
+
+---
+ src/rotp/Rotp.java               | 15 +++++++++++++++
+ src/rotp/lang/bn/labels.txt      |  2 +-
+ src/rotp/lang/en/labels.txt      |  2 +-
+ src/rotp/ui/UserPreferences.java |  7 ++++---
+ 4 files changed, 21 insertions(+), 5 deletions(-)
+
+diff --git a/src/rotp/Rotp.java b/src/rotp/Rotp.java
+index 72d8e446..a8fcd695 100644
+--- a/src/rotp/Rotp.java
++++ b/src/rotp/Rotp.java
+@@ -43,6 +43,7 @@ public class Rotp {
+     public static String exeFileName = "Remnants.exe";
+     public static boolean countWords = false;
+     private static String startupDir = System.getProperty("startupdir");
++    private static String configDir = null;
+     private static JFrame frame;
+     public static String releaseId = "1.04";
+     public static long startMs = System.currentTimeMillis();
+@@ -165,6 +166,20 @@ public class Rotp {
+         }
+         return startupDir;
+     }
++    public static String configDir()  {
++        if (configDir == null) {
++            configDir = getXdgConfigHome() + File.separator + "rotp" + File.separator;
++        }
++        return configDir;
++    }
++    private static String getXdgConfigHome() {
++        String value = System.getenv().get("XDG_CONFIG_HOME");
++        if (value == null || value.trim().length() == 0) {
++            String XDG_CONFIG_HOME_DEFAULT = System.getenv().get("HOME") + File.separator + ".config";
++            value = XDG_CONFIG_HOME_DEFAULT;
++        }
++        return value;
++    }
+     private static void stopIfInsufficientMemory(JFrame frame, int allocMb) {
+         if (allocMb < 260) {
+             JOptionPane.showMessageDialog(frame, "Error starting game: Not enough free memory to play");
+diff --git a/src/rotp/lang/bn/labels.txt b/src/rotp/lang/bn/labels.txt
+index bdbc47ef..6072c90a 100644
+--- a/src/rotp/lang/bn/labels.txt
++++ b/src/rotp/lang/bn/labels.txt
+@@ -362,7 +362,7 @@ GAME_SETTINGS_BACKUP_DESC         | Enable to have your current game periodicall
+ GAME_SETTINGS_SAVEDIR             | Save Directory: %1
+ GAME_SETTINGS_SAVEDIR_DEFAULT     | Default
+ GAME_SETTINGS_SAVEDIR_CUSTOM      | Custom
+-GAME_SETTINGS_SAVEDIR_DESC1       | The save directory is currently set to the same directory as the game.
++GAME_SETTINGS_SAVEDIR_DESC1       | The save directory is currently set to the default location.
+ GAME_SETTINGS_SAVEDIR_DESC2       | The save directory is currently set to: %1
+ 
+ // Load Game UI
+diff --git a/src/rotp/lang/en/labels.txt b/src/rotp/lang/en/labels.txt
+index 6ba316ae..59e3f0e6 100644
+--- a/src/rotp/lang/en/labels.txt
++++ b/src/rotp/lang/en/labels.txt
+@@ -362,7 +362,7 @@ GAME_SETTINGS_BACKUP_DESC         | Enable to have your current game periodicall
+ GAME_SETTINGS_SAVEDIR             | Save Directory: %1
+ GAME_SETTINGS_SAVEDIR_DEFAULT     | Default
+ GAME_SETTINGS_SAVEDIR_CUSTOM      | Custom
+-GAME_SETTINGS_SAVEDIR_DESC1       | The save directory is currently set to the same directory as the game.
++GAME_SETTINGS_SAVEDIR_DESC1       | The save directory is currently set to the default location.
+ GAME_SETTINGS_SAVEDIR_DESC2       | The save directory is currently set to: %1
+ 
+ // Load Game UI
+diff --git a/src/rotp/ui/UserPreferences.java b/src/rotp/ui/UserPreferences.java
+index 6deec256..a792091e 100644
+--- a/src/rotp/ui/UserPreferences.java
++++ b/src/rotp/ui/UserPreferences.java
+@@ -190,7 +190,7 @@ public class UserPreferences {
+     public static void screenSizePct(int i) { setScreenSizePct(i); }
+     public static String saveDirectoryPath() {
+         if (saveDir.isEmpty())
+-            return Rotp.jarPath();
++            return Rotp.configDir();
+         else
+             return saveDir;
+     }
+@@ -233,7 +233,7 @@ public class UserPreferences {
+         save();
+     }
+     public static void load() {
+-        String path = Rotp.jarPath();
++        String path = Rotp.configDir();
+         File configFile = new File(path, PREFERENCES_FILE);
+ 		// modnar: change to InputStreamReader, force UTF-8
+ 		try ( BufferedReader in = new BufferedReader( new InputStreamReader( new FileInputStream(configFile), "UTF-8"));) {
+@@ -251,7 +251,8 @@ public class UserPreferences {
+         }
+     }
+     public static int save() {
+-        String path = Rotp.jarPath();
++        String path = Rotp.configDir();
++        new File(path).mkdirs();
+         try (FileOutputStream fout = new FileOutputStream(new File(path, PREFERENCES_FILE));
+             // modnar: change to OutputStreamWriter, force UTF-8
+             PrintWriter out = new PrintWriter(new OutputStreamWriter(fout, "UTF-8")); ) {
+-- 
+2.38.3
+

--- a/pkgs/games/rotp/default.nix
+++ b/pkgs/games/rotp/default.nix
@@ -1,0 +1,87 @@
+{ lib, stdenv, fetchFromGitHub, makeWrapper, jdk, jre }:
+
+stdenv.mkDerivation {
+  pname = "remnants-of-the-precursors";
+  version = "1.04";
+
+  src = fetchFromGitHub {
+    owner = "rayfowler";
+    repo = "rotp-public";
+    rev = "e3726fc22c2c44316306c50c79779e3da1c4c140";
+    sha256 = "sha256-oMA8LRpBoBX7t4G+HuRz0a8g+UEwYO7Ya0Qq4j8AWec=";
+  };
+
+  nativeBuildInputs = [ jdk makeWrapper ];
+
+  # By default, the game tries to write to the java class path. If that fails
+  # (and it always does, since they are in the read-only nix store), it won't
+  # launch.
+  patches = [ ./0001-store-config-and-saves-in-XDG_CONFIG_HOME.patch ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    javac -d "$out/share/" -sourcepath src src/rotp/Rotp.java
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # We need the assets, but don't want the source files.
+    find "src/rotp" -type f -name '*java' -exec rm "{}" \;
+    cp -r src/rotp/* "$out/share/rotp/"
+
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/rotp \
+      --add-flags "-cp $out/share rotp.Rotp"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = ''Open-source modernization of the 1993 classic "Master of Orion", written in Java'';
+    homepage = "https://www.remnantsoftheprecursors.com/";
+
+    # See LICENSE file in source repo for more details.
+    license = with licenses; [
+      # All java files created by Ray Fowler:
+      gpl3Only
+
+      # All Java files in the src/rotp/apachemath folder:
+      asl20
+
+      # The /src/rotp/model/planet/PlanetHeightMap.java file:
+      #
+      # This file is a Java-rewrite of the "Planet Generator" code (originally in C)
+      # available from the following site:
+      #
+      #     http://hjemmesider.diku.dk/~torbenm/Planet
+      #
+      # That page includes the following statement: "Both the program itself and
+      # maps created by the program are free for use, modification and reproduction,
+      # both privately and for commercial purposes, as long as this does not limit
+      # what other people may do with the program and the images they produce with
+      # the program"
+      {
+        free = true;
+        url = "http://hjemmesider.diku.dk/~torbenm/Planet";
+      }
+
+      # All image files are copyright by Peter Penev.
+      #
+      # All sound files are copyright by Remi Agullo.
+      #
+      # Various *.txt files that contain a license notice are copyright by Jeff Colucci. This
+      # includes English text and any foreign language translations.
+      #
+      # The manual.pdf file is copyright by Tom Chick. This includes any foreign language
+      # translations of the manual contained in this repository
+      cc-by-nc-nd-40
+    ];
+
+    maintainers = with maintainers; [ jtrees ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37026,6 +37026,8 @@ with pkgs;
 
   qgo = libsForQt5.callPackage ../games/qgo { };
 
+  rotp = callPackage ../games/rotp { };
+
   rpg-cli = callPackage ../games/rpg-cli { };
 
   runelite = callPackage ../games/runelite { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Remnants of the Precursors](https://www.remnantsoftheprecursors.com/) is an open-source modernization of the 1993 classic "Master of Orion", written in Java.

Fixes #153666.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
