### PR TITLE
algolia-cli: init at 1.2.1

### DIFF
--- a/pkgs/development/tools/algolia-cli/default.nix
+++ b/pkgs/development/tools/algolia-cli/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "algolia-cli";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "algolia";
+    repo = "cli";
+    rev = "v${version}";
+    hash = "sha256-rmxLbxotATyURRcG9ryWCDHkH7a/bop/BCDQAoQjXSo=";
+  };
+
+  vendorHash = "sha256-iG8g7mBbIulKSxc1a3/fOBOCWoFYaB5FLwJPNKJRZDg=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  subPackages = [ "cmd/algolia" ];
+
+  ldflags = [ "-s" "-w" "-X github.com/algolia/cli/pkg/version.Version=${version}" ];
+
+  postInstall = ''
+    installShellCompletion --cmd algolia \
+      --bash <($out/bin/algolia completion bash) \
+      --fish <($out/bin/algolia completion fish) \
+      --zsh <($out/bin/algolia completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "Algolia’s official CLI devtool";
+    homepage = "https://algolia.com/doc/tools/cli/";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5788,6 +5788,8 @@ with pkgs;
 
   byzanz = callPackage ../applications/video/byzanz {};
 
+  algolia-cli = callPackage ../development/tools/algolia-cli { };
+
   anydesk = callPackage ../applications/networking/remote/anydesk { };
 
   anystyle-cli = callPackage ../tools/misc/anystyle-cli { };


### PR DESCRIPTION
###### Description of changes
Add https://github.com/algolia/cli
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
