### PR TITLE
Revert "python310Packages.elementpath: 3.0.2 -> 4.0.1"

### DIFF
--- a/pkgs/development/python-modules/elementpath/default.nix
+++ b/pkgs/development/python-modules/elementpath/default.nix
@@ -6,7 +6,7 @@
 
 buildPythonPackage rec {
   pname = "elementpath";
-  version = "4.0.1";
+  version = "3.0.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     owner = "sissaschool";
     repo = "elementpath";
     rev = "refs/tags/v${version}";
-    hash = "sha256-BEnSPRuQUnKXtPAJfjxS+fwE0rpPj1U2yRK8eImKMYw=";
+    hash = "sha256-b+Th28GI2UOmfO4jy4biohAJWPiYWkvFLqqs9lgR4Vc=";
   };
 
   # avoid circular dependency with xmlschema which directly depends on this
@@ -28,7 +28,6 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "XPath 1.0/2.0 parsers and selectors for ElementTree and lxml";
     homepage = "https://github.com/sissaschool/elementpath";
-    changelog = "https://github.com/sissaschool/elementpath/blob/${version}/CHANGELOG.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ jonringer ];
   };


### PR DESCRIPTION
Breaks basically every reverse dependency.

Reverts NixOS/nixpkgs#214558