### PR TITLE
folly: propagate dependencies

### DIFF
--- a/pkgs/development/libraries/folly/default.nix
+++ b/pkgs/development/libraries/folly/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   ];
 
   # See CMake/folly-deps.cmake in the Folly source tree.
-  buildInputs = [
+  propagatedBuildInputs = [
     boost
     double-conversion
     glog
@@ -53,9 +53,6 @@ stdenv.mkDerivation rec {
     zstd
   ] ++ lib.optional stdenv.isLinux jemalloc;
 
-  # jemalloc headers are required in include/folly/portability/Malloc.h
-  propagatedBuildInputs = lib.optional stdenv.isLinux jemalloc;
-
   NIX_CFLAGS_COMPILE = [ "-DFOLLY_MOBILE=${if follyMobile then "1" else "0"}" "-fpermissive" ];
   cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
 
@@ -64,13 +61,6 @@ stdenv.mkDerivation rec {
       --replace '=''${prefix}//' '=/' \
       --replace '=''${exec_prefix}//' '=/'
   '';
-
-  # folly-config.cmake, will `find_package` these, thus there should be
-  # a way to ensure abi compatibility.
-  passthru = {
-    inherit boost;
-    fmt = fmt_8;
-  };
 
   meta = with lib; {
     description = "An open-source C++ library developed and used at Facebook";


### PR DESCRIPTION
#### Description of changes
The dependencies in Folly are not correctly propagated, this pull requests fix the issue.

#### Steps to reproduce the issue
Consider the following flake.nix development environment
```
{
  inputs = { nixpkgs.url = "github:nixos/nixpkgs/master"; };

  outputs = { self, nixpkgs }:
    let
      targetSystems = [ "x86_64-linux" ];
      pkgsFor = system: import nixpkgs { inherit system; };
    in {
      devShells = nixpkgs.lib.genAttrs targetSystems (system:
        let
          pkgs = pkgsFor system;
        in {
          default = pkgs.mkShell {
            packages = with pkgs; [ folly ];
          };
        });
    };
}
```
Compiling the following main.cpp file leads to several linking errors
```
// g++ main.cpp -lfolly
#include <folly/base64.h>
#include <iostream>

int main() {
  std::cout << folly::base64Encode("Hello, world!") << "\n";
  return 0;
}
``` 

#### Additional information
Of particular interest are the first couple of warnings. They show that `libfolly.so` doesn't find its own dependencies.
```
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libfmt.so.8, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libboost_context.so.1.79.0, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libboost_filesystem.so.1.79.0, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libboost_program_options.so.1.79.0, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libdouble-conversion.so.3, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libgflags.so.2.2, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libglog.so.1, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libevent-2.1.so.7, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libz.so.1, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libssl.so.3, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libcrypto.so.3, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: liblzma.so.5, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: liblz4.so.1, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libzstd.so.1, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libunwind.so.8, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libstdc++.so.6, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
/nix/store/r2b9k28c6aghczpqfvh71y9xavm7rr68-binutils-2.39/bin/ld: warning: libm.so.6, needed by /nix/store/c9gqr1zxl29gxf1wi2c5j99sf0wkza2c-folly-2022.11.28.00/lib/libfolly.so, not found (try using -rpath or -rpath-link)
```

#### Expected behavior
We should be able to use folly without manually adding its dependencies to our project. With the proposed change we can successfully compile the example provided in here with
```
g++ main.cpp -lfolly -lfmt -lboost_context -lboost_filesystem -lboost_program_options -ldouble-conversion -lgflags -lglog -levent -lz -lssl -lcrypto -llzma -llz4 -lzstd -lunwind -lrt -lpthread -lboost_atomic -ldl
```

#### Things done
Changed buildInputs into propagatedBuildInputs and removed passthrou (it's now unneeded).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).