### PR TITLE
haskell.packages.ghc944.X11-xft: add missing build-time dependencies

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -202,4 +202,8 @@ in {
   fourmolu = overrideCabal (drv: {
     libraryHaskellDepends = drv.libraryHaskellDepends ++ [ self.file-embed ];
   }) (disableCabalFlag "fixity-th" super.fourmolu_0_10_1_0);
+
+  # The Haskell library has additional dependencies when compiled with ghc-9.4.x.
+  X11-xft = addExtraLibraries [pkgs.xorg.libXau pkgs.xorg.libXdmcp pkgs.expat] super.X11-xft;
+
 }


### PR DESCRIPTION
The packages has additional system dependencies when compiled in the ghc-9.4.x package set.