### PR TITLE
locate-dominating-file: fix Darwin build

### DIFF
--- a/pkgs/tools/misc/locate-dominating-file/default.nix
+++ b/pkgs/tools/misc/locate-dominating-file/default.nix
@@ -2,13 +2,14 @@
 , bash
 , fetchFromGitHub
 , lib
-, stdenvNoCC
+, resholve
+, coreutils
 , getopt
 }:
 let
   version = "0.0.1";
 in
-stdenvNoCC.mkDerivation {
+resholve.mkDerivation {
   pname = "locate-dominating-file";
   inherit version;
   src = fetchFromGitHub {
@@ -24,11 +25,11 @@ stdenvNoCC.mkDerivation {
     done
   '';
 
-  buildInputs = [ getopt ];
-
-  doCheck = true;
+  buildInputs = [ getopt coreutils ];
 
   checkInputs = [ (bats.withLibraries (p: [ p.bats-support p.bats-assert ])) ];
+
+  doCheck = true;
 
   checkPhase = ''
     runHook preCheck
@@ -46,6 +47,15 @@ stdenvNoCC.mkDerivation {
 
     runHook postInstall
   '';
+
+  solutions.default = {
+    scripts = [ "bin/locate-dominating-file" ];
+    interpreter = "${bash}/bin/bash";
+    inputs = [
+      coreutils
+      getopt
+    ];
+  };
 
   meta = with lib; {
     homepage = "https://github.com/roman/locate-dominating-file";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Discovered that some elements of this script were not portable in macOS. This PR uses `resholve` to ensure this utility works on macOS machines as well as linux machines.