### PR TITLE
csxcad: unstable-2020-02-08 -> unstable-2022-05-18

### DIFF
--- a/pkgs/applications/science/electronics/appcsxcad/default.nix
+++ b/pkgs/applications/science/electronics/appcsxcad/default.nix
@@ -5,7 +5,7 @@
 , csxcad
 , qcsxcad
 , hdf5
-, vtk_8_withQt5
+, vtkWithQt5
 , qtbase
 , fparser
 , tinyxml
@@ -15,13 +15,13 @@
 
 mkDerivation {
   pname = "appcsxcad";
-  version = "unstable-2020-01-04";
+  version = "unstable-2023-01-06";
 
   src = fetchFromGitHub {
     owner = "thliebig";
     repo = "AppCSXCAD";
-    rev = "de8c271ec8b57e80233cb2a432e3d7fd54d30876";
-    sha256 = "0shnfa0if3w588a68gr82qi6k7ldg1j2921fnzji90mmay21birp";
+    rev = "379ede4b8e00c11e8d0fb724c35547991b30c423";
+    hash = "sha256-L0ZEyovnfMzM7JuITBuhb4tJ2Aqgw52IiKEfEGq7Yo0=";
   };
 
   nativeBuildInputs = [
@@ -32,7 +32,7 @@ mkDerivation {
     csxcad
     qcsxcad
     hdf5
-    vtk_8_withQt5
+    vtkWithQt5
     qtbase
     fparser
     tinyxml

--- a/pkgs/applications/science/electronics/csxcad/default.nix
+++ b/pkgs/applications/science/electronics/csxcad/default.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "csxcad";
-  version = "unstable-2020-02-08";
+  version = "unstable-2022-05-18";
 
   src = fetchFromGitHub {
     owner = "thliebig";
     repo = "CSXCAD";
-    rev = "ef6e40931dbd80e0959f37c8e9614c437bf7e518";
-    sha256 = "072s765jyzpdq8qqysdy0dld17m6sr9zfcs0ip2zk8c4imxaysnb";
+    rev = "cd9decb4d9cebe3c8bf115e2c0ee73f730f22da1";
+    sha256 = "1604amhvp7dm8ych7gwzxwawqvb9hpjglk5ffd4qm0y3k6r89arn";
   };
 
   patches = [./searchPath.patch ];

--- a/pkgs/applications/science/electronics/csxcad/default.nix
+++ b/pkgs/applications/science/electronics/csxcad/default.nix
@@ -5,7 +5,7 @@
 , tinyxml
 , hdf5
 , cgal_5
-, vtk_8
+, vtk
 , boost
 , gmp
 , mpfr
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     boost
     gmp
     mpfr
-    vtk_8
+    vtk
     fparser
     tinyxml
     hdf5

--- a/pkgs/applications/science/electronics/openems/default.nix
+++ b/pkgs/applications/science/electronics/openems/default.nix
@@ -5,7 +5,7 @@
 , fparser
 , tinyxml
 , hdf5
-, vtk_8
+, vtk
 , boost
 , zlib
 , cmake
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
     fparser
     tinyxml
     hdf5
-    vtk_8
+    vtk
     boost
     zlib
     csxcad

--- a/pkgs/development/libraries/science/electronics/qcsxcad/default.nix
+++ b/pkgs/development/libraries/science/electronics/qcsxcad/default.nix
@@ -4,19 +4,19 @@
 , cmake
 , csxcad
 , tinyxml
-, vtk_8_withQt5
+, vtkWithQt5
 , qtbase
 }:
 
 mkDerivation {
   pname = "qcsxcad";
-  version = "unstable-2020-01-04";
+  version = "unstable-2023-01-06";
 
   src = fetchFromGitHub {
     owner = "thliebig";
     repo = "QCSXCAD";
-    rev = "0dabbaf2bc1190adec300871cf309791af842c8e";
-    sha256 = "11kbh0mxbdfh7s5azqin3i2alic5ihmdfj0jwgnrhlpjk4cbf9rn";
+    rev = "1cde9d560a5000f4c24c249d2dd5ccda12de38b6";
+    hash = "sha256-kc9Vnx6jGiQC2K88ZH00b61D/DbWxAIZZwYCsINqtrY=";
   };
 
   outputs = [ "out" "dev" ];
@@ -33,7 +33,7 @@ mkDerivation {
   buildInputs = [
     csxcad
     tinyxml
-    vtk_8_withQt5
+    vtkWithQt5
     qtbase
   ];
 


### PR DESCRIPTION
csxcad: unstable-2020-02-08 -> unstable-2022-05-18
qcsxcad: unstable-2020-01-04 -> unstable-2023-01-06
appcsxcad: unstable-2020-01-04 -> unstable-2023-01-06
openems: unpin vtk

###### Description of changes

Update the packages (for `csxcad`, cherry-pick @veprbl's commit from #178367) and unpin `vtk` dependencies.

`nixpkgs-review` is currently unhappy because `hyp2mat` is broken so `openems` and most other depending packages fail (this will be fixed when #196599 is merged - it currently breaks `wt` and `blender`), but I checked that `opemems` builds when this PR is applied.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).