### PR TITLE
gtkcord4: 0.0.6 -> 0.0.8

### DIFF
--- a/pkgs/applications/audio/gtkcord4/default.nix
+++ b/pkgs/applications/audio/gtkcord4/default.nix
@@ -5,24 +5,27 @@
 , glib
 , gobject-introspection
 , graphene
+, gst_all_1
 , gtk4
 , lib
 , libadwaita
+, libcanberra-gtk3
 , pango
 , pkg-config
+, sound-theme-freedesktop
 , withLibadwaita ? false
 , wrapGAppsHook4
 }:
 
 buildGoModule rec {
   pname = "gtkcord4";
-  version = "0.0.6";
+  version = "0.0.8";
 
   src = fetchFromGitHub {
     owner = "diamondburned";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-uEG1pAHMQT+C/E5rKByflvL0NNkC8SeSPMAXanzvhE4=";
+    hash = "sha256-aJRVk9KFCJbIFInkg5BCJ6ygBlDCFF53WXO9qyACFus=";
   };
 
   nativeBuildInputs = [
@@ -38,6 +41,14 @@ buildGoModule rec {
     graphene
     gtk4
     pango
+    # Optional according to upstream but required for sound and video
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gstreamer
+    libcanberra-gtk3
+    sound-theme-freedesktop
   ] ++ lib.optionals withLibadwaita [
     libadwaita
   ];
@@ -45,12 +56,12 @@ buildGoModule rec {
   tags = lib.optionals withLibadwaita [ "libadwaita" ];
 
   postInstall = ''
-    install -D -m 444 -t $out/share/applications .nix/com.github.diamondburned.gtkcord4.desktop
+    install -D -m 444 -t $out/share/applications nix/xyz.diamondb.gtkcord4.desktop
     install -D -m 444 internal/icons/svg/logo.svg $out/share/icons/hicolor/scalable/apps/gtkcord4.svg
     install -D -m 444 internal/icons/png/logo.png $out/share/icons/hicolor/256x256/apps/gtkcord4.png
   '';
 
-  vendorHash = "sha256-QZSjSk1xu5ZcrNEra5TxnUVvlQWb5/h31fm5Nc7WMoI=";
+  vendorHash = "sha256-usnlaOqyMd8rdnFpuCqfaCES8bPaB+NbdL4pFybKJbM=";
 
   meta = with lib; {
     description = "GTK4 Discord client in Go, attempt #4.";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

New upstream release: https://github.com/diamondburned/gtkcord4/releases/tag/v0.0.8
Also adding in support for gstreamer to play video and sound inside the application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
