### PR TITLE
make-squashfs,make-iso9660-image: use `__structuredAttrs`

### DIFF
--- a/nixos/lib/make-iso9660-image.nix
+++ b/nixos/lib/make-iso9660-image.nix
@@ -47,16 +47,16 @@ assert usbBootable -> isohybridMbrImage != "";
 
 stdenv.mkDerivation {
   name = isoName;
-  builder = ./make-iso9660-image.sh;
+  __structuredAttrs = true;
+
+  buildCommandPath = ./make-iso9660-image.sh;
   nativeBuildInputs = [ xorriso syslinux zstd libossp_uuid ];
 
   inherit isoName bootable bootImage compressImage volumeID efiBootImage efiBootable isohybridMbrImage usbBootable;
 
-  # !!! should use XML.
   sources = map (x: x.source) contents;
   targets = map (x: x.target) contents;
 
-  # !!! should use XML.
   objects = map (x: x.object) storeContents;
   symlinks = map (x: x.symlink) storeContents;
 

--- a/nixos/lib/make-iso9660-image.sh
+++ b/nixos/lib/make-iso9660-image.sh
@@ -1,12 +1,3 @@
-source $stdenv/setup
-
-sources_=($sources)
-targets_=($targets)
-
-objects=($objects)
-symlinks=($symlinks)
-
-
 # Remove the initial slash from a path, since genisofs likes it that way.
 stripSlash() {
     res="$1"
@@ -35,13 +26,13 @@ if test -n "$bootable"; then
     # The -boot-info-table option modifies the $bootImage file, so
     # find it in `contents' and make a copy of it (since the original
     # is read-only in the Nix store...).
-    for ((i = 0; i < ${#targets_[@]}; i++)); do
-        stripSlash "${targets_[$i]}"
+    for ((i = 0; i < ${#targets[@]}; i++)); do
+        stripSlash "${targets[$i]}"
         if test "$res" = "$bootImage"; then
-            echo "copying the boot image ${sources_[$i]}"
-            cp "${sources_[$i]}" boot.img
+            echo "copying the boot image ${sources[$i]}"
+            cp "${sources[$i]}" boot.img
             chmod u+w boot.img
-            sources_[$i]=boot.img
+            sources[$i]=boot.img
         fi
     done
 
@@ -66,9 +57,9 @@ touch pathlist
 
 
 # Add the individual files.
-for ((i = 0; i < ${#targets_[@]}; i++)); do
-    stripSlash "${targets_[$i]}"
-    addPath "$res" "${sources_[$i]}"
+for ((i = 0; i < ${#targets[@]}; i++)); do
+    stripSlash "${targets[$i]}"
+    addPath "$res" "${sources[$i]}"
 done
 
 

--- a/nixos/lib/make-squashfs.nix
+++ b/nixos/lib/make-squashfs.nix
@@ -10,6 +10,7 @@
 
 stdenv.mkDerivation {
   name = "squashfs.img";
+  __structuredAttrs = true;
 
   nativeBuildInputs = [ squashfsTools ];
 


### PR DESCRIPTION
Makes it easier to enable [discarding of references](https://github.com/NixOS/nix/pull/7087), an upcoming feature of Nix which requires structured attrs.

This also makes the builder for make-iso9660-image more robust since we can pass proper arrays instead of space-separated strings.

For reference, `__structuredAttrs` is supported since Nix 2.0 and nixpkgs https://github.com/NixOS/nixpkgs/pull/175649.