### PR TITLE
nixos-render-docs: improve error messages for multi-title manual chapters

### DIFF
--- a/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/__init__.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/nixos_render_docs/__init__.py
@@ -1,11 +1,37 @@
 import argparse
 import os
 import sys
+import textwrap
+import traceback
+from io import StringIO
+from pprint import pprint
 from typing import Any, Dict
 
 from .md import Converter
 from . import manual
 from . import options
+
+def pretty_print_exc(e: BaseException, *, _desc_text: str = "error") -> None:
+    print(f"\x1b[1;31m{_desc_text}:\x1b[0m", file=sys.stderr)
+    # destructure Exception and RuntimeError specifically so we can show nice
+    # messages for errors that weren't given their own exception type with
+    # a good pretty-printer.
+    if type(e) is Exception or type(e) is RuntimeError:
+        args = e.args
+        if len(args) and isinstance(args[0], str):
+            print("\t", args[0], file=sys.stderr, sep="")
+            args = args[1:]
+        buf = StringIO()
+        for arg in args:
+            pprint(arg, stream=buf)
+        if extra_info := buf.getvalue():
+            print(f"\x1b[1;34mextra info:\x1b[0m", file=sys.stderr)
+            print(textwrap.indent(extra_info, "\t"), file=sys.stderr, end="")
+    else:
+        print(e)
+    if e.__context__ is not None:
+        print("", file=sys.stderr)
+        pretty_print_exc(e.__context__, _desc_text="caused by")
 
 def main() -> None:
     parser = argparse.ArgumentParser(description='render nixos manual bits')
@@ -16,9 +42,14 @@ def main() -> None:
     manual.build_cli(commands.add_parser('manual'))
 
     args = parser.parse_args()
-    if args.command == 'options':
-        options.run_cli(args)
-    elif args.command == 'manual':
-        manual.run_cli(args)
-    else:
-        raise RuntimeError('command not hooked up', args)
+    try:
+        if args.command == 'options':
+            options.run_cli(args)
+        elif args.command == 'manual':
+            manual.run_cli(args)
+        else:
+            raise RuntimeError('command not hooked up', args)
+    except Exception as e:
+        traceback.print_exc()
+        pretty_print_exc(e)
+        sys.exit(1)


### PR DESCRIPTION
###### Description of changes

error messages for malformed manual chapters (and error message printing in general, to be honest) aren't great yet (see #214209). improve reporting a whole lot.

before:
![image](https://user-images.githubusercontent.com/82953136/216454428-0ee12da7-1200-4976-9ee0-f2efdc919725.png)

after:
![image](https://user-images.githubusercontent.com/82953136/216454491-f7e15192-30d6-4db4-9289-8a7379be676e.png)

cc @evrim 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
