### PR TITLE
poetryPlugins.poetry-plugin-up: init at 0.2.1

### DIFF
--- a/pkgs/tools/package-management/poetry/default.nix
+++ b/pkgs/tools/package-management/poetry/default.nix
@@ -1,13 +1,13 @@
 { lib
-, stdenv
 , python3
-, fetchFromGitHub
-, installShellFiles
 }:
 
 let
   python = python3.override {
     packageOverrides = self: super: {
+      poetry = self.callPackage ./unwrapped.nix { };
+
+      # version overrides required by poetry and its plugins
       dulwich = super.dulwich.overridePythonAttrs (old: rec {
         version = "0.20.50";
         src = self.fetchPypi {
@@ -18,118 +18,27 @@ let
       });
     };
   };
-in python.pkgs.buildPythonApplication rec {
-  pname = "poetry";
-  version = "1.3.2";
-  format = "pyproject";
 
-  disabled = python.pkgs.pythonOlder "3.7";
-
-  src = fetchFromGitHub {
-    owner = "python-poetry";
-    repo = pname;
-    rev = "refs/tags/${version}";
-    hash = "sha256-12EiEGI9Vkb6EUY/W2KWeLigxWra1Be4ozvi8njBpEU=";
+  plugins = with python.pkgs; {
   };
 
-  nativeBuildInputs = [
-    installShellFiles
-  ];
+  # selector is a function mapping pythonPackages to a list of plugins
+  withPlugins = selector: let
+    selected = selector plugins;
+  in python.pkgs.toPythonApplication (python.pkgs.poetry.overridePythonAttrs (old: {
+    propagatedBuildInputs = old.propagatedBuildInputs ++ selected;
 
-  propagatedBuildInputs = with python.pkgs; [
-    cachecontrol
-    cleo
-    crashtest
-    dulwich
-    filelock
-    html5lib
-    jsonschema
-    keyring
-    packaging
-    pexpect
-    pkginfo
-    platformdirs
-    poetry-core
-    poetry-plugin-export
-    requests
-    requests-toolbelt
-    shellingham
-    tomlkit
-    trove-classifiers
-    virtualenv
-  ] ++ lib.optionals (stdenv.isDarwin) [
-    xattr
-  ] ++ lib.optionals (pythonOlder "3.11") [
-    tomli
-  ] ++ lib.optionals (pythonOlder "3.10") [
-    importlib-metadata
-  ] ++ lib.optionals (pythonOlder "3.8") [
-    backports-cached-property
-  ] ++ cachecontrol.optional-dependencies.filecache;
+    # save some build time when adding plugins by disabling tests
+    doCheck = selected == [ ];
 
-  postInstall = ''
-    installShellCompletion --cmd poetry \
-      --bash <($out/bin/poetry completions bash) \
-      --fish <($out/bin/poetry completions fish) \
-      --zsh <($out/bin/poetry completions zsh) \
-  '';
+    # Propagating dependencies leaks them through $PYTHONPATH which causes issues
+    # when used in nix-shell.
+    postFixup = ''
+      rm $out/nix-support/propagated-build-inputs
+    '';
 
-  # Propagating dependencies leaks them through $PYTHONPATH which causes issues
-  # when used in nix-shell.
-  postFixup = ''
-    rm $out/nix-support/propagated-build-inputs
-  '';
-
-  nativeCheckInputs = with python.pkgs; [
-    cachy
-    deepdiff
-    flatdict
-    pytestCheckHook
-    httpretty
-    pytest-mock
-    pytest-xdist
-  ];
-
-  preCheck = (''
-    export HOME=$TMPDIR
-  '' + lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
-    # https://github.com/python/cpython/issues/74570#issuecomment-1093748531
-    export no_proxy='*';
-  '');
-
-  postCheck = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
-    unset no_proxy
-  '';
-
-  disabledTests = [
-    # touches network
-    "git"
-    "solver"
-    "load"
-    "vcs"
-    "prereleases_if_they_are_compatible"
-    "test_executor"
-    # requires git history to work correctly
-    "default_with_excluded_data"
-    # toml ordering has changed
-    "lock"
-    # fs permission errors
-    "test_builder_should_execute_build_scripts"
-  ] ++ lib.optionals (python.pythonAtLeast "3.10") [
-    # RuntimeError: 'auto_spec' might be a typo; use unsafe=True if this is intended
-    "test_info_setup_complex_pep517_error"
-  ];
-
-  # Allow for package to use pep420's native namespaces
-  pythonNamespaces = [
-    "poetry"
-  ];
-
-  meta = with lib; {
-    changelog = "https://github.com/python-poetry/poetry/blob/${src.rev}/CHANGELOG.md";
-    homepage = "https://python-poetry.org/";
-    description = "Python dependency management and packaging made easy";
-    license = licenses.mit;
-    maintainers = with maintainers; [ jakewaksbaum dotlambda ];
-  };
-}
+    passthru = rec {
+      inherit plugins withPlugins;
+    };
+  }));
+in withPlugins (ps: [ ])

--- a/pkgs/tools/package-management/poetry/default.nix
+++ b/pkgs/tools/package-management/poetry/default.nix
@@ -20,6 +20,7 @@ let
   };
 
   plugins = with python.pkgs; {
+    poetry-audit-plugin = callPackage ./plugins/poetry-audit-plugin.nix { };
     poetry-plugin-up = callPackage ./plugins/poetry-plugin-up.nix { };
   };
 

--- a/pkgs/tools/package-management/poetry/default.nix
+++ b/pkgs/tools/package-management/poetry/default.nix
@@ -20,9 +20,11 @@ let
   };
 
   plugins = with python.pkgs; {
+    poetry-plugin-up = callPackage ./plugins/poetry-plugin-up.nix { };
   };
 
   # selector is a function mapping pythonPackages to a list of plugins
+  # e.g. poetry.withPlugins (ps: with ps; [ poetry-plugin-up ])
   withPlugins = selector: let
     selected = selector plugins;
   in python.pkgs.toPythonApplication (python.pkgs.poetry.overridePythonAttrs (old: {

--- a/pkgs/tools/package-management/poetry/plugins/poetry-audit-plugin.nix
+++ b/pkgs/tools/package-management/poetry/plugins/poetry-audit-plugin.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, poetry-core
+, poetry
+, safety
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "poetry-audit-plugin";
+  version = "0.3.0";
+
+  disabled = pythonOlder "3.7";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "opeco17";
+    repo = "poetry-audit-plugin";
+    rev = "refs/tags/${version}";
+    hash = "sha256-49OnYz3EFiqOe+cLgfynjy14Ve4Ga6OUrLdM8HhZuKQ=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  buildInputs = [
+    poetry
+  ];
+
+  propagatedBuildInputs = [
+    safety
+  ];
+
+  pythonImportsCheck = [ "poetry_audit_plugin" ];
+
+  nativeCheckInputs = [
+    poetry  # for the executable
+    pytestCheckHook
+  ];
+
+  # requires networking
+  doCheck = false;
+
+  meta = {
+    description = "Poetry plugin for checking security vulnerabilities in dependencies";
+    homepage = "https://github.com/opeco17/poetry-audit-plugin";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/tools/package-management/poetry/plugins/poetry-plugin-up.nix
+++ b/pkgs/tools/package-management/poetry/plugins/poetry-plugin-up.nix
@@ -1,0 +1,43 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, poetry-core
+, pytestCheckHook
+, pytest-mock
+, poetry
+}:
+
+buildPythonPackage rec {
+  pname = "poetry-plugin-up";
+  version = "0.2.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "MousaZeidBaker";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-16p0emvgWa56Km8U5HualCSStbulqyINbC3Jez9Y1n0=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+    poetry
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  meta = with lib; {
+    description = "Poetry plugin to simplify package updates";
+    homepage = "https://github.com/MousaZeidBaker/poetry-plugin-up";
+    changelog = "https://github.com/MousaZeidBaker/poetry-plugin-up/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = [ maintainers.k900 ];
+  };
+}

--- a/pkgs/tools/package-management/poetry/unwrapped.nix
+++ b/pkgs/tools/package-management/poetry/unwrapped.nix
@@ -1,0 +1,149 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, installShellFiles
+, cachecontrol
+, cleo
+, crashtest
+, dulwich
+, filelock
+, html5lib
+, jsonschema
+, keyring
+, packaging
+, pexpect
+, pkginfo
+, platformdirs
+, poetry-core
+, poetry-plugin-export
+, requests
+, requests-toolbelt
+, shellingham
+, tomlkit
+, trove-classifiers
+, virtualenv
+, xattr
+, tomli
+, importlib-metadata
+, backports-cached-property
+, cachy
+, deepdiff
+, flatdict
+, pytestCheckHook
+, httpretty
+, pytest-mock
+, pytest-xdist
+, pythonAtLeast
+}:
+
+buildPythonPackage rec {
+  pname = "poetry";
+  version = "1.3.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "python-poetry";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-12EiEGI9Vkb6EUY/W2KWeLigxWra1Be4ozvi8njBpEU=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  propagatedBuildInputs = [
+    cachecontrol
+    cleo
+    crashtest
+    dulwich
+    filelock
+    html5lib
+    jsonschema
+    keyring
+    packaging
+    pexpect
+    pkginfo
+    platformdirs
+    poetry-core
+    poetry-plugin-export
+    requests
+    requests-toolbelt
+    shellingham
+    tomlkit
+    trove-classifiers
+    virtualenv
+  ] ++ lib.optionals (stdenv.isDarwin) [
+    xattr
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    tomli
+  ] ++ lib.optionals (pythonOlder "3.10") [
+    importlib-metadata
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    backports-cached-property
+  ] ++ cachecontrol.optional-dependencies.filecache;
+
+  postInstall = ''
+    installShellCompletion --cmd poetry \
+      --bash <($out/bin/poetry completions bash) \
+      --fish <($out/bin/poetry completions fish) \
+      --zsh <($out/bin/poetry completions zsh) \
+  '';
+
+  nativeCheckInputs = [
+    cachy
+    deepdiff
+    flatdict
+    pytestCheckHook
+    httpretty
+    pytest-mock
+    pytest-xdist
+  ];
+
+  preCheck = (''
+    export HOME=$TMPDIR
+  '' + lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
+    # https://github.com/python/cpython/issues/74570#issuecomment-1093748531
+    export no_proxy='*';
+  '');
+
+  postCheck = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
+    unset no_proxy
+  '';
+
+  disabledTests = [
+    # touches network
+    "git"
+    "solver"
+    "load"
+    "vcs"
+    "prereleases_if_they_are_compatible"
+    "test_executor"
+    # requires git history to work correctly
+    "default_with_excluded_data"
+    # toml ordering has changed
+    "lock"
+    # fs permission errors
+    "test_builder_should_execute_build_scripts"
+  ] ++ lib.optionals (pythonAtLeast "3.10") [
+    # RuntimeError: 'auto_spec' might be a typo; use unsafe=True if this is intended
+    "test_info_setup_complex_pep517_error"
+  ];
+
+  # Allow for package to use pep420's native namespaces
+  pythonNamespaces = [
+    "poetry"
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/python-poetry/poetry/blob/${src.rev}/CHANGELOG.md";
+    homepage = "https://python-poetry.org/";
+    description = "Python dependency management and packaging made easy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jakewaksbaum dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16597,6 +16597,8 @@ with pkgs;
 
   poetry = callPackage ../tools/package-management/poetry { };
 
+  poetryPlugins = recurseIntoAttrs poetry.plugins;
+
   poetry2nix = callPackage ../development/tools/poetry2nix/poetry2nix {
     inherit pkgs lib;
   };


### PR DESCRIPTION
###### Description of changes
All of these should now work:
```bash
nix-build -A poetry
nix-build -A poetry.plugins.poetry-plugin-up
nix-build -E "with import ./. { }; poetry.withPlugins (ps: with ps; [ poetry-plugin-up ])"
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
closes https://github.com/NixOS/nixpkgs/pull/211231