### PR TITLE
Remove lots more obsolete gobject-introspection build inputs

### DIFF
--- a/pkgs/applications/misc/genxword/default.nix
+++ b/pkgs/applications/misc/genxword/default.nix
@@ -26,7 +26,6 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   buildInputs = [
-    gobject-introspection
     pango
     gtksourceview3
   ];

--- a/pkgs/applications/misc/udiskie/default.nix
+++ b/pkgs/applications/misc/udiskie/default.nix
@@ -43,7 +43,6 @@ python3.pkgs.buildPythonApplication rec {
   dontWrapGApps = true;
 
   buildInputs = [
-    gobject-introspection
     gtk3
     libappindicator-gtk3
     libnotify

--- a/pkgs/applications/office/autokey/default.nix
+++ b/pkgs/applications/office/autokey/default.nix
@@ -25,7 +25,6 @@ python3Packages.buildPythonApplication rec {
   nativeBuildInputs = [ wrapGAppsHook gobject-introspection ];
 
   buildInputs = [
-    gobject-introspection
     gtksourceview3
     libappindicator-gtk3
     libnotify

--- a/pkgs/applications/terminal-emulators/terminator/default.nix
+++ b/pkgs/applications/terminal-emulators/terminator/default.nix
@@ -33,7 +33,6 @@ python3.pkgs.buildPythonApplication rec {
 
   buildInputs = [
     gtk3
-    gobject-introspection # Temporary fix, see https://github.com/NixOS/nixpkgs/issues/56943
     keybinder3
     libnotify
     python3

--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -62,8 +62,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gobject-introspection
     dbus
+    gettext
     glib
     polkit
     systemd

--- a/pkgs/development/libraries/gjs/default.nix
+++ b/pkgs/development/libraries/gjs/default.nix
@@ -27,7 +27,6 @@
 
 let
   testDeps = [
-    gobject-introspection # for Gio and cairo typelibs
     gtk3 atk pango.out gdk-pixbuf harfbuzz
   ];
 in stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/libgudev/default.nix
+++ b/pkgs/development/libraries/libgudev/default.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gobject-introspection
     udev
     glib
   ];

--- a/pkgs/development/libraries/libical/default.nix
+++ b/pkgs/development/libraries/libical/default.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
     glib
     libxml2
     icu
-    gobject-introspection
   ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/libmanette/default.nix
+++ b/pkgs/development/libraries/libmanette/default.nix
@@ -40,7 +40,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gobject-introspection
     glib
     libgudev
     libevdev

--- a/pkgs/development/libraries/libnotify/default.nix
+++ b/pkgs/development/libraries/libnotify/default.nix
@@ -44,10 +44,6 @@ stdenv.mkDerivation rec {
     gobject-introspection
   ];
 
-  buildInputs = lib.optionals withIntrospection [
-    gobject-introspection
-  ];
-
   propagatedBuildInputs = [
     gdk-pixbuf
     glib

--- a/pkgs/development/libraries/libqrtr-glib/default.nix
+++ b/pkgs/development/libraries/libqrtr-glib/default.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gobject-introspection
     glib
   ];
 

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -71,8 +71,6 @@ stdenv.mkDerivation rec {
     bzip2
     pango
     libintl
-  ] ++ lib.optionals withIntrospection [
-    gobject-introspection
   ] ++ lib.optionals stdenv.isDarwin [
     ApplicationServices
     Foundation

--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libgcrypt
-    gobject-introspection
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -55,8 +55,6 @@ stdenv.mkDerivation rec {
     libxml2
   ] ++ lib.optionals stdenv.isLinux [
     libcap_ng
-  ] ++ lib.optionals withIntrospection [
-    gobject-introspection
   ];
 
   strictDeps = true;

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -90,7 +90,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gobject-introspection
     expat
     pam
     dbus

--- a/pkgs/development/libraries/umockdev/default.nix
+++ b/pkgs/development/libraries/umockdev/default.nix
@@ -48,7 +48,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gobject-introspection
     glib
     systemd
     libgudev

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -42,8 +42,7 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [
-    # # .so files link to these
-    gobject-introspection
+    # # .so files link to this
     glib
   ] ++ lib.optionals stdenv.isDarwin [
     ncurses

--- a/pkgs/servers/gpsd/default.nix
+++ b/pkgs/servers/gpsd/default.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation rec {
     atk
     dbus-glib
     gdk-pixbuf
-    gobject-introspection
     libX11
     libXaw
     libXext


### PR DESCRIPTION
###### Description of changes

Continuation of https://github.com/NixOS/nixpkgs/pull/208945.  For each package I've tested the normal version, the `pkgsCross.ghcjs.buildPackages` version, and the `pkgsCross.aarch64-multiplatform` version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
