### PR TITLE
riscv-gnu-toolchain-*: init at 2023.01.04

### DIFF
--- a/pkgs/development/compilers/riscv-gnu-toolchain/default.nix
+++ b/pkgs/development/compilers/riscv-gnu-toolchain/default.nix
@@ -1,0 +1,99 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchurl
+
+, gcc12
+, glibc
+, newlib
+, gdb
+, qemu
+, musl
+, spike
+, riscv-pk
+
+, autoconf
+, curl
+, automake
+, python3
+, libmpc
+, gawk
+, bison
+, flex
+, texinfo
+, gperf
+, libtool
+, expat
+, gmp
+, mpfr
+, flock
+, zlib
+
+, srcs ? {
+  binutils = {
+    url = "mirror://gnu/binutils/binutils-2.39.tar.bz2";
+    hash = "sha256-2iSoT+8iAQLdJAQt8G/eqFHCYUpTd/hu/6KPM7exYUg=";
+  };
+  dejagnu = {
+    url = "mirror://gnu/dejagnu/dejagnu-1.6.3.tar.gz";
+    hash = "sha256-h9rvrNeVi0pp+IxoVtvRY0JhljxBQHnQw3H1ic1mouM=";
+  };
+  gcc = gcc12.cc.src;
+  glibc = glibc.src;
+  newlib = newlib.src;
+  gdb = gdb.src;
+  qemu = qemu.src;
+  musl = musl.src;
+  spike = spike.src;
+  pk = riscv-pk.src;
+}
+
+, isa ? "rv64gc"
+, withLinux ? false
+}:
+let
+
+extract = file: stdenv.mkDerivation {
+  name = file.name + "-unpacked";
+  src = file;
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  installPhase = "cp -r . $out";
+  dontFixup = true;
+};
+
+srcs_fetched = lib.mapAttrs (name: value: if value ? outPath then value else fetchurl value) srcs;
+srcs_extracted = lib.mapAttrs (name: value: extract value) srcs_fetched;
+srcFlags = lib.mapAttrsToList (name: value: "--with-${name}-src=${value}") srcs_extracted;
+
+in stdenv.mkDerivation rec {
+  pname = "riscv-gnu-toolchain-" + isa;
+  version = "2023.01.04";
+
+  src = fetchFromGitHub {
+    owner = "riscv-collab";
+    repo = "riscv-gnu-toolchain";
+    rev = version;
+    hash = "sha256-PXPQ/ho+fOudZRErnyQZTVFdceWGBF+geo+3y0tkNm4=";
+  };
+
+  nativeBuildInputs = [ autoconf automake flock curl python3 gawk bison flex texinfo gperf ];
+  buildInputs = [ libmpc libtool expat gmp mpfr zlib ];
+  hardeningDisable = [ "format" ];
+
+  patches = [ ./no-dot-git.patch ];
+  configureFlags = [
+    "--with-arch=${isa}"
+  ]
+  ++ srcFlags
+  ++ lib.optional withLinux "--enable-linux";
+
+  meta = with lib; {
+    homepage = "https://github.com/riscv-collab/riscv-gnu-toolchain";
+    description = "RISC-V C and C++ cross-compiler";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = with licenses; [ bsd3 gpl2 lgpl21 ];
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/development/compilers/riscv-gnu-toolchain/no-dot-git.patch
+++ b/pkgs/development/compilers/riscv-gnu-toolchain/no-dot-git.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile.in b/Makefile.in
+index 71369ab..53f5e0d 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -279,9 +279,6 @@ GCCPKGVER :=
+ endif
+ 
+ $(srcdir)/%/.git:
+-	cd $(srcdir) && \
+-	flock `git rev-parse --git-dir`/config git submodule init $(dir $@) && \
+-	flock `git rev-parse --git-dir`/config git submodule update $(dir $@)
+ 
+ #
+ # GLIBC

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27088,6 +27088,21 @@ with pkgs;
 
   rfkill_udev = callPackage ../os-specific/linux/rfkill/udev.nix { };
 
+  riscv-gnu-toolchain-rv64gc-linux = callPackage ../development/compilers/riscv-gnu-toolchain {
+    isa = "rv64gc";
+    withLinux = true;
+  };
+
+  riscv-gnu-toolchain-rv64gc = callPackage ../development/compilers/riscv-gnu-toolchain {
+    isa = "rv64gc";
+    withLinux = false;
+  };
+
+  riscv-gnu-toolchain-rv32gc = callPackage ../development/compilers/riscv-gnu-toolchain {
+    isa = "rv32gc";
+    withLinux = false;
+  };
+
   riscv-pk = callPackage ../misc/riscv-pk { };
 
   ristate = callPackage ../tools/misc/ristate { };


### PR DESCRIPTION
###### Description of changes

Added a toolchain which targets `riscv(64/32)-unkown-elf`. This is different to `pkgsCross.riscv(64/32)-embedded`, as that targets `riscv(64/32)-none-elf`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Relevant: #213222