### PR TITLE
briar-desktop: 0.3.1-beta -> 0.4.0-beta

### DIFF
--- a/pkgs/applications/networking/instant-messengers/briar-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/briar-desktop/default.nix
@@ -19,11 +19,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "briar-desktop";
-  version = "0.3.1-beta";
+  version = "0.4.0-beta";
 
   src = fetchurl {
-    url = "https://desktop.briarproject.org/jars/linux/0.3.1-beta/briar-desktop-linux-0.3.1-beta.jar";
-    sha256 = "841dc198101e6e8aa6b5ab6bd6b80e9c6b2593cb88bc3b2592f947baf963389d";
+    url = "https://desktop.briarproject.org/jars/linux/${version}/briar-desktop-linux-${version}.jar";
+    hash = "sha256-7zeIWsdPvROHGaf5igodlZss6Gow3kp6PX+QAzmxMnw=";
   };
 
   dontUnpack = true;
@@ -58,6 +58,6 @@ stdenv.mkDerivation rec {
     homepage = "https://code.briarproject.org/briar/briar-desktop";
     license = licenses.gpl3;
     maintainers = with maintainers; [ onny ];
-    platforms = [ "x86_64-linux" "aarch64-linux" "armv7l-linux" ];
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Description of changes
https://code.briarproject.org/briar/briar-desktop/-/tags/0.4.0-beta

Resolves #213851.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).