### PR TITLE
swift: 5.7 -> 5.7.3

### DIFF
--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -427,15 +427,20 @@ in stdenv.mkDerivation {
     #   builds, so we enable it as well. On Darwin, we have to use the system
     #   Swift libs because of ABI-stability, but this may be trouble if the
     #   builder is an older macOS.
-    # - Experimental features are OFF by default in CMake, but some are
-    #   required to build the stdlib.
+    # - Experimental features are OFF by default in CMake, but are enabled in
+    #   official builds, so we do the same. (Concurrency is also required in
+    #   the stdlib. StringProcessing is often implicitely imported, causing
+    #   lots of warnings if missing.)
     # - SWIFT_STDLIB_ENABLE_OBJC_INTEROP is set explicitely because its check
     #   is buggy. (Uses SWIFT_HOST_VARIANT_SDK before initialized.)
     #   Fixed in: https://github.com/apple/swift/commit/84083afef1de5931904d5c815d53856cdb3fb232
     cmakeFlags="
       -GNinja
       -DBOOTSTRAPPING_MODE=BOOTSTRAPPING${lib.optionalString stdenv.isDarwin "-WITH-HOSTLIBS"}
+      -DSWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=ON
       -DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=ON
+      -DSWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=ON
+      -DSWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=ON
       -DLLVM_DIR=$SWIFT_BUILD_ROOT/llvm/lib/cmake/llvm
       -DClang_DIR=$SWIFT_BUILD_ROOT/llvm/lib/cmake/clang
       -DSWIFT_PATH_TO_CMARK_SOURCE=$SWIFT_SOURCE_ROOT/swift-cmark

--- a/pkgs/development/compilers/swift/sourcekit-lsp/generated/default.nix
+++ b/pkgs/development/compilers/swift/sourcekit-lsp/generated/default.nix
@@ -2,15 +2,15 @@
 {
   workspaceStateFile = ./workspace-state.json;
   hashes = {
-    "indexstore-db" = "005vvkrncgpryzrn0hzgsapflpyga0n7152b2b565wislpx90cwl";
+    "indexstore-db" = "05d7l3fgcvbw8plaky3pgjm03x20a63z9r14njxg5qm2zcp5m6jx";
     "swift-argument-parser" = "1jph9w7lk9nr20fsv2c8p4hisx3dda817fh7pybd0r0j1jwa9nmw";
-    "swift-collections" = "0l0pv16zil3n7fac7mdf5qxklxr5rwiig5bixgca1ybq7arlnv7i";
+    "swift-collections" = "1k6sjx5rqmp3gklny77b480hyzy6gkhpi23r0s8ljfbrcwawgnan";
     "swift-crypto" = "020b8q4ss2k7a65r5dgh59z40i6sn7ij1allxkh8c8a9d0jzn313";
-    "swift-driver" = "0nblvs47kh2hl1l70rmrbablx4m5i27w8l3dfrv2h7zccqr8jl0a";
-    "swift-llbuild" = "1bvqbj8ji72ilh3ah2mw411jwzbbjxjyasa6sg4b8da0kqia4021";
-    "swift-package-manager" = "16qvk14f1l0hf5bphx6qk51nn9d36a2iw5v3sgkvmqi8h7l4kqg5";
+    "swift-driver" = "1lcb5wqragc74nd0fjnk47lyph9hs0i9cps1mplvp2i91yzjqk05";
+    "swift-llbuild" = "07zbp2dyfqd1bnyg7snpr9brn40jf22ivly5v10mql3hrg76a18h";
+    "swift-package-manager" = "0a3vahdkj35n0dkinwcgybgfb9dnq2lq1nknn874r38xbj3mhlff";
     "swift-system" = "0402hkx2q2dv27gccnn8ma79ngvwiwzkhcv4zlcdldmy6cgi0px7";
-    "swift-tools-support-core" = "1ryd5iyx5mfv8bhyq3bf08z7nv886chzzqnmwaj16r2cry9yml7c";
-    "Yams" = "11abhcfkmqm3cmh7vp7rqzvxd1zj02j2866a2pp6v9m89456xb76";
+    "swift-tools-support-core" = "134f9x44jnzdy8cwi6hs372dwbyqvr4qmsjzjy25wzpyv6m9rhrz";
+    "Yams" = "1893y13sis2aimi1a5kgkczbf06z4yig054xb565yg2xm13srb45";
   };
 }

--- a/pkgs/development/compilers/swift/sourcekit-lsp/generated/workspace-state.json
+++ b/pkgs/development/compilers/swift/sourcekit-lsp/generated/workspace-state.json
@@ -12,8 +12,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "main",
-            "revision": "2ff1c0491248cd958a2ac05da9aa613eb27a8eeb"
+            "branch": "release/5.7",
+            "revision": "9305648b0a8700434fa2e55eeacf7c7f4402a0d5"
           },
           "name": "sourceControlCheckout"
         },
@@ -46,8 +46,8 @@
         },
         "state": {
           "checkoutState": {
-            "revision": "f504716c27d2e5d4144fa4794b12129301d17729",
-            "version": "1.0.3"
+            "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+            "version": "1.0.4"
           },
           "name": "sourceControlCheckout"
         },
@@ -80,8 +80,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "main",
-            "revision": "6c71f58f89d65eb79f1f6b32a707ddc39cec5ad6"
+            "branch": "release/5.7",
+            "revision": "82b274af66cfbb8f3131677676517b34d01e30fd"
           },
           "name": "sourceControlCheckout"
         },
@@ -97,8 +97,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "main",
-            "revision": "d99c31577c60a247b065d29289a44fbdd141e2be"
+            "branch": "release/5.7",
+            "revision": "564424db5fdb62dcb5d863bdf7212500ef03a87b"
           },
           "name": "sourceControlCheckout"
         },
@@ -114,8 +114,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "main",
-            "revision": "f04ad469a6053d713c2fb854fbeb27ee3e6c9dee"
+            "branch": "release/5.7",
+            "revision": "c6e40adbfc78acc60ca464ae482b56442f9f34f4"
           },
           "name": "sourceControlCheckout"
         },
@@ -148,8 +148,8 @@
         },
         "state": {
           "checkoutState": {
-            "branch": "main",
-            "revision": "0220fc394f2ae820eeacd754fb2c7ce211e9979e"
+            "branch": "release/5.7",
+            "revision": "286b48b1d73388e1d49b2bb33aabf995838104e3"
           },
           "name": "sourceControlCheckout"
         },
@@ -165,8 +165,8 @@
         },
         "state": {
           "checkoutState": {
-            "revision": "01835dc202670b5bb90d07f3eae41867e9ed29f6",
-            "version": "5.0.1"
+            "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+            "version": "4.0.6"
           },
           "name": "sourceControlCheckout"
         },

--- a/pkgs/development/compilers/swift/sources.nix
+++ b/pkgs/development/compilers/swift/sources.nix
@@ -5,20 +5,20 @@ let
   # These packages are all part of the Swift toolchain, and have a single
   # upstream version that should match. We also list the hashes here so a basic
   # version upgrade touches only this file.
-  version = "5.7";
+  version = "5.7.3";
   hashes = {
-    llvm-project = "sha256-uW6dEAFaDOlHXnq8lFYxrKNLRPEukauZJxX4UCpWpIY=";
-    sourcekit-lsp = "sha256-uA3a+kAqI+XFzkDFEJ8XuRTgfYqacEuTsOU289Im+0Y=";
-    swift = "sha256-n8WVQYinAyIj4wmQnDhvPsH+t8ydANkGbjFJ6blfHOY=";
+    llvm-project = "sha256-IDtLPe0sXamnmovbFVKvmDMnci4u/A0urAPjWTYwJCo=";
+    sourcekit-lsp = "sha256-BT6+VCBSupKOg2mXo6HlkvNRc8pVZU772Mj3LKFamsU=";
+    swift = "sha256-essP2eIp1sLuROqk0OKGBPfJnvnyAW0moMk0cX1IVQQ=";
     swift-cmark = "sha256-f0BoTs4HYdx/aJ9HIGCWMalhl8PvClWD6R4QK3qSgAw=";
-    swift-corelibs-foundation = "sha256-6XUSC6759dcG24YapWicjRzUnmVVe0QPSsLEw4sQNjI=";
+    swift-corelibs-foundation = "sha256-g78zKSq/b/pVFAD2k2SoMpzJQIpkxMvZOaSz5JPaQmA=";
     swift-corelibs-libdispatch = "sha256-1qbXiC1k9+T+L6liqXKg6EZXqem6KEEx8OctuL4Kb2o=";
     swift-corelibs-xctest = "sha256-qLUO9/3tkJWorDMEHgHd8VC3ovLLq/UWXJWMtb6CMN0=";
     swift-docc = "sha256-WlXJMAnrlVPCM+iCIhG0Gyho76BsC2yVBEpX3m/WiIQ=";
     swift-docc-render-artifact = "sha256-ttdurN/K7OX+I4577jG3YGeRs+GLUTc7BiiEZGmFD+s=";
-    swift-driver = "sha256-sk7XWXYR1MGPEeVxA6eA/vxhN6Gq16iD1RHpVstL3zE=";
-    swift-experimental-string-processing = "sha256-Ar9fQWi8bYSvGErrS0SWrxIxwEwCjsYIZcWweZ8bV28=";
-    swift-package-manager = "sha256-MZah+/XfeK46YamxwuE3Kiv+u5bj7VmjEh6ztDF+0j4=";
+    swift-driver = "sha256-BUwsvw8pirvprUFfliLQMMHr6SHTSgeaJYc9lTEvi9E=";
+    swift-experimental-string-processing = "sha256-W0cQBkdR3A0hrV75Wwm0YULUDVg1bjT0O5w5VGBYDJs=";
+    swift-package-manager = "sha256-zlFYh1wdjUwOsnbagKnAtqXl3vKPcRtnA7YMORtUeyg=";
   };
 
   # Create fetch derivations.

--- a/pkgs/development/compilers/swift/swift-driver/generated/default.nix
+++ b/pkgs/development/compilers/swift/swift-driver/generated/default.nix
@@ -5,7 +5,7 @@
     "swift-argument-parser" = "11did5snqj8chcbdbiyx84mpif940ls2pr1iikwivvfp63i248hm";
     "swift-llbuild" = "07zbp2dyfqd1bnyg7snpr9brn40jf22ivly5v10mql3hrg76a18h";
     "swift-system" = "0402hkx2q2dv27gccnn8ma79ngvwiwzkhcv4zlcdldmy6cgi0px7";
-    "swift-tools-support-core" = "1vabl1z5sm2lrd75f5c781rkrq0liinpjvnrjr6i6r8cqrp0q5jb";
+    "swift-tools-support-core" = "134f9x44jnzdy8cwi6hs372dwbyqvr4qmsjzjy25wzpyv6m9rhrz";
     "Yams" = "1893y13sis2aimi1a5kgkczbf06z4yig054xb565yg2xm13srb45";
   };
 }

--- a/pkgs/development/compilers/swift/swift-driver/generated/workspace-state.json
+++ b/pkgs/development/compilers/swift/swift-driver/generated/workspace-state.json
@@ -64,7 +64,7 @@
         "state": {
           "checkoutState": {
             "branch": "release/5.7",
-            "revision": "afc0938503bac012f76ceb619d031f63edc4c5f7"
+            "revision": "286b48b1d73388e1d49b2bb33aabf995838104e3"
           },
           "name": "sourceControlCheckout"
         },

--- a/pkgs/development/compilers/swift/swiftpm/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm/default.nix
@@ -38,6 +38,7 @@ let
     propagatedBuildInputs = [ Foundation ];
     patches = [
       ./patches/cmake-disable-rpath.patch
+      ./patches/disable-index-store.patch
       ./patches/disable-sandbox.patch
       ./patches/fix-clang-cxx.patch
       (substituteAll {

--- a/pkgs/development/compilers/swift/swiftpm/generated/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm/generated/default.nix
@@ -3,12 +3,12 @@
   workspaceStateFile = ./workspace-state.json;
   hashes = {
     "swift-argument-parser" = "1jph9w7lk9nr20fsv2c8p4hisx3dda817fh7pybd0r0j1jwa9nmw";
-    "swift-collections" = "0l0pv16zil3n7fac7mdf5qxklxr5rwiig5bixgca1ybq7arlnv7i";
+    "swift-collections" = "1k6sjx5rqmp3gklny77b480hyzy6gkhpi23r0s8ljfbrcwawgnan";
     "swift-crypto" = "020b8q4ss2k7a65r5dgh59z40i6sn7ij1allxkh8c8a9d0jzn313";
     "swift-driver" = "1lcb5wqragc74nd0fjnk47lyph9hs0i9cps1mplvp2i91yzjqk05";
     "swift-llbuild" = "07zbp2dyfqd1bnyg7snpr9brn40jf22ivly5v10mql3hrg76a18h";
     "swift-system" = "0402hkx2q2dv27gccnn8ma79ngvwiwzkhcv4zlcdldmy6cgi0px7";
-    "swift-tools-support-core" = "1vabl1z5sm2lrd75f5c781rkrq0liinpjvnrjr6i6r8cqrp0q5jb";
+    "swift-tools-support-core" = "134f9x44jnzdy8cwi6hs372dwbyqvr4qmsjzjy25wzpyv6m9rhrz";
     "Yams" = "1893y13sis2aimi1a5kgkczbf06z4yig054xb565yg2xm13srb45";
   };
 }

--- a/pkgs/development/compilers/swift/swiftpm/generated/workspace-state.json
+++ b/pkgs/development/compilers/swift/swiftpm/generated/workspace-state.json
@@ -29,8 +29,8 @@
         },
         "state": {
           "checkoutState": {
-            "revision": "f504716c27d2e5d4144fa4794b12129301d17729",
-            "version": "1.0.3"
+            "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+            "version": "1.0.4"
           },
           "name": "sourceControlCheckout"
         },
@@ -115,7 +115,7 @@
         "state": {
           "checkoutState": {
             "branch": "release/5.7",
-            "revision": "afc0938503bac012f76ceb619d031f63edc4c5f7"
+            "revision": "286b48b1d73388e1d49b2bb33aabf995838104e3"
           },
           "name": "sourceControlCheckout"
         },

--- a/pkgs/development/compilers/swift/swiftpm/patches/disable-index-store.patch
+++ b/pkgs/development/compilers/swift/swiftpm/patches/disable-index-store.patch
@@ -1,0 +1,23 @@
+The `-index-store-path` option is an Apple extension not available in our
+Clang. Make it opt-in by default.
+
+(It is assumed the `target.type == test` check is for Xcode support, because
+there is no evidence of it in swift-corelibs-xctest.)
+
+--- a/Sources/Build/BuildPlan.swift
++++ b/Sources/Build/BuildPlan.swift
+@@ -103,14 +103,7 @@ extension BuildParameters {
+         case .off:
+             addIndexStoreArguments = false
+         case .auto:
+-            if configuration == .debug {
+-                addIndexStoreArguments = true
+-            } else if target.type == .test {
+-                // Test discovery requires an index store for the test target to discover the tests
+-                addIndexStoreArguments = true
+-            } else {
+                 addIndexStoreArguments = false
+-            }
+         }
+ 
+         if addIndexStoreArguments {


### PR DESCRIPTION
###### Description of changes

Two extra changes here besides the version upgrade:

- It looks like upstream has changed the logic when StringProcessing is implicitely included, and it's now more aggressive, causing more warnings. We now match upstream in what `SWIFT_EXPERIMENTAL_*` flags we enable, and this includes enabling StringProcessing.
- We discovered in https://github.com/cachix/devenv/pull/312 that SwiftPM debug builds were failing, because it builds an index by default (as opposed to release builds, which we do in packaging). This is an Apple extension to Clang we don't support in our Clang builds, so a patch was added to change it to opt-in.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
