### PR TITLE
ghidra.withPatches: init

### DIFF
--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -277,6 +277,8 @@ stdenv.mkDerivation rec {
     };
     patches = {
       scale-by-2 = callPackage ./patches/scale-by-2 { };
+      # patch is broken, just a demo how to add files
+      #flatlaf-dark-theme = callPackage ./patches/flatlaf-dark-theme { };
     };
   };
 

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -276,6 +276,7 @@ stdenv.mkDerivation rec {
       '';
     };
     patches = {
+      scale-by-2 = callPackage ./patches/scale-by-2 { };
     };
   };
 

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -279,6 +279,8 @@ stdenv.mkDerivation rec {
       scale-by-2 = callPackage ./patches/scale-by-2 { };
       # patch is broken, just a demo how to add files
       #flatlaf-dark-theme = callPackage ./patches/flatlaf-dark-theme { };
+      # patch is broken, just a demo how to patch files
+      #use-vmargs-env = callPackage ./patches/use-vmargs-env { };
     };
   };
 

--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -22,7 +22,11 @@ let
     categories = [ "Development" ];
   };
 
-in stdenv.mkDerivation rec {
+in
+
+let ghidra =
+
+stdenv.mkDerivation rec {
   pname = "ghidra";
   version = "10.2.2";
   versiondate = "20221115";
@@ -68,6 +72,14 @@ in stdenv.mkDerivation rec {
       --prefix PATH : ${lib.makeBinPath [ openjdk17 ]}
   '';
 
+  passthru = {
+    # TODO better? mkOverridable?
+    withPatches = patches: symlinkJoin {
+      name = ghidra.name + "-with-patches";
+      paths = [ ghidra ] ++ patches;
+    };
+  };
+
   meta = with lib; {
     description = "A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission";
     homepage = "https://github.com/NationalSecurityAgency/ghidra";
@@ -78,3 +90,5 @@ in stdenv.mkDerivation rec {
   };
 
 }
+
+; in ghidra

--- a/pkgs/tools/security/ghidra/patches/flatlaf-dark-theme/default.nix
+++ b/pkgs/tools/security/ghidra/patches/flatlaf-dark-theme/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchMavenArtifact
+, ghidra
+}:
+
+# based on https://github.com/zackelia/ghidra-dark
+stdenv.mkDerivation rec {
+  pname = "ghidra-patch-flatlaf-dark-theme";
+  version = "3.0";
+  src = fetchMavenArtifact {
+    artifactId = "flatlaf";
+    groupId = "com.formdev";
+    sha256 = "sha256-lpsnqmEscOy4VmTlXYxfdnimGI+dt8UUKoH25HXhmGc=";
+    inherit version;
+  };
+  buildPhase = ''
+    d=lib/ghidra/Ghidra
+    mkdir -p $out/$d
+    cd $out/$d
+    mkdir patch
+    ln -s ${src}/share/java/flatlaf-*.jar patch
+  '';
+  dontInstall = true;
+  passthru = {
+    postPatch = ''
+      replaceSymlinkWithFile() {
+        if [ -L "$1" ]; then
+          cp --remove-destination "$(readlink "$1")" "$1"
+        fi
+      }
+
+      d=lib/ghidra/support
+      cd $out/$d
+      f=launch.properties
+      s='VMARGS=-Dswing.systemlaf=com.formdev.flatlaf.FlatDarkLaf'
+      if ! grep -q -x -F "$s" $f; then
+        replaceSymlinkWithFile $f
+        chmod +w $f
+        printf "%s\n" "$s" >> $f
+      fi
+    '';
+  };
+  meta = with lib; {
+    description = "Flat themes for Java Swing desktop applications";
+    longDescription = ''
+      FlatLaf comes with Light, Dark, IntelliJ and Darcula themes,
+      scales on HiDPI displays and runs on Java 8 or newer.
+    '';
+    homepage = "https://github.com/JFormDesigner/FlatLaf";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/tools/security/ghidra/patches/scale-by-2/default.nix
+++ b/pkgs/tools/security/ghidra/patches/scale-by-2/default.nix
@@ -1,0 +1,23 @@
+{ lib }:
+
+# based on https://gist.github.com/nstarke/baa031e0cab64a608c9bd77d73c50fc6
+{
+  name = "ghidra-patch-scale-by-2";
+  postPatch = ''
+    replaceSymlinkWithFile() {
+      if [ -L "$1" ]; then
+        cp --remove-destination "$(readlink "$1")" "$1"
+      fi
+    }
+
+    d=lib/ghidra/support
+    cd $out/$d
+    f=launch.properties
+    s='VMARGS_LINUX=-Dsun.java2d.uiScale=2'
+    if ! grep -q -x -F "$s" $f; then
+      replaceSymlinkWithFile $f
+      chmod +w $f
+      printf "%s\n" "$s" >> $f
+    fi
+  '';
+}

--- a/pkgs/tools/security/ghidra/patches/use-vmargs-env/default.nix
+++ b/pkgs/tools/security/ghidra/patches/use-vmargs-env/default.nix
@@ -1,0 +1,21 @@
+{ lib }:
+
+{
+  name = "ghidra-patch-use-vmargs-env";
+  postPatch = ''
+    replaceSymlinkWithFile() {
+      if [ -L "$1" ]; then
+        cp --remove-destination "$(readlink "$1")" "$1"
+      fi
+    }
+
+    d=lib/ghidra
+    cd $out/$d
+    f=ghidraRun
+    replaceSymlinkWithFile $f
+    substituteInPlace $f \
+      --replace \
+        'Ghidra "''${MAXMEM}" "" ghidra.GhidraRun' \
+        'Ghidra "''${MAXMEM}" "$VMARGS" ghidra.GhidraRun'
+  '';
+}


### PR DESCRIPTION
lightweight patching of ghidra
workaround for https://github.com/NationalSecurityAgency/ghidra/issues/4960

see also https://github.com/NixOS/nixpkgs/issues/59344
see also https://github.com/deliciouslytyped/nix-ghidra-wip
ping @deliciouslytyped

ping ghidra maintainers @ck3d @govanify @mic92 @roblabla

## ghidra.patches.scale-by-2

increase font size for hidpi displays
limitation: accepts only integers, so cannot scale by 150%

## ghidra.patches.frida

WIP ghidra integration with [frida](https://github.com/frida) debugger

## ghidra.patches.lldb

TODO ghidra integration with [lldb](https://lldb.llvm.org/) debugger

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
