### PR TITLE
rocfft: split base outputs for hydra

### DIFF
--- a/pkgs/development/libraries/rocfft/default.nix
+++ b/pkgs/development/libraries/rocfft/default.nix
@@ -19,6 +19,11 @@
 }:
 
 let
+  name-zero = "librocfft-device-0.so.0.1";
+  name-one = "librocfft-device-1.so.0.1";
+  name-two = "librocfft-device-2.so.0.1";
+  name-three = "librocfft-device-3.so.0.1";
+
   # This is over 3GB, to allow hydra caching we separate it
   rf = stdenv.mkDerivation (finalAttrs: {
     pname = "rocfft";
@@ -26,6 +31,10 @@ let
 
     outputs = [
       "out"
+      "libzero"
+      "libone"
+      "libtwo"
+      "libthree"
     ] ++ lib.optionals buildTests [
       "test"
     ] ++ lib.optionals buildBenchmarks [
@@ -80,7 +89,16 @@ let
       "-DBUILD_CLIENTS_SAMPLES=ON"
     ];
 
-    postInstall = lib.optionalString buildTests ''
+    postInstall = ''
+      mv $out/lib/${name-zero} $libzero
+      mv $out/lib/${name-one} $libone
+      mv $out/lib/${name-two} $libtwo
+      mv $out/lib/${name-three} $libthree
+      ln -s $libzero $out/lib/${name-zero}
+      ln -s $libone $out/lib/${name-one}
+      ln -s $libtwo $out/lib/${name-two}
+      ln -s $libthree $out/lib/${name-three}
+    '' + lib.optionalString buildTests ''
       mkdir -p $test/{bin,lib/fftw}
       cp -a $out/bin/* $test/bin
       ln -s ${fftw}/lib/libfftw*.so $test/lib/fftw
@@ -113,23 +131,31 @@ let
     };
   });
 
-  rf-zero = runCommand "librocfft-device-0.so.0.1" { preferLocalBuild = true; } ''
-    cp -a ${rf}/lib/$name $out
+  rf-zero = runCommand name-zero { preferLocalBuild = true; } ''
+    cp -a ${rf.libzero} $out
   '';
 
-  rf-one = runCommand "librocfft-device-1.so.0.1" { preferLocalBuild = true; } ''
-    cp -a ${rf}/lib/$name $out
+  rf-one = runCommand name-one { preferLocalBuild = true; } ''
+    cp -a ${rf.libone} $out
   '';
 
-  rf-two = runCommand "librocfft-device-2.so.0.1" { preferLocalBuild = true; } ''
-    cp -a ${rf}/lib/$name $out
+  rf-two = runCommand name-two { preferLocalBuild = true; } ''
+    cp -a ${rf.libtwo} $out
   '';
 
-  rf-three = runCommand "librocfft-device-3.so.0.1" { preferLocalBuild = true; } ''
-    cp -a ${rf}/lib/$name $out
+  rf-three = runCommand name-three { preferLocalBuild = true; } ''
+    cp -a ${rf.libthree} $out
   '';
 in stdenv.mkDerivation {
-  inherit (rf) pname version outputs src passthru meta;
+  inherit (rf) pname version src passthru meta;
+
+  outputs = [
+    "out"
+  ] ++ lib.optionals buildTests [
+    "test"
+  ] ++ lib.optionals buildBenchmarks [
+    "benchmark"
+  ];
 
   dontUnpack = true;
   dontPatch = true;
@@ -140,10 +166,10 @@ in stdenv.mkDerivation {
     runHook preInstall
 
     mkdir -p $out/lib
-    cp -as ${rf-zero} $out/lib/${rf-zero.name}
-    cp -as ${rf-one} $out/lib/${rf-one.name}
-    cp -as ${rf-two} $out/lib/${rf-two.name}
-    cp -as ${rf-three} $out/lib/${rf-three.name}
+    ln -sf ${rf-zero} $out/lib/${name-zero}
+    ln -sf ${rf-one} $out/lib/${name-one}
+    ln -sf ${rf-two} $out/lib/${name-two}
+    ln -sf ${rf-three} $out/lib/${name-three}
     cp -an ${rf}/* $out
   '' + lib.optionalString buildTests ''
     cp -a ${rf.test} $test

--- a/pkgs/development/libraries/rocfft/default.nix
+++ b/pkgs/development/libraries/rocfft/default.nix
@@ -58,7 +58,7 @@ let
       openmp
     ];
 
-    propogatedBuildInputs = lib.optionals buildTests [
+    propagatedBuildInputs = lib.optionals buildTests [
       fftw
       fftwFloat
     ];


### PR DESCRIPTION
###### Description of changes
Tracking: #197885
Last thing I can do before giving up on trying to get this to cache on hydra.
Technically I can have rocfft build twice, but then we'd have to do the same for composable_kernel, which I've learned is just barely under the output limit.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
