### PR TITLE
_9base: init at unstable-2019-09-11

### DIFF
--- a/pkgs/by-name/_9/_9base/config-substitutions.patch
+++ b/pkgs/by-name/_9/_9base/config-substitutions.patch
@@ -1,0 +1,56 @@
+diff --git a/config.mk b/config.mk
+index 1ebfd49..ec076b3 100644
+--- a/config.mk
++++ b/config.mk
+@@ -1,25 +1,17 @@
+ # Customize to fit your system
+
+ # paths
+-PREFIX      = /usr/local/plan9
+ MANPREFIX   = ${PREFIX}/share/man
+
+ VERSION     = 7
+-OBJTYPE     = 386
+-#OBJTYPE     = arm
+-#OBJTYPE     = x86_64
+-#OBJTYPE     = sun4u
+
+ # Linux/BSD
+ #CFLAGS      += -Wall -Wno-missing-braces -Wno-parentheses -Wno-switch -c -I. -DPREFIX="\"${PREFIX}\""
+ CFLAGS      += -c -I. -DPLAN9PORT -DPREFIX="\"${PREFIX}\""
+-LDFLAGS     += -static
+
+ # Solaris
+ #CFLAGS      = -fast -xtarget=ultra -D__sun__ -c -I. -DPREFIX="\"${PREFIX}\""
+ #LDFLAGS     = -dn
+
+ # compiler
+-AR          = ar rc
+-CC          = cc
+ YACC        = ../yacc/9yacc
+diff --git a/lib9/Makefile b/lib9/Makefile
+index b83ab2b..e3744a4 100644
+--- a/lib9/Makefile
++++ b/lib9/Makefile
+@@ -221,7 +221,7 @@ uninstall:
+
+ ${LIB}: ${OFILES}
+ 	@echo AR ${TARG}
+-	@${AR} ${LIB} ${OFILES}
++	@${AR} rc ${LIB} ${OFILES}
+
+ .c.o:
+ 	@echo CC $<
+diff --git a/troff/Makefile b/troff/Makefile
+index b4e3d88..3aac6bf 100644
+--- a/troff/Makefile
++++ b/troff/Makefile
+@@ -6,7 +6,7 @@ TARG      = troff
+ OFILES    = n1.o n2.o n3.o n4.o n5.o t6.o n6.o n7.o n8.o n9.o t10.o\
+             n10.o t11.o ni.o hytab.o suftab.o dwbinit.o mbwc.o
+ MANFILES  = troff.1
+-TROFFDIR  = ${PREFIX}/lib/troff
++TROFFDIR  = ${PREFIX_TROFF}/lib/troff
+
+ include ../std.mk
+

--- a/pkgs/by-name/_9/_9base/dont-strip.patch
+++ b/pkgs/by-name/_9/_9base/dont-strip.patch
@@ -1,0 +1,12 @@
+diff --git a/sam/Makefile b/sam/Makefile
+index 17ada1f..1e9e9b8 100644
+--- a/sam/Makefile
++++ b/sam/Makefile
+@@ -10,7 +10,6 @@ MANFILES  = sam.1
+ include ../config.mk
+ 
+ all: ${TARG}
+-	@strip ${TARG}
+ 	@echo built ${TARG}
+ 
+ install: ${TARG}

--- a/pkgs/by-name/_9/_9base/getcallerpc-use-macro-or-stub.patch
+++ b/pkgs/by-name/_9/_9base/getcallerpc-use-macro-or-stub.patch
@@ -1,0 +1,115 @@
+diff --git a/lib9/Makefile b/lib9/Makefile
+index b83ab2b..2836b38 100644
+--- a/lib9/Makefile
++++ b/lib9/Makefile
+@@ -145,7 +145,7 @@ LIB9OFILES=\
+ 	exitcode.o\
+ 	fcallfmt.o\
+ 	get9root.o\
+-	getcallerpc-$(OBJTYPE).o\
++	getcallerpc.o\
+ 	getenv.o\
+ 	getfields.o\
+ 	getnetconn.o\
+diff --git a/lib9/getcallerpc-386.c b/lib9/getcallerpc-386.c
+deleted file mode 100644
+index 1367370..0000000
+--- a/lib9/getcallerpc-386.c
++++ /dev/null
+@@ -1,7 +0,0 @@
+-#include <lib9.h>
+-
+-ulong
+-getcallerpc(void *x)
+-{
+-	return (((ulong*)(x))[-1]);
+-}
+diff --git a/lib9/getcallerpc-PowerMacintosh.c b/lib9/getcallerpc-PowerMacintosh.c
+deleted file mode 100644
+index 679a72c..0000000
+--- a/lib9/getcallerpc-PowerMacintosh.c
++++ /dev/null
+@@ -1,7 +0,0 @@
+-#include <lib9.h>
+-
+-ulong
+-getcallerpc(void *x)
+-{
+-	return (((ulong*)(x))[-4]);
+-}
+diff --git a/lib9/getcallerpc-arm.c b/lib9/getcallerpc-arm.c
+deleted file mode 100644
+index 9bb4a95..0000000
+--- a/lib9/getcallerpc-arm.c
++++ /dev/null
+@@ -1,8 +0,0 @@
+-#include <lib9.h>
+-
+-ulong
+-getcallerpc(void *x)
+-{
+-	return ((ulong*)x)[-2];
+-}
+-
+diff --git a/lib9/getcallerpc-power.c b/lib9/getcallerpc-power.c
+deleted file mode 100644
+index b4bf698..0000000
+--- a/lib9/getcallerpc-power.c
++++ /dev/null
+@@ -1,11 +0,0 @@
+-#include <lib9.h>
+-
+-ulong
+-getcallerpc(void *x)
+-{
+-	ulong *lp;
+-
+-	lp = x;
+-
+-	return lp[-1];
+-}
+diff --git a/lib9/getcallerpc-ppc.c b/lib9/getcallerpc-ppc.c
+deleted file mode 100644
+index 679a72c..0000000
+--- a/lib9/getcallerpc-ppc.c
++++ /dev/null
+@@ -1,7 +0,0 @@
+-#include <lib9.h>
+-
+-ulong
+-getcallerpc(void *x)
+-{
+-	return (((ulong*)(x))[-4]);
+-}
+diff --git a/lib9/getcallerpc-x86_64.c b/lib9/getcallerpc-x86_64.c
+deleted file mode 100644
+index 1367370..0000000
+--- a/lib9/getcallerpc-x86_64.c
++++ /dev/null
+@@ -1,7 +0,0 @@
+-#include <lib9.h>
+-
+-ulong
+-getcallerpc(void *x)
+-{
+-	return (((ulong*)(x))[-1]);
+-}
+diff --git a/lib9/getcallerpc.c b/lib9/getcallerpc.c
+new file mode 100644
+index 0000000..7d2cdd7
+--- /dev/null
++++ b/lib9/getcallerpc.c
+@@ -0,0 +1,12 @@
++#include <lib9.h>
++
++/*
++ * On gcc and clang, getcallerpc is a macro invoking a compiler builtin.
++ * If the macro in libc.h did not trigger, there's no implementation.
++ */
++#undef getcallerpc
++ulong
++getcallerpc(void *v)
++{
++	return 1;
++}
+\ No newline at end of file

--- a/pkgs/by-name/_9/_9base/package.nix
+++ b/pkgs/by-name/_9/_9base/package.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, fetchgit
+, pkg-config
+, patches ? [ ]
+, pkgsBuildHost
+, enableStatic ? stdenv.hostPlatform.isStatic
+}:
+
+stdenv.mkDerivation {
+  pname = "9base";
+  version = "unstable-2019-09-11";
+
+  src = fetchgit {
+    url = "https://git.suckless.org/9base";
+    rev = "63916da7bd6d73d9a405ce83fc4ca34845667cce";
+    hash = "sha256-CNK7Ycmcl5vkmtA5VKwKxGZz8AoIG1JH/LTKoYmWSBI=";
+  };
+
+  patches = [
+    # expects to be used with getcallerpc macro or stub patch
+    # AR env var is now the location of `ar` not including the arg (`ar rc`)
+    ./config-substitutions.patch
+    ./dont-strip.patch
+    # plan9port dropped their own getcallerpc implementations
+    # in favour of using gcc/clang's macros or a stub
+    # we can do this here too to extend platform support
+    # https://github.com/9fans/plan9port/commit/540caa5873bcc3bc2a0e1896119f5b53a0e8e630
+    # https://github.com/9fans/plan9port/commit/323e1a8fac276f008e6d5146a83cbc88edeabc87
+    ./getcallerpc-use-macro-or-stub.patch
+  ] ++ patches;
+
+  # the 9yacc script needs to be executed to build other items
+  preBuild = lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    substituteInPlace ./yacc/9yacc \
+      --replace "../yacc/yacc" "${lib.getExe' pkgsBuildHost._9base "yacc"}"
+  '';
+
+  enableParallelBuilding = true;
+  strictDeps = true;
+  nativeBuildInputs = [ pkg-config ];
+  NIX_CFLAGS_COMPILE = [
+    # workaround build failure on -fno-common toolchains like upstream
+    # gcc-10. Otherwise build fails as:
+    #   ld: diffio.o:(.bss+0x16): multiple definition of `bflag'; diffdir.o:(.bss+0x6): first defined here
+    "-fcommon"
+    # hide really common warning that floods the logs:
+    #   warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
+    "-D_DEFAULT_SOURCE"
+  ];
+  LDFLAGS = lib.optionalString enableStatic "-static";
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+  installFlags = [
+    "PREFIX_TROFF=${placeholder "troff"}"
+  ];
+
+  outputs = [ "out" "man" "troff" ];
+
+  meta = with lib; {
+    homepage = "https://tools.suckless.org/9base/";
+    description = "9base is a port of various original Plan 9 tools for Unix, based on plan9port";
+    longDescription = ''
+      9base is a port of various original Plan 9 tools for Unix, based on plan9port.
+      It also contains the Plan 9 libc, libbio, libregexp, libfmt and libutf.
+      The overall SLOC is about 66kSLOC, so this userland + all libs is much smaller than, e.g. bash.
+      9base can be used to run werc instead of the full blown plan9port.
+    '';
+    license = with licenses; [ mit /* and */ lpl-102 ];
+    maintainers = with maintainers; [ jk ];
+    platforms = platforms.unix;
+    # needs additional work to support aarch64-darwin
+    # due to usage of _DARWIN_NO_64_BIT_INODE
+    broken = stdenv.isAarch64 && stdenv.isDarwin;
+  };
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The configuration is a bit of a pain and I've not really looked at the concequenses of putting troff stuff in a different output (since it's pretty huge), also I don't like this "/yacc" dir. but `rc` & `ls` works well
Thoughts welcome around those issues mentioned

```sh
λ nix bundle --bundler github:NixOS/bundlers#toDockerImage .#pkgsStatic._9base

λ docker load < 9base-static-x86_64-unknown-linux-musl-unstable-2019-09-11.tar.gz
41bf90e092c2: Loading layer [==================================================>]  10.24kB/10.24kB
7a88d4804328: Loading layer [==================================================>]  6.093MB/6.093MB
78a2a254bd17: Loading layer [==================================================>]  102.4kB/102.4kB
Loaded image: 9base-static-x86_64-unknown-linux-musl-unstable-2019-09-11:latest

λ docker run -it 9base-static-x86_64-unknown-linux-musl-unstable-2019-09-11 rc
; ls
.dockerenv
bin
dev
etc
lib
nix
nix-support
proc
sys
yacc
;
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
