### PR TITLE
python3Packages.backports-strenum: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12655,6 +12655,15 @@
     github = "ppenguin";
     githubId = 17690377;
   };
+  ppentchev = {
+    name = "Peter Pentchev";
+    email = "roam@ringlet.net";
+    github = "ppentchev";
+    githubId = 453114;
+    keys = [{
+      fingerprint = "2EE7 A7A5 17FC 124C F115  C354 651E EFB0 2527 DF13";
+    }];
+  };
   ppom = {
     name = "ppom";
     email = "ppom@ecomail.fr";

--- a/pkgs/development/python-modules/backports-strenum/default.nix
+++ b/pkgs/development/python-modules/backports-strenum/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonAtLeast
+, python
+, setuptools-scm
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "backports-strenum";
+  version = "1.2.4";
+
+  disabled = pythonAtLeast "3.11";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "backports.strenum";
+    sha256 = "sha256-h7Z/0UE6886Vm1ZdhN3vmXds3ZemLi/S0FUM2swhDe4=";
+  };
+
+  propagatedBuildInputs = [
+    setuptools-scm
+  ];
+
+  pythonImportsCheck = [ "backports.strenum" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Backport of the standard library module strenum";
+    homepage = "https://github.com/clbarnes/backports.strenum";
+    license = licenses.psfl;
+    maintainers = with maintainers; [ ppentchev ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1175,6 +1175,8 @@ self: super: with self; {
 
   backports-shutil-which = callPackage ../development/python-modules/backports-shutil-which { };
 
+  backports-strenum = callPackage ../development/python-modules/backports-strenum { };
+
   backports_tempfile = callPackage ../development/python-modules/backports_tempfile { };
 
   backports_unittest-mock = callPackage ../development/python-modules/backports_unittest-mock { };


### PR DESCRIPTION
###### Description of changes

Add the backports.strenum Python package as found at https://pypi.org/project/backports.strenum so that Python programs and libraries can use a straight backport of the Python 3.11 enum.StrEnum class. The python3Packages.strenum package already fulfills part of that role, but the backports.strenum one is closer to the one included in the Python 3.11 standard library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - the package's unit tests are invoked using `pytestCheckHook`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - since this is a new package, nothing depends on it yet, but [my sameconf Python package](https://gitlab.com/ppentchev/sameconf) uses it in [a `nix-shell` derivation](https://gitlab.com/ppentchev/sameconf/-/blob/main/nix/python-pytest.nix) and it works for Python 3.8 through 3.10
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
