### PR TITLE
phpExtensions.opcache: fix test environment for darwin

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -84,6 +84,7 @@ lib.makeScope pkgs.newScope (self: with self; {
     , zendExtension ? false
     , doCheck ? true
     , extName ? name
+    , allowLocalNetworking ? false
     , ...
     }@args: stdenv.mkDerivation ((builtins.removeAttrs args [ "name" ]) // {
       pname = "php-${name}";
@@ -103,6 +104,7 @@ lib.makeScope pkgs.newScope (self: with self; {
       ];
 
       inherit configureFlags internalDeps buildInputs zendExtension doCheck;
+      __darwinAllowLocalNetworking = allowLocalNetworking;
 
       preConfigurePhases = [
         "cdToExtensionRootPhase"
@@ -412,7 +414,7 @@ lib.makeScope pkgs.newScope (self: with self; {
           ];
           zendExtension = true;
           # Tests launch the builtin webserver.
-          __darwinAllowLocalNetworking = true;
+          allowLocalNetworking = true;
         }
         {
           name = "openssl";


### PR DESCRIPTION
###### Description of changes

The opcache extension has some tests starting a local server which is blocked by default on darwin systems.
The `__darwinAllowLocalNetworking` is set for the opcache extension but [it gets dropped](https://github.com/NixOS/nixpkgs/blob/2b013e9bc2a74fc63ff6714485b4a4325be59c00/pkgs/stdenv/generic/make-derivation.nix#L281).

I'm not sure if this is the right way to handle that but it looks like it is good enough to fix the test failures we were seeing. If someone knows if there is a better way to handle this and have the ability to test it, please advise.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Result of `nixpkgs-review pr 215004` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>tests.php.withExtensions-enables-previously-disabled-extensions</li>
  </ul>
</details>
<details>
  <summary>76 packages built:</summary>
  <ul>
    <li>adminer</li>
    <li>php (apacheHttpdPackages.php ,php81)</li>
    <li>arcanist</li>
    <li>bookstack</li>
    <li>drush</li>
    <li>easyeffects</li>
    <li>freshrss</li>
    <li>icingaweb2</li>
    <li>libsForQt5.kcachegrind (plasma5Packages.kcachegrind)</li>
    <li>lsp-plugins</li>
    <li>matomo</li>
    <li>matomo-beta</li>
    <li>n98-magerun</li>
    <li>n98-magerun2</li>
    <li>nagios</li>
    <li>nextcloud-news-updater</li>
    <li>nominatim</li>
    <li>pdepend</li>
    <li>phoronix-test-suite</li>
    <li>php80</li>
    <li>php80Extensions.opcache</li>
    <li>php80Packages.box</li>
    <li>php80Packages.composer</li>
    <li>php80Packages.deployer</li>
    <li>php80Packages.grumphp</li>
    <li>php80Packages.phan</li>
    <li>php80Packages.phing</li>
    <li>php80Packages.phive</li>
    <li>php80Packages.php-cs-fixer</li>
    <li>php80Packages.php-parallel-lint</li>
    <li>php80Packages.phpcbf</li>
    <li>php80Packages.phpcs</li>
    <li>php80Packages.phpmd</li>
    <li>php80Packages.phpstan</li>
    <li>php80Packages.psalm</li>
    <li>php80Packages.psysh</li>
    <li>php81Extensions.opcache</li>
    <li>php81Packages.box</li>
    <li>php81Packages.composer</li>
    <li>php81Packages.deployer</li>
    <li>php81Packages.grumphp</li>
    <li>php81Packages.phan</li>
    <li>php81Packages.phing</li>
    <li>php81Packages.phive</li>
    <li>php81Packages.php-cs-fixer</li>
    <li>php81Packages.php-parallel-lint</li>
    <li>php81Packages.phpcbf</li>
    <li>php81Packages.phpcs</li>
    <li>php81Packages.phpmd</li>
    <li>php81Packages.phpstan</li>
    <li>php81Packages.psalm</li>
    <li>php81Packages.psysh</li>
    <li>php82</li>
    <li>php82Extensions.opcache</li>
    <li>php82Packages.box</li>
    <li>php82Packages.composer</li>
    <li>php82Packages.deployer</li>
    <li>php82Packages.grumphp</li>
    <li>php82Packages.phan</li>
    <li>php82Packages.phing</li>
    <li>php82Packages.phive</li>
    <li>php82Packages.php-cs-fixer</li>
    <li>php82Packages.php-parallel-lint</li>
    <li>php82Packages.phpcbf</li>
    <li>php82Packages.phpcs</li>
    <li>php82Packages.phpmd</li>
    <li>php82Packages.phpstan</li>
    <li>php82Packages.psalm</li>
    <li>php82Packages.psysh</li>
    <li>platformsh</li>
    <li>pulseeffects-legacy</li>
    <li>qcachegrind</li>
    <li>snipe-it</li>
    <li>unit</li>
    <li>wp-cli</li>
    <li>yle-dl</li>
  </ul>
</details>