### PR TITLE
pgagroal: init at 1.5.1

### DIFF
--- a/pkgs/development/tools/database/pgagroal/default.nix
+++ b/pkgs/development/tools/database/pgagroal/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, cmake, docutils, libev, openssl, systemd }:
+
+stdenv.mkDerivation rec {
+  pname = "pgagroal";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "agroal";
+    repo = "pgagroal";
+    rev = version;
+    hash = "sha256-d6icEYlk0qnzmoP/mvSmTw16YfIYWc2WbY7sKguX7Ug=";
+  };
+
+  patches = [ ./do-not-search-libatomic.patch ];
+
+  nativeBuildInputs = [ cmake docutils ];
+
+  buildInputs = [ libev openssl systemd ];
+
+  meta = with lib; {
+    description = "High-performance connection pool for PostgreSQL";
+    homepage = "https://agroal.github.io/pgagroal/";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.marsam ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/tools/database/pgagroal/do-not-search-libatomic.patch
+++ b/pkgs/development/tools/database/pgagroal/do-not-search-libatomic.patch
@@ -1,0 +1,15 @@
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -78,12 +78,6 @@
+ endif()
+ 
+ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+-  find_package(Libatomic)
+-  if (LIBATOMIC_FOUND)
+-    message(STATUS "libatomic found")
+-  else ()
+-    message(FATAL_ERROR "libatomic needed")
+-  endif()
+ 
+   find_package(Systemd)
+   if (SYSTEMD_FOUND)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10788,6 +10788,8 @@ with pkgs;
 
   pg_top = callPackage ../tools/misc/pg_top { };
 
+  pgagroal = callPackage ../development/tools/database/pgagroal { };
+
   pgcenter = callPackage ../tools/misc/pgcenter { };
 
   pgmetrics = callPackage ../tools/misc/pgmetrics { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add https://agroal.github.io/pgagroal/
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
