### PR TITLE
python310Packages.accelerate: init at 0.16.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16187,6 +16187,12 @@
     githubId = 40352765;
     name = "Yoctocell";
   };
+  YodaEmbedding = {
+    email = "mulhaq2005@gmail.com";
+    github = "YodaEmbedding";
+    githubId = 721196;
+    name = "Mateen Ulhaq";
+  };
   yorickvp = {
     email = "yorickvanpelt@gmail.com";
     matrix = "@yorickvp:matrix.org";

--- a/pkgs/development/python-modules/accelerate/default.nix
+++ b/pkgs/development/python-modules/accelerate/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, datasets
+, evaluate
+, numpy
+, packaging
+, psutil
+, pyyaml
+, pytestCheckHook
+, torch
+}:
+
+buildPythonPackage rec {
+  pname = "accelerate";
+  version = "0.16.0";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-0T4w8+bev7Rsrae5Ma+FVgYZtqaoOdDK/uq27XxqSY0=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    packaging
+    psutil
+    pyyaml
+    torch
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    datasets
+    evaluate
+  ];
+
+  pythonImportsCheck = [
+    "accelerate"
+  ];
+
+  meta = with lib; {
+    description = "A simple way to train and use PyTorch models with multi-GPU, TPU, mixed-precision";
+    homepage = "https://github.com/huggingface/accelerate";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ YodaEmbedding ];
+  };
+}

--- a/pkgs/development/python-modules/cer/default.nix
+++ b/pkgs/development/python-modules/cer/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, levenshtein
+}:
+
+buildPythonPackage
+rec {
+  pname = "cer";
+  version = "1.2.0";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-SFy36i5suvyu0hR5Bb0Gw6VFPLqOWY/ltZdsYlulkE4=";
+  };
+
+  propagatedBuildInputs = [
+    levenshtein
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "cer"
+  ];
+
+  meta = with lib; {
+    description = "CharacTER: Translation Edit Rate on Character Level";
+    homepage = "https://github.com/BramVanroy/CharacTER";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ YodaEmbedding ];
+  };
+}

--- a/pkgs/development/python-modules/charcut/default.nix
+++ b/pkgs/development/python-modules/charcut/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+}:
+
+buildPythonPackage
+rec {
+  pname = "charcut";
+  version = "1.1.1";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-oWmszWGvvFF1to/AKQXV2iBFAUIIL6Fxk0xV3CgS1qs=";
+  };
+
+  propagatedBuildInputs = [
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "charcut"
+  ];
+
+  meta = with lib; {
+    description = "Character-based MT evaluation and difference highlighting";
+    homepage = "https://github.com/BramVanroy/CharCut";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ YodaEmbedding ];
+  };
+}

--- a/pkgs/development/python-modules/evaluate/default.nix
+++ b/pkgs/development/python-modules/evaluate/default.nix
@@ -1,0 +1,141 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+
+  # REQUIRED DEPENDENCIES:
+, datasets
+, dill
+, fsspec
+, huggingface-hub
+, importlib-metadata
+, multiprocess
+, numpy
+, packaging
+, pandas
+, requests
+, responses
+, tqdm
+, xxhash
+
+  # EVERYTHING THAT FOLLOWS ARE CHECK DEPENDENCIES:
+, pytestCheckHook
+
+  # test dependencies
+, absl-py
+, cer # for characTER
+, charcut # for charcut_mt
+, nltk # for NIST and probably others
+, pytest-datadir
+, pytest-xdist
+
+  # optional dependencies
+, tensorflow
+, torch
+
+  # metrics dependencies
+  # , bert_score
+  # , jiwer
+  # , mauve-text
+  # , rouge_score
+  # , sacrebleu
+, sacremoses
+, scikit-learn
+, scipy
+, sentencepiece # for bleurt
+, seqeval
+, transformers # for evaluator
+, trectools
+
+  # to speed up pip backtracking
+, requests-file
+, six
+, texttable
+, tldextract
+, toml
+, unidecode
+, werkzeug
+}:
+
+buildPythonPackage
+rec {
+  pname = "evaluate";
+  version = "0.4.0";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-vWpZh5vprhO2gWhOVq4+bqZXBzxEE7MDNenvqYVuT0Q=";
+  };
+
+  propagatedBuildInputs = [
+    datasets
+    dill
+    fsspec
+    huggingface-hub
+    importlib-metadata
+    multiprocess
+    numpy
+    packaging
+    pandas
+    requests
+    responses
+    tqdm
+    xxhash
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+
+    # test dependencies
+    absl-py
+    cer # for characTER
+    charcut # for charcut_mt
+    nltk # for NIST and probably others
+    pytest-datadir
+    pytest-xdist
+
+    # optional dependencies
+    tensorflow
+    torch
+
+    # metrics dependencies
+    # bert_score
+    # jiwer
+    # mauve-text
+    # rouge_score
+    # sacrebleu
+    sacremoses
+    scikit-learn
+    scipy
+    sentencepiece # for bleurt
+    seqeval
+    transformers # for evaluator
+    trectools
+
+    # to speed up pip backtracking
+    requests-file
+    six
+    texttable
+    tldextract
+    toml
+    unidecode
+    werkzeug
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "responses<0.19" "responses"
+      # As of 2023-02-05, nixpkgs responses==0.22.0
+  '';
+
+  pythonImportsCheck = [
+    "evaluate"
+  ];
+
+  meta = with lib; {
+    description = "A library for easily evaluating machine learning models and datasets";
+    homepage = "https://github.com/huggingface/evaluate";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ YodaEmbedding ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1685,6 +1685,8 @@ self: super: with self; {
 
   characteristic = callPackage ../development/python-modules/characteristic { };
 
+  charcut = callPackage ../development/python-modules/charcut { };
+
   chardet = callPackage ../development/python-modules/chardet { };
 
   charset-normalizer = callPackage ../development/python-modules/charset-normalizer { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20,6 +20,8 @@ self: super: with self; {
 
   absl-py = callPackage ../development/python-modules/absl-py { };
 
+  accelerate = callPackage ../development/python-modules/accelerate { };
+
   accuweather = callPackage ../development/python-modules/accuweather { };
 
   accupy = callPackage ../development/python-modules/accupy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3123,6 +3123,8 @@ self: super: with self; {
 
   ev3dev2 = callPackage ../development/python-modules/ev3dev2 { };
 
+  evaluate = callPackage ../development/python-modules/evaluate { };
+
   evdev = callPackage ../development/python-modules/evdev { };
 
   eve = callPackage ../development/python-modules/eve { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1619,6 +1619,8 @@ self: super: with self; {
 
   cepa = callPackage ../development/python-modules/cepa { };
 
+  cer = callPackage ../development/python-modules/cer { };
+
   cerberus = callPackage ../development/python-modules/cerberus { };
 
   cert-chain-resolver = callPackage ../development/python-modules/cert-chain-resolver { };


### PR DESCRIPTION
###### Description of changes

Initialize `python3Packages.accelerate`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
