### PR TITLE
multipass: init at 1.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7003,6 +7003,12 @@
     githubId = 2308444;
     name = "Joshua Gilman";
   };
+  jnsgruk = {
+    email = "jon@sgrs.uk";
+    github = "jnsgruk";
+    githubId = 668505;
+    name = "Jon Seager";
+  };
   jo1gi = {
     email = "joakimholm@protonmail.com";
     github = "jo1gi";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1364,6 +1364,7 @@
   ./virtualisation/lxc.nix
   ./virtualisation/lxcfs.nix
   ./virtualisation/lxd.nix
+  ./virtualisation/multipass.nix
   ./virtualisation/nixos-containers.nix
   ./virtualisation/oci-containers.nix
   ./virtualisation/openstack-options.nix

--- a/nixos/modules/virtualisation/multipass.nix
+++ b/nixos/modules/virtualisation/multipass.nix
@@ -1,0 +1,61 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+
+let
+  cfg = config.virtualisation.multipass;
+in
+{
+  options = {
+    virtualisation.multipass = {
+      enable = lib.mkEnableOption (lib.mdDoc ''
+        Multipass, a simple manager for virtualised Ubuntu instances.
+      '');
+
+      logLevel = lib.mkOption {
+        type = lib.types.enum [ "error" "warning" "info" "debug" "trace" ];
+        default = "debug";
+        description = lib.mdDoc ''
+          The logging verbosity of the multipassd binary.
+        '';
+      };
+
+      package = lib.mkPackageOptionMD pkgs "multipass" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.multipass = {
+      description = "Multipass orchestrates virtual Ubuntu instances.";
+
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network.target" ];
+      after = [ "network.target" ];
+
+      environment = {
+        "XDG_DATA_HOME" = "/var/lib/multipass/data";
+        "XDG_CACHE_HOME" = "/var/lib/multipass/cache";
+        "XDG_CONFIG_HOME" = "/var/lib/multipass/config";
+      };
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/multipassd --logger platform --verbosity ${cfg.logLevel}";
+        SyslogIdentifer = "multipassd";
+        Restart = "on-failure";
+        TimeoutStopSec = 300;
+        Type = "simple";
+
+        WorkingDirectory = "/var/lib/multipass";
+
+        StateDirectory = "multipass";
+        StateDirectoryMode = "0750";
+        CacheDirectory = "multipass";
+        CacheDirectoryMode = "0750";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -411,6 +411,7 @@ in {
   mpd = handleTest ./mpd.nix {};
   mpv = handleTest ./mpv.nix {};
   mtp = handleTest ./mtp.nix {};
+  multipass = handleTest ./multipass.nix {};
   mumble = handleTest ./mumble.nix {};
   musescore = handleTest ./musescore.nix {};
   munin = handleTest ./munin.nix {};

--- a/nixos/tests/multipass.nix
+++ b/nixos/tests/multipass.nix
@@ -1,0 +1,37 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+
+let
+  multipass-image = import ../release.nix {
+    configuration = {
+      # Building documentation makes the test unnecessarily take a longer time:
+      documentation.enable = lib.mkForce false;
+    };
+  };
+
+in
+{
+  name = "multipass";
+
+  meta.maintainers = [ lib.maintainers.jnsgruk ];
+
+  nodes.machine = { lib, ... }: {
+    virtualisation = {
+      cores = 1;
+      memorySize = 1024;
+      diskSize = 4096;
+
+      multipass.enable = true;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("sockets.target")
+    machine.wait_for_unit("multipass.service")
+    machine.wait_for_file("/var/lib/multipass/data/multipassd/network/multipass_subnet")
+
+    # Wait for Multipass to settle
+    machine.sleep(1)
+
+    machine.succeed("multipass list")
+  '';
+})

--- a/pkgs/tools/virtualization/multipass/default.nix
+++ b/pkgs/tools/virtualization/multipass/default.nix
@@ -1,0 +1,128 @@
+{ cmake
+, dnsmasq
+, fetchFromGitHub
+, git
+, gtest
+, iproute2
+, iptables
+, lib
+, libapparmor
+, libvirt
+, libxml2
+, nixosTests
+, openssl
+, OVMF
+, pkg-config
+, qemu
+, qemu-utils
+, qtbase
+, qtx11extras
+, slang
+, stdenv
+, wrapQtAppsHook
+, xterm
+}:
+
+let
+  pname = "multipass";
+  version = "1.11.0";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "multipass";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-2d8piIIecoSI3BfOgAVlXl5P2UYDaNlxUgHXWbnSdkg=";
+    fetchSubmodules = true;
+  };
+
+  preConfigure = ''
+    substituteInPlace ./CMakeLists.txt \
+      --replace "determine_version(MULTIPASS_VERSION)" "" \
+      --replace 'set(MULTIPASS_VERSION ''${MULTIPASS_VERSION})' 'set(MULTIPASS_VERSION "v${version}")'
+
+    substituteInPlace ./src/platform/backends/qemu/linux/qemu_platform_detail_linux.cpp \
+      --replace "OVMF.fd" "${OVMF.fd}/FV/OVMF.fd" \
+      --replace "QEMU_EFI.fd" "${OVMF.fd}/FV/QEMU_EFI.fd"
+  '';
+
+  postPatch = ''
+    # Patch all of the places where Multipass expects the LXD socket to be provided by a snap
+    substituteInPlace ./src/network/network_access_manager.cpp \
+      --replace "/var/snap/lxd/common/lxd/unix.socket" "/var/lib/lxd/unix.socket"
+
+    substituteInPlace ./src/platform/backends/lxd/lxd_virtual_machine.cpp \
+      --replace "/var/snap/lxd/common/lxd/unix.socket" "/var/lib/lxd/unix.socket"
+
+    substituteInPlace ./src/platform/backends/lxd/lxd_request.h \
+      --replace "/var/snap/lxd/common/lxd/unix.socket" "/var/lib/lxd/unix.socket"
+
+    substituteInPlace ./tests/CMakeLists.txt \
+      --replace "FetchContent_MakeAvailable(googletest)" ""
+
+    cat >> tests/CMakeLists.txt <<'EOF'
+      add_library(gtest INTERFACE)
+      target_include_directories(gtest INTERFACE ${gtest.dev}/include)
+      target_link_libraries(gtest INTERFACE ${gtest}/lib/libgtest.so ''${CMAKE_THREAD_LIBS_INIT})
+      add_dependencies(gtest GMock)
+
+      add_library(gtest_main INTERFACE)
+      target_include_directories(gtest_main INTERFACE ${gtest.dev}/include)
+      target_link_libraries(gtest_main INTERFACE ${gtest}/lib/libgtest_main.so gtest)
+
+      add_library(gmock INTERFACE)
+      target_include_directories(gmock INTERFACE ${gtest.dev}/include)
+      target_link_libraries(gmock INTERFACE ${gtest}/lib/libgmock.so gtest)
+
+      add_library(gmock_main INTERFACE)
+      target_include_directories(gmock_main INTERFACE ${gtest.dev}/include)
+      target_link_libraries(gmock_main INTERFACE ${gtest}/lib/libgmock_main.so gmock gtest_main)
+    EOF
+  '';
+
+  buildInputs = [
+    gtest
+    libapparmor
+    libvirt
+    libxml2
+    openssl
+    qtbase
+    qtx11extras
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    git
+    pkg-config
+    slang
+    wrapQtAppsHook
+  ];
+
+  nativeCheckInputs = [ gtest ];
+
+  postInstall = ''
+    wrapProgram $out/bin/multipassd --prefix PATH : ${lib.makeBinPath [
+      dnsmasq
+      iproute2
+      iptables
+      OVMF.fd
+      qemu
+      qemu-utils
+      xterm
+    ]}
+  '';
+
+  passthru.tests = {
+    multipass = nixosTests.multipass;
+  };
+
+  meta = with lib; {
+    description = "Ubuntu VMs on demand for any workstation.";
+    homepage = "https://multipass.run";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jnsgruk ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9868,6 +9868,8 @@ with pkgs;
 
   mubeng = callPackage ../tools/networking/mubeng { };
 
+  multipass = libsForQt5.callPackage ../tools/virtualization/multipass { };
+
   multitime = callPackage ../tools/misc/multitime { };
 
   sta = callPackage ../tools/misc/sta {};


### PR DESCRIPTION
###### Description of changes

Adds a [multipass](https://multipass.run) package and NixOS module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] ~~aarch64-linux~~
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- [ ] ~~For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~~
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

