### PR TITLE
wxmacmolplt: init at 7.7.2

### DIFF
--- a/pkgs/applications/science/chemistry/wxmacmolplt/default.nix
+++ b/pkgs/applications/science/chemistry/wxmacmolplt/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, wxGTK32
+, libGL
+, libGLU
+, pkg-config
+, xorg
+, autoreconfHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wxmacmolplt";
+  version = "7.7.2";
+
+  src = fetchFromGitHub {
+    owner = "brettbode";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-sNxCjIEJUrDWtcUqBQqvanNfgNQ7T4cabYy+x9D1U+Q=";
+  };
+
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+  buildInputs = [
+    wxGTK32
+    libGL
+    libGLU
+    xorg.libX11
+    xorg.libX11.dev
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Graphical user inteface for GAMESS-US";
+    homepage = "https://brettbode.github.io/wxmacmolplt/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sheepforce markuskowa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36043,6 +36043,8 @@ with pkgs;
 
   siesta-mpi = callPackage ../applications/science/chemistry/siesta { useMpi = true; };
 
+  wxmacmolplt = callPackage ../applications/science/chemistry/wxmacmolplt { };
+
   ### SCIENCE/GEOMETRY
 
   antiprism = callPackage ../applications/science/geometry/antiprism { };


### PR DESCRIPTION
###### Description of changes

Adds the wxMacMolPlt programme, a GUI for quantum chemistry programmes, mainly GAMESS-US. Part of the ongoing effort to upstream packages from NixOS-QChem, see https://github.com/markuskowa/NixOS-QChem/issues/146

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).