### PR TITLE
doc: use `gitignoreSource`

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -1,6 +1,5 @@
 { pkgs ? (import ./.. { }), nixpkgs ? { }}:
 let
-  lib = pkgs.lib;
   doc-support = import ./doc-support { inherit pkgs nixpkgs; };
 in pkgs.stdenv.mkDerivation {
   name = "nixpkgs-manual";
@@ -15,7 +14,7 @@ in pkgs.stdenv.mkDerivation {
     xmlformat
   ];
 
-  src = lib.cleanSource ./.;
+  src = pkgs.nix-gitignore.gitignoreSource [] ./.;
 
   postPatch = ''
     ln -s ${doc-support} ./doc-support/result


### PR DESCRIPTION
Running `make -C doc` to build the manual locally leaves .xml artifacts in the tree. These are ignored by git, but they still get included in the build when not using flakes, which causes the corresponding chapters not to be built.