### PR TITLE
heroic: Add GStreamer dependencies to FHS environment

### DIFF
--- a/pkgs/games/heroic/fhsenv.nix
+++ b/pkgs/games/heroic/fhsenv.nix
@@ -71,6 +71,7 @@ buildFHSUserEnv {
     libGLU
     libglvnd
     libgpg-error
+    libgudev
     libjpeg
     libkrb5
     libmpeg2
@@ -81,22 +82,31 @@ buildFHSUserEnv {
     libselinux
     libsndfile
     libsndfile
+    libsoup
     libtheora
     libtiff
     libusb1
     libv4l
     libva
+    libvdpau
     libvorbis
+    libvpx
+    libwebp
     libxkbcommon
     libxml2
     mpg123
     ncurses
     ocl-icd
+    openal
     openldap
+    openssl
+    openssl_1_1
+    pango
     pipewire
     samba4
     sane-backends
     SDL2
+    speex
     sqlite
     udev
     udev


### PR DESCRIPTION
###### Description of changes
Wine-GE bundles GStreamer, which is required to by some games to play in-game videos.  Without these packages, GStreamer fails to load, and the user gets a black screen instead of video playback.

Closes #215213

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
