### PR TITLE
linuxPackages.evdi: 1.12.0 -> unstable-2022-10-13

### DIFF
--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evdi";
-  version = "1.12.0";
+  version = "unstable-2022-10-13";
 
   src = fetchFromGitHub {
     owner = "DisplayLink";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-JZKZ7+1OMbBtUA7pAZ41TzeDDyiD0h7yTXJINJ5FjN4=";
+    repo = "evdi";
+    rev = "bdc258b25df4d00f222fde0e3c5003bf88ef17b5";
+    sha256 = "sha256-mt+vEp9FFf7smmE2PzuH/3EYl7h89RBN1zTVvv2qJ/o=";
   };
 
   NIX_CFLAGS_COMPILE = "-Wno-error -Wno-error=sign-compare";


### PR DESCRIPTION
linuxPackages.evdi: 1.12.0 -> unstable-2022-10-13

* Fixes Kernel 6.1