### PR TITLE
gcfflasher: init at 4.0.3-beta

### DIFF
--- a/pkgs/applications/misc/gcfflasher/default.nix
+++ b/pkgs/applications/misc/gcfflasher/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, libgpiod
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gcfflasher";
+  version = "4.0.3-beta";
+
+  src = fetchFromGitHub {
+    owner = "dresden-elektronik";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-m+iDBfsHo+PLYd3K8JaKwhIXcnj+Q8w7gIgmHp+0plk=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace 'main_windows.c' 'main_posix.c'
+    '';
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    libgpiod
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm0755 GCFFlasher $out/bin/GCFFlasher
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "CFFlasher is the tool to program the firmware of dresden elektronik's Zigbee products";
+    license = licenses.bsd3;
+    homepage = "https://github.com/dresden-elektronik/gcfflasher";
+    maintainers = with maintainers; [ fleaz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7353,6 +7353,8 @@ with pkgs;
     gtk = gtk2-x11;
   };
 
+  gcfflasher = callPackage ../applications/misc/gcfflasher { };
+
   gdmap = callPackage ../tools/system/gdmap { };
 
   gef = callPackage ../development/tools/misc/gef { };


### PR DESCRIPTION
###### Description of changes

CLI utility from "dresden elektronik" for their popular Zigbee Sticks Conbee and Raspbee to flash new firmware.

[Link to the repo](https://github.com/dresden-elektronik/gcfflasher)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
