### PR TITLE
haskell.packages.ghc94.X11-xft: extract cabal#8455 workaround into helper function

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -207,6 +207,10 @@ in {
   # by making `pkg-config --static` happy. Note: Cabal 3.9 is also affected, so
   # the GHC 9.6 configuration may need similar overrides eventually.
   X11-xft = __CabalEagerPkgConfigWorkaround super.X11-xft;
+  # Jailbreaks for https://github.com/gtk2hs/gtk2hs/issues/323#issuecomment-1416723309
+  glib = __CabalEagerPkgConfigWorkaround (doJailbreak super.glib);
+  cairo = __CabalEagerPkgConfigWorkaround (doJailbreak super.cairo);
+  pango = __CabalEagerPkgConfigWorkaround (doJailbreak super.pango);
 
   # The gtk2hs setup hook provided by this package lacks the ppOrdering field that
   # recent versions of Cabal require. This leads to builds like cairo and glib

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -208,4 +208,9 @@ in {
   # the GHC 9.6 configuration may need similar overrides eventually.
   X11-xft = __CabalEagerPkgConfigWorkaround super.X11-xft;
 
+  # The gtk2hs setup hook provided by this package lacks the ppOrdering field that
+  # recent versions of Cabal require. This leads to builds like cairo and glib
+  # failing during the Setup.hs phase: https://github.com/gtk2hs/gtk2hs/issues/323.
+  gtk2hs-buildtools = appendPatch ./patches/gtk2hs-buildtools-fix-ghc-9.4.x.patch super.gtk2hs-buildtools;
+
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -203,7 +203,9 @@ in {
     libraryHaskellDepends = drv.libraryHaskellDepends ++ [ self.file-embed ];
   }) (disableCabalFlag "fixity-th" super.fourmolu_0_10_1_0);
 
-  # The Haskell library has additional dependencies when compiled with ghc-9.4.x.
-  X11-xft = addExtraLibraries [pkgs.xorg.libXau pkgs.xorg.libXdmcp pkgs.expat] super.X11-xft;
+  # Apply workaround for Cabal 3.8 bug https://github.com/haskell/cabal/issues/8455
+  # by making `pkg-config --static` happy. Note: Cabal 3.9 is also affected, so
+  # the GHC 9.6 configuration may need similar overrides eventually.
+  X11-xft = __CabalEagerPkgConfigWorkaround super.X11-xft;
 
 }

--- a/pkgs/development/haskell-modules/lib/compose.nix
+++ b/pkgs/development/haskell-modules/lib/compose.nix
@@ -464,4 +464,44 @@ rec {
   allowInconsistentDependencies = overrideCabal (drv: {
     allowInconsistentDependencies = true;
   });
+
+  # Work around a Cabal bug requiring pkg-config --static --libs to work even
+  # when linking dynamically, affecting Cabal 3.8 and 3.9.
+  # https://github.com/haskell/cabal/issues/8455
+  #
+  # For this, we treat the runtime system/pkg-config dependencies of a Haskell
+  # derivation as if they were propagated from their dependencies which allows
+  # pkg-config --static to work in most cases.
+  #
+  # Warning: This function may change or be removed at any time, e.g. if we find
+  # a different workaround, upstream fixes the bug or we patch Cabal.
+  __CabalEagerPkgConfigWorkaround =
+    let
+      # Take list of derivations and return list of the transitive dependency
+      # closure, only taking into account buildInputs. Loosely based on
+      # closePropagationFast.
+      propagatedPlainBuildInputs = drvs:
+        builtins.map (i: i.val) (
+          builtins.genericClosure {
+            startSet = builtins.map (drv:
+              { key = drv.outPath; val = drv; }
+            ) drvs;
+            operator = { val, ... }:
+              if !lib.isDerivation val
+              then [ ]
+              else
+                builtins.concatMap (drv:
+                  if !lib.isDerivation drv
+                  then [ ]
+                  else [ { key = drv.outPath; val = drv; } ]
+                ) val.buildInputs or [ ];
+          }
+        );
+    in
+    overrideCabal (old: {
+      benchmarkPkgconfigDepends = propagatedPlainBuildInputs old.benchmarkPkgconfigDepends or [ ];
+      executablePkgconfigDepends = propagatedPlainBuildInputs old.executablePkgconfigDepends or [ ];
+      libraryPkgconfigDepends = propagatedPlainBuildInputs old.libraryPkgconfigDepends or [ ];
+      testPkgconfigDepends = propagatedPlainBuildInputs old.testPkgconfigDepends or [ ];
+    });
 }

--- a/pkgs/development/haskell-modules/lib/compose.nix
+++ b/pkgs/development/haskell-modules/lib/compose.nix
@@ -494,7 +494,7 @@ rec {
                   if !lib.isDerivation drv
                   then [ ]
                   else [ { key = drv.outPath; val = drv; } ]
-                ) val.buildInputs or [ ];
+                ) (val.buildInputs or [ ] ++ val.propagatedBuildInputs or [ ]);
           }
         );
     in

--- a/pkgs/development/haskell-modules/patches/gtk2hs-buildtools-fix-ghc-9.4.x.patch
+++ b/pkgs/development/haskell-modules/patches/gtk2hs-buildtools-fix-ghc-9.4.x.patch
@@ -1,0 +1,12 @@
+diff --git a/src/Gtk2HsSetup.hs b/src/Gtk2HsSetup.hs
+index 598048f..b652b76 100644
+--- a/src/Gtk2HsSetup.hs
++++ b/src/Gtk2HsSetup.hs
+@@ -300,6 +300,7 @@ ourC2hs :: BuildInfo -> LocalBuildInfo -> PreProcessor
+ ourC2hs bi lbi = PreProcessor {
+ #endif
+   platformIndependent = False,
++  ppOrdering = (\ _ _ ms -> return ms),
+   runPreProcessor = runC2HS bi lbi
+ }
+ 


### PR DESCRIPTION
###### Description of changes

See comments / commit messages. Having the function and common location in the file should make the overrides easy to clean up when we have a proper solution.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
