### PR TITLE
home-assistant: 2023.2.0 -> 2023.2.1

### DIFF
--- a/pkgs/development/python-modules/aiosomecomfort/default.nix
+++ b/pkgs/development/python-modules/aiosomecomfort/default.nix
@@ -3,13 +3,11 @@
 , fetchFromGitHub
 , aiohttp
 , prettytable
-, mock
-, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "aiosomecomfort";
-  version = "0.0.3";
+  version = "0.0.6";
 
   format = "setuptools";
 
@@ -17,26 +15,19 @@ buildPythonPackage rec {
     owner = "mkmer";
     repo = "AIOSomecomfort";
     rev = "refs/tags/${version}";
-    hash = "sha256-Qw0KR934GS7AuT3nRYaunypt091fZLRioVbNOp9JesY=";
+    hash = "sha256-3p38gWCqQVYz3sgu6SgfPH+wH/ZH2Qg+tVXiARuUh7s=";
   };
-
-  postPatch = ''
-    # https://github.com/mkmer/AIOSomecomfort/issues/1
-    mv aiosomecomfort AIOSomecomfort
-  '';
 
   propagatedBuildInputs = [
     aiohttp
     prettytable
   ];
 
-  checkInputs = [
-    mock
-    pytestCheckHook
+  pythonImportsCheck = [
+    "aiosomecomfort"
   ];
 
-  # SyntaxError in test.py
-  doCheck = false;
+  doCheck = false; # tests only run on windows, due to WindowsSelectorEventLoopPolicy
 
   meta = {
     description = "AsyicIO client for US models of Honeywell Thermostats";

--- a/pkgs/development/python-modules/py-synologydsm-api/default.nix
+++ b/pkgs/development/python-modules/py-synologydsm-api/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "py-synologydsm-api";
-  version = "2.1.0";
+  version = "2.1.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "mib1185";
     repo = "py-synologydsm-api";
     rev = "refs/tags/v${version}";
-    hash = "sha256-bolcqPIBHglZ7Em8/66MBypivDPehdgTaPOxAjR9Bd0=";
+    hash = "sha256-rT9KkSgIinJxTyJ40Z3VzMh23Ry9O3NFrLH4I2+NFPg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pyqwikswitch/default.nix
+++ b/pkgs/development/python-modules/pyqwikswitch/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, attrs
+, requests
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "pyqwikswitch";
+  version = "0.94";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-IpyWz+3EMr0I+xULBJJhBgdnQHNPJIM1SqKFLpszhQc=";
+  };
+
+  propagatedBuildInputs = [
+    attrs
+    requests
+  ];
+
+  pythonImportsCheck = [
+    "pyqwikswitch"
+    "pyqwikswitch.threaded"
+  ];
+
+  doCheck = false; # no tests in sdist
+
+  meta = with lib; {
+    description = "QwikSwitch USB Modem API binding for Python";
+    homepage = "https://github.com/kellerza/pyqwikswitch";
+    license = licenses.mit;
+    maintainers = teams.home-assistant.members;
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2970,7 +2970,8 @@
       pyqvrpro
     ];
     "qwikswitch" = ps: with ps; [
-    ]; # missing inputs: pyqwikswitch
+      pyqwikswitch
+    ];
     "rachio" = ps: with ps; [
       pyturbojpeg
       aiohttp-cors
@@ -4899,6 +4900,7 @@
     "qingping"
     "qld_bushfire"
     "qnap_qsw"
+    "qwikswitch"
     "rachio"
     "radarr"
     "radio_browser"

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2023.2.0";
+  version = "2023.2.1";
   components = {
     "3_day_blinds" = ps: with ps; [
     ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -292,6 +292,10 @@ in python.pkgs.buildPythonApplication rec {
     hash = "sha256-gWcq0E/k6c4YQJwLlU379kse2u4Yn6xvLZ5QnGXVTJA=";
   };
 
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools
+  ];
+
   # leave this in, so users don't have to constantly update their downstream patch handling
   patches = [
     (substituteAll {
@@ -328,7 +332,7 @@ in python.pkgs.buildPythonApplication rec {
   '';
 
   propagatedBuildInputs = with python.pkgs; [
-    # Only packages required in setup.py
+    # Only packages required in pyproject.toml
     aiohttp
     astral
     async-timeout
@@ -346,6 +350,7 @@ in python.pkgs.buildPythonApplication rec {
     lru-dict
     orjson
     pip
+    pyopenssl
     pyjwt
     python-slugify
     pyyaml
@@ -353,10 +358,8 @@ in python.pkgs.buildPythonApplication rec {
     voluptuous
     voluptuous-serialize
     yarl
-    # Not in setup.py, but used in homeassistant/util/package.py
+    # Implicit dependency via homeassistant/requirements.py
     setuptools
-    # Not in setup.py, but uncounditionally imported via tests/conftest.py
-    paho-mqtt
   ] ++ componentBuildInputs ++ extraBuildInputs;
 
   makeWrapperArgs = lib.optional skipPip "--add-flags --skip-pip";
@@ -369,22 +372,28 @@ in python.pkgs.buildPythonApplication rec {
     freezegun
     pytest-asyncio
     pytest-aiohttp
-    pytest-freezegun
+    pytest-freezer
     pytest-mock
     pytest-rerunfailures
     pytest-socket
+    pytest-timeout
     pytest-unordered
     pytest-xdist
     pytestCheckHook
     requests-mock
     respx
     stdlib-list
-    # required by tests/auth/mfa_modules
+    tomli
+    # required through tests/auth/mfa_modules/test_otp.py
     pyotp
+    # Sneakily imported in tests/conftest.py
+    paho-mqtt
   ] ++ lib.concatMap (component: getPackages component python.pkgs) [
     # some components are needed even if tests in tests/components are disabled
     "default_config"
     "hue"
+    # for tests/test_config.py::test_merge_id_schema
+    "qwikswitch"
   ];
 
   pytestFlagsArray = [
@@ -395,8 +404,8 @@ in python.pkgs.buildPythonApplication rec {
     "--only-rerun RuntimeError"
     # enable full variable printing on error
     "--showlocals"
-    # helpers/test_system_info.py: AssertionError: assert 'Unknown' == 'Home Assistant Container'
-    "--deselect tests/helpers/test_system_info.py::test_container_installationtype"
+    # AssertionError: assert 1 == 0
+    "--deselect tests/test_config.py::test_merge"
     # tests are located in tests/
     "tests"
   ];
@@ -408,17 +417,6 @@ in python.pkgs.buildPythonApplication rec {
     "tests/pylint"
     # don't bulk test all components
     "tests/components"
-    # pyotp since v2.4.0 complains about the short mock keys, hass pins v2.3.0
-    "tests/auth/mfa_modules/test_notify.py"
-  ];
-
-  disabledTests = [
-    # AssertionError: assert 1 == 0
-    "test_merge"
-    # Tests are flaky
-    "test_config_platform_valid"
-    # Test requires pylint>=2.13.0
-    "test_invalid_discovery_info"
   ];
 
   preCheck = ''

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -271,7 +271,7 @@ let
   extraPackagesFile = writeText "home-assistant-packages" (lib.concatMapStringsSep "\n" (pkg: pkg.pname) extraBuildInputs);
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2023.2.0";
+  hassVersion = "2023.2.1";
 
 in python.pkgs.buildPythonApplication rec {
   pname = "homeassistant";
@@ -289,7 +289,7 @@ in python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = "refs/tags/${version}";
-    hash = "sha256-tW1tVPJ50DIGIuxJP9nq4+Tw4fiPA+kINSclW7JkJmE=";
+    hash = "sha256-gWcq0E/k6c4YQJwLlU379kse2u4Yn6xvLZ5QnGXVTJA=";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,7 +4,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20230201.0";
+  version = "20230202.0";
   format = "wheel";
 
   src = fetchPypi {
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-CG4I3YI1swiAV02+NXvi9n87dXrTJFlMUcOnB9ebmWk=";
+    hash = "sha256-Wo3bQnwTDSAC4EhJeYIXx1wODyx3wA2KMMaM3pJEkGw=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -76,8 +76,8 @@ in lib.listToAttrs (map (component: lib.nameValuePair component (
       ++ home-assistant.getPackages component home-assistant.python.pkgs
       ++ extraCheckInputs.${component} or [ ];
 
-    disabledTests = old.disabledTests ++ extraDisabledTests.${component} or [];
-    disabledTestPaths = old.disabledTestPaths ++ extraDisabledTestPaths.${component} or [ ];
+    disabledTests = old.disabledTests or [] ++ extraDisabledTests.${component} or [];
+    disabledTestPaths = old.disabledTestPaths or [] ++ extraDisabledTestPaths.${component} or [ ];
 
     # components are more often racy than the core
     dontUsePytestXdist = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8620,6 +8620,8 @@ self: super: with self; {
 
   pyqvrpro = callPackage ../development/python-modules/pyqvrpro { };
 
+  pyqwikswitch = callPackage ../development/python-modules/pyqwikswitch { };
+
   pyrabbit2 = callPackage ../development/python-modules/pyrabbit2 { };
 
   pyrad = callPackage ../development/python-modules/pyrad { };


### PR DESCRIPTION
https://github.com/mkmer/AIOSomecomfort/releases/tag/0.0.5
https://github.com/mkmer/AIOSomecomfort/releases/tag/0.0.6
https://github.com/mib1185/py-synologydsm-api/releases/tag/v2.1.1
https://github.com/home-assistant/core/releases/tag/2023.2.1

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
