### PR TITLE
portaudio: only include alsa in linux builds

### DIFF
--- a/pkgs/development/libraries/portaudio/default.nix
+++ b/pkgs/development/libraries/portaudio/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   nativeBuildInputs = [ pkg-config which ];
-  buildInputs = [ libjack2 ] ++ lib.optional withALSA [ alsa-lib ];
+  buildInputs = [ libjack2 ] ++ lib.optionals withALSA [ alsa-lib ];
 
   configureFlags = [ "--disable-mac-universal" "--enable-cxx" ];
 

--- a/pkgs/development/libraries/portaudio/default.nix
+++ b/pkgs/development/libraries/portaudio/default.nix
@@ -9,7 +9,8 @@
 , AudioToolbox
 , CoreAudio
 , CoreServices
-, Carbon }:
+, Carbon
+, withALSA ? stdenv.hostPlatform.isLinux && !stdenv.isDarwin }:
 
 stdenv.mkDerivation rec {
   pname = "portaudio";
@@ -22,7 +23,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   nativeBuildInputs = [ pkg-config which ];
-  buildInputs = [ libjack2 ] ++ lib.optionals (!stdenv.isDarwin) [ alsa-lib ];
+  buildInputs = [ libjack2 ] ++ lib.optional withALSA [ alsa-lib ];
 
   configureFlags = [ "--disable-mac-universal" "--enable-cxx" ];
 
@@ -45,7 +46,7 @@ stdenv.mkDerivation rec {
   # not sure why, but all the headers seem to be installed by the make install
   installPhase = ''
     make install
-  '' + lib.optionalString (!stdenv.isDarwin) ''
+  '' + lib.optionalString withALSA ''
     # fixup .pc file to find alsa library
     sed -i "s|-lasound|-L${alsa-lib.out}/lib -lasound|" "$out/lib/pkgconfig/"*.pc
   '' + lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/libraries/portaudio/default.nix
+++ b/pkgs/development/libraries/portaudio/default.nix
@@ -10,7 +10,8 @@
 , CoreAudio
 , CoreServices
 , Carbon
-, withALSA ? stdenv.hostPlatform.isLinux && !stdenv.isDarwin }:
+, withALSA ? !stdenv.targetPlatform.isWindows && !stdenv.isDarwin
+}:
 
 stdenv.mkDerivation rec {
   pname = "portaudio";


### PR DESCRIPTION
###### Description of changes

Resolves #212870. Windows builds were failing due to inclusion of alsa. This ensures that alsa is only included when host platform is Linux.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
