### PR TITLE
python3Packages.spacy_models.*: add Croatian, Korean, Finnish and Ukrainian language models

### DIFF
--- a/pkgs/development/python-modules/pymorphy3/default.nix
+++ b/pkgs/development/python-modules/pymorphy3/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, dawg-python
+, docopt
+, pytestCheckHook
+, pymorphy3-dicts-ru
+, pymorphy3-dicts-uk
+}:
+
+buildPythonPackage rec {
+  pname = "pymorphy3";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "no-plagiarism";
+    repo = pname;
+    rev = version;
+    hash = "sha256-5MXAYcjZPUrGf5G5e7Yml1SLukrZURA0TCv0GiP56rM=";
+  };
+
+  propagatedBuildInputs = [
+    dawg-python
+    docopt
+    pymorphy3-dicts-ru
+    pymorphy3-dicts-uk
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pymorphy3" ];
+
+  meta = with lib; {
+    description = "Morphological analyzer/inflection engine for Russian and Ukrainian";
+    homepage = "https://github.com/no-plagiarism/pymorphy3";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jboy ];
+  };
+}

--- a/pkgs/development/python-modules/pymorphy3/dicts-ru.nix
+++ b/pkgs/development/python-modules/pymorphy3/dicts-ru.nix
@@ -1,0 +1,26 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+}:
+
+buildPythonPackage rec {
+  pname = "pymorphy3-dicts-ru";
+  version = "2.4.417150.4580142";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-Oas3nUypBbr+1Q9a/Do95vlkNgV3b7yrxNMIjU7TgrA=";
+  };
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pymorphy3_dicts_ru" ];
+
+  meta = with lib; {
+    description = "Russian dictionaries for pymorphy3";
+    homepage = "https://github.com/no-plagiarism/pymorphy3-dicts";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jboy ];
+  };
+}

--- a/pkgs/development/python-modules/pymorphy3/dicts-uk.nix
+++ b/pkgs/development/python-modules/pymorphy3/dicts-uk.nix
@@ -1,0 +1,26 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+}:
+
+buildPythonPackage rec {
+  pname = "pymorphy3-dicts-uk";
+  version = "2.4.1.1.1663094765";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-s5RaNBNuGTgGzeZXuicdiKYHYedRN8E9E4qNFCqNEqw=";
+  };
+
+  # has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pymorphy3_dicts_uk" ];
+
+  meta = with lib; {
+    description = "Ukrainian dictionaries for pymorphy3";
+    homepage = "https://github.com/no-plagiarism/pymorphy3-dicts";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jboy ];
+  };
+}

--- a/pkgs/development/python-modules/spacy-transformers/annotation-test/annotate.py
+++ b/pkgs/development/python-modules/spacy-transformers/annotation-test/annotate.py
@@ -59,10 +59,11 @@ def test_verbs(doc_en_core_web_trf):
     assert [
         token.lemma_ for token in doc_en_core_web_trf if token.pos_ == "VERB"] == [
         'start',
+        'work',
+        'drive',
         'take',
         'tell',
         'shake',
         'turn',
-        'be',
         'talk',
         'say']

--- a/pkgs/development/python-modules/spacy-transformers/default.nix
+++ b/pkgs/development/python-modules/spacy-transformers/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "spacy-transformers";
-  version = "1.1.9";
+  version = "1.2.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-2uU6y/rsvNSLpeXL6O9IOQ0RMN0AEMH+/IKH6uufusU=";
+    hash = "sha256-Up9ZlLlAM0CDXEYDI95KsLzA0TBz/uZFqEgZLmNIABA=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/spacy/models.json
+++ b/pkgs/development/python-modules/spacy/models.json
@@ -42,6 +42,12 @@
     "license": "cc-by-sa-40"
   },
   {
+    "pname": "da_core_news_trf",
+    "version": "3.5.0",
+    "sha256": "0b8mxr1ajyw8ccm0khmcp4n3jcxl4syfrmiy9kzf3cp4hcrnqnxy",
+    "license": "cc-by-sa-40"
+  },
+  {
     "pname": "de_core_news_lg",
     "version": "3.5.0",
     "sha256": "0l3sg853xfkab7mj41n370x37iksp79nrjp7s60hhajpfbl546a0",
@@ -132,6 +138,24 @@
     "license": "gpl3"
   },
   {
+    "pname": "fi_core_news_lg",
+    "version": "3.5.0",
+    "sha256": "0j3r01a0yqgj8apfjv1wkblhqg86yp2nzxv51nf99pi2nmh81jzx",
+    "license": "cc-by-sa-40"
+  },
+  {
+    "pname": "fi_core_news_md",
+    "version": "3.5.0",
+    "sha256": "09qfzwyw6wfdmw1bgd1kfg1gdbmzal5z1r240djivxygzn6f1ixs",
+    "license": "cc-by-sa-40"
+  },
+  {
+    "pname": "fi_core_news_sm",
+    "version": "3.5.0",
+    "sha256": "1ly71cacy0gr62acvc3vl8dxh2czd6zkm7ijprisdblw17ik9yln",
+    "license": "cc-by-sa-40"
+  },
+  {
     "pname": "fr_core_news_lg",
     "version": "3.5.0",
     "sha256": "1zjf348c60xf35zaldgykrlskvrryxv9vdaz49xlwq9caw0yzyh4",
@@ -156,6 +180,24 @@
     "license": "lgpllr"
   },
   {
+    "pname": "hr_core_news_lg",
+    "version": "3.5.0",
+    "sha256": "1fvkzfi539fmp6jy3hjcrwvdxw5k6zc3h351s887xidlw3gs1kr3",
+    "license": "cc-by-sa-40"
+  },
+  {
+    "pname": "hr_core_news_md",
+    "version": "3.5.0",
+    "sha256": "1mi6k9qjxbigrl2fa60blyyz8b54jda5hc1s96vn9rykg4rni8cr",
+    "license": "cc-by-sa-40"
+  },
+  {
+    "pname": "hr_core_news_sm",
+    "version": "3.5.0",
+    "sha256": "1s22mx7y5h135ry5l49az30l7mw7fdrz53s4a9gaxfsp9rzs474g",
+    "license": "cc-by-sa-40"
+  },
+  {
     "pname": "it_core_news_lg",
     "version": "3.5.0",
     "sha256": "1z64s632wbjlqmnmppcnpf2pfrjbml30gbil7mk0qln2i2hrh0qq",
@@ -172,6 +214,24 @@
     "version": "3.5.0",
     "sha256": "1fw262m7bl3g31gz0jb6fxrd385p67q82wfrsff6z9daxi3pi6ip",
     "license": "cc-by-nc-sa-30"
+  },
+  {
+    "pname": "ko_core_news_lg",
+    "version": "3.5.0",
+    "sha256": "1q314wb114ynkf455cm8jd9jsx3yb6y0rrgf820ww31jlk5jzaa9",
+    "license": "cc-by-sa-40"
+  },
+  {
+    "pname": "ko_core_news_md",
+    "version": "3.5.0",
+    "sha256": "0dy7kk4bvjl944vv2m4hcvppar7clwq28y2rk40i3022jbqh2nxq",
+    "license": "cc-by-sa-40"
+  },
+  {
+    "pname": "ko_core_news_sm",
+    "version": "3.5.0",
+    "sha256": "1i5q8dpyfa2sy80hr81r6s9dqpawp36ni8slz035b0wd9sq3i73v",
+    "license": "cc-by-sa-40"
   },
   {
     "pname": "lt_core_news_lg",
@@ -334,6 +394,30 @@
     "version": "3.5.0",
     "sha256": "1c0w85xn8lnx394qmmnv3px68w0pha7fxx0qlqa74r2mfi3sv6s7",
     "license": "cc-by-sa-40"
+  },
+  {
+    "pname": "uk_core_news_lg",
+    "version": "3.5.0",
+    "sha256": "0hl9xjnxslckc6wvfgkj30r3py8q95yj7mrxdb6m5gvknlq72kp2",
+    "license": "mit"
+  },
+  {
+    "pname": "uk_core_news_md",
+    "version": "3.5.0",
+    "sha256": "05mg719ra5khm61yr7xhfcsh3apl29s3h2wkq0v87gkyqn13812p",
+    "license": "mit"
+  },
+  {
+    "pname": "uk_core_news_sm",
+    "version": "3.5.0",
+    "sha256": "1dkbmjbyhf6vsr7c4m4njgi969sfhbdnp73skl3k206dign5qgnz",
+    "license": "mit"
+  },
+  {
+    "pname": "uk_core_news_trf",
+    "version": "3.5.0",
+    "sha256": "02bhvcivalifrxd3vl118799wvg6hgykj31wwfdsgnq68lwc28fb",
+    "license": "mit"
   },
   {
     "pname": "xx_ent_wiki_sm",

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8429,6 +8429,12 @@ self: super: with self; {
 
   pymorphy2-dicts-ru = callPackage ../development/python-modules/pymorphy2/dicts-ru.nix { };
 
+  pymorphy3 = callPackage ../development/python-modules/pymorphy3 { };
+
+  pymorphy3-dicts-ru = callPackage ../development/python-modules/pymorphy3/dicts-ru.nix { };
+
+  pymorphy3-dicts-uk = callPackage ../development/python-modules/pymorphy3/dicts-uk.nix { };
+
   pympler = callPackage ../development/python-modules/pympler { };
 
   pymsgbox = callPackage ../development/python-modules/pymsgbox { };


### PR DESCRIPTION
###### Description of changes

Update spaCy [language models](https://spacy.io/models/) to versions 3.5.0 and add language models for Croatian, Korean, Finnish, and Ukrainian that have been added upstream. 

Currently nixpkgs contains version 3.3 language models which don't work with spaCy 3.5 (which nixpkgs already has).

As in the [previous update](https://github.com/NixOS/nixpkgs/pull/91217) by @danieldk, I am omitting the Japanese models because of the difficulty of packaging `sudachidict-core` and `sudachipy`.

A new dependency that I did include is `pymorphy3`, required by the Russian and Ukrainian models. nixpkgs already contained `pymorphy2`, of which `pymorphy3` is a fork, and the derivation needed for pymorphy3 is virtually unchanged.

I also updated the `spacy-transformers` package because the transformer models require a newer release than the one currently in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).