### PR TITLE
python310Packages.flax: mark broken

### DIFF
--- a/pkgs/development/python-modules/flax/default.nix
+++ b/pkgs/development/python-modules/flax/default.nix
@@ -87,5 +87,8 @@ buildPythonPackage rec {
     homepage = "https://github.com/google/flax";
     license = licenses.asl20;
     maintainers = with maintainers; [ ndl ];
+    # Py3.10 requires orbax, tensorstore which needs packaging
+    # Py3.11 requires tensorboard, which is unsupported at py3.11 atm
+    broken = true; # At 2023-02-05
   };
 }


### PR DESCRIPTION
python310Packages.flax: mark broken

* python310Packages.flax
  ERROR: No matching distribution found for orbax
  (not packaged yet)
  Full logs: https://termbin.com/19eqc

* python311Packages.flax
  error: tensorboard-2.11.0 not supported for interpreter python3.11

ping @NickCao @ndl