### PR TITLE
_1password-gui: 8.9.10 -> 8.9.14, 8.9.12-4.BETA -> 8.10.0-20.BETA

### DIFF
--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -9,43 +9,43 @@
 let
 
   pname = "1password";
-  version = if channel == "stable" then "8.9.10" else "8.9.12-4.BETA";
+  version = if channel == "stable" then "8.9.14" else "8.10.0-20.BETA";
 
   sources = {
     stable = {
       x86_64-linux = {
         url = "https://downloads.1password.com/linux/tar/stable/x86_64/1password-${version}.x64.tar.gz";
-        sha256 = "sha256-aoa00W5zvZQeHKd2Eqyrxl5Z1PwLMHc5lkMUskLiD74=";
+        sha256 = "sha256-rlLzPDPOmzamDnRxuvgrpAW0QrMINw/PsdLxOiBpMnA=";
       };
       aarch64-linux = {
         url = "https://downloads.1password.com/linux/tar/stable/aarch64/1password-${version}.arm64.tar.gz";
-        sha256 = "sha256-Zt64UGKI3+DayS6XP7jTE+pxv52tUUZbUHiuzjcm1JI=";
+        sha256 = "sha256-hJTqFr6/KOl4C+1oyo/zrnCbqvRQin6HjyLKOppUl/M=";
       };
       x86_64-darwin = {
         url = "https://downloads.1password.com/mac/1Password-${version}-x86_64.zip";
-        sha256 = "sha256-sx9eASpMcgkIH1GRzJMqSQa5Y5GJlYU/20CZFyFK+OU=";
+        sha256 = "sha256-3/aiUj+WYZfPItYrYNQKsUSpkRTgOhyb8L5gURt1O74=";
       };
       aarch64-darwin = {
         url = "https://downloads.1password.com/mac/1Password-${version}-aarch64.zip";
-        sha256 = "sha256-Z1cEynO9iWZra542CVGmefrTNerMe13OcTAzWXNi8jI=";
+        sha256 = "sha256-n0xqD5WbcC9B6spisa5V7JJRXGZubBwzJFUS8edvz/Q=";
       };
     };
     beta = {
       x86_64-linux = {
         url = "https://downloads.1password.com/linux/tar/beta/x86_64/1password-${version}.x64.tar.gz";
-        sha256 = "sha256-/WXaLINqLFLft+wrmr+fV0kM9qS5w4etFiGltnzoVdo=";
+        sha256 = "sha256-r2MRyw0dfD3vGnCcPW624K5rSaNSCjTVW4cWFgPAIaY=";
       };
       aarch64-linux = {
         url = "https://downloads.1password.com/linux/tar/beta/aarch64/1password-${version}.arm64.tar.gz";
-        sha256 = "sha256-Zv9uHkFCZ0flBMAwQBjNhqFWhAXKyHBfZk733hbSag4=";
+        sha256 = "sha256-98sv4yLvLw8J5uQBB66qTV3lRWnyeZiifhEOW7shz8s=";
       };
       x86_64-darwin = {
         url = "https://downloads.1password.com/mac/1Password-${version}-x86_64.zip";
-        sha256 = "sha256-Vryk6nMQY+0NIgwJkZ2j3vrxyhrzxbe96jbyoNbPIR0=";
+        sha256 = "sha256-ezHk6OgUsmFfMfsY+yyWqn+6JgHSmpkFWGNCCaBv/Bo=";
       };
       aarch64-darwin = {
         url = "https://downloads.1password.com/mac/1Password-${version}-aarch64.zip";
-        sha256 = "sha256-74iOaNkuPRKUsTNNd7UTpy5ahjoMmxiNT84Op5ztRGk=";
+        sha256 = "sha256-JmCrEBucXGPpGbiKOxA8vu6bUVYsavfsYA5QY58Grnw=";
       };
     };
   };

--- a/pkgs/applications/misc/1password-gui/update.sh
+++ b/pkgs/applications/misc/1password-gui/update.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p jq
+#shellcheck shell=bash
+
+CURRENT_HASH=""
+
+print_hash() {
+    OS="$1"
+    CHANNEL="$2"
+    ARCH="$3"
+    VERSION="$4"
+
+    if [[ "$OS" == "linux" ]]; then
+        if [[ "$ARCH" == "x86_64" ]]; then
+            EXT="x64.tar.gz"
+        else
+            EXT="arm64.tar.gz"
+        fi
+        URL="https://downloads.1password.com/${OS}/tar/${CHANNEL}/${ARCH}/1password-${VERSION}.${EXT}"
+    else
+        EXT="$ARCH.zip"
+        URL="https://downloads.1password.com/${OS}/1Password-${VERSION}-${EXT}"
+    fi
+
+    CURRENT_HASH=$(nix store prefetch-file "$URL" --json | jq -r '.hash')
+
+    echo "$CHANNEL ${ARCH}-${OS}: $CURRENT_HASH"
+}
+
+if [[ -z "$STABLE_VER" ]]; then
+    echo "No 'STABLE_VER' environment variable provided, skipping"
+else
+    print_hash "linux" "stable" "x86_64" "$STABLE_VER"
+    print_hash "linux" "stable" "aarch64" "$STABLE_VER"
+    print_hash "mac" "stable" "x86_64" "$STABLE_VER"
+    print_hash "mac" "stable" "aarch64" "$STABLE_VER"
+fi
+
+if [[ -z "$BETA_VER" ]]; then
+    echo "No 'BETA_VER' environment variable provided, skipping"
+else
+    print_hash "linux" "beta" "x86_64" "$BETA_VER"
+    print_hash "linux" "beta" "aarch64" "$BETA_VER"
+    print_hash "mac" "beta" "x86_64" "$BETA_VER"
+    print_hash "mac" "beta" "aarch64" "$BETA_VER"
+fi


### PR DESCRIPTION
###### Description of changes

https://releases.1password.com/linux/8.9/#1password-for-linux-8.9.14
https://releases.1password.com/linux/beta/#1password-for-linux-8.10.0-20

Also added a janky update script. Hopefully it's helpful, but if someone has a better way to get the hashes for all the different variations let me know!

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).