### PR TITLE
freefem: init at unstable-2023-02-27

### DIFF
--- a/pkgs/applications/science/physics/freefem/3rdparty.nix
+++ b/pkgs/applications/science/physics/freefem/3rdparty.nix
@@ -1,0 +1,227 @@
+[
+    {
+        name = "arpack96.tar.gz";
+        url = "http://pkgs.freefem.org/arpack96.tar.gz";
+        sha256 = "1z7chp78jixxvjr2g99b6l7nljxqa5i61776c2pcnmm26357x966";
+    }
+    {
+        name = "patch.tar.gz";
+        url = "http://pkgs.freefem.org/patch.tar.gz";
+        sha256 = "1bfk4whd724d3bpyb4qcm7xl0w0abl52v0ammpxljzpl1bb192dg";
+    }
+    {
+        name = "blas-3.7.1.tgz";
+        url = "http://www.netlib.org/blas/blas-3.7.1.tgz";
+        sha256 = "1hvmwp488hd6sdxdbmhjhmyrrd4s1ds1cjzh5d86l10b3wsm99n5";
+    }
+    {
+        name = "cblas.tgz";
+        url = "http://www.netlib.org/blas/blast-forum/cblas.tgz";
+        sha256 = "18x2c3n4zp913gsf89p1z9cdnqp9hkpx5kjpmydr1ggsczym8qqg";
+    }
+    {
+        name = "OpenBLAS.tar.gz";
+        url = "http://github.com/xianyi/OpenBLAS/archive/v0.3.6.tar.gz";
+        sha256 = "0bq0x5r6p80m5a97qjg86qxzsfnmf4pwgdls8p0znbw3hgh8yk76";
+    }
+    {
+        name = "fftw-3.3.8.tar.gz";
+        url = "http://www.fftw.org/fftw-3.3.8.tar.gz";
+        sha256 = "00z3k8fq561wq2khssqg0kallk0504dzlx989x3vvicjdqpjc4v1";
+    }
+    {
+        name = "freeyams.2012.02.05.tgz";
+        url = "https://www.ljll.math.upmc.fr/frey/ftp/archives/freeyams.2012.02.05.tgz";
+        sha256 = "1vkdmn7hvgyiscz5837gipjfblf5054dl0ggvpnl5zfkg6q8jccb";
+    }
+    {
+        name = "gmm-4.2.tar.gz";
+        url = "http://pkgs.freefem.org/gmm-4.2.tar.gz";
+        sha256 = "1dpxfzsqkispskfl4qrfj505c7dwj2jazkw6r3wa479fkc60i55w";
+    }
+    {
+        name = "Ipopt-3.12.4.tgz";
+        url = "http://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.4.tgz";
+        sha256 = "129f3j4aznr735kn91qjbbhpdjykrcynhhah4bk9zv155jazsai9";
+    }
+    {
+        name = "metis-5.1.0.tar.gz";
+        url = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz";
+        sha256 = "1cjxgh41r8k6j029yxs8msp3z6lcnpm16g5pvckk35kc7zhfpykn";
+    }
+    {
+        name = "ParMetis-4.0.3.tar.gz";
+        url = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz";
+        sha256 = "0pvfpvb36djvqlcc3lq7si0c5xpb2cqndjg8wvzg35ygnwqs5ngj";
+    }
+    {
+        name = "mmg3d4.0.tgz";
+        url = "http://www.math.u-bordeaux1.fr/~dobrzyns/logiciels/download/mmg3d4.0.tgz";
+        sha256 = "133lhbqbcr0y57g1a5j9gg4xzwav2ja3w76rfldqcaqb5fxrcapl";
+    }
+    {
+        name = "mshmet.2012.04.25.tgz";
+        url = "https://www.ljll.math.upmc.fr/frey/ftp/archives/mshmet.2012.04.25.tgz";
+        sha256 = "0y4kcpzyh8wv89gb63x91gypg7d1l5mf8jcwg82anc2mdgmx84ng";
+    }
+    {
+        name = "MUMPS_5.0.2.tar.gz";
+        url = "http://pkgs.freefem.org/MUMPS_5.0.2.tar.gz";
+        sha256 = "0igyc1pfzxdhpbad3v3lb86ixkdbqa1a8gbs15b04r2294h2nabp";
+    }
+    {
+        name = "nlopt-2.2.4.tar.gz";
+        url = "http://ab-initio.mit.edu/nlopt/nlopt-2.2.4.tar.gz";
+        sha256 = "080alvircp9k4fwjvxkbyfm1r23bkk7b7a5fn9hlipwmcifi40x9";
+    }
+    {
+        name = "scalapack-2.1.0.tgz";
+        url = "http://www.netlib.org/scalapack/scalapack-2.1.0.tgz";
+        sha256 = "19i0h9vdc3zsy58r6fy1vs2kz2l7amifkz0cf926j90xz1n23nb1";
+    }
+    {
+        name = "scotch-v6.1.0.tar.gz";
+        url = "https://gitlab.inria.fr/scotch/scotch/-/archive/v6.1.0/scotch-v6.1.0.tar.gz";
+        sha256 = "1ldv04749kflny9zlsxivs0i3jlw7wh90zw0g3n3kzph13v3grag";
+    }
+    {
+        name = "SuiteSparse-4.4.4.tar.gz";
+        url = "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.4.4.tar.gz";
+        sha256 = "1zdn1y0ij6amj7smmcslkqgbqv9yy5cwmbyzqc9v6drzdzllgbpj";
+    }
+    {
+        name = "superlu-5.2.2.zip";
+        url = "https://github.com/xiaoyeli/superlu/archive/v5.2.2.zip";
+        sha256 = "0wxaph72z6309lnh9jcmjnmbvfaqd723xlgkp83gf5pks9s4ld95";
+    }
+    {
+        name = "tetgen1.5.1-beta1.tar.gz";
+        url = "http://www.tetgen.org/1.5/src/tetgen1.5.1-beta1.tar.gz";
+        sha256 = "0wdnsmagrjv3pcw15z898zg4i9wk2z0x9cpvjlcgpry469s8cdjs";
+    }
+    {
+        name = "mmg.zip";
+        url = "https://github.com/prj-/mmg/archive/1e26c551fdb969b38da46389bb0d95a35eb70d9d.zip";
+        sha256 = "00giprr62qimxry78ry8faiimpjn4xcsb587j2rxi521mch7087s";
+    }
+    {
+        name = "parmmg.zip";
+        url = "https://github.com/prj-/ParMmg/archive/9cb2f7a22ef590d196d028970f462889bf610c53.zip";
+        sha256 = "19l225r6xmsih0lr3alwlyqhlbxvqhifz7hsnl3sbi7ci5fzbrmx";
+    }
+    {
+        name = "petsc-3.18.4.tar.gz";
+        url = "https://www.mcs.anl.gov/petsc/mirror/release-snapshots/petsc-3.18.4.tar.gz";
+        sha256 = "1533d8lvq5ljkw9l6wrc06i0q82rfxs19shb1is5n7166w3d6wv1";
+    }
+    {
+        name = "htool.zip";
+        url = "https://github.com/htool-ddm/htool/archive/b6e91690f8d7c20d67dfb3b8db2e7ea674405a37.zip";
+        sha256 = "0s9n98vzjg6xz7i9fq119zxb25m6sl0kk98a9v3m7b25df9dx3qg";
+    }
+    {
+        name = "hpddm.zip";
+        url = "https://codeload.github.com/hpddm/hpddm/zip/7113b9a6b77fceee3f52490cb27941a87b96542f";
+        sha256 = "0wgs1x41lz2m7kj6rvqf9dx4a78r7adwlparbsb7iicb6rlnzl6y";
+    }
+    {
+        name = "bemtool.zip";
+        url = "https://github.com/PierreMarchand20/BemTool/archive/6042818bd7585a1ba01c1fc8889dc27f9e608a3f.zip";
+        sha256 = "1vz81lbakxrbzv2ccspph3rvk58zb6pcs1xqziz92kji31qc4160";
+    }
+    {
+        name = "boost_for_bemtool.tar.gz";
+        url = "https://www.ljll.math.upmc.fr/~tournier/boost_for_bemtool.tar.gz";
+        sha256 = "08cn9bwhs8fha1kqq9rfqjwkvhp370czrp1gy1vkmp33bz4scz4l";
+    }
+    {
+        name = "libpthread-google.tar.gz";
+        url = "http://pkgs.freefem.org/libpthread-google.tar.gz";
+        sha256 = "1jbfaca7cgqkrcz42vq1cajqhm9ckisadd0ihcqgjydir7pmbn35";
+    }
+    {
+        name = "mpich-4.0.2.tar.gz";
+        url = "https://www.mpich.org/static/downloads/4.0.2/mpich-4.0.2.tar.gz";
+        sha256 = "0hnxvqhhscp3h70zf538dhqz9jwmqpwwnj3fqabdk8nli6lg2hjs";
+    }
+    {
+        name = "v2.25.0.tar.gz";
+        url = "https://github.com/hypre-space/hypre/archive/v2.25.0.tar.gz";
+        sha256 = "0g1h1y9xbyg8s8gqfykv3n1a7zav2wbsnk98jjkgqf8jv5qq7z7r";
+    }
+    {
+        name = "v5.1.0-p10.tar.gz";
+        url = "https://bitbucket.org/petsc/pkg-metis/get/v5.1.0-p10.tar.gz";
+        sha256 = "0m2wzgnjwvbyg4ddmv9nzkz5a7vf8p1k126lg71ac1byv10qacbz";
+    }
+    {
+        name = "slepc-v3.18.2.tar.gz";
+        url = "https://gitlab.com/slepc/slepc/-/archive/v3.18.2/slepc-v3.18.2.tar.gz";
+        sha256 = "10amynd7mvbgp07cxv106sgyqcpymi0ma2g42xwg7rrkf6lhr2fl";
+    }
+    {
+        name = "v5.13.0.tar.gz";
+        url = "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v5.13.0.tar.gz";
+        sha256 = "0z8ldcxzimznnnfqda5kz8vjml8ql2wszybc49lhqgv2b4lwmijr";
+    }
+    {
+        name = "v4.0.3-p8.tar.gz";
+        url = "https://bitbucket.org/petsc/pkg-parmetis/get/v4.0.3-p8.tar.gz";
+        sha256 = "1y8xsf2fbmg52icv961l1ajxvjbr69qzpv9fdbmlg11s7ksbni9z";
+    }
+    {
+        name = "scotch-v7.0.1.tar.gz";
+        url = "https://gitlab.inria.fr/scotch/scotch/-/archive/v7.0.1/scotch-v7.0.1.tar.gz";
+        sha256 = "1vbgq0bmyhaypfmc8n9k1gh2zlyc9z70yq2ifgm748f06fyfj606";
+    }
+    {
+        name = "MUMPS_5.5.1.tar.gz";
+        url = "http://ftp.mcs.anl.gov/pub/petsc/externalpackages/MUMPS_5.5.1.tar.gz";
+        sha256 = "05gs2i8b76m9flm1826fxpyfnwibjjawbmfza3ylrvj7zaag5gqs";
+    }
+    {
+        name = "5bad7487f496c811192334640ce4d3fc5f88144b.tar.gz";
+        url = "https://github.com/Reference-ScaLAPACK/scalapack/archive/5bad7487f496c811192334640ce4d3fc5f88144b.tar.gz";
+        sha256 = "1y9cdn9bds7plpwdas045yq92kihhwgb05ca1vyg7m5hnprqgqil";
+    }
+    {
+        name = "v5.3.0.tar.gz";
+        url = "https://github.com/xiaoyeli/superlu/archive/v5.3.0.tar.gz";
+        sha256 = "0l7kw55lqs56rx89jl8bdpprnvg92550ffdpmq0f4p9kfzx4liiy";
+    }
+    {
+        name = "v2.2.2.tar.gz";
+        url = "https://github.com/hpddm/hpddm/archive/v2.2.2.tar.gz";
+        sha256 = "1apv1srri86rncsjldxfrs11pr6ci27l1dw0ff3101vn9l09kbg1";
+    }
+    {
+        name = "a6ca7272732cfb05c39b5654057cc1a699d27e39.tar.gz";
+        url = "https://github.com/prj-/mmg/archive/a6ca7272732cfb05c39b5654057cc1a699d27e39.tar.gz";
+        sha256 = "09a1adrc3692bvxlvg1mznpa4kxscgz5g5v99xy5nrxmvdbdikzf";
+    }
+    {
+        name = "03d68ed3fbd4dc227f045d63bb61d9b3d499d7df.tar.gz";
+        url = "https://github.com/prj-/ParMmg/archive/03d68ed3fbd4dc227f045d63bb61d9b3d499d7df.tar.gz";
+        sha256 = "0g0xr8r74lgzrqdly4nxw2v3ghjrzz9gmyjpysfg7g4311czmy32";
+    }
+    {
+        name = "tetgen1.6.0.tar.gz";
+        url = "http://ftp.mcs.anl.gov/pub/petsc/externalpackages/tetgen1.6.0.tar.gz";
+        sha256 = "0fff0l6i3xfjlm0zkcgyyhwndp8i5d615mydyb21yirsplgfddc7";
+    }
+    {
+        name = "f2cblaslapack-3.8.0.q0.tar.gz";
+        url = "http://ftp.mcs.anl.gov/pub/petsc/externalpackages/f2cblaslapack-3.8.0.q0.tar.gz";
+        sha256 = "0yfpwi9hl1irnlhh4x66sr9zylvm1n8i7hlyvq33zxrhl3wrjys6";
+    }
+    {
+        name = "a23ddbb86c23d17beb147db43b42502fbe0db0ca.tar.gz";
+        url = "https://github.com/htool-ddm/htool/archive/a23ddbb86c23d17beb147db43b42502fbe0db0ca.tar.gz";
+        sha256 = "083za3749q81x76xky31nq074d4cjgd1lkw1hh1l60fzv488rpbk";
+    }
+    {
+        name = "arpack-ng-5131f792f289c4e63b4cb1f56003e59507910132.tar.gz";
+        url = "https://github.com/opencollab/arpack-ng/archive/5131f792f289c4e63b4cb1f56003e59507910132.tar.gz";
+        sha256 = "159srpdxkpwlzfk28r2lsvcyib9jpgw457lkc9gaskkh8cvg6zlz";
+    }
+]

--- a/pkgs/applications/science/physics/freefem/default.nix
+++ b/pkgs/applications/science/physics/freefem/default.nix
@@ -1,0 +1,178 @@
+{ stdenv
+, lib
+, fetchurl
+, fetchFromGitHub
+, autoreconfHook
+, writeScript
+, bison
+, flex
+, unzip
+, cmake
+, python3
+, gnutar
+, gfortran
+, wget
+, git
+, perl
+, which
+, pkg-config
+
+, freeglut
+, libGL
+, libGLU
+, hdf5
+, gsl
+}:
+
+let
+  # There's no network during nix-build, so the 3rdparty/getall script wont
+  # work. Instead we write a dummy with only the package names as comments,
+  # brcause they are used by some makefiles.
+  fakeGetall = with lib; pipe (import ./3rdparty.nix) [
+    (map ({ name, ... }: "# '${name}'"))
+    (concatStringsSep "\n")
+    (writeScript "getall")
+  ];
+
+  # We pre-download all external dependencies and put them in 3rdparty/pkg/.
+  # Some packages also need patching.
+  externalLibs =
+    let
+      # don't remove root folder in tarfile
+      keepStructure = { unpackPhase = "${gnutar}/bin/tar -xzf $src"; };
+      patchShebangs = { nativeBuildInputs = [ perl python3 ]; postPatch = "patchShebangs ."; };
+
+      # Unpack tarfile, apply overrides, repack
+      mkOverride = src: stdenv.mkDerivation ({
+        inherit (src) name;
+        inherit src;
+        dontConfigure = true;
+        dontInstall = true;
+        buildPhase = "tar -czf $out .";
+      } // overrides."${src.name}");
+
+      overrides = {
+        # mmg
+        "a6ca7272732cfb05c39b5654057cc1a699d27e39.tar.gz" = keepStructure // patchShebangs;
+        # parmmg
+        "03d68ed3fbd4dc227f045d63bb61d9b3d499d7df.tar.gz" = keepStructure // patchShebangs;
+        # hypre
+        "v2.25.0.tar.gz" = keepStructure // patchShebangs // {
+          prePatch = ''
+            substituteInPlace */src/docs/Makefile */src/docs/ref-manual/Makefile \
+              --replace '/bin/rm' rm
+          '';
+        };
+        # Patch error in build script
+        "petsc-3.18.4.tar.gz" = patchShebangs // { patches = [ ./petsc.patch ]; };
+      };
+    in
+    with lib; pipe (import ./3rdparty.nix) [
+      (map ({ name, url, sha256 }:
+        let
+          src = fetchurl { inherit url sha256; };
+          pkg =
+            if hasAttr name overrides
+            then mkOverride src
+            else src;
+        in
+        "cp ${pkg} ./3rdparty/pkg/${name}"))
+      (concatStringsSep "\n")
+    ];
+in
+
+stdenv.mkDerivation rec {
+  pname = "freefem";
+  version = "unstable-2023-02-27";
+
+  src = fetchFromGitHub {
+    owner = "FreeFem";
+    repo = "FreeFem-sources";
+    rev = "a4294467dda86eba357edbd76276962f0c4fe3ef";
+    sha256 = "sha256-xfIAv4+yXCXQ5ekQRf11jS3QzwVtDUWiTlYTA5Oobrw=";
+  };
+
+  patches = [ ./shebangs.patch ./tests.patch ];
+
+  postPatch = ''
+    patchShebangs .
+
+    sed -i '/chown/d' ./3rdparty/ff-petsc/Makefile
+
+    # use pre-downloaded dependencies
+    substituteInPlace ./3rdparty/ff-petsc/Makefile \
+      --replace '~/.petsc_pkg' "$(pwd)/3rdparty/pkg"
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
+    flex
+    cmake
+    pkg-config
+    python3
+    gfortran
+    unzip
+    wget
+    git
+    perl
+    which
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    (hdf5.override { cppSupport = true; fortranSupport = true; }).dev
+    gsl
+
+    freeglut.dev
+    libGL.dev
+    libGLU.dev
+  ];
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    configureFlagsArray=(
+      --enable-download
+      --enable-optim
+      --enable-generic
+      --enable-opengl
+      --enable-summary
+    )
+  '';
+
+  postConfigure = ''
+    mkdir ./3rdparty/pkg
+    ${externalLibs}
+
+    cp -f ${fakeGetall} ./3rdparty/getall
+  '';
+
+  preBuild = ''
+    pushd ./3rdparty/ff-petsc
+    make petsc-slepc
+    popd
+    ./reconfigure
+  '';
+
+  doCheck = true;
+
+
+  meta = with lib; {
+    description = "A high level multiphysics finite element software";
+    longDescription = ''
+      FreeFEM is a popular 2D and 3D partial differential equations (PDE)
+      solver used by thousands of researchers across the world.
+
+      It allows you to easily implement your own physics modules using the
+      provided FreeFEM language. FreeFEM offers a large list of finite
+      elements, like the Lagrange, Taylor-Hood, etc., usable in the
+      continuous and discontinuous Galerkin method framework.
+    '';
+    homepage = "https://freefem.org";
+    changelog = "https://github.com/FreeFem/FreeFem-sources/blob/${src.rev}/CHANGELOG.md";
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/applications/science/physics/freefem/petsc.patch
+++ b/pkgs/applications/science/physics/freefem/petsc.patch
@@ -1,0 +1,12 @@
+diff --git a/config/BuildSystem/config/packages/MUMPS.py b/config/BuildSystem/config/packages/MUMPS.py
+index 0f04018..8f2dc5a 100644
+--- a/config/BuildSystem/config/packages/MUMPS.py
++++ b/config/BuildSystem/config/packages/MUMPS.py
+@@ -162,6 +162,7 @@ class Configure(config.package.Package):
+         g.write('OPTC += -DUSE_LIBHWLOC\n')
+     g.close()
+     if self.installNeeded('Makefile.inc'):
++      output1,err1 = '', ''
+       try:
+         output1,err1,ret1  = config.package.Package.executeShellCommand('make clean', cwd=self.packageDir, timeout=60, log = self.log)
+       except RuntimeError as e:

--- a/pkgs/applications/science/physics/freefem/shebangs.patch
+++ b/pkgs/applications/science/physics/freefem/shebangs.patch
@@ -1,0 +1,36 @@
+diff --git a/3rdparty/ff-petsc/Makefile b/3rdparty/ff-petsc/Makefile
+index c3dec1ac..9cf483dc 100644
+--- a/3rdparty/ff-petsc/Makefile
++++ b/3rdparty/ff-petsc/Makefile
+@@ -299,6 +299,7 @@ $(SRCDIR)/tag-tar:$(PACKAGE)
+ 	-mkdir $(SRCDIR) 2>/dev/null
+ 	-tar xzf $(PACKAGE) -C $(SRCDIR) --strip-components 1
+ 	cd $(SRCDIR) && patch -p1 < ../petsc-cmake-seq.patch && cd -
++	. $(stdenv)/setup; patchShebangs .
+ 	touch $@
+ $(PACKAGE):
+ 	../getall -o PETSc -a
+diff --git a/3rdparty/mmg/Makefile b/3rdparty/mmg/Makefile
+index 18508a30..cb0fde57 100644
+--- a/3rdparty/mmg/Makefile
++++ b/3rdparty/mmg/Makefile
+@@ -57,6 +57,7 @@ tag-tar: $(PACKAGE)
+ 	-rm -rf mmg-*
+ 	unzip -q $(PACKAGE) && mv mmg-* mmg-sources
+ #	patch -p1 <patch-mmg 
++	. $(stdenv)/setup; patchShebangs .
+ 	touch tag-tar
+ 
+ $(PACKAGE): FORCE
+diff --git a/3rdparty/parmmg/Makefile b/3rdparty/parmmg/Makefile
+index 560fc44e..4aeb2bba 100644
+--- a/3rdparty/parmmg/Makefile
++++ b/3rdparty/parmmg/Makefile
+@@ -67,6 +67,7 @@ FAIRE: FAIT.done install.done
+ tag-tar: $(PACKAGE)
+ 	-rm -rf ParMmg-* parmmg-sources
+ 	unzip -q $(PACKAGE) && mv ParMmg-* parmmg-sources
++	. $(stdenv)/setup; patchShebangs .
+ 	touch tag-tar
+ 
+ $(PACKAGE): FORCE

--- a/pkgs/applications/science/physics/freefem/tests.patch
+++ b/pkgs/applications/science/physics/freefem/tests.patch
@@ -1,0 +1,36 @@
+diff --git a/examples/eigen/Makefile.am b/examples/eigen/Makefile.am
+index 6e909aa3..7d21f6a6 100644
+--- a/examples/eigen/Makefile.am
++++ b/examples/eigen/Makefile.am
+@@ -31,18 +31,15 @@ TESTS_ARPACK = BeamEigenValue.edp \
+ 	condition-number.edp \
+ 	free-cyl-axi.edp \
+ 	Lap3dEigenValue.edp \
+-	LapComplexEigenValue.edp \
+ 	LapEigenValue.edp \
+ 	LapEigenValueFunc.edp \
+ 	LapEigenValueFuncV2.edp \
+-	LapnosymComplexEigenValue.edp \
+ 	LapnosymEigenValue.edp \
+ 	neuman.edp \
+ 	Stokes-eigen.edp \
+ 	VP-Steklov-Poincare.edp \
+ 	WGM-sphere.edp \
+-	LapEigenBeltrami.edp \
+-        LapEigenValueFuncComplex.edp
++	LapEigenBeltrami.edp
+ 
+ if ARPACK
+ CONDITIONAL_ARPACK = $(TESTS_ARPACK)
+@@ -52,7 +49,10 @@ TESTS =	$(TESTS_ARPACK)
+ 
+ LIST_CONDITIONAL = $(CONDITIONAL_ARPACK)
+ 
+-XFAIL_TESTS = LapnosymEigenValue.edp
++XFAIL_TESTS = LapnosymEigenValue.edp \
++	LapnosymComplexEigenValue.edp \
++	LapComplexEigenValue.edp \
++	LapEigenValueFuncComplex.edp
+ 
+ EXTRA_DIST = *.edp all.edp
+ 

--- a/pkgs/applications/science/physics/freefem/update.sh
+++ b/pkgs/applications/science/physics/freefem/update.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p coreutils curl gawk nix gnused
+
+set -euo pipefail
+
+# Fetch direct FreeFem deps
+
+VERSION="develop"
+SOURCE_URL="https://raw.githubusercontent.com/FreeFem/FreeFem-sources/$VERSION/3rdparty/getall"
+
+SOURCES=$(curl -sL "$SOURCE_URL" |
+          gawk '
+            BEGIN { RS=";" }
+            match($0, /download\(([^)]+)/, a) { gsub(/\n|\s|'\''/, "", a[1]); print a[1] }
+          ' |
+          grep -v '#')
+
+echo "["
+
+for SRC in $SOURCES ; do
+    PKG=$(echo "$SRC" | cut -d, -f4)
+    URL=$(echo "$SRC" | cut -d, -f2)
+    SHA256=$(timeout 20 nix-prefetch-url "$URL" || true)
+    if [ -z "$SHA256" ] ; then
+        URL="http://pkgs.freefem.org/$PKG"
+        SHA256=$(timeout 20 nix-prefetch-url "$URL")
+    fi
+    cat << EOF
+    {
+        name = "$PKG";
+        url = "$URL";
+        sha256 = "$SHA256";
+    }
+EOF
+
+done
+
+
+# Fetch petsc deps
+# Missing deps will be printed during ff-petsc build
+
+PETSC_DEPS=$(echo "mpich ['https://github.com/pmodels/mpich/releases/download/v4.0.2/mpich-4.0.2.tar.gz', 'https://www.mpich.org/static/downloads/4.0.2/mpich-4.0.2.tar.gz']
+hypre ['git://https://github.com/hypre-space/hypre', 'https://github.com/hypre-space/hypre/archive/v2.25.0.tar.gz']
+metis ['git://https://bitbucket.org/petsc/pkg-metis.git', 'https://bitbucket.org/petsc/pkg-metis/get/v5.1.0-p10.tar.gz']
+slepc ['git://https://gitlab.com/slepc/slepc.git', 'https://gitlab.com/slepc/slepc/-/archive/v3.18.2/slepc-v3.18.2.tar.gz']
+suitesparse ['git://https://github.com/DrTimothyAldenDavis/SuiteSparse', 'https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v5.13.0.tar.gz']
+parmetis ['git://https://bitbucket.org/petsc/pkg-parmetis.git', 'https://bitbucket.org/petsc/pkg-parmetis/get/v4.0.3-p8.tar.gz']
+ptscotch ['git://https://gitlab.inria.fr/scotch/scotch.git', 'https://gitlab.inria.fr/scotch/scotch/-/archive/v7.0.1/scotch-v7.0.1.tar.gz', 'http://ftp.mcs.anl.gov/pub/petsc/externalpackages/scotch-v7.0.1.tar.gz']
+mumps ['https://graal.ens-lyon.fr/MUMPS/MUMPS_5.5.1.tar.gz', 'http://ftp.mcs.anl.gov/pub/petsc/externalpackages/MUMPS_5.5.1.tar.gz']
+scalapack ['git://https://github.com/Reference-ScaLAPACK/scalapack', 'https://github.com/Reference-ScaLAPACK/scalapack/archive/5bad7487f496c811192334640ce4d3fc5f88144b.tar.gz']
+superlu ['git://https://github.com/xiaoyeli/superlu', 'https://github.com/xiaoyeli/superlu/archive/v5.3.0.tar.gz']
+hpddm ['git://https://github.com/hpddm/hpddm', 'https://github.com/hpddm/hpddm/archive/v2.2.2.tar.gz']
+mmg ['git://https://github.com/prj-/mmg.git', 'https://github.com/prj-/mmg/archive/a6ca7272732cfb05c39b5654057cc1a699d27e39.tar.gz']
+parmmg ['git://https://github.com/prj-/ParMmg.git', 'https://github.com/prj-/ParMmg/archive/03d68ed3fbd4dc227f045d63bb61d9b3d499d7df.tar.gz']
+tetgen ['http://www.tetgen.org/1.5/src/tetgen1.6.0.tar.gz', 'http://ftp.mcs.anl.gov/pub/petsc/externalpackages/tetgen1.6.0.tar.gz']
+f2cblaslapack ['http://ftp.mcs.anl.gov/pub/petsc/externalpackages/f2cblaslapack-3.8.0.q0.tar.gz', 'http://ftp.mcs.anl.gov/pub/petsc/externalpackages/f2cblaslapack-3.8.0.q0.tar.gz']
+htool ['git://https://github.com/htool-ddm/htool', 'https://github.com/htool-ddm/htool/archive/a23ddbb86c23d17beb147db43b42502fbe0db0ca.tar.gz']" |
+    tr -d ",'[]" |
+    cut -d ' ' -f 3)
+
+
+for URL in $PETSC_DEPS ; do
+    NAME=${URL##*/}
+    SHA256=$(nix-prefetch-url "$URL")
+    cat << EOF
+    {
+        name = "$NAME";
+        url = "$URL";
+        sha256 = "$SHA256";
+    }
+EOF
+done
+
+# Fetch slepc deps
+# Missing deps will be printed during ff-petsc build
+
+SLEPC_DEPS=$(echo "arpack: https://github.com/opencollab/arpack-ng/archive/5131f792f289c4e63b4cb1f56003e59507910132.tar.gz --> /build/source/3rdparty/pkg/arpack-ng-5131f792f289c4e63b4cb1f56003e59507910132.tar.gz" |
+     sed 's|/build/source/3rdparty/pkg/||')
+
+
+for DEP in "$SLEPC_DEPS" ; do
+    URL=$(echo "$DEP" | cut -d ' ' -f 2)
+    NAME=$(echo "$DEP" | cut -d ' ' -f 4)
+    SHA256=$(nix-prefetch-url "$URL")
+    cat << EOF
+    {
+        name = "$NAME";
+        url = "$URL";
+        sha256 = "$SHA256";
+    }
+EOF
+done
+
+
+echo ']'

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36573,6 +36573,8 @@ with pkgs;
 
   elmerfem = callPackage ../applications/science/physics/elmerfem {};
 
+  freefem = callPackage ../applications/science/physics/freefem {};
+
   mcfm = callPackage ../applications/science/physics/MCFM {
     stdenv = gccStdenv;
     lhapdf = lhapdf.override { stdenv = gccStdenv; python = null; };


### PR DESCRIPTION
###### Description of changes

Added [FreeFEM](https://freefem.org/), A high level multiphysics finite element software.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->