### PR TITLE
podman: 4.3.1 -> 4.4.0

### DIFF
--- a/nixos/tests/podman/default.nix
+++ b/nixos/tests/podman/default.nix
@@ -149,7 +149,6 @@ import ../make-test-python.nix (
           docker.succeed(su_cmd("docker version"))
 
       with subtest("Run container via docker cli"):
-          docker.succeed("docker network create default")
           docker.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
           docker.succeed(
             "docker run -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin localhost/scratchimg /bin/sleep 10"
@@ -158,7 +157,6 @@ import ../make-test-python.nix (
           docker.succeed("podman ps | grep sleeping")
           docker.succeed("docker stop sleeping")
           docker.succeed("docker rm sleeping")
-          docker.succeed("docker network rm default")
 
       with subtest("A podman non-member can not use the docker cli"):
           docker.fail(su_cmd("docker version", user="mallory"))

--- a/nixos/tests/podman/tls-ghostunnel.nix
+++ b/nixos/tests/podman/tls-ghostunnel.nix
@@ -113,9 +113,6 @@ import ../make-test-python.nix (
       podman.wait_for_unit("sockets.target")
       podman.wait_for_unit("ghostunnel-server-podman-socket.service")
 
-      with subtest("Create default network"):
-          podman.succeed("docker network create default")
-
       with subtest("Root docker cli also works"):
           podman.succeed("docker version")
 

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -18,13 +18,13 @@
 
 buildGoModule rec {
   pname = "podman";
-  version = "4.3.1";
+  version = "4.4.0";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "podman";
     rev = "v${version}";
-    sha256 = "sha256-UOAQtGDoZe+Av4+9RQCJiV3//B/pdF0pEsca4FonGxY=";
+    sha256 = "sha256-kyeON8S7CCVdHt09wigNXDWScgyaLzC4EhOts8ViP2w=";
   };
 
   patches = [

--- a/pkgs/applications/virtualization/podman/rm-podman-mac-helper-msg.patch
+++ b/pkgs/applications/virtualization/podman/rm-podman-mac-helper-msg.patch
@@ -1,16 +1,16 @@
 diff --git a/pkg/machine/qemu/machine.go b/pkg/machine/qemu/machine.go
-index a6907c0df..717d82ff3 100644
+index 4f25b4d26..8a79862fd 100644
 --- a/pkg/machine/qemu/machine.go
 +++ b/pkg/machine/qemu/machine.go
-@@ -1483,11 +1483,6 @@ func (v *MachineVM) waitAPIAndPrintInfo(forwardState apiForwardingState, forward
- 		case notInstalled:
- 			fmt.Printf("\nThe system helper service is not installed; the default Docker API socket\n")
- 			fmt.Printf("address can't be used by podman. ")
--			if helper := findClaimHelper(); len(helper) > 0 {
--				fmt.Printf("If you would like to install it run the\nfollowing commands:\n")
--				fmt.Printf("\n\tsudo %s install\n", helper)
--				fmt.Printf("\tpodman machine stop%s; podman machine start%s\n\n", suffix, suffix)
--			}
- 		case machineLocal:
- 			fmt.Printf("\nAnother process was listening on the default Docker API socket address.\n")
- 		case claimUnsupported:
+@@ -1509,11 +1509,6 @@ func (v *MachineVM) waitAPIAndPrintInfo(forwardState apiForwardingState, forward
+ 			case notInstalled:
+ 				fmt.Printf("\nThe system helper service is not installed; the default Docker API socket\n")
+ 				fmt.Printf("address can't be used by podman. ")
+-				if helper := findClaimHelper(); len(helper) > 0 {
+-					fmt.Printf("If you would like to install it run the\nfollowing commands:\n")
+-					fmt.Printf("\n\tsudo %s install\n", helper)
+-					fmt.Printf("\tpodman machine stop%s; podman machine start%s\n\n", suffix, suffix)
+-				}
+ 			case machineLocal:
+ 				fmt.Printf("\nAnother process was listening on the default Docker API socket address.\n")
+ 			case claimUnsupported:


### PR DESCRIPTION
https://github.com/containers/podman/releases/tag/v4.4.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
