### PR TITLE
rocfft: actually fix hydra caching

### DIFF
--- a/pkgs/development/libraries/rocfft/default.nix
+++ b/pkgs/development/libraries/rocfft/default.nix
@@ -19,7 +19,8 @@
 }:
 
 let
-  rocfft = stdenv.mkDerivation (finalAttrs: {
+  # This is over 3GB, to allow hydra caching we separate it
+  rf = stdenv.mkDerivation (finalAttrs: {
     pname = "rocfft";
     version = "5.4.2";
 
@@ -112,27 +113,23 @@ let
     };
   });
 
-  rocfft-zero = runCommand "rocfft-zero" { preferLocalBuild = true; } ''
-    mkdir -p $out
-    cp -a ${rocfft}/lib/librocfft-device-0* $out
+  rf-zero = runCommand "librocfft-device-0.so.0.1" { preferLocalBuild = true; } ''
+    cp -a ${rf}/lib/$name $out
   '';
 
-  rocfft-one = runCommand "rocfft-one" { preferLocalBuild = true; } ''
-    mkdir -p $out
-    cp -a ${rocfft}/lib/librocfft-device-1* $out
+  rf-one = runCommand "librocfft-device-1.so.0.1" { preferLocalBuild = true; } ''
+    cp -a ${rf}/lib/$name $out
   '';
 
-  rocfft-two = runCommand "rocfft-two" { preferLocalBuild = true; } ''
-    mkdir -p $out
-    cp -a ${rocfft}/lib/librocfft-device-2* $out
+  rf-two = runCommand "librocfft-device-2.so.0.1" { preferLocalBuild = true; } ''
+    cp -a ${rf}/lib/$name $out
   '';
 
-  rocfft-three = runCommand "rocfft-three" { preferLocalBuild = true; } ''
-    mkdir -p $out
-    cp -a ${rocfft}/lib/librocfft-device-3* $out
+  rf-three = runCommand "librocfft-device-3.so.0.1" { preferLocalBuild = true; } ''
+    cp -a ${rf}/lib/$name $out
   '';
 in stdenv.mkDerivation {
-  inherit (rocfft) pname version outputs src passthru meta;
+  inherit (rf) pname version outputs src passthru meta;
 
   dontUnpack = true;
   dontPatch = true;
@@ -143,16 +140,15 @@ in stdenv.mkDerivation {
     runHook preInstall
 
     mkdir -p $out/lib
-
-    for path in ${rocfft-zero} ${rocfft-one} ${rocfft-two} ${rocfft-three}; do
-      cp -as $path/* $out/lib
-    done
-
-    cp -an ${rocfft}/* $out
+    cp -as ${rf-zero} $out/lib/${rf-zero.name}
+    cp -as ${rf-one} $out/lib/${rf-one.name}
+    cp -as ${rf-two} $out/lib/${rf-two.name}
+    cp -as ${rf-three} $out/lib/${rf-three.name}
+    cp -an ${rf}/* $out
   '' + lib.optionalString buildTests ''
-    cp -a ${rocfft.test} $test
+    cp -a ${rf.test} $test
   '' + lib.optionalString buildBenchmarks ''
-    cp -a ${rocfft.benchmark} $benchmark
+    cp -a ${rf.benchmark} $benchmark
   '' + ''
     runHook postInstall
   '';
@@ -160,18 +156,18 @@ in stdenv.mkDerivation {
   # Fix paths
   preFixup = ''
     substituteInPlace $out/include/*.h $out/rocfft/include/*.h \
-      --replace "${rocfft}" "$out"
+      --replace "${rf}" "$out"
 
     patchelf --set-rpath \
-      $(patchelf --print-rpath $out/lib/librocfft.so | sed 's,${rocfft}/lib,'"$out/lib"',') \
+      $(patchelf --print-rpath $out/lib/librocfft.so | sed 's,${rf}/lib,'"$out/lib"',') \
       $out/lib/librocfft.so
   '' + lib.optionalString buildTests ''
     patchelf --set-rpath \
-      $(patchelf --print-rpath $test/bin/rocfft-test | sed 's,${rocfft}/lib,'"$out/lib"',') \
+      $(patchelf --print-rpath $test/bin/rocfft-test | sed 's,${rf}/lib,'"$out/lib"',') \
       $test/bin/rocfft-test
   '' + lib.optionalString buildBenchmarks ''
     patchelf --set-rpath \
-      $(patchelf --print-rpath $benchmark/bin/rocfft-rider | sed 's,${rocfft}/lib,'"$out/lib"',') \
+      $(patchelf --print-rpath $benchmark/bin/rocfft-rider | sed 's,${rf}/lib,'"$out/lib"',') \
       $benchmark/bin/rocfft-rider
   '';
 }


### PR DESCRIPTION
###### Description of changes
This was tricky, but I can definitely confirm hydra will cache this since it turns out collecting garbage will show if the base derivation is still there or not, and if it is not then the new one (which should still exist) no longer depends on it.
Tracking: #197885
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
