### PR TITLE
mpv: enable swift support

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -66,7 +66,7 @@
 , sdl2Support        ? true,           SDL2
 , sixelSupport       ? false,          libsixel
 , speexSupport       ? true,           speex
-, swiftSupport       ? stdenv.isDarwin, swift
+, swiftSupport       ? stdenv.isDarwin && stdenv.isAarch64, swift
 , theoraSupport      ? true,           libtheora
 , vaapiSupport       ? stdenv.isLinux, libva
 , vapoursynthSupport ? false,          vapoursynth

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -66,7 +66,7 @@
 , sdl2Support        ? true,           SDL2
 , sixelSupport       ? false,          libsixel
 , speexSupport       ? true,           speex
-, swiftSupport       ? false,          swift
+, swiftSupport       ? stdenv.isDarwin, swift
 , theoraSupport      ? true,           libtheora
 , vaapiSupport       ? stdenv.isLinux, libva
 , vapoursynthSupport ? false,          vapoursynth
@@ -78,7 +78,7 @@
 }:
 
 let
-  inherit (darwin.apple_sdk.frameworks) CoreFoundation Cocoa CoreAudio MediaPlayer;
+  inherit (darwin.apple_sdk.frameworks) AVFoundation CoreFoundation CoreMedia Cocoa CoreAudio MediaPlayer;
   luaEnv = lua.withPackages (ps: with ps; [ luasocket ]);
 in stdenv.mkDerivation (self: {
   pname = "mpv";
@@ -98,6 +98,11 @@ in stdenv.mkDerivation (self: {
   '';
 
   NIX_LDFLAGS = lib.optionalString x11Support "-lX11 -lXext ";
+
+  preConfigure = lib.optionalString swiftSupport ''
+    # Ensure we reference 'lib' (not 'out') of Swift.
+    export SWIFT_LIB_DYNAMIC=${lib.getLib swift.swift}/lib/swift/macosx
+  '';
 
   mesonFlags = [
     (lib.mesonOption "default_library" "shared")
@@ -167,7 +172,8 @@ in stdenv.mkDerivation (self: {
     ++ lib.optionals zimgSupport        [ zimg ]
     ++ lib.optionals stdenv.isLinux     [ nv-codec-headers ]
     ++ lib.optionals stdenv.isDarwin    [ libiconv ]
-    ++ lib.optionals stdenv.isDarwin    [ CoreFoundation Cocoa CoreAudio MediaPlayer ];
+    ++ lib.optionals stdenv.isDarwin    [ CoreFoundation Cocoa CoreAudio MediaPlayer ]
+    ++ lib.optionals (stdenv.isDarwin && swiftSupport) [ AVFoundation CoreMedia ];
 
   postBuild = lib.optionalString stdenv.isDarwin ''
     pushd .. # Must be run from the source dir because it uses relative paths

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -78,7 +78,7 @@
 }:
 
 let
-  inherit (darwin.apple_sdk.frameworks) AVFoundation CoreFoundation CoreMedia Cocoa CoreAudio MediaPlayer;
+  inherit (darwin.apple_sdk_11_0.frameworks) AVFoundation CoreFoundation CoreMedia Cocoa CoreAudio MediaPlayer;
   luaEnv = lua.withPackages (ps: with ps; [ luasocket ]);
 in stdenv.mkDerivation (self: {
   pname = "mpv";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31402,7 +31402,7 @@ with pkgs;
     libdvdnav = libdvdnav_4_2_1;
   } // (config.mplayer or {}));
 
-  mpv-unwrapped = callPackage ../applications/video/mpv {
+  mpv-unwrapped = darwin.apple_sdk_11_0.callPackage ../applications/video/mpv {
     inherit lua;
   };
 


### PR DESCRIPTION
###### Description of changes

Since swift is available on master now, I've rebased @stephank's work on mpv https://github.com/stephank/nixpkgs/commit/4ce183cdd525da0f3cf4cec14356d056dbabed0e to master, and made this pull request for discussion.

When I used nix-tree to check the closure size of the built mpv, I've found swift lib references clang, and make the closure size pretty big:

<img width="1066" alt="Screenshot 2023-02-06 at 22 19 14" src="https://user-images.githubusercontent.com/9315/216995420-a7e094ef-ce12-4386-8cb9-a5058d328ed4.png">

```
$ ls -l /nix/store/2cp55whf6v3631512w4hlsrc4v7r8w36-swift-5.7.3-lib/lib/swift
total 0
dr-xr-xr-x  6 root nixbld 192 Jan  1  1970 FrameworkABIBaseline
dr-xr-xr-x  5 root nixbld 160 Jan  1  1970 _InternalSwiftScan
dr-xr-xr-x  5 root nixbld 160 Jan  1  1970 _InternalSwiftStaticMirror
dr-xr-xr-x  5 root nixbld 160 Jan  1  1970 _InternalSwiftSyntaxParser
dr-xr-xr-x  4 root nixbld 128 Jan  1  1970 apinotes
lrwxr-xr-x  1 root nixbld  78 Jan  1  1970 clang -> /nix/store/avrf44cq2cr18vlvv20aa1pc85cl7rzg-clang-wrapper-14.0.6/resource-root
dr-xr-xr-x 28 root nixbld 896 Jan  1  1970 macosx
dr-xr-xr-x 12 root nixbld 384 Jan  1  1970 migrator
dr-xr-xr-x 27 root nixbld 864 Jan  1  1970 shims
```

Is that expected?

Removing `preConfigure` will make the closure size even bigger:

<img width="1060" alt="Screenshot 2023-02-06 at 22 27 09" src="https://user-images.githubusercontent.com/9315/216997415-efafb94b-81ef-42f3-8ad9-5400177e7317.png">

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
