### PR TITLE
pantheon.elementary-files: 6.2.1 -> 6.2.2

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-files/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-files/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -29,7 +28,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-files";
-  version = "6.2.1";
+  version = "6.2.2";
 
   outputs = [ "out" "dev" ];
 
@@ -37,17 +36,8 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = "files";
     rev = version;
-    sha256 = "sha256-pJFeMG2aGaMkS00fSoRlMR2YSg5YzwqwaQT8G7Gk5S4=";
+    sha256 = "sha256-YV7fcRaLaDwa0m6zbdhayCAqeON5nqEdQ1IUtDKu5AY=";
   };
-
-  patches = [
-    # Ensure special user directory icon used for bookmark
-    # https://github.com/elementary/files/pull/2106
-    (fetchpatch {
-      url = "https://github.com/elementary/files/commit/00b1c2a975aeab378ed6eb1d90c8988f82596add.patch";
-      sha256 = "sha256-F/Vk7dg57uBBMO4WOJ/7kKbRNMZuWZ3QfrBfEIBozbw=";
-    })
-  ];
 
   nativeBuildInputs = [
     desktop-file-utils


### PR DESCRIPTION
###### Description of changes

- [<code>Ensure special user directory icon used for bookmark (#2106)</code>](https://github.com/elementary/files/commit/00b1c2a975aeab378ed6eb1d90c8988f82596add)
- [<code>CommonJob: Continue the port to Vala (#2097)</code>](https://github.com/elementary/files/commit/6d615b1242169a446c094b49a9d5bbd905044f8e)
- [<code>FileOperations: Continue the port to Vala (#2109)</code>](https://github.com/elementary/files/commit/7e6762c9e7bb5be8bdd182da851c24a9730b8af1)
  - <sub>Files: <code>meson.build</code></sub>
- [<code>Add action to Paste Into menu item (#2118)</code>](https://github.com/elementary/files/commit/c26478562db4c86debb283e65f02dc55f25a74a4)
- [<code>AbstractDirectoryView: Change double-click setting label (#2107)</code>](https://github.com/elementary/files/commit/9f2eb9338de5cfbaf488cb9bb9c2b49c132f48ae)
- [<code>pantheon-files-cloud: Avoid crashes when disconnecting the provider (#2122)</code>](https://github.com/elementary/files/commit/a6b56655b3785e61a72e63a05fbfef713ecfb07c)
- [<code>Update appdata and meson.build for next release (#2127)</code>](https://github.com/elementary/files/commit/4e91dd958566218f2b15114c5f67c12ffefcc0e8)
  - <sub>Tags: <code>6.2.2</code></sub>
  - <sub>Files: <code>meson.build</code></sub>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
