### PR TITLE
graalvm*-ce: wrap native-image to pass -H:CLibraryPath, misc improvements

### DIFF
--- a/pkgs/build-support/build-graalvm-native-image/default.nix
+++ b/pkgs/build-support/build-graalvm-native-image/default.nix
@@ -10,7 +10,6 @@
   # except in special cases. In most cases, use extraNativeBuildArgs instead
 , nativeImageBuildArgs ? [
     "-jar" jar
-    "-H:CLibraryPath=${lib.getLib graalvm}/lib"
     (lib.optionalString stdenv.isDarwin "-H:-CheckToolchain")
     "-H:Name=${executable}"
     "--verbose"
@@ -49,6 +48,8 @@ stdenv.mkDerivation (args // {
 
     runHook postInstall
   '';
+
+  disallowedReferences = [ graalvmDrv ];
 
   meta = {
     # default to graalvm's platforms

--- a/pkgs/development/compilers/graalvm/community-edition/mkGraal.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/mkGraal.nix
@@ -28,12 +28,6 @@
   # Path for the sources file that will be used
   # See `update.nix` file for a description on how this file works
 , sourcesPath ? ./. + "/graalvm${javaVersion}-ce-sources.json"
-  # Use musl instead of glibc to allow true static builds in GraalVM's
-  # Native Image (i.e.: `--static --libc=musl`). This will cause glibc static
-  # builds to fail, so it should be used with care
-, useMusl ? false
-  # Extra libraries to be included in native-image using '-H:CLibraryPath' flag
-, extraCLibs ? [ ]
 }:
 
 { stdenv
@@ -68,6 +62,12 @@
 , gtk3
 , jq
 , writeShellScript
+  # Use musl instead of glibc to allow true static builds in GraalVM's
+  # Native Image (i.e.: `--static --libc=musl`). This will cause glibc static
+  # builds to fail, so it should be used with care
+, useMusl ? false
+  # Extra libraries to be included in native-image using '-H:CLibraryPath' flag
+, extraCLibs ? [ ]
 }:
 
 assert useMusl -> stdenv.isLinux;

--- a/pkgs/development/compilers/graalvm/community-edition/mkGraal.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/mkGraal.nix
@@ -32,6 +32,8 @@
   # Native Image (i.e.: `--static --libc=musl`). This will cause glibc static
   # builds to fail, so it should be used with care
 , useMusl ? false
+  # Extra libraries to be included in native-image using '-H:CLibraryPath' flag
+, extraCLibs ? [ ]
 }:
 
 { stdenv
@@ -76,6 +78,11 @@ let
   name = "graalvm${javaVersion}-ce";
   sources = builtins.fromJSON (builtins.readFile sourcesPath);
 
+  cLibs = [ glibc zlib.static ]
+    ++ lib.optionals (!useMusl) [ glibc.static ]
+    ++ lib.optionals useMusl [ musl ]
+    ++ extraCLibs;
+
   runtimeLibraryPath = lib.makeLibraryPath
     ([ cups ] ++ lib.optionals gtkSupport [ cairo glib gtk3 ]);
 
@@ -118,6 +125,8 @@ let
       ++ lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
 
     unpackPhase = ''
+      runHook preUnpack
+
       unpack_jar() {
         jar=$1
         unzip -q -o $jar -d $out
@@ -164,13 +173,13 @@ let
       for jar in "''${arr[@]:1}"; do
         unpack_jar "$jar"
       done
+
+      runHook postUnpack
     '';
 
-    outputs = [ "out" "lib" ];
-
     installPhase = ''
-      # ensure that $lib/lib exists to avoid breaking builds
-      mkdir -p "$lib/lib"
+      runHook preInstall
+
       # jni.h expects jni_md.h to be in the header search path.
       ln -s $out/include/linux/*_md.h $out/include/
 
@@ -181,26 +190,15 @@ let
         if [ -z "\''${JAVA_HOME-}" ]; then export JAVA_HOME=$out; fi
       EOF
       ${
-        lib.optionalString (stdenv.isLinux) ''
-          # provide libraries needed for static compilation
-          ${
-            if useMusl then
-              ''for f in "${musl.stdenv.cc.cc}/lib/"* "${musl}/lib/"* "${zlib.static}/lib/"*; do''
-            else
-              ''for f in "${glibc}/lib/"* "${glibc.static}/lib/"* "${zlib.static}/lib/"*; do''
-          }
-            ln -s "$f" "$out/lib/svm/clibraries/${platform.arch}/$(basename $f)"
-          done
-
-          # add those libraries to $lib output too, so we can use them with
-          # `native-image -H:CLibraryPath=''${lib.getLib graalvmXX-ce}/lib ...` and reduce
-          # closure size by not depending on GraalVM $out (that is much bigger)
-          # we always use glibc here, since musl is only supported for static compilation
-          for f in "${glibc}/lib/"*; do
-            ln -s "$f" "$lib/lib/$(basename $f)"
-          done
+        # Wrap native-image binary to pass -H:CLibraryPath flag and find glibc
+        lib.optionalString (withNativeImageSvm && stdenv.isLinux) ''
+          wrapProgram $out/bin/native-image \
+            ${lib.concatStringsSep " "
+              (map (l: "--add-flags '-H:CLibraryPath=${l}/lib'") cLibs)}
         ''
       }
+
+      runHook postInstall
     '';
 
     dontStrip = true;
@@ -240,6 +238,8 @@ let
 
     doInstallCheck = true;
     installCheckPhase = ''
+      runHook preInstallCheck
+
       echo ${
         lib.escapeShellArg ''
           public class HelloWorld {
@@ -252,16 +252,25 @@ let
       $out/bin/javac HelloWorld.java
 
       # run on JVM with Graal Compiler
+      echo "Testing GraalVM"
       $out/bin/java -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:+UseJVMCICompiler HelloWorld | fgrep 'Hello World'
+
+      ${
+        lib.optionalString withNativeImageSvm ''
+          echo "Ahead-Of-Time compilation"
+          $out/bin/native-image -H:-CheckToolchain -H:+ReportExceptionStackTraces HelloWorld
+          ./helloworld | fgrep 'Hello World'
+        ''
+      }
 
       ${# --static flag doesn't work for darwin
         lib.optionalString (withNativeImageSvm && stdenv.isLinux && !useMusl) ''
-          echo "Ahead-Of-Time compilation"
-          $out/bin/native-image -H:-CheckToolchain -H:+ReportExceptionStackTraces --no-server HelloWorld
+          echo "Ahead-Of-Time compilation with -H:+StaticExecutableWithDynamicLibC"
+          $out/bin/native-image -H:+StaticExecutableWithDynamicLibC HelloWorld
           ./helloworld | fgrep 'Hello World'
 
           echo "Ahead-Of-Time compilation with --static"
-          $out/bin/native-image --no-server --static HelloWorld
+          $out/bin/native-image --static HelloWorld
           ./helloworld | fgrep 'Hello World'
         ''
       }
@@ -269,7 +278,7 @@ let
       ${# --static flag doesn't work for darwin
         lib.optionalString (withNativeImageSvm && stdenv.isLinux && useMusl) ''
           echo "Ahead-Of-Time compilation with --static and --libc=musl"
-          $out/bin/native-image --no-server --libc=musl --static HelloWorld
+          $out/bin/native-image --libc=musl --static HelloWorld
           ./helloworld | fgrep 'Hello World'
         ''
       }
@@ -302,6 +311,8 @@ let
           echo '1 + 1' | $out/bin/irb
         ''
       }
+
+      runHook postInstallCheck
     '';
 
     passthru = {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes issue #214922 by not adding C libraries to the default library path of GraalVM. This should reduce the closure size of native compiled binaries in nixpkgs again, e.g.:

Before:
```
$ ldd ./result/bin/bb
	linux-vdso.so.1 (0x00007fff2669b000)
	libstdc++.so.6 => /nix/store/qbgfsaviwqi2p6jr7an1g2754sv3xqhn-gcc-11.3.0-lib/lib/libstdc++.so.6 (0x00007f77fc0cf000)
	libm.so.6 => /nix/store/l7vp7c9z03dspbmss3gq5wdwx5c6ifcq-graalvm11-ce-22.3.0/lib/svm/clibraries/linux-amd64/libm.so.6 (0x00007f77fbfef000)
	libpthread.so.0 => /nix/store/l7vp7c9z03dspbmss3gq5wdwx5c6ifcq-graalvm11-ce-22.3.0/lib/svm/clibraries/linux-amd64/libpthread.so.0 (0x00007f77fbfea000)
	libdl.so.2 => /nix/store/l7vp7c9z03dspbmss3gq5wdwx5c6ifcq-graalvm11-ce-22.3.0/lib/svm/clibraries/linux-amd64/libdl.so.2 (0x00007f77fbfe5000)
	librt.so.1 => /nix/store/l7vp7c9z03dspbmss3gq5wdwx5c6ifcq-graalvm11-ce-22.3.0/lib/svm/clibraries/linux-amd64/librt.so.1 (0x00007f77fbfde000)
	libc.so.6 => /nix/store/l7vp7c9z03dspbmss3gq5wdwx5c6ifcq-graalvm11-ce-22.3.0/lib/svm/clibraries/linux-amd64/libc.so.6 (0x00007f77fbdd5000)
	/nix/store/c35hf8g5b9vksadym9dbjrd6p2y11m8h-glibc-2.35-224/lib/ld-linux-x86-64.so.2 => /nix/store/9xfad3b5z4y00mzmk2wnn4900q0qmxns-glibc-2.35-224/lib64/ld-linux-x86-64.so.2 (0x00007f77fc2e7000)
	libgcc_s.so.1 => /nix/store/qbgfsaviwqi2p6jr7an1g2754sv3xqhn-gcc-11.3.0-lib/lib/libgcc_s.so.1 (0x00007f77fbdbb000)
```

After:
```
$ ldd ./result/bin/bb
	linux-vdso.so.1 (0x00007fffdfd4e000)
	libstdc++.so.6 => /nix/store/qbgfsaviwqi2p6jr7an1g2754sv3xqhn-gcc-11.3.0-lib/lib/libstdc++.so.6 (0x00007fc3a5658000)
	libm.so.6 => /nix/store/c35hf8g5b9vksadym9dbjrd6p2y11m8h-glibc-2.35-224/lib/libm.so.6 (0x00007fc3a5578000)
	libpthread.so.0 => /nix/store/c35hf8g5b9vksadym9dbjrd6p2y11m8h-glibc-2.35-224/lib/libpthread.so.0 (0x00007fc3a5573000)
	libdl.so.2 => /nix/store/c35hf8g5b9vksadym9dbjrd6p2y11m8h-glibc-2.35-224/lib/libdl.so.2 (0x00007fc3a556e000)
	librt.so.1 => /nix/store/c35hf8g5b9vksadym9dbjrd6p2y11m8h-glibc-2.35-224/lib/librt.so.1 (0x00007fc3a5569000)
	libc.so.6 => /nix/store/c35hf8g5b9vksadym9dbjrd6p2y11m8h-glibc-2.35-224/lib/libc.so.6 (0x00007fc3a535e000)
	/nix/store/c35hf8g5b9vksadym9dbjrd6p2y11m8h-glibc-2.35-224/lib/ld-linux-x86-64.so.2 => /nix/store/9xfad3b5z4y00mzmk2wnn4900q0qmxns-glibc-2.35-224/lib64/ld-linux-x86-64.so.2 (0x00007fc3a5870000)
	libgcc_s.so.1 => /nix/store/qbgfsaviwqi2p6jr7an1g2754sv3xqhn-gcc-11.3.0-lib/lib/libgcc_s.so.1 (0x00007fc3a5344000)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
