### PR TITLE
SDL2: 2.24.2 -> 2.26.3

### DIFF
--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -57,11 +57,11 @@
 
 stdenv.mkDerivation rec {
   pname = "SDL2";
-  version = "2.24.2";
+  version = "2.26.3";
 
   src = fetchurl {
     url = "https://www.libsdl.org/release/${pname}-${version}.tar.gz";
-    sha256 = "sha256-s17wqAKwnZDtOt0NysDpWCCAQgKRT1u3sP63EPGhMp8=";
+    sha256 = "sha256-xmEgWlU7fSUkJfS3Uf8TIJ5eAguHa7+hWYSUr2F5AFc=";
   };
   dontDisableStatic = if withStatic then 1 else 0;
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
<!--
# Please review the cherry-pick PRs

Cherry-picks: (please feel free to review and merge cherry-pick first)
* 
# Work in Progress
# Postpone reviewing SDL2 PR
!-->

SDL2: 2.24.2 -> 2.26.3

Release: https://github.com/libsdl-org/SDL/releases/tag/release-2.26.3

Diff: https://github.com/libsdl-org/SDL/compare/release-2.24.2...release-2.26.3

Downstream builds:
* webkitgtk: builds fine.
* pygame: breaks (and it's downstream dependencies).
  - *new release* pygame `2.1.3` is available upstream, but patching is necessary.