### PR TITLE
symlinkjoin: print warning when keeping existing file

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -509,8 +509,8 @@ rec {
       ''
         mkdir -p $out
         for i in $(cat $pathsPath); do
-          ${lndir}/bin/lndir -silent $i $out
-        done
+          ${lndir}/bin/lndir $i $out
+        done 2>&1 | sed 's/^/symlinkJoin: warning: keeping existing file: /'
         ${postBuild}
       '';
 


### PR DESCRIPTION
make symlinkjoin more verbose when files are not replaced

https://discourse.nixos.org/t/overriding-a-package-without-rebuilding-it/13898/8

## before

```sh
cd $(mktemp -d)
nix-shell -p xorg.lndir
mkdir a b z
touch a/f b/f
for path in a b; do lndir -silent $PWD/$path z; done
readlink z/f
# /tmp/tmp.wbIlOkiaFH/a/f
```

## after

```sh
cd $(mktemp -d)
nix-shell -p xorg.lndir
mkdir a b z
touch a/f b/f
for path in a b; do lndir $PWD/$path z; done 2>&1 | sed 's/^/symlinkJoin: warning: keeping existing file: /'
# symlinkJoin: warning: keeping existing file: f: /tmp/tmp.wbIlOkiaFH/a/f
readlink z/f
# /tmp/tmp.wbIlOkiaFH/a/f
```

## todo

for symlinkjoin, use a patched [lndir.c](https://github.com/freedesktop/xorg-lndir/blob/master/lndir.c) with better warning messages

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
