### PR TITLE
meep: init at 1.25.0

### DIFF
--- a/pkgs/development/libraries/science/chemistry/harminv/default.nix
+++ b/pkgs/development/libraries/science/chemistry/harminv/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, gfortran
+, blas
+, lapack
+}:
+
+assert !blas.isILP64;
+assert !lapack.isILP64;
+
+stdenv.mkDerivation rec {
+  pname = "harminv";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "NanoComp";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-EXEt7l69etcBdDdEDlD1ODOdhTBZCVjgY1jhRUDd/W0=";
+  };
+
+  # File is missing in the git checkout but required by autotools
+  postPatch = ''
+    touch ChangeLog
+  '';
+
+  nativeBuildInputs = [ autoreconfHook gfortran ];
+
+  buildInputs = [ blas lapack ];
+
+  configureFlags = [ "--enable-shared" ];
+
+  meta = with lib; {
+    description = "Harmonic inversion algorithm of Mandelshtam: decompose signal into sum of decaying sinusoids";
+    homepage = "https://github.com/NanoComp/harminv";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ sheepforce markuskowa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/science/chemistry/libGDSII/default.nix
+++ b/pkgs/development/libraries/science/chemistry/libGDSII/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libGDSII";
+  version = "0.21";
+
+  src = fetchFromGitHub {
+    owner = "HomerReid";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-EXEt7l69etcBdDdEDlD1ODOdhTBZCVjgY1jhRUDd/W0=";
+  };
+
+  # File is missing in the repo but automake requires it
+  postPatch = ''
+    touch ChangeLog
+  '';
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with lib; {
+    description = "Library and command-line utility for reading GDSII geometry files";
+    homepage = "https://github.com/HomerReid/libGDSII";
+    license = [ licenses.gpl2Only ];
+    maintainers = with maintainers; [ sheepforce markuskowa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/meep/default.nix
+++ b/pkgs/development/python-modules/meep/default.nix
@@ -1,0 +1,151 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, gfortran
+, mpi
+, blas
+, lapack
+, fftw
+, hdf5-mpi
+, swig
+, gsl
+, harminv
+, libctl
+, libGDSII
+, openssh
+, guile
+, python
+, numpy
+, scipy
+, matplotlib
+, h5py-mpi
+, cython
+, autograd
+, mpi4py
+}:
+
+assert !blas.isILP64;
+assert !lapack.isILP64;
+
+buildPythonPackage rec {
+  pname = "meep";
+  version = "1.25.0";
+
+  src = fetchFromGitHub {
+    owner = "NanoComp";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-4rIz2RXLSWzZbRuv8d4nidOa0ULYc4QHIdaYrGu1WkI=";
+  };
+
+  format = "other";
+
+  # MPI is needed in nativeBuildInputs too, otherwise MPI libs will be missing
+  # at runtime
+  nativeBuildInputs = [
+    autoreconfHook
+    gfortran
+    pkg-config
+    swig
+    mpi
+  ];
+
+  buildInputs = [
+    gsl
+    blas
+    lapack
+    fftw
+    hdf5-mpi
+    harminv
+    libctl
+    libGDSII
+    guile
+    gsl
+  ];
+
+  propagatedBuildInputs = [
+    mpi
+    numpy
+    scipy
+    matplotlib
+    h5py-mpi
+    cython
+    autograd
+    mpi4py
+  ];
+
+  propagatedUserEnvPkgs = [ mpi ];
+
+  dontUseSetuptoolsBuild = true;
+  dontUsePipInstall = true;
+  dontUseSetuptoolsCheck = true;
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    export HDF5_MPI=ON
+    export PYTHON=${python}/bin/${python.executable};
+  '';
+
+  configureFlags = [
+    "--without-libctl"
+    "--enable-shared"
+    "--with-mpi"
+    "--with-openmp"
+    "--enable-maintainer-mode"
+  ];
+
+  passthru = { inherit mpi; };
+
+  /*
+  This test is taken from the MEEP tutorial "Fields in a Waveguide" at
+  <https://meep.readthedocs.io/en/latest/Python_Tutorials/Basics/>.
+  It is important, that the test actually performs a calculation
+  (calls `sim.run()`), as only then MPI will be initialised and MPI linking
+  errors can be caught.
+  */
+  doCheck = true;
+  checkPhase = ''
+    export PATH=$PATH:${openssh}/bin
+    export PYTHONPATH="$out/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
+
+    export OMP_NUM_THREADS=1
+
+    # Fix to make mpich run in a sandbox
+    export HYDRA_IFACE=lo
+    export OMPI_MCA_rmaps_base_oversubscribe=1
+
+    # Generate a python test script
+    cat > test.py << EOF
+    import meep as mp
+    cell = mp.Vector3(16,8,0)
+    geometry = [mp.Block(mp.Vector3(mp.inf,1,mp.inf),
+                     center=mp.Vector3(),
+                     material=mp.Medium(epsilon=12))]
+    sources = [mp.Source(mp.ContinuousSource(frequency=0.15),
+                     component=mp.Ez,
+                     center=mp.Vector3(-7,0))]
+    pml_layers = [mp.PML(1.0)]
+    resolution = 10
+    sim = mp.Simulation(cell_size=cell,
+                    boundary_layers=pml_layers,
+                    geometry=geometry,
+                    sources=sources,
+                    resolution=resolution)
+    sim.run(until=200)
+    EOF
+
+    ${mpi}/bin/mpiexec -np 2 python3 test.py
+  '';
+
+  meta = with lib; {
+    description = "Free finite-difference time-domain (FDTD) software for electromagnetic simulations";
+    homepage = "https://meep.readthedocs.io/en/latest/";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sheepforce markuskowa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27322,6 +27322,8 @@ with pkgs;
 
   ledger-udev-rules = callPackage ../os-specific/linux/ledger-udev-rules {};
 
+  libGDSII = callPackage ../development/libraries/science/chemistry/libGDSII { };
+
   inherit (callPackages ../data/fonts/liberation-fonts { })
     liberation_ttf_v1
     liberation_ttf_v2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7899,6 +7899,8 @@ with pkgs;
 
   gyb = callPackage ../tools/backup/gyb { };
 
+  harminv = callPackage ../development/libraries/science/chemistry/harminv { };
+
   igrep = callPackage ../tools/text/igrep {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5804,6 +5804,8 @@ self: super: with self; {
 
   mediapy = callPackage ../development/python-modules/mediapy { };
 
+  meep = callPackage ../development/python-modules/meep { };
+
   meilisearch = callPackage ../development/python-modules/meilisearch { };
 
   meinheld = callPackage ../development/python-modules/meinheld { };


### PR DESCRIPTION
###### Description of changes

This adds the meep python package and its dependencies for simulation of electromagnetic interactions of materials. Part of the ongoing effort to upstream packages from NixOS-QChem, see https://github.com/markuskowa/NixOS-QChem/issues/146

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).