### PR TITLE
textadept:11.4 -> 12.0

### DIFF
--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -1,15 +1,14 @@
 { lib, stdenv, fetchFromGitHub, fetchurl, cmake, qtbase, wrapQtAppsHook }:
 stdenv.mkDerivation rec {
-  version = "11.4.15"; # TODO: THAT'S A DUMMY VERSION NUMBER; CHANGE TO 12.0 WHEN RELEASED.
+  version = "12.0";
   pname = "textadept";
 
   src = fetchFromGitHub {
     name = "textadept11";
     owner = "orbitalquark";
     repo = "textadept";
-#    rev = "textadept_${version}";
-    rev = "19cfa3ce0c7d2f981d2b8cbbee4f8e603be9b5db"; # TODO: WHEN PACKAGE RELEASE, UNCOMMENT PREVIOUS LINE AND REMOVE THIS ONE.
-    sha256 = "sha256-FkqoODP2nIOCBy2DqelAdGInizhADpc3ZdzbrRTnSdA=";
+    rev = "textadept_${version}";
+    sha256 = "sha256-KziVN0Fl/IvSnIJKK5s7UikXi3iP5mTauP0YxffKy9c=";
   };
 
   nativeBuildInputs = [ cmake wrapQtAppsHook ];

--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     owner = "orbitalquark";
     repo = "textadept";
 #    rev = "textadept_${version}";
-    rev = "d17aa1435d684daea25619e8f37a1cb0a8edf83c"; # TODO: WHEN PACKAGE RELEASE, UNCOMMENT PREVIOUS LINE AND REMOVE THIS ONE.
-    sha256 = "sha256-zyFHqXNL5E++ESX9DddfaYiVI41mk/b0tIVxd5a8WTo=";
+    rev = "19cfa3ce0c7d2f981d2b8cbbee4f8e603be9b5db"; # TODO: WHEN PACKAGE RELEASE, UNCOMMENT PREVIOUS LINE AND REMOVE THIS ONE.
+    sha256 = "sha256-FkqoODP2nIOCBy2DqelAdGInizhADpc3ZdzbrRTnSdA=";
   };
 
   nativeBuildInputs = [ cmake wrapQtAppsHook ];

--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchurl, cmake, qtbase, wrapQtAppsHook }:
 stdenv.mkDerivation rec {
-  version = "11.4.14"; # TODO: THAT'S A DUMMY VERSION NUMBER; CHANGE TO 12.0 WHEN RELEASED.
+  version = "11.4.15"; # TODO: THAT'S A DUMMY VERSION NUMBER; CHANGE TO 12.0 WHEN RELEASED.
   pname = "textadept";
 
   src = fetchFromGitHub {
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     owner = "orbitalquark";
     repo = "textadept";
 #    rev = "textadept_${version}";
-    rev = "995b00999872f09d1364daf6951830cb166925ac"; # TODO: WHEN PACKAGE RELEASE, UNCOMMENT PREVIOUS LINE AND REMOVE THIS ONE.
-    sha256 = "sha256-8u+FhfdMvKxgeESynb+/u1pr1bTTOfkKfFavVQMPzbo=";
+    rev = "d17aa1435d684daea25619e8f37a1cb0a8edf83c"; # TODO: WHEN PACKAGE RELEASE, UNCOMMENT PREVIOUS LINE AND REMOVE THIS ONE.
+    sha256 = "sha256-zyFHqXNL5E++ESX9DddfaYiVI41mk/b0tIVxd5a8WTo=";
   };
 
   nativeBuildInputs = [ cmake wrapQtAppsHook ];

--- a/pkgs/applications/editors/textadept/default.nix
+++ b/pkgs/applications/editors/textadept/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchurl, cmake, qtbase, wrapQtAppsHook }:
 stdenv.mkDerivation rec {
-  version = "11.4.9"; # TODO: THAT'S A DUMMY VERSION NUMBER; CHANGE TO 12.0 WHEN RELEASED.
+  version = "11.4.14"; # TODO: THAT'S A DUMMY VERSION NUMBER; CHANGE TO 12.0 WHEN RELEASED.
   pname = "textadept";
 
   src = fetchFromGitHub {
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     owner = "orbitalquark";
     repo = "textadept";
 #    rev = "textadept_${version}";
-    rev = "96f58f1fa34fa50feead22df21b34412c1327da1"; # TODO: WHEN PACKAGE RELEASE, UNCOMMENT PREVIOUS LINE AND REMOVE THIS ONE.
-    sha256 = "sha256-a8ZmGDee75HOyE0W3yFFPNjLWBz5WXktmt9B+61bCy8=";
+    rev = "995b00999872f09d1364daf6951830cb166925ac"; # TODO: WHEN PACKAGE RELEASE, UNCOMMENT PREVIOUS LINE AND REMOVE THIS ONE.
+    sha256 = "sha256-8u+FhfdMvKxgeESynb+/u1pr1bTTOfkKfFavVQMPzbo=";
   };
 
   nativeBuildInputs = [ cmake wrapQtAppsHook ];

--- a/pkgs/applications/editors/textadept/deps.nix
+++ b/pkgs/applications/editors/textadept/deps.nix
@@ -1,21 +1,19 @@
 {
-  "scintilla524.tgz" = {
-    url = "https://www.scintilla.org/scintilla524.tgz";
-    sha256 = "sha256-Su8UiMmkOxcuBat2JWYEnhNdG5HKnV1fn1ClnJhazGY=";
+  "scintilla530.tgz" = {
+    url = "https://www.scintilla.org/scintilla530.tgz";
+    sha256 = "sha256-/VJg9W3kTMnV4tkAhuxv/nCWq73JG8nBxF9Sic1AQHs=";
   };
   "lexilla510.tgz" = {
     url = "https://www.scintilla.org/lexilla510.tgz";
     sha256 = "sha256-azWVJ0AFSYZxuFTPV73uwiVJZvNxcS/POnFtl6p/P9g=";
   };
-  "9088723504b19f8611b66c119933a4dc7939d7b8.zip" = {
-    url =
-      "https://github.com/orbitalquark/scintillua/archive/9088723504b19f8611b66c119933a4dc7939d7b8.zip";
-    sha256 = "sha256-V2t1kt6+SpZQvQSzLhh8n+WiAnA32SRVFnrbTaJrHRo=";
+  "scinterm_4.1.zip" = {
+    url = "https://github.com/orbitalquark/scinterm/archive/scinterm_4.1.zip";
+    sha256 = "sha256-pdgf2m5Bmmgh470G2Cx62z414YBq10qqe1+80ZGFypI=";
   };
-  "475d8d43f3418590c28bd2fb07ee9229d1fa2d07.zip" = {
-    url =
-      "https://github.com/orbitalquark/scinterm/archive/475d8d43f3418590c28bd2fb07ee9229d1fa2d07.zip";
-    sha256 = "sha256-lNMK0RFcOLg9RRE5a6VelhSzUYVl5TiAiXcje2JOedE=";
+  "scintillua_6.1.zip" = {
+    url = "https://github.com/orbitalquark/scintillua/archive/scintillua_6.1.zip";
+    sha256 = "sha256-h2hr+SK+ahR0+KXe6HxObt1jJXZWJHA6yXuyX/JfNIo=";
   };
   "lua-5.4.4.tar.gz" = {
     url = "http://www.lua.org/ftp/lua-5.4.4.tar.gz";
@@ -29,11 +27,6 @@
     url = "https://github.com/keplerproject/luafilesystem/archive/v1_8_0.zip";
     sha256 = "sha256-46a+ynqKkFIu7THbbM3F7WWkM4JlAMaGJ4TidnG54Yo=";
   };
-  "444af9ca8a73151dbf759e6676d1035af469f01a.zip" = {
-    url =
-      "https://github.com/orbitalquark/gtdialog/archive/444af9ca8a73151dbf759e6676d1035af469f01a.zip";
-    sha256 = "sha256-7AkX7OWXJtzKq3h4uJeLzHpf6mrsz67SXtPvmyA5xxg=";
-  };
   "cdk-5.0-20200923.tgz" = {
     url = "http://invisible-mirror.net/archives/cdk/cdk-5.0-20200923.tgz";
     sha256 = "sha256-AH9d6IDLLuvYVW335M2Gc9XmTJlwFH7uaSOoFMKfqu0=";
@@ -43,3 +36,5 @@
     sha256 = "sha256-aUW9PEqqg9qD2AoEXFVj2k7dfQN0xiwNNa7AnrMBRgA=";
   };
 }
+
+

--- a/pkgs/applications/editors/textadept/deps.nix
+++ b/pkgs/applications/editors/textadept/deps.nix
@@ -1,7 +1,7 @@
 {
-  "scintilla534.tgz" = {
-    url = "https://www.scintilla.org/scintilla534.tgz";
-    sha256 = "sha256-PwGxrvK36Y9iivLP+WWHb10V7igB2d+W3TrO2PCHy0Y=";
+  "scintilla536.tgz" = {
+    url = "https://www.scintilla.org/scintilla536.tgz";
+    sha256 = "sha256-ib6CeKg+eBOSWq/il32quH0r1r69F7AXn+cq/dVIyyQ=";
   };
   "lexilla510.tgz" = {
     url = "https://www.scintilla.org/lexilla510.tgz";
@@ -11,18 +11,17 @@
     url = "https://github.com/orbitalquark/scinterm/archive/scinterm_5.0.zip";
     sha256 = "sha256-l1qeLMCrhyoZA/GfmXFR20rY5EsUoO5e+1vZJtYdb24=";
   };
-  # scintillua
-  "61900949800f9acc1238b45f4683250bd5c60755.zip" = {
-    url = "https://github.com/orbitalquark/scintillua/archive/61900949800f9acc1238b45f4683250bd5c60755.zip";
-    sha256 = "sha256-Zwg2MANNuQMW3JKY4XB1YBjGviiAIwDdrWRB5WtTPTI=";
+  "scintillua_6.2.zip" = {
+    url = "https://github.com/orbitalquark/scintillua/archive/scintillua_6.2.zip";
+    sha256 = "sha256-vjlN6MBz0xjBwWd8dpx/ks37WvdXt2vE1A71YM3uDik=";
   };
-  "lua-5.4.4.tar.gz" = {
-    url = "http://www.lua.org/ftp/lua-5.4.4.tar.gz";
-    sha256 = "sha256-Fkx4SWU7gK5nvsS3RzuIS/XMjS3KBWU0dewu0nuev2E=";
+  "lua-5.4.6.tar.gz" = {
+    url = "http://www.lua.org/ftp/lua-5.4.6.tar.gz";
+    sha256 = "sha256-fV6huctqoLWco93hxq3LV++DobqOVDLA7NBr9DmzrYg=";
   };
-  "lpeg-1.0.2.tar.gz" = {
-    url = "http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.0.2.tar.gz";
-    sha256 = "sha256-SNZldgUbbHg4j6rQm3BJMJMmRYj80PJY3aqxzdShX/4=";
+  "lpeg-1.1.0.tar.gz" = {
+    url = "http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.1.0.tar.gz";
+    sha256 = "sha256-SxVdZ9IkbB/6ete8RmweqJm7xA/vAlfMnAPOy67UNSo=";
   };
   "v1_8_0.zip" = {
     url = "https://github.com/keplerproject/luafilesystem/archive/v1_8_0.zip";
@@ -35,6 +34,11 @@
   "libtermkey-0.22.tar.gz" = {
     url = "http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.22.tar.gz";
     sha256 = "sha256-aUW9PEqqg9qD2AoEXFVj2k7dfQN0xiwNNa7AnrMBRgA=";
+  };
+  # lua-std-regex
+  "1.0.zip" = {
+    url = "https://github.com/orbitalquark/lua-std-regex/archive/1.0.zip";
+    sha256 = "sha256-W2hKHOfqYyo3qk+YvPJlzZfZ1wxZmMVphSlcaql+dOE=";
   };
 }
 

--- a/pkgs/applications/editors/textadept/deps.nix
+++ b/pkgs/applications/editors/textadept/deps.nix
@@ -11,9 +11,10 @@
     url = "https://github.com/orbitalquark/scinterm/archive/scinterm_4.1.zip";
     sha256 = "sha256-pdgf2m5Bmmgh470G2Cx62z414YBq10qqe1+80ZGFypI=";
   };
-  "scintillua_6.1.zip" = {
-    url = "https://github.com/orbitalquark/scintillua/archive/scintillua_6.1.zip";
-    sha256 = "sha256-h2hr+SK+ahR0+KXe6HxObt1jJXZWJHA6yXuyX/JfNIo=";
+  # scintillua
+  "61900949800f9acc1238b45f4683250bd5c60755.zip" = {
+    url = "https://github.com/orbitalquark/scintillua/archive/61900949800f9acc1238b45f4683250bd5c60755.zip";
+    sha256 = "sha256-Zwg2MANNuQMW3JKY4XB1YBjGviiAIwDdrWRB5WtTPTI=";
   };
   "lua-5.4.4.tar.gz" = {
     url = "http://www.lua.org/ftp/lua-5.4.4.tar.gz";

--- a/pkgs/applications/editors/textadept/deps.nix
+++ b/pkgs/applications/editors/textadept/deps.nix
@@ -1,15 +1,15 @@
 {
-  "scintilla530.tgz" = {
-    url = "https://www.scintilla.org/scintilla530.tgz";
-    sha256 = "sha256-/VJg9W3kTMnV4tkAhuxv/nCWq73JG8nBxF9Sic1AQHs=";
+  "scintilla534.tgz" = {
+    url = "https://www.scintilla.org/scintilla534.tgz";
+    sha256 = "sha256-PwGxrvK36Y9iivLP+WWHb10V7igB2d+W3TrO2PCHy0Y=";
   };
   "lexilla510.tgz" = {
     url = "https://www.scintilla.org/lexilla510.tgz";
     sha256 = "sha256-azWVJ0AFSYZxuFTPV73uwiVJZvNxcS/POnFtl6p/P9g=";
   };
-  "scinterm_4.1.zip" = {
-    url = "https://github.com/orbitalquark/scinterm/archive/scinterm_4.1.zip";
-    sha256 = "sha256-pdgf2m5Bmmgh470G2Cx62z414YBq10qqe1+80ZGFypI=";
+  "scinterm_5.0.zip" = {
+    url = "https://github.com/orbitalquark/scinterm/archive/scinterm_5.0.zip";
+    sha256 = "sha256-l1qeLMCrhyoZA/GfmXFR20rY5EsUoO5e+1vZJtYdb24=";
   };
   # scintillua
   "61900949800f9acc1238b45f4683250bd5c60755.zip" = {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1487,8 +1487,7 @@ mapAliases ({
   tex-gyre-pagella-math = throw "'tex-gyre-pagella-math' has been renamed to/replaced by 'tex-gyre-math.pagella'"; # Converted to throw 2022-02-22
   tex-gyre-schola-math = throw "'tex-gyre-schola-math' has been renamed to/replaced by 'tex-gyre-math.schola'"; # Converted to throw 2022-02-22
   tex-gyre-termes-math = throw "'tex-gyre-termes-math' has been renamed to/replaced by 'tex-gyre-math.termes'"; # Converted to throw 2022-02-22
-  textadept11 = throw "textadept11 has been removed. Please use textadept12 instead"; # Added 2022-12-23 TODO: UPDATE THE DATE
-  textadept12 = textadept; # Added 2022-12-23 TODO: UPDATE THE DATE
+  textadept11 = throw "textadept11 has been removed. Please use textadept instead"; # Added 2022-12-23 TODO: UPDATE THE DATE
   tftp_hpa = throw "'tftp_hpa' has been renamed to/replaced by 'tftp-hpa'"; # Converted to throw 2022-02-22
   thunderbird-68 = throw "Thunderbird 68 reached end of life with its final release 68.12.0 on 2020-08-25";
   thunderbird-bin-68 = thunderbird-68;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1487,7 +1487,8 @@ mapAliases ({
   tex-gyre-pagella-math = throw "'tex-gyre-pagella-math' has been renamed to/replaced by 'tex-gyre-math.pagella'"; # Converted to throw 2022-02-22
   tex-gyre-schola-math = throw "'tex-gyre-schola-math' has been renamed to/replaced by 'tex-gyre-math.schola'"; # Converted to throw 2022-02-22
   tex-gyre-termes-math = throw "'tex-gyre-termes-math' has been renamed to/replaced by 'tex-gyre-math.termes'"; # Converted to throw 2022-02-22
-  textadept11 = textadept; # Added 2022-06-07
+  textadept11 = throw "textadept11 has been removed. Please use textadept12 instead"; # Added 2022-12-23 TODO: UPDATE THE DATE
+  textadept12 = textadept; # Added 2022-12-23 TODO: UPDATE THE DATE
   tftp_hpa = throw "'tftp_hpa' has been renamed to/replaced by 'tftp-hpa'"; # Converted to throw 2022-02-22
   thunderbird-68 = throw "Thunderbird 68 reached end of life with its final release 68.12.0 on 2020-08-25";
   thunderbird-bin-68 = thunderbird-68;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12189,7 +12189,7 @@ with pkgs;
 
   texstudio = libsForQt5.callPackage ../applications/editors/texstudio { };
 
-  textadept = callPackage ../applications/editors/textadept { };
+  textadept = libsForQt5.callPackage ../applications/editors/textadept { };
 
   texworks = libsForQt5.callPackage ../applications/editors/texworks { };
 


### PR DESCRIPTION
###### Description of changes

This is for issue #214776.

The changes are described at https://github.com/orbitalquark/textadept/discussions/300, but here's a summary.

- Going forward, Qt will be the default GUI toolkit for Textadept on Windows, macOS, and Linux.
- The GTK version of Textadept is still supported, but only on Linux. If you want to build with GTK, you will need to do so manually; binaries will no longer be provided.
- Textadept has switched to a CMake-based build for building natively on Windows, macOS, and Linux.

I have modified the textadept package to reflect these changes. (The code has a few TODOs for things I will change once the new version is actually released.

In updating the package, I have switched over completely to Qt. There's no support for GTK in my updated package. If anyone really needs GTK, I will need time to figure out how to build it, and to find a way to test it. I also didn't include a way to build a curses version of Textadept. Again, if anyone needs that, it will take me time to figure out how to build and test it. _This is why I'm doing a premature pull request; to get feedback on these issues._

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
