### PR TITLE
xcaddy: 0.3.1 -> 0.3.2, add indeednotjames  as maintainer

### DIFF
--- a/pkgs/servers/caddy/xcaddy/default.nix
+++ b/pkgs/servers/caddy/xcaddy/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "xcaddy";
-  version = "0.3.1";
+  version = "0.3.2";
 
   subPackages = [ "cmd/xcaddy" ];
 
@@ -10,7 +10,7 @@ buildGoModule rec {
     owner = "caddyserver";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-oGTtS5UlEebIqv4SM4q0YclASJNu8DNOLrGLRRAtkd8=";
+    hash = "sha256-M0eMI/TtUNVqE4F1ifizVb0e4ACGa+yLkG3pJLaaDNs=";
   };
 
   patches = [

--- a/pkgs/servers/caddy/xcaddy/default.nix
+++ b/pkgs/servers/caddy/xcaddy/default.nix
@@ -23,6 +23,6 @@ buildGoModule rec {
     homepage = "https://github.com/caddyserver/xcaddy";
     description = "Build Caddy with plugins";
     license = licenses.asl20;
-    maintainers = with maintainers; [ tjni ];
+    maintainers = with maintainers; [ tjni indeednotjames ];
   };
 }

--- a/pkgs/servers/caddy/xcaddy/default.nix
+++ b/pkgs/servers/caddy/xcaddy/default.nix
@@ -14,7 +14,14 @@ buildGoModule rec {
   };
 
   patches = [
+    ./inject_version_info.diff
     ./use_tmpdir_on_darwin.diff
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/caddyserver/xcaddy/cmd.customVersion=v${version}"
   ];
 
   vendorHash = "sha256-RpbnoXyTrqGOI7DpgkO+J47P17T4QCVvM1CfS6kRO9Y=";

--- a/pkgs/servers/caddy/xcaddy/inject_version_info.diff
+++ b/pkgs/servers/caddy/xcaddy/inject_version_info.diff
@@ -1,0 +1,16 @@
+diff --git a/cmd/main.go b/cmd/main.go
+index ede7cd8..c553140 100644
+--- a/cmd/main.go
++++ b/cmd/main.go
+@@ -401,8 +401,11 @@ func splitWith(arg string) (module, version, replace string, err error) {
+ 	return
+ }
+
++var customVersion string
++
+ // xcaddyVersion returns a detailed version string, if available.
+ func xcaddyVersion() string {
++	return customVersion
+ 	mod := goModule()
+ 	ver := mod.Version
+ 	if mod.Sum != "" {


### PR DESCRIPTION
###### Description of changes

upstream: https://github.com/caddyserver/xcaddy/releases/tag/v0.3.2

nixpkgs: Patches the version reporting when running `xcaddy version` to return the proper version, instead of go's default "(devel)"

note: the `vendorHash` did not change, because the project's `go.sum` didn't change either

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
