### PR TITLE
python311Packages.fastapi: mark broken for python 3.11

### DIFF
--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -17,6 +17,7 @@
 , sqlalchemy
 , trio
 , pythonOlder
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
@@ -97,5 +98,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/tiangolo/fastapi";
     license = licenses.mit;
     maintainers = with maintainers; [ wd15 ];
+    # methodobject.h:59: PyCFunction_GET_FLAGS: Assertion `PyCFunction_Check(func)' failed
+    broken = pythonAtLeast "3.11"; # At 2023-02-05
   };
 }


### PR DESCRIPTION
python311Packages.fastapi: mark broken for python 3.11

* `methodobject.h:59: PyCFunction_GET_FLAGS: Assertion `PyCFunction_Check(func)' failed.`
  Full Logs: https://termbin.com/4dh0

#213025

ping @NickCao 