### PR TITLE
python3Packages.glean-sdk: 51.2.0 -> 52.2.0

### DIFF
--- a/pkgs/development/python-modules/glean-sdk/default.nix
+++ b/pkgs/development/python-modules/glean-sdk/default.nix
@@ -17,19 +17,19 @@
 
 buildPythonPackage rec {
   pname = "glean-sdk";
-  version = "51.2.0";
+  version = "52.2.0";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-4EXCYthMabdmxWYltcnO0UTNeAYXwXQeRfwxt1WD3Ug=";
+    hash = "sha256-iW432YtZtRGUWia33Lsnu+aQuedhBJdh8dZ30FPg6Vk=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-qOGoonutuIY+0UVaVSVVt0NbqEICdNs3qHWG0Epmkl0=";
+    hash = "sha256-/7qKIQglNKGveKFtPeqd35Mq2hH/20BGTgDBgip4PnI=";
   };
 
   nativeBuildInputs = [
@@ -56,11 +56,6 @@ buildPythonPackage rec {
     "test_client_activity_api"
   ];
 
-  postPatch = ''
-    substituteInPlace glean-core/python/setup.py \
-      --replace "glean_parser==5.0.1" "glean_parser>=5.0.1"
-  '';
-
   pythonImportsCheck = [
     "glean"
   ];
@@ -70,6 +65,6 @@ buildPythonPackage rec {
     description = "Telemetry client libraries and are a part of the Glean project";
     homepage = "https://mozilla.github.io/glean/book/index.html";
     license = licenses.mpl20;
-    maintainers = [];
+    maintainers = with maintainers; [ melling ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Update to 52.2.0, add self as maintainer.

This requires an upgrade to `python3Packages.glean-parser` which is open at #212894, both will fail until this PR or that one is merged.

nixpkgs-review on just this change:

<details>
  <summary>3 packages failed to build:</summary>
  <ul>
    <li>mozphab</li>
    <li>python310Packages.glean-sdk</li>
    <li>python311Packages.glean-sdk</li>
  </ul>
</details>

nixpkgs-review on top of the above PR:

<details>
  <summary>6 packages built:</summary>
  <ul>
    <li>mozillavpn</li>
    <li>mozphab</li>
    <li>python310Packages.glean-parser</li>
    <li>python310Packages.glean-sdk</li>
    <li>python311Packages.glean-parser</li>
    <li>python311Packages.glean-sdk</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
