### PR TITLE
torq: build frontend

### DIFF
--- a/pkgs/applications/blockchains/torq/default.nix
+++ b/pkgs/applications/blockchains/torq/default.nix
@@ -1,9 +1,10 @@
 { lib
 , buildGoModule
+, buildNpmPackage
 , fetchFromGitHub
 }:
 
-buildGoModule rec {
+let
   pname = "torq";
   version = "0.17.3";
 
@@ -14,6 +15,27 @@ buildGoModule rec {
     hash = "sha256-fqHJZi1NQCrZqsa+N+FVYZ8s9o0D555Sqn5qNlJ1MmI=";
   };
 
+  web = buildNpmPackage {
+    pname = "${pname}-frontend";
+    inherit version;
+    src = "${src}/web";
+    npmDepsHash = "sha256-8mUfTFzPjQlQvhC3zZf+WruDBkYnmGt3yckNi0CPWs0=";
+
+    # copied from upstream Dockerfile
+    npmInstallFlags = [ "--legacy-peer-deps" ];
+    TSX_COMPILE_ON_ERROR="true";
+    ESLINT_NO_DEV_ERRORS="true";
+
+    # override npmInstallHook, we only care about the build/ directory
+    installPhase = ''
+      mkdir $out
+      cp -r build $out/
+    '';
+  };
+in
+buildGoModule rec {
+  inherit pname version src;
+
   vendorHash = "sha256-HETN2IMnpxnTyg6bQDpoD0saJu+gKocdEf0VzEi12Gs=";
 
   subPackages = [ "cmd/torq" ];
@@ -23,6 +45,10 @@ buildGoModule rec {
     "-w"
     "-X github.com/lncapital/torq/build.version=v${version}"
   ];
+
+  postInstall = ''
+    ln -s ${web} $out/web
+  '';
 
   meta = with lib; {
     description = "Capital management tool for lightning network nodes";


### PR DESCRIPTION
###### Description of changes

The package is currently missing its frontend files, this PR adds build instructions for that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
