### PR TITLE
cobra-cli: fix the build

### DIFF
--- a/pkgs/development/tools/cobra-cli/default.nix
+++ b/pkgs/development/tools/cobra-cli/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, makeWrapper, go }:
 
 buildGoModule rec {
   pname = "cobra-cli";
@@ -12,6 +12,22 @@ buildGoModule rec {
   };
 
   vendorSha256 = "sha256-vrtGPQzY+NImOGaSxV+Dvch+GNPfL9XfY4lfCHTGXwY=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  allowGoReference = true;
+
+  postPatch = ''
+    substituteInPlace "cmd/add_test.go" \
+      --replace "TestGoldenAddCmd" "SkipGoldenAddCmd"
+    substituteInPlace "cmd/init_test.go" \
+      --replace "TestGoldenInitCmd" "SkipGoldenInitCmd"
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/cobra-cli" \
+      --prefix PATH : ${go}/bin
+  '';
 
   meta = with lib; {
     description = "Cobra CLI tool to generate applications and commands";


### PR DESCRIPTION
###### Description of changes

Fix two issues:
- Skip tests which depend on the current year.
- Ensure go is in PATH.

```
--- FAIL: TestGoldenAddCmd (0.00s)
    add_test.go:28: "/build/source/cmd/testproject/cmd/test.go" and "testdata/test.go.golden" are not equal!
        
        $ diff -u /build/source/cmd/testproject/cmd/test.go testdata/test.go.golden
        --- /build/source/cmd/testproject/cmd/test.go   2023-02-05 09:28:59.719342469 +0000
        +++ testdata/test.go.golden     1970-01-01 00:00:01.000000000 +0000
        @@ -1,5 +1,5 @@
         /*
        -Copyright © 2023 NAME HERE <EMAIL ADDRESS>
        +Copyright © 2022 NAME HERE <EMAIL ADDRESS>
         
         Licensed under the Apache License, Version 2.0 (the "License");
         you may not use this file except in compliance with the License.
        
        exit status 1
--- FAIL: TestGoldenInitCmd (0.17s)
    --- FAIL: TestGoldenInitCmd/successfully_creates_a_project_based_on_module (0.17s)
        init_test.go:77: "/build/source/cmd/testproject/main.go" and "testdata/main.go.golden" are not equal!
            
            $ diff -u /build/source/cmd/testproject/main.go testdata/main.go.golden
            --- /build/source/cmd/testproject/main.go   2023-02-05 09:28:59.892341870 +0000
            +++ testdata/main.go.golden 1970-01-01 00:00:01.000000000 +0000
            @@ -1,5 +1,5 @@
             /*
            -Copyright © 2023 NAME HERE <EMAIL ADDRESS>
            +Copyright © 2022 NAME HERE <EMAIL ADDRESS>
             
             Licensed under the Apache License, Version 2.0 (the "License");
             you may not use this file except in compliance with the License.
            
            exit status 1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
