### PR TITLE
python310Packages.jaraco-abode: use MANIFEST.in to include events.csv

### DIFF
--- a/pkgs/development/python-modules/jaraco-abode/default.nix
+++ b/pkgs/development/python-modules/jaraco-abode/default.nix
@@ -3,7 +3,6 @@
 , pythonOlder
 , fetchFromGitHub
 , fetchPypi
-, fetchpatch
 , setuptools
 , setuptools-scm
 , requests
@@ -39,14 +38,10 @@ buildPythonPackage rec {
     hash = "sha256-ZDdZba1oTOPaUm+r4fWC5E3ni/k8kXo6t5AWQTvfd5E=";
   };
 
-  patches = [
+  postPatch = ''
     # https://github.com/jaraco/jaraco.abode/issues/19
-    (fetchpatch {
-      name = "specify-options-package-data.patch";
-      url = "https://github.com/jaraco/jaraco.abode/commit/8deebf57162fa097243d2b280942b6b7f95174c8.patch";
-      hash = "sha256-Iu2uw9D+nMdVJZyoecEkwQaJH1oSzFN/ZLXKPZPGuPk=";
-    })
-  ];
+    echo "graft jaraco" > MANIFEST.in
+  '';
 
   nativeBuildInputs = [
     setuptools


### PR DESCRIPTION
###### Description of changes

Since `include_package_data = True` all files listed in MANIFEST.in are automatically installed. Doing so based on a GitHub tarball is unproblematic because it only contains files tracked by a VCS and thus also installed automatically when using setuptools-scm. See https://setuptools.pypa.io/en/latest/userguide/datafiles.html#include-package-data


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
