### PR TITLE
python3Packages.ruff-lsp: init at 0.0.24

### DIFF
--- a/pkgs/development/python-modules/ruff-lsp/default.nix
+++ b/pkgs/development/python-modules/ruff-lsp/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, pythonOlder
+, buildPythonPackage
+, fetchPypi
+, ruff
+, pygls
+, lsprotocol
+, hatchling
+, typing-extensions
+, unittestCheckHook
+, python-lsp-jsonrpc
+}:
+
+buildPythonPackage rec {
+  pname = "ruff-lsp";
+  version = "0.0.24";
+  format = "pyproject";
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "ruff_lsp";
+    sha256 = "sha256-1he/GYk8O9LqPXH3mu7eGWuRygiDG1OnJ+JNT2Pynzo=";
+  };
+
+  postPatch = ''
+    # ruff binary added to PATH in wrapper so it's not needed
+    sed -i '/"ruff>=/d' pyproject.toml
+  '';
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    pygls
+    lsprotocol
+    typing-extensions
+  ];
+
+  doCheck = stdenv.isDarwin;
+
+  nativeCheckInputs = [
+    unittestCheckHook
+    python-lsp-jsonrpc
+    ruff
+  ];
+
+  makeWrapperArgs = [
+    # prefer ruff from user's PATH, that's usually desired behavior
+    "--suffix PATH : ${lib.makeBinPath [ ruff ]}"
+  ];
+
+
+  meta = with lib; {
+    homepage = "https://github.com/charliermarsh/ruff-lsp";
+    description = "A Language Server Protocol implementation for Ruff";
+    changelog = "https://github.com/charliermarsh/ruff-lsp/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalekseev ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10457,6 +10457,8 @@ self: super: with self; {
 
   rubymarshal = callPackage ../development/python-modules/rubymarshal { };
 
+  ruff-lsp = callPackage ../development/python-modules/ruff-lsp { };
+
   ruffus = callPackage ../development/python-modules/ruffus { };
 
   runway-python = callPackage ../development/python-modules/runway-python { };


### PR DESCRIPTION
###### Description of changes

Init https://github.com/charliermarsh/ruff-lsp package, there's another pr but it doesn't work for me and no activity for two months https://github.com/NixOS/nixpkgs/pull/207250
I'll be happy with any of the PRs merged.
cc @cpcloud @fabaff 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
