### PR TITLE
add JPEG XL support

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kimageformats.nix
+++ b/pkgs/development/libraries/kde-frameworks/kimageformats.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib,
   extra-cmake-modules,
-  ilmbase, karchive, openexr, libavif, libheif, qtbase
+  ilmbase, karchive, openexr, libavif, libheif, libjxl, qtbase
 }:
 
 let inherit (lib) getDev; in
@@ -10,7 +10,7 @@ mkDerivation {
   pname = "kimageformats";
 
   nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = [ karchive openexr libavif libheif qtbase ];
+  buildInputs = [ karchive openexr libavif libheif libjxl qtbase ];
   outputs = [ "out" ]; # plugins only
   CXXFLAGS = "-I${getDev ilmbase}/include/OpenEXR";
   cmakeFlags = [


### PR DESCRIPTION
###### Description of changes

Add JPEG XL support to KImageFormats, this allows e.g. Gwenview and Co. to display such files.
