### PR TITLE
libptytty: fix cross compilation, musl (dynamic), static

### DIFF
--- a/pkgs/development/libraries/libptytty/default.nix
+++ b/pkgs/development/libraries/libptytty/default.nix
@@ -4,6 +4,12 @@
 , cmake
 }:
 
+let
+  isCross = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  isStatic = stdenv.hostPlatform.isStatic;
+  isMusl = stdenv.hostPlatform.isMusl;
+in
+
 stdenv.mkDerivation rec {
   pname = "libptytty";
   version = "2.0";
@@ -15,12 +21,24 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  cmakeFlags = lib.optional isStatic "-DBUILD_SHARED_LIBS=OFF"
+    ++ lib.optional (isCross || isStatic) "-DTTY_GID_SUPPORT=OFF"
+    # Musl lacks UTMP/WTMP built-in support
+    ++ lib.optionals isMusl [
+      "-DUTMP_SUPPORT=OFF"
+      "-DWTMP_SUPPORT=OFF"
+      "-DLASTLOG_SUPPORT=OFF"
+    ];
+
   meta = with lib; {
     description = "OS independent and secure pty/tty and utmp/wtmp/lastlog";
     homepage = "http://dist.schmorp.de/libptytty";
     maintainers = with maintainers; [ rnhmjoj ];
     platforms = platforms.unix;
     license = licenses.gpl2;
+    # pkgsMusl.pkgsStatic errors as:
+    #   ln: failed to create symbolic link './include': File exists
+    broken = isStatic && isMusl;
   };
 
 }


### PR DESCRIPTION
libptytty
* Fix cross compilation, musl (dynamic), static
* Marks broken Musl Static.

Note:
* This PR is targets staging because `libuv` is broken at master but fixed at staging.
* This is an inner dependency of terminal `rxvt-unicode`.