### PR TITLE
python310Packages.blackjax: init at 0.9.6

### DIFF
--- a/pkgs/development/python-modules/bambi/default.nix
+++ b/pkgs/development/python-modules/bambi/default.nix
@@ -4,9 +4,11 @@
 , fetchFromGitHub
 , pytestCheckHook
 , arviz
+, blackjax
 , formulae
 , graphviz
 , numpy
+, numpyro
 , pandas
 , pymc
 , scipy
@@ -35,14 +37,16 @@ buildPythonPackage rec {
 
   preCheck = ''export HOME=$(mktemp -d)'';
 
-  nativeCheckInputs = [ graphviz pytestCheckHook ];
+  nativeCheckInputs = [
+    blackjax
+    graphviz
+    numpyro
+    pytestCheckHook
+  ];
   disabledTests = [
     # attempt to fetch data:
     "test_data_is_copied"
     "test_predict_offset"
-    # require blackjax (not in Nixpkgs), numpyro, and jax:
-    "test_logistic_regression_categoric_alternative_samplers"
-    "test_regression_alternative_samplers"
   ];
 
   pythonImportsCheck = [ "bambi" ];

--- a/pkgs/development/python-modules/blackjax/default.nix
+++ b/pkgs/development/python-modules/blackjax/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, fetchpatch
+, pytestCheckHook
+, fastprogress
+, jax
+, jaxlib
+, jaxopt
+, optax
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "blackjax";
+  version = "0.9.6";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "blackjax-devs";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-EieDu9SJxi2cp1bHlxX4vvFZeDGMGIm24GoR8nSyjvE=";
+  };
+
+  patches = [
+    # remove in next release
+    (fetchpatch {
+      name = "fix-lbfgs-args";
+      url = "https://github.com/blackjax-devs/blackjax/commit/1aaa6f64bbcb0557b658604b2daba826e260cbc6.patch";
+      hash = "sha256-XyjorXPH5Ap35Tv1/lTeTWamjplJF29SsvOq59ypftE=";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    fastprogress
+    jax
+    jaxlib
+    jaxopt
+    optax
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  disabledTestPaths = [ "tests/test_benchmarks.py" ];
+  disabledTests = [
+    # too slow
+    "test_adaptive_tempered_smc"
+  ];
+
+  pythonImportsCheck = [
+    "blackjax"
+  ];
+
+  meta = with lib; {
+    homepage = "https://blackjax-devs.github.io/blackjax";
+    description = "Sampling library designed for ease of use, speed and modularity";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/jaxopt/default.nix
+++ b/pkgs/development/python-modules/jaxopt/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, pytestCheckHook
+, absl-py
+, cvxpy
+, jax
+, jaxlib
+, matplotlib
+, numpy
+, optax
+, scipy
+, scikitlearn
+}:
+
+buildPythonPackage rec {
+  pname = "jaxopt";
+  version = "0.5.5";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = pname;
+    rev = "refs/tags/${pname}-v${version}";
+    hash = "sha256-WOsr/Dvguu9/qX6+LMlAKM3EANtYPtDu8Uo2157+bs0=";
+  };
+
+  propagatedBuildInputs = [
+    absl-py
+    jax
+    jaxlib
+    matplotlib
+    numpy
+    scipy
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    cvxpy
+    optax
+    scikitlearn
+  ];
+
+  pythonImportsCheck = [
+    "jaxopt"
+    "jaxopt.implicit_diff"
+    "jaxopt.linear_solve"
+    "jaxopt.loss"
+    "jaxopt.tree_util"
+  ];
+
+  meta = with lib; {
+    homepage = "https://jaxopt.github.io";
+    description = "Hardware accelerated, batchable and differentiable optimizers in JAX";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4850,6 +4850,8 @@ self: super: with self; {
     cudaSupport = false;
   };
 
+  jaxopt = callPackage ../development/python-modules/jaxopt { };
+
   JayDeBeApi = callPackage ../development/python-modules/JayDeBeApi { };
 
   jc = callPackage ../development/python-modules/jc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1296,6 +1296,8 @@ self: super: with self; {
 
   black = callPackage ../development/python-modules/black { };
 
+  blackjax = callPackage ../development/python-modules/blackjax { };
+
   black-macchiato = callPackage ../development/python-modules/black-macchiato { };
 
   bleach = callPackage ../development/python-modules/bleach { };


### PR DESCRIPTION
python310Package.jaxopt: init at 0.5.5
python310Packages.bambi: enable more tests

###### Description of changes

Add `blackjax` and `jaxopt` and enable `bambi` tests using `blackjax` and `numpyro` backends.

Note that it would be trivial to create GPU versions of these packages similarly to `jaxlib`/`jaxlibWithCuda` but I'm not able to test them on a GPU on any OS at the moment (and Hydra wouldn't build them anyway).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
