### PR TITLE
python2Packages.wheel: keep 0.37.1 for python2 since 0.38 dropped support

### DIFF
--- a/pkgs/development/python2-modules/wheel/0001-tests-Rename-a-a-o-_-.py-_-.py.patch
+++ b/pkgs/development/python2-modules/wheel/0001-tests-Rename-a-a-o-_-.py-_-.py.patch
@@ -1,0 +1,37 @@
+From 5879a4bbc34d1eb25e160b15b2f5a4f10eac6bd2 Mon Sep 17 00:00:00 2001
+From: toonn <toonn@toonn.io>
+Date: Mon, 13 Sep 2021 18:07:26 +0200
+Subject: [PATCH] =?UTF-8?q?tests:=20Rename=20a=CC=8Aa=CC=88o=CC=88=5F?=
+ =?UTF-8?q?=E6=97=A5=E6=9C=AC=E8=AA=9E.py=20=3D>=20=C3=A6=C9=90=C3=B8=5F?=
+ =?UTF-8?q?=E6=97=A5=E6=9C=AC=E5=83=B9.py?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+`åäö_日本語.py` normalizes differently in NFC and NFD normal forms. This
+means a hash generated for the source directory can differ depending on
+whether or not the filesystem is normalizing and which normal form it
+uses.
+
+By renaming the file to `æɐø_日本價.py` we avoid this issue by using a
+name that has the same encoding in each normal form.
+---
+ tests/test_bdist_wheel.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/test_bdist_wheel.py b/tests/test_bdist_wheel.py
+index 651c034..9b94ac8 100644
+--- a/tests/test_bdist_wheel.py
++++ b/tests/test_bdist_wheel.py
+@@ -58,7 +58,7 @@ def test_unicode_record(wheel_paths):
+     with ZipFile(path) as zf:
+         record = zf.read('unicode.dist-0.1.dist-info/RECORD')
+ 
+-    assert u'åäö_日本語.py'.encode('utf-8') in record
++    assert u'æɐø_日本價.py'.encode('utf-8') in record
+ 
+ 
+ def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
+-- 
+2.17.2 (Apple Git-113)
+

--- a/pkgs/development/python2-modules/wheel/default.nix
+++ b/pkgs/development/python2-modules/wheel/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, bootstrapped-pip
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "wheel";
+  version = "0.37.1";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "pypa";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-JlTmUPY3yo/uROyd3nW1dJa23zbLhgQTwcmqZkPOrHs=";
+    name = "${pname}-${version}-source";
+    postFetch = ''
+      cd $out
+      mv tests/testdata/unicode.dist/unicodedist/åäö_日本語.py \
+        tests/testdata/unicode.dist/unicodedist/æɐø_日本價.py
+      patch -p1 < ${./0001-tests-Rename-a-a-o-_-.py-_-.py.patch}
+    '';
+  };
+
+  nativeBuildInputs = [
+    bootstrapped-pip
+    setuptools
+  ];
+
+  # No tests in archive
+  doCheck = false;
+  pythonImportsCheck = [ "wheel" ];
+
+  # We add this flag to ignore the copy installed by bootstrapped-pip
+  pipInstallFlags = [ "--ignore-installed" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/pypa/wheel";
+    description = "A built-package format for Python";
+    longDescription = ''
+      This library is the reference implementation of the Python wheel packaging standard,
+      as defined in PEP 427.
+
+      It has two different roles:
+
+      - A setuptools extension for building wheels that provides the bdist_wheel setuptools command
+      - A command line tool for working with wheel files
+
+      It should be noted that wheel is not intended to be used as a library,
+      and as such there is no stable, public API.
+    '';
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ siriobalmelli ];
+  };
+}

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -83,6 +83,8 @@ with self; with super; {
     doCheck = false;  # circular dependency with pytest
   });
 
+  wheel = callPackage ../development/python2-modules/wheel { };
+
   zeek = disabled super.zeek;
 
   zipp = callPackage ../development/python2-modules/zipp { };


### PR DESCRIPTION
###### Description of changes

Fix regression.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
