### PR TITLE
material-symbols: init at unstable-2023-01-07

### DIFF
--- a/pkgs/data/fonts/material-symbols/default.nix
+++ b/pkgs/data/fonts/material-symbols/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, rename
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "material-symbols";
+  version = "unstable-2023-01-07";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "material-design-icons";
+    rev = "511eea577b20d2b02ad77477750da1e44c66a52c";
+    sha256 = "sha256-ENoWeyV9Dw26pgjy0Xst+qpxJ/mjgfqrY2Du2VwzwCE=";
+    sparseCheckout = [ "variablefont" ];
+  };
+
+  nativeBuildInputs = [ rename ];
+
+  installPhase = ''
+    runHook preInstall
+
+    rename 's/\[FILL,GRAD,opsz,wght\]//g' variablefont/*
+    install -Dm755 variablefont/*.ttf -t $out/share/fonts/TTF
+    install -Dm755 variablefont/*.woff2 -t $out/share/fonts/woff2
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Material Symbols icons by Google";
+    homepage = "https://fonts.google.com/icons";
+    downloadPage = "https://github.com/google/material-design-icons";
+    license = lib.licenses.asl20;
+    maintainers = with maintainers; [ fufexan ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27398,6 +27398,8 @@ with pkgs;
 
   material-icons = callPackage ../data/fonts/material-icons { };
 
+  material-symbols = callPackage ../data/fonts/material-symbols { };
+
   material-kwin-decoration = libsForQt5.callPackage ../data/themes/material-kwin-decoration { };
 
   meslo-lg = callPackage ../data/fonts/meslo-lg {};


### PR DESCRIPTION
###### Description of changes
Add [Material Symbols](https://fonts.google.com/icons) TTF and WOFF fonts.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
