### PR TITLE
python3Packages.clldutils: 3.9.0 -> 3.19.0

### DIFF
--- a/pkgs/development/python-modules/clldutils/default.nix
+++ b/pkgs/development/python-modules/clldutils/default.nix
@@ -1,28 +1,33 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
-, isPy27
 , attrs
+, buildPythonPackage
 , colorlog
 , csvw
-, python-dateutil
-, tabulate
+, fetchFromGitHub
+, git
+, isPy27
+, lxml
+, markdown
+, markupsafe
 , mock
 , postgresql
-, pytestCheckHook
+, pylatexenc
 , pytest-mock
+, pytestCheckHook
+, python-dateutil
+, tabulate
 }:
 
 buildPythonPackage rec {
   pname = "clldutils";
-  version = "3.9.0";
+  version = "3.19.0";
   disabled = isPy27;
 
   src = fetchFromGitHub {
     owner = "clld";
     repo = pname;
     rev = "v${version}";
-    sha256 = "07ljq7v1zvaxyl6xn4a2p4097lgd5j9bz71lf05y5bz8k024mxbr";
+    sha256 = "sha256-dva0lbbTxvETDPkACxpI3PPzWh5gz87Fv6W3lTjNv3Q=";
   };
 
   patchPhase = ''
@@ -30,18 +35,23 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
+    attrs
+    colorlog
+    csvw
+    lxml
+    markdown
+    markupsafe
+    pylatexenc
     python-dateutil
     tabulate
-    colorlog
-    attrs
-    csvw
   ];
 
   nativeCheckInputs = [
     mock
     postgresql
-    pytestCheckHook
     pytest-mock
+    pytestCheckHook
+    git
   ];
 
   disabledTests = [
@@ -54,6 +64,6 @@ buildPythonPackage rec {
     description = "Utilities for clld apps without the overhead of requiring pyramid, rdflib et al";
     homepage = "https://github.com/clld/clldutils";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ melling ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Tidy up, add missing deps for new version, add self as maintainer. Fixes build for `python311Packages.segments`.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>phonemizer (python310Packages.phonemizer)</li>
    <li>python311Packages.phonemizer</li>
  </ul>
</details>
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>python310Packages.clldutils</li>
    <li>python310Packages.segments</li>
    <li>python311Packages.clldutils</li>
    <li>python311Packages.segments</li>
  </ul>
</details>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
