### PR TITLE
tests.defaultPkgConfigPackages: Test `meta.pkgConfigModules`

### DIFF
--- a/pkgs/top-level/pkg-config/test-defaultPkgConfigPackages.nix
+++ b/pkgs/top-level/pkg-config/test-defaultPkgConfigPackages.nix
@@ -44,14 +44,28 @@ let
     else if !pkg ? meta.broken then
       throw "pkg-config module `${escapeNixIdentifier moduleName}` does not have a `meta.broken` attribute. This can't be right. Please check the attribute value for `${escapeNixIdentifier moduleName}` in `pkgs/top-level/pkg-config.packages.nix` in Nixpkgs."
 
-    else if pkg.meta.broken then
-      null
-
     else
-      testers.hasPkgConfigModules {
-        moduleNames = [ moduleName ];
-        package = pkg;
-      };
+
+      # TODO make hard requirement instead of warning.
+      assert lib.warnIf (!lib.elem moduleName pkg.meta.pkgConfigModules or [ ])
+        "pkg-config module `${escapeNixIdentifier moduleName}` is not listed in the `meta.pkgConfigModules` of the package it is mapped to."
+        true;
+
+      # Less urgent to make hard requirement given annoyance of
+      # `tests.pkg-config` boilerplate (see
+      # https://github.com/NixOS/nixpkgs/issues/215162).
+      assert lib.warnIf ((pkg.tests.pkg-config or false) != testers.testMetaPkgConfig pkg)
+        "pkg-config module `${escapeNixIdentifier moduleName}` does not test its `meta.pkgConfigModules`."
+        true;
+
+      if pkg.meta.broken then
+        null
+
+      else
+        testers.hasPkgConfigModules {
+          moduleNames = [ moduleName ];
+          package = pkg;
+        };
 
 in
 lib.recurseIntoAttrs allTests // { inherit tests-combined; }


### PR DESCRIPTION
###### Description of changes

This is just in the tests for this alt package set, so hopefully regular users don't see this too much.

The main purpose is to assist in crowd-sourcing adding this metadata to more packages --- giving us todo list to coordinate around.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
