### PR TITLE
deepin.deepin-terminal: init at 5.4.34

### DIFF
--- a/pkgs/desktops/deepin/apps/deepin-terminal/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-terminal/default.nix
@@ -1,0 +1,76 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, dtkwidget
+, qt5integration
+, qt5platform-plugins
+, dde-qt-dbus-factory
+, cmake
+, qtbase
+, qttools
+, qtx11extras
+, pkg-config
+, wrapQtAppsHook
+, at-spi2-core
+, libsecret
+, chrpath
+, lxqt
+, gtest
+}:
+
+stdenv.mkDerivation rec {
+  pname = "deepin-terminal";
+  version = "5.4.34";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-CpI7dyQwrYOYzqVZ6aa+/OAUC3xRyY4ZwzH1mqURTfY=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "chore: use GNUInstallDirs in CmakeLists";
+      url = "https://github.com/linuxdeepin/deepin-terminal/commit/b18a2ca8411f09f5573aa2a8403a484b693ec975.patch";
+      sha256 = "sha256-Qy8Jg+7BfZr8tQEsCAzhMEwf6rU96gkgup5f9bMMELY=";
+    })
+  ];
+
+  cmakeFlags = [ "-DVERSION=${version}" ];
+
+  nativeBuildInputs = [
+    cmake
+    qttools
+    pkg-config
+    wrapQtAppsHook
+    lxqt.lxqt-build-tools
+  ];
+
+  buildInputs = [
+    dtkwidget
+    qt5platform-plugins
+    dde-qt-dbus-factory
+    qtx11extras
+    at-spi2-core
+    libsecret
+    chrpath
+    gtest
+  ];
+
+  strictDeps = true;
+
+  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
+  qtWrapperArgs = [
+    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
+  ];
+
+  meta = with lib; {
+    description = "Terminal emulator with workspace, multiple windows, remote management, quake mode and other features";
+    homepage = "https://github.com/linuxdeepin/deepin-terminal";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -22,6 +22,7 @@ let
 
     #### Dtk Application
     deepin-calculator = callPackage ./apps/deepin-calculator { };
+    deepin-terminal = callPackage ./apps/deepin-terminal { };
 
     #### ARTWORK
     dde-account-faces = callPackage ./artwork/dde-account-faces { };


### PR DESCRIPTION
###### Description of changes
https://github.com/linuxdeepin/dde-nixos/issues/9

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
