### PR TITLE
ocamlPackages.dune_3: enable for OCaml < 4.08

### DIFF
--- a/pkgs/development/ocaml-modules/checkseum/default.nix
+++ b/pkgs/development/ocaml-modules/checkseum/default.nix
@@ -10,10 +10,11 @@ buildDunePackage rec {
   pname = "checkseum";
 
   minimalOCamlVersion = "4.07";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/checkseum/releases/download/v${version}/checkseum-${version}.tbz";
-    sha256 = "sha256-K6QPMts5+hxH2a+WQ1N0lwMBoshG2T0bSozNgzRvAlo=";
+    hash = "sha256-K6QPMts5+hxH2a+WQ1N0lwMBoshG2T0bSozNgzRvAlo=";
   };
 
   buildInputs = [ dune-configurator ];

--- a/pkgs/development/ocaml-modules/chrome-trace/default.nix
+++ b/pkgs/development/ocaml-modules/chrome-trace/default.nix
@@ -4,6 +4,7 @@ buildDunePackage rec {
   pname = "chrome-trace";
   inherit (dune_3) src version;
 
+  minimalOCamlVersion = "4.08";
   duneVersion = "3";
 
   dontAddPrefix = true;

--- a/pkgs/development/ocaml-modules/ordering/default.nix
+++ b/pkgs/development/ocaml-modules/ordering/default.nix
@@ -4,6 +4,7 @@ buildDunePackage {
   pname = "ordering";
   inherit (dune_3) version src;
   duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   dontAddPrefix = true;
 

--- a/pkgs/development/ocaml-modules/xdg/default.nix
+++ b/pkgs/development/ocaml-modules/xdg/default.nix
@@ -5,6 +5,7 @@ buildDunePackage rec {
   inherit (dune_3) src version;
 
   duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   dontAddPrefix = true;
 

--- a/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/compiler.nix
@@ -7,6 +7,7 @@ buildDunePackage rec {
   pname = "js_of_ocaml-compiler";
   version = "4.1.0";
   duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -357,7 +357,12 @@ let
       then pkgs.dune_2
       else throw "dune_2 is not available for OCaml ${ocaml.version}";
 
-    dune_3 = callPackage ../development/tools/ocaml/dune/3.nix { };
+    dune_3 =
+      if lib.versionAtLeast ocaml.version "4.08"
+      then callPackage ../development/tools/ocaml/dune/3.nix { }
+      else if lib.versionAtLeast ocaml.version "4.02"
+      then pkgs.dune_3
+      else throw "dune_3 is not available for OCaml ${ocaml.version}";
 
     dune-action-plugin = callPackage ../development/ocaml-modules/dune-action-plugin { };
 


### PR DESCRIPTION
###### Description of changes

This allows building with Dune 3 some OCaml libraries that are also available for older versions of OCaml, as exemplified by the second commit.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
