### PR TITLE
python310Packages.python-box: 6.1.0 -> 7.0.0

### DIFF
--- a/pkgs/development/python-modules/python-box/default.nix
+++ b/pkgs/development/python-modules/python-box/default.nix
@@ -81,6 +81,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python dictionaries with advanced dot notation access";
     homepage = "https://github.com/cdgriffith/Box";
+    changelog = "https://github.com/cdgriffith/Box/blob/${version}/CHANGES.rst";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/python-box/default.nix
+++ b/pkgs/development/python-modules/python-box/default.nix
@@ -1,11 +1,14 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , msgpack
+, poetry-core
 , pytestCheckHook
 , pythonOlder
 , pyyaml
 , ruamel-yaml
+, setuptools
 , toml
 , tomli
 , tomli-w
@@ -13,8 +16,8 @@
 
 buildPythonPackage rec {
   pname = "python-box";
-  version = "6.1.0";
-  format = "setuptools";
+  version = "7.0.0";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
@@ -22,8 +25,22 @@ buildPythonPackage rec {
     owner = "cdgriffith";
     repo = "Box";
     rev = "refs/tags/${version}";
-    hash = "sha256-42VDZ4aASFFWhRY3ApBQ4dq76eD1flZtxUM9hpA9iiI=";
+    hash = "sha256-CvcVN5DTaT8mSf2FtFrt7DHP+YLbVI15/5Vjfmgae34=";
   };
+
+  patches = [
+    # Switch to poetry-core, https://github.com/cdgriffith/Box/pull/247
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/cdgriffith/Box/commit/a43b98c5f5ff1074568dcef27cf17e7065d1019c.patch";
+      hash = "sha256-ul/MVSzgjN3D+Vuzn7YPITaDrtS58vDmA23hy1EVF9U=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    poetry-core
+    setuptools
+  ];
 
   passthru.optional-dependencies = {
     all = [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
