### PR TITLE
mycli: skip broken test

### DIFF
--- a/pkgs/tools/admin/mycli/default.nix
+++ b/pkgs/tools/admin/mycli/default.nix
@@ -30,15 +30,23 @@ buildPythonApplication rec {
     sqlparse
   ];
 
-  nativeCheckInputs = [ pytest glibcLocales ];
+  nativeCheckInputs = [ pytestCheckHook glibcLocales ];
 
-  checkPhase = ''
+  preCheck = ''
     export HOME=.
     export LC_ALL="en_US.UTF-8"
-
-    py.test \
-      --ignore=mycli/packages/paramiko_stub/__init__.py
   '';
+
+  disabledTestPaths = [
+    "mycli/packages/paramiko_stub/__init__.py"
+  ];
+
+  disabledTests = [
+    # Note: test_auto_escaped_col_names is currently failing due to a bug upstream.
+    # TODO: re-enable this test once there is a fix upstream. See
+    # https://github.com/dbcli/mycli/issues/1103 for details.
+    "test_auto_escaped_col_names"
+  ];
 
   postPatch = ''
     substituteInPlace setup.py \


### PR DESCRIPTION
###### Description of changes

This fixes https://github.com/NixOS/nixpkgs/issues/211415 (maybe this is more of a workaround?).

This build was failing due to a broken test upstream. I've instructed nix to skip that test for now.

I also changed the `py.test` to plain `pytest`. I'm not familiar with the difference, but according to [this SO
answer](https://stackoverflow.com/a/41893170/1739415), it sounds like `pytest` is the new hotness and should be used wherever possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
