### PR TITLE
verible: 0.0-2472-ga80124e1 -> 0.0.2821

### DIFF
--- a/pkgs/development/tools/language-servers/verible/default.nix
+++ b/pkgs/development/tools/language-servers/verible/default.nix
@@ -13,18 +13,21 @@ let
 in
 buildBazelPackage rec {
   pname = "verible";
-  version = "0.0-2472-ga80124e1";
 
   # These environment variables are read in bazel/build-version.py to create
-  # a build string. Otherwise it would attempt to extract it from .git/.
-  GIT_DATE = "2022-10-21";
-  GIT_VERSION = version;
+  # a build string shown in the tools --version output.
+  # If env variables not set, it would attempt to extract it from .git/.
+  GIT_DATE = "2023-02-02";
+  GIT_VERSION = "v0.0-2821-gb2180bfa";
+
+  # Derive nix package version from GIT_VERSION: "v1.2-345-abcde" -> "1.2.345"
+  version = builtins.concatStringsSep "." (lib.take 3 (lib.drop 1 (builtins.splitVersion GIT_VERSION)));
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = "verible";
-    rev = "v${version}";
-    sha256 = "sha256:0jpdxqhnawrl80pbc8544pyggdp5s3cbc7byc423d5v0sri2f96v";
+    rev = "${GIT_VERSION}";
+    sha256 = "sha256-etcimvInhebH2zRPyZnWUq6m3VnCq44w32GJrIacULo=";
   };
 
   patches = [
@@ -46,8 +49,8 @@ buildBazelPackage rec {
     # of the output derivation ? Is there a more robust way to do this ?
     # (Hashes extracted from the ofborg build logs)
     sha256 = {
-      aarch64-linux = "sha256-6Udp7sZKGU8gcy6+5WPhkSWunf1sVkha8l5S1UQsC04=";
-      x86_64-linux = "sha256-WfhgbJFaM/ipdd1dRjPeVZ1mK2hotb0wLmKjO7e+BO4=";
+      aarch64-linux = "sha256-dYJoae3+u+gpULHS8nteFzzL974cVJ+cJzeG/Dz2HaQ=";
+      x86_64-linux = "sha256-Jd99+nhqgZ2Gwd78eyXfnSSfbl8C3hoWkiUnzJG1jqM=";
     }.${system} or (throw "No hash for system: ${system}");
   };
 
@@ -62,12 +65,9 @@ buildBazelPackage rec {
       bazel/build-version.py \
       bazel/sh_test_with_runfiles_lib.sh \
       common/lsp/dummy-ls_test.sh \
-      common/parser/move_yacc_stack_symbols.sh \
-      common/parser/record_syntax_error.sh \
       common/tools/patch_tool_test.sh \
       common/tools/verible-transform-interactive.sh \
       common/tools/verible-transform-interactive-test.sh \
-      common/util/create_version_header.sh \
       kythe-browse.sh \
       verilog/tools
   '';

--- a/pkgs/development/tools/language-servers/verible/remove-unused-deps.patch
+++ b/pkgs/development/tools/language-servers/verible/remove-unused-deps.patch
@@ -1,5 +1,5 @@
 diff --git a/WORKSPACE b/WORKSPACE
-index 696cc7ef..55a5bb8a 100644
+index ad16b3a1..52b66703 100644
 --- a/WORKSPACE
 +++ b/WORKSPACE
 @@ -81,17 +81,6 @@ load("@com_github_google_rules_install//:setup.bzl", "install_rules_setup")
@@ -12,11 +12,11 @@ index 696cc7ef..55a5bb8a 100644
 -
 -win_flex_configure(
 -    name = "win_flex_bison",
--    sha256 = "095cf65cb3f12ee5888022f93109acbe6264e5f18f6ffce0bda77feb31b65bd8",
--    # bison 3.3.2, flex 2.6.4
--    url = "https://github.com/lexxmark/winflexbison/releases/download/v2.5.18/win_flex_bison-2.5.18.zip",
+-    sha256 = "8d324b62be33604b2c45ad1dd34ab93d722534448f55a16ca7292de32b6ac135",
+-    # bison 3.8.2, flex 2.6.4
+-    url = "https://github.com/lexxmark/winflexbison/releases/download/v2.5.25/win_flex_bison-2.5.25.zip",
 -)
 -
  http_archive(
      name = "rules_m4",
-     sha256 = "c67fa9891bb19e9e6c1050003ba648d35383b8cb3c9572f397ad24040fb7f0eb",
+     sha256 = "b0309baacfd1b736ed82dc2bb27b0ec38455a31a3d5d20f8d05e831ebeef1a8e",


### PR DESCRIPTION
Upgrade to latest version, with the language server now building a symbol table and provide 'go-to-definition' feature.

Cleaned the version number to only contain tag number + commit-count and leave out the git-hash; This results in a more common way version numbers usually look like.

The version number is derived from the git tag used to check out the particular revision from git.

Signed-off-by: Henner Zeller <h.zeller@acm.org>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - checkPhase: all 568 unit tests pass.
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
