### PR TITLE
tbb: 2020.3 -> 2021.8.0

### DIFF
--- a/pkgs/development/libraries/tbb/default.nix
+++ b/pkgs/development/libraries/tbb/default.nix
@@ -1,90 +1,37 @@
 { lib
 , stdenv
-, fetchurl
 , fetchFromGitHub
-, fixDarwinDylibNames
+, fetchpatch
+, cmake
 }:
 
 stdenv.mkDerivation rec {
   pname = "tbb";
-  version = "2020.3";
+  version = "2021.8.0";
 
   src = fetchFromGitHub {
     owner = "oneapi-src";
     repo = "oneTBB";
-    rev = "v${version}";
-    sha256 = "prO2O5hd+Wz5iA0vfrqmyHFr0Ptzk64so5KpSpvuKmU=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-7MjUdPB1GsPt7ZkYj7DCisq20X8psljsVCjDpCSTYT4=";
   };
 
+  nativeBuildInputs = [
+    cmake
+  ];
+
   patches = [
-    # Fixes build with Musl.
-    (fetchurl {
-      url = "https://github.com/openembedded/meta-openembedded/raw/39185eb1d1615e919e3ae14ae63b8ed7d3e5d83f/meta-oe/recipes-support/tbb/tbb/GLIBC-PREREQ-is-not-defined-on-musl.patch";
-      sha256 = "gUfXQ9OZQ82qD6brgauBCsKdjLvyHafMc18B+KxZoYs=";
-    })
-
-    # Fixes build with Musl.
-    (fetchurl {
-      url = "https://github.com/openembedded/meta-openembedded/raw/39185eb1d1615e919e3ae14ae63b8ed7d3e5d83f/meta-oe/recipes-support/tbb/tbb/0001-mallinfo-is-glibc-specific-API-mark-it-so.patch";
-      sha256 = "fhorfqO1hHKZ61uq+yTR7eQ8KYdyLwpM3K7WpwJpV74=";
-    })
-
-    # Fixes build with upcoming gcc-13:
-    #  https://github.com/oneapi-src/oneTBB/pull/833
-    (fetchurl {
-      name = "gcc-13.patch";
-      url = "https://github.com/oneapi-src/oneTBB/pull/833/commits/c18342ba667d1f33f5e9a773aa86b091a9694b97.patch";
-      sha256 = "ZUExE3nsW80Z5GPWZnDNuDiHHaD1EF7qNl/G5M+Wcxg=";
-    })
-
-    # Fixes build for aarch64-darwin
-    (fetchurl {
-      name = "aarch64-darwin.patch";
-      url = "https://github.com/oneapi-src/oneTBB/pull/258/commits/86f6dcdc17a8f5ef2382faaef860cfa5243984fe.patch";
-      sha256 = "sha256-JXqrFPCb3q1vfxk752tQu7HhApCB4YH2LoVnGRwmspk=";
-    })
+    # Fix musl build; vendored from https://github.com/oneapi-src/oneTBB/pull/899
+    ./musl.patch
   ];
 
-  nativeBuildInputs = lib.optionals stdenv.isDarwin [
-    fixDarwinDylibNames
-  ];
-
-  makeFlags = lib.optionals stdenv.cc.isClang [
-    "compiler=clang"
-  ] ++ (lib.optional (stdenv.buildPlatform != stdenv.hostPlatform)
-    (if stdenv.hostPlatform.isAarch64 then "arch=arm64"
-    else if stdenv.hostPlatform.isx86_64 then "arch=intel64"
-    else throw "Unsupported cross architecture"));
+  # Disable failing test on musl
+  # test/conformance/conformance_resumable_tasks.cpp:37:24: error: ‘suspend’ is not a member of ‘tbb::v1::task’; did you mean ‘tbb::detail::r1::suspend’?
+  postPatch = lib.optionalString stdenv.hostPlatform.isMusl ''
+    sed -i "/conformance_resumable_tasks/d" test/CMakeLists.txt
+  '';
 
   enableParallelBuilding = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/lib
-    cp "build/"*release*"/"*${stdenv.hostPlatform.extensions.sharedLibrary}* $out/lib/
-    mv include $out/
-    rm $out/include/index.html
-
-    runHook postInstall
-  '';
-
-  postInstall = let
-    pcTemplate = fetchurl {
-      url = "https://github.com/oneapi-src/oneTBB/raw/478de5b1887c928e52f029d706af6ea640a877be/integration/pkg-config/tbb.pc.in";
-      sha256 = "2pCad9txSpNbzac0vp/VY3x7HNySaYkbH3Rx8LK53pI=";
-    };
-  in ''
-    # Generate pkg-config file based on upstream template.
-    # It should not be necessary with tbb after 2021.2.
-    mkdir -p "$out/lib/pkgconfig"
-    substitute "${pcTemplate}" "$out/lib/pkgconfig/tbb.pc" \
-      --subst-var-by CMAKE_INSTALL_PREFIX "$out" \
-      --subst-var-by CMAKE_INSTALL_LIBDIR "lib" \
-      --subst-var-by CMAKE_INSTALL_INCLUDEDIR "include" \
-      --subst-var-by TBB_VERSION "${version}" \
-      --subst-var-by TBB_LIB_NAME "tbb"
-  '';
 
   meta = with lib; {
     description = "Intel Thread Building Blocks C++ Library";

--- a/pkgs/development/libraries/tbb/musl.patch
+++ b/pkgs/development/libraries/tbb/musl.patch
@@ -1,0 +1,24 @@
+From 493774eb57f9c424fc8907d137665e687861ad94 Mon Sep 17 00:00:00 2001
+From: Ismael Luceno <ismael@iodev.co.uk>
+Date: Fri, 9 Sep 2022 16:18:18 +0200
+Subject: [PATCH] Fix build against musl libc
+
+Probably MALLOC_UNIXLIKE_OVERLOAD_ENABLED only works with glibc, so use
+__GLIBC__ in addition to __linux__ to define it.
+---
+ src/tbbmalloc_proxy/proxy.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/tbbmalloc_proxy/proxy.h b/src/tbbmalloc_proxy/proxy.h
+index 5f0133f9e..ba1a07c39 100644
+--- a/src/tbbmalloc_proxy/proxy.h
++++ b/src/tbbmalloc_proxy/proxy.h
+@@ -17,7 +17,7 @@
+ #ifndef _TBB_malloc_proxy_H_
+ #define _TBB_malloc_proxy_H_
+ 
+-#define MALLOC_UNIXLIKE_OVERLOAD_ENABLED __linux__
++#define MALLOC_UNIXLIKE_OVERLOAD_ENABLED (__linux__ && __GLIBC__)
+ #define MALLOC_ZONE_OVERLOAD_ENABLED __APPLE__
+ 
+ // MALLOC_UNIXLIKE_OVERLOAD_ENABLED depends on MALLOC_CHECK_RECURSION stuff


### PR DESCRIPTION
https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-threading-building-blocks-release-notes.html\
https://github.com/oneapi-src/oneTBB/releases/tag/v2021.5.0
https://github.com/oneapi-src/oneTBB/releases/tag/v2021.6.0
https://github.com/oneapi-src/oneTBB/releases/tag/v2021.7.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
