### PR TITLE
bambootracker: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -3,12 +3,15 @@
 , fetchFromGitHub
 , pkg-config
 , qmake
+, qt5compat ? null
 , qtbase
 , qttools
 , rtaudio
 , rtmidi
 , wrapQtAppsHook
 }:
+
+assert lib.versionAtLeast qtbase.version "6.0" -> qt5compat != null;
 
 stdenv.mkDerivation rec {
   pname = "bambootracker";
@@ -22,6 +25,13 @@ stdenv.mkDerivation rec {
     hash = "sha256-Ymi1tjJCgStF0Rtseelq/YuTtBs2PrbF898TlbjyYUw=";
   };
 
+  postPatch = lib.optionalString (lib.versionAtLeast qtbase.version "6.0") ''
+    # Work around lrelease finding in qmake being broken by using pre-Qt5.12 code path
+    # https://github.com/NixOS/nixpkgs/issues/214765
+    substituteInPlace BambooTracker/lang/lang.pri \
+      --replace 'equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 12)' 'if(true)'
+  '';
+
   nativeBuildInputs = [
     pkg-config
     qmake
@@ -33,6 +43,8 @@ stdenv.mkDerivation rec {
     qtbase
     rtaudio
     rtmidi
+  ] ++ lib.optionals (lib.versionAtLeast qtbase.version "6.0") [
+    qt5compat
   ];
 
   qmakeFlags = [

--- a/pkgs/applications/audio/bambootracker/default.nix
+++ b/pkgs/applications/audio/bambootracker/default.nix
@@ -1,39 +1,55 @@
-{ mkDerivation
-, stdenv
+{ stdenv
 , lib
 , fetchFromGitHub
-, qmake
 , pkg-config
-, qttools
+, qmake
 , qtbase
+, qttools
 , rtaudio
 , rtmidi
+, wrapQtAppsHook
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "bambootracker";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "BambooTracker";
     repo = "BambooTracker";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-yubaKTc8NFLxMY0/5c2VubRHgAGOsRlitmXJ1UHzl60=";
+    hash = "sha256-Ymi1tjJCgStF0Rtseelq/YuTtBs2PrbF898TlbjyYUw=";
   };
 
-  nativeBuildInputs = [ qmake qttools pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    qmake
+    qttools
+    wrapQtAppsHook
+  ];
 
-  buildInputs = [ qtbase rtaudio rtmidi ];
+  buildInputs = [
+    qtbase
+    rtaudio
+    rtmidi
+  ];
 
-  qmakeFlags = [ "CONFIG+=system_rtaudio" "CONFIG+=system_rtmidi" ];
+  qmakeFlags = [
+    "CONFIG+=system_rtaudio"
+    "CONFIG+=system_rtmidi"
+  ];
 
   postConfigure = "make qmake_all";
+
+  # Wrapping the inside of the app bundles, avoiding double-wrapping
+  dontWrapQtApps = stdenv.hostPlatform.isDarwin;
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/Applications
     mv $out/{bin,Applications}/BambooTracker.app
     ln -s $out/{Applications/BambooTracker.app/Contents/MacOS,bin}/BambooTracker
+    wrapQtApp $out/Applications/BambooTracker.app/Contents/MacOS/BambooTracker
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28238,6 +28238,12 @@ with pkgs;
     else
       stdenv;
   };
+  bambootracker-qt6 = qt6Packages.callPackage ../applications/audio/bambootracker {
+    stdenv = if stdenv.hostPlatform.isDarwin then
+      darwin.apple_sdk_11_0.stdenv
+    else
+      stdenv;
+  };
 
   blocky = callPackage ../applications/networking/blocky { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28232,7 +28232,12 @@ with pkgs;
 
   azpainter = callPackage ../applications/graphics/azpainter { };
 
-  bambootracker = libsForQt5.callPackage ../applications/audio/bambootracker { };
+  bambootracker = libsForQt5.callPackage ../applications/audio/bambootracker {
+    stdenv = if stdenv.hostPlatform.isDarwin then
+      darwin.apple_sdk_11_0.stdenv
+    else
+      stdenv;
+  };
 
   blocky = callPackage ../applications/networking/blocky { };
 


### PR DESCRIPTION
###### Description of changes
Struggling with Darwin:

1. All Qt5 applications are currently failing to launch on my system.
```
qt.qpa.plugin: Could not load the Qt platform plugin "cocoa" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: cocoa, minimal, offscreen.

Abort trap: 6
```

2. I tried to migrate this to `stdenv.mkDerivation` which would also allow a Qt6 variant, but that causes the build to fail:
```
In file included from audio/audio_stream_rtaudio.cpp:29:
In file included from /nix/store/b1d9agnhl0p5fp298yz0hkxx9s75rnlf-rtaudio-5.2.0/include/rtaudio/RtAudio.h:877:
In file included from /nix/store/nzg19z5bqikz64k8z6wy16yia0wc7p0l-apple-framework-CoreAudio-11.0.0/Library/Frameworks/CoreAudio.framework/Headers/AudioHardware.h:86:
In file included from /nix/store/57giqsy5k5gcrz7gvyaik91izgj0n3z1-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/CoreFoundation.framework/Headers/CoreFoundation.h:60:
In file included from /nix/store/57giqsy5k5gcrz7gvyaik91izgj0n3z1-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/CoreFoundation.framework/Headers/CFPropertyList.h:17:
In file included from /nix/store/57giqsy5k5gcrz7gvyaik91izgj0n3z1-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/CoreFoundation.framework/Headers/CFStream.h:16:
/nix/store/57giqsy5k5gcrz7gvyaik91izgj0n3z1-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/CoreFoundation.framework/Headers/CFURL.h:1189:83: error: expected ','
    kCFURLBookmarkCreationWithSecurityScope API_AVAILABLE(macos(10.7), macCatalyst(13.0))  API_UNAVAILABLE(ios, watchos, tvos) = ( 1UL << 11 ), // Mac OS X 10.7.3 and later, include information in the bookmark data which allows the same sandboxed process to access the resource after being relaunched
                                                                                  ^
/nix/store/57giqsy5k5gcrz7gvyaik91izgj0n3z1-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/CoreFoundation.framework/Headers/CFURL.h:1190:98: error: expected ','
    kCFURLBookmarkCreationSecurityScopeAllowOnlyReadAccess API_AVAILABLE(macos(10.7), macCatalyst(13.0)) API_UNAVAILABLE(ios, watchos, tvos) = ( 1UL << 12 ), // Mac OS X 10.7.3 and later, if used with kCFURLBookmarkCreationWithSecurityScope, at resolution time only read access to the resource will be granted
                                                                                                 ^
/nix/store/57giqsy5k5gcrz7gvyaik91izgj0n3z1-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/CoreFoundation.framework/Headers/CFURL.h:1200:85: error: expected ','
    kCFURLBookmarkResolutionWithSecurityScope API_AVAILABLE(macos(10.7), macCatalyst(13.0)) API_UNAVAILABLE(ios, watchos, tvos) = ( 1UL << 10 ), // Mac OS X 10.7.3 and later, use the secure information included at creation time to provide the ability to access the resource in a sandboxed process.
                                                                                    ^
3 errors generated.
make[1]: *** [Makefile:4186: audio_stream_rtaudio.o] Error 1
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
