### PR TITLE
modemmanager: 1.18.12 → 1.20.4

### DIFF
--- a/pkgs/development/libraries/libmbim/default.nix
+++ b/pkgs/development/libraries/libmbim/default.nix
@@ -1,46 +1,63 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromGitLab
+, meson
+, ninja
 , pkg-config
 , glib
 , python3
+, help2man
 , systemd
+, bash-completion
 , withIntrospection ? stdenv.hostPlatform == stdenv.buildPlatform
 , gobject-introspection
 }:
 
 stdenv.mkDerivation rec {
   pname = "libmbim";
-  version = "1.26.4";
+  version = "1.28.2";
 
   outputs = [ "out" "dev" "man" ];
 
-  src = fetchurl {
-    url = "https://www.freedesktop.org/software/libmbim/${pname}-${version}.tar.xz";
-    sha256 = "sha256-9ojOxMRYahdXX14ydEjOYvIADvagfJ5FiYc9SmhWitk=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "mobile-broadband";
+    repo = "libmbim";
+    rev = version;
+    hash = "sha256-EtjUaSNBT1e/eeTX4oHzQolGrisbsGKBK8Cfl3rRQTQ=";
   };
 
-  configureFlags = [
-    "--with-udev-base-dir=${placeholder "out"}/lib/udev"
-    (lib.enableFeature withIntrospection "introspection")
+  mesonFlags = [
+    "-Dudevdir=${placeholder "out"}/lib/udev"
+    (lib.mesonBool "introspection" withIntrospection)
   ];
 
   nativeBuildInputs = [
+    meson
+    ninja
     pkg-config
     python3
+    help2man
     gobject-introspection
   ];
 
   buildInputs = [
     glib
     systemd
+    bash-completion
   ];
 
   doCheck = true;
 
+  postPatch = ''
+    patchShebangs \
+      build-aux/mbim-codegen/mbim-codegen
+  '';
+
   meta = with lib; {
     homepage = "https://www.freedesktop.org/wiki/Software/libmbim/";
     description = "Library for talking to WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol";
+    maintainers = teams.freedesktop.members;
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
   };

--- a/pkgs/development/libraries/libqmi/default.nix
+++ b/pkgs/development/libraries/libqmi/default.nix
@@ -1,40 +1,61 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromGitLab
+, fetchpatch2
+, meson
+, ninja
 , pkg-config
 , gobject-introspection
 , gtk-doc
 , docbook-xsl-nons
 , docbook_xml_dtd_43
+, help2man
 , glib
 , python3
 , libgudev
+, bash-completion
 , libmbim
 , libqrtr-glib
 }:
 
 stdenv.mkDerivation rec {
   pname = "libqmi";
-  version = "1.30.8";
+  version = "1.32.2";
 
   outputs = [ "out" "dev" "devdoc" ];
 
-  src = fetchurl {
-    url = "https://www.freedesktop.org/software/libqmi/${pname}-${version}.tar.xz";
-    sha256 = "sha256-hiSCzp460L1l0mQzTuMRzblLnfKGO1txNjCbQbisGZA=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "mobile-broadband";
+    repo = "libqmi";
+    rev = version;
+    hash = "sha256-XIbeWgkPiJL8hN8Rb6KFt5Q5sG3KsiEQr0EnhwmI6h8=";
   };
 
+  patches = [
+    # Fix pkg-config file missing qrtr in Requires.
+    # https://gitlab.freedesktop.org/mobile-broadband/libqmi/-/issues/99
+    (fetchpatch2 {
+      url = "https://gitlab.freedesktop.org/mobile-broadband/libqmi/-/commit/7d08150910974c6bd2c29f887c2c6d4a3526e085.patch";
+      hash = "sha256-LFrlm2ZqLqewLGO2FxL5kFYbZ7HaxdxvVHsFHYSgZ4Y=";
+    })
+  ];
+
   nativeBuildInputs = [
+    meson
+    ninja
     pkg-config
     gobject-introspection
     python3
     gtk-doc
     docbook-xsl-nons
     docbook_xml_dtd_43
+    help2man
   ];
 
   buildInputs = [
     libgudev
+    bash-completion
     libmbim
   ];
 
@@ -43,15 +64,18 @@ stdenv.mkDerivation rec {
     libqrtr-glib
   ];
 
-  configureFlags = [
-    "--with-udev-base-dir=${placeholder "out"}/lib/udev"
-    "--enable-gtk-doc=${if (stdenv.buildPlatform == stdenv.hostPlatform) then "yes" else "no"}"
-    "--enable-introspection=${if (stdenv.buildPlatform == stdenv.hostPlatform) then "yes" else "no"}"
+  mesonFlags = [
+    "-Dudevdir=${placeholder "out"}/lib/udev"
+    (lib.mesonBool "gtk_doc" (stdenv.buildPlatform == stdenv.hostPlatform))
+    (lib.mesonBool "introspection" (stdenv.buildPlatform == stdenv.hostPlatform))
   ];
 
-  enableParallelBuilding = true;
-
   doCheck = true;
+
+  postPatch = ''
+    patchShebangs \
+      build-aux/qmi-codegen/qmi-codegen
+  '';
 
   meta = with lib; {
     homepage = "https://www.freedesktop.org/wiki/Software/libqmi/";

--- a/pkgs/tools/networking/modemmanager/default.nix
+++ b/pkgs/tools/networking/modemmanager/default.nix
@@ -1,38 +1,77 @@
-{ lib, stdenv, fetchurl
-, glib, udev, libgudev, polkit, ppp, gettext, pkg-config, python3
-, libmbim, libqmi, systemd, vala, gobject-introspection, dbus
+{ lib
+, stdenv
+, fetchFromGitLab
+, glib
+, udev
+, libgudev
+, polkit
+, ppp
+, gettext
+, pkg-config
+, libxslt
+, python3
+, libmbim
+, libqmi
+, systemd
+, bash-completion
+, meson
+, ninja
+, vala
+, gobject-introspection
+, dbus
 }:
 
 stdenv.mkDerivation rec {
   pname = "modemmanager";
-  version = "1.18.12";
+  version = "1.20.4";
 
-  src = fetchurl {
-    url = "https://www.freedesktop.org/software/ModemManager/ModemManager-${version}.tar.xz";
-    sha256 = "sha256-tGTkkl2VWmyobdCGFudjsmrkbX/Tfb4oFnjjQGWx5DA=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "mobile-broadband";
+    repo = "ModemManager";
+    rev = version;
+    hash = "sha256-OWP23EQ7a8rghhV7AC9yinCxRI0xwcntB5dl9XtgK6M=";
   };
 
-  nativeBuildInputs = [ vala gobject-introspection gettext pkg-config ];
-
-  buildInputs = [ glib udev libgudev polkit ppp libmbim libqmi systemd ];
-
-  nativeInstallCheckInputs = [
-    python3 python3.pkgs.dbus-python python3.pkgs.pygobject3
+  nativeBuildInputs = [
+    meson
+    ninja
+    vala
+    gobject-introspection
+    gettext
+    pkg-config
+    libxslt
   ];
 
-  configureFlags = [
-    "--with-polkit"
-    "--with-udev-base-dir=${placeholder "out"}/lib/udev"
-    "--with-dbus-sys-dir=${placeholder "out"}/share/dbus-1/system.d"
-    "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
+  buildInputs = [
+    glib
+    udev
+    libgudev
+    polkit
+    ppp
+    libmbim
+    libqmi
+    systemd
+    bash-completion
+    dbus
+  ];
+
+  nativeInstallCheckInputs = [
+    python3
+    python3.pkgs.dbus-python
+    python3.pkgs.pygobject3
+  ];
+
+  mesonFlags = [
+    "-Dudevdir=${placeholder "out"}/lib/udev"
     "--sysconfdir=/etc"
     "--localstatedir=/var"
-    "--with-systemd-suspend-resume"
-    "--with-systemd-journal"
+    "-Dvapi=true"
   ];
 
   postPatch = ''
-    patchShebangs tools/test-modemmanager-service.py
+    patchShebangs \
+      tools/test-modemmanager-service.py
   '';
 
   # In Nixpkgs g-ir-scanner is patched to produce absolute paths, and
@@ -46,8 +85,6 @@ stdenv.mkDerivation rec {
     patchShebangs tools/tests/test-wrapper.sh
   '';
   installCheckTarget = "check";
-
-  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "WWAN modem manager, part of NetworkManager";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] pkg-config files look okay
- [x] output diffs look okay
- [x] news look okay
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
