### PR TITLE
pythonPackages.promnesia: init at 1.1.20230129

### DIFF
--- a/pkgs/development/python-modules/HPI/default.nix
+++ b/pkgs/development/python-modules/HPI/default.nix
@@ -5,7 +5,7 @@
 , click
 , decorator
 , logzero
-, lxml 
+, lxml
 , more-itertools
 , mypy
 , orjson

--- a/pkgs/development/python-modules/HPI/default.nix
+++ b/pkgs/development/python-modules/HPI/default.nix
@@ -1,0 +1,47 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, appdirs
+, click
+, decorator
+, logzero
+, lxml 
+, more-itertools
+, mypy
+, orjson
+, pandas
+, pytz
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "HPI";
+  version = "0.0.20200417";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-cozMmfBF7D1qCZFjf48wRQaeN4MhdHAAxS8tGp/krK8=";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  propagatedBuildInputs = [
+    appdirs
+    click
+    decorator
+    logzero
+    lxml
+    more-itertools
+    mypy
+    orjson
+    pandas
+    pytz
+  ];
+
+  meta = with lib; {
+    description = "Human programming interface";
+    homepage = "https://beepb00p.xyz/hpi.html";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ qbit ];
+  };
+}

--- a/pkgs/development/python-modules/HPI/default.nix
+++ b/pkgs/development/python-modules/HPI/default.nix
@@ -1,5 +1,5 @@
 { buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , lib
 , appdirs
 , click
@@ -9,33 +9,85 @@
 , more-itertools
 , mypy
 , orjson
+, pytestCheckHook
 , pandas
 , pytz
 , setuptools-scm
+, python3
+
+, cachew
+, orgparse
+, influxdb
+, geopy
+, pillow
+, simplejson
+, browserexport
+, gpxpy
+, pdfannots
+, google-takeout-parser
+, GitPython
+, pinbexport
+, goodrexport
 }:
 
 buildPythonPackage rec {
   pname = "HPI";
-  version = "0.0.20200417";
+  version = "0.3.20230207";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-cozMmfBF7D1qCZFjf48wRQaeN4MhdHAAxS8tGp/krK8=";
+  src = fetchFromGitHub {
+    owner = "karlicoss";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-+7jy+JmCHw1Fqtn0DGlSO+XirBEKZHqA+9+Rm8ZaDbQ=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    cachew
+    geopy
+    influxdb
+    orgparse
+    pillow
+    pytestCheckHook
+    simplejson
+    browserexport
+    lxml
+    mypy
+    pandas
+  ];
 
   propagatedBuildInputs = [
     appdirs
     click
     decorator
     logzero
-    lxml
     more-itertools
     mypy
     orjson
-    pandas
     pytz
+    pdfannots
+    gpxpy
+    google-takeout-parser
+    GitPython
+    pinbexport
+    goodrexport
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # /nix/store/iysjd0sb3pc1rakncazfm023n3ga95x2-python3-3.9.16/lib/python3.9/importlib/__init__.py:127
+  doCheck = false;
+
+  makeWrapperArgs = [
+    "--prefix PYTHONPATH : ${python3.pkgs.makePythonPath propagatedBuildInputs}"
+    "--prefix PYTHONPATH : $out/lib/${python3.libPrefix}/site-packages"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/browserexport/default.nix
+++ b/pkgs/development/python-modules/browserexport/default.nix
@@ -1,26 +1,26 @@
 { buildPythonPackage
 , fetchFromGitHub
 , lib
-, appdirs
-, more-itertools
-, patchy
 , pytestCheckHook
-, pytz
 , setuptools-scm
-, sqlalchemy
-, sqlite
+, click
+, logzero
+, ipython
+, mypy
+, flake8
+, sqlite-backup
 }:
 
 buildPythonPackage rec {
-  pname = "cachew";
-  version = "0.11.0";
+  pname = "browserexport";
+  version = "0.2.9";
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = "karlicoss";
+    owner = "seanbreckenridge";
     repo = pname;
-    rev = "v${version}";
-    hash = "sha256-R268+zhf7MnIF5YTW+/zkdzEa6k4ZDk7upxA7yK05cA=";
+    rev = "9b8413f239ce0d152bc6766c1bd12a8afc7aea80";
+    hash = "sha256-jzXczP1ZqPYzUXFV11zEyfWuQUildXmuYfDh3C+otSc=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -30,22 +30,22 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    appdirs
-    sqlalchemy
+    logzero
+    click
+    ipython
+    sqlite-backup
   ];
 
   checkInputs = [
-    more-itertools
-    patchy
     pytestCheckHook
-    pytz
+    flake8
+    mypy
   ];
 
   doCheck = true;
 
   preCheck = ''
     export HOME=$(mktemp -d)
-    export PATH=$PATH:${sqlite}/bin
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/cachew/default.nix
+++ b/pkgs/development/python-modules/cachew/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage, fetchPypi, lib, appdirs, sqlalchemy, setuptools-scm }:
+
+buildPythonPackage rec {
+  pname = "cachew";
+  version = "0.11.0";
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  propagatedBuildInputs = [ appdirs sqlalchemy ];
+
+  doCheck = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-4qjgvffInKRpKST9xbwwC2+m8h3ups0ZePyJLUU+KhA=";
+  };
+
+  meta = with lib; {
+    description =
+      "Transparent and persistent cache/serialization powered by type hints";
+    homepage = "https://github.com/karlicoss/cachew";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ qbit ];
+  };
+}

--- a/pkgs/development/python-modules/goodrexport/default.nix
+++ b/pkgs/development/python-modules/goodrexport/default.nix
@@ -1,26 +1,22 @@
 { buildPythonPackage
 , fetchFromGitHub
 , lib
-, appdirs
-, more-itertools
-, patchy
 , pytestCheckHook
-, pytz
 , setuptools-scm
-, sqlalchemy
-, sqlite
+, lxml
 }:
 
 buildPythonPackage rec {
-  pname = "cachew";
-  version = "0.11.0";
+  pname = "goodrexport";
+  version = "2021-03-26";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "karlicoss";
     repo = pname;
-    rev = "v${version}";
-    hash = "sha256-R268+zhf7MnIF5YTW+/zkdzEa6k4ZDk7upxA7yK05cA=";
+    rev = "10d8cc86a121b9c1e99bb0b27a1bdd18c16ce270";
+    hash = "sha256-R2u8ud2r8zCaOlhjK1XQ1KPjnrFHTPZNeUnw2wKLdD0=";
+    fetchSubmodules = true;
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -30,27 +26,20 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    appdirs
-    sqlalchemy
+    lxml
   ];
 
   checkInputs = [
-    more-itertools
-    patchy
     pytestCheckHook
-    pytz
   ];
-
-  doCheck = true;
 
   preCheck = ''
     export HOME=$(mktemp -d)
-    export PATH=$PATH:${sqlite}/bin
   '';
 
   meta = with lib; {
-    description = "Transparent and persistent cache/serialization powered by type hints";
-    homepage = "https://github.com/karlicoss/cachew";
+    description = "Goodreads data export";
+    homepage = "https://github.com/karlicoss/goodrexport";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ qbit ];
   };

--- a/pkgs/development/python-modules/google-takeout-parser/default.nix
+++ b/pkgs/development/python-modules/google-takeout-parser/default.nix
@@ -1,0 +1,60 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, pytestCheckHook
+, setuptools-scm
+, click
+, logzero
+, lxml
+, beautifulsoup4
+, cachew
+, pytz
+, ipython
+, platformdirs
+}:
+
+buildPythonPackage rec {
+  pname = "google-takeout-parser";
+  version = "2023-02-01";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "seanbreckenridge";
+    repo = "google_takeout_parser";
+    rev = "c4ce0fd4862605b6ddc1e7f71b845102f7589e20";
+    hash = "sha256-PurQ1MCwMGl39Y/mX4BLXC9y/Rjj2JssuMCgGOBlsJQ=";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    logzero
+    click
+    ipython
+    lxml
+    beautifulsoup4
+    cachew
+    pytz
+    ipython
+    platformdirs
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  meta = with lib; {
+    description = "Parses data out of your Google Takeout";
+    homepage = "https://github.com/seanbreckenridge/google_takeout_parser";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ qbit ];
+  };
+}

--- a/pkgs/development/python-modules/orgparse/default.nix
+++ b/pkgs/development/python-modules/orgparse/default.nix
@@ -1,0 +1,24 @@
+{ buildPythonPackage, fetchPypi, lib, setuptools-scm, pytest }:
+
+buildPythonPackage rec {
+  pname = "orgparse";
+  version = "0.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-RRBQ55rLelHGXcmbkJXq5NUL1ZhUE1T552PLTL31mlU=";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  nativeCheckInputs = [ pytest ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "";
+    homepage = "https://orgparse.readthedocs.org/";
+    license = with licenses; [ bsd2 ];
+    maintainers = with maintainers; [ qbit ];
+  };
+}

--- a/pkgs/development/python-modules/patchy/default.nix
+++ b/pkgs/development/python-modules/patchy/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, pytestCheckHook
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "patchy";
+  version = "2.6.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "adamchainz";
+    repo = pname;
+    rev = version;
+    hash = "sha256-fQ4nOLpZ0XKN3W1PyhtoCgaSEiTVzrxCvYEoreZEtcQ=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Patch the inner source of python functions at runtime.";
+    homepage = "https://github.com/adamchainz/patchy";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ qbit ];
+  };
+}

--- a/pkgs/development/python-modules/pdfannots/default.nix
+++ b/pkgs/development/python-modules/pdfannots/default.nix
@@ -1,0 +1,50 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, pytestCheckHook
+, setuptools-scm
+, pdfminer-six
+}:
+
+buildPythonPackage rec {
+  pname = "pdfannots";
+  version = "0.3";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "0xabu";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-VG8pECjDHxAA5+pGRgb6dmyPMoRxZm91Yay3bq4FlBM=";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    pdfminer-six
+  ];
+
+  # TODO: Is this not needed?
+  #checkInputs = [
+  #  pytestCheckHook
+  #];
+
+  pyttestFlagsArray = [
+    "tests.py"
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  meta = with lib; {
+    description = "Extracts and formats text annotations from PDFs";
+    homepage = "https://github.com/9xabu/pdfnotes";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ qbit ];
+  };
+}

--- a/pkgs/development/python-modules/pinbexport/default.nix
+++ b/pkgs/development/python-modules/pinbexport/default.nix
@@ -1,26 +1,22 @@
 { buildPythonPackage
 , fetchFromGitHub
 , lib
-, appdirs
-, more-itertools
-, patchy
 , pytestCheckHook
-, pytz
 , setuptools-scm
-, sqlalchemy
-, sqlite
+, pytz
 }:
 
 buildPythonPackage rec {
-  pname = "cachew";
-  version = "0.11.0";
+  pname = "pinbexport";
+  version = "2022-05-14";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "karlicoss";
     repo = pname;
-    rev = "v${version}";
-    hash = "sha256-R268+zhf7MnIF5YTW+/zkdzEa6k4ZDk7upxA7yK05cA=";
+    rev = "f161f9fbb51bf8f907252d971435b5085e25ff13";
+    hash = "sha256-TiGjNHpKtykKxfH6/m/B2kxeDLvO+sAphkOiYzoej8c=";
+    fetchSubmodules = true;
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -30,27 +26,20 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    appdirs
-    sqlalchemy
-  ];
-
-  checkInputs = [
-    more-itertools
-    patchy
-    pytestCheckHook
     pytz
   ];
 
-  doCheck = true;
+  checkInputs = [
+    pytestCheckHook
+  ];
 
   preCheck = ''
     export HOME=$(mktemp -d)
-    export PATH=$PATH:${sqlite}/bin
   '';
 
   meta = with lib; {
-    description = "Transparent and persistent cache/serialization powered by type hints";
-    homepage = "https://github.com/karlicoss/cachew";
+    description = "Export your bookmarks from Pinboard";
+    homepage = "https://github.com/karlicoss/pinbexport";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ qbit ];
   };

--- a/pkgs/development/python-modules/promnesia/default.nix
+++ b/pkgs/development/python-modules/promnesia/default.nix
@@ -1,0 +1,69 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, beautifulsoup4
+, cachew
+, fastapi
+, HPI 
+, httptools
+, logzero
+, lxml
+, mistletoe
+, more-itertools
+, mypy
+, orgparse
+, pytz 
+, setuptools
+, setuptools-scm
+, sqlcipher3
+, tzlocal
+, urlextract
+, uvicorn
+, uvloop 
+, watchfiles
+, websockets
+}:
+
+buildPythonPackage rec {
+  pname = "promnesia";
+  version = "1.1.20230129";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-T6sayrPkz8I0u11ZvFbkDdOyVodbaTVkRzLib5lMX+Q=";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    cachew
+    fastapi
+    HPI
+    httptools
+    logzero
+    lxml
+    mistletoe
+    more-itertools
+    mypy
+    orgparse
+    pytz
+    setuptools
+    sqlcipher3
+    tzlocal
+    urlextract
+    uvicorn
+    uvloop
+    watchfiles
+    websockets
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/karlicoss/promnesia";
+    description = "Another piece of your extended mind";
+    license = licenses.mit;
+    maintainers = with maintainers; [ qbit ];
+  };
+}

--- a/pkgs/development/python-modules/promnesia/default.nix
+++ b/pkgs/development/python-modules/promnesia/default.nix
@@ -4,7 +4,7 @@
 , beautifulsoup4
 , cachew
 , fastapi
-, HPI 
+, HPI
 , httptools
 , logzero
 , lxml
@@ -12,14 +12,14 @@
 , more-itertools
 , mypy
 , orgparse
-, pytz 
+, pytz
 , setuptools
 , setuptools-scm
 , sqlcipher3
 , tzlocal
 , urlextract
 , uvicorn
-, uvloop 
+, uvloop
 , watchfiles
 , websockets
 }:

--- a/pkgs/development/python-modules/promnesia/default.nix
+++ b/pkgs/development/python-modules/promnesia/default.nix
@@ -4,7 +4,7 @@
 , beautifulsoup4
 , cachew
 , fastapi
-, HPI
+, hpi
 , httptools
 , logzero
 , lxml
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     beautifulsoup4
     cachew
     fastapi
-    HPI
+    hpi
     httptools
     logzero
     lxml

--- a/pkgs/development/python-modules/pytest-reraise/default.nix
+++ b/pkgs/development/python-modules/pytest-reraise/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, poetry-core
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-reraise";
+  version = "2.1.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "bjoluc";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-mgNKoZ+2sinArTZhSwhLxzBTb4QfiT1LWBs7w5MHXWA=";
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pytest_reraise" ];
+
+  checkInputs = [
+    poetry-core
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "poetry.masonry.api" "poetry.core.masonry.api"
+  '';
+
+
+  meta = with lib; {
+    description = "";
+    homepage = "";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ qbit ];
+  };
+}

--- a/pkgs/development/python-modules/sqlcipher3/default.nix
+++ b/pkgs/development/python-modules/sqlcipher3/default.nix
@@ -1,0 +1,22 @@
+{ buildPythonPackage, fetchPypi, lib, sqlcipher }:
+
+buildPythonPackage rec {
+  pname = "sqlcipher3";
+  version = "0.5.0";
+
+  propagatedBuildInputs = [ sqlcipher ];
+
+  doCheck = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-+wa7UzaCWvIE6Obb/Ihema8UnFPr2P+HeDe1R4+iU+U=";
+  };
+
+  meta = with lib; {
+    description = "Python 3 bindings for SQLCipher";
+    homepage = "https://github.com/coleifer/sqlcipher3";
+    license = with licenses; [ zlib ];
+    maintainers = with maintainers; [ qbit ];
+  };
+}

--- a/pkgs/development/python-modules/sqlite_backup/default.nix
+++ b/pkgs/development/python-modules/sqlite_backup/default.nix
@@ -1,26 +1,25 @@
 { buildPythonPackage
 , fetchFromGitHub
 , lib
-, appdirs
-, more-itertools
-, patchy
 , pytestCheckHook
-, pytz
 , setuptools-scm
-, sqlalchemy
-, sqlite
+, click
+, logzero
+, mypy
+, flake8
+, pytest-reraise
 }:
 
 buildPythonPackage rec {
-  pname = "cachew";
-  version = "0.11.0";
+  pname = "sqlite_backup";
+  version = "0.1.6";
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = "karlicoss";
+    owner = "seanbreckenridge";
     repo = pname;
-    rev = "v${version}";
-    hash = "sha256-R268+zhf7MnIF5YTW+/zkdzEa6k4ZDk7upxA7yK05cA=";
+    rev = "2e12f471676bc43dcc8bff68f579f3c25cfed4d9";
+    hash = "sha256-BlH0tCriieR1vwmBA+MFVkf6PmGsPXt6G8aIj7Y1SsU=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -30,27 +29,26 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    appdirs
-    sqlalchemy
+    logzero
+    click
   ];
 
   checkInputs = [
-    more-itertools
-    patchy
     pytestCheckHook
-    pytz
+    flake8
+    mypy
+    pytest-reraise
   ];
 
   doCheck = true;
 
   preCheck = ''
     export HOME=$(mktemp -d)
-    export PATH=$PATH:${sqlite}/bin
   '';
 
   meta = with lib; {
-    description = "Transparent and persistent cache/serialization powered by type hints";
-    homepage = "https://github.com/karlicoss/cachew";
+    description = "";
+    homepage = "";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ qbit ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4378,6 +4378,8 @@ self: super: with self; {
 
   hpccm = callPackage ../development/python-modules/hpccm { };
 
+  HPI = callPackage ../development/python-modules/HPI { };
+
   hs-dbus-signature = callPackage ../development/python-modules/hs-dbus-signature { };
 
   hsaudiotag3k = callPackage ../development/python-modules/hsaudiotag3k { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1513,6 +1513,8 @@ self: super: with self; {
 
   cachetools = callPackage ../development/python-modules/cachetools { };
 
+  cachew = callPackage ../development/python-modules/cachew { };
+
   cachey = callPackage ../development/python-modules/cachey { };
 
   cachy = callPackage ../development/python-modules/cachy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10972,6 +10972,8 @@ self: super: with self; {
 
   sqlalchemy-utils = callPackage ../development/python-modules/sqlalchemy-utils { };
 
+  sqlcipher3 = callPackage ../development/python-modules/sqlcipher3 { };
+
   sqlglot = callPackage ../development/python-modules/sqlglot { };
 
   sqlitedict = callPackage ../development/python-modules/sqlitedict { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7553,6 +7553,8 @@ self: super: with self; {
 
   promise = callPackage ../development/python-modules/promise { };
 
+  promnesia = callPackage ../development/python-modules/promnesia { };
+
   prompt-toolkit = callPackage ../development/python-modules/prompt-toolkit { };
 
   property-manager = callPackage ../development/python-modules/property-manager { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6738,6 +6738,8 @@ self: super: with self; {
 
   orderedset = callPackage ../development/python-modules/orderedset { };
 
+  orgparse = callPackage ../development/python-modules/orgparse { };
+
   orjson = callPackage ../development/python-modules/orjson { };
 
   orm = callPackage ../development/python-modules/orm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1435,6 +1435,8 @@ self: super: with self; {
 
   browser-cookie3 = callPackage ../development/python-modules/browser-cookie3 { };
 
+  browserexport = callPackage ../development/python-modules/browserexport { };
+
   brunt = callPackage ../development/python-modules/brunt { };
 
   bsddb3 = callPackage ../development/python-modules/bsddb3 { };
@@ -3886,6 +3888,8 @@ self: super: with self; {
 
   goocalendar = callPackage ../development/python-modules/goocalendar { };
 
+  goodrexport = callPackage ../development/python-modules/goodrexport { };
+
   goodwe = callPackage ../development/python-modules/goodwe { };
 
   google-api-core = callPackage ../development/python-modules/google-api-core { };
@@ -4013,6 +4017,8 @@ self: super: with self; {
   google-reauth = callPackage ../development/python-modules/google-reauth { };
 
   google-resumable-media = callPackage ../development/python-modules/google-resumable-media { };
+
+  google-takeout-parser = callPackage ../development/python-modules/google-takeout-parser { };
 
   googletrans = callPackage ../development/python-modules/googletrans { };
 
@@ -4378,7 +4384,7 @@ self: super: with self; {
 
   hpccm = callPackage ../development/python-modules/hpccm { };
 
-  HPI = callPackage ../development/python-modules/HPI { };
+  hpi = callPackage ../development/python-modules/HPI { };
 
   hs-dbus-signature = callPackage ../development/python-modules/hs-dbus-signature { };
 
@@ -6920,6 +6926,8 @@ self: super: with self; {
 
   patch-ng = callPackage ../development/python-modules/patch-ng { };
 
+  patchy = callPackage ../development/python-modules/patchy { };
+
   path = callPackage ../development/python-modules/path { };
 
   path-and-address = callPackage ../development/python-modules/path-and-address { };
@@ -6965,6 +6973,8 @@ self: super: with self; {
   pcpp = callPackage ../development/python-modules/pcpp { };
 
   pdf2image = callPackage ../development/python-modules/pdf2image { };
+
+  pdfannots = callPackage ../development/python-modules/pdfannots { };
 
   pdfkit = callPackage ../development/python-modules/pdfkit { };
 
@@ -7145,6 +7155,8 @@ self: super: with self; {
   };
 
   pims = callPackage ../development/python-modules/pims { };
+
+  pinbexport = callPackage ../development/python-modules/pinbexport { };
 
   pinboard = callPackage ../development/python-modules/pinboard { };
 
@@ -9122,6 +9134,8 @@ self: super: with self; {
 
   pytest-remotedata = callPackage ../development/python-modules/pytest-remotedata { };
 
+  pytest-reraise = callPackage ../development/python-modules/pytest-reraise { };
+
   pytest-repeat = callPackage ../development/python-modules/pytest-repeat { };
 
   pytest-rerunfailures = callPackage ../development/python-modules/pytest-rerunfailures { };
@@ -10979,6 +10993,8 @@ self: super: with self; {
   sqlglot = callPackage ../development/python-modules/sqlglot { };
 
   sqlitedict = callPackage ../development/python-modules/sqlitedict { };
+
+  sqlite-backup = callPackage ../development/python-modules/sqlite_backup { };
 
   sqlite-fts4 = callPackage ../development/python-modules/sqlite-fts4 { };
 


### PR DESCRIPTION
This add promnesia and its dependencies.

There are a few things I am not sure about:
- HPI should be installing `$out/bin/hpi`, but it doesn't seem to be doing so.
- `promnesia` runs a `config.py` configuration that users create / modify. Currently, that `config.py` fails to load `HPI` (lib is named `my`) and the `promnesia` lib when commands like `promnesia doctor` are used.

CC @mweinelt 

---

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
