### PR TITLE
nixos/doc: set groff mdoc os registers properly

### DIFF
--- a/nixos/doc/manual/manpages/nixos-build-vms.8
+++ b/nixos/doc/manual/manpages/nixos-build-vms.8
@@ -1,10 +1,12 @@
 .Dd January 1, 1980
 .\" nixpkgs groff will use Nixpkgs as the OS in the title by default, taking it from
-.\" doc-default-operating-system. mandoc doesn't have this register set by default,
-.\" so we can use it as a groff/mandoc switch.
-.ie ddoc-default-operating-system .Dt nixos-build-vms \&8 "NixOS System Manager's Manual"
-.el .Dt nixos-build-vms 8
-.Os NixOS
+.\" doc-{default,volume}-operating-system, while mandoc correctly uses NixOS on NixOS.
+.if '\*[doc-default-operating-system]'Nixpkgs' \{\
+.  ds doc-default-operating-system NixOS
+.  ds doc-volume-operating-system NixOS
+.\}
+.Dt nixos-build-vms 8
+.Os
 .Sh NAME
 .Nm nixos-build-vms
 .Nd build a network of virtual machines from a network of NixOS configurations

--- a/nixos/doc/manual/manpages/nixos-enter.8
+++ b/nixos/doc/manual/manpages/nixos-enter.8
@@ -1,10 +1,12 @@
 .Dd January 1, 1980
 .\" nixpkgs groff will use Nixpkgs as the OS in the title by default, taking it from
-.\" doc-default-operating-system. mandoc doesn't have this register set by default,
-.\" so we can use it as a groff/mandoc switch.
-.ie ddoc-default-operating-system .Dt nixos-enter \&8 "NixOS System Manager's Manual"
-.el .Dt nixos-enter 8
-.Os NixOS
+.\" doc-{default,volume}-operating-system, while mandoc correctly uses NixOS on NixOS.
+.if '\*[doc-default-operating-system]'Nixpkgs' \{\
+.  ds doc-default-operating-system NixOS
+.  ds doc-volume-operating-system NixOS
+.\}
+.Dt nixos-enter 8
+.Os
 .Sh NAME
 .Nm nixos-enter
 .Nd run a command in a NixOS chroot environment

--- a/nixos/doc/manual/manpages/nixos-generate-config.8
+++ b/nixos/doc/manual/manpages/nixos-generate-config.8
@@ -1,10 +1,12 @@
 .Dd January 1, 1980
 .\" nixpkgs groff will use Nixpkgs as the OS in the title by default, taking it from
-.\" doc-default-operating-system. mandoc doesn't have this register set by default,
-.\" so we can use it as a groff/mandoc switch.
-.ie ddoc-default-operating-system .Dt nixos-generate-config \&8 "NixOS System Manager's Manual"
-.el .Dt nixos-generate-config 8
-.Os NixOS
+.\" doc-{default,volume}-operating-system, while mandoc correctly uses NixOS on NixOS.
+.if '\*[doc-default-operating-system]'Nixpkgs' \{\
+.  ds doc-default-operating-system NixOS
+.  ds doc-volume-operating-system NixOS
+.\}
+.Dt nixos-generate-config 8
+.Os
 .Sh NAME
 .Nm nixos-generate-config
 .Nd generate NixOS configuration modules

--- a/nixos/doc/manual/manpages/nixos-install.8
+++ b/nixos/doc/manual/manpages/nixos-install.8
@@ -1,10 +1,12 @@
 .Dd January 1, 1980
 .\" nixpkgs groff will use Nixpkgs as the OS in the title by default, taking it from
-.\" doc-default-operating-system. mandoc doesn't have this register set by default,
-.\" so we can use it as a groff/mandoc switch.
-.ie ddoc-default-operating-system .Dt nixos-install \&8 "NixOS System Manager's Manual"
-.el .Dt nixos-install 8
-.Os NixOS
+.\" doc-{default,volume}-operating-system, while mandoc correctly uses NixOS on NixOS.
+.if '\*[doc-default-operating-system]'Nixpkgs' \{\
+.  ds doc-default-operating-system NixOS
+.  ds doc-volume-operating-system NixOS
+.\}
+.Dt nixos-install 8
+.Os
 .Sh NAME
 .Nm nixos-install
 .Nd install bootloader and NixOS

--- a/nixos/doc/manual/manpages/nixos-option.8
+++ b/nixos/doc/manual/manpages/nixos-option.8
@@ -1,10 +1,12 @@
 .Dd January 1, 1980
 .\" nixpkgs groff will use Nixpkgs as the OS in the title by default, taking it from
-.\" doc-default-operating-system. mandoc doesn't have this register set by default,
-.\" so we can use it as a groff/mandoc switch.
-.ie ddoc-default-operating-system .Dt nixos-option \&8 "NixOS System Manager's Manual"
-.el .Dt nixos-option 8
-.Os NixOS
+.\" doc-{default,volume}-operating-system, while mandoc correctly uses NixOS on NixOS.
+.if '\*[doc-default-operating-system]'Nixpkgs' \{\
+.  ds doc-default-operating-system NixOS
+.  ds doc-volume-operating-system NixOS
+.\}
+.Dt nixos-option 8
+.Os
 .Sh NAME
 .Nm nixos-option
 .Nd inspect a NixOS configuration

--- a/nixos/doc/manual/manpages/nixos-rebuild.8
+++ b/nixos/doc/manual/manpages/nixos-rebuild.8
@@ -1,10 +1,12 @@
 .Dd January 1, 1980
-.\" nixpkgs groff will use Nixpkgs the OS in the title by default, taking it from
-.\" doc-default-operating-system. mandoc doesn't have this register set by default,
-.\" so we can use it as a groff/mandoc switch.
-.ie ddoc-default-operating-system .Dt nixos-rebuild \&8 "NixOS System Manager's Manual"
-.el .Dt nixos-rebuild 8
-.Os NixOS
+.\" nixpkgs groff will use Nixpkgs as the OS in the title by default, taking it from
+.\" doc-{default,volume}-operating-system, while mandoc correctly uses NixOS on NixOS.
+.if '\*[doc-default-operating-system]'Nixpkgs' \{\
+.  ds doc-default-operating-system NixOS
+.  ds doc-volume-operating-system NixOS
+.\}
+.Dt nixos-rebuild 8
+.Os
 .Sh NAME
 .Nm nixos-rebuild
 .Nd reconfigure a NixOS machine

--- a/nixos/doc/manual/manpages/nixos-version.8
+++ b/nixos/doc/manual/manpages/nixos-version.8
@@ -1,10 +1,12 @@
 .Dd January 1, 1980
 .\" nixpkgs groff will use Nixpkgs as the OS in the title by default, taking it from
-.\" doc-default-operating-system. mandoc doesn't have this register set by default,
-.\" so we can use it as a groff/mandoc switch.
-.ie ddoc-default-operating-system .Dt nixos-version \&8 "NixOS System Manager's Manual"
-.el .Dt nixos-version 8
-.Os NixOS
+.\" doc-{default,volume}-operating-system, while mandoc correctly uses NixOS on NixOS.
+.if '\*[doc-default-operating-system]'Nixpkgs' \{\
+.  ds doc-default-operating-system NixOS
+.  ds doc-volume-operating-system NixOS
+.\}
+.Dt nixos-version 8
+.Os
 .Sh NAME
 .Nm nixos-version
 .Nd show the NixOS version


### PR DESCRIPTION
###### Description of changes

the nixpkgs site-tmac sets doc-default-operating-system and doc-volume-operating-system to Nixpkgs, which is mostly correct but somewhat confusing for Nix*OS* manpages. luckily the previous dance was overly complicated and we can instead just change the registers differently if we detect a nixpkgs groff. this also means we can use plain `.Os` without hard-coding the os as detected by mandoc.

followup from https://github.com/NixOS/nixpkgs/pull/213256#discussion_r1093024815

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
