### PR TITLE
[staging-next] meson: fix checks on darwin

### DIFF
--- a/pkgs/development/tools/build-managers/meson/disable-bitcode.patch
+++ b/pkgs/development/tools/build-managers/meson/disable-bitcode.patch
@@ -1,0 +1,24 @@
+--- a/mesonbuild/compilers/mixins/clang.py
++++ b/mesonbuild/compilers/mixins/clang.py
+@@ -56,10 +56,6 @@ class ClangCompiler(GnuLikeCompiler):
+             {OptionKey('b_colorout'), OptionKey('b_lto_threads'), OptionKey('b_lto_mode'), OptionKey('b_thinlto_cache'),
+              OptionKey('b_thinlto_cache_dir')})
+ 
+-        # TODO: this really should be part of the linker base_options, but
+-        # linkers don't have base_options.
+-        if isinstance(self.linker, AppleDynamicLinker):
+-            self.base_options.add(OptionKey('b_bitcode'))
+         # All Clang backends can also do LLVM IR
+         self.can_compile_suffixes.add('ll')
+ 
+--- a/mesonbuild/linkers/linkers.py
++++ b/mesonbuild/linkers/linkers.py
+@@ -785,7 +785,7 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
+         return self._apply_prefix('-headerpad_max_install_names')
+ 
+     def bitcode_args(self) -> T.List[str]:
+-        return self._apply_prefix('-bitcode_bundle')
++        raise MesonException('Nixpkgs cctools does not support bitcode bundles')
+ 
+     def fatal_warnings(self) -> T.List[str]:
+         return self._apply_prefix('-fatal_warnings')

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5121,7 +5121,9 @@ with pkgs;
 
   merriweather-sans = callPackage ../data/fonts/merriweather-sans { };
 
-  meson = callPackage ../development/tools/build-managers/meson { };
+  meson = callPackage ../development/tools/build-managers/meson {
+    inherit (darwin.apple_sdk.frameworks) Foundation OpenGL AppKit Cocoa;
+  };
 
   # while building documentation meson may want to run binaries for host
   # which needs an emulator


### PR DESCRIPTION
###### Description of changes

#211864 enabled tests, but they were failing on Darwin.

The bitcode patch does mean we exclude a custom cctools build (or the recently merged Apple cctools), but I think we can consider that niche? Our default ld (from cctools-port) was reporting: `-bitcode_bundle support via llvm/libxar not compiled in`

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
