### PR TITLE
circt: fix darwin build

### DIFF
--- a/pkgs/development/compilers/circt/default.nix
+++ b/pkgs/development/compilers/circt/default.nix
@@ -38,6 +38,19 @@ stdenv.mkDerivation rec {
     "-DCIRCT_LLHD_SIM_ENABLED=OFF"
   ];
 
+  # There are some tests depending on `clang-tools` to work. They are activated only when detected
+  # `clang-tidy` in PATH, However, we cannot simply put `clang-tools` in checkInputs to make these
+  # tests work. Because
+  #
+  # 1. The absolute paths of binaries used in tests are resolved in configure phase.
+  # 2. When stdenv = clangStdenv, the `clang-tidy` binary appears in PATH via `clang-unwrapped`,
+  #    which is always placed before `${clang-tools}/bin` in PATH. `clang-tidy` provided in
+  #    `clang-unwrapped` cause tests failing because it is not wrapped to resolve header search paths.
+  #    https://github.com/NixOS/nixpkgs/issues/214945 discusses this issue.
+  #
+  # As a temporary fix, we disabled these tests when using clang stdenv
+  LIT_FILTER_OUT = lib.optionalString stdenv.cc.isClang "CIRCT :: Target/ExportSystemC/.*\.mlir";
+
   preConfigure = ''
     substituteInPlace test/circt-reduce/test/annotation-remover.mlir --replace "/usr/bin/env" "${coreutils}/bin/env"
   '';


### PR DESCRIPTION
###### Description of changes

Fix darwin build (https://hydra.nixos.org/build/208226935)

Darwin build failed because it is using clang stdenv. Clang stdenv provides `clang-tidy`, which activates some tests ([basic.mlir](https://github.com/llvm/circt/blob/main/integration_test/Target/ExportSystemC/basic.mlir), [func.mlir](https://github.com/llvm/circt/blob/main/integration_test/Target/ExportSystemC/func.mlir)) not activated on gcc stdenv. However, `clang-tidy` in clang stdenv is provided by `clang-unwrapped`, and cannot resolve header search.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
