### PR TITLE
freeswitch: 1.10.8 -> 1.10.9

### DIFF
--- a/pkgs/development/libraries/libks/default.nix
+++ b/pkgs/development/libraries/libks/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libks";
-  version = "1.8.0";
+  version = "1.8.2";
 
   src = fetchFromGitHub {
     owner = "signalwire";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-Bfp8+jqXu1utlaYuPewm+t3zHxaTWEw+cGZu1nFzkDk=";
+    sha256 = "sha256-TJ3q97K3m3zYGB1D5lLVyrh61L3vtnP5I64lP/DYzW4=";
   };
 
   patches = [

--- a/pkgs/development/libraries/libks/default.nix
+++ b/pkgs/development/libraries/libks/default.nix
@@ -6,6 +6,7 @@
 , pkg-config
 , libuuid
 , openssl
+, libossp_uuid
 }:
 
 stdenv.mkDerivation rec {
@@ -33,16 +34,15 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
-  buildInputs = [
-    libuuid
-    openssl
-  ];
+  buildInputs = [ openssl ]
+    ++ lib.optional stdenv.isLinux libuuid
+    ++ lib.optional stdenv.isDarwin libossp_uuid;
 
   meta = with lib; {
     description = "Foundational support for signalwire C products";
     homepage = "https://github.com/signalwire/libks";
     maintainers = with lib.maintainers; [ misuzu ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.mit;
   };
 }

--- a/pkgs/servers/sip/freeswitch/default.nix
+++ b/pkgs/servers/sip/freeswitch/default.nix
@@ -88,12 +88,12 @@ in
 
 stdenv.mkDerivation rec {
   pname = "freeswitch";
-  version = "1.10.8";
+  version = "1.10.9";
   src = fetchFromGitHub {
     owner = "signalwire";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-66kwEN42LjTh/oEdFeOyXP2fU88tjR1K5ZWQJkKcDLQ=";
+    sha256 = "sha256-65DH2HxiF8wqzmzbIqaQZjSa/JPERHIS2FW6F18c6Pw=";
   };
 
   postPatch = ''

--- a/pkgs/servers/sip/freeswitch/default.nix
+++ b/pkgs/servers/sip/freeswitch/default.nix
@@ -153,5 +153,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mpl11;
     maintainers = with lib.maintainers; [ misuzu ];
     platforms = with lib.platforms; unix;
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/signalwire/libks/releases/tag/v1.8.2
https://github.com/signalwire/libks/compare/v1.8.0...v1.8.2

https://developer.signalwire.com/freeswitch/FreeSWITCH-Explained/Release-Notes/FreeSWITCH-1.10.x-Release-notes_25460878/

https://github.com/signalwire/freeswitch/releases/tag/v1.10.9
https://github.com/signalwire/freeswitch/compare/v1.10.8...v1.10.9

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
