### PR TITLE
nextcloud-client: 3.6.6 -> 3.7.1

### DIFF
--- a/pkgs/applications/networking/nextcloud-client/0001-Explicitly-copy-dbus-files-into-the-store-dir.patch
+++ b/pkgs/applications/networking/nextcloud-client/0001-Explicitly-copy-dbus-files-into-the-store-dir.patch
@@ -8,18 +8,13 @@ Subject: [PATCH] Explicitly copy dbus files into the store dir
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/shell_integration/libcloudproviders/CMakeLists.txt b/shell_integration/libcloudproviders/CMakeLists.txt
-index 1f35335..7f76951 100644
+index 2e7349ef7..512d4b188 100644
 --- a/shell_integration/libcloudproviders/CMakeLists.txt
 +++ b/shell_integration/libcloudproviders/CMakeLists.txt
-@@ -19,7 +19,7 @@ MACRO(PKGCONFIG_GETVAR _package _var _output_variable)
- ENDMACRO(PKGCONFIG_GETVAR _package _var _output_variable)
- 
+@@ -1,5 +1,6 @@
  macro(dbus_add_activation_service _sources)
--    PKGCONFIG_GETVAR(dbus-1 session_bus_services_dir _install_dir)
+     pkg_get_variable(_install_dir dbus-1 session_bus_services_dir)
 +    set(_install_dir "${CMAKE_INSTALL_DATADIR}/dbus-1/service")
      foreach (_i ${_sources})
          get_filename_component(_service_file ${_i} ABSOLUTE)
          string(REGEX REPLACE "\\.service.*$" ".service" _output_file ${_i})
--- 
-2.19.2
-

--- a/pkgs/applications/networking/nextcloud-client/default.nix
+++ b/pkgs/applications/networking/nextcloud-client/default.nix
@@ -26,7 +26,7 @@
 
 mkDerivation rec {
   pname = "nextcloud-client";
-  version = "3.6.6";
+  version = "3.7.1";
 
   outputs = [ "out" "dev" ];
 
@@ -34,7 +34,7 @@ mkDerivation rec {
     owner = "nextcloud";
     repo = "desktop";
     rev = "v${version}";
-    sha256 = "sha256-P3LSgrcMZZM0OY3yQz8t3Cf5spJJTB+JTIpoT9U3+xc=";
+    sha256 = "sha256-MbxGS1Msb3xCW0z8FrIZEY3XaBa4BmN+JFBkV/Pf79A=";
   };
 
   patches = [


### PR DESCRIPTION
###### Description of changes

See changelog https://github.com/nextcloud/desktop/releases/tag/v3.7.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
