### PR TITLE
pulumiPackages.pulumi-language-go: init at 3.53.1

### DIFF
--- a/pkgs/tools/admin/pulumi-packages/default.nix
+++ b/pkgs/tools/admin/pulumi-packages/default.nix
@@ -7,6 +7,7 @@ in
   pulumi-aws-native = callPackage' ./pulumi-aws-native.nix { };
   pulumi-azure-native = callPackage' ./pulumi-azure-native.nix { };
   pulumi-command = callPackage' ./pulumi-command.nix { };
+  pulumi-language-go = callPackage ./pulumi-language-go.nix { };
   pulumi-language-nodejs = callPackage ./pulumi-language-nodejs.nix { };
   pulumi-language-python = callPackage ./pulumi-language-python.nix { };
   pulumi-random = callPackage' ./pulumi-random.nix { };

--- a/pkgs/tools/admin/pulumi-packages/pulumi-language-go.nix
+++ b/pkgs/tools/admin/pulumi-packages/pulumi-language-go.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildGoModule
+, pulumi
+}:
+buildGoModule rec {
+  pname = "pulumi-language-go";
+  inherit (pulumi) version src;
+
+  sourceRoot = "${src.name}/sdk";
+
+  vendorHash = pulumi.sdkVendorHash;
+
+  subPackages = [
+    "go/pulumi-language-go"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${version}"
+  ];
+  meta = with lib; {
+    description = "Golang language host plugin for Pulumi";
+    homepage = "https://github.com/pulumi/pulumi/tree/master/sdk/go";
+    license = licenses.asl20;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Added new package `pulumiPackages.pulumi-language-go`, built and used successfully on my nixos, and on aws ec2 server with Amazon Linux 2 + nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
