### PR TITLE
deepin(application part2): init at 20.8

### DIFF
--- a/pkgs/desktops/deepin/apps/deepin-album/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-album/default.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, qttools
+, wrapQtAppsHook
+, dtkwidget
+, qt5integration
+, qt5platform-plugins
+, udisks2-qt5
+, gio-qt
+, image-editor
+, glibmm
+, freeimage
+, opencv
+, ffmpeg
+, ffmpegthumbnailer
+, qtbase
+}:
+
+stdenv.mkDerivation rec {
+  pname = "deepin-album";
+  version = "5.10.9";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-S/oVRD72dtpnvfGV6YfN5/syrmWA44H/1BbmAe0xjAY=";
+  };
+
+  # This patch should be removed after upgrading to 6.0.0
+  postPatch = ''
+    substituteInPlace libUnionImage/CMakeLists.txt \
+      --replace "/usr" "$out"
+    substituteInPlace src/CMakeLists.txt \
+      --replace "set(PREFIX /usr)" "set(PREFIX $out)" \
+      --replace "/usr/bin" "$out/bin" \
+      --replace "/usr/share/deepin-manual/manual-assets/application/)" "share/deepin-manual/manual-assets/application/)"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qttools
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    dtkwidget
+    qt5platform-plugins
+    udisks2-qt5
+    gio-qt
+    image-editor
+    glibmm
+    freeimage
+    opencv
+    ffmpeg
+    ffmpegthumbnailer
+  ];
+
+  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
+  qtWrapperArgs = [
+    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
+  ];
+
+  cmakeFlags = [ "-DVERSION=${version}" ];
+
+  meta = with lib; {
+    description = "A fashion photo manager for viewing and organizing pictures";
+    homepage = "https://github.com/linuxdeepin/deepin-album";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/apps/deepin-draw/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-draw/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, dtkwidget
+, qt5integration
+, qt5platform-plugins
+, cmake
+, qttools
+, pkg-config
+, wrapQtAppsHook
+, qtbase
+}:
+
+stdenv.mkDerivation rec {
+  pname = "deepin-draw";
+  version = "5.11.4";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-49RQQ52HR5aqzeVEjGm9vQpTOxhY7I0X724x/Bboo90=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "chore: use GNUInstallDirs in CmakeLists";
+      url = "https://github.com/linuxdeepin/deepin-draw/commit/dac714fe603e1b77fc39952bfe6949852ee6c2d5.patch";
+      sha256 = "sha256-zajxmKkZJT1lcyvPv/PRPMxcstF69PB1tC50gYKDlWA=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace com.deepin.Draw.service \
+      --replace "/usr/bin/deepin-draw" "$out/bin/deepin-draw"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    qttools
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    dtkwidget
+    qt5platform-plugins
+  ];
+
+  cmakeFlags = [ "-DVERSION=${version}" ];
+
+  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
+  qtWrapperArgs = [
+    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
+  ];
+
+  meta = with lib; {
+    description = "Lightweight drawing tool for users to freely draw and simply edit images";
+    homepage = "https://github.com/linuxdeepin/deepin-draw";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/apps/deepin-image-viewer/0001-fix-install-path-for-nix.patch
+++ b/pkgs/desktops/deepin/apps/deepin-image-viewer/0001-fix-install-path-for-nix.patch
@@ -1,0 +1,25 @@
+From c2fa29800c64f5bda04203bb2eb1845b29c1de3c Mon Sep 17 00:00:00 2001
+From: rewine <luhongxu@deepin.org>
+Date: Fri, 25 Mar 2022 18:20:17 +0800
+Subject: [PATCH] fix install path for nix
+
+---
+ qimage-plugins/libraw/CMakeLists.txt | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/qimage-plugins/libraw/CMakeLists.txt b/qimage-plugins/libraw/CMakeLists.txt
+index 4bfd85ad..00d11bd3 100644
+--- a/qimage-plugins/libraw/CMakeLists.txt
++++ b/qimage-plugins/libraw/CMakeLists.txt
+@@ -44,7 +44,6 @@ target_include_directories(xraw PUBLIC ${RAW_INCLUDE_DIRS}  ${Qt5Gui_INCLUDE_DIR
+ 
+ target_link_libraries(${CMD_NAME} Qt5::Core Qt5::Gui raw)
+ 
+-install(TARGETS ${CMD_NAME} DESTINATION ${Qt5Core_DIR}/../../qt5/plugins/imageformats)
+-
++install(TARGETS ${CMD_NAME} DESTINATION qt5/plugins/imageformats)
+ 
+ QT5_USE_MODULES(${PROJECT_NAME} Core Gui)
+-- 
+2.35.1
+

--- a/pkgs/desktops/deepin/apps/deepin-image-viewer/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-image-viewer/default.nix
@@ -1,0 +1,76 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, dtkwidget
+, qt5integration
+, qt5platform-plugins
+, gio-qt
+, udisks2-qt5
+, image-editor
+, cmake
+, pkg-config
+, qttools
+, wrapQtAppsHook
+, libraw
+, libexif
+, qtbase
+}:
+
+stdenv.mkDerivation rec {
+  pname = "deepin-image-viewer";
+  version = "5.9.4";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-5A6K47NcMkvncZIF5CXeHYYZWEHQ4YDnPDQr2axCmaI=";
+  };
+
+  patches = [
+    ./0001-fix-install-path-for-nix.patch
+    (fetchpatch {
+      name = "chore: use GNUInstallDirs in CmakeLists";
+      url = "https://github.com/linuxdeepin/deepin-image-viewer/commit/4a046e6207fea306e592fddc33c1285cf719a63d.patch";
+      sha256 = "sha256-aIgYmq6WDfCE+ZcD0GshxM+QmBWZGjh9MzZcTMrhBJ0=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace src/com.deepin.ImageViewer.service \
+      --replace "/usr/bin/deepin-image-viewer" "$out/bin/deepin-image-viewer"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qttools
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    dtkwidget
+    qt5platform-plugins
+    gio-qt
+    udisks2-qt5
+    image-editor
+    libraw
+    libexif
+  ];
+
+  cmakeFlags = [ "-DVERSION=${version}" ];
+
+  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
+  qtWrapperArgs = [
+    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
+  ];
+
+  meta = with lib; {
+    description = "An image viewing tool with fashion interface and smooth performance";
+    homepage = "https://github.com/linuxdeepin/deepin-image-viewer";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/apps/deepin-picker/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-picker/default.nix
@@ -1,0 +1,58 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, qmake
+, qttools
+, pkg-config
+, wrapQtAppsHook
+, dtkwidget
+, qtsvg
+, xorg
+, qtbase
+}:
+
+stdenv.mkDerivation rec {
+  pname = "deepin-picker";
+  version = "5.0.28";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-b463PqrCpt/DQqint5Xb0cRT66iHNPavj0lsTMv801k=";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    qttools
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    dtkwidget
+    qtsvg
+    xorg.libXtst
+  ];
+
+  postPatch = ''
+    substituteInPlace com.deepin.Picker.service \
+      --replace "/usr/bin/deepin-picker" "$out/bin/deepin-picker"
+  '';
+
+  qmakeFlags = [
+    "BINDIR=${placeholder "out"}/bin"
+    "ICONDIR=${placeholder "out"}/share/icons/hicolor/scalable/apps"
+    "APPDIR=${placeholder "out"}/share/applications"
+    "DSRDIR=${placeholder "out"}/share/deepin-picker"
+    "DOCDIR=${placeholder "out"}/share/dman/deepin-picker"
+  ];
+
+  meta = with lib; {
+    description = "Color picker application";
+    homepage = "https://github.com/linuxdeepin/deepin-picker";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -27,6 +27,7 @@ let
     deepin-draw = callPackage ./apps/deepin-draw { };
     deepin-editor = callPackage ./apps/deepin-editor { };
     deepin-image-viewer = callPackage ./apps/deepin-image-viewer { };
+    deepin-picker = callPackage ./apps/deepin-picker { };
     deepin-terminal = callPackage ./apps/deepin-terminal { };
 
     #### ARTWORK

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -25,6 +25,7 @@ let
     deepin-compressor = callPackage ./apps/deepin-compressor { };
     deepin-draw = callPackage ./apps/deepin-draw { };
     deepin-editor = callPackage ./apps/deepin-editor { };
+    deepin-image-viewer = callPackage ./apps/deepin-image-viewer { };
     deepin-terminal = callPackage ./apps/deepin-terminal { };
 
     #### ARTWORK

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -21,6 +21,7 @@ let
     udisks2-qt5 = callPackage ./library/udisks2-qt5 { };
 
     #### Dtk Application
+    deepin-album = callPackage ./apps/deepin-album { };
     deepin-calculator = callPackage ./apps/deepin-calculator { };
     deepin-compressor = callPackage ./apps/deepin-compressor { };
     deepin-draw = callPackage ./apps/deepin-draw { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -23,6 +23,7 @@ let
     #### Dtk Application
     deepin-calculator = callPackage ./apps/deepin-calculator { };
     deepin-compressor = callPackage ./apps/deepin-compressor { };
+    deepin-draw = callPackage ./apps/deepin-draw { };
     deepin-editor = callPackage ./apps/deepin-editor { };
     deepin-terminal = callPackage ./apps/deepin-terminal { };
 


### PR DESCRIPTION
###### Description of changes

Add more deepin packages 

https://github.com/linuxdeepin/dde-nixos/issues/9

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
