### PR TITLE
treewide: use optionalString

### DIFF
--- a/nixos/tests/predictable-interface-names.nix
+++ b/nixos/tests/predictable-interface-names.nix
@@ -13,7 +13,7 @@ in pkgs.lib.listToAttrs (builtins.map ({ predictable, withNetworkd }: {
   name = pkgs.lib.optionalString (!predictable) "un" + "predictable"
        + pkgs.lib.optionalString withNetworkd "Networkd";
   value = makeTest {
-    name = "${if predictable then "" else "un"}predictableInterfaceNames${if withNetworkd then "-with-networkd" else ""}";
+    name = "${lib.optionalString (!predictable) "un"}predictableInterfaceNames${lib.optionalString withNetworkd "-with-networkd"}";
     meta = {};
 
     nodes.machine = { lib, ... }: {

--- a/pkgs/applications/audio/espeak/default.nix
+++ b/pkgs/applications/audio/espeak/default.nix
@@ -19,9 +19,9 @@ stdenv.mkDerivation rec {
   prePatch = ''
     sed -e s,/bin/ln,ln,g -i src/Makefile
     sed -e 's,^CXXFLAGS=-O2,CXXFLAGS=-O2 -D PATH_ESPEAK_DATA=\\\"$(DATADIR)\\\",' -i src/Makefile
-  '' + (if portaudio.api_version == 19 then ''
+  '' + (lib.optionalString (portaudio.api_version == 19) ''
     cp src/portaudio19.h src/portaudio.h
-  '' else "");
+  '');
 
   configurePhase = ''
     cd src

--- a/pkgs/applications/audio/musly/default.nix
+++ b/pkgs/applications/audio/musly/default.nix
@@ -10,11 +10,11 @@ stdenv.mkDerivation {
   };
   nativeBuildInputs = [ cmake ];
   buildInputs = [ eigen ffmpeg ];
-  fixupPhase = if stdenv.isDarwin then ''
+  fixupPhase = lib.optionalString stdenv.isDarwin ''
     install_name_tool -change libmusly.dylib $out/lib/libmusly.dylib $out/bin/musly
     install_name_tool -change libmusly_resample.dylib $out/lib/libmusly_resample.dylib $out/bin/musly
     install_name_tool -change libmusly_resample.dylib $out/lib/libmusly_resample.dylib $out/lib/libmusly.dylib
-  '' else "";
+  '';
 
   meta = with lib; {
     homepage = "https://www.musly.org";

--- a/pkgs/applications/display-managers/lightdm-tiny-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-tiny-greeter/default.nix
@@ -15,9 +15,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config wrapGAppsHook ];
   buildInputs = [ lightdm gtk3 glib ];
 
-  postUnpack = if conf != "" then ''
+  postUnpack = lib.optionalString (conf != "") ''
     cp ${builtins.toFile "config.h" conf} source/config.h
-  '' else "";
+  '';
 
   buildPhase = ''
     mkdir -p $out/bin $out/share/xgreeters

--- a/pkgs/applications/editors/texmacs/common.nix
+++ b/pkgs/applications/editors/texmacs/common.nix
@@ -27,18 +27,18 @@ rec {
 
   postPatch = (if tex == null then ''
     gunzip < ${fullFontsSrc} | (cd TeXmacs && tar xvf -)
-   '' else if extraFonts then ''
+   '' else lib.optionalString extraFonts ''
     gunzip < ${extraFontsSrc} | (cd TeXmacs && tar xvf -)
-   '' else "") +
-   (if chineseFonts then ''
+   '') +
+   (lib.optionalString chineseFonts ''
     gunzip < ${chineseFontsSrc} | (cd TeXmacs && tar xvf -)
-   '' else "") +
-   (if japaneseFonts then ''
+   '') +
+   (lib.optionalString japaneseFonts ''
     gunzip < ${japaneseFontsSrc} | (cd TeXmacs && tar xvf -)
-   '' else "") +
-   (if koreanFonts then ''
+   '') +
+   (lib.optionalString koreanFonts ''
     gunzip < ${koreanFontsSrc} | (cd TeXmacs && tar xvf -)
-   '' else "");
+   '');
 
 
   meta = {

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -317,8 +317,8 @@ rec {
       lib.warnIf (wrapManual != null) ''
         vim.customize: wrapManual is deprecated: the manual is now included by default if `name == "vim"`.
         ${if wrapManual == true && name != "vim" then "Set `standalone = false` to include the manual."
-        else if wrapManual == false && name == "vim" then "Set `standalone = true` to get the *vim wrappers only."
-        else ""}''
+        else lib.optionalString (wrapManual == false && name == "vim") "Set `standalone = true` to get the *vim wrappers only."
+        }''
       lib.warnIf (wrapGui != null)
         "vim.customize: wrapGui is deprecated: gvim is now automatically included if present"
       lib.throwIfNot (vimExecutableName == null && gvimExecutableName == null)
@@ -330,7 +330,7 @@ rec {
           else throw "at least one of vimrcConfig and vimrcFile must be specified";
         bin = runCommand "${name}-bin" { nativeBuildInputs = [ makeWrapper ]; } ''
           vimrc=${lib.escapeShellArg vimrc}
-          gvimrc=${if gvimrcFile != null then lib.escapeShellArg gvimrcFile else ""}
+          gvimrc=${lib.optionalString (gvimrcFile != null) (lib.escapeShellArg gvimrcFile)}
 
           mkdir -p "$out/bin"
           for exe in ${

--- a/pkgs/applications/file-managers/vifm/default.nix
+++ b/pkgs/applications/file-managers/vifm/default.nix
@@ -34,11 +34,11 @@ in stdenv.mkDerivation rec {
 
     wrapVifmMedia = "wrapProgram $out/share/vifm/vifm-media --prefix PATH : ${path}";
   in ''
-    ${if mediaSupport then wrapVifmMedia else ""}
+    ${lib.optionalString mediaSupport wrapVifmMedia}
   '';
 
   meta = with lib; {
-    description = "A vi-like file manager${if isFullPackage then "; Includes support for optional features" else ""}";
+    description = "A vi-like file manager${lib.optionalString isFullPackage "; Includes support for optional features"}";
     maintainers = with maintainers; [ raskin ];
     platforms = if mediaSupport then platforms.linux else platforms.unix;
     license = licenses.gpl2;

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -87,10 +87,10 @@ stdenv.mkDerivation rec {
     '' else ''
       substituteInPlace extern/clew/src/clew.c --replace '"libOpenCL.so"' '"${ocl-icd}/lib/libOpenCL.so"'
     '') +
-    (if hipSupport then ''
+    (lib.optionalString hipSupport ''
       substituteInPlace extern/hipew/src/hipew.c --replace '"/opt/rocm/hip/lib/libamdhip64.so"' '"${hip}/lib/libamdhip64.so"'
       substituteInPlace extern/hipew/src/hipew.c --replace '"opt/rocm/hip/bin"' '"${hip}/bin"'
-    '' else "");
+    '');
 
   cmakeFlags =
     [

--- a/pkgs/applications/networking/browsers/firefox-bin/update.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/update.nix
@@ -46,7 +46,7 @@ in writeScript "update-${pname}" ''
            grep "^[0-9]" | \
            sort --version-sort | \
            grep -v "funnelcake" | \
-           grep -e "${if isBeta then "b" else ""}\([[:digit:]]\|[[:digit:]][[:digit:]]\)$" | ${if isBeta then "" else "grep -v \"b\" |"} \
+           grep -e "${lib.optionalString isBeta "b"}\([[:digit:]]\|[[:digit:]][[:digit:]]\)$" | ${lib.optionalString (not isBeta) "grep -v \"b\" |"} \
            tail -1`
 
   curl --silent -o $HOME/shasums "$url$version/SHA256SUMS"

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -70,7 +70,7 @@ let
     ++ lib.optional libvaSupport libva
     ++ [ gtk3 ];
 
-  suffix = if channel != "stable" then "-" + channel else "";
+  suffix = lib.optionalString (channel != "stable") "-${channel}";
 
   crashpadHandlerBinary = if lib.versionAtLeast version "94"
     then "chrome_crashpad_handler"

--- a/pkgs/applications/science/biology/plink-ng/default.nix
+++ b/pkgs/applications/science/biology/plink-ng/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   preBuild = ''
     sed -i 's|zlib-1.2.8/zlib.h|zlib.h|g' *.c *.h
-    ${if stdenv.cc.isClang then "sed -i 's|g++|clang++|g' Makefile.std" else ""}
+    ${lib.optionalString stdenv.cc.isClang "sed -i 's|g++|clang++|g' Makefile.std"}
 
     makeFlagsArray+=(
       ZLIB=-lz

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -76,11 +76,10 @@ stdenv.mkDerivation rec {
   # tagged releases don't have "unknown"
   # kicad nightlies use git describe --dirty
   # nix removes .git, so its approximated here
-  postPatch = if (!stable) then ''
+  postPatch = lib.optionalString (!stable) ''
     substituteInPlace cmake/KiCadVersion.cmake \
       --replace "unknown" "${builtins.substring 0 10 src.rev}"
-  ''
-  else "";
+  '';
 
   makeFlags = optionals (debug) [ "CFLAGS+=-Og" "CFLAGS+=-ggdb" ];
 

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -214,7 +214,7 @@ stdenv.mkDerivation rec {
     description = (if (stable)
     then "Open Source Electronics Design Automation suite"
     else "Open Source EDA suite, development build")
-    + (if (!with3d) then ", without 3D models" else "");
+    + (lib.optionalString (!with3d) ", without 3D models");
     homepage = "https://www.kicad.org/";
     longDescription = ''
       KiCad is an open source software suite for Electronic Design Automation.

--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -66,10 +66,10 @@ let
   buildIde = args.buildIde or (!coqAtLeast "8.14");
   ideFlags = optionalString (buildIde && !coqAtLeast "8.10")
     "-lablgtkdir ${ocamlPackages.lablgtk}/lib/ocaml/*/site-lib/lablgtk2 -coqide opt";
-  csdpPatch = if csdp != null then ''
+  csdpPatch = lib.optionalString (csdp != null) ''
     substituteInPlace plugins/micromega/sos.ml --replace "; csdp" "; ${csdp}/bin/csdp"
     substituteInPlace plugins/micromega/coq_micromega.ml --replace "System.is_in_system_path \"csdp\"" "true"
-  '' else "";
+  '';
   ocamlPackages = if !isNull customOCamlPackages then customOCamlPackages
     else with versions; switch coq-version [
       { case = range "8.16" "8.17"; out = ocamlPackages_4_14; }
@@ -158,7 +158,7 @@ self = stdenv.mkDerivation {
     UNAME=$(type -tp uname)
     RM=$(type -tp rm)
     substituteInPlace tools/beautify-archive --replace "/bin/rm" "$RM"
-    ${if !coqAtLeast "8.7" then "substituteInPlace configure.ml --replace \"md5 -q\" \"md5sum\"" else ""}
+    ${lib.optionalString (!coqAtLeast "8.7") "substituteInPlace configure.ml --replace \"md5 -q\" \"md5sum\""}
     ${csdpPatch}
   '';
 
@@ -196,7 +196,7 @@ self = stdenv.mkDerivation {
     categories = [ "Development" "Science" "Math" "IDE" "GTK" ];
   });
 
-  postInstall = let suffix = if coqAtLeast "8.14" then "-core" else ""; in optionalString (!coqAtLeast "8.17") ''
+  postInstall = let suffix = optionalString (coqAtLeast "8.14") "-core"; in optionalString (!coqAtLeast "8.17") ''
     cp bin/votour $out/bin/
   '' + ''
     ln -s $out/lib/coq${suffix} $OCAMLFIND_DESTDIR/coq${suffix}
@@ -227,12 +227,12 @@ if coqAtLeast "8.17" then self.overrideAttrs(_: {
   buildPhase = ''
     runHook preBuild
     make dunestrap
-    dune build -p coq-core,coq-stdlib,coq,coqide-server${if buildIde then ",coqide" else ""} -j $NIX_BUILD_CORES
+    dune build -p coq-core,coq-stdlib,coq,coqide-server${lib.optionalString buildIde ",coqide"} -j $NIX_BUILD_CORES
     runHook postBuild
   '';
   installPhase = ''
     runHook preInstall
-    dune install --prefix $out coq-core coq-stdlib coq coqide-server${if buildIde then " coqide" else ""}
+    dune install --prefix $out coq-core coq-stdlib coq coqide-server${lib.optionalString buildIde " coqide"}
     runHook postInstall
   '';
 }) else self

--- a/pkgs/applications/science/math/sage/sage-tests.nix
+++ b/pkgs/applications/science/math/sage/sage-tests.nix
@@ -18,7 +18,7 @@ let
   src = sage-with-env.env.lib.src;
   runAllTests = files == null;
   testArgs = if runAllTests then "--all" else testFileList;
-  patienceSpecifier = if longTests then "--long" else "";
+  patienceSpecifier = lib.optionalString longTests "--long";
   timeSpecifier = if timeLimit == null then "" else "--short ${toString timeLimit}";
   relpathToArg = relpath: lib.escapeShellArg "${src}/${relpath}"; # paths need to be absolute
   testFileList = lib.concatStringsSep " " (map relpathToArg files);

--- a/pkgs/applications/science/misc/openmodelica/mkderivation/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/mkderivation/default.nix
@@ -16,7 +16,7 @@ let
   # getAttr-like helper for optional append to string:
   # "Hello" + appendByAttr "a" " " {a = "world";} = "Hello world"
   # "Hello" + appendByAttr "a" " " {} = "Hello"
-  appendByAttr = attr: sep: x: if hasAttr attr x then sep + (getAttr attr x) else "";
+  appendByAttr = attr: sep: x: lib.optionalString (hasAttr attr x) (sep + (getAttr attr x));
 
   # Are there any OM dependencies at all?
   ifDeps = length pkg.omdeps != 0;

--- a/pkgs/applications/window-managers/dwl/default.nix
+++ b/pkgs/applications/window-managers/dwl/default.nix
@@ -63,8 +63,8 @@ stdenv.mkDerivation (self: {
 
   preBuild = ''
     makeFlagsArray+=(
-      XWAYLAND=${if enableXWayland then "-DXWAYLAND" else ""}
-      XLIBS=${if enableXWayland then "xcb\\ xcb-icccm" else ""}
+      XWAYLAND=${lib.optionalString enableXWayland "-DXWAYLAND"}
+      XLIBS=${lib.optionalString enableXWayland "xcb\\ xcb-icccm"}
     )
   '';
 

--- a/pkgs/build-support/alternatives/blas/default.nix
+++ b/pkgs/build-support/alternatives/blas/default.nix
@@ -83,12 +83,12 @@ stdenv.mkDerivation {
 '' + (if stdenv.hostPlatform.parsed.kernel.execFormat.name == "elf" then ''
   patchelf --set-soname libblas${canonicalExtension} $out/lib/libblas${canonicalExtension}
   patchelf --set-rpath "$(patchelf --print-rpath $out/lib/libblas${canonicalExtension}):${lib.getLib blasProvider'}/lib" $out/lib/libblas${canonicalExtension}
-'' else if stdenv.hostPlatform.isDarwin then ''
+'' else lib.optionalString (stdenv.hostPlatform.isDarwin) ''
   install_name_tool \
     -id $out/lib/libblas${canonicalExtension} \
     -add_rpath ${lib.getLib blasProvider'}/lib \
     $out/lib/libblas${canonicalExtension}
-'' else "") + ''
+'') + ''
 
   if [ "$out/lib/libblas${canonicalExtension}" != "$out/lib/libblas${stdenv.hostPlatform.extensions.sharedLibrary}" ]; then
     ln -s $out/lib/libblas${canonicalExtension} "$out/lib/libblas${stdenv.hostPlatform.extensions.sharedLibrary}"
@@ -115,12 +115,12 @@ EOF
 '' + (if stdenv.hostPlatform.parsed.kernel.execFormat.name == "elf" then ''
   patchelf --set-soname libcblas${canonicalExtension} $out/lib/libcblas${canonicalExtension}
   patchelf --set-rpath "$(patchelf --print-rpath $out/lib/libcblas${canonicalExtension}):${lib.getLib blasProvider'}/lib" $out/lib/libcblas${canonicalExtension}
-'' else if stdenv.hostPlatform.isDarwin then ''
+'' else lib.optionalString stdenv.hostPlatform.isDarwin ''
   install_name_tool \
     -id $out/lib/libcblas${canonicalExtension} \
     -add_rpath ${lib.getLib blasProvider'}/lib \
     $out/lib/libcblas${canonicalExtension}
-'' else "") + ''
+'') + ''
   if [ "$out/lib/libcblas${canonicalExtension}" != "$out/lib/libcblas${stdenv.hostPlatform.extensions.sharedLibrary}" ]; then
     ln -s $out/lib/libcblas${canonicalExtension} "$out/lib/libcblas${stdenv.hostPlatform.extensions.sharedLibrary}"
   fi

--- a/pkgs/build-support/alternatives/lapack/default.nix
+++ b/pkgs/build-support/alternatives/lapack/default.nix
@@ -54,10 +54,10 @@ stdenv.mkDerivation {
   cp -L "$liblapack" $out/lib/liblapack${canonicalExtension}
   chmod +w $out/lib/liblapack${canonicalExtension}
 
-'' + (if stdenv.hostPlatform.parsed.kernel.execFormat.name == "elf" then ''
+'' + (lib.optionalString (stdenv.hostPlatform.parsed.kernel.execFormat.name == "elf") ''
   patchelf --set-soname liblapack${canonicalExtension} $out/lib/liblapack${canonicalExtension}
   patchelf --set-rpath "$(patchelf --print-rpath $out/lib/liblapack${canonicalExtension}):${lapackProvider'}/lib" $out/lib/liblapack${canonicalExtension}
-'' else "") + ''
+'') + ''
 
   if [ "$out/lib/liblapack${canonicalExtension}" != "$out/lib/liblapack${stdenv.hostPlatform.extensions.sharedLibrary}" ]; then
     ln -s $out/lib/liblapack${canonicalExtension} "$out/lib/liblapack${stdenv.hostPlatform.extensions.sharedLibrary}"
@@ -83,10 +83,10 @@ EOF
   cp -L "$liblapacke" $out/lib/liblapacke${canonicalExtension}
   chmod +w $out/lib/liblapacke${canonicalExtension}
 
-'' + (if stdenv.hostPlatform.parsed.kernel.execFormat.name == "elf" then ''
+'' + (lib.optionalString (stdenv.hostPlatform.parsed.kernel.execFormat.name == "elf") ''
   patchelf --set-soname liblapacke${canonicalExtension} $out/lib/liblapacke${canonicalExtension}
   patchelf --set-rpath "$(patchelf --print-rpath $out/lib/liblapacke${canonicalExtension}):${lib.getLib lapackProvider'}/lib" $out/lib/liblapacke${canonicalExtension}
-'' else "") + ''
+'') + ''
 
   if [ -f "$out/lib/liblapacke.so.3" ]; then
     ln -s $out/lib/liblapacke.so.3 $out/lib/liblapacke.so

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -92,9 +92,8 @@ let
     else "";
 
   expand-response-params =
-    if buildPackages ? stdenv && buildPackages.stdenv.hasCC && buildPackages.stdenv.cc != "/dev/null"
-    then import ../expand-response-params { inherit (buildPackages) stdenv; }
-    else "";
+    lib.optionalString (buildPackages ? stdenv && buildPackages.stdenv.hasCC && buildPackages.stdenv.cc != "/dev/null")
+    (import ../expand-response-params { inherit (buildPackages) stdenv; });
 
 in
 

--- a/pkgs/build-support/build-bazel-package/default.nix
+++ b/pkgs/build-support/build-bazel-package/default.nix
@@ -118,10 +118,10 @@ stdenv.mkDerivation (fBuildAttrs // {
 
       # Remove all built in external workspaces, Bazel will recreate them when building
       rm -rf $bazelOut/external/{bazel_tools,\@bazel_tools.marker}
-      ${if removeRulesCC then "rm -rf $bazelOut/external/{rules_cc,\\@rules_cc.marker}" else ""}
+      ${lib.optionalString removeRulesCC "rm -rf $bazelOut/external/{rules_cc,\\@rules_cc.marker}"}
       rm -rf $bazelOut/external/{embedded_jdk,\@embedded_jdk.marker}
-      ${if removeLocalConfigCc then "rm -rf $bazelOut/external/{local_config_cc,\\@local_config_cc.marker}" else ""}
-      ${if removeLocal then "rm -rf $bazelOut/external/{local_*,\\@local_*.marker}" else ""}
+      ${lib.optionalString removeLocalConfigCc "rm -rf $bazelOut/external/{local_config_cc,\\@local_config_cc.marker}"}
+      ${lib.optionalString removeLocal "rm -rf $bazelOut/external/{local_*,\\@local_*.marker}"}
 
       # Clear markers
       find $bazelOut/external -name '@*\.marker' -exec sh -c 'echo > {}' \;

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
@@ -212,7 +212,7 @@ in stdenv.mkDerivation {
     cd $out
     ${extraBuildCommands}
     cd $out
-    ${if isMultiBuild then extraBuildCommandsMulti else ""}
+    ${lib.optionalString isMultiBuild extraBuildCommandsMulti}
   '';
   preferLocalBuild = true;
   allowSubstitutes = false;

--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildEnv, writeText, pkgs, pkgsi686Linux }:
+{ stdenv, lib, buildEnv, writeText, pkgs, pkgsi686Linux }:
 
 { name
 , profile ? ""
@@ -237,7 +237,7 @@ in stdenv.mkDerivation {
     cd $out
     ${extraBuildCommands}
     cd $out
-    ${if isMultiBuild then extraBuildCommandsMulti else ""}
+    ${lib.optionalString isMultiBuild extraBuildCommandsMulti}
   '';
   preferLocalBuild = true;
   allowSubstitutes = false;

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -59,9 +59,7 @@ let
   suffixSalt = replaceStrings ["-" "."] ["_" "_"] targetPlatform.config;
 
   expand-response-params =
-    if (buildPackages.stdenv.hasCC or false) && buildPackages.stdenv.cc != "/dev/null"
-    then import ../expand-response-params { inherit (buildPackages) stdenv; }
-    else "";
+    lib.optionalString ((buildPackages.stdenv.hasCC or false) && buildPackages.stdenv.cc != "/dev/null") (import ../expand-response-params { inherit (buildPackages) stdenv; });
 
   useGccForLibs = isClang
     && libcxx == null

--- a/pkgs/build-support/fetchdocker/credentials.nix
+++ b/pkgs/build-support/fetchdocker/credentials.nix
@@ -35,4 +35,4 @@ let
     ({prefix, path}: "DOCKER_CREDENTIALS" == prefix)
     builtins.nixPath);
 in
-  if (pathParts != []) then (builtins.head pathParts).path else ""
+  lib.optionalString (pathParts != []) ((builtins.head pathParts).path)

--- a/pkgs/build-support/fetchfossil/default.nix
+++ b/pkgs/build-support/fetchfossil/default.nix
@@ -1,9 +1,9 @@
-{stdenv, fossil, cacert}:
+{stdenv, lib, fossil, cacert}:
 
 {name ? null, url, rev, sha256}:
 
 stdenv.mkDerivation {
-  name = "fossil-archive" + (if name != null then "-${name}" else "");
+  name = "fossil-archive" + (lib.optionalString (name != null) "-${name}");
   builder = ./builder.sh;
   nativeBuildInputs = [fossil cacert];
 

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -7,9 +7,7 @@
 
     short = builtins.substring 0 7 rev;
 
-    appendShort = if (builtins.match "[a-f0-9]*" rev) != null
-      then "-${short}"
-      else "";
+    appendShort = lib.optionalString ((builtins.match "[a-f0-9]*" rev) != null) "-${short}";
   in "${if matched == null then base else builtins.head matched}${appendShort}";
 in
 { url, rev ? "HEAD", md5 ? "", sha256 ? "", hash ? "", leaveDotGit ? deepClone

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -12,13 +12,13 @@ if md5 != null then
 else
 # TODO: statically check if mercurial as the https support if the url starts woth https.
 stdenvNoCC.mkDerivation {
-  name = "hg-archive" + (if name != null then "-${name}" else "");
+  name = "hg-archive" + (lib.optionalString (name != null) "-${name}");
   builder = ./builder.sh;
   nativeBuildInputs = [mercurial];
 
   impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 
-  subrepoClause = if fetchSubrepos then "S" else "";
+  subrepoClause = lib.optionalString fetchSubrepos "S";
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";

--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -18,7 +18,7 @@
 let
   args' = if relative != null then {
     stripLen = 1 + lib.length (lib.splitString "/" relative) + stripLen;
-    extraPrefix = if extraPrefix != null then extraPrefix else "";
+    extraPrefix = lib.optionalString (extraPrefix != null) extraPrefix;
   } else {
     inherit stripLen extraPrefix;
   };

--- a/pkgs/build-support/nuke-references/default.nix
+++ b/pkgs/build-support/nuke-references/default.nix
@@ -36,6 +36,6 @@ stdenvNoCC.mkDerivation {
     inherit perl;
     inherit (builtins) storeDir;
     shell = lib.getBin shell + (shell.shellPath or "");
-    signingUtils = if darwinCodeSign then signingUtils else "";
+    signingUtils = lib.optionalString darwinCodeSign signingUtils;
   };
 }

--- a/pkgs/build-support/release/binary-tarball.nix
+++ b/pkgs/build-support/release/binary-tarball.nix
@@ -10,7 +10,7 @@
    directory, so the Makefile of the package should support DESTDIR.
 */
 
-{ src, stdenv
+{ src, lib, stdenv
 , name ? "binary-tarball"
 , ... } @ args:
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation (
   // args //
 
   {
-    name = name + (if src ? version then "-" + src.version else "");
+    name = name + (lib.optionalString (src ? version) "-${src.version}");
 
     postHook = ''
       mkdir -p $out/nix-support

--- a/pkgs/build-support/release/debian-build.nix
+++ b/pkgs/build-support/release/debian-build.nix
@@ -24,7 +24,7 @@ vmTools.runInLinuxImage (stdenv.mkDerivation (
   // removeAttrs args ["vmTools" "lib"] //
 
   {
-    name = name + "-" + diskImage.name + (if src ? version then "-" + src.version else "");
+    name = name + "-" + diskImage.name + (lib.optionalString (src ? version) "-${src.version}");
 
     # !!! cut&paste from rpm-build.nix
     postHook = ''

--- a/pkgs/build-support/release/default.nix
+++ b/pkgs/build-support/release/default.nix
@@ -11,7 +11,7 @@ rec {
   makeSourceTarball = sourceTarball; # compatibility
 
   binaryTarball = args: import ./binary-tarball.nix (
-    { inherit stdenv;
+    { inherit lib stdenv;
     } // args);
 
   mvnBuild = args: import ./maven-build.nix (
@@ -38,7 +38,7 @@ rec {
     } // args);
 
   rpmBuild = args: import ./rpm-build.nix (
-    { inherit vmTools;
+    { inherit lib vmTools;
     } // args);
 
   debBuild = args: import ./debian-build.nix (

--- a/pkgs/build-support/release/maven-build.nix
+++ b/pkgs/build-support/release/maven-build.nix
@@ -22,7 +22,7 @@ in
 
 stdenv.mkDerivation ( {
   inherit name src;
-  phases = "setupPhase unpackPhase patchPhase mvnCompile ${if doTestCompile then "mvnTestCompile mvnTestJar" else ""} ${if doTest then "mvnTest" else ""} ${if doJavadoc then "mvnJavadoc" else ""} ${if doCheckstyle then "mvnCheckstyle" else ""} mvnJar mvnAssembly mvnRelease finalPhase";
+  phases = "setupPhase unpackPhase patchPhase mvnCompile ${lib.optionalString doTestCompile "mvnTestCompile mvnTestJar"} ${lib.optionalString doTest "mvnTest"} ${lib.optionalString doJavadoc "mvnJavadoc"} ${lib.optionalString doCheckstyle "mvnCheckstyle"} mvnJar mvnAssembly mvnRelease finalPhase";
 
   setupPhase = ''
     runHook preSetupPhase
@@ -88,9 +88,9 @@ stdenv.mkDerivation ( {
 
     echo "$releaseName" > $out/nix-support/hydra-release-name
 
-    ${if doRelease then  ''
+    ${lib.optionalString doRelease ''
     echo "file zip $out/release/$releaseName.zip" >> $out/nix-support/hydra-build-products
-    '' else ""}
+    ''}
   '';
 
   finalPhase = ''

--- a/pkgs/build-support/release/nix-build.nix
+++ b/pkgs/build-support/release/nix-build.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation (
   // removeAttrs args [ "lib" ] # Propagating lib causes the evaluation to fail, because lib is a function that can't be converted to a string
 
   // {
-    name = name + (if src ? version then "-" + src.version else "");
+    name = name + (lib.optionalString (src ? version) "-${src.version}");
 
     postHook = ''
       . ${./functions.sh}
@@ -167,7 +167,7 @@ stdenv.mkDerivation (
 
           echo "building out of source tree, from \`$PWD'..."
 
-          ${if preConfigure != null then preConfigure else ""}
+          ${lib.optionalString (preConfigure != null) preConfigure}
        '';
    }
    else {})

--- a/pkgs/build-support/release/rpm-build.nix
+++ b/pkgs/build-support/release/rpm-build.nix
@@ -3,7 +3,7 @@
 
 { name ? "rpm-build"
 , diskImage
-, src, vmTools
+, src, lib, vmTools
 , ... } @ args:
 
 vmTools.buildRPM (
@@ -11,7 +11,7 @@ vmTools.buildRPM (
   removeAttrs args ["vmTools"] //
 
   {
-    name = name + "-" + diskImage.name + (if src ? version then "-" + src.version else "");
+    name = name + "-" + diskImage.name + (lib.optionalString (src ? version) "-${src.version}");
 
     preBuild = ''
       . ${./functions.sh}

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -299,7 +299,7 @@ crate_: lib.makeOverridable
         );
 
       libName = if crate ? libName then crate.libName else crate.crateName;
-      libPath = if crate ? libPath then crate.libPath else "";
+      libPath = lib.optionalString (crate ? libPath) crate.libPath;
 
       # Seed the symbol hashes with something unique every time.
       # https://doc.rust-lang.org/1.0.0/rustc/metadata/loader/index.html#frobbing-symbols

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -406,7 +406,7 @@ rec {
       eval "$origPostHook"
     '';
 
-    origPostHook = if attrs ? postHook then attrs.postHook else "";
+    origPostHook = lib.optionalString (attrs ? postHook) attrs.postHook;
 
     /* Don't run Nix-specific build steps like patchelf. */
     fixupPhase = "true";

--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -186,10 +186,10 @@ stdenv.mkDerivation ({
       --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
   ''
   + (
-    if targetPlatform != hostPlatform || stdenv.cc.libc != null then
+    lib.optionalString (targetPlatform != hostPlatform || stdenv.cc.libc != null)
       # On NixOS, use the right path to the dynamic linker instead of
       # `/lib/ld*.so'.
-      let
+      (let
         libc = if libcCross != null then libcCross else stdenv.cc.libc;
       in
         (
@@ -207,8 +207,8 @@ stdenv.mkDerivation ({
         ''
             sed -i gcc/config/linux.h -e '1i#undef LOCAL_INCLUDE_DIR'
         ''
-        )
-    else "")
+        ))
+      )
       + lib.optionalString targetPlatform.isAvr ''
             makeFlagsArray+=(
                '-s' # workaround for hitting hydra log limit

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -195,10 +195,10 @@ stdenv.mkDerivation ({
       --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
   ''
   + (
-    if targetPlatform != hostPlatform || stdenv.cc.libc != null then
+    lib.optionalString (targetPlatform != hostPlatform || stdenv.cc.libc != null)
       # On NixOS, use the right path to the dynamic linker instead of
       # `/lib/ld*.so'.
-      let
+      (let
         libc = if libcCross != null then libcCross else stdenv.cc.libc;
       in
         (
@@ -216,8 +216,8 @@ stdenv.mkDerivation ({
         ''
             sed -i gcc/config/linux.h -e '1i#undef LOCAL_INCLUDE_DIR'
         ''
-        )
-    else "")
+        ))
+    )
       + lib.optionalString targetPlatform.isAvr ''
             makeFlagsArray+=(
                '-s' # workaround for hitting hydra log limit

--- a/pkgs/development/compilers/gcc/12/default.nix
+++ b/pkgs/development/compilers/gcc/12/default.nix
@@ -226,10 +226,10 @@ stdenv.mkDerivation ({
       --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
   ''
   + (
-    if targetPlatform != hostPlatform || stdenv.cc.libc != null then
+    lib.optionalString (targetPlatform != hostPlatform || stdenv.cc.libc != null)
       # On NixOS, use the right path to the dynamic linker instead of
       # `/lib/ld*.so'.
-      let
+      (let
         libc = if libcCross != null then libcCross else stdenv.cc.libc;
       in
         (
@@ -248,7 +248,7 @@ stdenv.mkDerivation ({
             sed -i gcc/config/linux.h -e '1i#undef LOCAL_INCLUDE_DIR'
         ''
         )
-    else "")
+    ))
       + lib.optionalString targetPlatform.isAvr ''
             makeFlagsArray+=(
                '-s' # workaround for hitting hydra log limit

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -246,10 +246,10 @@ stdenv.mkDerivation ({
         --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
     ''
   + (
-    if targetPlatform != hostPlatform || stdenv.cc.libc != null then
+    lib.optionalString (targetPlatform != hostPlatform || stdenv.cc.libc != null)
       # On NixOS, use the right path to the dynamic linker instead of
       # `/lib/ld*.so'.
-      let
+      (let
         libc = if libcCross != null then libcCross else stdenv.cc.libc;
       in
         (
@@ -267,8 +267,8 @@ stdenv.mkDerivation ({
         ''
             sed -i gcc/config/linux.h -e '1i#undef LOCAL_INCLUDE_DIR'
         ''
-        )
-    else "");
+        ))
+    );
 
   inherit noSysDirs staticCompiler langJava crossStageStatic
     libcCross crossMingw;

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -190,10 +190,10 @@ stdenv.mkDerivation ({
       --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
   ''
   + (
-    if targetPlatform != hostPlatform || stdenv.cc.libc != null then
+    lib.optionalString (targetPlatform != hostPlatform || stdenv.cc.libc != null)
       # On NixOS, use the right path to the dynamic linker instead of
       # `/lib/ld*.so'.
-      let
+      (let
         libc = if libcCross != null then libcCross else stdenv.cc.libc;
       in
         (
@@ -211,8 +211,8 @@ stdenv.mkDerivation ({
         ''
             sed -i gcc/config/linux.h -e '1i#undef LOCAL_INCLUDE_DIR'
         ''
-        )
-    else "")
+        ))
+    )
       + lib.optionalString targetPlatform.isAvr ''
         makeFlagsArray+=(
            'LIMITS_H_TEST=false'

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -172,10 +172,10 @@ stdenv.mkDerivation ({
       --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
   ''
   + (
-    if targetPlatform != hostPlatform || stdenv.cc.libc != null then
+    lib.optionalString (targetPlatform != hostPlatform || stdenv.cc.libc != null)
       # On NixOS, use the right path to the dynamic linker instead of
       # `/lib/ld*.so'.
-      let
+      (let
         libc = if libcCross != null then libcCross else stdenv.cc.libc;
       in
         (
@@ -193,8 +193,8 @@ stdenv.mkDerivation ({
         ''
             sed -i gcc/config/linux.h -e '1i#undef LOCAL_INCLUDE_DIR'
         ''
-        )
-    else "")
+        ))
+    )
       + lib.optionalString targetPlatform.isAvr ''
             makeFlagsArray+=(
                'LIMITS_H_TEST=false'

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -186,10 +186,10 @@ stdenv.mkDerivation ({
       --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
   ''
   + (
-    if targetPlatform != hostPlatform || stdenv.cc.libc != null then
+    lib.optionalString (targetPlatform != hostPlatform || stdenv.cc.libc != null)
       # On NixOS, use the right path to the dynamic linker instead of
       # `/lib/ld*.so'.
-      let
+      (let
         libc = if libcCross != null then libcCross else stdenv.cc.libc;
       in
         (
@@ -207,8 +207,8 @@ stdenv.mkDerivation ({
         ''
             sed -i gcc/config/linux.h -e '1i#undef LOCAL_INCLUDE_DIR'
         ''
-        )
-    else "")
+        ))
+    )
       + lib.optionalString targetPlatform.isAvr ''
           makeFlagsArray+=(
              'LIMITS_H_TEST=false'

--- a/pkgs/development/compilers/go/1.18.nix
+++ b/pkgs/development/compilers/go/1.18.nix
@@ -155,12 +155,12 @@ stdenv.mkDerivation rec {
     ${lib.optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
       rm -rf pkg/${GOHOSTOS}_${GOHOSTARCH} pkg/tool/${GOHOSTOS}_${GOHOSTARCH}
     ''}
-  '' else if (stdenv.hostPlatform != stdenv.targetPlatform) then ''
+  '' else lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
     rm -rf bin/*_*
     ${lib.optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
       rm -rf pkg/${GOOS}_${GOARCH} pkg/tool/${GOOS}_${GOARCH}
     ''}
-  '' else "");
+  '');
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/development/compilers/go/1.19.nix
+++ b/pkgs/development/compilers/go/1.19.nix
@@ -155,12 +155,12 @@ stdenv.mkDerivation rec {
     ${lib.optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
       rm -rf pkg/${GOHOSTOS}_${GOHOSTARCH} pkg/tool/${GOHOSTOS}_${GOHOSTARCH}
     ''}
-  '' else if (stdenv.hostPlatform != stdenv.targetPlatform) then ''
+  '' else lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
     rm -rf bin/*_*
     ${lib.optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
       rm -rf pkg/${GOOS}_${GOARCH} pkg/tool/${GOOS}_${GOARCH}
     ''}
-  '' else "");
+  '');
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/development/compilers/go/1.20.nix
+++ b/pkgs/development/compilers/go/1.20.nix
@@ -147,12 +147,12 @@ stdenv.mkDerivation rec {
     ${lib.optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
       rm -rf pkg/${GOHOSTOS}_${GOHOSTARCH} pkg/tool/${GOHOSTOS}_${GOHOSTARCH}
     ''}
-  '' else if (stdenv.hostPlatform != stdenv.targetPlatform) then ''
+  '' else lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
     rm -rf bin/*_*
     ${lib.optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
       rm -rf pkg/${GOOS}_${GOARCH} pkg/tool/${GOOS}_${GOARCH}
     ''}
-  '' else "");
+  '');
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -79,8 +79,8 @@ openjdk17.overrideAttrs (oldAttrs: rec {
 
   installPhase = let
     buildType = if debugBuild then "fastdebug" else "release";
-    debugSuffix = if debugBuild then "-fastdebug" else "";
-    jcefSuffix = if debugBuild then "" else "_jcef";
+    debugSuffix = lib.optionalString debugBuild "-fastdebug";
+    jcefSuffix = lib.optionalString (!debugBuild) "_jcef";
   in ''
     runHook preInstall
 

--- a/pkgs/development/compilers/llvm/10/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/10/bintools/default.nix
@@ -1,10 +1,7 @@
-{ runCommand, stdenv, llvm, lld, version }:
+{ lib, runCommand, stdenv, llvm, lld, version }:
 
 let
-  prefix =
-    if stdenv.hostPlatform != stdenv.targetPlatform
-    then "${stdenv.targetPlatform.config}-"
-    else "";
+  prefix = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in runCommand "llvm-binutils-${version}" {
   preferLocalBuild = true;
   passthru = {

--- a/pkgs/development/compilers/llvm/11/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/11/bintools/default.nix
@@ -1,10 +1,7 @@
-{ runCommand, stdenv, llvm, lld, version }:
+{ lib, runCommand, stdenv, llvm, lld, version }:
 
 let
-  prefix =
-    if stdenv.hostPlatform != stdenv.targetPlatform
-    then "${stdenv.targetPlatform.config}-"
-    else "";
+  prefix = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in runCommand "llvm-binutils-${version}" {
   preferLocalBuild = true;
   passthru = {

--- a/pkgs/development/compilers/llvm/12/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/12/bintools/default.nix
@@ -1,10 +1,7 @@
-{ runCommand, stdenv, llvm, lld, version }:
+{ lib, runCommand, stdenv, llvm, lld, version }:
 
 let
-  prefix =
-    if stdenv.hostPlatform != stdenv.targetPlatform
-    then "${stdenv.targetPlatform.config}-"
-    else "";
+  prefix = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in runCommand "llvm-binutils-${version}" {
   preferLocalBuild = true;
   passthru = {

--- a/pkgs/development/compilers/llvm/13/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/13/bintools/default.nix
@@ -1,10 +1,7 @@
-{ runCommand, stdenv, llvm, lld, version }:
+{ lib, runCommand, stdenv, llvm, lld, version }:
 
 let
-  prefix =
-    if stdenv.hostPlatform != stdenv.targetPlatform
-    then "${stdenv.targetPlatform.config}-"
-    else "";
+  prefix = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in runCommand "llvm-binutils-${version}" {
   preferLocalBuild = true;
   passthru = {

--- a/pkgs/development/compilers/llvm/14/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/14/bintools/default.nix
@@ -1,10 +1,7 @@
-{ runCommand, stdenv, llvm, lld, version }:
+{ lib, runCommand, stdenv, llvm, lld, version }:
 
 let
-  prefix =
-    if stdenv.hostPlatform != stdenv.targetPlatform
-    then "${stdenv.targetPlatform.config}-"
-    else "";
+  prefix = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in runCommand "llvm-binutils-${version}" {
   preferLocalBuild = true;
   passthru = {

--- a/pkgs/development/compilers/llvm/15/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/15/bintools/default.nix
@@ -1,10 +1,7 @@
-{ runCommand, stdenv, llvm, lld, version }:
+{ lib, runCommand, stdenv, llvm, lld, version }:
 
 let
-  prefix =
-    if stdenv.hostPlatform != stdenv.targetPlatform
-    then "${stdenv.targetPlatform.config}-"
-    else "";
+  prefix = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in runCommand "llvm-binutils-${version}" {
   preferLocalBuild = true;
   passthru = {

--- a/pkgs/development/compilers/llvm/7/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/7/bintools/default.nix
@@ -1,10 +1,7 @@
-{ runCommand, stdenv, llvm, lld, version }:
+{ lib, runCommand, stdenv, llvm, lld, version }:
 
 let
-  prefix =
-    if stdenv.hostPlatform != stdenv.targetPlatform
-    then "${stdenv.targetPlatform.config}-"
-    else "";
+  prefix = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in runCommand "llvm-binutils-${version}" {
   preferLocalBuild = true;
   passthru = {

--- a/pkgs/development/compilers/llvm/8/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/8/bintools/default.nix
@@ -1,10 +1,7 @@
-{ runCommand, stdenv, llvm, lld, version }:
+{ lib, runCommand, stdenv, llvm, lld, version }:
 
 let
-  prefix =
-    if stdenv.hostPlatform != stdenv.targetPlatform
-    then "${stdenv.targetPlatform.config}-"
-    else "";
+  prefix = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in runCommand "llvm-binutils-${version}" {
   preferLocalBuild = true;
   passthru = {

--- a/pkgs/development/compilers/llvm/9/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/9/bintools/default.nix
@@ -1,10 +1,7 @@
-{ runCommand, stdenv, llvm, lld, version }:
+{ lib, runCommand, stdenv, llvm, lld, version }:
 
 let
-  prefix =
-    if stdenv.hostPlatform != stdenv.targetPlatform
-    then "${stdenv.targetPlatform.config}-"
-    else "";
+  prefix = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in runCommand "llvm-binutils-${version}" {
   preferLocalBuild = true;
   passthru = {

--- a/pkgs/development/compilers/llvm/git/bintools/default.nix
+++ b/pkgs/development/compilers/llvm/git/bintools/default.nix
@@ -1,10 +1,7 @@
 { runCommand, stdenv, llvm, lld, version }:
 
 let
-  prefix =
-    if stdenv.hostPlatform != stdenv.targetPlatform
-    then "${stdenv.targetPlatform.config}-"
-    else "";
+  prefix = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in runCommand "llvm-binutils-${version}" {
   preferLocalBuild = true;
   passthru = {

--- a/pkgs/development/compilers/sbcl/2.x.nix
+++ b/pkgs/development/compilers/sbcl/2.x.nix
@@ -188,7 +188,7 @@ stdenv.mkDerivation rec {
                   lib.concatStringsSep " "
                     (builtins.map (x: "--with-${x}") enableFeatures ++
                      builtins.map (x: "--without-${x}") disableFeatures)
-                } ${if stdenv.hostPlatform.system == "aarch64-darwin" then "--arch=arm64" else ""}
+                } ${lib.optionalString (stdenv.hostPlatform.system == "aarch64-darwin") "--arch=arm64"}
     (cd doc/manual ; make info)
 
     runHook postBuild

--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -96,7 +96,7 @@ let
       for i in ./scripts/*.sh ./scripts/*.py ./test/*.sh ./test/*.py; do
         patchShebangs "$i"
       done
-      TERM=xterm ./scripts/tests.sh ${if z3Support then "--no-smt" else ""}
+      TERM=xterm ./scripts/tests.sh ${lib.optionalString z3Support "--no-smt"}
       popd
     '';
 

--- a/pkgs/development/compilers/swift/wrapper/default.nix
+++ b/pkgs/development/compilers/swift/wrapper/default.nix
@@ -16,8 +16,7 @@ stdenv.mkDerivation (swift._wrapperParams // {
     swiftOs swiftArch
     swiftModuleSubdir swiftLibSubdir
     swiftStaticModuleSubdir swiftStaticLibSubdir;
-  swiftDriver = if useSwiftDriver
-    then "${swift-driver}/bin/swift-driver" else "";
+  swiftDriver = lib.optionalString useSwiftDriver "${swift-driver}/bin/swift-driver";
 
   passAsFile = [ "buildCommand" ];
   buildCommand = ''

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -254,7 +254,7 @@ in package-set { inherit pkgs lib callPackage; } self // {
     # a cabal flag with '--flag=myflag'.
     developPackage =
       { root
-      , name ? if builtins.typeOf root == "path" then builtins.baseNameOf root else ""
+      , name ? lib.optionalString (builtins.typeOf root == "path") (builtins.baseNameOf root)
       , source-overrides ? {}
       , overrides ? self: super: {}
       , modifier ? drv: drv

--- a/pkgs/development/haskell-modules/package-list.nix
+++ b/pkgs/development/haskell-modules/package-list.nix
@@ -10,9 +10,8 @@ let
     let
       version = pkg.version or "";
     in
-    if isPvpVersion version then
-      ''"${name}","${version}","http://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.${name}.x86_64-linux"''
-    else "";
+    lib.optionalString (isPvpVersion version)
+      ''"${name}","${version}","http://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.${name}.x86_64-linux"'';
   all-haskellPackages = builtins.toFile "all-haskellPackages" (lib.concatStringsSep "\n" (lib.filter (x: x != "") (lib.mapAttrsToList pkgLine haskellPackages)));
 in
 runCommand "hackage-package-list" { }

--- a/pkgs/development/interpreters/dhall/generate-dhall-directory-package.nix
+++ b/pkgs/development/interpreters/dhall/generate-dhall-directory-package.nix
@@ -19,7 +19,7 @@ lib.makePackageOverridable
       name = "dhall-directory-package.nix";
 
       buildCommand = ''
-        dhall-to-nixpkgs directory --fixed-output-derivations --file "${file}" "${src}" ${if document then "--document" else ""} > $out
+        dhall-to-nixpkgs directory --fixed-output-derivations --file "${file}" "${src}" ${lib.optionalString document "--document"} > $out
       '';
 
       nativeBuildInputs = [ dhall-nixpkgs ];

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -186,7 +186,7 @@ let
     NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lobjc";
 
     # See https://savannah.gnu.org/bugs/?50339
-    F77_INTEGER_8_FLAG = if use64BitIdx then "-fdefault-integer-8" else "";
+    F77_INTEGER_8_FLAG = lib.optionalString use64BitIdx "-fdefault-integer-8";
 
     configureFlags = [
       "--with-blas=blas"

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -26,7 +26,7 @@ let
     inherit self sourceVersion pythonVersion packageOverrides;
     implementation = "pypy";
     libPrefix = "pypy${pythonVersion}";
-    executable = "pypy${if isPy39OrNewer then lib.versions.majorMinor pythonVersion else if isPy3k then "3" else ""}";
+    executable = "pypy${if isPy39OrNewer then lib.versions.majorMinor pythonVersion else lib.optionalString isPy3k "3"}";
     sitePackages = "site-packages";
     hasDistutilsCxxPatch = false;
     inherit pythonAttr;

--- a/pkgs/development/interpreters/python/pypy/prebuilt.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt.nix
@@ -32,7 +32,7 @@ let
     inherit self sourceVersion pythonVersion packageOverrides;
     implementation = "pypy";
     libPrefix = "pypy${pythonVersion}";
-    executable = "pypy${if isPy3k then "3" else ""}";
+    executable = "pypy${lib.optionalString isPy3k "3"}";
     sitePackages = "lib/${libPrefix}/site-packages";
     hasDistutilsCxxPatch = false;
 

--- a/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
@@ -32,7 +32,7 @@ let
     inherit self sourceVersion pythonVersion packageOverrides;
     implementation = "pypy";
     libPrefix = "pypy${pythonVersion}";
-    executable = "pypy${if isPy3k then "3" else ""}";
+    executable = "pypy${lib.optionalString isPy3k "3"}";
     sitePackages = "site-packages";
     hasDistutilsCxxPatch = false;
 

--- a/pkgs/development/interpreters/ruby/ruby-version.nix
+++ b/pkgs/development/interpreters/ruby/ruby-version.nix
@@ -55,9 +55,9 @@ let
         self.majMinTiny + (
           if self.patchLevel != null then
             "-p${self.patchLevel}"
-          else if self.tail != "" then
-            "-${self.tail}"
-          else "");
+          else
+            lib.optionalString (self.tail != "") "-${self.tail}"
+        );
     };
 in
   rubyVersion

--- a/pkgs/development/libraries/botan/generic.nix
+++ b/pkgs/development/libraries/botan/generic.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals stdenv.isDarwin [ CoreServices Security ];
 
   configurePhase = ''
-    python configure.py --prefix=$out --with-bzip2 --with-zlib ${extraConfigureFlags}${if stdenv.cc.isClang then " --cc=clang" else "" }
+    python configure.py --prefix=$out --with-bzip2 --with-zlib ${extraConfigureFlags}${lib.optionalString stdenv.cc.isClang " --cc=clang"}
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/galario/default.nix
+++ b/pkgs/development/libraries/galario/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   preCheck = ''
     ${if stdenv.isDarwin then "export DYLD_LIBRARY_PATH=$(pwd)/src/" else "export LD_LIBRARY_PATH=$(pwd)/src/"}
-    ${if enablePython then "sed -i -e 's|^#!.*|#!${stdenv.shell}|' python/py.test.sh" else ""}
+    ${lib.optionalString enablePython "sed -i -e 's|^#!.*|#!${stdenv.shell}|' python/py.test.sh"}
   '';
 
   cmakeFlags = lib.optionals enablePython [

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  LDFLAGS = if stdenv.isSunOS then "-lm -lmd -lmp -luutil -lnvpair -lnsl -lidmap -lavl -lsec" else "";
+  LDFLAGS = lib.optionalString stdenv.isSunOS "-lm -lmd -lmp -luutil -lnvpair -lnsl -lidmap -lavl -lsec";
 
   configureFlags = [
      "--disable-csharp" "--with-xz"

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -169,7 +169,7 @@ stdenv.mkDerivation ({
   buildInputs = [ linuxHeaders ] ++ lib.optionals withGd [ gd libpng ] ++ extraBuildInputs;
 
   env = {
-    linuxHeaders = if withLinuxHeaders then linuxHeaders else "";
+    linuxHeaders = lib.optionalString withLinuxHeaders linuxHeaders;
     inherit (stdenv) is64bit;
     # Needed to install share/zoneinfo/zone.tab.  Set to impure /bin/sh to
     # prevent a retained dependency on the bootstrap tools in the stdenv-linux

--- a/pkgs/development/libraries/lame/default.nix
+++ b/pkgs/development/libraries/lame/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     (lib.enableFeature frontendSupport "dynamic-frontends")
     #(enableFeature mp3xSupport "mp3x")
     (lib.enableFeature mp3rtpSupport "mp3rtp")
-    (if debugSupport then "--enable-debug=alot" else "")
+    (lib.optionalString debugSupport "--enable-debug=alot")
   ];
 
   preConfigure = ''

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -269,7 +269,7 @@ stdenv.mkDerivation rec {
       (cfg "runstatedir" "/run")
 
       (cfg "init_script" (if isDarwin then "none" else "systemd"))
-      (cfg "qemu_datadir" (if isDarwin then "${qemu}/share/qemu" else ""))
+      (cfg "qemu_datadir" (lib.optionalString isDarwin "${qemu}/share/qemu"))
 
       (feat "apparmor" isLinux)
       (feat "attr" isLinux)

--- a/pkgs/development/libraries/libvpx/1_8.nix
+++ b/pkgs/development/libraries/libvpx/1_8.nix
@@ -156,7 +156,7 @@ stdenv.mkDerivation rec {
               else if stdenv.hostPlatform.osxMinVersion == "10.5"  then "9"
               else "8"
             else ""}-gcc"
-    (if stdenv.hostPlatform.isCygwin then "--enable-static-msvcrt" else "")
+    (lib.optionalString stdenv.hostPlatform.isCygwin "--enable-static-msvcrt")
   ] # Experimental features
     ++ optional experimentalSpatialSvcSupport "--enable-spatial-svc"
     ++ optional experimentalFpMbStatsSupport "--enable-fp-mb-stats"

--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -165,7 +165,7 @@ stdenv.mkDerivation rec {
                     experimentalEmulateHardwareSupport) "experimental")
   ] ++ optionals (stdenv.isBSD || stdenv.hostPlatform != stdenv.buildPlatform) [
     "--force-target=${stdenv.hostPlatform.parsed.cpu.name}-${kernel}-gcc"
-    (if stdenv.hostPlatform.isCygwin then "--enable-static-msvcrt" else "")
+    (lib.optionalString stdenv.hostPlatform.isCygwin "--enable-static-msvcrt")
   ] # Experimental features
     ++ optional experimentalSpatialSvcSupport "--enable-spatial-svc"
     ++ optional experimentalFpMbStatsSupport "--enable-fp-mb-stats"

--- a/pkgs/development/libraries/physics/applgrid/default.nix
+++ b/pkgs/development/libraries/physics/applgrid/default.nix
@@ -21,10 +21,10 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     substituteInPlace src/Makefile.in \
       --replace "-L\$(subst /libgfortran.a, ,\$(FRTLIB) )" "-L${gfortran.cc.lib}/lib"
-  '' + (if stdenv.isDarwin then ''
+  '' + (lib.optionalString stdenv.isDarwin ''
     substituteInPlace src/Makefile.in \
       --replace "gfortran -print-file-name=libgfortran.a" "gfortran -print-file-name=libgfortran.dylib"
-  '' else "");
+  '');
 
   enableParallelBuilding = false; # broken
 

--- a/pkgs/development/libraries/science/math/amd-blis/default.nix
+++ b/pkgs/development/libraries/science/math/amd-blis/default.nix
@@ -16,7 +16,7 @@
 }:
 
 let
-  threadingSuffix = if withOpenMP then "-mt" else "";
+  threadingSuffix = lib.optionalString withOpenMP "-mt";
   blasIntSize = if blas64 then "64" else "32";
 in stdenv.mkDerivation rec {
   pname = "amd-blis";

--- a/pkgs/development/libraries/science/math/p4est-sc/default.nix
+++ b/pkgs/development/libraries/science/math/p4est-sc/default.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  dbg = if debugEnable then "-dbg" else "";
+  dbg = lib.optionalString debugEnable "-dbg";
   debugEnable = p4est-sc-debugEnable;
   mpiSupport = p4est-sc-mpiSupport;
   isOpenmpi = mpiSupport && mpi.pname == "openmpi";
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
   '';
   preConfigure = ''
     echo "2.8.0" > .tarball-version
-    ${if mpiSupport then "unset CC" else ""}
+    ${lib.optionalString mpiSupport "unset CC"}
   '';
 
   configureFlags = [ "--enable-pthread=-pthread" ]

--- a/pkgs/development/libraries/science/math/p4est/default.nix
+++ b/pkgs/development/libraries/science/math/p4est/default.nix
@@ -9,7 +9,7 @@
 
 let
   inherit (p4est-sc) debugEnable mpiSupport;
-  dbg = if debugEnable then "-dbg" else "";
+  dbg = lib.optionalString debugEnable "-dbg";
   withMetis = p4est-withMetis;
 in
 stdenv.mkDerivation {

--- a/pkgs/development/libraries/science/math/petsc/default.nix
+++ b/pkgs/development/libraries/science/math/petsc/default.nix
@@ -55,11 +55,11 @@ stdenv.mkDerivation rec {
         "--with-fc=mpif90"
         "--with-mpi=1"
       ''}
-      ${if withp4est then ''
+      ${lib.optionalString withp4est ''
         "--with-p4est=1"
         "--with-zlib-include=${zlib.dev}/include"
         "--with-zlib-lib=-L${zlib}/lib -lz"
-      '' else ""}
+      ''}
       "--with-blas=1"
       "--with-lapack=1"
     )

--- a/pkgs/development/libraries/udns/default.nix
+++ b/pkgs/development/libraries/udns/default.nix
@@ -19,14 +19,10 @@ stdenv.mkDerivation rec {
   # udns uses a very custom build and hardcodes a .so name in a few places.
   # Instead of fighting with it to apply the standard dylib script, change
   # the right place in the Makefile itself.
-  postPatch =
-    if stdenv.isDarwin
-    then
-      ''
-        substituteInPlace Makefile.in \
-          --replace --soname, -install_name,$out/lib/
-      ''
-    else "";
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace Makefile.in \
+      --replace --soname, -install_name,$out/lib/
+  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/development/mobile/titaniumenv/build-app.nix
+++ b/pkgs/development/mobile/titaniumenv/build-app.nix
@@ -167,7 +167,7 @@ stdenv.mkDerivation ({
       echo "file binary-dist \"$(ls $out/*.apk)\"" > $out/nix-support/hydra-build-products
     ''
     else if target == "iphone" then
-      if release then ''
+      lib.optionalString release ''
         mkdir -p $out/nix-support
         echo "file binary-dist \"$(echo $out/*.ipa)\"" > $out/nix-support/hydra-build-products
 
@@ -180,7 +180,6 @@ stdenv.mkDerivation ({
           echo "doc install \"$out/$appname.html\"" >> $out/nix-support/hydra-build-products
         ''}
       ''
-      else ""
     else throw "Target: ${target} is not supported!"}
   '';
 

--- a/pkgs/development/mobile/titaniumenv/titaniumsdk-7.5.nix
+++ b/pkgs/development/mobile/titaniumenv/titaniumsdk-7.5.nix
@@ -103,10 +103,9 @@ stdenv.mkDerivation {
       ''
         patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux.so.2 android/titanium_prep.linux32
       ''
-      else if stdenv.system == "x86_64-linux" then
-      ''
+      else lib.optionalString (stdenv.system == "x86_64-linux") ''
         patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 android/titanium_prep.linux64
       ''
-      else ""}
+    }
   '';
 }

--- a/pkgs/development/mobile/titaniumenv/titaniumsdk-8.2.nix
+++ b/pkgs/development/mobile/titaniumenv/titaniumsdk-8.2.nix
@@ -105,10 +105,9 @@ stdenv.mkDerivation {
       ''
         patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux.so.2 android/titanium_prep.linux32
       ''
-      else if stdenv.system == "x86_64-linux" then
-      ''
+      else lib.optionalString (stdenv.system == "x86_64-linux") ''
         patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 android/titanium_prep.linux64
       ''
-      else ""}
+    }
   '';
 }

--- a/pkgs/development/mobile/xcodeenv/build-app.nix
+++ b/pkgs/development/mobile/xcodeenv/build-app.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation ({
     # Do the building
     export LD=/usr/bin/clang # To avoid problem with -isysroot parameter that is unrecognized by the stock ld. Comparison with an impure build shows that it uses clang instead. Ugly, but it works
 
-    xcodebuild -target ${_target} -configuration ${_configuration} ${lib.optionalString (scheme != null) "-scheme ${scheme}"} -sdk ${_sdk} TARGETED_DEVICE_FAMILY="1, 2" ONLY_ACTIVE_ARCH=NO CONFIGURATION_TEMP_DIR=$TMPDIR CONFIGURATION_BUILD_DIR=$out ${if generateIPA || generateXCArchive then "-archivePath \"${name}.xcarchive\" archive" else ""} ${if release then '' PROVISIONING_PROFILE=$PROVISIONING_PROFILE OTHER_CODE_SIGN_FLAGS="--keychain $HOME/Library/Keychains/$keychainName-db"'' else ""} ${xcodeFlags}
+    xcodebuild -target ${_target} -configuration ${_configuration} ${lib.optionalString (scheme != null) "-scheme ${scheme}"} -sdk ${_sdk} TARGETED_DEVICE_FAMILY="1, 2" ONLY_ACTIVE_ARCH=NO CONFIGURATION_TEMP_DIR=$TMPDIR CONFIGURATION_BUILD_DIR=$out ${lib.optionalString (generateIPA || generateXCArchive) "-archivePath \"${name}.xcarchive\" archive"} ${lib.optionalString release '' PROVISIONING_PROFILE=$PROVISIONING_PROFILE OTHER_CODE_SIGN_FLAGS="--keychain $HOME/Library/Keychains/$keychainName-db"''} ${xcodeFlags}
 
     ${lib.optionalString release ''
       ${lib.optionalString generateIPA ''

--- a/pkgs/development/node-packages/overrides.nix
+++ b/pkgs/development/node-packages/overrides.nix
@@ -268,11 +268,7 @@ final: prev: {
     nativeBuildInputs = [ pkgs.buildPackages.makeWrapper ];
     postFixup = ''
       wrapProgram "$out/bin/makam" --prefix PATH : ${lib.makeBinPath [ nodejs ]}
-      ${
-        if stdenv.isLinux
-          then "patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 \"$out/lib/node_modules/makam/makam-bin-linux64\""
-          else ""
-      }
+      ${lib.optionalString stdenv.isLinux "patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2 \"$out/lib/node_modules/makam/makam-bin-linux64\""}
     '';
   };
 

--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -46,7 +46,7 @@ in buildPythonPackage rec {
     ${lib.optionalString mpiSupport "export OMPI_MCA_rmaps_base_oversubscribe=yes"}
   '';
 
-  preBuild = if mpiSupport then "export CC=${mpi}/bin/mpicc" else "";
+  preBuild = lib.optionalString mpiSupport "export CC=${mpi}/bin/mpicc";
 
   nativeBuildInputs = [
     cython

--- a/pkgs/development/python-modules/optuna/default.nix
+++ b/pkgs/development/python-modules/optuna/default.nix
@@ -70,10 +70,10 @@ buildPythonPackage rec {
     typing
   ];
 
-  configurePhase = if !(pythonOlder "3.5") then ''
+  configurePhase = lib.optionalString (! pythonOlder "3.5") ''
     substituteInPlace setup.py \
       --replace "'typing'," ""
-  '' else "";
+  '';
 
   checkPhase = ''
     pytest --ignore tests/test_cli.py \

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -75,7 +75,7 @@ let
   tfFeature = x: if x then "1" else "0";
 
   version = "2.11.0";
-  variant = if cudaSupport then "-gpu" else "";
+  variant = lib.optionalString cudaSupport "-gpu";
   pname = "tensorflow${variant}";
 
   pythonEnv = python.withPackages (_:

--- a/pkgs/development/ruby-modules/bundled-common/default.nix
+++ b/pkgs/development/ruby-modules/bundled-common/default.nix
@@ -66,9 +66,8 @@ let
     name;
 
   copyIfBundledByPath = { bundledByPath ? false, ...}:
-  (if bundledByPath then
-      assert gemFiles.gemdir != null; "cp -a ${gemFiles.gemdir}/* $out/" #*/
-    else ""
+  (lib.optionalString bundledByPath (
+      assert gemFiles.gemdir != null; "cp -a ${gemFiles.gemdir}/* $out/") #*/
   );
 
   maybeCopyAll = pkgname: if pkgname == null then "" else

--- a/pkgs/development/tools/misc/distcc/default.nix
+++ b/pkgs/development/tools/misc/distcc/default.nix
@@ -27,10 +27,10 @@ let
                             CXXFLAGS="-O2 -fno-strict-aliasing"
           --mandir=$out/share/man
                             ${if sysconfDir == "" then "" else "--sysconfdir=${sysconfDir}"}
-                            ${if static then "LDFLAGS=-static" else ""}
-                            --with${if static == true || popt == null then "" else "out"}-included-popt
-                            --with${if avahi != null then "" else "out"}-avahi
-                            --with${if gtk3 != null then "" else "out"}-gtk
+                            ${lib.optionalString static "LDFLAGS=-static"}
+                            ${lib.withFeature (static == true || popt == null) "included-popt"}
+                            ${lib.withFeature (avahi != null) "avahi"}
+                            ${lib.withFeature (gtk3 != null) "gtk"}
                             --without-gnome
                             --enable-rfc2553
                             --disable-Werror   # a must on gcc 4.6

--- a/pkgs/development/tools/poetry2nix/poetry2nix/lib.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/lib.nix
@@ -151,7 +151,7 @@ let
         (builtins.filter
           ({ prefix, path }: "NETRC" == prefix)
           builtins.nixPath);
-      netrc_file = if (pathParts != [ ]) then (builtins.head pathParts).path else "";
+      netrc_file = lib.optionalString (pathParts != [ ]) (builtins.head pathParts).path;
     in
     pkgs.runCommand file
       {

--- a/pkgs/development/tools/poetry2nix/poetry2nix/overrides/default.nix
+++ b/pkgs/development/tools/poetry2nix/poetry2nix/overrides/default.nix
@@ -457,9 +457,9 @@ lib.composeManyExtensions [
 
         preConfigure = lib.concatStringsSep "\n" [
           (old.preConfigure or "")
-          (if (lib.versionAtLeast stdenv.hostPlatform.darwinMinVersion "11" && stdenv.isDarwin) then ''
+          (lib.optionalString (lib.versionAtLeast stdenv.hostPlatform.darwinMinVersion "11" && stdenv.isDarwin) ''
             MACOSX_DEPLOYMENT_TARGET=10.16
-          '' else "")
+          '')
         ];
 
         preBuild = old.preBuild or "" + ''
@@ -720,7 +720,7 @@ lib.composeManyExtensions [
                 (old.propagatedBuildInputs or [ ])
                 ++ lib.optionals mpiSupport [ self.mpi4py self.openssh ]
               ;
-              preBuild = if mpiSupport then "export CC=${mpi}/bin/mpicc" else "";
+              preBuild = lib.optionalString mpiSupport "export CC=${mpi}/bin/mpicc";
               HDF5_DIR = "${pkgs.hdf5}";
               HDF5_MPI = if mpiSupport then "ON" else "OFF";
               # avoid strict pinning of numpy

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -202,7 +202,7 @@ let
           --run "$out/share/factorio/update-config.sh"               \
           --argv0 ""                                                 \
           --add-flags "-c \$HOME/.factorio/config.cfg"               \
-          ${if mods!=[] then "--add-flags --mod-directory=${modDir}" else ""}
+          ${lib.optionalString (mods!=[]) "--add-flags --mod-directory=${modDir}"}
 
           # TODO Currently, every time a mod is changed/added/removed using the
           # modlist, a new derivation will take up the entire footprint of the

--- a/pkgs/games/oilrush/default.nix
+++ b/pkgs/games/oilrush/default.nix
@@ -14,8 +14,7 @@ stdenv.mkDerivation {
     fetchurl { inherit url sha256; };
   shell = stdenv.shell;
   arch = if stdenv.hostPlatform.system == "x86_64-linux" then "x64"
-         else if stdenv.hostPlatform.system == "i686-linux" then "x86"
-         else "";
+         else lib.optionalString (stdenv.hostPlatform.system == "i686-linux") "x86";
   unpackPhase = ''
     mkdir oilrush
     cd oilrush

--- a/pkgs/games/sgt-puzzles/default.nix
+++ b/pkgs/games/sgt-puzzles/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     wrapGAppsHook
   ];
 
-  NIX_CFLAGS_COMPILE = if isMobile then "-DSTYLUS_BASED" else "";
+  NIX_CFLAGS_COMPILE = lib.optionalString isMobile "-DSTYLUS_BASED";
 
   buildInputs = [ gtk3 libX11 ];
 

--- a/pkgs/misc/cups/drivers/samsung/4.01.17.nix
+++ b/pkgs/misc/cups/drivers/samsung/4.01.17.nix
@@ -23,7 +23,7 @@
 # to see what will break when upgrading. Consider a new versioned attribute.
 let
   installationPath = if stdenv.hostPlatform.system == "x86_64-linux" then "x86_64" else "i386";
-  appendPath = if stdenv.hostPlatform.system == "x86_64-linux" then "64" else "";
+  appendPath = lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") "64";
   libPath = lib.makeLibraryPath [ cups libusb-compat-0_1 ] + ":$out/lib:${stdenv.cc.cc.lib}/lib${appendPath}";
 in stdenv.mkDerivation rec {
   pname = "samsung-UnifiedLinuxDriver";

--- a/pkgs/misc/source-and-tags/default.nix
+++ b/pkgs/misc/source-and-tags/default.nix
@@ -59,7 +59,7 @@
                     # without this creating tag files for lifted-base fails
                     export LC_ALL=en_US.UTF-8
                     export LANG=en_US.UTF-8
-                    ${if stdenv.isLinux then "export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive;" else ""}
+                    ${lib.optionalString stdenv.isLinux "export LOCALE_ARCHIVE=${glibcLocales}/lib/locale/locale-archive;"}
 
                     ${toString hasktags}/bin/hasktags --ignore-close-implementation --ctags .
                     mv tags \$TAG_FILE

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -94,12 +94,11 @@ stdenv.mkDerivation rec {
   NIX_DONT_SET_RPATH = true;
 
   preBuild = ''
-    ${if (stdenv.targetPlatform.libc == "musl" && stdenv.targetPlatform.isx86_32) then
+    ${lib.optionalString (stdenv.targetPlatform.libc == "musl" && stdenv.targetPlatform.isx86_32)
     "# the -x c flag is required since the file extension confuses gcc
     # that detect the file as a linker script.
     $CC -x c -c ${stack_chk_fail_local_c} -o __stack_chk_fail_local.o
     $AR r libssp_nonshared.a __stack_chk_fail_local.o"
-      else ""
     }
   '';
 

--- a/pkgs/os-specific/linux/pcmciautils/default.nix
+++ b/pkgs/os-specific/linux/pcmciautils/default.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
       s,/etc/pcmcia,$out&,;
     " src/{startup.c,pcmcia-check-broken-cis.c} # fix-color */
   ''
-  + (if firmware == [] then ''sed -i "s,STARTUP = true,STARTUP = false," Makefile'' else "")
-  + (if configOpts == null then "" else "ln -sf ${configOpts} ./config/config.opts")
+  + (lib.optionalString (firmware == []) ''sed -i "s,STARTUP = true,STARTUP = false," Makefile'')
+  + (lib.optionalString (configOpts != null) "ln -sf ${configOpts} ./config/config.opts")
   ;
 
   makeFlags = [ "LEX=flex" ];

--- a/pkgs/os-specific/windows/wxMSW-2.8/default.nix
+++ b/pkgs/os-specific/windows/wxMSW-2.8/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     (if compat24 then "--enable-compat24" else "--disable-compat24")
     (if compat26 then "--enable-compat26" else "--disable-compat26")
     "--disable-precomp-headers"
-    (if unicode then "--enable-unicode" else "")
+    (lib.optionalString unicode "--enable-unicode")
     "--with-opengl"
   ];
 

--- a/pkgs/servers/computing/storm/default.nix
+++ b/pkgs/servers/computing/storm/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
        -e 's|java.library.path: .*|java.library.path: "${lib.concatStringsSep ":" extraLibraryPaths}"|' \
        -e 's|storm.log4j2.conf.dir: .*|storm.log4j2.conf.dir: "conf/log4j2"|' \
       defaults.yaml
-    ${if confFile != "" then "cat ${confFile} >> defaults.yaml" else ""}
+    ${lib.optionalString (confFile != "") "cat ${confFile} >> defaults.yaml"}
     mv defaults.yaml $out/conf;
 
     # Link to extra jars

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -36,7 +36,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  pname = "${if libOnly then "lib" else ""}pulseaudio";
+  pname = "${lib.optionalString libOnly "lib"}pulseaudio";
   version = "16.1";
 
   src = fetchurl {

--- a/pkgs/servers/roapi/http.nix
+++ b/pkgs/servers/roapi/http.nix
@@ -5,7 +5,7 @@
 let
   pname = "roapi-http";
   version = "0.6.0";
-  target = if stdenv.isDarwin then "apple-darwin" else "";
+  target = lib.optionalString stdenv.isDarwin "apple-darwin";
 in
 # TODO build from source, currently compilation fails on darwin on snmalloc with
 #  ./mem/../ds/../pal/pal_apple.h:277:64: error: use of undeclared identifier 'kCCSuccess'

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -242,7 +242,7 @@ let
       remediationMsg = (builtins.getAttr reason remediation) attrs;
       msg = if inHydra then "Warning while evaluating ${getName attrs}: «${reason}»: ${errormsg}"
         else "Package ${getName attrs} in ${pos_str meta} ${errormsg}, continuing anyway."
-             + (if remediationMsg != "" then "\n${remediationMsg}" else "");
+             + (lib.optionalString (remediationMsg != "") "\n${remediationMsg}");
       isEnabled = lib.findFirst (x: x == reason) null showWarnings;
     in if isEnabled != null then builtins.trace msg true else true;
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -104,8 +104,8 @@ let
     ''
       export NIX_ENFORCE_PURITY="''${NIX_ENFORCE_PURITY-1}"
       export NIX_ENFORCE_NO_NATIVE="''${NIX_ENFORCE_NO_NATIVE-1}"
-      ${if system == "x86_64-linux" then "NIX_LIB64_IN_SELF_RPATH=1" else ""}
-      ${if system == "mipsel-linux" then "NIX_LIB32_IN_SELF_RPATH=1" else ""}
+      ${lib.optionalString (system == "x86_64-linux") "NIX_LIB64_IN_SELF_RPATH=1"}
+      ${lib.optionalString (system == "mipsel-linux") "NIX_LIB32_IN_SELF_RPATH=1"}
     '';
 
 

--- a/pkgs/tools/admin/google-cloud-sdk/components.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/components.nix
@@ -100,9 +100,7 @@ let
         pname = component.id;
         version = component.version.version_string;
         src =
-          if lib.hasAttrByPath [ "data" "source" ] component
-          then "${baseUrl}/${component.data.source}"
-          else "";
+          lib.optionalString (lib.hasAttrByPath [ "data" "source" ] component) "${baseUrl}/${component.data.source}";
         sha256 = lib.attrByPath [ "data" "checksum" ] "" component;
         dependencies = builtins.map (dep: builtins.getAttr dep components) component.dependencies;
         platforms =
@@ -137,12 +135,12 @@ let
     }: stdenv.mkDerivation {
       inherit pname version snapshot;
       src =
-        if src != "" then
-          builtins.fetchurl
+        lib.optionalString (src != "")
+          (builtins.fetchurl
             {
               url = src;
               inherit sha256;
-            } else "";
+            }) ;
       dontUnpack = true;
       installPhase = ''
         mkdir -p $out/google-cloud-sdk/.install

--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -386,9 +386,7 @@ stdenv.mkDerivation rec {
   # save target that grub is compiled for
   grubTarget = if efiSupport
                then "${efiSystemsInstall.${stdenv.hostPlatform.system}.target}-efi"
-               else if inPCSystems
-                    then "${pcSystems.${stdenv.hostPlatform.system}.target}-pc"
-                    else "";
+               else lib.optionalString inPCSystems "${pcSystems.${stdenv.hostPlatform.system}.target}-pc";
 
   doCheck = false;
   enableParallelBuilding = true;

--- a/pkgs/tools/misc/grub/trusted.nix
+++ b/pkgs/tools/misc/grub/trusted.nix
@@ -103,10 +103,7 @@ stdenv.mkDerivation rec {
   ];
 
   # save target that grub is compiled for
-  grubTarget =
-    if inPCSystems
-    then "${pcSystems.${stdenv.hostPlatform.system}.target}-pc"
-    else "";
+  grubTarget = lib.optionalString inPCSystems "${pcSystems.${stdenv.hostPlatform.system}.target}-pc";
 
   doCheck = false;
   # On -j16 races with early header creation:

--- a/pkgs/tools/misc/hdf4/default.nix
+++ b/pkgs/tools/misc/hdf4/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchpatch
 , fetchurl
 , fixDarwinDylibNames
@@ -95,13 +96,15 @@ stdenv.mkDerivation rec {
     "NC_TEST-nctest"
   ];
 
-  checkPhase = let excludedTestsRegex = if (excludedTests != [])
-    then "(" + (lib.concatStringsSep "|" excludedTests) + ")"
-    else ""; in ''
-    runHook preCheck
-    ctest -E "${excludedTestsRegex}" --output-on-failure
-    runHook postCheck
-  '';
+  checkPhase =
+    let
+      excludedTestsRegex = lib.optionalString (excludedTests != [ ]) "(${lib.concatStringsSep "|" excludedTests})";
+    in
+    ''
+      runHook preCheck
+      ctest -E "${excludedTestsRegex}" --output-on-failure
+      runHook postCheck
+    '';
 
   outputs = [ "bin" "dev" "out" ];
 
@@ -117,7 +120,7 @@ stdenv.mkDerivation rec {
       szip
       javaSupport
       jdk
-    ;
+      ;
   };
 
   meta = with lib; {

--- a/pkgs/tools/networking/networkmanager/fortisslvpn/default.nix
+++ b/pkgs/tools/networking/networkmanager/fortisslvpn/default.nix
@@ -21,7 +21,7 @@
 stdenv.mkDerivation rec {
   pname = "NetworkManager-fortisslvpn";
   version = "1.4.0";
-  name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
+  name = "${pname}${lib.optionalString withGnome "-gnome"}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";

--- a/pkgs/tools/networking/networkmanager/iodine/default.nix
+++ b/pkgs/tools/networking/networkmanager/iodine/default.nix
@@ -5,7 +5,7 @@ let
   pname = "NetworkManager-iodine";
   version = "unstable-2019-11-05";
 in stdenv.mkDerivation {
-  name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
+  name = "${pname}${lib.optionalString withGnome "-gnome"}-${version}";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";

--- a/pkgs/tools/networking/networkmanager/l2tp/default.nix
+++ b/pkgs/tools/networking/networkmanager/l2tp/default.nix
@@ -20,7 +20,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
+  name = "${pname}${lib.optionalString withGnome "-gnome"}-${version}";
   pname = "NetworkManager-l2tp";
   version = "1.20.4";
 

--- a/pkgs/tools/networking/networkmanager/sstp/default.nix
+++ b/pkgs/tools/networking/networkmanager/sstp/default.nix
@@ -20,7 +20,7 @@
 stdenv.mkDerivation rec {
   pname = "NetworkManager-sstp";
   version = "1.3.1";
-  name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
+  name = "${pname}${lib.optionalString withGnome "-gnome"}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";

--- a/pkgs/tools/text/unoconv/default.nix
+++ b/pkgs/tools/text/unoconv/default.nix
@@ -26,9 +26,9 @@ stdenv.mkDerivation rec {
   postInstall = ''
     sed -i "s|/usr/bin/env python.*|${python3}/bin/${python3.executable}|" "$out/bin/unoconv"
     wrapProgram "$out/bin/unoconv" --set UNO_PATH "${libreoffice-unwrapped}/lib/libreoffice/program/"
-  '' + (if installSymlinks then ''
+  '' + lib.optionalString installSymlinks ''
     make install-links prefix="$out"
-  '' else "");
+  '';
 
   meta = with lib; {
     description = "Convert between any document format supported by LibreOffice/OpenOffice";


### PR DESCRIPTION
###### Description of changes

currently the opportunity to use `lib.optionalString` is missed out. With this I think the code gets more readable.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
