### PR TITLE
revup: init at 0.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3973,6 +3973,12 @@
     githubId = 24233408;
     name = "Ate Eskola";
   };
+  dukeofcool199 = {
+    email = "jenkin.schibel@protonmail.com";
+    github = "dukeofcool199";
+    githubId = 11435199;
+    name = "Jenkin Schibel";
+  };
   dump_stack = {
     email = "root@dumpstack.io";
     github = "jollheef";
@@ -16484,7 +16490,6 @@
   };
   zyansheep = {
     email = "zyansheep@protonmail.com";
-    github = "zyansheep";
     githubId = 20029431;
     name = "Zyansheep";
   };

--- a/pkgs/development/python-modules/revup/default.nix
+++ b/pkgs/development/python-modules/revup/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+, rich
+}:
+
+buildPythonPackage rec {
+  pname = "revup";
+  version = "0.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-JUQqKKIilb5Gl3ZsfXO4OaSoyD/WyfcUkT7x+e4xu0Y=";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    rich
+  ];
+
+  meta = with lib; {
+    description = "a command-line tool that allow developers to iterate faster on parallel changes and reduce the overhead of creating and maintaining code reviews in Github.";
+    homepage = "https://github.com/Skydio/revup";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dukeofcool199 ];
+    mainProgram = "revup";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18564,6 +18564,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  revup = with python3Packages; callPackage ../development/python-modules/revup {};
+
   spruce = callPackage ../development/tools/misc/spruce {};
 
   sqlc = callPackage ../development/tools/database/sqlc { };


### PR DESCRIPTION
###### Description of changes

Revup provides command-line tools that allow developers to iterate faster on parallel changes and reduce the overhead of creating and maintaining code reviews.

https://github.com/skydio/revup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

tested full functionality of the tool using a testing repo as per their getting started guide.
