### PR TITLE
flexoptix-app: 5.13.3 -> 5.13.4

### DIFF
--- a/pkgs/tools/misc/flexoptix-app/default.nix
+++ b/pkgs/tools/misc/flexoptix-app/default.nix
@@ -1,11 +1,11 @@
 { lib, appimageTools, fetchurl, nodePackages }: let
   pname = "flexoptix-app";
-  version = "5.13.3";
+  version = "5.13.4";
 
   src = fetchurl {
     name = "${pname}-${version}.AppImage";
     url = "https://flexbox.reconfigure.me/download/electron/linux/x64/FLEXOPTIX%20App.${version}.AppImage";
-    hash = "sha256-kDw9+Llqvq4NgN89Cw/HwEqYlv42wLbho1eHjI6wVSQ=";
+    hash = "sha256-W+9KmKZ1bPfQfv1DXCJrIswriw4ivBVZPW81tfvRBc0=";
   };
 
   udevRules = fetchurl {
@@ -47,7 +47,7 @@ in appimageTools.wrapAppImage {
   '';
 
   meta = {
-    description = "Configure FLEXOPTIX Universal Transcievers in seconds";
+    description = "Configure FLEXOPTIX Universal Transceivers in seconds";
     homepage = "https://www.flexoptix.net";
     changelog = "https://www.flexoptix.net/en/flexoptix-app/?os=linux#flexapp__modal__changelog";
     license = lib.licenses.unfree;


### PR DESCRIPTION
flexoptix-app: 5.13.3 -> 5.13.4

(I was going to mark broken, but fixed instead. I have no interest in this package.)