### PR TITLE
clickable: 7.4.0 -> 7.11.0

### DIFF
--- a/pkgs/development/tools/clickable/default.nix
+++ b/pkgs/development/tools/clickable/default.nix
@@ -7,17 +7,19 @@
 , jsonschema
 , argcomplete
 , pytestCheckHook
+, watchdog
+, stdenv
 }:
 
 buildPythonPackage rec {
   pname = "clickable";
-  version = "7.4.0";
+  version = "7.11.0";
 
   src = fetchFromGitLab {
     owner = "clickable";
     repo = "clickable";
     rev = "v${version}";
-    sha256 = "sha256-QS7vi0gUQbqqRYkZwD2B+zkt6DQ6AamQO7sihD8qWS0=";
+    sha256 = "sha256-OVS+FK2ABoKbBFLDc3drcjeaa3yO9/8Ah8FzlN2fd8g=";
   };
 
   propagatedBuildInputs = [
@@ -26,18 +28,51 @@ buildPythonPackage rec {
     pyyaml
     jsonschema
     argcomplete
+    watchdog
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
   disabledTests = [
-    # Test require network connection
+    # Tests require docker
     "test_cpp_plugin"
     "test_html"
     "test_python"
     "test_qml_only"
     "test_rust"
-  ];
+    "test_review"
+    "test_click_build"
+    "test_no_device"
+    "test_no_file_temp"
+    "test_update"
+    "test_lib_build"
+    "test_clean"
+    "test_temp_exception"
+    "test_create_interactive"
+    "test_create_non_interactive"
+    "test_kill"
+    "test_writable_image"
+    "test_no_desktop_mode"
+    "test_no_lock"
+    "test_run_default_command"
+    "test_run"
+    "test_no_container_mode_log"
+    "test_custom_mode_log"
+    "test_skip_desktop_mode"
+    "test_log"
+    "test_custom_lock_file"
+    "test_launch_custom"
+    "test_launch"
+    "test_devices"
+    "test_install"
+    "test_skip_container_mode"
+  ] ++
+    # There are no docker images available for the aarch64 architecutre
+    # which are required for tests.
+    lib.optionals stdenv.isAarch64 [
+      "test_arch"
+      "test_restricted_arch"
+    ];
 
   meta = {
     description = "A build system for Ubuntu Touch apps";


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
