### PR TITLE
mkCoqDerivation: findlib is an optional input

### DIFF
--- a/pkgs/build-support/coq/default.nix
+++ b/pkgs/build-support/coq/default.nix
@@ -84,9 +84,9 @@ stdenv.mkDerivation (removeAttrs ({
   inherit (fetched) version src;
 
   nativeBuildInputs = args.overrideNativeBuildInputs
-    or ([ which coq.ocamlPackages.findlib ]
+    or ([ which ]
         ++ optional useDune coq.ocamlPackages.dune_3
-        ++ optional (useDune || mlPlugin) coq.ocamlPackages.ocaml
+        ++ optionals (useDune || mlPlugin) [ coq.ocamlPackages.ocaml coq.ocamlPackages.findlib ]
         ++ (args.nativeBuildInputs or []) ++ extraNativeBuildInputs);
   buildInputs = args.overrideBuildInputs
     or ([ coq ] ++ (args.buildInputs or []) ++ extraBuildInputs);

--- a/pkgs/development/coq-modules/coq-elpi/default.nix
+++ b/pkgs/development/coq-modules/coq-elpi/default.nix
@@ -56,7 +56,7 @@ in mkCoqDerivation {
   buildFlags = [ "OCAMLWARN=" ];
 
   mlPlugin = true;
-  propagatedBuildInputs = [ elpi ];
+  propagatedBuildInputs = [ coq.ocamlPackages.findlib elpi ];
 
   meta = {
     description = "Coq plugin embedding ELPI.";

--- a/pkgs/development/coq-modules/coqhammer/default.nix
+++ b/pkgs/development/coq-modules/coqhammer/default.nix
@@ -42,7 +42,7 @@ mkCoqDerivation {
   release."1.3-coq8.10".version  = "1.3";
   release."1.1.1-coq8.9".version = "1.1.1";
   release."1.1-coq8.9".version   = "1.1";
-  releaseRev = v: "v${v}";
+  releaseRev = v: "refs/tags/v${v}";
 
   postPatch = ''
     substituteInPlace Makefile.coq.local --replace \


### PR DESCRIPTION
###### Description of changes

This fixes `coqPackages_8_14.compcert`.

This breaks `coqPackages.graph-theory`, which can be fixed in turn by setting `mlPlugin = true;` but this sounds bad. Any better idea?

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

