### PR TITLE
kalendar: add missing dependency kirigami-addons

### DIFF
--- a/pkgs/applications/kde/kalendar.nix
+++ b/pkgs/applications/kde/kalendar.nix
@@ -13,6 +13,7 @@
 , qqc2-desktop-style
 
 , kirigami2
+, kirigami-addons
 , kdbusaddons
 , ki18n
 , kcalendarcore
@@ -59,6 +60,7 @@ mkDerivation rec {
     qqc2-desktop-style
 
     kirigami2
+    kirigami-addons
     kdbusaddons
     ki18n
     kcalendarcore


### PR DESCRIPTION
###### Description of changes
At the moment, certain parts of kalendar don't work due to a missing dependency. For example:
1. Launch kalendar from a terminal
2. Go to settings > configure kalendar
3. Click the "Accounts" tab.
4. Nothing shows in the GUI, the following is output in the terminal:
```
kf.kirigami: (qrc:/ViewSettingsPage.qml:9:1: module "org.kde.kirigamiaddons.labs.mobileform" is not installed
    import org.kde.kirigamiaddons.labs.mobileform 0.1 as MobileForm
    ^)
file:///nix/store/q7f6z1qw1579flszg5dm5045vj89xwx4-kirigami2-5.102.0/lib/qt-5.15.8/qml/org/kde/kirigami.2/templates/AbstractApplicationHeader.qml:37:5: Unable to assign SettingsPage_QMLTYPE_396 to Page_QMLTYPE_37
kf.kirigami: (qrc:/ViewSettingsPage.qml:9:1: module "org.kde.kirigamiaddons.labs.mobileform" is not installed
    import org.kde.kirigamiaddons.labs.mobileform 0.1 as MobileForm
    ^)
kf.kirigami: (qrc:/SourceSettingsPage.qml:16:9: Type AgentConfigurationForm unavailable
            AgentConfigurationForm {
            ^, file:///nix/store/kd6rl651b8yf1000g0rix7zz1rf2wrhj-kalendar-22.12.2/lib/qt-5.15.8/qml/org/kde/akonadi/AgentConfigurationForm.qml:9:1: module "org.kde.kirigamiaddons.labs.mobileform" is not installed
    import org.kde.kirigamiaddons.labs.mobileform 0.1 as MobileForm
    ^)
```

This PR adds the missing dependency, `kirigami-addons`. With this PR, the account settings page appears and functions correctly, allowing users to add calendars to kalendar.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

