### PR TITLE
python310Packages.angr: 9.2.36 -> 9.2.37

### DIFF
--- a/pkgs/development/python-modules/ailment/default.nix
+++ b/pkgs/development/python-modules/ailment/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "ailment";
-  version = "9.2.36";
+  version = "9.2.37";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-PEX2SanglMqjtJHuH+gA5dnikh7qqLFiXbmrcIzs1+A=";
+    hash = "sha256-MFQiLOCqEAKzST7voMIQH0TYGuwICSVBcQZwUkk9S1Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/angr/default.nix
+++ b/pkgs/development/python-modules/angr/default.nix
@@ -31,7 +31,7 @@
 
 buildPythonPackage rec {
   pname = "angr";
-  version = "9.2.36";
+  version = "9.2.37";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-KVIrhzd3EoDIVImshfjZrBAiNkCtlFAd6Ox9ATsvPTY=";
+    hash = "sha256-sl3GzNMN90ez1Zks43B2How7QTaaJZbxOxK2hl/UzdQ=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/archinfo/default.nix
+++ b/pkgs/development/python-modules/archinfo/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "archinfo";
-  version = "9.2.36";
+  version = "9.2.37";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-anZsvDIH1AWaFUG5UTuyQiOKeoUB/+MSbu5pjPZJxag=";
+    hash = "sha256-WGc6FmrS0aVmiY5s8fUVHCT6cqcmj52H6FD2TR1HyK0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/claripy/default.nix
+++ b/pkgs/development/python-modules/claripy/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "claripy";
-  version = "9.2.36";
+  version = "9.2.37";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-gF8T1ZTvTjyt+kEOxI3ryDJOZv4go54VTxSGEdUyGt4=";
+    hash = "sha256-8kABsLp3Nrzjn7staiNfU6HdQTu1x6DNQzilMceqKVY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/cle/default.nix
+++ b/pkgs/development/python-modules/cle/default.nix
@@ -16,7 +16,7 @@
 
 let
   # The binaries are following the argr projects release cycle
-  version = "9.2.36";
+  version = "9.2.37";
 
   # Binary files from https://github.com/angr/binaries (only used for testing and only here)
   binaries = fetchFromGitHub {
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     owner = "angr";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-XqoBFV87m/uz0proGDtbaewsoY8vsA6ToGwdv7xvO9Y=";
+    hash = "sha256-vgH8UAR8B4l29RH0dwMlGVjOHgdcOTfLMHPiKN9Z36s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pyvex/default.nix
+++ b/pkgs/development/python-modules/pyvex/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "pyvex";
-  version = "9.2.36";
+  version = "9.2.37";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-KV/fkgYUt8hfpGxDO3CNNrC91BaI9W8T2mr2H4eJdxo=";
+    hash = "sha256-JGTfOE16tycBkbsihKPgSZPlfqun1vr/86kAlNwrSZA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes
Bump `angr` stack to 9.2.37
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
