### PR TITLE
ocamlPackages.irmin: 3.4.1 → 3.5.1

### DIFF
--- a/pkgs/development/ocaml-modules/irmin/chunk.nix
+++ b/pkgs/development/ocaml-modules/irmin/chunk.nix
@@ -4,6 +4,7 @@ buildDunePackage rec {
 
   pname = "irmin-chunk";
   inherit (irmin) version src strictDeps;
+  duneVersion = "3";
 
   propagatedBuildInputs = [ irmin fmt logs lwt ];
 

--- a/pkgs/development/ocaml-modules/irmin/containers.nix
+++ b/pkgs/development/ocaml-modules/irmin/containers.nix
@@ -7,6 +7,7 @@ buildDunePackage {
   pname = "irmin-containers";
 
   inherit (ppx_irmin) src version strictDeps;
+  duneVersion = "3";
 
   nativeBuildInputs = [
     ppx_irmin

--- a/pkgs/development/ocaml-modules/irmin/default.nix
+++ b/pkgs/development/ocaml-modules/irmin/default.nix
@@ -9,7 +9,8 @@ buildDunePackage {
 
   inherit (ppx_irmin) src version strictDeps;
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.10";
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     astring

--- a/pkgs/development/ocaml-modules/irmin/fs.nix
+++ b/pkgs/development/ocaml-modules/irmin/fs.nix
@@ -7,6 +7,7 @@ buildDunePackage rec {
   pname = "irmin-fs";
 
   inherit (irmin) version src strictDeps;
+  duneVersion = "3";
 
   propagatedBuildInputs = [ irmin astring logs lwt ];
 

--- a/pkgs/development/ocaml-modules/irmin/mirage.nix
+++ b/pkgs/development/ocaml-modules/irmin/mirage.nix
@@ -4,6 +4,7 @@ buildDunePackage {
   pname = "irmin-mirage";
 
   inherit (irmin) version src strictDeps;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     irmin fmt ptime mirage-clock

--- a/pkgs/development/ocaml-modules/irmin/pack.nix
+++ b/pkgs/development/ocaml-modules/irmin/pack.nix
@@ -1,10 +1,11 @@
 { lib, buildDunePackage
-, index, ppx_irmin, irmin, optint, fmt, logs, lwt, mtime, cmdliner
+, index, ppx_irmin, irmin, optint, fmt, logs, lwt, mtime, cmdliner, checkseum, rusage
 , alcotest, alcotest-lwt, astring, irmin-test
 }:
 
 buildDunePackage rec {
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.10";
+  duneVersion = "3";
 
   pname = "irmin-pack";
 
@@ -12,7 +13,7 @@ buildDunePackage rec {
 
   nativeBuildInputs = [ ppx_irmin ];
 
-  propagatedBuildInputs = [ index irmin optint fmt logs lwt mtime cmdliner ];
+  propagatedBuildInputs = [ index irmin optint fmt logs lwt mtime cmdliner checkseum rusage ];
 
   checkInputs = [ astring alcotest alcotest-lwt irmin-test ];
 

--- a/pkgs/development/ocaml-modules/irmin/ppx.nix
+++ b/pkgs/development/ocaml-modules/irmin/ppx.nix
@@ -2,14 +2,15 @@
 
 buildDunePackage rec {
   pname = "ppx_irmin";
-  version = "3.4.1";
+  version = "3.5.1";
 
   src = fetchurl {
     url = "https://github.com/mirage/irmin/releases/download/${version}/irmin-${version}.tbz";
-    sha256 = "sha256-kig2EWww7GgGijhpSgm7pSHPR+3Q5K5E4Ha5tJY9oYA=";
+    hash = "sha256-zXiKjT9KPdGNwWChU9SuyR6vaw+0GtQUZNJsecMEqY4=";
   };
 
   minimalOCamlVersion = "4.10";
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     ppx_repr

--- a/pkgs/development/ocaml-modules/irmin/test.nix
+++ b/pkgs/development/ocaml-modules/irmin/test.nix
@@ -8,6 +8,7 @@ buildDunePackage {
   pname = "irmin-test";
 
   inherit (irmin) version src strictDeps;
+  duneVersion = "3";
 
   nativeBuildInputs = [ ppx_irmin ];
 

--- a/pkgs/development/ocaml-modules/irmin/tezos.nix
+++ b/pkgs/development/ocaml-modules/irmin/tezos.nix
@@ -7,6 +7,7 @@ buildDunePackage rec {
   pname = "irmin-tezos";
 
   inherit (irmin) version src strictDeps;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     irmin

--- a/pkgs/development/ocaml-modules/rusage/default.nix
+++ b/pkgs/development/ocaml-modules/rusage/default.nix
@@ -1,0 +1,20 @@
+{ lib, fetchurl, buildDunePackage }:
+
+buildDunePackage rec {
+  pname = "rusage";
+  version = "1.0.0";
+
+  duneVersion = "3";
+
+  src = fetchurl {
+    url = "https://github.com/CraigFe/ocaml-rusage/releases/download/${version}/rusage-${version}.tbz";
+    hash = "sha256-OgYA2Fe1goqoaOS45Z6FBJNNYN/uq+KQoUwG8KSo6Fk=";
+  };
+
+  meta = {
+    description = "Bindings to the GETRUSAGE(2) syscall";
+    homepage = "https://github.com/CraigFe/ocaml-rusage";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1233,6 +1233,8 @@ let
 
     rock = callPackage ../development/ocaml-modules/rock { };
 
+    rusage = callPackage ../development/ocaml-modules/rusage { };
+
     samplerate = callPackage ../development/ocaml-modules/samplerate { };
 
     secp256k1 = callPackage ../development/ocaml-modules/secp256k1 {


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/irmin/blob/3.5.1/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
