### PR TITLE
python311Packages.python-zbar: fix build since Py_SIZE is turned into…

### DIFF
--- a/pkgs/development/python-modules/python-zbar/0001-python-enum-fix-build-for-Python-3.11.patch
+++ b/pkgs/development/python-modules/python-zbar/0001-python-enum-fix-build-for-Python-3.11.patch
@@ -1,0 +1,61 @@
+From 64de7911d2938fc3601fec39c08008465b9d4f6f Mon Sep 17 00:00:00 2001
+From: Nick Cao <nickcao@nichi.co>
+Date: Tue, 7 Feb 2023 17:12:50 +0800
+Subject: [PATCH] python: enum: fix build for Python 3.11
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Python 3.9 introduced Py_SET_SIZE function to set size instead of
+relying on Py_SIZE() as a macro [3.9].
+
+Python 3.10 started to encourage to use Py_SET_SIZE instead of
+assigning into return value of Py_SIZE [3.10].
+
+Python 3.11 flips the switch, turn Py_SIZE into a function [3.11],
+thus Py_SIZE(obj) will be a rvalue. We need to use Py_SET_SIZE
+to set size now.
+
+[3.9]: https://docs.python.org/3.9/c-api/structures.html#c.Py_SET_SIZE
+[3.10]: https://docs.python.org/3.10/c-api/structures.html#c.Py_SIZE
+[3.11]: https://docs.python.org/3.11/c-api/structures.html#c.Py_SIZE
+
+Adapted from https://github.com/mchehab/zbar/pull/231
+
+Signed-off-by: Đoàn Trần Công Danh <congdanhqx@gmail.com>
+Signed-off-by: Nick Cao <nickcao@nichi.co>
+---
+ python/enum.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/python/enum.c b/python/enum.c
+index dfe1b1e..4833a20 100644
+--- a/python/enum.c
++++ b/python/enum.c
+@@ -52,7 +52,11 @@ enumitem_new (PyTypeObject *type,
+ 
+     /* we assume the "fast path" for a single-digit ints (see longobject.c) */
+     /* this also holds if we get a small_int preallocated long */
++#if PY_VERSION_HEX >= 0x030900A4
++    Py_SET_SIZE(&self->val, Py_SIZE(longval));
++#else
+     Py_SIZE(&self->val) = Py_SIZE(longval);
++#endif
+     self->val.ob_digit[0] = longval->ob_digit[0];
+     Py_DECREF(longval);
+ #else
+@@ -143,7 +147,11 @@ zbarEnumItem_New (PyObject *byname,
+ 
+     /* we assume the "fast path" for a single-digit ints (see longobject.c) */
+     /* this also holds if we get a small_int preallocated long */
++#if PY_VERSION_HEX >= 0x030900A4
++    Py_SET_SIZE(&self->val, Py_SIZE(longval));
++#else
+     Py_SIZE(&self->val) = Py_SIZE(longval);
++#endif
+     self->val.ob_digit[0] = longval->ob_digit[0];
+     Py_DECREF(longval);
+ 
+-- 
+2.39.1
+

--- a/pkgs/development/python-modules/python-zbar/default.nix
+++ b/pkgs/development/python-modules/python-zbar/default.nix
@@ -1,4 +1,10 @@
-{ lib , buildPythonPackage , fetchFromGitHub , pillow , zbar , pytestCheckHook }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pillow
+, zbar
+, pytestCheckHook
+}:
 
 buildPythonPackage rec {
   pname = "python-zbar";
@@ -11,6 +17,13 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "sha256-FvV7TMc4JbOiRjWLka0IhtpGGqGm5fis7h870OmJw2U=";
   };
+
+  patches = [
+    # python: enum: fix build for Python 3.11
+    # https://github.com/mchehab/zbar/pull/231
+    # the patch is reworked as it does not cleanly apply
+    ./0001-python-enum-fix-build-for-Python-3.11.patch
+  ];
 
   propagatedBuildInputs = [ pillow ];
 


### PR DESCRIPTION
… a function

Python 3.11 turned Py_SIZE into a function, thus Py_SIZE(obj) will be a rvalue, we need to use Py_SET_SIZE to set size now.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
