### PR TITLE
python3Packages.leidenalg: init at 0.9.1

### DIFF
--- a/pkgs/development/python-modules/leidenalg/default.nix
+++ b/pkgs/development/python-modules/leidenalg/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, ddt
+, fetchPypi
+, igraph
+, igraph-c
+, pythonOlder
+, setuptools-scm
+, unittestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "leidenalg";
+  version = "0.9.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-flz+O2+A8yuQ9V81xo1KmQsEibEoLPP6usjNpJiJdfM=";
+  };
+
+  postPatch = ''
+    substituteInPlace ./setup.py \
+      --replace "[\"/usr/include/igraph\", \"/usr/local/include/igraph\"]" \
+                "[\"${igraph-c.dev}/include/igraph\"]"
+
+    rm -r vendor
+  '';
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    igraph
+    igraph-c
+  ];
+
+  doCheck = true;
+
+  checkInputs = [
+    ddt
+    unittestCheckHook
+  ];
+
+  pythonImportsCheck = [ "leidenalg" ];
+
+  meta = with lib; {
+    description = "Implementation of the Leiden algorithm for various quality functions to be used with igraph in Python";
+    homepage = "https://leidenalg.readthedocs.io";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ jboy ];
+  };
+}

--- a/pkgs/development/python-modules/leidenalg/default.nix
+++ b/pkgs/development/python-modules/leidenalg/default.nix
@@ -38,8 +38,6 @@ buildPythonPackage rec {
     igraph-c
   ];
 
-  doCheck = true;
-
   checkInputs = [
     ddt
     unittestCheckHook

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5249,6 +5249,10 @@ self: super: with self; {
     inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
   };
 
+  leidenalg = callPackage ../development/python-modules/leidenalg {
+    igraph-c = pkgs.igraph;
+  };
+
   lektor = callPackage ../development/python-modules/lektor { };
 
   leveldb = callPackage ../development/python-modules/leveldb { };


### PR DESCRIPTION
###### Description of changes

Add [leidenalg](https://leidenalg.readthedocs.io/), an implementation of the Leiden algorithm for various quality functions to be used with igraph in Python. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
