### PR TITLE
python3Packages.pygments: 0.13.0 -> 0.14.0; python3Packages.jupyterlab-pygments: 0.1.2 -> 0.2.2

### DIFF
--- a/pkgs/development/python-modules/jupyterlab-pygments/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-pygments/default.nix
@@ -1,22 +1,33 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pygments }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, jupyter-packaging
+, jupyterlab
+, pygments
+ }:
 
 buildPythonPackage rec {
-  pname = "jupyterlab_pygments";
-  version = "0.1.2";
+  pname = "jupyterlab-pygments";
+  version = "0.2.2";
+  format = "pyproject";
 
-  src = fetchFromGitHub {
-    owner = "jupyterlab";
-    repo = pname;
-    rev = version;
-    sha256 = "02lv63qalw4x6xs70n2w2p3c2cnhk91sr961wlbi77xs0g8fcman";
+  # requires yarn to build
+  src = fetchPypi {
+    pname = "jupyterlab_pygments";
+    inherit version;
+    hash = "sha256-dAXX/eYIGdkFqfqM6J5M2DDjGM2tIqADD3qQHacFWF0=";
   };
 
-  # no tests exist on upstream repo
-  doCheck = false;
+  nativeBuildInputs = [
+    jupyter-packaging
+    pygments
+  ];
 
-  propagatedBuildInputs = [ pygments ];
+  doCheck = false; # no tests
 
-  pythonImportsCheck = [ "jupyterlab_pygments" ];
+  pythonImportsCheck = [
+    "jupyterlab_pygments"
+  ];
 
   meta = with lib; {
     description = "Jupyterlab syntax coloring theme for pygments";

--- a/pkgs/development/python-modules/pygments/default.nix
+++ b/pkgs/development/python-modules/pygments/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, docutils
+, setuptools
 , lxml
 , pytestCheckHook
 , wcag-contrast-ratio
@@ -10,20 +10,22 @@
 let pygments = buildPythonPackage
   rec {
     pname = "pygments";
-    version = "2.13.0";
+    version = "2.14.0";
+    format = "pyproject";
 
     src = fetchPypi {
       pname = "Pygments";
       inherit version;
-      sha256 = "sha256-VqhQiulfmOK5vfk6a+WuP32K+Fi0PgLFov8INya+QME=";
+      hash = "sha256-s+0GqeismpquWm9dvniopYZV0XtDuTwHjwlN3Edq4pc=";
     };
 
-    propagatedBuildInputs = [
-      docutils
+    nativeBuildInputs = [
+      setuptools
     ];
 
     # circular dependencies if enabled by default
     doCheck = false;
+
     nativeCheckInputs = [
       lxml
       pytestCheckHook


### PR DESCRIPTION
###### Description of changes
https://github.com/pygments/pygments/releases/tag/2.14.0


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
