### PR TITLE
musikcube: activate portaudio, pipewire, sndio, core audio plugins

### DIFF
--- a/pkgs/applications/audio/musikcube/default.nix
+++ b/pkgs/applications/audio/musikcube/default.nix
@@ -15,13 +15,18 @@
 , libopenmpt
 , mpg123
 , ncurses
+, portaudio
 , taglib
 # Linux Dependencies
 , alsa-lib
+, pipewireSupport ? true, pipewire
 , pulseaudio
+, sndioSupport ? true, sndio
+
 , systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd
 , systemd
 # Darwin Dependencies
+, coreaudioSupport ? stdenv.hostPlatform.isDarwin
 , Cocoa
 , SystemConfiguration
 }:
@@ -50,6 +55,7 @@ stdenv.mkDerivation rec {
     ffmpeg
     gnutls
     lame
+    portaudio
     libev
     game-music-emu
     libmicrohttpd
@@ -62,7 +68,11 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals stdenv.isLinux [
     alsa-lib pulseaudio
   ] ++ lib.optionals stdenv.isDarwin [
-    Cocoa SystemConfiguration
+    Cocoa coreaudioSupport SystemConfiguration
+  ] ++ lib.optionals sndioSupport [
+    sndio
+  ] ++ lib.optionals pipewireSupport [
+    pipewire
   ];
 
   cmakeFlags = [

--- a/pkgs/applications/audio/musikcube/default.nix
+++ b/pkgs/applications/audio/musikcube/default.nix
@@ -1,34 +1,33 @@
-{ lib
-, stdenv
+{ asio
 , cmake
-, pkg-config
 , curl
-, asio
 , fetchFromGitHub
 , fetchpatch
 , ffmpeg
 , gnutls
 , lame
+, lib
 , libev
 , game-music-emu
 , libmicrohttpd
 , libopenmpt
 , mpg123
 , ncurses
+, pkg-config
 , portaudio
+, stdenv
 , taglib
 # Linux Dependencies
 , alsa-lib
 , pipewireSupport ? true, pipewire
 , pulseaudio
 , sndioSupport ? true, sndio
-
-, systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd
 , systemd
+, systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd
 # Darwin Dependencies
-, coreaudioSupport ? stdenv.hostPlatform.isDarwin
 , Cocoa
 , SystemConfiguration
+, coreaudioSupport ? stdenv.hostPlatform.isDarwin
 }:
 
 stdenv.mkDerivation rec {
@@ -55,13 +54,13 @@ stdenv.mkDerivation rec {
     ffmpeg
     gnutls
     lame
-    portaudio
     libev
     game-music-emu
     libmicrohttpd
     libopenmpt
     mpg123
     ncurses
+    portaudio
     taglib
   ] ++ lib.optionals systemdSupport [
     systemd
@@ -69,9 +68,9 @@ stdenv.mkDerivation rec {
     alsa-lib pulseaudio
   ] ++ lib.optionals stdenv.isDarwin [
     Cocoa coreaudioSupport SystemConfiguration
-  ] ++ lib.optionals sndioSupport [
+  ] ++ lib.optional sndioSupport [
     sndio
-  ] ++ lib.optionals pipewireSupport [
+  ] ++ lib.optional pipewireSupport [
     pipewire
   ];
 


### PR DESCRIPTION
###### Description of changes

Activate following plugins

* `portaudio`
* `pipewire`
* `sndio`
* `core audio`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review pr 214077"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
