### PR TITLE
darwin.openwith: init at unstable-2022-10-28

### DIFF
--- a/pkgs/os-specific/darwin/openwith/default.nix
+++ b/pkgs/os-specific/darwin/openwith/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchFromGitHub, swift, AppKit, Foundation, UniformTypeIdentifiers }:
+
+let
+  arch = if stdenv.isAarch64 then "arm64" else "x86_64";
+in
+stdenv.mkDerivation rec {
+  pname = "openwith";
+  version = "unstable-2022-10-28";
+
+  src = fetchFromGitHub {
+    owner = "jdek";
+    repo = "openwith";
+    rev = "a8a99ba0d1cabee7cb470994a1e2507385c30b6e";
+    hash = "sha256-lysleg3qM2MndXeKjNk+Y9Tkk40urXA2ZdxY5KZNANo=";
+  };
+
+  nativeBuildInputs = [ swift ];
+
+  buildInputs = [ AppKit Foundation UniformTypeIdentifiers ];
+
+  makeFlags = [ "openwith_${arch}" ];
+
+  installPhase = ''
+    runHook preInstall
+    install openwith_${arch} -D $out/bin/openwith
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Utility to specify which application bundle should open specific file extensions";
+    homepage = "https://github.com/jdek/openwith";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ zowoq ];
+    platforms = [ "aarch64-darwin" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -170,6 +170,10 @@ impure-cmds // appleSourcePackages // chooseLibs // {
 
   opencflite = callPackage ../os-specific/darwin/opencflite { };
 
+  openwith = pkgs.darwin.apple_sdk_11_0.callPackage ../os-specific/darwin/openwith {
+    inherit (apple_sdk_11_0.frameworks) AppKit Foundation UniformTypeIdentifiers;
+  };
+
   stubs = pkgs.callPackages ../os-specific/darwin/stubs { };
 
   trash = callPackage ../os-specific/darwin/trash { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
