### PR TITLE
pythonPackages.aio-pika: init at 8.3.0

### DIFF
--- a/pkgs/development/python-modules/aio-pika/default.nix
+++ b/pkgs/development/python-modules/aio-pika/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, aiormq
+, yarl
+, aiomisc
+, shortuuid
+}:
+
+buildPythonPackage rec {
+  pname = "aio-pika";
+  version = "8.3.0";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "mosquito";
+    repo = pname;
+    rev = version;
+    sha256 = "CYfj6V/91J7JA8YSctG/FkSHRkwyLKxr27eREbA+MtQ=";
+  };
+
+  propagatedBuildInputs = [
+    aiormq
+    yarl
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+  checkInputs = [
+    aiomisc
+    shortuuid
+  ];
+  # Tests attempt to connect to a RabbitMQ server
+  disabledTestPaths = [
+    "tests/test_amqp.py"
+    "tests/test_amqp_robust.py"
+    "tests/test_amqp_robust_proxy.py"
+    "tests/test_amqps.py"
+    "tests/test_master.py"
+    "tests/test_memory_leak.py"
+    "tests/test_rpc.py"
+    "tests/test_types.py"
+  ];
+  pythonImportsCheck = [ "aio_pika" ];
+
+  meta = with lib; {
+    description = "AMQP 0.9 client designed for asyncio and humans";
+    homepage = "https://github.com/mosquito/aio-pika";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ emilytrau ];
+  };
+}

--- a/pkgs/development/python-modules/aiormq/default.nix
+++ b/pkgs/development/python-modules/aiormq/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, pamqp
+, yarl
+, setuptools
+, poetry-core
+, aiomisc
+}:
+
+buildPythonPackage rec {
+  pname = "aiormq";
+  version = "6.6.4";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "mosquito";
+    repo = pname;
+    rev = version;
+    sha256 = "+zTSaQzBoIHDUQgOpD6xvoruFFHZBb0z5D6uAUo0W5A=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    pamqp
+    yarl
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+  checkInputs = [
+    aiomisc
+  ];
+  # Tests attempt to connect to a RabbitMQ server
+  disabledTestPaths = [
+    "tests/test_channel.py"
+    "tests/test_connection.py"
+  ];
+  pythonImportsCheck = [ "aiormq" ];
+
+  meta = with lib; {
+    description = "AMQP 0.9.1 asynchronous client library";
+    homepage = "https://github.com/mosquito/aiormq";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ emilytrau ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -302,6 +302,8 @@ self: super: with self; {
 
   aioridwell = callPackage ../development/python-modules/aioridwell { };
 
+  aiormq = callPackage ../development/python-modules/aiormq { };
+
   aiorpcx = callPackage ../development/python-modules/aiorpcx { };
 
   aiortm = callPackage ../development/python-modules/aiortm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -122,6 +122,8 @@ self: super: with self; {
 
   aio-georss-gdacs = callPackage ../development/python-modules/aio-georss-gdacs { };
 
+  aio-pika = callPackage ../development/python-modules/aio-pika { };
+
   aioairzone = callPackage ../development/python-modules/aioairzone { };
 
   aioairq = callPackage ../development/python-modules/aioairq { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

AMQP 0.9 client designed for asyncio and humans

https://github.com/mosquito/aio-pika

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
