### PR TITLE
python310Packages.gensim: mark broken

### DIFF
--- a/pkgs/development/python-modules/gensim/default.nix
+++ b/pkgs/development/python-modules/gensim/default.nix
@@ -56,5 +56,8 @@ buildPythonPackage rec {
     homepage = "https://radimrehurek.com/gensim/";
     license = licenses.lgpl21Only;
     maintainers = with maintainers; [ jyp ];
+    # python310 errors as: No matching distribution found for FuzzyTM>=0.4.0
+    # python311 errors as: longintrepr.h: No such file or directory
+    broken = true; # At 2023-02-05
   };
 }


### PR DESCRIPTION
* python310Packages.gensim: mark broken
  - ERROR: No matching distribution found for FuzzyTM>=0.4.0
    FuzzyTM does not **seem** to exist in nixpkgs.
  - Full logs: https://termbin.com/q7z7 
* python311Packages.gensim: mark broken
  - fatal error: longintrepr.h: No such file or directory
  - Full logs: https://termbin.com/aikm 

No attempt has been made to fix it. I'm reporting it's broken.