### PR TITLE
python3Packages.torch-bin, python3Packages.torchvision-bin, python3Packages.torchaudio-bin: update cuda 11.6 -> 11.7

### DIFF
--- a/pkgs/development/python-modules/torch/binary-hashes.nix
+++ b/pkgs/development/python-modules/torch/binary-hashes.nix
@@ -9,23 +9,23 @@ version : builtins.getAttr version {
   "1.13.1" = {
     x86_64-linux-37 = {
       name = "torch-1.13.1-cp37-cp37m-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu116/torch-1.13.1%2Bcu116-cp37-cp37m-linux_x86_64.whl";
-      hash = "sha256-INfG4AgEtr6m9pt3JAxPzfJEzOL2sf9zvv98DfZVPZ0=";
+      url = "https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp37-cp37m-linux_x86_64.whl";
+      hash = "sha256-bXg6H3mHFyTK2jw3TKUJiGNZqMSseNBT34mxQu6QREA=";
     };
     x86_64-linux-38 = {
       name = "torch-1.13.1-cp38-cp38-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu116/torch-1.13.1%2Bcu116-cp38-cp38-linux_x86_64.whl";
-      hash = "sha256-kzj6oKWg62JeF+OXKfBvsKV0CY16uI2Fa72ky3agtmU=";
+      url = "https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp38-cp38-linux_x86_64.whl";
+      hash = "sha256-u/lUbw0Ni1EmPKR5Y3tCaogzX8oANPQs7GPU0y3uBa8=";
     };
     x86_64-linux-39 = {
       name = "torch-1.13.1-cp39-cp39-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu116/torch-1.13.1%2Bcu116-cp39-cp39-linux_x86_64.whl";
-      hash = "sha256-20V6gi1zYBO2/+UJBTABvJGL3Xj+aJZ7YF9TmEqa+sU=";
+      url = "https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp39-cp39-linux_x86_64.whl";
+      hash = "sha256-s6wTng1KCzA8wW9R63cUbsfRTAsecCrWOGE2KPUIavc=";
     };
     x86_64-linux-310 = {
       name = "torch-1.13.1-cp310-cp310-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu116/torch-1.13.1%2Bcu116-cp310-cp310-linux_x86_64.whl";
-      hash = "sha256-UdWHDN8FtiCLHHOf4LpRG5d+yjf5UHgpZ1WWrMEbbKQ=";
+      url = "https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp310-cp310-linux_x86_64.whl";
+      hash = "sha256-FMXJ2wnfjPGzlCo0ecd52m4pOoShYtimrHHiveMOMMU=";
     };
     x86_64-darwin-37 = {
       name = "torch-1.13.1-cp37-none-macosx_10_9_x86_64.whl";
@@ -62,6 +62,5 @@ version : builtins.getAttr version {
       url = "https://download.pytorch.org/whl/cpu/torch-1.13.1-cp310-none-macosx_11_0_arm64.whl";
       hash = "sha256-ASKAaxEblJ0h+hpfl2TR/S/MSkfLf4/5FCBP1Px1LtU=";
     };
-
   };
 }

--- a/pkgs/development/python-modules/torch/prefetch.sh
+++ b/pkgs/development/python-modules/torch/prefetch.sh
@@ -5,7 +5,7 @@ set -eou pipefail
 
 version=$1
 
-linux_cuda_version="cu116"
+linux_cuda_version="cu117"
 linux_bucket="https://download.pytorch.org/whl/${linux_cuda_version}"
 darwin_bucket="https://download.pytorch.org/whl/cpu"
 

--- a/pkgs/development/python-modules/torchaudio/binary-hashes.nix
+++ b/pkgs/development/python-modules/torchaudio/binary-hashes.nix
@@ -9,23 +9,23 @@ version : builtins.getAttr version {
   "0.13.1" = {
     x86_64-linux-37 = {
       name = "torchaudio-0.13.1-cp37-cp37m-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu116/torchaudio-0.13.1%2Bcu116-cp37-cp37m-linux_x86_64.whl";
-      hash = "sha256-jrztfOrRCFKVNuXqnyeM3GCRDj/K8DDmW9jNLckCEAs=";
+      url = "https://download.pytorch.org/whl/cu117/torchaudio-0.13.1%2Bcu117-cp37-cp37m-linux_x86_64.whl";
+      hash = "sha256-wQJJ2BPkQAGxXx8H0rt3P39wsl/6KhbF27wYHT5L6/o=";
     };
     x86_64-linux-38 = {
       name = "torchaudio-0.13.1-cp38-cp38-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu116/torchaudio-0.13.1%2Bcu116-cp38-cp38-linux_x86_64.whl";
-      hash = "sha256-oESJecUUYoHWYkPa8/+t86rjEj4F4CNpvPpCwZAk5AY=";
+      url = "https://download.pytorch.org/whl/cu117/torchaudio-0.13.1%2Bcu117-cp38-cp38-linux_x86_64.whl";
+      hash = "sha256-QCY7LUVyj7/x2zOBJyvkKXD/blj5KZSqWHKlvUx+cmQ=";
     };
     x86_64-linux-39 = {
       name = "torchaudio-0.13.1-cp39-cp39-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu116/torchaudio-0.13.1%2Bcu116-cp39-cp39-linux_x86_64.whl";
-      hash = "sha256-W8DinLePfEUu608nApxABJdw1RVTv4QLTKLt1j2iie4=";
+      url = "https://download.pytorch.org/whl/cu117/torchaudio-0.13.1%2Bcu117-cp39-cp39-linux_x86_64.whl";
+      hash = "sha256-Zbs2FdQz1bkwrNwQNu+xJAR9VxfbpN63D0GSkNlC+DY=";
     };
     x86_64-linux-310 = {
       name = "torchaudio-0.13.1-cp310-cp310-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu116/torchaudio-0.13.1%2Bcu116-cp310-cp310-linux_x86_64.whl";
-      hash = "sha256-3vRLFxUB3LmU9aGUjVWWYnBXBe475veBvRHvzTu/zTA=";
+      url = "https://download.pytorch.org/whl/cu117/torchaudio-0.13.1%2Bcu117-cp310-cp310-linux_x86_64.whl";
+      hash = "sha256-k/RVSktT+WmNAiJJA8kjwSpsIrPJQtz8IXm1gdjzcUY=";
     };
     x86_64-darwin-37 = {
       name = "torchaudio-0.13.1-cp37-cp37m-macosx_10_9_x86_64.whl";

--- a/pkgs/development/python-modules/torchaudio/prefetch.sh
+++ b/pkgs/development/python-modules/torchaudio/prefetch.sh
@@ -5,7 +5,7 @@ set -eou pipefail
 
 version=$1
 
-linux_cuda_version="cu116"
+linux_cuda_version="cu117"
 linux_bucket="https://download.pytorch.org/whl/${linux_cuda_version}"
 darwin_bucket="https://download.pytorch.org/whl"
 

--- a/pkgs/development/python-modules/torchvision/binary-hashes.nix
+++ b/pkgs/development/python-modules/torchvision/binary-hashes.nix
@@ -9,23 +9,23 @@ version : builtins.getAttr version {
   "0.14.1" = {
     x86_64-linux-37 = {
       name = "torchvision-0.14.1-cp37-cp37m-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu116/torchvision-0.14.1%2Bcu116-cp37-cp37m-linux_x86_64.whl";
-      hash = "sha256-SYVxnGbJYS/0uy06U8P6r92TQVKyqHQU0nvceHSkNg8=";
+      url = "https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp37-cp37m-linux_x86_64.whl";
+      hash = "sha256-vOOhWqGuclcvjNKOSdHsGtjwhm+7ZhxzaNnBKF9psi4=";
     };
     x86_64-linux-38 = {
       name = "torchvision-0.14.1-cp38-cp38-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu116/torchvision-0.14.1%2Bcu116-cp38-cp38-linux_x86_64.whl";
-      hash = "sha256-R1k1helxw+DJgPq/v7iF61/wVHFrqlVWYMWwMEyeo50=";
+      url = "https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp38-cp38-linux_x86_64.whl";
+      hash = "sha256-dAk4UTnOiGTOssgv/OM46+FaVRk/S4DEKm0PnP14Fik=";
     };
     x86_64-linux-39 = {
       name = "torchvision-0.14.1-cp39-cp39-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu116/torchvision-0.14.1%2Bcu116-cp39-cp39-linux_x86_64.whl";
-      hash = "sha256-qfw4BA4TPRd58TG0SXyu+DDp5pn6+JzTI81YeU/7MFs=";
+      url = "https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp39-cp39-linux_x86_64.whl";
+      hash = "sha256-iomg7gB9fNulO9VkJth5UGCgZLiRm2GsOeAOOZ3ta+I=";
     };
     x86_64-linux-310 = {
       name = "torchvision-0.14.1-cp310-cp310-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu116/torchvision-0.14.1%2Bcu116-cp310-cp310-linux_x86_64.whl";
-      hash = "sha256-/LWNQb+V3YuF04j6GWnR3K1V7sBV4xeYHWU6BcTKbYs=";
+      url = "https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp310-cp310-linux_x86_64.whl";
+      hash = "sha256-g9JxpTA5KBS4x/aTgihcrHx9p5uPXcxrz1bGKFR7zlM=";
     };
     x86_64-darwin-37 = {
       name = "torchvision-0.14.1-cp37-cp37m-macosx_10_9_x86_64.whl";

--- a/pkgs/development/python-modules/torchvision/prefetch.sh
+++ b/pkgs/development/python-modules/torchvision/prefetch.sh
@@ -5,7 +5,7 @@ set -eou pipefail
 
 version=$1
 
-linux_cuda_version="cu116"
+linux_cuda_version="cu117"
 linux_bucket="https://download.pytorch.org/whl/${linux_cuda_version}"
 darwin_bucket="https://download.pytorch.org/whl"
 


### PR DESCRIPTION
###### Description of changes

Updated the cuda version that torch-bin, torchvision-bin and torchaudio-bin are built on from 11.6 to 11.7.
This is the cuda version currrently shipped in NixOS and it is the one that this version of pytorch is officially supporting.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Testing

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>python310Packages.torch-bin</li>
    <li>python310Packages.torchaudio-bin</li>
    <li>python310Packages.torchvision-bin</li>
    <li>python310Packages.trainer</li>
    <li>tts</li>
  </ul>
</details>


@junjihashimoto 
