### PR TITLE
ocamlPackages.rpclib: 8.1.0 → 9.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_rpc/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_rpc/default.nix
@@ -3,9 +3,10 @@
 buildDunePackage rec {
   pname = "ppx_deriving_rpc";
 
-  inherit (rpclib) version useDune2 src;
+  inherit (rpclib) version src;
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [ ppxlib rpclib ppx_deriving ];
 

--- a/pkgs/development/ocaml-modules/rpclib/default.nix
+++ b/pkgs/development/ocaml-modules/rpclib/default.nix
@@ -1,24 +1,25 @@
-{ lib, fetchurl, buildDunePackage, ocaml
+{ lib, fetchurl, buildDunePackage
 , alcotest
 , base64, cmdliner, rresult, xmlm, yojson
 }:
 
 buildDunePackage rec {
   pname = "rpclib";
-  version = "8.1.0";
+  version = "9.0.0";
 
-  useDune2 = true;
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-rpc/releases/download/v${version}/rpclib-v${version}.tbz";
-    sha256 = "0fbajg8wq8hjhkvvfnq68br0m0pa8zf2qzadhfgi2nnr9713rada";
+    url = "https://github.com/mirage/ocaml-rpc/releases/download/${version}/rpclib-${version}.tbz";
+    hash = "sha256-ziPrdWwCjZN0vRmCMpa923wjfT8FVFLTDRz30VIW6WM=";
   };
 
   buildInputs = [ cmdliner yojson ];
   propagatedBuildInputs = [ base64 rresult xmlm ];
   checkInputs = [ alcotest ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/mirage/ocaml-rpc";

--- a/pkgs/development/ocaml-modules/rpclib/lwt.nix
+++ b/pkgs/development/ocaml-modules/rpclib/lwt.nix
@@ -9,7 +9,8 @@
 
 buildDunePackage {
   pname = "rpclib-lwt";
-  inherit (rpclib) version useDune2 src;
+  inherit (rpclib) version src;
+  duneVersion = "3";
 
   propagatedBuildInputs = [ lwt rpclib ];
 

--- a/pkgs/development/ocaml-modules/rresult/default.nix
+++ b/pkgs/development/ocaml-modules/rresult/default.nix
@@ -1,5 +1,8 @@
 { stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, result }:
 
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.07")
+  "rresult is not available for OCaml ${ocaml.version}"
+
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-rresult";
   version = "0.7.0";


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/ocaml-rpc/blob/9.0.0/CHANGES.md

The first commit addresses a build failure introduced in #165097.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

