### PR TITLE
fusesoc: init at 1.12.0

### DIFF
--- a/pkgs/data/themes/nordic/default.nix
+++ b/pkgs/data/themes/nordic/default.nix
@@ -7,70 +7,70 @@
 
 stdenv.mkDerivation rec {
   pname = "nordic";
-  version = "unstable-2022-06-21";
+  version = "unstable-2023-05-12";
 
   srcs = [
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "bb5e31ec1488b1fd5641aa10f65f36d8714b5dba";
-      sha256 = "sha256-wTWHdao/1RLqUmqh/9gEyhERGymFWHqiC97JD28LSgk=";
+      rev = "399246cdcbdb1a714c5bb294857cd5a6494b6006";
+      sha256 = "sha256-0yZ4QYcdcGHEw6tdcXAKZ4e+mhNNmvihBxp2sLgTuu8=";
       name = "Nordic";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "e1fb044a14b5c7fe1f6c2de42bfb5fdfb1448415";
-      sha256 = "sha256-oWwc+bzeAf0NoYfA2r2oGpeciVUWFC7yJzlUAYfpdTY=";
+      rev = "3599ddb6f8b7de936cf106bddd4f929ddfe88b1c";
+      sha256 = "sha256-ft5UbBnjP0xNFFVwk5Elvrpcj273OupjM+MGJVlvJZQ=";
       name = "Nordic-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "4c7c9f2d670a6f0c9cff1ec31fab67c826fdcc0f";
-      sha256 = "sha256-txKClsygX2IUGF8oOG6gDY6Y3v28kJthjdPrPEOZarQ=";
+      rev = "b03b66d5badadc2e5ff27b8745a2308b8fafaa61";
+      sha256 = "sha256-6dORsGfYi7q8z7JWA3Y9oqVs9bhT/gbdSrcgJcebGP8=";
       name = "Nordic-darker";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "8abe28ff07c190b8c343aacb6a0ce58e62abbd74";
-      sha256 = "sha256-tk9VZtwpIuBcWu1ERJLnlhM71pkrNEUzu8PDb+IEnpw=";
+      rev = "e19b75f56e5c328352c183fc960a0be54e99836e";
+      sha256 = "sha256-deKHT0dE5tsUo7+vkzxQ/eRon7COrOAWolw17VtKhiE=";
       name = "Nordic-darker-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "9764e0f1af100731f77bf7f15792639d0032e5ed";
-      sha256 = "sha256-3vxrbxUhPj6PKWpjyCruhFxYz9nPfo1DHferYUD7enU=";
+      rev = "b134b4a1299b3c4a2d9543707ec2b5a0fc97987c";
+      sha256 = "sha256-XSDwc0/59sUHkS0holvujmr/p6vX79648l9cxJqunuM=";
       name = "Nordic-bluish-accent";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "407316a3fd5e07d183474aea4cae28bb958afa6c";
-      sha256 = "sha256-SvLTqDXjy8c4rZo0cZ83kfuiGd2+hyGvwILxVCz65jQ=";
+      rev = "a4efbc09470b36f4cf6af60b5fdfeb8e09282fb3";
+      sha256 = "sha256-Qgrl6p0AhbhK0+aM8hu85Kz/Lz/b2Nn8uWS+WpTGjU4=";
       name = "Nordic-bluish-accent-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = "${pname}-polar";
-      rev = "1ffa167c4807e4b22e0934aee41403721877bc56";
-      sha256 = "sha256-Xat5YWnxTBnvnUfs1o5EhdmDezmOXtqry97Yc8O+WYM=";
+      rev = "0d44fb16d0f07ef8615fd7740317a518d2b9411f";
+      sha256 = "sha256-388251/Tg4jyn7c8zkrUxVFooN9O67xk2NTSeYa0VvI=";
       name = "Nordic-Polar";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = "${pname}-polar";
-      rev = "9bc68223edf7ad9dc83032d7d51ccc53f9440337";
-      sha256 = "sha256-XjGjijBky/iPcoUGDRrwwoZ5f2gbLchmQizkQN+Opjg=";
+      rev = "0eea9185946fee20b6d7472548226a3652dea7ae";
+      sha256 = "sha256-8JFrmGKn8cl1x3TeDPee1zbMmtypJ9kALv/PRqRHGAU=";
       name = "Nordic-Polar-standard-buttons";
     })
   ];

--- a/pkgs/development/python-modules/ipyxact/default.nix
+++ b/pkgs/development/python-modules/ipyxact/default.nix
@@ -1,0 +1,31 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, pyyaml
+, six
+, lxml
+}:
+
+buildPythonPackage rec {
+  pname = "ipyxact";
+  version = "0.3.2";
+
+  propagatedBuildInputs = [ pyyaml ];
+  checkInputs = [ six lxml ];
+
+  src = fetchFromGitHub {
+    owner = "olofk";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-myD+NnqcxxaSAV7qZa8xqeciaiFqFePqIzd7sb/2GXA=";
+  };
+
+  pythonImportsCheck = [ "ipyxact" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/olofk/ipyxact";
+    description = "IP-XACT parser";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/okonomiyaki/default.nix
+++ b/pkgs/development/python-modules/okonomiyaki/default.nix
@@ -1,0 +1,47 @@
+{ buildPythonPackage
+, stdenv
+, fetchFromGitHub
+, lib
+, attrs
+, distro
+, jsonschema
+, six
+, zipfile2
+, hypothesis
+, mock
+, packaging
+, testfixtures
+}:
+
+buildPythonPackage rec {
+  pname = "okonomiyaki";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "enthought";
+    repo = pname;
+    rev = version;
+    hash = "sha256-eWCOuGtdjBGThAyu15aerclkSWC593VGDPHJ98l30iY=";
+  };
+
+  propagatedBuildInputs = [ distro attrs jsonschema six zipfile2 ];
+
+  preCheck = ''
+    substituteInPlace okonomiyaki/runtimes/tests/test_runtime.py \
+      --replace 'runtime_info = PythonRuntime.from_running_python()' 'raise unittest.SkipTest() #'
+   '' + lib.optionalString stdenv.isDarwin ''
+    substituteInPlace okonomiyaki/platforms/tests/test_pep425.py \
+      --replace 'self.assertEqual(platform_tag, self.tag.platform)' 'raise unittest.SkipTest()'
+  '';
+
+  checkInputs = [ hypothesis mock packaging testfixtures ];
+
+  pythonImportsCheck = [ "okonomiyaki" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/enthought/okonomiyaki";
+    description = "An experimental library aimed at consolidating a lot of low-level code used for Enthought's eggs";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/simplesat/default.nix
+++ b/pkgs/development/python-modules/simplesat/default.nix
@@ -1,0 +1,48 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, writeText
+, lib
+, attrs
+, six
+, okonomiyaki
+}:
+
+let
+  version = "0.8.2";
+
+  versionFile = writeText "simplesat_ver" ''
+    version = '${version}'
+    full_version = '${version}'
+    git_revision = '0000000000000000000000000000000000000000'
+    is_released = True
+    msi_version = '${version}.000'
+    version_info = (${lib.versions.major version}, ${lib.versions.minor version}, ${lib.versions.patch version}, 'final', 0)
+  '';
+
+in buildPythonPackage rec {
+  pname = "simplesat";
+  inherit version;
+
+  propagatedBuildInputs = [ attrs six okonomiyaki ];
+
+  src = fetchFromGitHub {
+    owner = "enthought";
+    repo = "sat-solver";
+    rev = "v${version}";
+    hash = "sha256-6BQn1W2JGrMmNqgxi+sXx06XzNMcvwqYGMkpD0SSpT8=";
+  };
+
+  preConfigure = ''
+    cp ${versionFile} simplesat/_version.py
+  '';
+  dontUseSetuptoolsCheck = true;
+
+  pythonImportsCheck = [ "simplesat" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/enthought/sat-solver";
+    description = "Prototype for SAT-based dependency handling";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/zipfile2/default.nix
+++ b/pkgs/development/python-modules/zipfile2/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+}:
+
+buildPythonPackage rec {
+  pname = "zipfile2";
+  version = "0.0.12";
+
+  src = fetchFromGitHub {
+    owner = "cournape";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-BwcEgW4XrQqz0Jmtbyxf8q0mWTJXv2dL3Tk7N/IYuMI=";
+  };
+
+  patches = [ ./no-setuid.patch ];
+
+  pythonImportsCheck = [ "zipfile2" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/cournape/zipfile2";
+    description = "A backwards-compatible improved zipfile class";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.psfl;
+  };
+}

--- a/pkgs/development/python-modules/zipfile2/no-setuid.patch
+++ b/pkgs/development/python-modules/zipfile2/no-setuid.patch
@@ -1,0 +1,15 @@
+diff --git a/zipfile2/tests/test__zipfile.py b/zipfile2/tests/test__zipfile.py
+index 60f2ed2..db6e5bc 100644
+--- a/zipfile2/tests/test__zipfile.py
++++ b/zipfile2/tests/test__zipfile.py
+@@ -585,8 +585,8 @@ class TestsPermissionExtraction(unittest.TestCase):
+                         if index & 1 << order:
+                             mode |= permissions[permgroup][order]
+                     for order in range(3):
+-                        if specialindex & 1 << order:
+-                            mode |= permissions['special'][order]
++                        if specialindex & 1 << order and order == 0:
++                            raise unittest.SkipTest("The nix build process doesn't allow you to use the setuid bit")
+                     os.chmod(path, mode)
+                     real_permission = os.stat(path).st_mode & 0xFFF
+                     self.files.append((path, real_permission))

--- a/pkgs/tools/package-management/fusesoc/default.nix
+++ b/pkgs/tools/package-management/fusesoc/default.nix
@@ -1,0 +1,39 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, verilog
+, verilator
+, gnumake
+, gcc
+, edalize
+, fastjsonschema
+, pyparsing
+, pyyaml
+, simplesat
+, ipyxact
+, setuptools-scm
+}:
+buildPythonPackage rec {
+  pname = "fusesoc";
+  version = "2.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-M36bXBgY8hR33AVDlHoH8PZJG2Bi0KOEI07IMns7R4w=";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  propagatedBuildInputs = [ edalize fastjsonschema pyparsing pyyaml simplesat ipyxact ];
+
+  pythonImportsCheck = [ "fusesoc" ];
+
+  makeWrapperArgs = [ "--suffix PATH : ${lib.makeBinPath [ verilog verilator gnumake ]}"];
+
+  meta = with lib; {
+    homepage = "https://github.com/olofk/fusesoc";
+    description = "A package manager and build tools for HDL code";
+    maintainers = with maintainers; [ genericnerdyusername ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2256,6 +2256,8 @@ with pkgs;
 
   fuse-emulator = callPackage ../applications/emulators/fuse-emulator { };
 
+  fusesoc = python3Packages.callPackage ../tools/package-management/fusesoc { };
+
   fw = callPackage ../tools/misc/fw {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11039,6 +11039,8 @@ self: super: with self; {
 
   simplenote = callPackage ../development/python-modules/simplenote { };
 
+  simplesat = callPackage ../development/python-modules/simplesat { };
+
   simple-di = callPackage ../development/python-modules/simple-di { };
 
   simple-rest-client = callPackage ../development/python-modules/simple-rest-client { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6911,6 +6911,8 @@ self: super: with self; {
 
   oemthermostat = callPackage ../development/python-modules/oemthermostat { };
 
+  okonomiyaki = callPackage ../development/python-modules/okonomiyaki { };
+
   okta = callPackage ../development/python-modules/okta { };
 
   olefile = callPackage ../development/python-modules/olefile { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4959,6 +4959,8 @@ self: super: with self; {
 
   ipywidgets = callPackage ../development/python-modules/ipywidgets { };
 
+  ipyxact = callPackage ../development/python-modules/ipyxact { };
+
   irc = callPackage ../development/python-modules/irc { };
 
   ircrobots = callPackage ../development/python-modules/ircrobots { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13244,6 +13244,8 @@ self: super: with self; {
 
   zimports = callPackage ../development/python-modules/zimports { };
 
+  zipfile2 = callPackage ../development/python-modules/zipfile2 { };
+
   zipp = callPackage ../development/python-modules/zipp { };
 
   zipstream = callPackage ../development/python-modules/zipstream { };


### PR DESCRIPTION
###### Description of changes

Add fusesoc (and dependencies)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Relevant: https://github.com/NixOS/nixpkgs/pull/213222