### PR TITLE
python3Packages.fiona: 1.8.22 -> 1.9.0

### DIFF
--- a/pkgs/development/python-modules/fiona/default.nix
+++ b/pkgs/development/python-modules/fiona/default.nix
@@ -1,31 +1,23 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, isPy3k, pythonOlder
+{ stdenv, lib, buildPythonPackage, fetchPypi, isPy3k, pythonOlder, cython
 , attrs, click, cligj, click-plugins, six, munch, enum34
 , pytestCheckHook, boto3, mock, giflib, pytz
 , gdal, certifi
-, fetchpatch
 }:
 
 buildPythonPackage rec {
   pname = "fiona";
-  version = "1.8.22";
+  version = "1.9.0";
 
   src = fetchPypi {
     pname = "Fiona";
     inherit version;
-    sha256 = "sha256-qCqZzps+eCV0AVfEXJ+yJZ1OkvCohqqsJfDbQP/h7qM=";
+    hash = "sha256-bkh8v7pahJ+98G5FFp/X4fFmL0Tz1xerS5RgRrJFfq4=";
   };
-
-  patches = [
-    # https://github.com/Toblerity/Fiona/pull/1122
-    (fetchpatch {
-      url = "https://github.com/Toblerity/Fiona/commit/fa632130dcd9dfbb982ecaa4911b3fab3459168f.patch";
-      hash = "sha256-IuNHr3yBqS1jY9Swvcq8XPv6BpVlInDx0FVuzEMaYTY=";
-    })
-  ];
 
   CXXFLAGS = lib.optionalString stdenv.cc.isClang "-std=c++11";
 
   nativeBuildInputs = [
+    cython
     gdal # for gdal-config
   ];
 
@@ -61,6 +53,8 @@ buildPythonPackage rec {
     # https://github.com/Toblerity/Fiona/issues/1164
     "test_no_append_driver_cannot_append"
   ];
+
+  pythonImportsCheck = [ "fiona" ];
 
   meta = with lib; {
     description = "OGR's neat, nimble, no-nonsense API for Python";


### PR DESCRIPTION
###### Description of changes

* update package to version 1.9.0
* drop patch which is applied by upstream
* add pythonImportsCheck
* add cython to nativeBuildInputs, otherwise build fails on
```
building
Executing setuptoolsBuildPhase
Cython.Build.cythonize not found. Cython is required to build fiona.
/nix/store/3yfs41f4b60jya2gk6xikx4s97zsxjr0-stdenv-linux/setup: line 1573: pop_var_context: head of shell_variables not a function context
error: builder for '/nix/store/wkccm704smp8ghbisxnpxfyf039i81q1-python3.10-fiona-1.9.0.drv' failed with exit code 1;
       last 10 log lines:
       > unpacking source archive /nix/store/3hll76zy3kjnsymwv1qxcf5jsqjmk1xh-Fiona-1.9.0.tar.gz
       > source root is Fiona-1.9.0
       > setting SOURCE_DATE_EPOCH to timestamp 1675092257 of file Fiona-1.9.0/setup.cfg
       > patching sources
       > configuring
       > no configure script, doing nothing
       > building
       > Executing setuptoolsBuildPhase
       > Cython.Build.cythonize not found. Cython is required to build fiona.
       > /nix/store/3yfs41f4b60jya2gk6xikx4s97zsxjr0-stdenv-linux/setup: line 1573: pop_var_context: head of shell_variables not a function context
```


List of changes: https://github.com/Toblerity/Fiona/releases/tag/1.9.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
