### PR TITLE
pjsip: add pythonSupport option

### DIFF
--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -54,6 +54,8 @@ stdenv.mkDerivation rec {
   outputs = [ "out" ]
     ++ lib.optional pythonSupport "py";
 
+  configureFlags = [ "--enable-shared" ];
+
   postInstall = ''
     mkdir -p $out/bin
     cp pjsip-apps/bin/pjsua-* $out/bin/pjsua

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -4,8 +4,11 @@
 , fetchpatch
 , openssl
 , libsamplerate
+, swig
 , alsa-lib
 , AppKit
+, python3
+, pythonSupport ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -33,6 +36,9 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  nativeBuildInputs =
+    lib.optionals pythonSupport [ swig python3 ];
+
   buildInputs = [ openssl libsamplerate ]
     ++ lib.optional stdenv.isLinux alsa-lib
     ++ lib.optional stdenv.isDarwin AppKit;
@@ -41,11 +47,22 @@ stdenv.mkDerivation rec {
     export LD=$CC
   '';
 
+  postBuild = lib.optionalString pythonSupport ''
+    make -C pjsip-apps/src/swig/python
+  '';
+
+  outputs = [ "out" ]
+    ++ lib.optional pythonSupport "py";
+
   postInstall = ''
     mkdir -p $out/bin
     cp pjsip-apps/bin/pjsua-* $out/bin/pjsua
     mkdir -p $out/share/${pname}-${version}/samples
     cp pjsip-apps/bin/samples/*/* $out/share/${pname}-${version}/samples
+  '' + lib.optionalString pythonSupport ''
+    (cd pjsip-apps/src/swig/python && \
+      python setup.py install --prefix=$py
+    )
   '';
 
   # We need the libgcc_s.so.1 loadable (for pthread_cancel to work)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7174,6 +7174,11 @@ self: super: with self; {
 
   pixelmatch = callPackage ../development/python-modules/pixelmatch { };
 
+  pjsua2 = (toPythonModule (pkgs.pjsip.override {
+    pythonSupport = true;
+    python3 = self.python;
+  })).py;
+
   pkce = callPackage ../development/python-modules/pkce { };
 
   pkgconfig = callPackage ../development/python-modules/pkgconfig { };


### PR DESCRIPTION
###### Description of changes

Currently the pjsip package doesn't expose Python bindings to use the pjsua2 module. This PR attempts to add this when pythonSupport is enabled. The resulting package has site-packages available:

```console
$ ls -1 result/lib/python3.10/site-packages/
pjsua2-2.13-py3.10.egg-info
_pjsua2.cpython-310-x86_64-linux-gnu.so
pjsua2.py
__pycache__
```

I could import pjsua in python:

```
$ PYTHONPATH=/nix/store/73cf30ypmhy4dp8k8qp4z53giwqfz6cq-pjsip-2.13/lib/python3.10/site-packages nix run .#python3
Python 3.10.9 (main, Dec  6 2022, 18:44:57) [GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pjsua2
>>> 
```

Note that I enabled `pythonSupport` by default, but I don't know what the policy is for such options.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
