### PR TITLE
der-ascii: init at unstable-2022-01-18

### DIFF
--- a/pkgs/tools/security/der-ascii/default.nix
+++ b/pkgs/tools/security/der-ascii/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "der-ascii";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1my93m1rx08kn2yms6k8w43byr8k61r1nra4b082j8b393wwxkqc";
+  };
+  vendorSha256 = null;
+
+  ldflags = [ "-s" "-w" ];
+
+  meta = with lib; {
+    description = ''
+      A small human-editable language to emit DER or BER encodings of ASN.1
+      structures and malformed variants of them
+    '';
+    homepage = "https://github.com/google/der-ascii";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ alexshpilkin cpu hawkw ];
+    mainProgram = "ascii2der"; # has stable output, unlike its inverse
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7333,6 +7333,8 @@ with pkgs;
 
   deluge-2_x = deluge;
 
+  der-ascii = callPackage ../tools/security/der-ascii { };
+
   desktop-file-utils = callPackage ../tools/misc/desktop-file-utils { };
 
   dfc  = callPackage ../tools/system/dfc { };


### PR DESCRIPTION
###### Description of changes

[DER ASCII](https://github.com/google/der-ascii) is a readable lossless representation for ASN.1 BER serializations (including DER), used for TLS certificates among others. The package includes a pair of tools, `der2ascii` and `ascii2der`, that can convert a BER blob to a text representation and back.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).