### PR TITLE
adguardhome: 0.107.22 -> 0.107.23

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,23 +1,23 @@
 { fetchurl, fetchzip }:
 {
 x86_64-darwin = fetchzip {
-  sha256 = "sha256-grxGXMskjpNHcL61xgX02ouxFodxnzuhORby0wcZM7E=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.22/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-ZhezLVn4PHPAnKCjlR9zI4zt9eJZYIUUODjS01M7q1E=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.23/AdGuardHome_darwin_amd64.zip";
 };
 aarch64-darwin = fetchzip {
-  sha256 = "sha256-J98fqxPlr8XZMll63GC5G8SvzOS6egViHATKSKCfYQ4=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.22/AdGuardHome_darwin_arm64.zip";
+  sha256 = "sha256-Vfu/mCR1rMBtYMsm/l5cfIwBnNNeJ7G0pC42rLdqWOk=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.23/AdGuardHome_darwin_arm64.zip";
 };
 i686-linux = fetchurl {
-  sha256 = "sha256-09HyY9WL2vzA5L0nDG/ByHs/fWj+GiJUy3Rq9yWd4Ak=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.22/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-1pgGKUE9hHFGPNAOYNEM0VTYBDdmcrXyJjcT9ymyyiM=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.23/AdGuardHome_linux_386.tar.gz";
 };
 x86_64-linux = fetchurl {
-  sha256 = "sha256-1mFOlerwTOLUQGiVX1nyFfMC1vl7W0c+P/xnPjNTrYE=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.22/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-ApCBjbhfoGYm0rmjQ8U1zA/VHNJgC1kBlk5DvmQ6wTc=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.23/AdGuardHome_linux_amd64.tar.gz";
 };
 aarch64-linux = fetchurl {
-  sha256 = "sha256-eoITV5oAyGJBn607lfJgH/1C0dHkoEIvk3x6rKxKn+k=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.22/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-qC7BrBhI9berbuIVIQ6yOo74eHRsoneVRJMx1K/Ljds=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.23/AdGuardHome_linux_arm64.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -7,7 +7,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.22";
+  version = "0.107.23";
   src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

