### PR TITLE
python3Packages.pyopenssl: 22.1.0 -> 23.0.0

### DIFF
--- a/pkgs/development/python-modules/pyopenssl/default.nix
+++ b/pkgs/development/python-modules/pyopenssl/default.nix
@@ -2,32 +2,36 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
-, fetchpatch
 , openssl
 , cryptography
 , pytestCheckHook
 , pretend
+, sphinxHook
+, sphinx-rtd-theme
 , flaky
 }:
 
 buildPythonPackage rec {
   pname = "pyopenssl";
-  version = "22.1.0";
-
-  outputs = [ "out" "dev" ];
+  version = "23.0.0";
+  format = "setuptools";
 
   src = fetchPypi {
     pname = "pyOpenSSL";
     inherit version;
-    sha256 = "sha256-eoO3snLdWVIi1nL1zimqAw8fuDdjDvIp9i5y45XOiWg=";
+    hash = "sha256-wcxfhrys78hNrafTEXXK4bFRjV9g09C7WVpngiqGim8=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "fix-flaky-darwin-handshake-tests.patch";
-      url = "https://github.com/pyca/pyopenssl/commit/8a75898356806784caf742e8277ef03de830ce11.patch";
-      hash = "sha256-UVsZ8Nq1jUTZhOUAilRgdtqMYp4AN7qvWHqc6RleqRI=";
-    })
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  nativeBuildInputs = [
+    openssl
+    sphinxHook
+    sphinx-rtd-theme
   ];
 
   postPatch = ''
@@ -35,10 +39,17 @@ buildPythonPackage rec {
     sed "/cryptography/ s/,<[0-9]*//g" setup.py
   '';
 
-  nativeBuildInputs = [ openssl ];
-  propagatedBuildInputs = [ cryptography ];
+  propagatedBuildInputs = [
+    cryptography
+  ];
 
-  nativeCheckInputs = [ pytestCheckHook pretend flaky ];
+  nativeCheckInputs = [
+    flaky
+    pretend
+    pytestCheckHook
+  ];
+
+  __darwinAllowLocalNetworking = true;
 
   preCheck = ''
     export LANG="en_US.UTF-8"
@@ -82,6 +93,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python wrapper around the OpenSSL library";
     homepage = "https://github.com/pyca/pyopenssl";
+    changelog = "https://github.com/pyca/pyopenssl/blob/${version}/CHANGELOG.rst";
     license = licenses.asl20;
     maintainers = with maintainers; [ SuperSandro2000 ];
   };


### PR DESCRIPTION
https://github.com/pyca/pyopenssl/blob/23.0.0/CHANGELOG.rst

Some light reformatting and we are building the documentation now.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
