### PR TITLE
python310Packages.robotframework-pythonlibcore: 4.0.0 -> 4.1.0

### DIFF
--- a/pkgs/development/python-modules/approval-utilities/default.nix
+++ b/pkgs/development/python-modules/approval-utilities/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, approvaltests
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "approval-utilities";
+  inherit (approvaltests) version src;
+  disabled = pythonOlder "3.7";
+  format = "setuptools";
+
+  postPatch = ''
+    mv setup.approval_utilities.py setup.py
+  '';
+
+  pythonImportsCheck = [ "approval_utilities" ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  meta = {
+    description = "Utilities for your production code that work well with approvaltests";
+    homepage = "https://github.com/approvals/ApprovalTests.Python";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/approvaltests/default.nix
+++ b/pkgs/development/python-modules/approvaltests/default.nix
@@ -5,10 +5,13 @@
 
 # propagates
 , allpairspy
+, approval-utilities
 , beautifulsoup4
 , empty-files
+, mrjob
 , pyperclip
 , pytest
+, typing-extensions
 
 # tests
 , numpy
@@ -16,26 +19,29 @@
 }:
 
 buildPythonPackage rec {
-  version = "5.4.2";
+  version = "8.1.0";
   pname = "approvaltests";
   format = "setuptools";
 
-  disabled = pythonOlder "3.6.1";
+  disabled = pythonOlder "3.7";
 
   # no tests included in PyPI tarball
   src = fetchFromGitHub {
     owner = "approvals";
     repo = "ApprovalTests.Python";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-ZXtIM3McpfDFCaedlbJ6SU+Er5NyfI8kGnrn7sb1V5M=";
+    hash = "sha256-01OgofksXFglohcQtJqkir/nqBJArw3pXEmnX9P7rOA=";
   };
 
   propagatedBuildInputs = [
     allpairspy
+    approval-utilities
     beautifulsoup4
     empty-files
+    mrjob
     pyperclip
     pytest
+    typing-extensions
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/robotframework-pythonlibcore/default.nix
+++ b/pkgs/development/python-modules/robotframework-pythonlibcore/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, fetchpatch
 , pytest-mockito
 , pytestCheckHook
 , robotframework
@@ -10,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "robotframework-pythonlibcore";
-  version = "4.0.0";
+  version = "4.1.0";
 
   disabled = pythonOlder "3.7";
 
@@ -20,16 +19,8 @@ buildPythonPackage rec {
     owner = "robotframework";
     repo = "PythonLibCore";
     rev = "v${version}";
-    hash = "sha256-86o5Lh9zWo4vUF2186dN7e8tTUu5PIxM/ZukPwNl0S8=";
+    hash = "sha256-BgnllONYJjfeKIN8BLfMw1iZrVewtXB1KN8b9KjdtK0=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-finding-version.patch";
-      url = "https://github.com/robotframework/PythonLibCore/commit/84c73979e309f59de057ae6a77725ab0f468b71f.patch";
-      hash = "sha256-zrjsNvXpJDLpXql200NV+QGWFLtnRVZTeAjT52dRn2s=";
-    })
-  ];
 
   nativeCheckInputs = [
     pytest-mockito

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -532,6 +532,8 @@ self: super: with self; {
 
   apprise = callPackage ../development/python-modules/apprise { };
 
+  approval-utilities = callPackage ../development/python-modules/approval-utilities { };
+
   approvaltests = callPackage ../development/python-modules/approvaltests { };
 
   apptools = callPackage ../development/python-modules/apptools { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
