### PR TITLE
deepin.deepin-reader: init at 5.10.28

### DIFF
--- a/pkgs/desktops/deepin/apps/deepin-reader/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-reader/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, qmake
+, pkg-config
+, qttools
+, wrapQtAppsHook
+, dtkwidget
+, qt5integration
+, qt5platform-plugins
+, dde-qt-dbus-factory
+, qtwebengine
+, karchive
+, poppler
+, libchardet
+, libspectre
+, openjpeg
+, djvulibre
+, gtest
+, qtbase
+}:
+
+stdenv.mkDerivation rec {
+  pname = "deepin-reader";
+  version = "5.10.28";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-0jHhsxEjBbu3ktvjX1eKnkZDwzRk9MrUSJSdYeOvWtI=";
+  };
+
+  patches = [ ./use-pkg-config.diff ];
+
+  postPatch = ''
+    substituteInPlace reader/{reader.pro,document/Model.cpp} htmltopdf/htmltopdf.pro 3rdparty/deepin-pdfium/src/src.pro \
+      --replace "/usr" "$out"
+  '';
+
+  nativeBuildInputs = [
+    qmake
+    pkg-config
+    qttools
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    dtkwidget
+    qt5platform-plugins
+    dde-qt-dbus-factory
+    qtwebengine
+    karchive
+    poppler
+    libchardet
+    libspectre
+    djvulibre
+    openjpeg
+    gtest
+  ];
+
+  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
+  qtWrapperArgs = [
+    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
+  ];
+
+  meta = with lib; {
+    description = "A simple memo software with texts and voice recordings";
+    homepage = "https://github.com/linuxdeepin/deepin-reader";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/apps/deepin-reader/use-pkg-config.diff
+++ b/pkgs/desktops/deepin/apps/deepin-reader/use-pkg-config.diff
@@ -1,0 +1,46 @@
+diff --git a/3rdparty/deepin-pdfium/src/3rdparty/pdfium/pdfium.pri b/3rdparty/deepin-pdfium/src/3rdparty/pdfium/pdfium.pri
+index 3e04f340..894b0ac7 100755
+--- a/3rdparty/deepin-pdfium/src/3rdparty/pdfium/pdfium.pri
++++ b/3rdparty/deepin-pdfium/src/3rdparty/pdfium/pdfium.pri
+@@ -20,13 +20,8 @@ DEFINES +=  USE_SYSTEM_LIBJPEG \
+             USE_SYSTEM_LIBOPENJPEG2 \
+             USE_SYSTEM_FREETYPE
+ 
+-INCLUDEPATH += /usr/include/openjpeg-2.3 \
+-               /usr/include/openjpeg-2.4 \
+-               /usr/include/freetype2 \
+-               /usr/include/freetype2/freetype \
+-               /usr/include/freetype2/freetype/config
+-
+-LIBS += -lopenjp2 -llcms2 -lfreetype
++CONFIG += link_pkgconfig
++PKGCONFIG += libopenjp2 lcms2 freetype2
+ 
+ #QMAKE_CXXFLAGS += "-Wc++11-narrowing"  #is_clang
+ #QMAKE_CXXFLAGS += "-Wno-inconsistent-missing-override"  #is_clang Suppress no override warning for overridden functions.
+diff --git a/3rdparty/deepin-pdfium/src/src.pro b/3rdparty/deepin-pdfium/src/src.pro
+index 196b91d3..bda71ff4 100755
+--- a/3rdparty/deepin-pdfium/src/src.pro
++++ b/3rdparty/deepin-pdfium/src/src.pro
+@@ -2,7 +2,9 @@ TARGET = $$PWD/../lib/deepin-pdfium
+ 
+ TEMPLATE = lib
+ 
+-CONFIG += c++14
++CONFIG += c++14 link_pkgconfig
++
++PKGCONFIG += chardet
+ 
+ ###安全漏洞检测
+ #QMAKE_CXX += -g -fsanitize=undefined,address -O2
+@@ -28,10 +30,6 @@ include($$PWD/3rdparty/pdfium/pdfium.pri)
+ 
+ INCLUDEPATH += $$PWD/../include
+ 
+-INCLUDEPATH += /usr/include/chardet
+-
+-LIBS += -lchardet
+-
+ public_headers += \
+     $$PWD/../include/dpdfglobal.h \
+     $$PWD/../include/dpdfdoc.h \

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -29,6 +29,7 @@ let
     deepin-image-viewer = callPackage ./apps/deepin-image-viewer { };
     deepin-picker = callPackage ./apps/deepin-picker { };
     deepin-terminal = callPackage ./apps/deepin-terminal { };
+    deepin-reader = callPackage ./apps/deepin-reader { };
 
     #### ARTWORK
     dde-account-faces = callPackage ./artwork/dde-account-faces { };


### PR DESCRIPTION
###### Description of changes
https://github.com/linuxdeepin/dde-nixos/issues/9
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
