### PR TITLE
spice: 0.15.0 -> 0.15.1

### DIFF
--- a/pkgs/development/libraries/spice/default.nix
+++ b/pkgs/development/libraries/spice/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv
+, fetchzip
 , fetchurl
 , meson
 , ninja
@@ -25,37 +26,24 @@
 , gdk-pixbuf
 }:
 
-let
-  # This file was mistakenly not included with the 0.15.0 release tarball.
-  # Should be fixed with the next release.
-  # https://gitlab.freedesktop.org/spice/spice/-/issues/56
-  doxygen_sh = fetchurl {
-    url = "https://gitlab.freedesktop.org/spice/spice/-/raw/v0.15.0/doxygen.sh";
-    sha256 = "0g4bx91qclihp1jfhdhyj7wp4hf4289794xxbw32kk58lnd7bzkg";
-  };
-in
-
 stdenv.mkDerivation rec {
   pname = "spice";
-  version = "0.15.0";
+  version = "0.15.1";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://www.spice-space.org/download/releases/spice-server/${pname}-${version}.tar.bz2";
-    sha256 = "1xd0xffw0g5vvwbq4ksmm3jjfq45f9dw20xpmi82g1fj9f7wy85k";
+    sha256 = "sha256-gmbtCCAOaDQ/Qn8n0aLuPpNpnsxIecFtJgillDb+9eY=";
   };
 
   patches = [
     ./remove-rt-on-darwin.patch
   ];
   postPatch = ''
-    install ${doxygen_sh} doxygen.sh
     patchShebangs build-aux
 
-    # https://gitlab.freedesktop.org/spice/spice-common/-/issues/5
-    substituteInPlace subprojects/spice-common/meson.build \
-      --replace \
-      "cmd = run_command(python, '-m', module)" \
-      "cmd = run_command(python, '-c', 'import @0@'.format(module))"
+    # ERROR: Program 'build-aux/meson-dist' not found or not executable
+    # Arch does the same.
+    sed -i "/meson-dist/d" meson.build
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
Switched to the direct source because the tarball wouldn't build due to an error related to build-aux.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
