### PR TITLE
sniffnet: 1.0.1 -> 1.1.0

### DIFF
--- a/pkgs/applications/networking/sniffnet/default.nix
+++ b/pkgs/applications/networking/sniffnet/default.nix
@@ -1,9 +1,11 @@
 { lib
 , rustPlatform
-, fetchCrate
+, fetchFromGitHub
 , pkg-config
 , libpcap
 , stdenv
+, alsa-lib
+, expat
 , fontconfig
 , libGL
 , xorg
@@ -12,20 +14,24 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sniffnet";
-  version = "1.0.1";
+  version = "1.1.0";
 
-  src = fetchCrate {
-    inherit pname version;
-    sha256 = "sha256-8K774j04BOEuJjnFYjaSctPwBrKYYKqjFS2+PyxJ2FM=";
+  src = fetchFromGitHub {
+    owner = "gyulyvgc";
+    repo = "sniffnet";
+    rev = "v${version}";
+    hash = "sha256-zqk0N1S0vylleyyXaSflIZyWncZV0+wbSy1oAbyLx/4=";
   };
 
-  cargoSha256 = "sha256-096i4wDdoJCICd0L2QNY+7cKHQnijK22zj4XaQNuko8=";
+  cargoHash = "sha256-9CTA7Yh2O5S8DvRjwvkrb4ye0/8f+l0tsTxNBMmxLpQ=";
 
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
     libpcap
   ] ++ lib.optionals stdenv.isLinux [
+    alsa-lib
+    expat
     fontconfig
     libGL
     xorg.libX11
@@ -34,6 +40,7 @@ rustPlatform.buildRustPackage rec {
     xorg.libXrandr
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.AppKit
+    rustPlatform.bindgenHook
   ];
 
   postFixup = lib.optionalString stdenv.isLinux ''


### PR DESCRIPTION
Changelog: https://github.com/gyulyvgc/sniffnet/blob/main/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
