### PR TITLE
katawa-shoujo: init at 1.3.1

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -220,6 +220,12 @@ in mkLicense lset) ({
     fullName = "Creative Commons Zero v1.0 Universal";
   };
 
+  cc-by-nc-nd-30 = {
+    spdxId = "CC-BY-NC-ND-3.0";
+    fullName = "Creative Commons Attribution Non Commercial No Derivative Works 3.0 Unported";
+    free = false;
+  };
+
   cc-by-nc-sa-20 = {
     spdxId = "CC-BY-NC-SA-2.0";
     fullName = "Creative Commons Attribution Non Commercial Share Alike 2.0";

--- a/pkgs/games/katawa-shoujo/default.nix
+++ b/pkgs/games/katawa-shoujo/default.nix
@@ -1,0 +1,163 @@
+{ stdenvNoCC
+, lib
+, fetchurl
+, autoPatchelfHook
+, freetype
+, makeWrapper
+, libGL
+, libGLU
+# Darwin cannot handle these when devendored:
+# - DYLD_LIBRARY_PATH masks system libraries with similar, differently-cased names and cause missing symbol errors
+# - symlinks cause unrelated BMP image loading to fail(?)
+, devendorImageLibs ? !stdenvNoCC.hostPlatform.isDarwin
+, libjpeg
+, libpng12
+, libX11
+, libXext
+, libXi
+, libXmu
+, runtimeShell
+, SDL_compat
+, SDL_image
+, SDL_ttf
+, undmg
+, zlib
+}:
+
+let
+  stdenv = stdenvNoCC;
+  srcDetails = rec {
+    x86_64-linux = {
+      urlSuffix = "%5blinux-x86%5d%5b18161880%5d.tar.bz2";
+      hash = "sha256-7FoFz88dWYHs2/pxkEwnmiFeeb3+slayrWknEJoAB9o=";
+    };
+    i686-linux = x86_64-linux;
+    x86_64-darwin = {
+      urlSuffix = "%5bmac%5d%5b1DFC84A6%5d.dmg";
+      hash = "sha256-Sc5BAlpJsffjcNrZ8+VU3n7G10DoqDKQn/leHDW32Y8=";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "Don't know how to fetch source for ${stdenv.hostPlatform.system}!");
+in
+stdenv.mkDerivation rec {
+  pname = "katawa-shoujo";
+  version = "1.3.1";
+
+  src = fetchurl {
+    url = "https://dl.katawa-shoujo.com/gold_${version}/%5b4ls%5d_katawa_shoujo_${version}-${srcDetails.urlSuffix}";
+    inherit (srcDetails) hash;
+  };
+
+  # fetchzip requires a custom unpackPhase to handle dmg, fetchurl cannot handle undmg producing >1 directory without this
+  sourceRoot = ".";
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    makeWrapper
+    undmg
+  ];
+
+  buildInputs = [
+    freetype
+    SDL_compat
+    zlib
+  ] ++ lib.optionals devendorImageLibs [
+    libjpeg
+    libpng12
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    libX11
+    libXext
+    libXi
+    libXmu
+    libGL
+    libGLU
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = let
+    platformDetails = with stdenv.hostPlatform; if isDarwin then rec {
+      arch = "darwin-x86_64";
+      sourceDir = "'Katawa Shoujo'.app";
+      installDir = "$out/Applications/'Katawa Shoujo'.app";
+      dataDir = "${installDir}/Contents/Resources/autorun";
+      bin = "${installDir}/Contents/MacOS/'Katawa Shoujo'";
+    } else rec {
+      arch = "linux-${if isx86_64 then "x86_64" else "i686"}";
+      sourceDir = "'Katawa Shoujo'-${version}-linux";
+      installDir = "$out/share/katawa-shoujo";
+      dataDir = installDir;
+      bin = "${installDir}/'Katawa Shoujo'.sh";
+    };
+    libDir = with platformDetails; "${dataDir}/lib/${arch}";
+  in with platformDetails; ''
+    runHook preInstall
+
+    mkdir -p "$(dirname ${installDir})"
+    cp -R ${sourceDir} ${installDir}
+
+    # Simplify launcher script
+    cat <<EOF >${bin}
+    #!${runtimeShell}
+    exec \$RENPY_GDB ${libDir}/'Katawa Shoujo' \$RENPY_PYARGS -EO ${dataDir}/'Katawa Shoujo'.py "\$@"
+    EOF
+
+  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # No autoPatchelfHook on Darwin
+    wrapProgram ${bin} \
+      --prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs}
+  '' + ''
+
+    # Delete binaries for wrong arch, autoPatchelfHook gets confused by them & less to keep in the store
+    find "$(dirname ${libDir})" -mindepth 1 -maxdepth 1 \
+      -not -name 'python*' -not -name ${arch} \
+      -exec rm -r {} \;
+
+    # Replace some bundled libs so Nixpkgs' versions are used
+    rm ${libDir}/libz*
+    rm ${libDir}/libfreetype*
+    rm ${libDir}/libSDL-1.2*
+  '' + lib.optionalString devendorImageLibs ''
+    rm ${libDir}/libjpeg*
+    rm ${libDir}/libpng12*
+  '' + ''
+
+    mkdir -p $out/share/{doc,licenses}/katawa-shoujo
+    mv ${dataDir}/'Game Manual'.pdf $out/share/doc/katawa-shoujo/
+    mv ${dataDir}/LICENSE.txt $out/share/licenses/katawa-shoujo/
+
+    mkdir -p $out/bin
+    ln -s ${bin} $out/bin/katawa-shoujo
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Bishoujo-style visual novel by Four Leaf Studios, built in Ren'Py";
+    longDescription = ''
+      Katawa Shoujo is a bishoujo-style visual novel set in the fictional Yamaku High School for disabled children,
+      located somewhere in modern Japan. Hisao Nakai, a normal boy living a normal life, has his life turned upside down
+      when a congenital heart defect forces him to move to a new school after a long hospitalization. Despite his difficulties,
+      Hisao is able to find friends—and perhaps love, if he plays his cards right. There are five main paths corresponding
+      to the 5 main female characters, each path following the storyline pertaining to that character.
+
+      The story is told through the perspective of the main character, using a first person narrative. The game uses a
+      traditional text and sprite-based visual novel model with an ADV text box.
+
+      Katawa Shoujo contains adult material, and was created using the Ren'Py scripting system. It is the product of an
+      international team of amateur developers, and is available free of charge under the Creative Commons BY-NC-ND License.
+    '';
+    homepage = "https://www.katawa-shoujo.com/";
+    # https://www.katawa-shoujo.com/about.php
+    # November 2022: Update, is it still ND?
+    # https://ks.renai.us/viewtopic.php?f=13&p=248149#p248149
+    license = with licenses; [ cc-by-nc-nd-30 ];
+    maintainers = with maintainers; [ OPNA2608 ];
+    # Building Ren'Py6 from source would allow more, but too much of a hassle
+    platforms = platforms.x86;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    # Needs different srcDetails & installPhase
+    broken = stdenv.hostPlatform.isWindows;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34763,6 +34763,8 @@ with pkgs;
 
   jumpnbump = callPackage ../games/jumpnbump { };
 
+  katawa-shoujo = callPackage ../games/katawa-shoujo { };
+
   keeperrl = callPackage ../games/keeperrl { };
 
   ### GAMES/LGAMES


### PR DESCRIPTION
###### Description of changes
Packages [Katawa Shoujo](https://www.katawa-shoujo.com/), a free visual novel game.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] i686-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
