### PR TITLE
catppuccin-papirus-folders: init at unstable-2023-02-03

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12725,6 +12725,12 @@
     githubId = 61306;
     name = "Rene Treffer";
   };
+  rubyowo = {
+    name = "Rei Star";
+    email = "perhaps-you-know@what-is.ml";
+    github = "rubyowo";
+    githubId = 105302757;
+  };
   rumpelsepp = {
     name = "Stefan Tatschner";
     email = "stefan@rumpelsepp.org";

--- a/pkgs/data/icons/catppuccin-papirus-folders/default.nix
+++ b/pkgs/data/icons/catppuccin-papirus-folders/default.nix
@@ -1,0 +1,54 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchFromGitHub,
+  gtk3,
+  papirus-icon-theme,
+  flavor ? "mocha",
+  accent ? "blue"
+}: let
+  validAccents = ["blue" "flamingo" "green" "lavender" "maroon" "mauve" "peach" "pink" "red" "rosewater" "sapphire" "sky" "teal" "yellow"];
+  validFlavors = ["latte" "frappe" "macchiato" "mocha"];
+  pname = "catppuccin-papirus-folders";
+in
+  lib.checkListOfEnum "${pname}: accent colors" validAccents [ accent ]
+  lib.checkListOfEnum "${pname}: flavors" validFlavors [ flavor ]
+
+  stdenvNoCC.mkDerivation {
+    inherit pname;
+    version = "unstable-2022-12-04";
+
+    src = fetchFromGitHub {
+      owner = "catppuccin";
+      repo = "papirus-folders";
+      rev = "1a367642df9cf340770bd7097fbe85b9cea65bcb";
+      sha256 = "sha256-mFDfRVDA9WyriyFVzsI7iqmPopN56z54FvLkZDS2Dv8=";
+    };
+
+    nativeBuildInputs = [ gtk3 ];
+
+    postPatch = ''
+      patchShebangs ./papirus-folders
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/share/icons
+      cp -r --no-preserve=mode ${papirus-icon-theme}/share/icons/Papirus* $out/share/icons
+      cp -r src/* $out/share/icons/Papirus
+      for theme in $out/share/icons/*; do
+          USER_HOME=$HOME DISABLE_UPDATE_ICON_CACHE=1 \
+            ./papirus-folders -t $theme -o -C cat-${flavor}-${accent}
+          gtk-update-icon-cache --force $theme
+      done
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "Soothing pastel theme for Papirus Icon Theme folders";
+      homepage = "https://github.com/catppuccin/papirus-folders";
+      license = licenses.mit;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ rubyowo ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -378,6 +378,8 @@ with pkgs;
 
   catppuccin-kde = callPackage ../data/themes/catppuccin-kde { };
 
+  catppuccin-papirus-folders = callPackage ../data/icons/catppuccin-papirus-folders { };
+
   btdu = callPackage ../tools/misc/btdu { };
 
   cereal = callPackage ../development/libraries/cereal { };


### PR DESCRIPTION
###### Description of changes
Soothing pastel theme for Papirus Icon Theme folders. A Catppuccin port for https://github.com/PapirusDevelopmentTeam/papirus-folders.
Home Page: https://github.com/catppuccin/papirus-folders

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).