### PR TITLE
tree-sitter-grammars: update

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-beancount.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-beancount.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/polarmutex/tree-sitter-beancount",
-  "rev": "b807e0c5255221f5e4baa08b3325d08e2ba56ba2",
-  "date": "2022-07-02T10:33:09-04:00",
-  "path": "/nix/store/9kqvj3rpqlqgxr5nkcc43pkcvs460h14-tree-sitter-beancount",
-  "sha256": "0vh2sz5qjsgkmqlcw0kyq01wj5mxwymhyg9w8hfyd7kd779lfa86",
+  "rev": "6d580bc408741ce2ba1a566c972e9ff414c65456",
+  "date": "2023-01-27T21:26:56-05:00",
+  "path": "/nix/store/8sfwfmc20bs3vmfns5qb82jf63h625hb-tree-sitter-beancount",
+  "sha256": "0q4f1qqd8m7x4qxj4bpwgk8fxksh60n1m4payvhd0y0xrrhb06v8",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-clojure.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-clojure.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/sogaiu/tree-sitter-clojure",
-  "rev": "087bac78c53fe1387756cd5b8e68a69b3f6d7244",
-  "date": "2022-07-19T19:21:35+09:00",
-  "path": "/nix/store/n0kwbvimmzp36y789sb5jrbarjzlwmyf-tree-sitter-clojure",
-  "sha256": "018xrralv15d7r1v63knds7cyix77ssy4jr0qdjmbakdr00r4ara",
+  "rev": "262d6d60f39f0f77b3dd08da8ec895bd5a044416",
+  "date": "2023-01-22T08:16:32+09:00",
+  "path": "/nix/store/hcfhkyafrdrkxxl326vc9p0ahgg4s1xj-tree-sitter-clojure",
+  "sha256": "0bgd9g1j4ww45g0l0aa1jac49421z95cc2rhcgqmgx7nzn94rszp",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cmake.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cmake.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/uyha/tree-sitter-cmake",
-  "rev": "6e51463ef3052dd3b328322c22172eda093727ad",
-  "date": "2022-08-26T09:50:26+02:00",
-  "path": "/nix/store/h7v6r9x9d552gfl8s8dwf26azvdrmsc1-tree-sitter-cmake",
-  "sha256": "14l7l6cc9pdqinff9hjda7rakzfvwk0qcbv6djl0s9f21875l4nv",
+  "rev": "a32265307aa2d31941056d69e8b6633e61750b2f",
+  "date": "2022-12-03T13:09:00+01:00",
+  "path": "/nix/store/mrafvbbjkpvrmxc49zbzjg4flqvy8cz9-tree-sitter-cmake",
+  "sha256": "19pzhi6kgclf2fccn7vylwik2d0m8jbp8kppmxcxrmd6qx47f5rc",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "5ead1e26c6ab71919db0f1880c46a278a93bc5ea",
-  "date": "2022-10-19T20:38:44-05:00",
-  "path": "/nix/store/0zigaml3k0fk0w9mzsjrhrp1968hd6r7-tree-sitter-cpp",
-  "sha256": "1572qhfw1jjkm1q6c110lnnj2n384a97fgn645c5q9ikciv8kac7",
+  "rev": "56cec4c2eb5d6af3d2942e69e35db15ae2433740",
+  "date": "2023-01-27T11:24:06-06:00",
+  "path": "/nix/store/22qiavlbn6vk5hgd1w8xqxhdds0rs6xg-tree-sitter-cpp",
+  "sha256": "0c5iwg9j6naivvr18glfp095x32nfl9hbw0q02rhh1b59fkpjs09",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-cuda",
-  "rev": "7f1a79e612160aa02be87f1a24469ae3655fe818",
-  "date": "2022-10-19T23:28:33-07:00",
-  "path": "/nix/store/6sgr13lqfw9s9lzlq4m116kvazzkkbmk-tree-sitter-cuda",
-  "sha256": "1bcci9v61lcgiqq3jqf4gl0kbq89w2h5kjn70g8x2g4lmky6y6fc",
+  "rev": "a02c21408c592e6e6856eaabe4727faa97cf8d85",
+  "date": "2023-01-31T12:30:22+01:00",
+  "path": "/nix/store/hv7p4dc4zbgq5j1zylxy25s96720dm29-tree-sitter-cuda",
+  "sha256": "00hz0p97nbiskph35lginjyn3r9dz7q489sx7ippjrfdffqs433f",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-embedded-template",
-  "rev": "91fc5ae1140d5c9d922312431f7d251a48d7b8ce",
-  "date": "2022-11-03T14:16:56-07:00",
-  "path": "/nix/store/6z47mgb533bf76l1x22bh64rck5phq8z-tree-sitter-embedded-template",
-  "sha256": "161bw6hhx4pgzdav5hah4is5w0rfhyid4q9gak0yp05ylk0040sq",
+  "rev": "a13085849cf69e2401ec44e38cffc3d73f22f3df",
+  "date": "2023-01-10T14:45:33+01:00",
+  "path": "/nix/store/p519pn15mzkjgsnd0229ifcljk6q0p95-tree-sitter-embedded-template",
+  "sha256": "0fjvza6apc2w08pwcq5925gr8bxqq7yhw2sbb1sc4sz7dwwqpp14",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ram02z/tree-sitter-fish",
-  "rev": "84436cf24c2b3176bfbb220922a0fdbd0141e406",
-  "date": "2022-08-21T20:31:28+01:00",
-  "path": "/nix/store/mf86jwsgjr0jdsdp88haqlqhfnpwvsh9-tree-sitter-fish",
-  "sha256": "12s3db2mg9qa8l1i4a5h59kd7kl5j83wyl5kzq7j2k56xmvq56x0",
+  "rev": "6675b56266b3f615fb112205b6b83a79315309c4",
+  "date": "2022-11-23T19:08:14+00:00",
+  "path": "/nix/store/28gk36jbxb18i2z410r3fxdc2shs1rdc-tree-sitter-fish",
+  "sha256": "1w4zyjg32irhn246ck64zlmmli7l3f2l4x1rmv1ryfsz4cr90kc5",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fortran.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fortran.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/stadelmanma/tree-sitter-fortran",
-  "rev": "f0f2f100952a353e64e26b0fa710b4c296d7af13",
-  "date": "2021-09-02T21:24:27-04:00",
-  "path": "/nix/store/5abj5miyzb7dvyq4zw0j1mxgdxqyj2yx-tree-sitter-fortran",
-  "sha256": "17iiz38s7adkzv9rw97nn5nd9kvn1vyccm7r6ywipaa5aim0nm6a",
+  "rev": "edcb3374f4698aaedf24bc572f6b2f5ef0e89ac7",
+  "date": "2023-01-05T22:51:37-05:00",
+  "path": "/nix/store/hw63cwp1z9b3q8vmla2g81bcjvh0cqqb-tree-sitter-fortran",
+  "sha256": "1kr2hhjmzn4q9i5jaijwp7001sy7n0sgdkacnq877jyn26sxd5y5",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-glsl",
-  "rev": "a743ada24fa17da9acc5665133f07d56e03530be",
-  "date": "2022-09-04T21:41:54+02:00",
-  "path": "/nix/store/z4bzmqy26xqwi4lysjicllf2jrk6pvvm-tree-sitter-glsl",
-  "sha256": "04naalz59mczi0dlnjg49z5ygl0f9v1byr2kfclw6q6rhx9pcswp",
+  "rev": "e2c2214045de2628b81089b1a739962f59654558",
+  "date": "2022-11-24T01:46:06+01:00",
+  "path": "/nix/store/s203fvxw2v3gvbnf5qavms10f308ssl0-tree-sitter-glsl",
+  "sha256": "146v3ki2c2g8grlkz40iay6wi2crkxiy3i3jkcpv096ya9wf3dhs",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-go",
-  "rev": "05900faa3cdb5d2d8c8bd5e77ee698487e0a8611",
-  "date": "2022-10-20T09:01:48+02:00",
-  "path": "/nix/store/p44flk3wlp5n99jc550pkm8rzjqnvy84-tree-sitter-go",
-  "sha256": "1qymkdi4qcnj8ywmsanb6pdl9zd71cbm6kzl87zk241h7dhkkkvz",
+  "rev": "64457ea6b73ef5422ed1687178d4545c3e91334a",
+  "date": "2022-12-08T10:45:14+01:00",
+  "path": "/nix/store/4kdv3qc219w96wcciypw0znkv2izbpd2-tree-sitter-go",
+  "sha256": "16d32m78y8jricba9xav35c9y0k2r29irj5xyqgq24323yln9jnz",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "bee6b49543e34c2967c6294a4b05e8bd2bf2da59",
-  "date": "2022-09-30T18:11:21+02:00",
-  "path": "/nix/store/d6c30iv724f2kpcb969zskcxbh6fcrdz-tree-sitter-haskell",
-  "sha256": "069pyll6nvzakj5rhpd28md9dfzhcap2jwffqkwjyaavwcwar9gz",
+  "rev": "aee3725d02cf3bca5f307b35dd3a96a97e109b4e",
+  "date": "2022-11-19T03:13:19+01:00",
+  "path": "/nix/store/40szsli32ssyyxf78xy23yvan24b6df7-tree-sitter-haskell",
+  "sha256": "19yvvny7z18bxjwx3ajbz66vh5gv9ds0h2gbz134i0vp3d3fnshf",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hcl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hcl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MichaHoffmann/tree-sitter-hcl",
-  "rev": "4ff21306a71269c4ac814769b90b0ecf3194d21d",
-  "date": "2022-06-02T20:13:06+02:00",
-  "path": "/nix/store/jsn5dixjqqvwagcgwgjdr91igic2r42w-tree-sitter-hcl",
-  "sha256": "1gvpl6kw83ywwd64ssz5xs4idc8ip2jmiz2mfy9xlkjbl9nfngci",
+  "rev": "6b74f88b3d396e0f101c93f807e0b3667cd3e3a2",
+  "date": "2022-12-02T21:24:38+01:00",
+  "path": "/nix/store/nn324j92ywapf4smjhkjyljlf6f5f96q-tree-sitter-hcl",
+  "sha256": "1dm129c91qyg955mpxy408wa7cmxyvh5n79c8rlb3yhc77f4z2px",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-http.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-http.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ntbbloodbath/tree-sitter-http",
-  "rev": "30a9c1789d64429a830802cde5b1760ff1064312",
-  "date": "2022-08-21T21:33:18-04:00",
-  "path": "/nix/store/0zk2zzhhx9vsp7h7gsb57db5sk20p3ji-tree-sitter-http",
-  "sha256": "0gd3dv8kr0rzhagxi729fwjzsnipyxln823a4qfqr7lzzvmb14jy",
+  "rev": "2c6c44574031263326cb1e51658bbc0c084326e7",
+  "date": "2023-01-06T03:29:38+01:00",
+  "path": "/nix/store/p6dxp8z5fyyjs9s0lky651dhmln7ciw0-tree-sitter-http",
+  "sha256": "15spzks4wpd1zvqkaq9irlr5xqk1n144lyxdkijkc9zvyvm6gka7",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-janet-simple.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-janet-simple.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/sogaiu/tree-sitter-janet-simple",
-  "rev": "e6c04e4b243cf3e5aca8f201e48926a72cc18334",
-  "date": "2022-03-29T10:00:03+09:00",
-  "path": "/nix/store/4ynwhc2s20xm093inlpyxgdb6pbc753m-tree-sitter-janet-simple",
-  "sha256": "1anbd0bx8vcg1rb6mr8hknnd5f9f6zr3h7kn98x8s7znyvlj4w6q",
+  "rev": "c995ea84d009b14aeb64da4824834a1af6afde02",
+  "date": "2022-12-23T15:20:54+09:00",
+  "path": "/nix/store/3fz5s1rcib6i1f3si16j63x19akck7ak-tree-sitter-janet-simple",
+  "sha256": "0rr82sd2dybbbsmdq3x8fx5amq4li49wpi51a9fsh42ym6r560xx",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-java",
-  "rev": "ac14b4b1884102839455d32543ab6d53ae089ab7",
-  "date": "2022-05-30T15:48:08+02:00",
-  "path": "/nix/store/plcr9wxxfhsfgwb9xfj3xwns2sh53xsa-tree-sitter-java",
-  "sha256": "1i9zfgqibinz3rkx6yws1wk49iys32x901dki65qihbxcmcfh341",
+  "rev": "09d650def6cdf7f479f4b78f595e9ef5b58ce31e",
+  "date": "2022-09-19T09:37:51+02:00",
+  "path": "/nix/store/478mfssm2335hdflgba22n4f0dir7xmr-tree-sitter-java",
+  "sha256": "0440xh8x8rkbdlc1f1ail9wzl4583l29ic43x9lzl8290bm64q5l",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-javascript",
-  "rev": "936d976a782e75395d9b1c8c7c7bf4ba6fe0d86b",
-  "date": "2022-08-18T14:29:19+02:00",
-  "path": "/nix/store/y3ndi84v9y3li5vnfyyp9xhb8hsgsipf-tree-sitter-javascript",
-  "sha256": "1g252s51amn9w0j6wi4jk6zic9rbw8hajqhcdycq9ma4sqpvb5dr",
+  "rev": "15e85e80b851983fab6b12dce5a535f5a0df0f9c",
+  "date": "2023-01-24T19:35:07+01:00",
+  "path": "/nix/store/f1vgnmzyf77hj3238bw6ddwj02328z5q-tree-sitter-javascript",
+  "sha256": "1hwmj8r2snr2bszy0fr4zfi0mq3rhxd3jz503aknr9iwfq30j86r",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-jsonnet.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-jsonnet.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/sourcegraph/tree-sitter-jsonnet",
-  "rev": "0475a5017ad7dc84845d1d33187f2321abcb261d",
-  "date": "2022-05-27T01:23:53-04:00",
-  "path": "/nix/store/n4yijz5b0bky4zd8kvh632a5zlxc3rfv-tree-sitter-jsonnet",
-  "sha256": "1dh8wqi8mnsapzicrdjg6cj6skj9f2ia4ijg08pl45bcxc1lidzc",
+  "rev": "505f5bd90053ae895aa3d6f2bac8071dd9abd8b2",
+  "date": "2022-12-19T21:45:54-05:00",
+  "path": "/nix/store/pmpam2wcxkmyfs1h0ssj2n0lwvngmqkc-tree-sitter-jsonnet",
+  "sha256": "1hiym39d0n8dxmar2bjm449nj546fiz1dklgns541yfc1k0b56jx",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-julia",
-  "rev": "628713553c42f30595a3b0085bb587e9359b986a",
-  "date": "2022-11-15T18:14:44-05:00",
-  "path": "/nix/store/4d712q8sjvbh845cd2b0xbvlng1iasaj-tree-sitter-julia",
-  "sha256": "12xlv4gbqdw0mr1zgnzs74pxpdkq4vfvs77gnr49zsrycjflf7xw",
+  "rev": "9d368185be7e8139f2eda93d8b0acc2a54031718",
+  "date": "2023-01-22T20:02:36-05:00",
+  "path": "/nix/store/sih93k1xkd8c7kdvvz5vl0dwzygn9qfa-tree-sitter-julia",
+  "sha256": "15rcrn4gbkbpvndzw9jp4p802si9a8rqnj31a3mj2z9w7ala4cpa",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MunifTanjim/tree-sitter-lua",
-  "rev": "fb30e8cb605e2ebd6c643e6981325a63fbbde320",
-  "date": "2022-10-31T13:56:07+06:00",
-  "path": "/nix/store/ifpy40hx70sg9syjr3d35ngrfkmmqi18-tree-sitter-lua",
-  "sha256": "1hhffz45ilni4g9idsbpp1aymdjkjnyd4491xbdmr47bglf9cgc1",
+  "rev": "0fc89962b7ff5c7d676b8592c1cbce1ceaa806fd",
+  "date": "2022-12-16T15:23:55+06:00",
+  "path": "/nix/store/cm9ff3d8f48sqgjkrc38sqjg7lbpswz9-tree-sitter-lua",
+  "sha256": "07mj9jydnxmp2dr7ssj58qlwrjx3gp6jnri79wa2jxaaygblzcri",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MDeiml/tree-sitter-markdown",
-  "rev": "272e080bca0efd19a06a7f4252d746417224959e",
-  "date": "2022-10-27T17:15:20+02:00",
-  "path": "/nix/store/n8n85lvdf3galrlr5ywjjkpsny6mvg7n-tree-sitter-markdown",
-  "sha256": "1q9s8ln6pag0362ckvzid8jpc2h14pd7kfr1qq4dpirzqq0y79l0",
+  "rev": "abea13b86c404564991244b69b7afc4ca362d0c0",
+  "date": "2023-02-02T17:49:52+01:00",
+  "path": "/nix/store/iiabr5y9d424b68rrbxi6g2dvgs4d79s-tree-sitter-markdown",
+  "sha256": "1xg8707ga8hslmaj9kb3i6jjal0ab189zqbzffimh6nj6kx6bm41",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nickel.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nickel.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nickel-lang/tree-sitter-nickel",
-  "rev": "9d83db400b6c11260b9106f131f93ddda8131933",
-  "date": "2022-07-06T11:43:01+02:00",
-  "path": "/nix/store/i7arz4binnq34j1k0hwlpl4apd9b4j4x-tree-sitter-nickel",
-  "sha256": "0rm63fnxja59zzkm7gz4vbzics8mdf7d6ijazcy9394kdqrcdzi6",
+  "rev": "d6c7eeb751038f934b5b1aa7ff236376d0235c56",
+  "date": "2023-01-27T10:31:38+01:00",
+  "path": "/nix/store/nyv8hdasyh5hgs65r38saxdn2m26b70r-tree-sitter-nickel",
+  "sha256": "1qdhggiprs1z5nnans2a876znfga95az3nafl4qp7j0ngg0m3x0g",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nvim-neorg/tree-sitter-norg",
-  "rev": "dfac5ad2740a79b18ae849590a924e7bad3f1b23",
-  "date": "2022-10-13T09:07:45+02:00",
-  "path": "/nix/store/9csv2xax6ris1wghj83gdf1sjvbh7jfq-tree-sitter-norg",
-  "sha256": "0jws376b7a2jqr0d32c20qh9v3d0wi8af95dprmfhi8pcvd5hzww",
+  "rev": "6348056b999f06c2c7f43bb0a5aa7cfde5302712",
+  "date": "2022-11-30T11:06:43+01:00",
+  "path": "/nix/store/2szgkbzabvvsp7y5n0a1gp7mi8q86dxd-tree-sitter-norg",
+  "sha256": "14l09yrnagp26bcbpy8r07bw78vv8a004ji8c7r40jr9jvx0l3p6",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ocaml",
-  "rev": "cc26b1ef111100f26a137bcbcd39fd4e35be9a59",
-  "date": "2022-06-19T21:41:43+02:00",
-  "path": "/nix/store/m5z0cdxb8mg1ff64529p8sfj9afq50l5-tree-sitter-ocaml",
-  "sha256": "1qra2zihw09ff16gxfmpmdmyj0rilvnk1xc9y4wb01j2a4292fc1",
+  "rev": "de07323343946c32759933cb3b7c78e821098cad",
+  "date": "2022-12-14T19:50:15+01:00",
+  "path": "/nix/store/h6h50380i2gp7j00i525vgs9llv58jzs-tree-sitter-ocaml",
+  "sha256": "021vnbpzzb4cca3ncd4qhzy583vynhndn3qhwayxrpgdl61m44i6",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "ab2e72179ceb8bb0b249c8ac9162a148e911b3dc",
-  "date": "2022-09-24T09:03:15+02:00",
-  "path": "/nix/store/99jwdb92ng3xr6j881aja24dgwra4lvx-tree-sitter-php",
-  "sha256": "0gfjvpa5rfi1lgz30jhmdfr8f09vl34k3xjad8n8l2cv5q9203if",
+  "rev": "973694ffcdeebca245b7ecf0d7c4cadd4f41b3c9",
+  "date": "2023-01-20T09:23:32+01:00",
+  "path": "/nix/store/acl02v859mpc84g0nqj6rjh63p7jav9m-tree-sitter-php",
+  "sha256": "16jcv77wjjxxmznr3yyj48ny2m2iam0jvzgipwbywf9c19dpr4ms",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-prisma.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-prisma.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/victorhqc/tree-sitter-prisma",
-  "rev": "17a59236ac25413b81b1613ea6ba5d8d52d7cd6c",
-  "date": "2022-06-11T23:04:44+02:00",
-  "path": "/nix/store/qdkwinjdy495z59wvxhifk8caksndswj-tree-sitter-prisma",
-  "sha256": "1pw9mi6hhvww4i7gf7snl893b3hwnfwp18rhbcsf7z52cr78mmqi",
+  "rev": "eca2596a355b1a9952b4f80f8f9caed300a272b5",
+  "date": "2023-01-05T15:24:25+01:00",
+  "path": "/nix/store/hj6bbz4zdfwi7ps72zbbv0hg132g13gr-tree-sitter-prisma",
+  "sha256": "19zb3dkwp2kpyivygqxk8yph0jpl7hn9zzcry15mshn2n0rs9sih",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pug.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pug.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/zealot128/tree-sitter-pug",
-  "rev": "63e214905970e75f065688b1e8aa90823c3aacdc",
-  "date": "2022-05-05T14:29:30+02:00",
-  "path": "/nix/store/8nwqja3ff6cmy06sgxx6wzlbg7qx6x1r-tree-sitter-pug",
-  "sha256": "1r3zhz4adfpg2ihlbdfx4nb9svv6apnlahgfqqzmacj3bm8r3wmp",
+  "rev": "26f6ac805e11e19c4492089f24aa44fe71be7c1f",
+  "date": "2023-01-20T22:49:33+01:00",
+  "path": "/nix/store/9mrd8wi2n04vgwihc4738vgh21vn2rra-tree-sitter-pug",
+  "sha256": "0202a4xc23b91frvc3nxqxhdkz9xzmi41lfvagmp41vqravj6hi9",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-python",
-  "rev": "b14614e2144b8f9ee54deed5a24f3c6f51f9ffa8",
-  "date": "2022-10-24T22:08:56+02:00",
-  "path": "/nix/store/n4jhzd32dykrfxzar6cymx1b8njmmsxs-tree-sitter-python",
-  "sha256": "086v2mrczj8gavl4w8w8m982pg94w8ph5vf5iaksi1pvgcmw8c71",
+  "rev": "9e53981ec31b789ee26162ea335de71f02186003",
+  "date": "2022-12-07T09:03:23-08:00",
+  "path": "/nix/store/9rda709b6hq344v0cyc7g768bz1p1b3k-tree-sitter-python",
+  "sha256": "1lv3pgb7h2a0f121897r0lwc228rjwb77y3a6g3ghifx1rgbwvqg",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-query.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-query.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nvim-treesitter/tree-sitter-query",
-  "rev": "0695cd0760532de7b54f23c667d459b5d1332b44",
-  "date": "2022-10-14T22:40:48+02:00",
-  "path": "/nix/store/s8jkcp7vk5hpw9qxwkr4xq926na9sxa6-tree-sitter-query",
-  "sha256": "1m8dsni3wzs94yc7y6zydh4l6zgm35wy9r1lcmk17phvylx6y20g",
+  "rev": "0717de07078a20a8608c98ad5f26c208949d0e15",
+  "date": "2022-12-19T17:53:12+01:00",
+  "path": "/nix/store/gdf77qz6qmfikks2vjqh38wxsvn80r8w-tree-sitter-query",
+  "sha256": "19025zagdmimqixd25gh2rwn5hr9jfr7s08fvil3n5fqr9zshrbm",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "0431a2c60828731f27491ee9fdefe25e250ce9c9",
-  "date": "2022-11-03T12:28:18-07:00",
-  "path": "/nix/store/w0c9d84wvp2d8zx15h7dc3v33n1njmfz-tree-sitter-rust",
-  "sha256": "149jhy01mqvavwa8jlxb8bnn7sxpfq2x1w35si6zn60b7kqjlx8f",
+  "rev": "f7fb205c424b0962de59b26b931fe484e1262b35",
+  "date": "2022-12-06T10:41:07+01:00",
+  "path": "/nix/store/i4gpgyrpsh222d62284qa1r3p4mwkba0-tree-sitter-rust",
+  "sha256": "099w9hrglpydwgxryvrpk07abcwpdzkdrkhgisn287y6df5kqy9s",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-scala",
-  "rev": "140c96cf398693189d4e50f76d19ddfcd8a018f8",
-  "date": "2022-06-06T08:54:55+02:00",
-  "path": "/nix/store/a1pi2xyaq2jjllbkj44xhi5cp0vnlnm4-tree-sitter-scala",
-  "sha256": "1hfx696x5pfww6zsfv36wkmxld14f02krmx55fy5rgzlz1m3xgja",
+  "rev": "918f0fb948405181707a1772cab639f2d278d384",
+  "date": "2023-01-05T16:03:13-05:00",
+  "path": "/nix/store/38yd5q5d19fdry4icmq5fqz0kkmz3xi3-tree-sitter-scala",
+  "sha256": "0ffcx6lrpvg56wci0a4crk58as8hs8aljrqsim2kqbb171mc4wzy",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/6cdh/tree-sitter-scheme",
-  "rev": "bdcd2c8496701153506a9e3e1b76dfed852873ba",
-  "date": "2022-11-06T17:17:49+08:00",
-  "path": "/nix/store/l096qb2872kab34avgscn9bwizrzail5-tree-sitter-scheme",
-  "sha256": "12knvhmayck9da3zj2w55al4yjhkkr9gxmfdmrjiz7vn9wc1dxr9",
+  "rev": "67b90a365bebf4406af4e5a546d6336de787e135",
+  "date": "2023-01-16T14:32:14+08:00",
+  "path": "/nix/store/vsbfzbn9phgkn008633yjxr3d95zf4y1-tree-sitter-scheme",
+  "sha256": "1pvxckza1kdfwqs78ka3lbwldrwkgymb31f5x1fq5vyawg60wxk8",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/derekstride/tree-sitter-sql",
-  "rev": "4f1b91246b43190e34957d9de9a0f3625879ba33",
-  "date": "2022-11-18T10:16:02-05:00",
-  "path": "/nix/store/l84kfw631akx7v4k6c0s4hdvaanjh8a1-tree-sitter-sql",
-  "sha256": "03wbxfkwk5i31knf1hgqkb56r66vk18k5n4919hhnhy9vvrm0mw3",
+  "rev": "30e15d45dceb24ea51acf81ee7d75d81567b6e02",
+  "date": "2023-02-02T09:55:44-05:00",
+  "path": "/nix/store/f8cchfpaawdiv0sn1rpz7wg268h9jiz5-tree-sitter-sql",
+  "sha256": "0higd3pavwa54d7rg8iwy4rj3fqsfqnmdd4ayh8g832iq55xxj5k",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tiger.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tiger.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ambroisie/tree-sitter-tiger",
-  "rev": "eb1d3714998977ae76ca7c6a102b10ee37efc2b5",
-  "date": "2022-06-13T13:43:12+02:00",
-  "path": "/nix/store/97jbgip2nh59zrxyhnqlmw14g25c7g89-tree-sitter-tiger",
-  "sha256": "1p1hn99lsmqlmqgv7i3yw2jsqbj5xrrnvs87wkir74y7li2h9g4i",
+  "rev": "a233ebe360a73a92c50978e5c4e9e471bc59ff42",
+  "date": "2022-11-22T10:59:45+01:00",
+  "path": "/nix/store/30fd7jd6p4rc2x1ahax19jxxa0blz7lq-tree-sitter-tiger",
+  "sha256": "0jv8dawvdjws0klypf80z4fff4va5963vcxdp22rvp3g1n8dc3cm",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tlaplus.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tlaplus.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tlaplus-community/tree-sitter-tlaplus",
-  "rev": "deaf0e5c573ad4e2bbfc9a29abb7b6dcb572556e",
-  "date": "2022-07-26T16:48:02-04:00",
-  "path": "/nix/store/40jlhkwlrvzdg3s95w132kvs5rax8mbj-tree-sitter-tlaplus",
-  "sha256": "01nsi5403vxcc725x9rvd0ff6xfkg2lw5350i1w5998jbs9kd00g",
+  "rev": "6fd16d8469c6898317423d61738d97e2b3f5caf7",
+  "date": "2023-01-24T13:01:29-05:00",
+  "path": "/nix/store/vd8n5n1kqcnlgvfw60gq7daq4pv3ipwx-tree-sitter-tlaplus",
+  "sha256": "0lhkjm1z314p078x6037676myc06aqp7hnbdhq3qqrqgz5rri6dk",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "0ab9d99867435a7667c5548a6617a6bf73dbd830",
-  "date": "2022-10-10T11:19:39-07:00",
-  "path": "/nix/store/fjbslm2md38afkaxbnc3l537j23z9mvv-tree-sitter-typescript",
-  "sha256": "0kv91f8k7jwzkmkz2zvx9rh0ncgbcys9c37jbj0g4y1zhzn8l7rp",
+  "rev": "5d20856f34315b068c41edaee2ac8a100081d259",
+  "date": "2023-01-24T16:36:32+01:00",
+  "path": "/nix/store/0zkm35593yv26vs5qlm2af6pm1r0if4n-tree-sitter-typescript",
+  "sha256": "0934c35as3wgakqw20ilii8lvby5ns36mmqsxjwz8zg5zfsq14vj",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/vigoux/tree-sitter-viml",
-  "rev": "4ae7bd67706d7e10afed827ce2ded884ab41650f",
-  "date": "2022-11-02T08:03:51+01:00",
-  "path": "/nix/store/k2fsslkwfsxscmcghiz6qqah9v275hy9-tree-sitter-viml",
-  "sha256": "082yw8qgi4fp9wfjfinnyh60f6rvp7fbyi88yaw6kdx4mjrnl0z6",
+  "rev": "55ff1b080c09edeced9b748cf4c16d0b49d17fb9",
+  "date": "2022-11-21T10:29:58+01:00",
+  "path": "/nix/store/dbsgb2p0yvpqaj7a114ndqdzm4mslp9i-tree-sitter-viml",
+  "sha256": "080vimv12rrvfc9qkfzs8bsa1asdrab9mgy4j16kmyzlyd27mj3c",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yang.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yang.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/hubro/tree-sitter-yang",
-  "rev": "8e9d175982afcefa3dac8ca20d40d1643accd2bd",
-  "date": "2021-07-29T23:07:25+02:00",
-  "path": "/nix/store/ark7nssjv3jzy1kw9anlma7li5k9zpnb-tree-sitter-yang",
-  "sha256": "044q9fikaxnrcrnfwc7cfjnwdg6v7jb6rg7mj556iryv0bkv48s1",
+  "rev": "2c0e6be8dd4dcb961c345fa35c309ad4f5bd3502",
+  "date": "2022-11-21T21:25:21+01:00",
+  "path": "/nix/store/ypd2cggg44l0sx0snvkgjbspkfcyscmf-tree-sitter-yang",
+  "sha256": "1vwcsp20dhccr2ag5s09j3jz9cnlkndb2hdn0h3va7md8ka0lhp8",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,


### PR DESCRIPTION
###### Description of changes

The C++ grammar was broken again (I need it on a day-by-day basis for my work), possibly others (C, CMake). I have not tested ALL of them but only the ones I use. Superficially everything seems ok.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
