### PR TITLE
zig: fix impurities for Zig compiler and Zig outputs

### DIFF
--- a/pkgs/applications/misc/mepo/default.nix
+++ b/pkgs/applications/misc/mepo/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    zig build -Drelease-safe=true -Dcpu=baseline --prefix $out install
+    zig build -Drelease-safe=true --prefix $out install
     install -d $out/share/man/man1
     $out/bin/mepo -docman > $out/share/man/man1/mepo.1
 

--- a/pkgs/applications/misc/rivercarro/default.nix
+++ b/pkgs/applications/misc/rivercarro/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    zig build -Drelease-safe -Dcpu=baseline --prefix $out install
+    zig build -Drelease-safe --prefix $out install
     runHook postInstall
   '';
 

--- a/pkgs/applications/misc/waylock/default.nix
+++ b/pkgs/applications/misc/waylock/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    zig build -Drelease-safe -Dman-pages -Dcpu=baseline --prefix $out install
+    zig build -Drelease-safe -Dman-pages --prefix $out install
     runHook postInstall
   '';
 

--- a/pkgs/applications/window-managers/river/default.nix
+++ b/pkgs/applications/window-managers/river/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    zig build -Drelease-safe -Dcpu=baseline ${lib.optionalString xwaylandSupport "-Dxwayland"} -Dman-pages --prefix $out install
+    zig build -Drelease-safe ${lib.optionalString xwaylandSupport "-Dxwayland"} -Dman-pages --prefix $out install
     install contrib/river.desktop -Dt $out/share/wayland-sessions
     runHook postInstall
   '';

--- a/pkgs/development/compilers/zig/0.10.nix
+++ b/pkgs/development/compilers/zig/0.10.nix
@@ -19,6 +19,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-69QIkkKzApOGfrBdgtmxFMDytRkSh+0YiaJQPbXsBeo=";
   };
 
+  patches = [
+    # Fix impurities.
+    ./cpu-purity.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     llvmPackages.llvm.dev

--- a/pkgs/development/compilers/zig/0.9.1.nix
+++ b/pkgs/development/compilers/zig/0.9.1.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Fix impurities.
+    ./cpu-purity.patch
     # Fix index out of bounds reading RPATH (cherry-picked from 0.10-dev)
     ./rpath.patch
     # Fix build on macOS 13 (cherry-picked from 0.10-dev)

--- a/pkgs/development/compilers/zig/cpu-purity.patch
+++ b/pkgs/development/compilers/zig/cpu-purity.patch
@@ -1,0 +1,20 @@
+By default, Zig will use the generate code for the native CPU. This is impure.
+Change the default to -mcpu=baseline.
+
+https://github.com/NixOS/nixpkgs/issues/169461
+https://github.com/NixOS/nixpkgs/issues/214356
+https://github.com/NixOS/nixpkgs/issues/185665
+
+diff --git a/lib/std/zig/CrossTarget.zig b/lib/std/zig/CrossTarget.zig
+index 6c59a4a3a..d45e9ab5a 100644
+--- a/lib/std/zig/CrossTarget.zig
++++ b/lib/std/zig/CrossTarget.zig
+@@ -12,7 +12,7 @@ const mem = std.mem;
+ /// `null` means native.
+ cpu_arch: ?Target.Cpu.Arch = null,
+
+-cpu_model: CpuModel = CpuModel.determined_by_cpu_arch,
++cpu_model: CpuModel = CpuModel.baseline,
+
+ /// Sparse set of CPU features to add to the set from `cpu_model`.
+ cpu_features_add: Target.Cpu.Feature.Set = Target.Cpu.Feature.Set.empty,

--- a/pkgs/development/tools/zls/default.nix
+++ b/pkgs/development/tools/zls/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    zig build -Drelease-safe -Dcpu=baseline --prefix $out install
+    zig build -Drelease-safe --prefix $out install
   '';
 
   meta = with lib; {

--- a/pkgs/games/blackshades/default.nix
+++ b/pkgs/games/blackshades/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    zig build -Drelease-fast -Dcpu=baseline --prefix $out install
+    zig build -Drelease-fast --prefix $out install
   '';
 
   meta = {

--- a/pkgs/tools/misc/clipbuzz/default.nix
+++ b/pkgs/tools/misc/clipbuzz/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    zig build -Drelease-safe -Dcpu=baseline --prefix $out install
+    zig build -Drelease-safe --prefix $out install
   '';
 
   meta = with lib; {

--- a/pkgs/tools/misc/findup/default.nix
+++ b/pkgs/tools/misc/findup/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    zig build -Drelease-safe -Dcpu=baseline --prefix $out
+    zig build -Drelease-safe --prefix $out
     runHook postInstall
   '';
 

--- a/pkgs/tools/misc/ncdu/default.nix
+++ b/pkgs/tools/misc/ncdu/default.nix
@@ -19,8 +19,7 @@ stdenv.mkDerivation rec {
 
   PREFIX = placeholder "out";
 
-  # Avoid CPU feature impurity, see https://github.com/NixOS/nixpkgs/issues/169461
-  ZIG_FLAGS = "-Drelease-safe -Dcpu=baseline";
+  ZIG_FLAGS = "-Drelease-safe";
 
   meta = with lib; {
     description = "Disk usage analyzer with an ncurses interface";


### PR DESCRIPTION
###### Description of changes

By default, Zig will use the generate code for the native CPU. This is impure and leads to illegal instruction crashes for users which have different CPUs than the build bots.

Change Zig's default to -mcpu=baseline.

To test, I built on my new AMD Zen 3 machine used qemu to emulate an old Intel Sandy Bridge machine, and observed no crashes with this patch:

    $ nix-shell -I ~/Projects/ -p ncdu \
        --run 'qemu-x86_64-static -cpu SandyBridge $(which ncdu)'

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
