### PR TITLE
haguichi: Add passthru.updateScript

### DIFF
--- a/pkgs/tools/networking/haguichi/default.nix
+++ b/pkgs/tools/networking/haguichi/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     owner = "ztefn";
     repo = "haguichi";
     rev = version;
-    sha256 = "1kgjl9g9lyg00cfx4x28s4xyqsqk5057xv6k2cj6ckg9lkxaixvc";
+    hash = "sha256-bPeo+qTpTWYkE9PsfgooE2vsO9FIdNIdA+B5ml6i8s0=";
   };
 
   nativeBuildInputs = [
@@ -43,6 +43,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     patchShebangs meson_post_install.py
   '';
+
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "Graphical frontend for Hamachi on Linux";

--- a/pkgs/tools/networking/haguichi/update.sh
+++ b/pkgs/tools/networking/haguichi/update.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+
+set -euo pipefail
+
+version="$(
+    curl -s https://api.github.com/repos/ztefn/haguichi/releases |
+    jq '.[] | select(.target_commitish!="elementary") | .tag_name' --raw-output |
+    sort --version-sort --reverse |
+    head -n1
+)"
+
+update-source-version haguichi "$version"


### PR DESCRIPTION
###### Description of changes

Closes #214488
CC @wegank 

The upstream repo has regular releases and elementaryOS-specific releases. We only want the regular releases, so filter out the elementaryOS ones in a custom updateScript.

Tested by removing the `--reverse` from `sort --version-sort --reverse` - so it downgrades to the oldest release - then adding it back - which correctly upgrades to the currently packaged version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
