### PR TITLE
kbibtex: 0.9.2 -> 0.9.3.1

### DIFF
--- a/pkgs/applications/office/kbibtex/default.nix
+++ b/pkgs/applications/office/kbibtex/default.nix
@@ -5,6 +5,7 @@
 , extra-cmake-modules
 , shared-mime-info
 # Qt
+, qtnetworkauth
 , qtxmlpatterns
 , qtwebengine
 , qca-qt5
@@ -28,11 +29,13 @@
 
 mkDerivation rec {
   pname = "kbibtex";
-  version = "0.9.2";
+  version = "0.9.3.1";
 
-  src = fetchurl {
-    url = "mirror://kde/stable/KBibTeX/${version}/kbibtex-${version}.tar.xz";
-    sha256 = "09xcdx363z9hps3wbr1kx96a6q6678y8pg8r3apyps4xm7xm31nr";
+  src = let
+    majorMinorPatch = lib.concatStringsSep "." (lib.take 3 (lib.splitVersion version));
+  in fetchurl {
+    url = "mirror://kde/stable/KBibTeX/${majorMinorPatch}/kbibtex-${version}.tar.xz";
+    hash = "sha256-kH/E5xv9dmzM7WrIMlGCo4y0Xv/7XHowELJP3OJz8kQ=";
   };
 
   nativeBuildInputs = [
@@ -41,6 +44,7 @@ mkDerivation rec {
   ];
 
   buildInputs = [
+    qtnetworkauth
     qtxmlpatterns
     qtwebengine
     qca-qt5


### PR DESCRIPTION
###### Description of changes
Changelog: https://invent.kde.org/office/kbibtex/-/raw/v0.9.3.1/ChangeLog


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
