### PR TITLE
lua-language-server: rename from sumneko-lua-language-server, 3.6.7 -> 3.6.10, add figsoda as a maintainer

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/lua/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/lua/default.nix
@@ -1,6 +1,6 @@
 { lib
 , vscode-utils
-, sumneko-lua-language-server
+, lua-language-server
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -14,7 +14,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
   patches = [ ./remove-chmod.patch ];
 
   postInstall = ''
-    ln -sf ${sumneko-lua-language-server}/bin/lua-language-server \
+    ln -sf ${lua-language-server}/bin/lua-language-server \
       $out/$installPrefix/server/bin/lua-language-server
   '';
 

--- a/pkgs/development/tools/language-servers/lua-language-server/default.nix
+++ b/pkgs/development/tools/language-servers/lua-language-server/default.nix
@@ -1,9 +1,7 @@
 { lib, stdenv, fetchFromGitHub, ninja, makeWrapper, CoreFoundation, Foundation }:
-let
-  target = if stdenv.isDarwin then "macOS" else "Linux";
-in
+
 stdenv.mkDerivation rec {
-  pname = "sumneko-lua-language-server";
+  pname = "lua-language-server";
   version = "3.6.10";
 
   src = fetchFromGitHub {
@@ -45,7 +43,7 @@ stdenv.mkDerivation rec {
   '';
 
   ninjaFlags = [
-    "-fcompile/ninja/${lib.toLower target}.ninja"
+    "-fcompile/ninja/${if stdenv.isDarwin then "macos" else "linux"}.ninja"
   ];
 
   postBuild = ''
@@ -67,8 +65,8 @@ stdenv.mkDerivation rec {
     makeWrapper "$out"/share/lua-language-server/bin/lua-language-server \
       $out/bin/lua-language-server \
       --add-flags "-E $out/share/lua-language-server/main.lua \
-      --logpath=\''${XDG_CACHE_HOME:-\$HOME/.cache}/sumneko_lua/log \
-      --metapath=\''${XDG_CACHE_HOME:-\$HOME/.cache}/sumneko_lua/meta"
+      --logpath=\''${XDG_CACHE_HOME:-\$HOME/.cache}/lua-language-server/log \
+      --metapath=\''${XDG_CACHE_HOME:-\$HOME/.cache}/lua-language-server/meta"
 
     runHook postInstall
   '';
@@ -77,11 +75,10 @@ stdenv.mkDerivation rec {
   __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
-    description = "Lua Language Server coded by Lua";
+    description = "A language server that offers Lua language support";
     homepage = "https://github.com/luals/lua-language-server";
     license = licenses.mit;
-    maintainers = with maintainers; [ sei40kr ];
+    maintainers = with maintainers; [ figsoda sei40kr ];
     platforms = platforms.linux ++ platforms.darwin;
-    mainProgram = "lua-language-server";
   };
 }

--- a/pkgs/development/tools/language-servers/sumneko-lua-language-server/default.nix
+++ b/pkgs/development/tools/language-servers/sumneko-lua-language-server/default.nix
@@ -4,13 +4,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "sumneko-lua-language-server";
-  version = "3.6.7";
+  version = "3.6.10";
 
   src = fetchFromGitHub {
-    owner = "sumneko";
+    owner = "luals";
     repo = "lua-language-server";
     rev = version;
-    sha256 = "sha256-x7/yO1rJ+VBG4EFpISYblRECLW2lsLz5wcqLR14UV/g=";
+    sha256 = "sha256-QnkWEf1Uv+CZwEyv1b3WMPvaOZEn+mKH5w3CPyw02CQ=";
     fetchSubmodules = true;
   };
 
@@ -24,12 +24,13 @@ stdenv.mkDerivation rec {
     Foundation
   ];
 
-  preBuild = ''
-    cd 3rd/luamake
-  ''
-  + lib.optionalString stdenv.isDarwin ''
-    # Needed for the test
-    export HOME=/var/empty
+  postPatch = ''
+    # filewatch tests are failing on darwin
+    # this feature is not used in lua-language-server
+    sed -i /filewatch/d 3rd/bee.lua/test/test.lua
+
+    pushd 3rd/luamake
+  '' + lib.optionalString stdenv.isDarwin ''
     # This package uses the program clang for C and C++ files. The language
     # is selected via the command line argument -std, but this do not work
     # in combination with the nixpkgs clang wrapper. Therefor we have to
@@ -48,7 +49,7 @@ stdenv.mkDerivation rec {
   ];
 
   postBuild = ''
-    cd ../..
+    popd
     ./3rd/luamake/luamake rebuild
   '';
 
@@ -72,9 +73,12 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  # some tests require local networking
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "Lua Language Server coded by Lua";
-    homepage = "https://github.com/sumneko/lua-language-server";
+    homepage = "https://github.com/luals/lua-language-server";
     license = licenses.mit;
     maintainers = with maintainers; [ sei40kr ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1471,6 +1471,7 @@ mapAliases ({
   subversion_1_10 = throw "subversion_1_10 has been removed as it has reached its end of life"; # Added 2022-04-26
   subversion19 = throw "subversion19 has been removed as it has reached its end of life"; # Added 2021-03-31
   sudolikeaboss = throw "sudolikeaboss is no longer maintained by upstream"; # Added 2022-04-16
+  sumneko-lua-language-server = lua-language-server; # Added 2023-02-07
   sundials_3 = throw "sundials_3 was removed in 2020-02. outdated and no longer needed";
   surf-webkit2 = throw "'surf-webkit2' has been renamed to/replaced by 'surf'"; # Converted to throw 2022-02-22
   swec = throw "swec has been removed; broken and abandoned upstream"; # Added 2021-10-14

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16977,6 +16977,10 @@ with pkgs;
 
   kotlin-language-server = callPackage ../development/tools/language-servers/kotlin-language-server { };
 
+  lua-language-server = darwin.apple_sdk_11_0.callPackage ../development/tools/language-servers/lua-language-server {
+    inherit (darwin.apple_sdk_11_0.frameworks) CoreFoundation Foundation;
+  };
+
   metals = callPackage ../development/tools/language-servers/metals { };
 
   millet = callPackage ../development/tools/language-servers/millet { };
@@ -16984,10 +16988,6 @@ with pkgs;
   nil = callPackage ../development/tools/language-servers/nil { };
 
   rnix-lsp = callPackage ../development/tools/language-servers/rnix-lsp { };
-
-  sumneko-lua-language-server = darwin.apple_sdk_11_0.callPackage ../development/tools/language-servers/sumneko-lua-language-server {
-    inherit (darwin.apple_sdk_11_0.frameworks) CoreFoundation Foundation;
-  };
 
   svls = callPackage ../development/tools/language-servers/svls { };
 


### PR DESCRIPTION
###### Description of changes

Diff: https://github.com/LuaLS/lua-language-server/compare/3.6.7...3.6.10

lua-language-server to a new GitHub organization (@luals), https://github.com/sumneko/lua-language-server now redirects to https://github.com/LuaLS/lua-language-server

In terms of popularity, there are no competing language servers named `lua-language-server`, and the package is named `lua-language-server` on [repology](https://repology.org/project/lua-language-server/versions), nixpkgs is the only repository on there that has `sumneko` in its name

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
