### PR TITLE
sourcehut.dispatchsrht: respect allowAliases

### DIFF
--- a/pkgs/applications/version-management/sourcehut/default.nix
+++ b/pkgs/applications/version-management/sourcehut/default.nix
@@ -2,6 +2,7 @@
 , callPackage
 , recurseIntoAttrs
 , nixosTests
+, config
 }:
 
 # To expose the *srht modules, they have to be a python module so we use `buildPythonModule`
@@ -28,12 +29,10 @@ let
     };
   };
 in
-with python.pkgs; recurseIntoAttrs {
+with python.pkgs; recurseIntoAttrs ({
   inherit python;
   coresrht = toPythonApplication srht;
   buildsrht = toPythonApplication buildsrht;
-  # Added 2022-10-29
-  dispatchsrht = throw "dispatch is deprecated. See https://sourcehut.org/blog/2022-08-01-dispatch-deprecation-plans/ for more information.";
   gitsrht = toPythonApplication gitsrht;
   hgsrht = toPythonApplication hgsrht;
   hubsrht = toPythonApplication hubsrht;
@@ -46,4 +45,7 @@ with python.pkgs; recurseIntoAttrs {
   passthru.tests = {
     nixos-sourcehut = nixosTests.sourcehut;
   };
-}
+} // lib.optionalAttrs config.allowAliases {
+  # Added 2022-10-29
+  dispatchsrht = throw "dispatch is deprecated. See https://sourcehut.org/blog/2022-08-01-dispatch-deprecation-plans/ for more information.";
+})


### PR DESCRIPTION
###### Description of changes

Nixpkgs convention is to only add attributes for deprecation throws when config.allowAliases hasn't been explicitly disabled.  This is useful as it makes it easy to test building all non-deprecated packages:

	nix-build --arg config '{ allowAliases = false; }' -A sourcehut

Precedent for this convention in Nixpkgs is easy to find by grepping for "config.allowAliases".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
