### PR TITLE
python3Packages.onnx: use github source & enable many more tests

### DIFF
--- a/pkgs/development/libraries/gtest/default.nix
+++ b/pkgs/development/libraries/gtest/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, cmake, ninja, fetchFromGitHub }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+, static ? stdenv.hostPlatform.isStatic,
+}:
 
 stdenv.mkDerivation rec {
   pname = "gtest";
@@ -20,7 +26,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ninja ];
 
   cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=ON"
+    "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
   ] ++ lib.optionals (stdenv.cc.isClang && (lib.versionOlder stdenv.cc.version "16.0")) [
     # Enable C++17 support
     # https://github.com/google/googletest/issues/3081

--- a/pkgs/development/python-modules/onnx/default.nix
+++ b/pkgs/development/python-modules/onnx/default.nix
@@ -1,35 +1,42 @@
 { lib
 , buildPythonPackage
+, python3
 , bash
 , cmake
-, fetchPypi
+, fetchFromGitHub
+, gtest
 , isPy27
 , nbval
 , numpy
 , protobuf
+, pybind11
 , pytestCheckHook
 , six
 , tabulate
 , typing-extensions
 , pythonRelaxDepsHook
-, pytest-runner
 }:
 
-buildPythonPackage rec {
+let
+  gtestStatic = gtest.override { static = true; };
+in buildPythonPackage rec {
   pname = "onnx";
   version = "1.13.0";
   format = "setuptools";
 
   disabled = isPy27;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-QQs5lQNnhX+XtlCTaB/iSVouI9Y3d6is6vlsVqFtFm4=";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-D8POBAkZVr0O5i4qsSuYRkDfL8WsDTqzgNACmmkFwGs=";
   };
 
   nativeBuildInputs = [
     cmake
     pythonRelaxDepsHook
+    pybind11
   ];
 
   pythonRelaxDeps = [ "protobuf" ];
@@ -44,29 +51,35 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     nbval
     pytestCheckHook
-    pytest-runner
     tabulate
   ];
 
   postPatch = ''
     chmod +x tools/protoc-gen-mypy.sh.in
     patchShebangs tools/protoc-gen-mypy.sh.in
+
+    substituteInPlace setup.py \
+      --replace 'setup_requires.append("pytest-runner")' ""
+
+    # prevent from fetching & building own gtest
+    substituteInPlace CMakeLists.txt \
+      --replace 'include(googletest)' ""
+    substituteInPlace cmake/unittest.cmake \
+      --replace 'googletest)' ')'
   '';
 
-  # Set CMAKE_INSTALL_LIBDIR to lib explicitly, because otherwise it gets set
-  # to lib64 and cmake incorrectly looks for the protobuf library in lib64
   preConfigure = ''
+    # Set CMAKE_INSTALL_LIBDIR to lib explicitly, because otherwise it gets set
+    # to lib64 and cmake incorrectly looks for the protobuf library in lib64
     export CMAKE_ARGS="-DCMAKE_INSTALL_LIBDIR=lib -DONNX_USE_PROTOBUF_SHARED_LIBS=ON"
+  '' + lib.optionalString doCheck ''
+    export CMAKE_ARGS+=" -Dgoogletest_STATIC_LIBRARIES=${gtestStatic}/lib/libgtest.a -Dgoogletest_INCLUDE_DIRS=${lib.getDev gtestStatic}/include"
+    export ONNX_BUILD_TESTS=1
   '';
 
   preBuild = ''
     export MAX_JOBS=$NIX_BUILD_CORES
   '';
-
-  disabledTestPaths = [
-    # Unexpected output fields from running code: {'stderr'}
-    "onnx/examples/np_array_tensorproto.ipynb"
-  ];
 
   # The executables are just utility scripts that aren't too important
   postInstall = ''
@@ -75,6 +88,35 @@ buildPythonPackage rec {
 
   # The setup.py does all the configuration
   dontUseCmakeConfigure = true;
+
+  doCheck = true;
+  preCheck = ''
+    export HOME=$(mktemp -d)
+
+    # detecting source dir as a python package confuses pytest
+    mv onnx/__init__.py onnx/__init__.py.hidden
+  '';
+  pytestFlagsArray = [ "onnx/test" "onnx/examples" ];
+  disabledTests = [
+    # attempts to fetch data from web
+    "test_bvlc_alexnet_cpu"
+    "test_densenet121_cpu"
+    "test_inception_v1_cpu"
+    "test_inception_v2_cpu"
+    "test_resnet50_cpu"
+    "test_shufflenet_cpu"
+    "test_squeezenet_cpu"
+    "test_vgg19_cpu"
+    "test_zfnet512_cpu"
+  ];
+  disabledTestPaths = [
+    # Unexpected output fields from running code: {'stderr'}
+    "onnx/examples/np_array_tensorproto.ipynb"
+  ];
+  postCheck = ''
+    # run "cpp" tests
+    .setuptools-cmake-build/onnx_gtests
+  '';
 
   pythonImportsCheck = [
     "onnx"


### PR DESCRIPTION
###### Description of changes

In #214742 I noted that patching would have been tricky because we build from the pypi source, which has been preprocessed, rather than the absolute source. The raw github source also includes the full test suite, which I was able to get working with a little effort.

This required adding a `static` option to `gtest` to give us a gtest which sufficiently emulates the bundled gtest copy that the cmake scripts would otherwise want to fetch & build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
