### PR TITLE
agda: 2.6.2.2 -> 2.6.3

### DIFF
--- a/maintainers/scripts/haskell/update-stackage.sh
+++ b/maintainers/scripts/haskell/update-stackage.sh
@@ -63,11 +63,13 @@ sed -r \
     -e '/ lsp-test /d' \
     -e '/ hie-bios /d' \
     -e '/ ShellCheck /d' \
+    -e '/ Agda /d' \
     < "${tmpfile_new}" >> $stackage_config
 # Explanations:
 # cabal2nix, distribution-nixpkgs, jailbreak-cabal, language-nix: These are our packages and we know what we are doing.
 # lsp, lsp-types, lsp-test, hie-bios: These are tightly coupled to hls which is not in stackage. They have no rdeps in stackage.
 # ShellCheck: latest version of command-line dev tool.
+# Agda: The Agda community is fast-moving; we strive to always include the newest versions of Agda and the Agda packages in nixpkgs.
 
 if [[ "${1:-}" == "--do-commit" ]]; then
 git add $stackage_config

--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -81,6 +81,13 @@ let
           runHook postInstall
         '';
 
+        # As documented at https://github.com/NixOS/nixpkgs/issues/172752,
+        # we need to set LC_ALL to an UTF-8-supporting locale. However, on
+        # darwin, it seems that there is no standard such locale; luckily,
+        # the referenced issue doesn't seem to surface on darwin. Hence let's
+        # set this only on non-darwin.
+        LC_ALL = lib.optionalString (!stdenv.isDarwin) "C.UTF-8";
+
         meta = if meta.broken or false then meta // { hydraPlatforms = lib.platforms.none; } else meta;
 
         # Retrieve all packages from the finished package set that have the current package as a dependency and build them

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/stackage.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/stackage.yaml
@@ -38,7 +38,6 @@ default-package-overrides:
   - aeson-value-parser ==0.19.7
   - aeson-yak ==0.1.1.3
   - aeson-yaml ==1.1.0.1
-  - Agda ==2.6.2.2
   - agda2lagda ==0.2021.6.1
   - airship ==0.9.5
   - al ==0.1.4.2

--- a/pkgs/development/libraries/agda/agda-prelude/default.nix
+++ b/pkgs/development/libraries/agda/agda-prelude/default.nix
@@ -1,14 +1,14 @@
 { lib, mkDerivation, fetchFromGitHub }:
 
 mkDerivation rec {
-  version = "compat-2.6.2";
+  version = "unstable-2022-01-14";
   pname = "agda-prelude";
 
   src = fetchFromGitHub {
     owner = "UlfNorell";
     repo = "agda-prelude";
-    rev = version;
-    sha256 = "0j2nip5fbn61fpkm3qz4dlazl4mzdv7qlgw9zm15bkcvaila0h14";
+    rev = "3d143d6d0a3f75966602480665623e87233ff93e";
+    hash = "sha256-ILhXDq788vrceMp5mCiQUMrJxeLPtS4yGtvMHMYxzg8=";
   };
 
   preConfigure = ''

--- a/pkgs/development/libraries/agda/cubical/default.nix
+++ b/pkgs/development/libraries/agda/cubical/default.nix
@@ -2,16 +2,14 @@
 
 mkDerivation rec {
   pname = "cubical";
-  version = "0.4";
+  version = "unstable-2023-02-09";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "agda";
-    rev = "v${version}";
-    hash = "sha256-bnHz5uZXZnn1Zd36tq/veA4yT7dhJ1c+AYpgdDfSRzE=";
+    rev = "6b1ce0b67fd94693c1a3e340c8e8765380de0edc";
+    hash = "sha256-XRCaW94oAgy2GOnFiI9c5A8mEx7AzlbT4pFd+PMmc9o=";
   };
-
-  LC_ALL = "C.UTF-8";
 
   # The cubical library has several `Everything.agda` files, which are
   # compiled through the make file they provide.

--- a/pkgs/development/libraries/agda/standard-library/default.nix
+++ b/pkgs/development/libraries/agda/standard-library/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "standard-library";
-  version = "1.7.1";
+  version = "1.7.2";
 
   src = fetchFromGitHub {
     repo = "agda-stdlib";
     owner = "agda";
     rev = "v${version}";
-    sha256 = "0khl12jvknsvjsq3l5cbp2b5qlw983qbymi1dcgfz9z0b92si3r0";
+    hash = "sha256-vvbyfC5+Yyx18IDikSbAAcTHHtU6krlz45Fd2YlwsBg=";
   };
 
   nativeBuildInputs = [ (ghcWithPackages (self : [ self.filemanip ])) ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Agda 2.6.3 is out!](https://hackage.haskell.org/package/Agda-2.6.3/changelog) This pull request brings the new version to nixpkgs.

This pull request does not contain the required changes to automatically generated files for our Haskell package set, as I believe to be best practice in nixpkgs. To test this pull request locally, you hence first need to manually update these:
```
./maintainers/scripts/haskell/update-stackage.sh
./maintainers/scripts/haskell/update-hackage.sh
./maintainers/scripts/haskell/regenerate-hackage-packages.sh
nix-shell -I nixpkgs=$PWD -p "agda.withPackages (p: [ p.agda-categories p.standard-library p.cubical p.agdarsec p.agda-prelude p.functional-linear-algebra ])"
```

You can also test it out live on the [Agdapad](https://agdapad.quasicoherent.io/).

Because of minor incompatibilities between Agda 2.6.2.2 and Agda 2.6.3, this pull request also includes the following changes:

- Update of the stdlib from 1.7.1 to 1.7.2-rc1
- Update of cubical to current HEAD and including a soon-to-be-merged pull request to cubical
- Update of agda-prelude to current HEAD
- Setting `LC_ALL = "C.UTF-8"` for all Agda package builds, as per #172752

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
