### PR TITLE
curv: init at 0.5

### DIFF
--- a/pkgs/applications/graphics/curv/default.nix
+++ b/pkgs/applications/graphics/curv/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, boost
+, eigen
+, glm
+, libGL
+, libpng
+, openexr
+, tbb
+, xorg
+, ilmbase
+, llvmPackages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "curv";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "curv3d";
+    repo = "curv";
+    rev = "refs/tags/${version}";
+    hash = "sha256-m4p5uxRk6kEJUilmbQ1zJcQDRvRCV7pkxnqupZJxyjo=";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    boost
+    eigen
+    glm
+    libGL
+    libpng
+    openexr
+    tbb
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXext
+    xorg.libXi
+    xorg.libXinerama
+    xorg.libXrandr
+  ] ++ lib.optionals stdenv.isDarwin [
+    ilmbase
+    llvmPackages.openmp
+  ];
+
+  # GPU tests do not work in sandbox, instead we do this for sanity
+  checkPhase = ''
+    runHook preCheck
+    test "$($out/bin/curv -x 2 + 2)" -eq "4"
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "A 2D and 3D geometric modelling programming language for creating art with maths";
+    homepage = "https://github.com/curv3d/curv";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    broken = stdenv.isDarwin;
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6803,6 +6803,8 @@ with pkgs;
 
   trurl = callPackage ../tools/networking/trurl { };
 
+  curv = callPackage ../applications/graphics/curv { };
+
   cunit = callPackage ../tools/misc/cunit { };
   bcunit = callPackage ../tools/misc/bcunit { };
 


### PR DESCRIPTION
###### Description of changes

* curv: init at 0.5

Curv is a programming language for creating art using mathematics. It's a 2D and 3D geometric modelling tool that supports full colour, animation and 3D printing.

https://github.com/curv3d/curv

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
