### PR TITLE
unison: 2.52.1 -> 2.53.0

### DIFF
--- a/pkgs/applications/networking/sync/unison/default.nix
+++ b/pkgs/applications/networking/sync/unison/default.nix
@@ -2,42 +2,45 @@
 , stdenv
 , fetchFromGitHub
 , ocamlPackages
-, fontschumachermisc
-, xset
-, makeWrapper
 , ncurses
-, gnugrep
 , copyDesktopItems
 , makeDesktopItem
+, wrapGAppsHook
+, glib
+, gsettings-desktop-schemas
+, zlib
 , enableX11 ? true
+, Cocoa
 }:
 
 stdenv.mkDerivation rec {
   pname = "unison";
-  version = "2.52.1";
+  version = "2.53.0";
 
   src = fetchFromGitHub {
     owner = "bcpierce00";
     repo = "unison";
     rev = "v${version}";
-    sha256 = "sha256-taA8eZ/wOe9uMccXVYfe34/XzWgqYKA3tLZnIOahOrQ=";
+    sha256 = "sha256-4Lyn1UecpVIhoEXIFu35XK4aoAfYGPCZ9L4ZY7224yo=";
   };
 
   strictDeps = true;
 
-  nativeBuildInputs = [ makeWrapper ocamlPackages.ocaml ]
+  nativeBuildInputs = [ glib wrapGAppsHook ocamlPackages.ocaml ]
     ++ lib.optional enableX11 copyDesktopItems;
-  buildInputs = [ ncurses ];
+  buildInputs = [ gsettings-desktop-schemas ncurses zlib ]
+    ++ lib.optional stdenv.isDarwin Cocoa;
 
   preBuild = lib.optionalString enableX11 ''
-    sed -i "s|\(OCAMLOPT=.*\)$|\1 -I $(echo "${ocamlPackages.lablgtk}"/lib/ocaml/*/site-lib/lablgtk2)|" src/Makefile.OCaml
+    sed -i "s|\(OCAMLOPT=.*\)$|\1 -I $(echo "${ocamlPackages.lablgtk3}"/lib/ocaml/*/site-lib/lablgtk3)|" src/Makefile.OCaml
+    sed -i "s|\(OCAMLOPT=.*\)$|\1 -I $(echo "${ocamlPackages.cairo2}"/lib/ocaml/*/site-lib/cairo2)|" src/Makefile.OCaml
   '' + ''
     echo -e '\ninstall:\n\tcp $(FSMONITOR)$(EXEC_EXT) $(INSTALLDIR)' >> src/fsmonitor/linux/Makefile
   '';
 
   makeFlags = [
     "INSTALLDIR=$(out)/bin/"
-    "UISTYLE=${if enableX11 then "gtk2" else "text"}"
+    "UISTYLE=${if enableX11 then "gtk3" else "text"}"
   ] ++ lib.optional (!ocamlPackages.ocaml.nativeCompilers) "NATIVE=false";
 
   preInstall = ''
@@ -45,11 +48,6 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = lib.optionalString enableX11 ''
-    for i in $(cd $out/bin && ls); do
-      wrapProgram $out/bin/$i \
-        --run "[ -n \"\$DISPLAY\" ] && (${xset}/bin/xset q | ${gnugrep}/bin/grep -q \"${fontschumachermisc}\" || ${xset}/bin/xset +fp \"${fontschumachermisc}/lib/X11/fonts/misc\")"
-    done
-
     install -D $src/icons/U.svg $out/share/icons/hicolor/scalable/apps/unison.svg
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33619,6 +33619,7 @@ with pkgs;
 
   unison = callPackage ../applications/networking/sync/unison {
     enableX11 = config.unison.enableX11 or true;
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
   unpaper = callPackage ../tools/graphics/unpaper { };


### PR DESCRIPTION
besides updating the version/src sha, upstream switched to GTK3, as can be seen in the release notes [0]. This apparently requires the ocaml cairo2 bindings an zlib. I also used wrapGAppsHook to supply the schemas from gsettings-desktop-schemas. Screenshot: https://i.imgur.com/CrPvLgQ.png I can not test the Icon creation since I am not using a desktop, @viric please check. Maybe this is also done by wrapGAppsHook..

[0] https://github.com/bcpierce00/unison/releases/tag/v2.53.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
