### PR TITLE
advi: init at 2.0.0

### DIFF
--- a/pkgs/tools/typesetting/tex/advi/default.nix
+++ b/pkgs/tools/typesetting/tex/advi/default.nix
@@ -30,8 +30,7 @@ let
     exec kpsetool -v
   '';
 in
-ocamlPackages.buildDunePackage
-rec {
+ocamlPackages.buildDunePackage rec {
   pname = "advi";
   version = "2.0.0";
 
@@ -56,11 +55,10 @@ rec {
   # TODO: redirect /share/advi/tex/latex to tex output compatible with texlive.combine
   # (requires patching check() in advi-latex-files)
 
-  meta = with lib;
-    {
-      homepage = "http://advi.inria.fr/";
-      description = "Active-DVI is a Unix-platform DVI previewer and a programmable presenter for slides written in LaTeX.";
-      license = licenses.lgpl21Only;
-      maintainers = [ maintainers.xworld21 ];
-    };
+  meta = with lib; {
+    homepage = "http://advi.inria.fr/";
+    description = "Active-DVI is a Unix-platform DVI previewer and a programmable presenter for slides written in LaTeX.";
+    license = licenses.lgpl21Only;
+    maintainers = [ maintainers.xworld21 ];
+  };
 }

--- a/pkgs/tools/typesetting/tex/advi/default.nix
+++ b/pkgs/tools/typesetting/tex/advi/default.nix
@@ -1,0 +1,66 @@
+{ fetchurl
+, lib
+, makeWrapper
+, writeShellScriptBin
+, ghostscriptX
+, ocamlPackages
+, texlive
+, which
+}:
+
+let
+  # simplified fake-opam edited from tweag's opam-nix
+  fake-opam = writeShellScriptBin "opam" ''
+    case "$1 $2" in
+      "config var")
+        case "$3" in
+          man) echo "$out/share/man";;
+          etc) echo "$out/etc";;
+          doc) echo "$out/share/doc";;
+          share) echo "$out/share";;
+          prefix) echo "$out";;
+          *) echo "fake-opam does not understand arguments: $@" ; exit 1 ;;
+        esac;;
+      *) echo "fake-opam does not understand arguments: $@" ; exit 1 ;;
+    esac
+  '';
+
+  # texlive currently does not symlink kpsexpand
+  kpsexpand = writeShellScriptBin "kpsexpand" ''
+    exec kpsetool -v
+  '';
+in
+ocamlPackages.buildDunePackage
+rec {
+  pname = "advi";
+  version = "2.0.0";
+
+  useDune2 = true;
+
+  minimalOCamlVersion = "4.11";
+
+  src = fetchurl {
+    url = "http://advi.inria.fr/advi-${version}.tar.gz";
+    hash = "sha256-c0DQHlvdekJyXCxmR4+Ut/njtoCzmqX6hNazNv8PpBQ=";
+  };
+
+  nativeBuildInputs = [ fake-opam kpsexpand makeWrapper texlive.combined.scheme-medium which ];
+  buildInputs = with ocamlPackages; [ camlimages ghostscriptX graphics ];
+
+  # TODO: ghostscript linked from texlive.combine will override ghostscriptX and break advi
+  preInstall = ''
+    make install
+    wrapProgram "$out/bin/advi" --prefix PATH : "${lib.makeBinPath [ ghostscriptX ]}"
+  '';
+
+  # TODO: redirect /share/advi/tex/latex to tex output compatible with texlive.combine
+  # (requires patching check() in advi-latex-files)
+
+  meta = with lib;
+    {
+      homepage = "http://advi.inria.fr/";
+      description = "Active-DVI is a Unix-platform DVI previewer and a programmable presenter for slides written in LaTeX.";
+      license = licenses.lgpl21Only;
+      maintainers = [ maintainers.xworld21 ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4585,6 +4585,8 @@ with pkgs;
 
   ### TOOLS/TYPESETTING/TEX
 
+  advi = callPackage ../tools/typesetting/tex/advi { };
+
   auctex = callPackage ../tools/typesetting/tex/auctex { };
 
   blahtexml = callPackage ../tools/typesetting/tex/blahtexml { };


### PR DESCRIPTION
###### Description of changes
Add "Active-DVI" from http://advi.inria.fr/:

> Active-DVI is a Unix-platform *DVI previewer* and a *programmable presenter for slides* written in LaTeX.

Typically used with the [whizzytex](http://cristal.inria.fr/whizzytex/) Emacs package, but I believe some people use it on its own.

Unfortunately, there are still some issues (see comments for details), one serious which requiring a fix in texlive, one that can be sorted out later.

Opinion from OCaml packagers are very welcome, by the way!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
