### PR TITLE
qt6: fix mkspecs files for qmake

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -162,6 +162,9 @@ let
         qtbase = {
           i18n = callPackage ./examples/qtbase/i18n.nix { };
         };
+        qtdeclarative = {
+          qml-i18n = callPackage ./examples/qtdeclarative/qml-i18n.nix { };
+        };
       };
     };
 

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -15,6 +15,8 @@
 , cmake
 , ninja
 , writeText
+, writeShellScript
+, substituteAll
 , gstreamer
 , gst-plugins-base
 , gst-plugins-good
@@ -64,6 +66,11 @@ let
           (fetchpatch {
             url = "https://github.com/Homebrew/formula-patches/raw/c363f0edf9e90598d54bc3f4f1bacf95abbda282/qt/qt_internal_check_if_path_has_symlinks.patch";
             sha256 = "sha256-Gv2L8ymZSbJxcmUijKlT2NnkIB3bVH9D7YSsDX2noTU=";
+          })
+          (substituteAll {
+            src = ./patches/qtbase-qmake-qt-prepare-tool.diff;
+            findQtTool = writeShellScript "find-qt-tool.sh" (
+              builtins.readFile ./patches/qtbase-qmake-qt-prepare-tool-find-qt-tool.sh);
           })
         ];
       };

--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -157,6 +157,12 @@ let
           fix_qmake_libtool = ./hooks/fix-qmake-libtool.sh;
         };
       } ./hooks/qmake-hook.sh;
+
+      examples = {
+        qtbase = {
+          i18n = callPackage ./examples/qtbase/i18n.nix { };
+        };
+      };
     };
 
   # TODO(@Artturin): convert to makeScopeWithSplicing

--- a/pkgs/development/libraries/qt-6/examples/qtbase/i18n.nix
+++ b/pkgs/development/libraries/qt-6/examples/qtbase/i18n.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, qtbase
+, qmake
+, qttools
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qtbase-example-i18n";
+  # src is a tar.xz file
+  inherit (qtbase) version src;
+  prePatch = ''
+    cd examples/widgets/tools/i18n
+  '';
+  # fix default install location: ${qtbase.out}/examples/
+  installPhase = ''
+    runHook preInstall
+    install -Dm 555 i18n $out/bin/i18n
+    runHook postInstall
+  '';
+  nativeBuildInputs = [
+    qmake
+    qttools
+    wrapQtAppsHook
+  ];
+  buildInputs = [
+    qtbase
+  ];
+}

--- a/pkgs/development/libraries/qt-6/examples/qtdeclarative/qml-i18n.nix
+++ b/pkgs/development/libraries/qt-6/examples/qtdeclarative/qml-i18n.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, qtbase
+, qtdeclarative
+, qmake
+, qttools
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qtdeclarative-example-qml-i18n";
+  # src is a tar.xz file
+  inherit (qtdeclarative) version src;
+  postPatch = ''
+    cd examples/qml/qml-i18n
+  '';
+  # fix default install location: ${qtbase.out}/examples/
+  installPhase = ''
+    runHook preInstall
+    install -Dm 555 qml-i18n $out/bin/qml-i18n
+    runHook postInstall
+  '';
+  nativeBuildInputs = [
+    qmake
+    qttools
+    wrapQtAppsHook
+  ];
+  buildInputs = [
+    qtbase
+    qtdeclarative
+  ];
+}

--- a/pkgs/development/libraries/qt-6/patches/qtbase-qmake-qt-prepare-tool-find-qt-tool.sh
+++ b/pkgs/development/libraries/qt-6/patches/qtbase-qmake-qt-prepare-tool-find-qt-tool.sh
@@ -1,0 +1,81 @@
+# find absolute path of a qt tool
+
+# this script is called from qtbase-dev/mkspecs/features/qt_functions.prf
+
+# resolution order:
+# 1. try $QMAKE_<TOOL_NAME> - example: tool_name=lrelease -> $QMAKE_LRELEASE
+# 2. search in $instloc passed by qt_functions.prf
+# 3. search in all prefixes in $QMAKEPATH
+# 4. search in $PATH
+
+# limitations:
+# tool_name and instloc_dir must be a basename, cannot be a path.
+
+if [ $# == 0 ] || (( $# > 2 )) || [ -z "$1" ]; then
+    echo 'usage: find-qt-tool.sh tool_name [instloc]' >&2
+    exit 1
+fi
+
+# example: lrelease
+tool_name="$1"
+
+# absolute path to bin/ or libexec/.
+# can also be just bin or libexec, or empty.
+instloc="${2:-bin}"
+
+if (( "${NIX_DEBUG:-0}" >= 1 )); then
+  log() {
+    echo "find-qt-tool.sh $tool_name: $*" >&2
+  }
+else
+  log() { :; }
+fi
+
+# test: tool was not found
+#log "not found"; exit
+
+# example: some-tool.pl -> QMAKE_SOME_TOOL_PL
+tool_cmd_env=QMAKE_$(echo "$tool_name" | tr '[:lower:][:punct:]' '[:upper:]_')
+tool_cmd="${!tool_cmd_env}"
+if [ -n "$tool_cmd" ]; then
+  log "using env $tool_cmd_env: $tool_cmd"
+  echo "$tool_cmd"
+  exit
+fi
+
+instloc_prefix=${instloc%/*} # usually ${qtbase.dev}
+instloc_dir=${instloc##*/} # bin or libexec
+
+if [ "${instloc_prefix:0:1}" != '/' ]; then
+    log "ignoring non-absolute instloc_prefix: $instloc_prefix"
+    instloc_prefix=
+fi
+
+if [ -z "$instloc_dir" ]; then
+    log 'instloc_dir is empty, using instloc_dir=bin'
+    instloc_dir=bin
+fi
+
+tool_relpath="$instloc_dir/$tool_name"
+while read -d: prefix; do
+  if ! [ -e "$prefix" ]; then continue; fi
+  tool_cmd="$prefix/$tool_relpath"
+  if ! [ -e "$tool_cmd" ]; then
+    #log "missing in QMAKEPATH: tool_cmd=$tool_cmd"
+    continue
+  fi
+  log "found in QMAKEPATH: $tool_cmd"
+  echo "$tool_cmd"
+  exit
+done <<< "$instloc_prefix:$QMAKEPATH:" # append : to path to also read last item
+log "not found ${tool_relpath@Q} in instloc_prefix=$instloc_prefix or QMAKEPATH=$QMAKEPATH"
+
+#log "trying PATH ..."
+if tool_cmd=$(command -v "$tool_name"); then
+  log "found in PATH: $tool_cmd"
+    echo "$tool_cmd"
+    exit
+fi
+log "not found ${tool_name@Q} in PATH=${PATH@Q}"
+
+log "not found, giving up. hint: set env: $tool_cmd_env=/absolute/path/to/$tool_name"

--- a/pkgs/development/libraries/qt-6/patches/qtbase-qmake-qt-prepare-tool.diff
+++ b/pkgs/development/libraries/qt-6/patches/qtbase-qmake-qt-prepare-tool.diff
@@ -1,0 +1,41 @@
+--- a/mkspecs/features/qt_functions.prf
++++ b/mkspecs/features/qt_functions.prf
+@@ -95,20 +95,28 @@
+         } else {
+             instloc = $$5
+         }
+-        cmd = $$instloc/$$2
+-        exists($${cmd}.pl) {
+-            $${1}_EXE = $${cmd}.pl
+-            cmd = perl -w $$system_path($${cmd}.pl)
++        # ${qtbase.dev}/mkspecs/features/find-qt-tool.sh
++        find_qt_tool = @findQtTool@
++        # extensions: pl, exe, app
++        cmd = $$system("$${find_qt_tool} $${2}.pl $${instloc}")
++        !isEmpty(cmd) {
++            # pl
++            $${1}_EXE = $${cmd}
++            cmd = perl -w $$system_path($${cmd})
+         } else: contains(QMAKE_HOST.os, Windows) {
+-            $${1}_EXE = $${cmd}.exe
+-            cmd = $$system_path($${cmd}.exe)
++            # exe
++            cmd = $$system("$${find_qt_tool} $${2}.exe $${instloc}")
++            $${1}_EXE = $${cmd}
+         } else:contains(QMAKE_HOST.os, Darwin) {
+-            BUNDLENAME = $${cmd}.app/Contents/MacOS/$$2
+-            exists($$BUNDLENAME) {
+-                cmd = $$BUNDLENAME
++            # app
++            cmd = $$system("$${find_qt_tool} $${2}.app $${instloc}")
++            !isEmpty(cmd) {
++                cmd = $${cmd}/Contents/MacOS/$${2}
++                $${1}_EXE = $$cmd
+             }
+-            $${1}_EXE = $$cmd
+         } else {
++            # no extension
++            cmd = $$system("$${find_qt_tool} $${2} $${instloc}")
+             $${1}_EXE = $$cmd
+         }
+     } else {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22733,7 +22733,7 @@ with pkgs;
   qt6 = recurseIntoAttrs (makeOverridable
     (import ../development/libraries/qt-6) {
       inherit newScope;
-      inherit lib fetchurl fetchpatch fetchgit fetchFromGitHub makeSetupHook makeWrapper writeText;
+      inherit lib fetchurl fetchpatch fetchgit fetchFromGitHub makeSetupHook makeWrapper writeText writeShellScript substituteAll;
       inherit bison cups dconf harfbuzz libGL perl gtk3 ninja;
       inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good gst-libav gst-vaapi;
       inherit darwin buildPackages libglvnd;


### PR DESCRIPTION
move mkspecs files from `qt6.qtbase.dev` to the right `qt6.*.dev` derivations, where the tools are installed in `bin/` and `libexec/`, so `qmake` uses the right path for tools

mkspecs files are similar to pkgconfig or cmake files

the qt5 packages use a quick hack (`command -v`) to locate binaries ...

https://github.com/NixOS/nixpkgs/blob/216fbe09999764469066b1ccf05dcff45cf078e7/pkgs/development/libraries/qt-5/5.15/qtbase.patch.d/0003-qtbase-mkspecs.patch#L390

... but this is a more "proper" fix

fix #214765

ping @NickCao @OPNA2608

## build

`nix-build . -A qt6.qtbase.dev && mv result-dev qtbase-dev`

<details>
<summary>
<code>find qtbase-dev/mkspecs/ -name "*.bak"</code>
</summary>

```
qtbase-dev/mkspecs/features/qt_module_headers.prf.bak
qtbase-dev/mkspecs/features/qlalr.prf.bak
qtbase-dev/mkspecs/features/qt_docs.prf.bak
qtbase-dev/mkspecs/features/qgltf.prf.bak
qtbase-dev/mkspecs/features/win32/idcidl.prf.bak
qtbase-dev/mkspecs/features/win32/dumpcpp.prf.bak
qtbase-dev/mkspecs/features/win32/windeployqt.prf.bak
qtbase-dev/mkspecs/features/lrelease.prf.bak
qtbase-dev/mkspecs/features/moc.prf.bak
qtbase-dev/mkspecs/features/testcase.prf.bak
qtbase-dev/mkspecs/features/uic.prf.bak
qtbase-dev/mkspecs/features/qml_plugin.prf.bak
qtbase-dev/mkspecs/features/android/android.prf.bak
qtbase-dev/mkspecs/features/wayland-scanner.prf.bak
qtbase-dev/mkspecs/features/metatypes.prf.bak
qtbase-dev/mkspecs/features/qt_tracepoints.prf.bak
qtbase-dev/mkspecs/features/qt.prf.bak
qtbase-dev/mkspecs/features/resources.prf.bak
qtbase-dev/mkspecs/features/qmltestcase.prf.bak
```

</details>

`nix-build . -A qt6.qttools.dev && mv result-dev qttools-dev`

```
grep qtPrepareTool qttools-dev/mkspecs/features/lrelease.prf 
qtPrepareTool(QMAKE_LRELEASE, lrelease, , , /nix/store/7j3xdphwjbbpm1d3n84apd8z69a9dbvy-qttools-6.4.2-dev/bin)
```

&rarr; ok, instloc was patched

<details>
<summary>
logs for qttools
</summary>

```
brokenMkspecsFilesRestore: found tool: /nix/store/41gwq65mgm29ypcam780xcdnkab7mgj0-qttools-6.4.2-dev/bin/lrelease
brokenMkspecsFilesRestore: restoring mkspecs file: /nix/store/41gwq65mgm29ypcam780xcdnkab7mgj0-qttools-6.4.2-dev/mkspecs/features/lrelease.prf
brokenMkspecsFilesRestore: patching mkspecs file: /nix/store/41gwq65mgm29ypcam780xcdnkab7mgj0-qttools-6.4.2-dev/mkspecs/features/lrelease.prf
substituteStream(): WARNING: pattern '/nix/store/3rlw5rrrgfmvr1bba9z2j36cipavdfp6-qtbase-6.4.2-dev' doesn't match anything in file '/nix/store/41gwq65mgm29ypcam780xcdnkab7mgj0-qttools-6.4.2-dev/mkspecs/features/lrelease.prf'
--- /nix/store/41gwq65mgm29ypcam780xcdnkab7mgj0-qttools-6.4.2-dev/mkspecs/features/lrelease.prf.bak     2023-02-06 16:28:14.167647765 +0000
+++ /nix/store/41gwq65mgm29ypcam780xcdnkab7mgj0-qttools-6.4.2-dev/mkspecs/features/lrelease.prf 2023-02-06 16:28:14.169647871 +0000
@@ -7,7 +7,7 @@
 # Otherwise, the .qm files are available in the build directory in LRELEASE_DIR.
 # They can also be automatically installed by setting QM_FILES_INSTALL_PATH.
 
-qtPrepareTool(QMAKE_LRELEASE, lrelease)
+qtPrepareTool(QMAKE_LRELEASE, lrelease, , , /nix/store/41gwq65mgm29ypcam780xcdnkab7mgj0-qttools-6.4.2-dev/bin)
 
 isEmpty(LRELEASE_DIR): LRELEASE_DIR = .qm
 isEmpty(QM_FILES_RESOURCE_PREFIX): QM_FILES_RESOURCE_PREFIX = i18n
```
</details>


<details>
<summary>
dryrun brokenMkspecsFilesRestore
</summary>

```
source pkgs/development/libraries/qt-6/functions/brokenMkspecsFilesRestore.sh
DEBUG=true DRYRUN=true brokenMkspecsFilesRestore qtbase-dev qttools-dev qttools-dev/bin qtPrepareTool

file_match_line=mkspecs/features/lrelease.prf.bak:qtPrepareTool(QMAKE_LRELEASE, lrelease)
match_line=qtPrepareTool(QMAKE_LRELEASE, lrelease)
mkspecs_file=mkspecs/features/lrelease.prf
funcname=qtPrepareTool
variable=QMAKE_LRELEASE
default_tool=lrelease
suffix=
prepare=
instloc=
tool_file=qttools-dev/bin/lrelease
brokenMkspecsFilesRestore: found tool: qttools-dev/bin/lrelease
brokenMkspecsFilesRestore: mkspecs file exists: qttools-dev/mkspecs/features/lrelease.prf
brokenMkspecsFilesRestore: patching mkspecs file: qttools-dev/mkspecs/features/lrelease.prf
chmod +w qttools-dev/mkspecs/features/lrelease.prf
cp qttools-dev/mkspecs/features/lrelease.prf qttools-dev/mkspecs/features/lrelease.prf.bak
substituteInPlace qttools-dev/mkspecs/features/lrelease.prf --replace qtbase-dev qttools-dev --replace qtPrepareTool(QMAKE_LRELEASE, lrelease) qtPrepareTool(QMAKE_LRELEASE, lrelease, , , qttools-dev/bin)
diff -u qttools-dev/mkspecs/features/lrelease.prf.bak qttools-dev/mkspecs/features/lrelease.prf
rm qttools-dev/mkspecs/features/lrelease.prf.bak
```

</details>

<details>
<summary>
example app
</summary>

testing build with [qtbase/examples/widgets/tools/i18n](https://code.qt.io/cgit/qt/qtbase.git/tree/examples/widgets/tools/i18n?h=6.4)

qtbase-example-i18n.nix

```nix
{ pkgs ? import ./. {} }:
with pkgs;
with qt6;
stdenv.mkDerivation {
name = "qtbase-example-i18n";
src = qtbase.src;
prePatch = ''
cd examples/widgets/tools/i18n
'';
# tries to install to ${qtbase.out}/examples/
installPhase = ''
mkdir -p $out/bin
cp i18n $out/bin
'';
nativeBuildInputs = [ qmake qttools wrapQtAppsHook ];
buildInputs = [ qtbase ];
}
```

&rarr; ok

</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
