### PR TITLE
rpcemu: init at 0.9.4

### DIFF
--- a/pkgs/applications/emulators/rpcemu/default.nix
+++ b/pkgs/applications/emulators/rpcemu/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, fetchhg
+, qt5
+}:
+
+let
+  inherit (qt5) qtbase qtmultimedia wrapQtAppsHook;
+in
+stdenv.mkDerivation (self: {
+  pname = "rpcemu";
+  version = "0.9.4";
+
+  src = fetchhg {
+    url = "http://www.home.marutan.net/hg/rpcemu";
+    rev = "release_${self.version}";
+    sha256 = "sha256-UyjfTfUpSvJNFPkQWPKppxp/kO0hVGo5cE9RuCU8GJI=";
+  };
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+    qtmultimedia
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cd src/qt5
+    qmake
+
+    runHook postConfigure
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cd ../..
+    install -Dm755 rpcemu-interpreter -t $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://www.marutan.net/rpcemu/index.php";
+    description = "Risc PC Emulator";
+    longDescription = ''
+      RPCEmu is an emulator of classic Acorn computer systems, such as the Risc
+      PC and A7000. It runs on multiple platforms including Windows, Linux and
+      Mac OS X.
+
+      RPCEmu should be considered Alpha Quality code. It has many known and
+      unknown bugs, and all files used with it should be well backed up before
+      using them with RPCEmu.
+    '';
+    license = lib.licenses.gpl2Plus;
+    maintainers =  builtins.attrValues {
+      inherit (lib.maintainers) AndersonTorres;
+    };
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2164,6 +2164,8 @@ with pkgs;
 
   ripes = libsForQt5.callPackage ../applications/emulators/ripes { };
 
+  rpcemu = callPackage ../applications/emulators/rpcemu { };
+
   rpcs3 = libsForQt5.callPackage ../applications/emulators/rpcs3 { };
 
   ruffle = callPackage ../applications/emulators/ruffle { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Closes #212790 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
