### PR TITLE
python3Packages.pyathena: Add fsspec to propagatedBuildInputs

### DIFF
--- a/pkgs/development/python-modules/pyathena/default.nix
+++ b/pkgs/development/python-modules/pyathena/default.nix
@@ -3,6 +3,7 @@
 , botocore
 , buildPythonPackage
 , fetchPypi
+, fsspec
 , pandas
 , pythonOlder
 , tenacity
@@ -23,6 +24,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     boto3
     botocore
+    fsspec
     pandas
     tenacity
   ];


### PR DESCRIPTION
###### Description of changes

Add fsspec to `python3Packages.pyathena` propagatedBuildInputs.


Before the change `pyathena` failed with

```
$ nix build --no-link github:NixOS/nixpkgs#python3.pkgs.pyathena
error: builder for '/nix/store/vrr5fb76cg5si8a41chfc3ghnfcq0rb3-python3.10-pyathena-2.19.0.drv' failed with exit code 1;
       last 10 log lines:
       > removing build/bdist.linux-x86_64/wheel
       > Finished executing setuptoolsBuildPhase
       > installing
       > Executing pipInstallPhase
       > /build/pyathena-2.19.0/dist /build/pyathena-2.19.0
       > Processing ./pyathena-2.19.0-py3-none-any.whl
       > Requirement already satisfied: boto3>=1.26.4 in /nix/store/xb7y4jgmb89fn9vzcdyqsgavc16yiw7i-python3.10-boto3-1.26.38/lib/python3.10/site-packages (from pyathena==2.19.0) (1.26.38)
       > ERROR: Could not find a version that satisfies the requirement fsspec (from pyathena) (from versions: none)
       > ERROR: No matching distribution found for fsspec
       >
       For full logs, run 'nix log /nix/store/vrr5fb76cg5si8a41chfc3ghnfcq0rb3-python3.10-pyathena-2.19.0.drv'.
```

@turion 