### PR TITLE
python3.pkgs.scipy: 1.9.3 -> 1.10.1

### DIFF
--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -15,24 +15,33 @@
 , pytest-xdist
 , numpy
 , pybind11
+, pooch
 , libxcrypt
 }:
 
 buildPythonPackage rec {
   pname = "scipy";
-  version = "1.9.3";
+  version = "1.10.1";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-+8XAXIXBoCvnex/1kQh8g7xEV5xtK9n7eYu2TqXhoCc=";
+    sha256 = "sha256-LPnfuAp7RYm6TEDOdYiYbW1c68VFfK0sKID2vC1C86U=";
   };
+
+  patches = [
+    # These tests require internet connection, currently impossible to disable
+    # them otherwise, see:
+    # https://github.com/scipy/scipy/pull/17965
+    ./disable-datasets-tests.patch
+  ];
 
   nativeBuildInputs = [ cython gfortran meson-python pythran pkg-config wheel ];
 
   buildInputs = [
     numpy.blas
     pybind11
+    pooch
   ] ++ lib.optionals (pythonOlder "3.9") [
     libxcrypt
   ];

--- a/pkgs/development/python-modules/scipy/disable-datasets-tests.patch
+++ b/pkgs/development/python-modules/scipy/disable-datasets-tests.patch
@@ -1,0 +1,9 @@
+diff --git i/scipy/datasets/meson.build w/scipy/datasets/meson.build
+index 101377253..eec2feea4 100644
+--- i/scipy/datasets/meson.build
++++ w/scipy/datasets/meson.build
+@@ -11,4 +11,3 @@ py3.install_sources(
+   subdir: 'scipy/datasets'
+ )
+ 
+-subdir('tests')


### PR DESCRIPTION
###### Description of changes

Close https://github.com/NixOS/nixpkgs/issues/209428 .

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
