### PR TITLE
SDL2_image: 2.0.5 -> 2.6.3

### DIFF
--- a/pkgs/development/libraries/SDL2_image/default.nix
+++ b/pkgs/development/libraries/SDL2_image/default.nix
@@ -1,15 +1,20 @@
 { lib, stdenv, fetchurl
 , pkg-config
 , SDL2, libpng, libjpeg, libtiff, giflib, libwebp, libXpm, zlib, Foundation
+, version ? "2.6.3"
+, hash ? "sha256-kxyb5b8dfI+um33BV4KLfu6HTiPH8ktEun7/a0g2MSw="
 }:
 
-stdenv.mkDerivation rec {
+let
   pname = "SDL2_image";
-  version = "2.0.5";
+in
+
+stdenv.mkDerivation {
+  inherit pname version;
 
   src = fetchurl {
     url = "https://www.libsdl.org/projects/SDL_image/release/${pname}-${version}.tar.gz";
-    sha256 = "1l0864kas9cwpp2d32yxl81g98lx40dhbdp03dz7sbv84vhgdmdx";
+    inherit hash;
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35746,7 +35746,9 @@ with pkgs;
 
   tome4 = callPackage ../games/tome4 { };
 
-  toppler = callPackage ../games/toppler { };
+  toppler = callPackage ../games/toppler {
+    SDL2_image = SDL2_image_2_0_5;
+  };
 
   torus-trooper = callPackage ../games/torus-trooper { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23047,6 +23047,10 @@ with pkgs;
   SDL2_image = callPackage ../development/libraries/SDL2_image {
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };
+  SDL2_image_2_0_5 = SDL2_image.override({ # Pinned for pygame, toppler
+    version = "2.0.5";
+    hash = "sha256-vdX24CZoL31+G+C2BRsgnaL0AqLdi9HEvZwlrSYxCNA";
+  });
 
   SDL2_mixer = callPackage ../development/libraries/SDL2_mixer {
     inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit AudioToolbox;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8070,6 +8070,7 @@ self: super: with self; {
 
   pygame = callPackage ../development/python-modules/pygame {
     inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
+    SDL2_image = pkgs.SDL2_image_2_0_5;
   };
 
   pygame_sdl2 = callPackage ../development/python-modules/pygame_sdl2 { };


### PR DESCRIPTION
* SDL2_image: 2.0.5 -> 2.6.3
* python310Packages.pygame: pin SDL2_image to 2.0.5
  - Upstream decision: https://github.com/pygame/pygame/issues/3430#issuecomment-1279955564

Fixes #187685

Release: https://github.com/libsdl-org/SDL_image/releases/tag/release-2.6.3

This PR is ready to be reviewed/merged.