### PR TITLE
flaresolverr: init at 3.0.2

### DIFF
--- a/pkgs/servers/flaresolverr/chromedriver_path.patch
+++ b/pkgs/servers/flaresolverr/chromedriver_path.patch
@@ -1,0 +1,41 @@
+diff --git a/src/utils.py b/src/utils.py
+index ceff7ec..a65dc17 100644
+--- a/src/utils.py
++++ b/src/utils.py
+@@ -56,35 +56,8 @@ def get_webdriver() -> WebDriver:
+         else:
+             start_xvfb_display()
+ 
+-    # if we are inside the Docker container, we avoid downloading the driver
+-    driver_exe_path = None
+-    version_main = None
+-    if os.path.exists("/app/chromedriver"):
+-        # running inside Docker
+-        driver_exe_path = "/app/chromedriver"
+-    else:
+-        version_main = get_chrome_major_version()
+-        if PATCHED_DRIVER_PATH is not None:
+-            driver_exe_path = PATCHED_DRIVER_PATH
+-
+-    # downloads and patches the chromedriver
+-    # if we don't set driver_executable_path it downloads, patches, and deletes the driver each time
+-    driver = uc.Chrome(options=options, driver_executable_path=driver_exe_path, version_main=version_main,
++    driver = uc.Chrome(options=options, driver_executable_path="NIX_STORE_DRIVER_PATH",
+                        windows_headless=windows_headless)
+-
+-    # save the patched driver to avoid re-downloads
+-    if driver_exe_path is None:
+-        PATCHED_DRIVER_PATH = os.path.join(driver.patcher.data_path, driver.patcher.exe_name)
+-        shutil.copy(driver.patcher.executable_path, PATCHED_DRIVER_PATH)
+-
+-    # selenium vanilla
+-    # options = webdriver.ChromeOptions()
+-    # options.add_argument('--no-sandbox')
+-    # options.add_argument('--window-size=1920,1080')
+-    # options.add_argument('--disable-setuid-sandbox')
+-    # options.add_argument('--disable-dev-shm-usage')
+-    # driver = webdriver.Chrome(options=options)
+-
+     return driver
+ 
+ 

--- a/pkgs/servers/flaresolverr/default.nix
+++ b/pkgs/servers/flaresolverr/default.nix
@@ -1,0 +1,50 @@
+{ lib, stdenv, python3, chromium, xvfb-run, xorgserver, makeWrapper, chromedriver, fetchFromGitHub }:
+
+let
+  python_env = python3.withPackages
+    (p: with p; [ bottle waitress selenium func-timeout requests websockets xvfbwrapper webtest ]);
+in
+stdenv.mkDerivation rec {
+  pname = "flaresolverr";
+  version = "3.0.2";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-zpeJf1CaQ4bsncZz44sH+tFKddYrZf7YdNYL50d9GA4=";
+  };
+
+  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ chromedriver ];
+  patches = [ ./chromedriver_path.patch ];
+
+  postPatch = ''
+    substituteInPlace src/utils.py \
+    --replace "NIX_STORE_DRIVER_PATH" "${chromedriver}/bin/chromedriver"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share
+    cp -r src $out/share
+    cp package.json $out/share
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper ${python_env}/bin/python $out/bin/flaresolverr \
+      --prefix PATH : ${lib.makeBinPath [ chromium xvfb-run xorgserver chromedriver ]} \
+      --add-flags $out/share/src/flaresolverr.py \
+      --chdir $out/share/
+  '';
+
+  meta = with lib; {
+    description = "Proxy server to bypass Cloudflare protection";
+    homepage = "https://github.com/FlareSolverr/FlareSolverr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ julienmalka ];
+    # Flaresolverr will not run without chromedriver and xvfb-run
+    platforms = lib.intersectLists chromedriver.meta.platforms xvfb-run.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3154,6 +3154,8 @@ with pkgs;
 
   fitnesstrax = callPackage ../applications/misc/fitnesstrax { };
 
+  flaresolverr = callPackage ../servers/flaresolverr { };
+
   flavours = callPackage ../applications/misc/flavours { };
 
   flirc = libsForQt5.callPackage ../applications/video/flirc { };


### PR DESCRIPTION
###### Description of changes

This PR adds the flaresolverr package. Flaresolverr is a proxy server to bypass Cloudflare protection, very usefull in conjonction with jackett (already packaged in nixpkgs).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
