### PR TITLE
dumpasn1: init at 20210212

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -327,6 +327,11 @@ in mkLicense lset) ({
     fullName = "Detection Rule License 1.0";
   };
 
+  dumpasn1 = {
+    fullName = "dumpasn1 License";
+    url = "https://salsa.debian.org/debian/dumpasn1/-/blob/7a10baa8eebcef053c100b27a70e245313611cbb/debian/copyright";
+  };
+
   eapl = {
     fullName = "EPSON AVASYS PUBLIC LICENSE";
     url = "https://avasys.jp/hp/menu000000700/hpg000000603.htm";

--- a/pkgs/tools/security/dumpasn1/default.nix
+++ b/pkgs/tools/security/dumpasn1/default.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, fetchFromGitLab, help2man }:
+
+let
+  pname = "dumpasn1";
+  version = "20210212";
+  isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
+    repo = pname;
+    rev = "7a10baa8eebcef053c100b27a70e245313611cbb";
+    sha256 = "0a4nhzj30i5d1wqpjrxi1a93x0h19yzf9z2nrb2ri5qy5yc6p1iw";
+  };
+
+  patches = [ ./paths.patch ];
+
+  nativeBuildInputs = lib.optional (!isCross) help2man;
+
+  makefile = "debian/rules";
+  makeFlags = [ "CPPFLAGS=-DPREFIX=$(prefix)" "VER_FULL=${version}" ];
+
+  buildFlags = [ pname ] ++ lib.optional (!isCross) "debian/${pname}.1";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm 755 -t $out/bin/ ${pname}
+    install -Dm 644 -t $out/share/${pname}/ ${pname}.cfg
+    ${lib.optionalString (!isCross) ''
+    install -Dm 644 -t $out/share/man/man1/ debian/${pname}.1
+    ''}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = ''
+      ASN.1 object dump program that will dump data encoded using any of the ASN.1
+      encoding rules in a variety of user-specified formats
+    '';
+    homepage = "https://www.cs.auckland.ac.nz/~pgut001/";
+    maintainers = with maintainers; [ alexshpilkin ];
+    license = licenses.dumpasn1;
+  };
+}

--- a/pkgs/tools/security/dumpasn1/paths.patch
+++ b/pkgs/tools/security/dumpasn1/paths.patch
@@ -1,0 +1,54 @@
+From c503ef9c68a90f296a85ab908203b23e007066b5 Mon Sep 17 00:00:00 2001
+From: Alexander Shpilkin <ashpilkin@gmail.com>
+Date: Tue, 7 Feb 2023 17:13:16 +0200
+Subject: [PATCH] Set configuration paths for Nix
+
+---
+ debian/dumpasn1.1.in |  2 +-
+ dumpasn1.c           | 17 +----------------
+ 2 files changed, 2 insertions(+), 17 deletions(-)
+
+diff --git a/debian/dumpasn1.1.in b/debian/dumpasn1.1.in
+index 2fc2c6d..d257cef 100644
+--- a/debian/dumpasn1.1.in
++++ b/debian/dumpasn1.1.in
+@@ -4,7 +4,7 @@ ASN.1 encoding rules in a variety of user-specified formats.
+ 
+ [FILES]
+ .ul
+-$HOME/.dumpasn1.cfg, /etc/dumpasn1/dumpasn1.cfg:
++$HOME/.config/dumpasn1/dumpasn1.cfg, $HOME/.dumpasn1.cfg, /etc/dumpasn1/dumpasn1.cfg:
+ 
+ This is the configuration file, it will be searched in this order. It contains
+ OIDs commonly used.
+diff --git a/dumpasn1.c b/dumpasn1.c
+index 9dcf443..64c49cb 100644
+--- a/dumpasn1.c
++++ b/dumpasn1.c
+@@ -430,22 +430,7 @@ static const char *configPaths[] = {
+ #else
+ 
+ static const char *configPaths[] = {
+-  #ifndef DEBIAN
+-	/* Unix absolute paths */
+-	"/usr/bin/", "/usr/local/bin/", "/etc/dumpasn1/",
+-
+-	/* Unix environment-based paths */
+-	"$HOME/", "$HOME/bin/",
+-
+-	/* It's my program, I'm allowed to hardcode in strange paths that no-one
+-	   else uses */
+-	"$HOME/BIN/",
+-  #else
+-	/* Debian has specific places where you're supposed to dump things.  Note
+-	   the dot after $HOME, since config files are supposed to start with a
+-	   dot for Debian */
+-	"$HOME/.", "/etc/dumpasn1/",
+-  #endif /* DEBIAN-specific paths */
++	"$HOME/.config/dumpasn1/", "$HOME/.", "/etc/dumpasn1/", PREFIX "/share/dumpasn1/",
+ 
+ 	/* General environment-based paths */
+ 	"$DUMPASN1_PATH/",
+-- 
+2.38.1
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6526,6 +6526,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  dumpasn1 = callPackage ../tools/security/dumpasn1 { };
+
   dumptorrent = callPackage ../tools/misc/dumptorrent { };
 
   duo-unix = callPackage ../tools/security/duo-unix { };


### PR DESCRIPTION
###### Description of changes

`dumpasn1` is a tool by [Peter Gutmann](https://www.cs.auckland.ac.nz/~pgut001/) (of *X.509 Style Guide* fame) that prints ASN.1 BER blobs such as TLS certificates in a readable format.

This package is based on https://github.com/NixOS/nixpkgs/pull/80201 by @btlvr; I’ll add them to maintainers if they’re still interested. There aren’t really official upstream releases, only a date in a C file available over HTTP, so that PR used the source packaged in [clibs](https://github.com/clibs/dumpasn1). This version instead takes the more up-to-date version used by Debian that’s [used](https://repology.org/project/dumpasn1/versions) by many other distros and includes the "configuration file" (more properly OID dictionary) `dumpasn1.cfg`. The `YYYYMMDD` version (instead of `unstable-YYYY-MM-DD`) also originates there.

Fixes #212704.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).