### PR TITLE
sunshine: 0.16.0 -> 0.18.4

### DIFF
--- a/pkgs/development/libraries/amf-headers/default.nix
+++ b/pkgs/development/libraries/amf-headers/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "amf-headers";
+  version = "1.4.29";
+
+  src = fetchFromGitHub {
+    owner = "GPUOpen-LibrariesAndSDKs";
+    repo = "AMF";
+    rev = "v${version}";
+    sha256 = "sha256-gu8plGUUVE/De2bRjTUN8JKsmj/0r/IsqhMpln1DZGU=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/include/AMF
+    cp -r amf/public/include/* $out/include/AMF
+  '';
+
+  meta = with lib; {
+    description = "Headers for The Advanced Media Framework (AMF)";
+    homepage = "https://github.com/GPUOpen-LibrariesAndSDKs/AMF";
+    license = licenses.mit;
+    maintainers = with maintainers; [ devusb ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/sunshine/ffmpeg.diff
+++ b/pkgs/servers/sunshine/ffmpeg.diff
@@ -1,49 +1,73 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fad60ef..64b68ae 100644
+index 1842c67..8afd0e9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -212,6 +212,8 @@ else()
- 		set(WAYLAND_FOUND OFF)
- 	endif()
+@@ -280,6 +280,8 @@ else()
+         set(WAYLAND_FOUND OFF)
+     endif()
  
-+	find_package(FFMPEG REQUIRED)
++    find_package(FFMPEG REQUIRED)
 +
- 	if(X11_FOUND)
- 		add_compile_definitions(SUNSHINE_BUILD_X11)
- 		include_directories(${X11_INCLUDE_DIR})
-@@ -372,35 +374,6 @@ set(SUNSHINE_TARGET_FILES
- 
- set_source_files_properties(src/upnp.cpp PROPERTIES COMPILE_FLAGS -Wno-pedantic)
+     if(X11_FOUND)
+         add_compile_definitions(SUNSHINE_BUILD_X11)
+         include_directories(${X11_INCLUDE_DIR})
+@@ -451,51 +453,12 @@ set_source_files_properties(src/upnp.cpp PROPERTIES COMPILE_FLAGS -Wno-pedantic)
+ set_source_files_properties(third-party/nanors/rs.c
+         PROPERTIES COMPILE_FLAGS "-include deps/obl/autoshim.h -ftree-vectorize")
  
 -# Pre-compiled binaries
 -if(WIN32)
--	set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/ffmpeg-windows-x86_64")
--	set(FFMPEG_PLATFORM_LIBRARIES mfplat ole32 strmiids mfuuid)
+-    set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/ffmpeg-windows-x86_64")
+-    set(FFMPEG_PLATFORM_LIBRARIES mfplat ole32 strmiids mfuuid mfx)
 -elseif(APPLE)
--	set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/ffmpeg-macos-x86_64")
+-    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+-        set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/ffmpeg-macos-aarch64")
+-    else()
+-        set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/ffmpeg-macos-x86_64")
+-    endif()
 -else()
--	if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
--		set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/ffmpeg-linux-aarch64")
--	else()
--		set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/ffmpeg-linux-x86_64")
--	endif()
--	set(FFMPEG_PLATFORM_LIBRARIES va va-drm va-x11 vdpau X11)
+-    set(FFMPEG_PLATFORM_LIBRARIES va va-drm va-x11 vdpau X11)
+-    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+-        set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/ffmpeg-linux-aarch64")
+-    else()
+-        set(FFMPEG_PREPARED_BINARIES "${CMAKE_CURRENT_SOURCE_DIR}/third-party/ffmpeg-linux-x86_64")
+-        list(APPEND FFMPEG_PLATFORM_LIBRARIES mfx)
+-        set(CPACK_DEB_PLATFORM_PACKAGE_DEPENDS "libmfx1,")
+-        set(CPACK_RPM_PLATFORM_PACKAGE_REQUIRES "intel-mediasdk >= 22.3.0,")
+-    endif()
 -endif()
 -set(FFMPEG_INCLUDE_DIRS
--	${FFMPEG_PREPARED_BINARIES}/include)
+-        ${FFMPEG_PREPARED_BINARIES}/include)
 -if(EXISTS ${FFMPEG_PREPARED_BINARIES}/lib/libhdr10plus.a)
--	set(HDR10_PLUS_LIBRARY
--		${FFMPEG_PREPARED_BINARIES}/lib/libhdr10plus.a)
+-    set(HDR10_PLUS_LIBRARY
+-            ${FFMPEG_PREPARED_BINARIES}/lib/libhdr10plus.a)
 -endif()
 -set(FFMPEG_LIBRARIES
--	${FFMPEG_PREPARED_BINARIES}/lib/libavcodec.a
--	${FFMPEG_PREPARED_BINARIES}/lib/libavutil.a
--	${FFMPEG_PREPARED_BINARIES}/lib/libswscale.a
--	${FFMPEG_PREPARED_BINARIES}/lib/libx264.a
--	${FFMPEG_PREPARED_BINARIES}/lib/libx265.a
--	${HDR10_PLUS_LIBRARY}
--	${FFMPEG_PLATFORM_LIBRARIES})
+-        ${FFMPEG_PREPARED_BINARIES}/lib/libavcodec.a
+-        ${FFMPEG_PREPARED_BINARIES}/lib/libavutil.a
+-        ${FFMPEG_PREPARED_BINARIES}/lib/libcbs.a
+-        ${FFMPEG_PREPARED_BINARIES}/lib/libSvtAv1Enc.a
+-        ${FFMPEG_PREPARED_BINARIES}/lib/libswscale.a
+-        ${FFMPEG_PREPARED_BINARIES}/lib/libx264.a
+-        ${FFMPEG_PREPARED_BINARIES}/lib/libx265.a
+-        ${HDR10_PLUS_LIBRARY}
+-        ${FFMPEG_PLATFORM_LIBRARIES})
 -
  include_directories(
-   ${CMAKE_CURRENT_SOURCE_DIR}
-   ${CMAKE_CURRENT_SOURCE_DIR}/third-party
+         ${CMAKE_CURRENT_SOURCE_DIR}
+         ${CMAKE_CURRENT_SOURCE_DIR}/third-party
+         ${CMAKE_CURRENT_SOURCE_DIR}/third-party/moonlight-common-c/enet/include
+         ${CMAKE_CURRENT_SOURCE_DIR}/third-party/nanors
+         ${CMAKE_CURRENT_SOURCE_DIR}/third-party/nanors/deps/obl
+-        ${FFMPEG_INCLUDE_DIRS}
+         ${PLATFORM_INCLUDE_DIRS}
+ )
+ 
+@@ -529,6 +492,7 @@ list(APPEND SUNSHINE_EXTERNAL_LIBRARIES
+         ${CMAKE_THREAD_LIBS_INIT}
+         enet
+         opus
++        cbs
+         ${FFMPEG_LIBRARIES}
+         ${Boost_LIBRARIES}
+         ${OPENSSL_LIBRARIES}

--- a/pkgs/servers/sunshine/libcbs.nix
+++ b/pkgs/servers/sunshine/libcbs.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, nasm
+}:
+stdenv.mkDerivation {
+  pname = "libcbs";
+  version = "unstable-2022-02-07";
+
+  src = fetchFromGitHub {
+    owner = "LizardByte";
+    repo = "build-deps";
+    # repo is not versioned -- used latest commit combined with sunshine release
+    rev = "d6e889188ca10118d769ee1ee3cddf9cf485642b";
+    fetchSubmodules = true;
+    sha256 = "sha256-6xQDJey5JrZXyZxS/yhUBvFi6UD5MsQ3uVtUFrG09Vc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    nasm
+  ];
+
+  # modify paths to allow patches to be applied directly by derivation
+  prePatch = ''
+    substituteInPlace ffmpeg_patches/cbs/* \
+      --replace 'a/libavcodec' 'a/ffmpeg_sources/ffmpeg/libavcodec' \
+      --replace 'b/libavcodec' 'b/ffmpeg_sources/ffmpeg/libavcodec' \
+      --replace 'a/libavutil' 'a/ffmpeg_sources/ffmpeg/libavutil' \
+      --replace 'b/libavutil' 'b/ffmpeg_sources/ffmpeg/libavutil'
+
+    substituteInPlace cmake/ffmpeg_cbs.cmake \
+      --replace '--enable-static' '--enable-shared --enable-pic' \
+      --replace 'add_library(cbs' 'add_library(cbs SHARED' \
+      --replace 'libcbs.a' 'libcbs.so'
+  '';
+
+  patches = [
+    "ffmpeg_patches/cbs/01-explicit-intmath.patch"
+    "ffmpeg_patches/cbs/02-include-cbs-config.patch"
+    "ffmpeg_patches/cbs/03-remove-register.patch"
+    "ffmpeg_patches/cbs/04-size-specifier.patch"
+  ];
+
+  CFLAGS = [
+    "-Wno-format-security"
+  ];
+}

--- a/pkgs/servers/sunshine/package-lock.json
+++ b/pkgs/servers/sunshine/package-lock.json
@@ -1,19 +1,19 @@
 {
-  "name": "web",
+  "name": "Sunshine",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
-        "@fortawesome/fontawesome-free": "6.2.0",
-        "bootstrap": "5.0.0",
+        "@fortawesome/fontawesome-free": "6.2.1",
+        "bootstrap": "5.2.3",
         "vue": "2.6.12"
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.2.0.tgz",
-      "integrity": "sha512-CNR7qRIfCwWHNN7FnKUniva94edPdyQzil/zCwk3v6k4R6rR2Fr8i4s3PM7n/lyfPA6Zfko9z5WDzFxG9SW1uQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.2.1.tgz",
+      "integrity": "sha512-viouXhegu/TjkvYQoiRZK3aax69dGXxgEjpvZW81wIJdxm5Fnvp3VVIP4VHKqX4SvFw6qpmkILkD4RJWAdrt7A==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"
@@ -30,15 +30,21 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.0.tgz",
-      "integrity": "sha512-tmhPET9B9qCl8dCofvHeiIhi49iBt0EehmIsziZib65k1erBW1rHhj2s/2JsuQh5Pq+xz2E9bEbzp9B7xHG+VA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
+      "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
       "peerDependencies": {
-        "@popperjs/core": "^2.9.2"
+        "@popperjs/core": "^2.11.6"
       }
     },
     "node_modules/vue": {
@@ -49,9 +55,9 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.2.0.tgz",
-      "integrity": "sha512-CNR7qRIfCwWHNN7FnKUniva94edPdyQzil/zCwk3v6k4R6rR2Fr8i4s3PM7n/lyfPA6Zfko9z5WDzFxG9SW1uQ=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.2.1.tgz",
+      "integrity": "sha512-viouXhegu/TjkvYQoiRZK3aax69dGXxgEjpvZW81wIJdxm5Fnvp3VVIP4VHKqX4SvFw6qpmkILkD4RJWAdrt7A=="
     },
     "@popperjs/core": {
       "version": "2.11.6",
@@ -60,9 +66,9 @@
       "peer": true
     },
     "bootstrap": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.0.tgz",
-      "integrity": "sha512-tmhPET9B9qCl8dCofvHeiIhi49iBt0EehmIsziZib65k1erBW1rHhj2s/2JsuQh5Pq+xz2E9bEbzp9B7xHG+VA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
+      "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
       "requires": {}
     },
     "vue": {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39398,7 +39398,9 @@ with pkgs;
 
   stayrtr = callPackage ../servers/stayrtr { };
 
-  sunshine = callPackage ../servers/sunshine { };
+  sunshine = callPackage ../servers/sunshine {
+    ffmpeg_5-full = ffmpeg_5-full.override { nv-codec-headers = nv-codec-headers-11; };
+  };
 
   sentencepiece = callPackage ../development/libraries/sentencepiece { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19149,6 +19149,8 @@ with pkgs;
 
   amdvlk = callPackage ../development/libraries/amdvlk { };
 
+  amf-headers = callPackage ../development/libraries/amf-headers { };
+
   aml = callPackage ../development/libraries/aml { };
 
   amrnb = callPackage ../development/libraries/amrnb { };


### PR DESCRIPTION
###### Description of changes

- upgrade Sunshine to 0.18.4
- init `amf-headers` package
- add `libcbs` dependency for Sunshine (essentially, `libcbs` is an internal library of `ffmpeg` -- Sunshine upstream patches ffmpeg source to make it directly available for them to use)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Fixes #213769
