### PR TITLE
python310Packages.flask-wtf: 1.0.1 -> 1.1.1

### DIFF
--- a/pkgs/development/python-modules/flask-wtf/default.nix
+++ b/pkgs/development/python-modules/flask-wtf/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchPypi
-, fetchpatch
 , buildPythonPackage
 , flask
 , itsdangerous
@@ -11,27 +10,13 @@
 
 buildPythonPackage rec {
   pname = "flask-wtf";
-  version = "1.0.1";
+  version = "1.1.1";
 
   src = fetchPypi {
     pname = "Flask-WTF";
     inherit version;
-    sha256 = "34fe5c6fee0f69b50e30f81a3b7ea16aa1492a771fe9ad0974d164610c09a6c9";
+    hash = "sha256-QcQkTprmJtY77UKuR4W5Bme4hbFTXVpAleH2MGDRKqk=";
   };
-
- patches = [
-    # Fix failing `test_set_default_message_language` test
-    #
-    # Caused by Flask 2.2 that throws an error when setup methods are
-    # mistakenly called before the first request.
-    #
-    # Will be fixed upstream with: https://github.com/wtforms/flask-wtf/pull/533
-    #
-    (fetchpatch {
-      url = "https://github.com/wtforms/flask-wtf/commit/36a53fadf7bc42c79a1428657531961ec30ca003.patch";
-      hash = "sha256-bgLwDG9Wpufm6fd/6PS83Jvvuk1Ha6XdyaWngluPs30=";
-    })
-  ];
 
   propagatedBuildInputs = [
     flask
@@ -52,5 +37,6 @@ buildPythonPackage rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ mic92 anthonyroussel ];
     homepage = "https://github.com/lepture/flask-wtf/";
+    changelog = "https://github.com/wtforms/flask-wtf/releases/tag/v${version}";
   };
 }


### PR DESCRIPTION
###### Description of changes

* https://github.com/wtforms/flask-wtf/releases/tag/v1.1.1
* https://github.com/wtforms/flask-wtf/releases/tag/v1.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
