### PR TITLE
Revert "Revert Merge #214786: libvmaf: fix build for BSD"

### DIFF
--- a/pkgs/development/libraries/libvmaf/default.nix
+++ b/pkgs/development/libraries/libvmaf/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, nasm }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, meson, ninja, nasm }:
 
 stdenv.mkDerivation rec {
   pname = "libvmaf";
@@ -12,6 +12,15 @@ stdenv.mkDerivation rec {
   };
 
   sourceRoot = "source/libvmaf";
+
+  patches = [
+    # Backport fix for non-Linux, non-Darwin platforms.
+    (fetchpatch {
+      url = "https://github.com/Netflix/vmaf/commit/f47640f9ffee9494571bd7c9622e353660c93fc4.patch";
+      stripLen = 1;
+      sha256 = "rsTKuqp8VJG5DBDpixPke3LrdfjKzUO945i+iL0n7CY=";
+    })
+  ];
 
   nativeBuildInputs = [ meson ninja nasm ];
 


### PR DESCRIPTION
This reverts commit 8030c64577a7973d07537e2bb446c14ccedaa14c.

Reverted due to an accidental mass rebuild.  Relanding on staging.