### PR TITLE
tailwindcss-bin: init at 3.2.4

### DIFF
--- a/pkgs/development/tools/tailwindcss/default.nix
+++ b/pkgs/development/tools/tailwindcss/default.nix
@@ -1,0 +1,59 @@
+{ lib, fetchurl, system, stdenv, runCommand, tailwindcss-bin }:
+
+let
+  pname = "tailwindcss";
+  version = "3.2.4";
+
+  archs = {
+    x86_64-linux = {
+      archStr = "linux-x64";
+      sha256 = "15hj95qdx7z3gdmhb3826h98296rk18j2yi0y0w55l8brdbyflnd";
+    };
+    aarch64-linux = {
+      archStr = "linux-arm64";
+      sha256 = "14icqfc5s3dalxa0pp481aj4i1nvcv0rnxhpv92k7mlfldrf80vk";
+    };
+    aarch64-darwin = {
+      archStr = "macos-arm64";
+      sha256 = "1p6gqpj718dfkgz6l6carrca65zlfyj8dayjnbdbh59mblqs6q86";
+    };
+    x86_64-darwin = {
+      archStr = "macos-x64";
+      sha256 = "02xc6q6pjkqc5vq6wby1sv3bnjjkjycg64khidccwx595dl95gzy";
+    };
+  };
+  srcFor = urlpart: fetchurl {
+    url = "https://github.com/tailwindlabs/tailwindcss/releases/download/v${version}/tailwindcss-${urlpart.archStr}";
+    inherit (urlpart) sha256;
+  };
+
+  src = srcFor archs.${system} or (throw "tailwind has not been packaged for ${system} yet.");
+in
+
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${src} $out/bin/tailwindcss
+    chmod 755 $out/bin/tailwindcss
+  '';
+
+  passthru.tests.helptext = runCommand "tailwindcss-test-helptext" { } ''
+    ${tailwindcss-bin}/bin/tailwindcss --help > $out
+  '';
+
+  meta = with lib; {
+    description = "Command-line tool for the CSS framework with composable CSS classes";
+    homepage = "https://tailwindcss.com/blog/standalone-cli";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ tfc ];
+    platforms = builtins.attrNames archs;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1553,6 +1553,8 @@ with pkgs;
 
   systeroid = callPackage ../tools/system/systeroid { };
 
+  tailwindcss-bin = callPackage ../development/tools/tailwindcss { };
+
   tauon = callPackage ../applications/audio/tauon { };
 
   tere = callPackage ../tools/misc/tere { };


### PR DESCRIPTION
###### Description of changes

The Tailwindcss project provides a pre-packed binary so that users don't have to use NPM to use this great CSS framework.

I was able to check if all the downloads for different architectures work, but not if they actually execute.
I added a passthru test so hopefully the CI can test the executability.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
