### PR TITLE
openmpi: fix for newer libfabric

### DIFF
--- a/pkgs/development/libraries/libfabric/default.nix
+++ b/pkgs/development/libraries/libfabric/default.nix
@@ -1,9 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, autoreconfHook, libpsm2
-, enablePsm2 ? (stdenv.isx86_64 && stdenv.isLinux) }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, autoreconfHook
+, enablePsm2 ? (stdenv.isx86_64 && stdenv.isLinux)
+, libpsm2
+, enableOpx ? (stdenv.isx86_64 && stdenv.isLinux)
+, libuuid
+, numactl
+}:
 
 stdenv.mkDerivation rec {
   pname = "libfabric";
-  version = "1.15.1";
+  version = "1.17.0";
 
   enableParallelBuilding = true;
 
@@ -11,14 +20,17 @@ stdenv.mkDerivation rec {
     owner = "ofiwg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-uL3L9k9yqdZXQmR1zi8OEIGLAZ8cf7EBnlDhetaMA08=";
+    sha256 = "sha256-tXfAn8hkasA2UuA4/8dOE3EcORyJo/A33TtSNdzDXD8=";
   };
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];
 
-  buildInputs = lib.optional enablePsm2 libpsm2;
+  buildInputs = lib.optionals enableOpx [ libuuid numactl ] ++ lib.optional enablePsm2 [ libpsm2 ];
 
-  configureFlags = [ (if enablePsm2 then "--enable-psm2=${libpsm2}" else "--disable-psm2") ];
+  configureFlags = [
+    (if enablePsm2 then "--enable-psm2=${libpsm2}" else "--disable-psm2")
+    (if enableOpx then "--enable-opx" else "--disable-opx")
+  ];
 
   meta = with lib; {
     homepage = "https://ofiwg.github.io/libfabric/";

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, gfortran, perl, libnl
+{ lib, stdenv, fetchurl, fetchpatch, gfortran, perl, libnl
 , rdma-core, zlib, numactl, libevent, hwloc, targetPackages, symlinkJoin
 , libpsm2, libfabric, pmix, ucx
 
@@ -31,6 +31,14 @@ in stdenv.mkDerivation rec {
     url = "https://www.open-mpi.org/software/ompi/v${major version}.${minor version}/downloads/${pname}-${version}.tar.bz2";
     sha256 = "03ckngrff1cl0l81vfvrfhp99rbgk7s0633kr1l468yibwbjx4cj";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "RDMA-osc-perform-CAS-in-shared-memory-if-possible.patch";
+      url = "https://github.com/open-mpi/ompi/pull/10513/commits/0512c135a77a0278e5288e0e119dce24c95ebed4.patch";
+      sha256 = "sha256-K1Gc+hBUkTPY1WqLP6JWo623EUhkoL4ONrqPVDNfFuE=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs ./


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This applies a fix for OpenMPI to work with newer libfabric which will be part of the next OpenMPI release version.
Also the PR to revert the libfabric update is reverted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
