### PR TITLE
python310Packages.niaclass: init at 0.1.3

### DIFF
--- a/pkgs/development/python-modules/niaclass/default.nix
+++ b/pkgs/development/python-modules/niaclass/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, niapy
+, numpy
+, pandas
+, poetry-core
+, scikit-learn
+, toml-adapt
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "niaclass";
+  version = "0.1.3";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "lukapecnik";
+    repo = "NiaClass";
+    rev = "${version}";
+    sha256 = "sha256-BDGDcIlunnaH3J9sEuDrwWsBR4Wjcy6Kxpxy9Dr6BlM=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+    toml-adapt
+  ];
+
+  propagatedBuildInputs = [
+    niapy
+    numpy
+    pandas
+    scikit-learn
+  ];
+
+  # create scikit-learn dep version consistent
+  preBuild = ''
+    toml-adapt -path pyproject.toml -a change -dep scikit-learn -ver X
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "niaclass"
+  ];
+
+  meta = with lib; {
+    description = "A framework for solving classification tasks using Nature-inspired algorithms";
+    homepage = "https://github.com/lukapecnik/NiaClass";
+    license = licenses.mit;
+    maintainers = with maintainers; [ firefly-cpp ];
+  };
+}
+

--- a/pkgs/development/python-modules/niaclass/default.nix
+++ b/pkgs/development/python-modules/niaclass/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "lukapecnik";
     repo = "NiaClass";
-    rev = "${version}";
+    rev = version;
     sha256 = "sha256-BDGDcIlunnaH3J9sEuDrwWsBR4Wjcy6Kxpxy9Dr6BlM=";
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6334,6 +6334,8 @@ self: super: with self; {
 
   niaarm = callPackage ../development/python-modules/niaarm { };
 
+  niaclass = callPackage ../development/python-modules/niaclass { };
+
   niapy = callPackage ../development/python-modules/niapy { };
 
   nibabel = callPackage ../development/python-modules/nibabel { };


### PR DESCRIPTION
###### Description of changes

[NiaClass](https://github.com/lukapecnik/NiaClass) is a framework for solving classification tasks using nature-inspired algorithms. The framework is written fully in Python. Its goal is to find the best possible set of classification rules for the input data using the [NiaPy framework](https://github.com/NiaOrg/NiaPy), which is a popular Python collection of nature-inspired algorithms. The NiaClass classifier supports numerical and categorical features.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
