### PR TITLE
openfortigui: init at 0.9.8-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7292,6 +7292,12 @@
     githubId = 3267697;
     name = "Joshua Potter";
   };
+  jrrmyr = {
+    email = "jrrmyr@gmail.com";
+    github = "jrrmyr";
+    githubId = 102282561;
+    name = "Jeremy Robinson";
+  };
   jshcmpbll = {
     email = "me@joshuadcampbell.com";
     github = "jshcmpbll";

--- a/pkgs/applications/networking/openfortigui/default.nix
+++ b/pkgs/applications/networking/openfortigui/default.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, lib
+, git
+, libsForQt5
+, fetchgit
+}:
+
+stdenv.mkDerivation rec {
+    pname = "openfortigui";
+    version = "0.9.8-1";
+
+    src = fetchgit {
+        url = "https://github.com/theinvisible/openfortigui.git";
+        rev = "v${version}";
+        sha256 = "sha256-Lbc/SKrGx2DbIfhtqWnS81RVc1EMz8NnYEvULuL9J50=";
+        fetchSubmodules = true;
+        leaveDotGit = true;
+    };
+
+    nativeBuildInputs = [
+        libsForQt5.wrapQtAppsHook
+        git
+    ];
+    buildInputs = [
+        libsForQt5.qtbase
+        libsForQt5.qtkeychain
+    ];
+
+    preConfigure = ''
+        cd openfortigui
+        git submodule init
+        git submodule update
+    '';
+
+    buildPhase = ''
+        qmake
+        make -j4
+    '';
+
+    installPhase = ''
+        mkdir -p $out/bin
+        mv openfortigui $out/bin
+    '';
+
+    meta = with lib; {
+        description = "VPN-GUI to connect to Fortigate-Hardware, based on openfortivpn";
+        homepage = "https://github.com/theinvisible/openfortigui";
+        license = licenses.gpl3;
+        maintainers = with maintainers; [ jrrmyr ];
+        platforms = platforms.linux;
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10302,6 +10302,8 @@ with pkgs;
 
   openfpgaloader = callPackage ../development/embedded/fpga/openfpgaloader { };
 
+  openfortigui = callPackage ../applications/networking/openfortigui { };
+
   openfortivpn = callPackage ../tools/networking/openfortivpn { };
 
   opensnitch = callPackage ../tools/networking/opensnitch/daemon.nix { };


### PR DESCRIPTION
###### Description of changes
Added [openfortigui](https://github.com/theinvisible/openfortigui), which provides a VPN GUI for openfortivpn.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
