### PR TITLE
nix-init: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/tools/nix/nix-init/default.nix
+++ b/pkgs/tools/nix/nix-init/default.nix
@@ -15,16 +15,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nix-init";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nix-init";
     rev = "v${version}";
-    hash = "sha256-97aAlH03H8xTVhp45FwecNb7i/ZUtJG9OOYBx8Sf+YI=";
+    hash = "sha256-x9UrBCnEGz6nI1XGBLjIeiF3qi3EvynAfafiuhQdt9Q=";
   };
 
-  cargoHash = "sha256-uvn1cP6aIxfPKG/QLtHBd6fHjl7JNRtkZ4gIG2tpHVg=";
+  cargoHash = "sha256-RUfprANAbj8w8LPRwQEF9SD9fhWb1CEcwbvOa6DX9Xk=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/tools/nix/nix-init/license.nix
+++ b/pkgs/tools/nix/nix-init/license.nix
@@ -3,12 +3,66 @@
 { lib, writeText }:
 
 let
-  inherit (builtins) concatLists concatStringsSep length;
-  inherit (lib) flip licenses mapAttrsToList optional;
+  inherit (lib)
+    concatMapAttrs
+    filterAttrs
+    flip
+    id
+    intersectLists
+    licenses
+    mapAttrsToList
+    optionalAttrs
+    pipe
+    warn
+    attrNames
+    concatStringsSep
+    length
+    ;
 
-  inserts = concatLists
-    (flip mapAttrsToList licenses
-      (k: v: optional (v ? spdxId) ''  xs.insert("${v.spdxId}", "${k}");''));
+  licenseMap = flip concatMapAttrs licenses
+    (k: v: optionalAttrs (v ? spdxId && !v.deprecated) { ${v.spdxId} = k; });
+
+  deprecatedAliases = {
+    "AGPL-3.0" = "agpl3Only";
+    "BSD-2-Clause-FreeBSD" = "bsd2WithViews";
+    "BSD-2-Clause-NetBSD" = "bsd2";
+    "GFDL-1.1" = "fdl11Only";
+    "GFDL-1.2" = "fdl12Only";
+    "GFDL-1.3" = "fdl13Only";
+    "GPL-1.0" = "gpl1Only";
+    "GPL-1.0+" = "gpl1Plus";
+    "GPL-2.0" = "gpl2Only";
+    "GPL-2.0+" = "gpl2Plus";
+    "GPL-3.0" = "gpl3Only";
+    "GPL-3.0+" = "gpl3Plus";
+    "LGPL-2.0" = "lgpl2Only";
+    "LGPL-2.0+" = "lgpl2Plus";
+    "LGPL-2.1" = "lgpl21Only";
+    "LGPL-2.1+" = "lgpl21Plus";
+    "LGPL-3.0" = "lgpl3Only";
+    "LGPL-3.0+" = "lgpl3Plus";
+  };
+
+  lints = {
+    "deprecated licenses" = intersectLists
+      (attrNames licenseMap)
+      (attrNames deprecatedAliases);
+
+    "invalid aliases" = attrNames (filterAttrs
+      (k: v: licenses.${v}.deprecated or true)
+      deprecatedAliases);
+  };
+
+  lint = flip pipe
+    (flip mapAttrsToList lints (k: v:
+      if v == [ ] then
+        id
+      else
+        warn "${k}: ${concatStringsSep ", " v}"));
+
+  inserts = lint (mapAttrsToList
+    (k: v: ''  xs.insert("${k}", "${v}");'')
+    (deprecatedAliases // licenseMap));
 in
 
 writeText "license.rs" ''


### PR DESCRIPTION
Diff: https://github.com/nix-community/nix-init/compare/v0.1.0...v0.1.1

Changelog: https://github.com/nix-community/nix-init/blob/v0.1.1/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
