### PR TITLE
touchegg: 2.0.15 -> 2.0.16

### DIFF
--- a/pkgs/tools/inputmethods/touchegg/default.nix
+++ b/pkgs/tools/inputmethods/touchegg/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "touchegg";
-  version = "2.0.15";
+  version = "2.0.16";
 
   src = fetchFromGitHub {
     owner = "JoseExposito";
     repo = pname;
     rev = version;
-    sha256 = "sha256-oz3+hNNjQ/5vXWPMuhA2N2KK8W8S42WeSeDbhV4oJ9M=";
+    sha256 = "sha256-/0XeFW0cdS1/UaE/z2FROwk2dTyZMqXjiBzt62x8f8o=";
   };
 
   patches = lib.optionals withPantheon [


### PR DESCRIPTION
https://github.com/JoseExposito/touchegg/compare/2.0.15...2.0.16

###### Description of changes

- [<code>dbus: Do not use abstract socket on FreeBSD</code>](https://github.com/JoseExposito/touchegg/commit/cc74aa88ec73e75d91bf6d4eecb5049bdd43fcb5)
- [<code>Add <cstdint> header to avoid compilation errors on GCC 13</code>](https://github.com/JoseExposito/touchegg/commit/a458bc89806dedc548761f8a04c6c2a910ae1b04)
- [<code>Update to v2.0.16</code>](https://github.com/JoseExposito/touchegg/commit/ef2360ba8fba1a148d9e7c52df8c82dfa4f7648f)
  - <sub>Tags: <code>2.0.16</code></sub>
  - <sub>Files: <code>CMakeLists.txt</code></sub>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
