### PR TITLE
schildichat-{web,desktop}: 1.11.13-sc.1 -> 1.11.22-sc.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/schildichat/pin.json
+++ b/pkgs/applications/networking/instant-messengers/schildichat/pin.json
@@ -1,9 +1,9 @@
 {
-  "version": "1.11.13-sc.1",
-  "rev": "v1.11.13-sc.1",
-  "srcHash": "1yvd0mzw4qz03nf6im2msi1lp1v4ca9zknvb3ls6va11nxr01h3g",
-  "webYarnHash": "0bmjg9qhd89bdnh398lp257mxdgdd88wj5g3fmc3cavyd6hmgzbn",
-  "jsSdkYarnHash": "0j0jhbfhq0zabnc4glk2kypn53mi5s09l39i41p0zv7g1riwz7al",
-  "reactSdkYarnHash": "195ck2k5fhzi1b8grh5c88aiq4i3baqanjx48dam76li2msfxxfn",
-  "desktopYarnHash": "1scp9y2lmah3n20f1kpc9paspd3qgslg129diis7g11cz4h0wyi5"
+  "version": "1.11.22-sc.1",
+  "rev": "v1.11.22-sc.1",
+  "srcHash": "0di80hjd0d8bsbgbnddbmdjllc7cssgaxy27kd50j4dmw8qll1hv",
+  "webYarnHash": "182fh1ayh1y98kbg4mn8fxqvljs19b02j4ivvjszm55dcpwfp1df",
+  "jsSdkYarnHash": "0a8c7y34wh8bk1v35sa1s3s4piqkzvhjrzzapack4kzl1pfn0vix",
+  "reactSdkYarnHash": "0nhw9vk0yk2v738b2w6jjq5pfib5j66m5maxczhm40zync8b1wmp",
+  "desktopYarnHash": "0bq24rjf63rkq3jphv7raqaz2fnibmj41z905k5f3l4ln835ndfv"
 }

--- a/pkgs/applications/networking/instant-messengers/schildichat/schildichat-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/schildichat/schildichat-desktop.nix
@@ -58,13 +58,18 @@ stdenv.mkDerivation rec {
     runHook postConfigure
   '';
 
+  # Only affects unused scripts in $out/share/element/electron/scripts. Also
+  # breaks because there are some `node`-scripts with a `npx`-shebang and
+  # this shouldn't be in the closure just for unused scripts.
+  dontPatchShebangs = true;
+
   buildPhase = ''
     runHook preBuild
 
     pushd element-desktop
-    npx tsc
-    yarn run i18n
-    node ./scripts/copy-res.js
+    yarn --offline run build:ts
+    yarn --offline run i18n
+    yarn --offline run build:res
     popd
 
     runHook postBuild
@@ -96,10 +101,6 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
-
-  # Do not attempt generating a tarball for element-web again.
-  # note: `doDist = false;` does not work.
-  distPhase = ";";
 
   # The desktop item properties should be kept in sync with data from upstream:
   # https://github.com/schildichat/element-desktop/blob/sc/package.json

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6806,7 +6806,7 @@ with pkgs;
 
   schildichat-desktop = callPackage ../applications/networking/instant-messengers/schildichat/schildichat-desktop.nix {
     inherit (darwin.apple_sdk.frameworks) Security AppKit CoreServices;
-    electron = electron_20;
+    electron = electron_22;
   };
   schildichat-desktop-wayland = writeScriptBin "schildichat-desktop" ''
     #!/bin/sh


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
