### PR TITLE
circt: init at 1.29.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13338,6 +13338,12 @@
     githubId = 16765155;
     name = "Shardul Baral";
   };
+  sharzy = {
+    email = "me@sharzy.in";
+    github = "SharzyL";
+    githubId = 46294732;
+    name = "Sharzy";
+  };
   shawndellysse = {
     email = "sdellysse@gmail.com";
     github = "sdellysse";

--- a/pkgs/development/compilers/circt/default.nix
+++ b/pkgs/development/compilers/circt/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, lib
+, cmake
+, coreutils
+, python3
+, git
+, fetchFromGitHub
+, ninja
+}:
+
+let
+  pythonEnv = python3.withPackages (ps: [ ps.psutil ]);
+in
+stdenv.mkDerivation rec {
+  pname = "circt";
+  version = "1.29.0";
+  src = fetchFromGitHub {
+    owner = "llvm";
+    repo = "circt";
+    rev = "firtool-${version}";
+    sha256 = "sha256-HsXwh98RZuXvK/KkZ2NAGwWNLxUAQVj+WKzZXd4C4Is=";
+    fetchSubmodules = true;
+  };
+
+  requiredSystemFeatures = [ "big-parallel" ];
+
+  nativeBuildInputs = [ cmake ninja git pythonEnv ];
+
+  cmakeDir = "../llvm/llvm";
+  cmakeFlags = [
+    "-DLLVM_ENABLE_BINDINGS=OFF"
+    "-DLLVM_ENABLE_OCAMLDOC=OFF"
+    "-DLLVM_BUILD_EXAMPLES=OFF"
+    "-DLLVM_OPTIMIZED_TABLEGEN=ON"
+    "-DLLVM_ENABLE_PROJECTS=mlir"
+    "-DLLVM_EXTERNAL_PROJECTS=circt"
+    "-DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=.."
+    "-DCIRCT_LLHD_SIM_ENABLED=OFF"
+  ];
+
+  preConfigure = ''
+    substituteInPlace test/circt-reduce/test/annotation-remover.mlir --replace "/usr/bin/env" "${coreutils}/bin/env"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mv bin/{{fir,hls}tool,circt-{as,dis,lsp-server,opt,reduce,translate}} $out/bin
+    runHook postInstall
+  '';
+
+  doCheck = true;
+  checkTarget = "check-circt check-circt-integration";
+
+  meta = {
+    description = "Circuit IR compilers and tools";
+    homepage = "https://circt.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ sharzy ];
+    platforms = lib.platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -390,6 +390,8 @@ with pkgs;
 
   chrysalis = callPackage ../applications/misc/chrysalis { };
 
+  circt = callPackage ../development/compilers/circt { };
+
   classicube = callPackage ../games/classicube { };
 
   clj-kondo = callPackage ../development/tools/clj-kondo { };


### PR DESCRIPTION
Circuit IR Compilers and Tools (https://github.com/llvm/circt)

Pending issues:
- I am experiencing sporadic internal compiler error when building circt on both my pc and server. The error remains occuring even when switching from `stdenv` to `clangStdenv`, but disappears when building with `--cores 1`. May somebody help testing on his/her machine (`nix build github:SharzyL/nixpkgs/circt#circt`)?

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
