### PR TITLE
pythonPackages.geojson: 2.5.0 -> 3.0.0

### DIFF
--- a/pkgs/development/python-modules/geojson/default.nix
+++ b/pkgs/development/python-modules/geojson/default.nix
@@ -1,21 +1,34 @@
-{ lib, buildPythonPackage, fetchPypi, glibcLocales }:
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, fetchpatch
+}:
 
 buildPythonPackage rec {
   pname = "geojson";
-  version = "2.5.0";
+  version = "3.0.0";
 
-  format = "wheel";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
-    inherit pname version format;
-    sha256 = "1filqm050ixy53kdv81bd4n80vjvfapnmzizy7jg8a6pilv17gfc";
+    inherit pname version;
+    sha256 = "sha256-6h34JGvesrvyDQdWcgkRiTQU+c7kazNqHogtLNYM+6E=";
   };
 
-  LC_ALL = "en_US.UTF-8";
-  nativeCheckInputs = [ glibcLocales ];
+  patches = [
+    # Support for Python 3.11 patch versions
+    # https://github.com/jazzband/geojson/pull/198
+    (fetchpatch {
+      url = "https://github.com/jazzband/geojson/commit/3b1698a92c6d62b160bd566511fcd7834e3f0537.patch";
+      sha256 = "sha256-xSSWq2zvk9LYGkZ6+r2yvqHWBYm17oAFHr+EGLer5fU=";
+    })
+  ];
+
+  pythonImportsCheck = [ "geojson" ];
 
   meta = {
-    homepage = "https://github.com/frewsxcv/python-geojson";
+    homepage = "https://github.com/jazzband/geojson";
     description = "Python bindings and utilities for GeoJSON";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ oxzi ];


### PR DESCRIPTION
###### Description of changes
Version bump, https://github.com/jazzband/geojson/blob/3.0.0/CHANGELOG.rst#300-2022-01-26

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
