### PR TITLE
[staging-next] libredirect: fix build on musl libc

### DIFF
--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -201,7 +201,7 @@ WRAPPER(int, __xstat64)(int ver, const char * path, struct stat64 * st)
 WRAPPER_DEF(__xstat64)
 #endif
 
-#ifdef __linux__
+#if defined(__linux__) && defined(STATX_TYPE)
 WRAPPER(int, statx)(int dirfd, const char * restrict pathname, int flags,
     unsigned int mask, struct statx * restrict statxbuf)
 {

--- a/pkgs/build-support/libredirect/test.c
+++ b/pkgs/build-support/libredirect/test.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
 #ifndef __APPLE__
     struct stat64 testsb64;
 #endif
-#ifdef __linux__
+#if defined(__linux__) && defined(STATX_TYPE)
     struct statx testsbx;
 #endif
     char buf[PATH_MAX];
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
 #ifndef __APPLE__
     assert(fstatat64(123, TESTPATH, &testsb64, 0) != -1);
 #endif
-#ifdef __linux__
+#if defined(__linux__) && defined(STATX_TYPE)
     assert(statx(123, TESTPATH, 0, STATX_ALL, &testsbx) != -1);
 #endif
 


### PR DESCRIPTION
###### Description of changes

musl doesn't yet provide a wrapper for the statx syscall, so don't bother wrapping it here unless it's actually available.

Tested that pkgsMusl.libredirect and libredirect both build now for x86_64-linux when rebased on master.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
