### PR TITLE
deepin.deepin-compressor: init at 5.12.9

### DIFF
--- a/pkgs/desktops/deepin/apps/deepin-compressor/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-compressor/default.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, dtkwidget
+, qt5integration
+, qt5platform-plugins
+, udisks2-qt5
+, cmake
+, qtbase
+, qttools
+, pkg-config
+, kcodecs
+, karchive
+, wrapQtAppsHook
+, minizip
+, libzip
+, libarchive
+}:
+
+stdenv.mkDerivation rec {
+  pname = "deepin-compressor";
+  version = "5.12.9";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-HJDtUvXUT94G4WqrK92UMmijnuC4ApkKHU3yE3rOKHQ=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/source/common/pluginmanager.cpp \
+      --replace "/usr/lib/" "$out/lib/"
+    substituteInPlace src/desktop/deepin-compressor.desktop \
+      --replace "/usr" "$out"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    qttools
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    dtkwidget
+    qt5platform-plugins
+    udisks2-qt5
+    kcodecs
+    karchive
+    minizip
+    libzip
+    libarchive
+  ];
+
+  cmakeFlags = [
+    "-DVERSION=${version}"
+    "-DUSE_TEST=OFF"
+  ];
+
+  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
+  qtWrapperArgs = [
+    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
+  ];
+
+  meta = with lib; {
+    description = "A fast and lightweight application for creating and extracting archives";
+    homepage = "https://github.com/linuxdeepin/deepin-compressor";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -22,6 +22,7 @@ let
 
     #### Dtk Application
     deepin-calculator = callPackage ./apps/deepin-calculator { };
+    deepin-compressor = callPackage ./apps/deepin-compressor { };
     deepin-editor = callPackage ./apps/deepin-editor { };
     deepin-terminal = callPackage ./apps/deepin-terminal { };
 


### PR DESCRIPTION
###### Description of changes

Part of https://github.com/linuxdeepin/dde-nixos/issues/9


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
