### PR TITLE
python310Packages.scim2-filter-parser: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/scim2-filter-parser/default.nix
+++ b/pkgs/development/python-modules/scim2-filter-parser/default.nix
@@ -1,38 +1,58 @@
-{ stdenv, lib, fetchFromGitHub, buildPythonPackage, unittestCheckHook
-, pytest-runner, django
-, sly }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, django
+, sly
+, mock
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "scim2-filter-parser";
-  version = "0.4.0";
-  format = "setuptools";
+  version = "0.5.0";
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "15five";
     repo = pname;
-    # gets rarely updated, we can then just replace the hash
     rev = "refs/tags/${version}";
-    hash = "sha256-ZemR5tn+T9WWgNB1FYrPJO6zh8g9zjobFZemi+MHkEE=";
+    hash = "sha256-QEPTYpWlRPWO6Evyt4zoqUST4ousF67GmiOpD7WUqcI=";
   };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "poetry.masonry.api" "poetry.core.masonry.api"
+  '';
 
   propagatedBuildInputs = [
     sly
   ];
+
+  passthru.optional-dependencies = {
+    django-query = [
+      django
+    ];
+  };
 
   pythonImportsCheck = [
     "scim2_filter_parser"
   ];
 
   nativeCheckInputs = [
-    django
-    pytest-runner
-    unittestCheckHook
-  ];
+    mock
+    pytestCheckHook
+  ] ++ passthru.optional-dependencies.django-query;
 
   meta = with lib; {
     description = "A customizable parser/transpiler for SCIM2.0 filters";
-    homepage    = "https://github.com/15five/scim2-filter-parser";
-    license     = licenses.mit;
+    homepage = "https://github.com/15five/scim2-filter-parser";
+    changelog = "https://github.com/15five/scim2-filter-parser/blob/${version}/CHANGELOG.rst";
+    license = licenses.mit;
     maintainers = with maintainers; [ s1341 ];
   };
 }


### PR DESCRIPTION
Fixes the build with `sly==0.5.0`.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
