### PR TITLE
[22.11] Prepare for backporting Chromium M110

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -34,6 +34,7 @@
 , libva
 , libdrm, wayland, libxkbcommon # Ozone
 , curl
+, libffi
 , libepoxy
 # postPatch:
 , glibc # gconv + locale
@@ -153,7 +154,8 @@ let
       libepoxy
     ] ++ optional systemdSupport systemd
       ++ optionals cupsSupport [ libgcrypt cups ]
-      ++ optional pulseSupport libpulseaudio;
+      ++ optional pulseSupport libpulseaudio
+      ++ lib.optional (chromiumVersionAtLeast "110") libffi;
 
     patches = [
       # Optional patch to use SOURCE_DATE_EPOCH in compute_build_timestamp.py (should be upstreamed):
@@ -301,6 +303,10 @@ let
       use_system_libwayland = true;
       # The default value is hardcoded instead of using pkg-config:
       system_wayland_scanner_path = "${wayland.bin}/bin/wayland-scanner";
+    } // lib.optionalAttrs (chromiumVersionAtLeast "110") {
+      # To fix the build as we don't provide libffi_pic.a
+      # (ld.lld: error: unable to find library -l:libffi_pic.a):
+      use_system_libffi = true;
     } // lib.optionalAttrs proprietaryCodecs {
       # enable support for the H.264 codec
       proprietary_codecs = true;

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -260,8 +260,6 @@ let
       host_toolchain = "//build/toolchain/linux/unbundle:default";
       # Don't build against a sysroot image downloaded from Cloud Storage:
       use_sysroot = false;
-      # The default value is hardcoded instead of using pkg-config:
-      system_wayland_scanner_path = "${wayland.bin}/bin/wayland-scanner";
       # Because we use a different toolchain / compiler version:
       treat_warnings_as_errors = false;
       # We aren't compiling with Chrome's Clang (would enable Chrome-specific
@@ -295,12 +293,15 @@ let
       chrome_pgo_phase = 0;
       clang_base_path = "${llvmPackages.clang}";
       use_qt = false;
+    } // lib.optionalAttrs (!chromiumVersionAtLeast "110") {
       # The default has changed to false. We'll build with libwayland from
       # Nixpkgs for now but might want to eventually use the bundled libwayland
       # as well to avoid incompatibilities (if this continues to be a problem
       # from time to time):
       use_system_libwayland = true;
-    } // optionalAttrs proprietaryCodecs {
+      # The default value is hardcoded instead of using pkg-config:
+      system_wayland_scanner_path = "${wayland.bin}/bin/wayland-scanner";
+    } // lib.optionalAttrs proprietaryCodecs {
       # enable support for the H.264 codec
       proprietary_codecs = true;
       enable_hangout_services_extension = true;

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "110.0.5481.30",
-    "sha256": "03r2mpnrw9p188lajf69lpd94rcgj5a9hs2nlf01f0czl6nij0bx",
-    "sha256bin64": "0wdvqq9h5vzmlwysnlw7wk4bzkmra7qp9k4p1c0phl05863ykasv",
+    "version": "111.0.5532.2",
+    "sha256": "0aaxfi4f88s1cfzyhngmsmb84awy85xjy6a8pk3bfamssgxj0981",
+    "sha256bin64": "1jjmqi27qwbnmcfq043gxws31v47yfkzs7jk7mxzzxbaqj7v3wf6",
     "deps": {
       "gn": {
         "version": "2022-12-12",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,15 +19,15 @@
     }
   },
   "beta": {
-    "version": "109.0.5414.74",
-    "sha256": "0pcfaj3n3rjk4va9g0ajlsv1719kdhqcnjdd4piinqxb4qy27vgd",
-    "sha256bin64": "1ihjjf8x5080p9bizhqrrr0rcjf0l1nps9xq9naa2f48y5zfshkd",
+    "version": "110.0.5481.30",
+    "sha256": "03r2mpnrw9p188lajf69lpd94rcgj5a9hs2nlf01f0czl6nij0bx",
+    "sha256bin64": "0bpv4qgbbi8651x5mp8qyqxlxqm5x9csml1yi3789f7d40hs4vj9",
     "deps": {
       "gn": {
-        "version": "2022-11-10",
+        "version": "2022-12-12",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "1c4151ff5c1d6fbf7fa800b8d4bb34d3abc03a41",
-        "sha256": "02621c9nqpr4pwcapy31x36l5kbyd0vdgd0wdaxj5p8hrxk67d6b"
+        "rev": "5e19d2fb166fbd4f6f32147fbb2f497091a54ad8",
+        "sha256": "1b5fwldfmkkbpp5x63n1dxv0nc965hphc8rm8ah7zg44zscm9z30"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "110.0.5481.24",
-    "sha256": "1656qjbrrv276xxdlw0iv635sgm89r7nx32780zglm0lag3jx6ai",
-    "sha256bin64": "0pzd441qghdhibcnh1f2fldsx5ddjjwfrjv1nwi15pf3cabymz5g",
+    "version": "110.0.5481.30",
+    "sha256": "03r2mpnrw9p188lajf69lpd94rcgj5a9hs2nlf01f0czl6nij0bx",
+    "sha256bin64": "0wdvqq9h5vzmlwysnlw7wk4bzkmra7qp9k4p1c0phl05863ykasv",
     "deps": {
       "gn": {
         "version": "2022-12-12",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "111.0.5532.2",
-    "sha256": "0aaxfi4f88s1cfzyhngmsmb84awy85xjy6a8pk3bfamssgxj0981",
-    "sha256bin64": "1jjmqi27qwbnmcfq043gxws31v47yfkzs7jk7mxzzxbaqj7v3wf6",
+    "version": "111.0.5545.6",
+    "sha256": "0c5v7w0fbhrgqialncx0adyyah2026icwrxjwywridah1jrbm90a",
+    "sha256bin64": "1m3s40hibs3f1j3g2asq102iijjd59xrqqz7iv82za1slnrcbfg5",
     "deps": {
       "gn": {
         "version": "2022-12-12",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "110.0.5481.52",
-    "sha256": "09khb67xl1b2caw0j9lmv6a9iyms9sprn2r7wsgqzjn9dzd9wwcq",
-    "sha256bin64": "0dv9fxwqn50hl06y7zfqby8hd9lwqwk2q3856fygbn82qppkbl4r",
+    "version": "110.0.5481.77",
+    "sha256": "1kl1k29sr5qw8pg7shvizw4b37fxjlgah56p57kq641iqhnsnj73",
+    "sha256bin64": "0wnzgvwbpmb5ja4ba5mjk4bk0aaxzbw4zi509vw96q6mbqmr4iwr",
     "deps": {
       "gn": {
         "version": "2022-12-12",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "110.0.5481.30",
-    "sha256": "03r2mpnrw9p188lajf69lpd94rcgj5a9hs2nlf01f0czl6nij0bx",
-    "sha256bin64": "0bpv4qgbbi8651x5mp8qyqxlxqm5x9csml1yi3789f7d40hs4vj9",
+    "version": "110.0.5481.38",
+    "sha256": "0y3clfzqnbyz0v53w3ha1kx4jb9skdf22ihs09i8b568dj1m9mwj",
+    "sha256bin64": "0gvxsgw0ywq8d689g8790fymhksqg744m3j7kg4hcnmiyqdajl0n",
     "deps": {
       "gn": {
         "version": "2022-12-12",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "110.0.5481.38",
-    "sha256": "0y3clfzqnbyz0v53w3ha1kx4jb9skdf22ihs09i8b568dj1m9mwj",
-    "sha256bin64": "0gvxsgw0ywq8d689g8790fymhksqg744m3j7kg4hcnmiyqdajl0n",
+    "version": "110.0.5481.52",
+    "sha256": "09khb67xl1b2caw0j9lmv6a9iyms9sprn2r7wsgqzjn9dzd9wwcq",
+    "sha256bin64": "0dv9fxwqn50hl06y7zfqby8hd9lwqwk2q3856fygbn82qppkbl4r",
     "deps": {
       "gn": {
         "version": "2022-12-12",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "111.0.5545.6",
-    "sha256": "0c5v7w0fbhrgqialncx0adyyah2026icwrxjwywridah1jrbm90a",
-    "sha256bin64": "1m3s40hibs3f1j3g2asq102iijjd59xrqqz7iv82za1slnrcbfg5",
+    "version": "111.0.5562.0",
+    "sha256": "0aviz1cjm00lya530n0wyqn85d3idzn3bbp8065ygvfawqcf163j",
+    "sha256bin64": "0azkcvbl645c9ph4vn4502qbgfcb7zbs4ycy3q73nj5al642absm",
     "deps": {
       "gn": {
         "version": "2022-12-12",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "111.0.5562.0",
-    "sha256": "0aviz1cjm00lya530n0wyqn85d3idzn3bbp8065ygvfawqcf163j",
-    "sha256bin64": "0azkcvbl645c9ph4vn4502qbgfcb7zbs4ycy3q73nj5al642absm",
+    "version": "111.0.5563.8",
+    "sha256": "0gflrk5i6dr5vrywhxab73044gryxj49px59blgl6nyphw7swpwy",
+    "sha256bin64": "1dgfjz9pnziy1zymk7g15i5zdb002g77q8kqhkwgi4m0fndknpmj",
     "deps": {
       "gn": {
         "version": "2022-12-12",


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
