### PR TITLE
mutagen: 0.16.0 -> 0.16.4

### DIFF
--- a/pkgs/tools/misc/mutagen/default.nix
+++ b/pkgs/tools/misc/mutagen/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "mutagen";
-  version = "0.16.0";
+  version = "0.16.4";
 
   src = fetchFromGitHub {
     owner = "mutagen-io";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-nKt/A1LIr+cPWASWFYiOebxsuWcbzd23CQ32GgnWvLA=";
+    sha256 = "sha256-vIq6dNceLOvmhaE7g8lURS86SZdqRIeKWmftmHVgagI=";
   };
 
-  vendorSha256 = "sha256-feQOrZmJ656yD3HsxnN8JFXoP/XM2Gobyzj5MHyH/Xw=";
+  vendorSha256 = "sha256-iLLxGDdC4KHfbPFDRMmC7CV/HFpaBvx3c7FqQoNl/io=";
 
   agents = fetchzip {
     name = "mutagen-agents-${version}";
@@ -21,7 +21,7 @@ buildGoModule rec {
     postFetch = ''
       rm $out/mutagen # Keep only mutagen-agents.tar.gz.
     '';
-    sha256 = "sha256-QkleSf/Npbqrx2049tKxxwJk+996gM5AU/BIoyplDYo=";
+    sha256 = "sha256-vsKziTc+B1NvIfogaBx8yE6fNzaZZGkByqjpEkrYddM=";
   };
 
   doCheck = false;


### PR DESCRIPTION
###### Description of changes

The primary motivation for this change can be found in [this discussion](https://github.com/NixOS/nixpkgs/issues/81219#issuecomment-1418373820). In short, the underlying `mutagen` project was not handling symlinks of binaries in a way that was suitable for how much nix relies on symlinks. In particular, the nix store `libexec` path was being appended to the directory `mutagen` was found in instead of being treated as an absolute path.

Example:

```
Extracting agent...
Error: unable to connect to beta: unable to connect to endpoint: unable to dial agent endpoint: unable to install agent: unable to get agent for platform: unable to locate agent bundle (search paths: [/Users/beausimensen/.nix-profile/bin /Users/beausimensen/.nix-profile/bin/nix/store/kir3243y2wqsxz762pmj0kvd5b7hk2c7-mutagen-0.16.0/libexec])
```

More details from that discussion.

```
beausimensen@Beaus-MacBook-Pro whrc-portal % ls -l /Users/beausimensen/.nix-profile/bin/mutagen
lrwxr-xr-x 1 root wheel 70 Dec 31  1969 /Users/beausimensen/.nix-profile/bin/mutagen -> /nix/store/kir3243y2wqsxz762pmj0kvd5b7hk2c7-mutagen-0.16.0/bin/mutagen
beausimensen@Beaus-MacBook-Pro whrc-portal % ls -l /Users/beausimensen/.nix-profile/bin/nix/store/kir3243y2wqsxz762pmj0kvd5b7hk2c7-mutagen-0.16.0/libexec
ls: cannot access '/Users/beausimensen/.nix-profile/bin/nix/store/kir3243y2wqsxz762pmj0kvd5b7hk2c7-mutagen-0.16.0/libexec': No such file or directory
beausimensen@Beaus-MacBook-Pro whrc-portal % ls -l /nix/store/kir3243y2wqsxz762pmj0kvd5b7hk2c7-mutagen-0.16.0/libexec
total 0
lrwxr-xr-x 1 root wheel 87 Dec 31  1969 mutagen-agents.tar.gz -> /nix/store/nvyj8id029ighslr27jwb3plrrsm94gk-mutagen-agents-0.16.0/mutagen-agents.tar.gz
beausimensen@Beaus-MacBook-Pro whrc-portal % ls -l /nix/store/nvyj8id029ighslr27jwb3plrrsm94gk-mutagen-agents-0.16.0/mutagen-agents.tar.gz
-r--r--r-- 1 root nixbld 77M Dec 31  1969 /nix/store/nvyj8id029ighslr27jwb3plrrsm94gk-mutagen-agents-0.16.0/mutagen-agents.tar.gz
```

For the full list of changes between 0.16.0 and 0.16.4, you can refer to [this link on GitHub](https://github.com/mutagen-io/mutagen/compare/v0.16.0...v0.16.4).

You can find a more friendly changelog by looking at [this link on GitHub](https://github.com/mutagen-io/mutagen/releases).


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
     * I have `sandbox = false`.
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

This is my first contribution to anything related to nix and I'm not sure if I set up everything correctly. I'm happy to jump through more hoops to get it right.

###### TLDR

This PR solves the original problem by upgrading to a version of mutagen that can correctly locate the agents in libexec. However, it does not appear to work for docker containers without manual intervention, so I think I need to send another PR just to fix that.

More details about the Docker issue follows below.

-----

@xenoscopic I've been able to build and use this locally. It seems to work now, which is great, with one exception.

When started from `launchctl`, `mutagen daemon run` cannot find `docker`. I believe this is because it runs as `root` in that context, and thus doesn't know where docker was installed as my user under nix.

The only way I can successfully get mutagen started *and also connect to my docker containers*, is by starting it like this:

```
MUTAGEN_DOCKER_PATH=/run/current-system/sw/bin mutagen daemon run
```

I'm not sure if this is mutagen related or more about how nix works, and maybe even specific to `nix-darwin`.

To be clear, I'm trying to connect to a beta via docker:

```
mutagen sync create \
    --name acme-portal \
    --default-owner-beta="id:1000" \
    $PWD \
    docker://acme-portal_mutagen/volumes/acme-portal_mutagen
```

If I don't start the daemon automatically with `MUTAGEN_DOCKER_PATH` specified, I get the following output:

```
Started Mutagen daemon in background (terminate with "mutagen daemon stop")
Connecting to agent (POSIX)...
Error: unable to connect to beta: unable to connect to endpoint: unable to dial agent endpoint: unable to create agent command: unable to probe container: unable to set up Docker invocation: unable to identify 'docker' command: unable to locate command
```

It is possible I can set `MUTAGEN_DOCKER_PATH` globally somehow so that mutagen can run correctly from launchcontrol or `daemon run` without manually specifying where docker is installed, but I think it would be less hacky and better if this didn't require extra configuration outside nix in order to get it working.