### PR TITLE
element-{web,desktop}: 1.11.20 -> 1.11.22

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/pin.json
+++ b/pkgs/applications/networking/instant-messengers/element/pin.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.11.20",
-  "desktopSrcHash": "mlB2UvRYzaJ6FWGDOqyZY6NTY7QoWCiCvmFDyWTPuMQ=",
-  "desktopYarnHash": "0ccwsy9ma7sn6d5f9jfv40dhj0y6aax8msx9bihjdmx989nkkh2m",
-  "webSrcHash": "55oLS89Pmy4d7DhBQc4i6boQIH2LgujE7kl6QwcKltw=",
-  "webYarnHash": "1aiq5wvb8cz2a5rc0h11s16fnyak0p9zhzbqwhf1rs6c1gav7777"
+  "version": "1.11.22",
+  "desktopSrcHash": "UJesD6cshsf/NK2ZTzOtAUfH+8JcGP9oCLFhkgfM0E0=",
+  "desktopYarnHash": "0bq24rjf63rkq3jphv7raqaz2fnibmj41z905k5f3l4ln835ndfv",
+  "webSrcHash": "B2clSJgKkjvQdIXQgi3bBPaVTDKOjeNBOvkAtcPOkFI=",
+  "webYarnHash": "182fh1ayh1y98kbg4mn8fxqvljs19b02j4ivvjszm55dcpwfp1df"
 }

--- a/pkgs/applications/networking/instant-messengers/element/update.sh
+++ b/pkgs/applications/networking/instant-messengers/element/update.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -I nixpkgs=../../../../../ -i bash -p nix wget prefetch-yarn-deps nix-prefetch-github
 
-# FIXME should fix itself on the next release -> remove the warning if that's the case
-echo "WARNING: on the last update, the yarn.lock had to be patched. Please be careful when updating the hashes!"
-
 if [ "$#" -gt 1 ] || [[ "$1" == -* ]]; then
   echo "Regenerates packaging data for the element packages."
   echo "Usage: $0 [git release tag]"


### PR DESCRIPTION

###### Description of changes
ChangeLog web:
* https://github.com/vector-im/element-web/releases/tag/v1.11.22
* https://github.com/vector-im/element-web/releases/tag/v1.11.21

ChangeLog desktop:
* https://github.com/vector-im/element-desktop/releases/tag/v1.11.22
* https://github.com/vector-im/element-desktop/releases/tag/v1.11.21

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
