### PR TITLE
wayland-scanner: split from wayland

### DIFF
--- a/pkgs/applications/accessibility/squeekboard/default.nix
+++ b/pkgs/applications/accessibility/squeekboard/default.nix
@@ -10,6 +10,7 @@
 , gtk3
 , wayland
 , wayland-protocols
+, wayland-scanner
 , libbsd
 , libxml2
 , libxkbcommon
@@ -44,7 +45,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     glib
-    wayland
+    wayland-scanner
     wrapGAppsHook3
     rustPlatform.cargoSetupHook
     cargo

--- a/pkgs/applications/graphics/hello-wayland/default.nix
+++ b/pkgs/applications/graphics/hello-wayland/default.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation {
   };
 
   separateDebugInfo = true;
-
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [ imagemagick pkg-config wayland-scanner ];
   buildInputs = [ wayland wayland-protocols ];

--- a/pkgs/applications/kde/krfb.nix
+++ b/pkgs/applications/kde/krfb.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib
-, extra-cmake-modules, kdoctools
+, extra-cmake-modules, kdoctools, wayland-scanner
 , kconfig, kcoreaddons, kcrash, kdbusaddons, kdnssd, knotifications, kwallet
 , kwidgetsaddons, kwindowsystem, kxmlgui, kwayland, kpipewire
 , libvncserver, libXtst, libXdamage
@@ -14,7 +14,7 @@ mkDerivation {
     license = with lib.licenses; [ gpl2Plus fdl12Plus ];
     maintainers = with lib.maintainers; [ jerith666 ];
   };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ extra-cmake-modules kdoctools wayland-scanner ];
   buildInputs = [
     libvncserver libXtst libXdamage
     kconfig kcoreaddons kcrash kdbusaddons knotifications kwallet kwidgetsaddons

--- a/pkgs/applications/misc/clight/clightd.nix
+++ b/pkgs/applications/misc/clight/clightd.nix
@@ -45,13 +45,13 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    dbus
     cmake
     pkg-config
     wayland-scanner
   ];
 
   buildInputs = with lib; [
+    dbus
     glib
     udev
     polkit

--- a/pkgs/applications/misc/clight/clightd.nix
+++ b/pkgs/applications/misc/clight/clightd.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub
-, dbus, cmake, pkg-config
+, dbus, cmake, pkg-config, wayland-scanner
 , glib, udev, polkit, libusb1, libjpeg, libmodule
 , pcre, libXdmcp, util-linux, libpthreadstubs
 , enableDdc ? true, ddcutil
@@ -40,10 +40,15 @@ stdenv.mkDerivation rec {
       ++ optional enableScreen     "-DENABLE_SCREEN=1"
       ++ optional enableYoctolight "-DENABLE_YOCTOLIGHT=1";
 
+  depsBuildBuild = [
+    pkg-config
+  ];
+
   nativeBuildInputs = [
     dbus
     cmake
     pkg-config
+    wayland-scanner
   ];
 
   buildInputs = with lib; [

--- a/pkgs/applications/misc/latte-dock/default.nix
+++ b/pkgs/applications/misc/latte-dock/default.nix
@@ -1,6 +1,9 @@
-{ mkDerivation, lib, cmake, xorg, plasma-framework, plasma-wayland-protocols, fetchFromGitLab
-, extra-cmake-modules, karchive, kwindowsystem, qtx11extras, qtwayland, kcrash, knewstuff
-, wayland, plasma-workspace, plasma-desktop }:
+{ lib, mkDerivation, fetchFromGitLab
+, cmake, extra-cmake-modules, karchive, kwindowsystem, qtx11extras, kcrash
+, knewstuff, wayland-scanner
+, plasma-framework, plasma-wayland-protocols, plasma-workspace, plasma-desktop, qtwayland
+, wayland, xorg
+}:
 
 mkDerivation rec {
   pname = "latte-dock";
@@ -17,7 +20,7 @@ mkDerivation rec {
   buildInputs = [ plasma-framework plasma-wayland-protocols qtwayland xorg.libpthreadstubs xorg.libXdmcp xorg.libSM wayland plasma-workspace plasma-desktop ];
 
   nativeBuildInputs = [ extra-cmake-modules cmake karchive kwindowsystem
-    qtx11extras kcrash knewstuff ];
+    qtx11extras kcrash knewstuff wayland-scanner ];
 
   patches = [
     ./0001-Disable-autostart.patch

--- a/pkgs/applications/misc/maliit-framework/default.nix
+++ b/pkgs/applications/misc/maliit-framework/default.nix
@@ -20,6 +20,7 @@
 , doxygen
 , pkg-config
 , wayland-protocols
+, wayland-scanner
 }:
 
 mkDerivation rec {
@@ -62,6 +63,7 @@ mkDerivation rec {
     doxygen
     pkg-config
     wayland-protocols
+    wayland-scanner
   ];
 
   preConfigure = ''

--- a/pkgs/applications/misc/phoc/default.nix
+++ b/pkgs/applications/misc/phoc/default.nix
@@ -6,6 +6,7 @@
 , ninja
 , pkg-config
 , python3
+, wayland-scanner
 , wrapGAppsHook3
 , libinput
 , gobject-introspection
@@ -40,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     python3
+    wayland-scanner
     wrapGAppsHook3
   ];
 

--- a/pkgs/applications/misc/qt-video-wlr/default.nix
+++ b/pkgs/applications/misc/qt-video-wlr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, pkg-config, meson, cmake, ninja, gst_all_1, wrapQtAppsHook, qtbase, qtmultimedia, layer-shell-qt }:
+{ stdenv, lib, fetchFromGitHub, pkg-config, meson, cmake, ninja, gst_all_1, wrapQtAppsHook, qtbase, qtmultimedia, layer-shell-qt, wayland-scanner }:
 let
  gstreamerPath = with gst_all_1; lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
      gstreamer
@@ -24,6 +24,7 @@ in stdenv.mkDerivation rec {
     cmake # only used for find layer-shell-qt
     ninja
     wrapQtAppsHook
+    wayland-scanner
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/river-tag-overlay/default.nix
+++ b/pkgs/applications/misc/river-tag-overlay/default.nix
@@ -1,5 +1,11 @@
-{ lib, stdenv, fetchFromSourcehut, fetchpatch
-, wayland, pixman, pkg-config, wayland-scanner
+{ lib
+, stdenv
+, fetchFromSourcehut
+, fetchpatch
+, wayland
+, pixman
+, pkg-config
+, wayland-scanner
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/applications/misc/rofi/wayland.nix
+++ b/pkgs/applications/misc/rofi/wayland.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , rofi-unwrapped
 , wayland-scanner
+, pkg-config
 , wayland-protocols
 , wayland
 }:
@@ -18,7 +19,8 @@ rofi-unwrapped.overrideAttrs (oldAttrs: rec {
     hash = "sha256-pKxraG3fhBh53m+bLPzCigRr6dBcH/A9vbdf67CO2d8=";
   };
 
-  nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ wayland-scanner ];
+  depsBuildBuild = oldAttrs.depsBuildBuild ++ [ pkg-config ];
+  nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ wayland-protocols wayland-scanner ];
   buildInputs = oldAttrs.buildInputs ++ [ wayland wayland-protocols ];
 
   meta = with lib; {

--- a/pkgs/applications/misc/tofi/default.nix
+++ b/pkgs/applications/misc/tofi/default.nix
@@ -28,7 +28,12 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [
-    meson ninja pkg-config scdoc wayland-protocols wayland-scanner
+    meson
+    ninja
+    pkg-config
+    scdoc
+    wayland-protocols
+    wayland-scanner
   ];
   buildInputs = [ freetype harfbuzz cairo pango wayland libxkbcommon ];
 

--- a/pkgs/applications/networking/remote/freerdp/3.nix
+++ b/pkgs/applications/networking/remote/freerdp/3.nix
@@ -145,6 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
     fuse3
     systemd
     wayland
+    wayland-scanner
   ] ++ lib.optionals stdenv.isDarwin [
     AudioToolbox
     AVFoundation
@@ -160,7 +161,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-Wno-dev"
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DDOCBOOKXSL_DIR=${docbook-xsl-nons}/xml/xsl/docbook"
-    "-DWAYLAND_SCANNER=${buildPackages.wayland-scanner}/bin/wayland-scanner"
   ] ++ lib.mapAttrsToList (k: v: "-D${k}=${cmFlag v}") {
     BUILD_TESTING = false; # false is recommended by upstream
     WITH_CAIRO = (cairo != null);

--- a/pkgs/applications/networking/remote/freerdp/default.nix
+++ b/pkgs/applications/networking/remote/freerdp/default.nix
@@ -167,7 +167,6 @@ stdenv.mkDerivation rec {
     "-Wno-dev"
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DDOCBOOKXSL_DIR=${docbook-xsl-nons}/xml/xsl/docbook"
-    "-DWAYLAND_SCANNER=${buildPackages.wayland-scanner}/bin/wayland-scanner"
   ]
   ++ lib.mapAttrsToList (k: v: "-D${k}=${cmFlag v}") {
     BUILD_TESTING = false; # false is recommended by upstream

--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -15,6 +15,7 @@
 , UserNotifications
 , libcanberra
 , libicns
+, wayland-scanner
 , libpng
 , python3
 , zlib
@@ -84,7 +85,11 @@ buildPythonApplication rec {
   ] ++ lib.optionals stdenv.isDarwin [
     imagemagick
     libicns  # For the png2icns tool.
+  ] ++ lib.optionals stdenv.isLinux [
+    wayland-scanner
   ];
+
+  depsBuildBuild = [ pkg-config ];
 
   outputs = [ "out" "terminfo" "shell_integration" "kitten" ];
 

--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -26,6 +26,7 @@
 
 , wayland
 , wayland-protocols
+, wayland-scanner
 
 , pipewire
 , pulseaudio
@@ -64,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./0001-client-cmake-move-X11-config-directives-to-displayse.patch
   ];
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [ cmake pkg-config wayland-scanner ];
 
   buildInputs = [ libX11 libGL freefont_ttf spice-protocol expat libbfd nettle fontconfig libffi ]
     ++ lib.optionals xorgSupport [ libxkbcommon libXi libXScrnSaver libXinerama libXcursor libXpresent libXext libXrandr libXdmcp ]

--- a/pkgs/applications/window-managers/cagebreak/default.nix
+++ b/pkgs/applications/window-managers/cagebreak/default.nix
@@ -19,6 +19,7 @@
 , systemd
 , wayland
 , wayland-protocols
+, wayland-scanner
 , withXwayland ? true , xwayland
 , wlroots
 }:
@@ -40,7 +41,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     scdoc
-    wayland
+    wayland-scanner
   ];
 
   buildInputs = [

--- a/pkgs/applications/window-managers/owl/default.nix
+++ b/pkgs/applications/window-managers/owl/default.nix
@@ -9,8 +9,6 @@
 , darwin
 }:
 
-assert wayland.withLibraries;
-
 let
   stdenv = clangStdenv;
 in

--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -6,6 +6,7 @@
 , ninja
 , pkg-config
 , python3
+, wayland-scanner
 , wrapGAppsHook4
 , libadwaita
 , libhandy
@@ -50,6 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     python3
+    wayland-scanner
     wrapGAppsHook4
   ];
 

--- a/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
+++ b/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
@@ -6,6 +6,7 @@
 , meson
 , ninja
 , pkg-config
+, wayland-scanner
 , wrapGAppsHook4
 , desktop-file-utils
 , feedbackd
@@ -34,6 +35,7 @@ stdenv.mkDerivation rec {
     ninja
     phosh
     pkg-config
+    wayland-scanner
     wrapGAppsHook4
   ];
 

--- a/pkgs/by-name/ca/cardboard/package.nix
+++ b/pkgs/by-name/ca/cardboard/package.nix
@@ -21,6 +21,7 @@
 , unzip
 , wayland
 , wayland-protocols
+, wayland-scanner
 , xcbutilerrors
 , xcbutilimage
 , xcbutilwm
@@ -79,6 +80,7 @@ stdenv.mkDerivation {
     pandoc
     pkg-config
     unzip
+    wayland-scanner
   ];
 
   buildInputs = [

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -12,6 +12,7 @@
 , vulkan-headers
 , wayland
 , wayland-protocols
+, wayland-scanner
 , libxkbcommon
 , glm
 , gbenchmark
@@ -99,6 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals enableExecutable [
     makeBinaryWrapper
     glslang
+    wayland-scanner
   ];
 
   buildInputs = [

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -1,4 +1,5 @@
 { stdenv
+, buildPackages
 , edid-decode
 , fetchFromGitHub
 , meson
@@ -31,7 +32,6 @@
 , lcms
 , lib
 , makeBinaryWrapper
-, patchelfUnstable
 , nix-update-script
 , enableExecutable ? true
 , enableWsi ? true
@@ -140,7 +140,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = lib.optionalString enableExecutable ''
     # using patchelf unstable because the stable version corrupts the binary
-    ${lib.getExe patchelfUnstable} $out/bin/gamescope \
+    ${lib.getExe buildPackages.patchelfUnstable} $out/bin/gamescope \
       --add-rpath ${vulkan-loader}/lib --add-needed libvulkan.so.1
 
     # --debug-layers flag expects these in the path

--- a/pkgs/by-name/ri/river/package.nix
+++ b/pkgs/by-name/ri/river/package.nix
@@ -13,6 +13,7 @@
 , udev
 , wayland
 , wayland-protocols
+, wayland-scanner
 , wlroots_0_18
 , xwayland
 , zig_0_13
@@ -39,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
-    wayland
+    wayland-scanner
     xwayland
     zig_0_13.hook
   ]
@@ -52,6 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxkbcommon
     pixman
     udev
+    wayland
     wayland-protocols
     wlroots_0_18
   ] ++ lib.optional xwaylandSupport libX11;

--- a/pkgs/by-name/vl/vlc/package.nix
+++ b/pkgs/by-name/vl/vlc/package.nix
@@ -79,6 +79,7 @@
 , unzip
 , wayland
 , wayland-protocols
+, wayland-scanner
 , wrapGAppsHook3
 , writeShellScript
 , xcbutilkeysyms
@@ -120,8 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals chromecastSupport [ protobuf ]
   ++ optionals withQt5 [ libsForQt5.wrapQtAppsHook ]
   ++ optionals waylandSupport [
-    wayland
-    wayland-protocols
+    wayland-scanner
   ];
 
   # VLC uses a *ton* of libraries for various pieces of functionality, many of

--- a/pkgs/by-name/wa/waylock/package.nix
+++ b/pkgs/by-name/wa/waylock/package.nix
@@ -8,6 +8,7 @@
   pkg-config,
   scdoc,
   wayland,
+  wayland-scanner,
   wayland-protocols,
   zig_0_12,
 }:
@@ -30,11 +31,12 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     scdoc
-    wayland
+    wayland-scanner
     zig_0_12.hook
   ];
 
   buildInputs = [
+    wayland
     wayland-protocols
     libxkbcommon
     pam

--- a/pkgs/by-name/wi/wio/package.nix
+++ b/pkgs/by-name/wi/wio/package.nix
@@ -10,6 +10,7 @@
 , meson
 , ninja
 , pkg-config
+, wayland-scanner
 , udev
 , unstableGitUpdater
 , wayland
@@ -34,6 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
+    wayland-scanner
   ];
 
   buildInputs = [

--- a/pkgs/desktops/deepin/library/dwayland/default.nix
+++ b/pkgs/desktops/deepin/library/dwayland/default.nix
@@ -6,6 +6,7 @@
 , qtwayland
 , wayland
 , wayland-protocols
+, wayland-scanner
 , extra-cmake-modules
 , deepin-wayland-protocols
 , qttools
@@ -26,6 +27,7 @@ stdenv.mkDerivation rec {
     cmake
     extra-cmake-modules
     qttools
+    wayland-scanner
   ];
 
   buildInputs = [

--- a/pkgs/desktops/enlightenment/efl/default.nix
+++ b/pkgs/desktops/enlightenment/efl/default.nix
@@ -50,6 +50,7 @@
 , util-linux
 , wayland
 , wayland-protocols
+, wayland-scanner
 , writeText
 , xorg
 , zlib
@@ -71,6 +72,7 @@ stdenv.mkDerivation rec {
     gtk3
     pkg-config
     check
+    wayland-scanner
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome/core/mutter/43/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/43/default.nix
@@ -37,6 +37,7 @@
 , gnome-settings-daemon
 , xorgserver
 , python3
+, wayland-scanner
 , wrapGAppsHook3
 , gi-docgen
 , sysprof
@@ -111,6 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
     xvfb-run
     pkg-config
     python3
+    wayland-scanner
     wrapGAppsHook3
     gi-docgen
     xorgserver

--- a/pkgs/desktops/gnome/core/mutter/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/default.nix
@@ -53,6 +53,7 @@
 , gnome-settings-daemon
 , xorgserver
 , python3
+, wayland-scanner
 , wrapGAppsHook4
 , gi-docgen
 , sysprof
@@ -103,6 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
     xvfb-run
     pkg-config
     python3
+    wayland-scanner
     wrapGAppsHook4
     gi-docgen
     xorgserver

--- a/pkgs/desktops/plasma-5/kscreenlocker.nix
+++ b/pkgs/desktops/plasma-5/kscreenlocker.nix
@@ -1,6 +1,7 @@
 { mkDerivation
 , extra-cmake-modules
 , kdoctools
+, wayland-scanner
 , kcmutils
 , kcrash
 , kdeclarative
@@ -19,7 +20,7 @@
 
 mkDerivation {
   pname = "kscreenlocker";
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ extra-cmake-modules kdoctools wayland-scanner ];
   buildInputs = [
     kcmutils
     kcrash

--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -2,6 +2,7 @@
 , lib
 , extra-cmake-modules
 , kdoctools
+, wayland-scanner
 , fetchpatch
 , libepoxy
 , lcms2
@@ -61,7 +62,7 @@
 
 mkDerivation {
   pname = "kwin";
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ extra-cmake-modules kdoctools wayland-scanner ];
   buildInputs = [
     libepoxy
     lcms2

--- a/pkgs/desktops/plasma-5/plasma-integration/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-integration/default.nix
@@ -1,5 +1,6 @@
 { mkDerivation
 , extra-cmake-modules
+, wayland-scanner
 , breeze-qt5
 , kconfig
 , kconfigwidgets
@@ -18,7 +19,7 @@
 
 mkDerivation {
   pname = "plasma-integration";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ extra-cmake-modules wayland-scanner ];
   buildInputs = [
     breeze-qt5
     kconfig

--- a/pkgs/desktops/plasma-5/plasma-remotecontrollers.nix
+++ b/pkgs/desktops/plasma-5/plasma-remotecontrollers.nix
@@ -11,6 +11,7 @@
 , kscreenlocker
 , kwindowsystem
 , wayland
+, wayland-scanner
 , pkg-config
 , libcec
 , libcec_platform
@@ -20,7 +21,7 @@
 }:
 mkDerivation {
   pname = "plasma-remotecontrollers";
-  nativeBuildInputs = [ extra-cmake-modules pkg-config ];
+  nativeBuildInputs = [ extra-cmake-modules pkg-config wayland-scanner ];
   buildInputs = [
     kconfig
     knotifications

--- a/pkgs/desktops/plasma-5/plasma-workspace/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-workspace/default.nix
@@ -2,6 +2,7 @@
 , lib
 , extra-cmake-modules
 , kdoctools
+, wayland-scanner
 , isocodes
 , libdbusmenu
 , libSM
@@ -74,7 +75,7 @@ mkDerivation {
   pname = "plasma-workspace";
   passthru.providedSessions = [ "plasma" "plasmawayland" ];
 
-  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  nativeBuildInputs = [ extra-cmake-modules kdoctools wayland-scanner ];
   buildInputs = [
     isocodes
     libdbusmenu

--- a/pkgs/desktops/plasma-5/xdg-desktop-portal-kde.nix
+++ b/pkgs/desktops/plasma-5/xdg-desktop-portal-kde.nix
@@ -2,6 +2,7 @@
 , extra-cmake-modules
 , gettext
 , kdoctools
+, wayland-scanner
 , cups
 , libepoxy
 , mesa
@@ -25,7 +26,7 @@
 
 mkDerivation {
   pname = "xdg-desktop-portal-kde";
-  nativeBuildInputs = [ extra-cmake-modules gettext kdoctools ];
+  nativeBuildInputs = [ extra-cmake-modules gettext kdoctools wayland-scanner ];
   buildInputs = [
     cups
     libepoxy

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -11,6 +11,7 @@
 , orc
 , gstreamer
 , gobject-introspection
+, wayland-scanner
 , enableZbar ? false
 , faacSupport ? false
 , faac
@@ -142,7 +143,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals enableDocumentation [
     hotdoc
   ] ++ lib.optionals (gst-plugins-base.waylandEnabled && stdenv.isLinux) [
-    wayland # for wayland-scanner
+    wayland-scanner
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -26,6 +26,7 @@
 , libXv
 , libdrm
 , enableWayland ? stdenv.isLinux
+, wayland-scanner
 , wayland
 , wayland-protocols
 , enableAlsa ? stdenv.isLinux
@@ -76,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals enableDocumentation [
     hotdoc
   ] ++ lib.optionals enableWayland [
-    wayland
+    wayland-scanner
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/gtk-layer-shell/default.nix
+++ b/pkgs/development/libraries/gtk-layer-shell/default.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     gtk-doc
     docbook-xsl-nons
     docbook_xml_dtd_43
+    wayland-scanner
     vala
     wayland-scanner
   ];

--- a/pkgs/development/libraries/intel-vaapi-driver/default.nix
+++ b/pkgs/development/libraries/intel-vaapi-driver/default.nix
@@ -1,7 +1,8 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, gnum4, pkg-config, python3
-, intel-gpu-tools, libdrm, libva
+{ lib, stdenv, fetchFromGitHub
+, autoreconfHook, gnum4, pkg-config, python3, wayland-scanner
+, intel-gpu-tools, libdrm, libva, libX11, libGL, wayland, libXext
 , enableHybridCodec ? false, vaapi-intel-hybrid
-, enableGui ? true, libX11, libGL, wayland, libXext
+, enableGui ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -27,7 +28,9 @@ stdenv.mkDerivation rec {
     (lib.enableFeature enableGui "wayland")
   ] ++ lib.optional enableHybridCodec "--enable-hybrid-codec";
 
-  nativeBuildInputs = [ autoreconfHook gnum4 pkg-config python3 ];
+  nativeBuildInputs = [
+    autoreconfHook gnum4 pkg-config python3 wayland-scanner
+  ];
 
   buildInputs = [ intel-gpu-tools libdrm libva ]
     ++ lib.optionals enableGui [ libX11 libXext libGL wayland ]

--- a/pkgs/development/libraries/kde-frameworks/kguiaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kguiaddons.nix
@@ -1,12 +1,12 @@
 { mkDerivation
-, extra-cmake-modules
+, extra-cmake-modules, wayland-scanner
 , qtbase, qtx11extras, wayland, plasma-wayland-protocols
 }:
 
 mkDerivation {
   pname = "kguiaddons";
 
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ extra-cmake-modules wayland-scanner ];
   buildInputs = [ qtx11extras wayland plasma-wayland-protocols ];
   propagatedBuildInputs = [ qtbase ];
 

--- a/pkgs/development/libraries/kde-frameworks/kidletime.nix
+++ b/pkgs/development/libraries/kde-frameworks/kidletime.nix
@@ -1,13 +1,12 @@
-{
-  mkDerivation,
-  extra-cmake-modules,
-  qtbase, qtx11extras,
-  wayland, wayland-protocols, plasma-wayland-protocols
+{ mkDerivation
+, extra-cmake-modules, wayland-scanner
+, qtbase, qtx11extras
+, wayland, wayland-protocols, plasma-wayland-protocols
 }:
 
 mkDerivation {
   pname = "kidletime";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ extra-cmake-modules wayland-scanner ];
   buildInputs = [ qtx11extras wayland wayland-protocols plasma-wayland-protocols ];
   propagatedBuildInputs = [ qtbase ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kwayland.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwayland.nix
@@ -1,12 +1,12 @@
 {
   mkDerivation, propagateBin, lib,
-  extra-cmake-modules,
+  extra-cmake-modules, wayland-scanner,
   plasma-wayland-protocols, qtbase, wayland, wayland-protocols
 }:
 
 mkDerivation {
   pname = "kwayland";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ extra-cmake-modules wayland-scanner ];
   buildInputs = [ plasma-wayland-protocols wayland wayland-protocols ];
   propagatedBuildInputs = [ qtbase ];
   setupHook = propagateBin; # XDG_CONFIG_DIRS

--- a/pkgs/development/libraries/libwpe/fdo.nix
+++ b/pkgs/development/libraries/libwpe/fdo.nix
@@ -4,6 +4,7 @@
 , meson
 , pkg-config
 , ninja
+, wayland-scanner
 , wayland
 , libepoxy
 , glib
@@ -30,7 +31,7 @@ stdenv.mkDerivation rec {
     pkg-config
     meson
     ninja
-    wayland
+    wayland-scanner
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/waffle/default.nix
+++ b/pkgs/development/libraries/waffle/default.nix
@@ -11,7 +11,7 @@
 , pkg-config
 , python3
 , x11Support ? true, libxcb, libX11
-, waylandSupport ? true, wayland, wayland-protocols
+, waylandSupport ? true, wayland, wayland-protocols, wayland-scanner
 , useGbm ? true, mesa, udev
 }:
 
@@ -43,6 +43,8 @@ stdenv.mkDerivation rec {
     mesa
   ];
 
+  depsBuildBuild = [ pkg-config ];
+
   dontUseCmakeConfigure = true;
 
   nativeBuildInputs = [
@@ -52,6 +54,8 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
+  ] ++ lib.optionals waylandSupport [
+    wayland-scanner
   ];
 
   PKG_CONFIG_BASH_COMPLETION_COMPLETIONSDIR= "${placeholder "out"}/share/bash-completion/completions";

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -5,13 +5,10 @@
 , pkg-config
 , ninja
 , wayland-scanner
-, expat
-, libxml2
-, withLibraries ? stdenv.isLinux || stdenv.isDarwin
 , withTests ? stdenv.isLinux
 , libffi
 , epoll-shim
-, withDocumentation ? withLibraries && stdenv.hostPlatform == stdenv.buildPlatform
+, withDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform
 , graphviz-nox
 , doxygen
 , libxslt
@@ -23,15 +20,6 @@
 , testers
 }:
 
-# Documentation is only built when building libraries.
-assert withDocumentation -> withLibraries;
-
-# Tests are only built when building libraries.
-assert withTests -> withLibraries;
-
-let
-  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayland";
   version = "1.23.0";
@@ -53,13 +41,13 @@ stdenv.mkDerivation (finalAttrs: {
     sed -i '/os-wrappers-test/d' tests/meson.build
   '';
 
-  outputs = [ "out" "bin" "dev" ] ++ lib.optionals withDocumentation [ "doc" "man" ];
+  outputs = [ "out" "dev" ] ++ lib.optionals withDocumentation [ "doc" "man" ];
   separateDebugInfo = true;
 
   mesonFlags = [
-    "-Ddocumentation=${lib.boolToString withDocumentation}"
-    "-Dlibraries=${lib.boolToString withLibraries}"
-    "-Dtests=${lib.boolToString withTests}"
+    (lib.mesonBool "documentation" withDocumentation)
+    (lib.mesonBool "tests" withTests)
+    (lib.mesonBool "scanner" false) # wayland-scanner is a separate derivation
   ];
 
   depsBuildBuild = [
@@ -70,7 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     pkg-config
     ninja
-  ] ++ lib.optionals isCross [
     wayland-scanner
   ] ++ lib.optionals withDocumentation [
     (graphviz-nox.override { pango = null; }) # To avoid an infinite recursion
@@ -83,11 +70,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    expat
-    libxml2
-  ] ++ lib.optionals withLibraries [
     libffi
-  ] ++ lib.optionals (withLibraries && !stdenv.hostPlatform.isLinux) [
+  ] ++ lib.optionals (!stdenv.hostPlatform.isLinux) [
     epoll-shim
   ] ++ lib.optionals withDocumentation [
     docbook_xsl
@@ -95,20 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     docbook_xml_dtd_42
   ];
 
-  postFixup = ''
-    # The pkg-config file is required for cross-compilation:
-    mkdir -p $bin/lib/pkgconfig/
-    cat <<EOF > $bin/lib/pkgconfig/wayland-scanner.pc
-    wayland_scanner=$bin/bin/wayland-scanner
-
-    Name: Wayland Scanner
-    Description: Wayland scanner
-    Version: ${finalAttrs.version}
-    EOF
-  '';
-
   passthru = {
-    inherit withLibraries;
     tests.pkg-config = testers.hasPkgConfigModules {
       package = finalAttrs.finalPackage;
     };
@@ -130,8 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = platforms.unix;
     maintainers = with maintainers; [ primeos codyopel qyliss ];
     pkgConfigModules = [
-      "wayland-scanner"
-    ] ++ lib.optionals withLibraries [
       "wayland-client"
       "wayland-cursor"
       "wayland-egl"

--- a/pkgs/development/libraries/wayland/protocols.nix
+++ b/pkgs/development/libraries/wayland/protocols.nix
@@ -8,8 +8,9 @@ stdenv.mkDerivation rec {
   pname = "wayland-protocols";
   version = "1.36";
 
+  doCheck = stdenv.hostPlatform == stdenv.buildPlatform &&
   # https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/48
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform && stdenv.hostPlatform.linker == "bfd" && wayland.withLibraries;
+  stdenv.hostPlatform.linker == "bfd" && lib.meta.availableOn stdenv.hostPlatform wayland;
 
   src = fetchurl {
     url = "https://gitlab.freedesktop.org/wayland/${pname}/-/releases/${version}/downloads/${pname}-${version}.tar.xz";
@@ -22,7 +23,8 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [ meson ninja wayland-scanner ];
-  nativeCheckInputs = [ python3 wayland ];
+  nativeCheckInputs = [ python3 ];
+  checkInputs = [ wayland ];
 
   mesonFlags = [ "-Dtests=${lib.boolToString doCheck}" ];
 

--- a/pkgs/development/libraries/wayland/scanner.nix
+++ b/pkgs/development/libraries/wayland/scanner.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     inherit (wayland.meta) homepage license maintainers;
+    mainProgram = "wayland-scanner";
     description = "C code generator for Wayland protocol XML files";
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/wayland/scanner.nix
+++ b/pkgs/development/libraries/wayland/scanner.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  wayland,
+  meson,
+  pkg-config,
+  ninja,
+  wayland-scanner,
+  expat,
+  libxml2,
+}:
+
+stdenv.mkDerivation {
+  pname = "wayland-scanner";
+  inherit (wayland) version src;
+
+  outputs = [
+    "out"
+    "bin"
+    "dev"
+  ];
+  separateDebugInfo = true;
+
+  mesonFlags = [
+    (lib.mesonBool "documentation" false)
+    (lib.mesonBool "libraries" false)
+    (lib.mesonBool "tests" false)
+  ];
+
+  depsBuildBuild = [ pkg-config ];
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) wayland-scanner;
+
+  buildInputs = [
+    expat
+    libxml2
+  ];
+
+  meta = with lib; {
+    inherit (wayland.meta) homepage license maintainers;
+    description = "C code generator for Wayland protocol XML files";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/pywayland/default.nix
+++ b/pkgs/development/python-modules/pywayland/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   };
 
   depsBuildBuild = [ pkg-config ];
-  nativeBuildInputs = [ pkg-config wayland-scanner ];
+  nativeBuildInputs = [ wayland-scanner ];
   propagatedNativeBuildInputs = [ cffi ];
   buildInputs = [ wayland ];
   propagatedBuildInputs = [ cffi ];

--- a/pkgs/development/python-modules/pywayland/default.nix
+++ b/pkgs/development/python-modules/pywayland/default.nix
@@ -6,6 +6,7 @@
   cffi,
   pkg-config,
   wayland,
+  wayland-scanner,
   pytestCheckHook,
 }:
 
@@ -19,7 +20,8 @@ buildPythonPackage rec {
     hash = "sha256-WYreAng6rQWjKPZjtRtpTFq2i9XR4JJsDaPFISxWZTM=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  depsBuildBuild = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config wayland-scanner ];
   propagatedNativeBuildInputs = [ cffi ];
   buildInputs = [ wayland ];
   propagatedBuildInputs = [ cffi ];

--- a/pkgs/tools/graphics/mesa-demos/default.nix
+++ b/pkgs/tools/graphics/mesa-demos/default.nix
@@ -28,8 +28,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-MEaj0mp7BRr3690lel8jv+sWDK1u2VIynN/x6fHtSWs=";
   };
 
-  strictDeps = true;
-
   depsBuildBuild = [
     pkg-config
   ];
@@ -57,9 +55,10 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dwith-system-data-files=true"
-    "-Dgles1=disabled"
-    "-Dosmesa=disabled"
+    "-Degl=${if stdenv.isDarwin then "disabled" else "auto"}"
+    (lib.mesonEnable "libdrm" (stdenv.isLinux))
+    (lib.mesonEnable "osmesa" (mesa ? osmesa))
+    (lib.mesonEnable "wayland" (lib.meta.availableOn stdenv.hostPlatform wayland))
   ];
 
   meta = with lib; {

--- a/pkgs/tools/graphics/vulkan-cts/default.nix
+++ b/pkgs/tools/graphics/vulkan-cts/default.nix
@@ -91,6 +91,10 @@ stdenv.mkDerivation (finalAttrs: {
     wayland-scanner
   ];
 
+  depsBuildBuild = [
+    pkg-config
+  ];
+
   cmakeFlags = [
     # Fix cts cmake not coping with absolute install dirs
     "-DCMAKE_INSTALL_BINDIR=bin"

--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
 
   dontPatchELF = true;
 
-  env.PKG_CONFIG_WAYLAND_SCANNER_WAYLAND_SCANNER = "${lib.getBin buildPackages.wayland-scanner}/bin/wayland-scanner";
+  env.PKG_CONFIG_WAYLAND_SCANNER_WAYLAND_SCANNER = lib.getExe buildPackages.wayland-scanner;
 
   cmakeFlags = [
     # Don't build the mock ICD as it may get used instead of other drivers, if installed

--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -17,6 +17,7 @@
 , vulkan-volk
 , wayland
 , wayland-protocols
+, wayland-scanner
 , moltenvk
 , AppKit
 , Cocoa
@@ -53,6 +54,7 @@ stdenv.mkDerivation rec {
     libXrandr
     wayland
     wayland-protocols
+    wayland-scanner
   ] ++ lib.optionals stdenv.isDarwin [
     moltenvk
     moltenvk.dev
@@ -64,14 +66,13 @@ stdenv.mkDerivation rec {
 
   dontPatchELF = true;
 
-  env.PKG_CONFIG_WAYLAND_SCANNER_WAYLAND_SCANNER="${buildPackages.wayland-scanner}/bin/wayland-scanner";
+  env.PKG_CONFIG_WAYLAND_SCANNER_WAYLAND_SCANNER = "${lib.getBin buildPackages.wayland-scanner}/bin/wayland-scanner";
 
   cmakeFlags = [
     # Don't build the mock ICD as it may get used instead of other drivers, if installed
     "-DBUILD_ICD=OFF"
     # vulkaninfo loads libvulkan using dlopen, so we have to add it manually to RPATH
     "-DCMAKE_INSTALL_RPATH=${libraryPath}"
-    "-DPKG_CONFIG_EXECUTABLE=${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config"
     "-DGLSLANG_INSTALL_DIR=${glslang}"
     # Hide dev warnings that are useless for packaging
     "-Wno-dev"

--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -5,6 +5,7 @@
 , pkg-config
 , cmake
 , extra-cmake-modules
+, wayland-scanner
 , cairo
 , pango
 , expat
@@ -60,6 +61,7 @@ stdenv.mkDerivation rec {
     cmake
     extra-cmake-modules
     pkg-config
+    wayland-scanner
   ];
 
   buildInputs = [

--- a/pkgs/tools/wayland/way-displays/default.nix
+++ b/pkgs/tools/wayland/way-displays/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , pkg-config
+, wayland-scanner
 , wayland
 , libinput
 , yaml-cpp
@@ -20,9 +21,13 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
+  depsBuildBuild = [
+    pkg-config
+  ];
+
   nativeBuildInputs = [
     pkg-config
-    wayland
+    wayland-scanner
   ];
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24271,7 +24271,7 @@ with pkgs;
   wavpack = callPackage ../development/libraries/wavpack { };
 
   wayland = darwin.apple_sdk_11_0.callPackage ../development/libraries/wayland { };
-  wayland-scanner = wayland.bin;
+  wayland-scanner = callPackage ../development/libraries/wayland/scanner.nix { };
 
   wayland-protocols = callPackage ../development/libraries/wayland/protocols.nix { };
 


### PR DESCRIPTION
###### Description of changes

We've used a `wayland-scanner = wayland.bin` alias for ages, to make packages clearer and allow them to be independently overridden. Going the whole way into splitting them into separate packages is useful because it means we can have different meta.platforms attributes for libwayland and wayland-scanner.

There is no duplication in outputs between the two packages — they don't install any files in common.

Draft because I'm going to need to test the downstream packages and make sure none were relying on pulling wayland-scanner from the wayland attribute.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
