### PR TITLE
gprbuild: try

### DIFF
--- a/pkgs/development/tools/build-managers/gprbuild/default.nix
+++ b/pkgs/development/tools/build-managers/gprbuild/default.nix
@@ -6,10 +6,11 @@
 , which
 , gnat
 , xmlada
+, fixDarwinDylibNames
 , enableShared ? !stdenv.hostPlatform.isStatic
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation ({
   pname = "gprbuild";
 
   # See ./boot.nix for an explanation of the gprbuild setupHook,
@@ -26,7 +27,7 @@ stdenv.mkDerivation {
     gnat
     gprbuild-boot
     which
-  ];
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ fixDarwinDylibNames ];
 
   propagatedBuildInputs = [
     xmlada
@@ -63,4 +64,6 @@ stdenv.mkDerivation {
   postInstall = ''
     rm $out/doinstall
   '';
-}
+} // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+  NIX_LDFLAGS = "-rpath $out/lib";
+})

--- a/pkgs/development/tools/build-managers/gprbuild/default.nix
+++ b/pkgs/development/tools/build-managers/gprbuild/default.nix
@@ -6,6 +6,7 @@
 , which
 , gnat
 , xmlada
+, enableShared ? !stdenv.hostPlatform.isStatic
 }:
 
 stdenv.mkDerivation {
@@ -32,17 +33,17 @@ stdenv.mkDerivation {
   ];
 
   makeFlags = [
-    "ENABLE_SHARED=${if stdenv.hostPlatform.isStatic then "no" else "yes"}"
+    "ENABLE_SHARED=${if enableShared then "yes" else "no"}"
     "PROCESSORS=$(NIX_BUILD_CORES)"
     # confusingly, for gprbuild --target is autoconf --host
     "TARGET=${stdenv.hostPlatform.config}"
     "prefix=${placeholder "out"}"
-  ] ++ lib.optionals (!stdenv.hostPlatform.isStatic) [
+  ] ++ lib.optionals enableShared [
     "LIBRARY_TYPE=relocatable"
   ];
 
   # Fixes gprbuild being linked statically always
-  patches = lib.optional (!stdenv.hostPlatform.isStatic) (fetchpatch {
+  patches = lib.optional enableShared (fetchpatch {
     name = "gprbuild-relocatable-build.patch";
     url = "https://aur.archlinux.org/cgit/aur.git/plain/relocatable-build.patch?h=gprbuild&id=1d4e8a5cb982e79135a0aaa3ef87654bed1fe4f0";
     sha256 = "1r3xsp1pk9h666mm8mdravkybmd5gv2f751x2ffb1kxnwq1rwiyn";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
