### PR TITLE
python3Packages.soundfile: 0.10.3.post1 -> 0.11.0

### DIFF
--- a/pkgs/development/python-modules/soundfile/default.nix
+++ b/pkgs/development/python-modules/soundfile/default.nix
@@ -12,23 +12,14 @@
 
 buildPythonPackage rec {
   pname = "soundfile";
-  version = "0.10.3.post1";
+  version = "0.11.0";
   # https://github.com/bastibe/python-soundfile/issues/157
   disabled = isPyPy || stdenv.isi686;
 
   src = fetchPypi {
-    pname = "SoundFile";
-    inherit version;
-    sha256 = "0yqhrfz7xkvqrwdxdx2ydy4h467sk7z3gf984y1x2cq7cm1gy329";
+    inherit pname version;
+    sha256 = "sha256-kxc4ock+hoTC0+HVFKxjRAzoJ+x4PqCi0+RzDj3FjBg=";
   };
-
-  patches = [
-    # Fix build on macOS arm64, https://github.com/bastibe/python-soundfile/pull/332
-    (fetchpatch {
-      url = "https://github.com/bastibe/python-soundfile/commit/e554e9ce8bed96207d587e6aa661e4b08f1c6a79.patch";
-      sha256 = "sha256-vu/7s5q4I3yBnoNHmmFmcXvOLFcPwY9ri9ri6cKLDwU=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace soundfile.py --replace "_find_library('sndfile')" "'${libsndfile.out}/lib/libsndfile${stdenv.hostPlatform.extensions.sharedLibrary}'"
@@ -37,10 +28,6 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
   propagatedBuildInputs = [ numpy libsndfile cffi ];
   propagatedNativeBuildInputs = [ cffi ];
-
-  # Test fails on aarch64-darwin with `MemoryError`, 53 failed, 31 errors, see
-  # https://github.com/bastibe/python-soundfile/issues/331
-  doCheck = stdenv.system != "aarch64-darwin";
 
   meta = {
     description = "An audio library based on libsndfile, CFFI and NumPy";


### PR DESCRIPTION
###### Description of changes

https://github.com/bastibe/python-soundfile/releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
