### PR TITLE
tarball job: more --show-trace

### DIFF
--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -64,7 +64,7 @@ pkgs.releaseTools.sourceTarball {
     echo "generating packages.json"
     mkdir -p $out/nix-support
     echo -n '{"version":2,"packages":' > tmp
-    nix-env -f . -I nixpkgs=$src -qa --meta --json --arg config 'import ${./packages-config.nix}' "''${opts[@]}" >> tmp
+    nix-env -f . -I nixpkgs=$src -qa --show-trace --meta --json --arg config 'import ${./packages-config.nix}' "''${opts[@]}" >> tmp
     echo -n '}' >> tmp
     packages=$out/packages.json.br
     < tmp sed "s|$(pwd)/||g" | jq -c | brotli -9 > $packages


### PR DESCRIPTION
We ran into a really useless log here:
https://hydra.nixos.org/log/487b2k81x1nkhgi13b8z1xdw4ibj97iv-nixos-channel-23.05pre450719.c11c55dd08a.drv
Now we'd get a full trace instead, pointing to the bad package.