### PR TITLE
s0ix-selftest-tool: init at 2022-11-04

### DIFF
--- a/pkgs/tools/system/s0ix-selftest-tool/default.nix
+++ b/pkgs/tools/system/s0ix-selftest-tool/default.nix
@@ -1,0 +1,81 @@
+{
+  acpica-tools,
+  bash,
+  bc,
+  coreutils,
+  fetchFromGitHub,
+  gawk,
+  gnugrep,
+  gnused,
+  linuxPackages,
+  lib,
+  pciutils,
+  powertop,
+  resholve,
+  stdenv,
+  util-linux,
+  xorg,
+  xxd,
+}:
+resholve.mkDerivation {
+  pname = "s0ix-selftest-tool";
+  version = "unstable-2022-11-04";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "S0ixSelftestTool";
+    rev = "1b6db3c3470a3a74b052cb728a544199661d18ec";
+    hash = "sha256-w97jfdppW8kC8K8XvBntmkfntIctXDQCWmvug+H1hKA=";
+  };
+
+  # don't use the bundled turbostat binary
+  postPatch = ''
+    substituteInPlace s0ix-selftest-tool.sh --replace '"$DIR"/turbostat' 'turbostat'
+    substituteInPlace s0ix-selftest-tool.sh --replace 'sudo ' ""
+
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 s0ix-selftest-tool.sh "$out/bin/s0ix-selftest-tool"
+    runHook postInstall
+  '';
+
+  solutions = {
+    default = {
+      scripts = ["bin/s0ix-selftest-tool"];
+      interpreter = lib.getExe bash;
+      inputs = [
+        acpica-tools
+        bc
+        coreutils
+        gawk
+        gnugrep
+        gnused
+        linuxPackages.turbostat
+        pciutils
+        powertop
+        util-linux
+        xorg.xset
+        xxd
+      ];
+      execer = [
+        "cannot:${util-linux}/bin/dmesg"
+        "cannot:${powertop}/bin/powertop"
+        "cannot:${util-linux}/bin/rtcwake"
+        "cannot:${linuxPackages.turbostat}/bin/turbostat"
+      ];
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/intel/S0ixSelftestTool";
+    description = "A tool for testing the S2idle path CPU Package C-state and S0ix failures";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [adamcstephens];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1525,6 +1525,8 @@ with pkgs;
 
   redfang = callPackage ../tools/networking/redfang { };
 
+  s0ix-selftest-tool = callPackage ../tools/system/s0ix-selftest-tool { };
+
   scarab = callPackage ../tools/games/scarab { };
 
   sdbus-cpp = callPackage ../development/libraries/sdbus-cpp { };


### PR DESCRIPTION
###### Description of changes

Init a package for https://github.com/intel/S0ixSelftestTool

This is a tool for running a set of checks to validate Intel machines are correctly entering the lower power and/or s2idle states. Offering this package up as it requires a number of dependencies and does not work out of the box on NixOS.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
