### PR TITLE
fava: support flask-babel 3

### DIFF
--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -10,7 +10,14 @@ python3.pkgs.buildPythonApplication rec {
     sha256 = "sha256-Uw8UIJa+Dtsy+o31I1ynLyhZrFNX42NFRXu1O2ISbzU=";
   };
 
-  pythonRelaxDeps = [ "cheroot" ];
+  patches = [
+    ./flask-babel.patch
+  ];
+
+  pythonRelaxDeps = [
+    "cheroot"
+    "Flask-Babel"
+  ];
 
   nativeBuildInputs = with python3.pkgs; [ setuptools-scm pythonRelaxDepsHook ];
 

--- a/pkgs/applications/office/fava/flask-babel.patch
+++ b/pkgs/applications/office/fava/flask-babel.patch
@@ -1,0 +1,14 @@
+diff --git a/src/fava/application.py b/src/fava/application.py
+index 811c1de4..19de051a 100644
+--- a/src/fava/application.py
++++ b/src/fava/application.py
+@@ -148,8 +148,7 @@ def get_locale() -> str | None:
+     return request.accept_languages.best_match(["en"] + LANGUAGES)
+ 
+ 
+-BABEL = Babel(app)
+-BABEL.localeselector(get_locale)
++BABEL = Babel(app, locale_selector=get_locale)
+ 
+ 
+ for function in template_filters.FILTERS:


### PR DESCRIPTION
###### Description of changes
The webui lauches and works.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
