### PR TITLE
obs-studio-plugins.obs-vaapi: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-vaapi/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-vaapi/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "obs-vaapi";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "fzwoch";
     repo = pname;
     rev = version;
-    hash = "sha256-qA4xVVShkp40QHp2HmmRzVxQaBwskRpUNEULKetVMu8=";
+    hash = "sha256-wrbVuqIe+DY3R+Jp3zCy2Uw3fv5ejYHtRV2Sv+y/n0w=";
   };
 
   nativeBuildInputs = [ pkg-config meson ninja ];
@@ -38,6 +38,12 @@ stdenv.mkDerivation rec {
       gst-plugins-bad
       gst-vaapi
     ];
+
+  # Fix output directory
+  postInstall = ''
+    mkdir $out/lib/obs-plugins
+    mv $out/lib/obs-vaapi.so $out/lib/obs-plugins/
+  '';
 
   meta = with lib; {
     description = "OBS Studio VAAPI support via GStreamer";


### PR DESCRIPTION
###### Description of changes

- Bump to latest version:

> - Support for new VA plugins from GStreamer 1.22.
> - Previous encoders are labeled "Legacy", but are still select-able.
> - Support for low power encoder variants (by kode54).
> - Support for AV1 encoder (AV1 is WIP by upstream, expected to hit in the next GStreamer > cycle).
> - Support for more input color formats.
> - Much more informative logging all over the place.
> - Probably other small fixes and hiccups.
> 
> Starting with this version the minimum required OBS version is now v28.
> 
> Note that the default install path has changed to the user's home directory. If you want a system wide install, use Meson's --prefix and --libdir options accordingly.

Source: https://github.com/fzwoch/obs-vaapi/releases/tag/0.2.0

- The new fix is mentioned in the changelog's "Note".

- Current nixpkgs' master still don't offer gstreamer 1.22 (we have 1.20), but this does not block this bump since obs-vaapi shows the old ones as "(Legacy)" (and don't offer the new ones to us)

###### Things done

Tested building and `wrapOBS`.

![screenshot](https://user-images.githubusercontent.com/1368952/216961231-1e0fd0a3-f09b-427c-8658-e0d163f9b406.png)


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).