### PR TITLE
ripunzip: init at 1.1.0

### DIFF
--- a/pkgs/by-name/ri/ripunzip/package.nix
+++ b/pkgs/by-name/ri/ripunzip/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, openssl
+, darwin
+, pkg-config
+, testers
+, fetchzip
+, ripunzip
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ripunzip";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "ripunzip";
+    rev = "v${version}";
+    hash = "sha256-GyP4OPnPKhu9nXYXIfWCVLF/thwWiP0OqAQY/1D05LE=";
+  };
+
+  cargoHash = "sha256-Jv9bCHT5xl/2CPnSuWd9HZuaGOttBC5iAbbpr3jaIhM=";
+
+  buildInputs = [ openssl ]
+    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security SystemConfiguration ]);
+  nativeBuildInputs = [ pkg-config ];
+
+  setupHook = ./setup-hook.sh;
+
+  passthru.tests = {
+    fetchzipWithRipunzip = testers.invalidateFetcherByDrvHash (fetchzip.override { unzip = ripunzip; }) {
+      url = "https://github.com/google/ripunzip/archive/cb9caa3ba4b0e27a85e165be64c40f1f6dfcc085.zip";
+      hash = "sha256-BoErC5VL3Vpvkx6xJq6J+eUJrBnjVEdTuSo7zh98Jy4=";
+    };
+    version = testers.testVersion {
+      package = ripunzip;
+    };
+  };
+
+  meta = with lib; {
+    description = "A tool to unzip files in parallel";
+    homepage = "https://github.com/google/ripunzip";
+    license = with lib.licenses; [ mit asl20 ];
+    maintainers = [ maintainers.lesuisse ];
+  };
+}

--- a/pkgs/by-name/ri/ripunzip/setup-hook.sh
+++ b/pkgs/by-name/ri/ripunzip/setup-hook.sh
@@ -1,0 +1,6 @@
+unpackCmdHooks+=(_tryRipunzip)
+_tryRipunzip() {
+    if ! [[ "$curSrc" =~ \.zip$ ]]; then return 1; fi
+
+    ripunzip unzip-file "$curSrc" 2> /dev/null
+}


### PR DESCRIPTION

###### Description of changes

https://github.com/google/ripunzip

A setup hook script is provided to make possible to use `ripunzip` as a replacement of `unzip` in `fetchzip`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
