### PR TITLE
python3Packages.hatch-jupyter-builder: init at 0.8.2

### DIFF
--- a/pkgs/development/python-modules/hatch-jupyter-builder/default.nix
+++ b/pkgs/development/python-modules/hatch-jupyter-builder/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, hatchling
+, hatch
+, pytest-mock
+, pytestCheckHook
+, tomli
+, twine
+}:
+
+buildPythonPackage rec {
+  pname = "hatch-jupyter-builder";
+  version = "0.8.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "jupyterlab";
+    repo = "hatch-jupyter-builder";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Ns5jrVfTAA7NuvUok3/13nIpXSSVZ6WRkgHyTuxkSKA=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  checkInputs = [
+    hatch
+    pytest-mock
+    pytestCheckHook
+    tomli
+    twine
+  ];
+
+  disabledTests = [
+    # tests pip install, which unsuprisingly fails
+    "test_hatch_build"
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/jupyterlab/hatch-jupyter-builder/releases/tag/v${version}";
+    description = "hatch plugin to help build Jupyter packages";
+    homepage = "https://github.com/jupyterlab/hatch-jupyter-builder";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4133,6 +4133,8 @@ self: super: with self; {
 
   hatch-fancy-pypi-readme = callPackage ../development/python-modules/hatch-fancy-pypi-readme { };
 
+  hatch-jupyter-builder = callPackage ../development/python-modules/hatch-jupyter-builder { };
+
   hatch-vcs = callPackage ../development/python-modules/hatch-vcs { };
 
   hatch-nodejs-version = callPackage ../development/python-modules/hatch-nodejs-version { };


### PR DESCRIPTION
(cherry picked from commit 998f4d139c26ca2ae809dbe0f8f218f0a33e1304)

###### Description of changes

Backport for [poetry2nix JupyterLab support](https://github.com/nix-community/poetry2nix/pull/975).

@mweinelt

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).