### PR TITLE
oxigraph: init at 0.3.11

### DIFF
--- a/pkgs/servers/oxigraph/default.nix
+++ b/pkgs/servers/oxigraph/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, IOKit
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "oxigraph";
+  version = "0.3.11";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-7KbDZKKJPk3QTp4siIbdB6xKbslw73Lhc7NoeOuA0Og=";
+    fetchSubmodules = true;
+  };
+
+  cargoSha256 = "sha256-Yqn6hwejg6LzcqW0MiUN3tqrOql6cpu/5plaOz+2/ns=";
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+  ];
+  buildInputs = lib.optionals stdenv.isDarwin [ IOKit Security ];
+
+  cargoBuildFlags = [ "--package" "oxigraph_server" ];
+
+  # requires packaging of the associated python modules
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/oxigraph/oxigraph";
+    description = "SPARQL graph database";
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+    maintainers = with maintainers; [ astro ];
+    license = with licenses; [ asl20 mit ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9301,6 +9301,10 @@ with pkgs;
 
   ox = callPackage ../applications/editors/ox { };
 
+  oxigraph = callPackage ../servers/oxigraph {
+    inherit (darwin.apple_sdk.frameworks) IOKit Security;
+  };
+
   file-rename = callPackage ../tools/filesystems/file-rename { };
 
   kcollectd = libsForQt5.callPackage ../tools/misc/kcollectd {};


### PR DESCRIPTION
###### Description of changes

There are associated Python libraries to be packaged in the future. Yet the server is usable on its own through HTTP APIs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
