### PR TITLE
apr: 1.7.0 -> 1.7.2

### DIFF
--- a/pkgs/development/libraries/apr/cross-assume-dev-zero-mmappable.patch
+++ b/pkgs/development/libraries/apr/cross-assume-dev-zero-mmappable.patch
@@ -1,0 +1,14 @@
+based onhttps://830833.bugs.gentoo.org/attachment.cgi?id=761676,
+adjusted for 1.7.2
+
+--- a/configure.in	2022-01-09 00:31:05.552582255 -0800
++++ b/configure.in	2022-01-09 00:31:19.824582533 -0800
+@@ -1329,7 +1329,7 @@
+             return 3;
+         }
+         return 0;
+-    }], [], [ac_cv_file__dev_zero=no], [ac_cv_file__dev_zero=no])])
++    }], [], [ac_cv_file__dev_zero=no], [:])])
+ fi
+ 
+ # Now we determine which one is our anonymous shmem preference.

--- a/pkgs/development/libraries/apr/default.nix
+++ b/pkgs/development/libraries/apr/default.nix
@@ -2,38 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "apr";
-  version = "1.7.0";
+  version = "1.7.2";
 
   src = fetchurl {
     url = "mirror://apache/apr/${pname}-${version}.tar.bz2";
-    sha256 = "1spp6r2a3xcl5yajm9safhzyilsdzgagc2dadif8x6z9nbq4iqg2";
+    sha256 = "sha256-ded8yGd2wDDApcQI370L8qC3Xu1TUeUtVDn6HlUJpD4=";
   };
 
   patches = [
-    (fetchpatch {
-      name = "CVE-2021-35940.patch";
-      url = "https://dist.apache.org/repos/dist/release/apr/patches/apr-1.7.0-CVE-2021-35940.patch";
-      sha256 = "1qd511dyqa1b7bj89iihrlbaavbzl6yyblqginghmcnhw8adymbs";
-      # convince fetchpatch to restore missing `a/`, `b/` to paths
-      extraPrefix = "";
-    })
-
-    # Fix cross.
-    (fetchpatch {
-      url = "https://github.com/apache/apr/commit/374210c50ee9f4dbf265f0172dcf2d45b97d0550.patch";
-      sha256 = "04k62c5dh043jhkgs5qma6yqkq4q7nh0zswr81il4l7q1zil581y";
-    })
-    (fetchpatch {
-      url = "https://github.com/apache/apr/commit/866e1df66be6704a584feaf5c3d241e3d631d03a.patch";
-      sha256 = "0hhm5v5wx985c28dq6d9ngnyqihpsphq4mw7rwylk39k2p90ppcm";
-    })
-
-    # Cross fix. Patch the /dev/zero mmapable detection logic. https://bugs.gentoo.org/show_bug.cgi?id=830833
-    (fetchpatch {
-      url = "https://830833.bugs.gentoo.org/attachment.cgi?id=761676";
-      name = "cross-assume-dev-zero-mmappable.patch";
-      sha256 = "sha256-rsouJp1o7p0d+AJ5KvyhUU79vAJOcVHEuwSEKaCEGa8=";
-    })
+    ./cross-assume-dev-zero-mmappable.patch
   ];
 
   # This test needs the net


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2021-35940 (yes they managed to fix it in 1.6.3 but then omit the fix from 1.7.0 :trophy:)
https://nvd.nist.gov/vuln/detail/CVE-2022-28331
https://nvd.nist.gov/vuln/detail/CVE-2022-24963

Most patches now included upstream, one needing some customization so brought in-repo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
