### PR TITLE
nixosTests.bpf: disable kfunc test on aarch64

### DIFF
--- a/nixos/tests/bpf.nix
+++ b/nixos/tests/bpf.nix
@@ -26,8 +26,11 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         "    printf(\"tgid: %d\", ((struct task_struct*) curtask)->tgid); exit() "
         "}'"))
     # module BTF (bpftrace >= 0.17)
-    print(machine.succeed("bpftrace -e 'kfunc:nft_trans_alloc_gfp { "
-        "    printf(\"portid: %d\\n\",args->ctx->portid); "
+    # test is currently disabled on aarch64 as kfunc does not work there yet
+    # https://github.com/iovisor/bpftrace/issues/2496
+    print(machine.succeed("uname -m | grep aarch64 || "
+        "bpftrace -e 'kfunc:nft_trans_alloc_gfp { "
+        "    printf(\"portid: %d\\n\", args->ctx->portid); "
         "} BEGIN { exit() }'"))
   '';
 })

--- a/pkgs/os-specific/linux/libbpf/default.nix
+++ b/pkgs/os-specific/linux/libbpf/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libbpf";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "libbpf";
     repo = "libbpf";
     rev = "v${version}";
-    sha256 = "sha256-/vt6IA1o0gjFtXUWhEKIZ1DUWIN2LOvrhLfFzJBACGY=";
+    sha256 = "sha256-NimK4pdYcai21hZHdP1mBX1MOlNY61iDJ+PDYwpRuVE=";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
###### Description of changes

commit fd5d7b258694 ("tests/bpf: add module BTF test") added a new test for module BTF, but that test does not work on aarch64. (merged in https://github.com/NixOS/nixpkgs/pull/214001 )

This is not a regression (kfuncs didn't work on bpftrace 0.16, even if you do not use features requiring BTF like argument name or type), so just disable the test on aarch64 until it is fixed.