### PR TITLE
squawk: init at 0.20.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -926,6 +926,12 @@
     githubId = 106511;
     name = "Andrew Kelley";
   };
+  andrewsmith = {
+    email = "andrew@velvet.software";
+    github = "andrewsmith";
+    githubId = 29887;
+    name = "Andrew Smith";
+  };
   andsild = {
     email = "andsild@gmail.com";
     github = "andsild";

--- a/pkgs/development/tools/squawk/correct-Cargo.lock.patch
+++ b/pkgs/development/tools/squawk/correct-Cargo.lock.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index d5803a8..384224d 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1585,7 +1585,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+ 
+ [[package]]
+ name = "squawk"
+-version = "0.19.0"
++version = "0.20.0"
+ dependencies = [
+  "atty",
+  "base64 0.12.3",

--- a/pkgs/development/tools/squawk/default.nix
+++ b/pkgs/development/tools/squawk/default.nix
@@ -1,0 +1,67 @@
+{ darwin
+, fetchFromGitHub
+, lib
+, libiconv
+, libpg_query
+, openssl
+, pkg-config
+, rustPlatform
+, stdenv
+}:
+let
+  # The query parser produces a slightly different AST between major versions
+  # and Squawk is not capable of handling >=14 correctly yet.
+  libpg_query13 = libpg_query.overrideAttrs (_: rec {
+    version = "13-2.2.0";
+    src = fetchFromGitHub {
+      owner = "pganalyze";
+      repo = "libpg_query";
+      rev = version;
+      hash = "sha256-gEkcv/j8ySUYmM9lx1hRF/SmuQMYVHwZAIYOaCQWAFs=";
+    };
+  });
+in
+rustPlatform.buildRustPackage rec {
+  pname = "squawk";
+  version = "0.20.0";
+
+  src = fetchFromGitHub {
+    owner = "sbdchd";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-v9F+HfscX4dIExIP1YvxOldZPPtmxh8lO3SREu6M+C0=";
+  };
+
+  cargoHash = "sha256-kSaQxqom8LSCOQBoIZ1iv+q2+Ih8l61L97xXv5c4a0k=";
+
+  cargoPatches = [
+    ./correct-Cargo.lock.patch
+  ];
+
+  patches = [
+    ./fix-postgresql-version-in-snapshot-test.patch
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = lib.optionals (!stdenv.isDarwin) [
+    libiconv
+    openssl
+  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    CoreFoundation
+    Security
+  ]);
+
+  LIBPG_QUERY_PATH = libpg_query13;
+
+  meta = with lib; {
+    description = "Linter for PostgreSQL, focused on migrations";
+    homepage = "https://squawkhq.com/";
+    changelog = "https://github.com/sbdchd/squawk/blob/v${version}/CHANGELOG.md";
+    license = licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ andrewsmith ];
+  };
+}

--- a/pkgs/development/tools/squawk/fix-postgresql-version-in-snapshot-test.patch
+++ b/pkgs/development/tools/squawk/fix-postgresql-version-in-snapshot-test.patch
@@ -1,0 +1,13 @@
+diff --git a/parser/src/snapshots/squawk_parser__parse__tests__parse_sql_query_json.snap b/parser/src/snapshots/squawk_parser__parse__tests__parse_sql_query_json.snap
+index 7273b74..ae94927 100644
+--- a/parser/src/snapshots/squawk_parser__parse__tests__parse_sql_query_json.snap
++++ b/parser/src/snapshots/squawk_parser__parse__tests__parse_sql_query_json.snap
+@@ -133,7 +133,7 @@ Ok(
+             }),
+         ]),
+         "version": Number(
+-            130003,
++            130008,
+         ),
+     }),
+ )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5663,6 +5663,8 @@ with pkgs;
 
   sqlint = callPackage ../development/tools/sqlint { };
 
+  squawk = callPackage ../development/tools/squawk { };
+
   antibody = callPackage ../shells/zsh/antibody { };
 
   antigen = callPackage ../shells/zsh/antigen { };


### PR DESCRIPTION
###### Description of changes

Squawk (https://squawkhq.com/) is a tool to lint PostgreSQL DDL migrations, specifically for issues that may cause downtime when the migrations are being run. In order to package this, it needs a slightly older version of libpg_query, hence the changes there.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
