### PR TITLE
mononoki: 1.3 -> 1.5

### DIFF
--- a/pkgs/data/fonts/mononoki/default.nix
+++ b/pkgs/data/fonts/mononoki/default.nix
@@ -2,19 +2,19 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mononoki";
-  version = "1.3";
+  version = "1.5";
 
   src = fetchzip {
     url = "https://github.com/madmalik/mononoki/releases/download/${version}/mononoki.zip";
     stripRoot = false;
-    hash = "sha256-bZYBRdmbQVs4i6UzMIHwJnoLWggX4CW8ZogNFYiX/9w=";
+    hash = "sha256-H5Iu7nSrB5UGlCSjTM3SLu+IjaAffk9TCm5OoOleKvw=";
   };
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/share/fonts/mononoki
-    cp webfont/* $out/share/fonts/mononoki
+    cp * $out/share/fonts/mononoki
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update mononoki from 1.3 to 1.5

I guess this supersedes #202217
I did not try to do the things that were commented on in this PR.
Reason being that this font was recently refactored in https://github.com/NixOS/nixpkgs/commit/f71d67800f55e7f4f4e00fda5bba3aa4d4184534#diff-65a0c27add0de775283f34c8579bbfa22f563dc45a8d66dc75fa5a47409622ef

I therefore think the current structure of this package should be fine.

Regarding the install folder; there does not seem to be a guideline for where to put them.
All the fonts seem to put them into a slightly different sub-directory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
