### PR TITLE
vifm: fix `:help` by pulling in `perl` to build depends

### DIFF
--- a/pkgs/applications/file-managers/vifm/default.nix
+++ b/pkgs/applications/file-managers/vifm/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, makeWrapper
+, perl # used to generate help tags
 , pkg-config
 , ncurses, libX11
 , util-linux, file, which, groff
@@ -17,8 +18,13 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-j+KBPr3Mz+ma7OArBdYqIJkVJdRrDM+67Dr2FMZlVog=";
   };
 
-  nativeBuildInputs = [ pkg-config makeWrapper ];
+  nativeBuildInputs = [ perl pkg-config makeWrapper ];
   buildInputs = [ ncurses libX11 util-linux file which groff ];
+
+  postPatch = ''
+    # Avoid '#!/usr/bin/env perl' reverences to build help.
+    patchShebangs --build src/helpztags
+  '';
 
   postFixup = let
     path = lib.makeBinPath


### PR DESCRIPTION
Related: https://github.com/vifm/vifm/issues/873

Without the change `:help` command failed to find the help as:

    $ rm -rfv ~/.config/vifm/ ~/.vifm
    $ vifm
    <in vifm>:help
    Error detected while processing command line:
    E149: Sorry, no help for vifm-app.txt

This happened because `tags` in `doc` directory was empty:

    $(top_srcdir)/data/vim/doc/plugin/tags: \
                               $(top_srcdir)/data/vim/doc/plugin/vifm-plugin.txt
        $(AM_V_GEN)mkdir -p ../data/vim/doc/plugin/; \
        if [ -n "$(PERL)" ]; then \
                $(srcdir)/helpztags "$(top_srcdir)/data/vim/doc/plugin"; \
        elif [ -n "$(VIM)" ]; then \
                vim -e -s -c 'helptags $(top_srcdir)/data/vim/doc/plugin|q'; \
        else \
                touch $@; \
        fi

The change pulls in `perl` into build depends to get tags working.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
