### PR TITLE
mopac: init at 22.0.6

### DIFF
--- a/pkgs/applications/science/chemistry/mopac/default.nix
+++ b/pkgs/applications/science/chemistry/mopac/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, lib
+, gfortran
+, fetchFromGitHub
+, cmake
+, blas
+, lapack
+, python3Packages
+}:
+
+assert blas.isILP64 == lapack.isILP64;
+
+stdenv.mkDerivation rec {
+  pname = "mopac";
+  version = "22.0.6";
+
+  src = fetchFromGitHub {
+    owner = "openmopac";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-j4AP3tki+Ep9Pv+pDg8TwCiJvpF2j5npW3Kpat+7gGg=";
+  };
+
+  nativeBuildInputs = [ gfortran cmake ];
+
+  buildInputs = [ blas lapack ];
+
+  checkInputs = with python3Packages; [ python numpy ];
+
+  doCheck = true;
+
+  preCheck = ''
+    export OMP_NUM_THREADS=2
+  '';
+
+  meta = with lib; {
+    description = "Semiempirical quantum chemistry";
+    homepage = "https://github.com/openmopac/mopac";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sheepforce markuskowa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36021,6 +36021,8 @@ with pkgs;
 
   molden = callPackage ../applications/science/chemistry/molden { };
 
+  mopac = callPackage ../applications/science/chemistry/mopac { };
+
   octopus = callPackage ../applications/science/chemistry/octopus { };
 
   openlp = libsForQt5.callPackage ../applications/misc/openlp { };


### PR DESCRIPTION
###### Description of changes

Addition of the semiempirical quantum chemistry programme Mopac. Part of the ongoing effort to upstream packages from NixOS-QChem, see https://github.com/markuskowa/NixOS-QChem/issues/146

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
