### PR TITLE
transmission_4: init at 4.0.3

### DIFF
--- a/pkgs/applications/networking/p2p/fragments/default.nix
+++ b/pkgs/applications/networking/p2p/fragments/default.nix
@@ -17,12 +17,12 @@
 , rustPlatform
 , rustc
 , sqlite
-, transmission
+, transmission_3
 , wrapGAppsHook4
 }:
 
 let
-  patchedTransmission = transmission.overrideAttrs (oldAttrs: {
+  patchedTransmission = transmission_3.overrideAttrs (oldAttrs: {
     patches = (oldAttrs.patches or []) ++ [
       (fetchpatch {
         url = "https://raw.githubusercontent.com/flathub/de.haeckerfelix.Fragments/2aee477c8e26a24570f8dbbdbd1c49e017ae32eb/transmission_pdeathsig.patch";

--- a/pkgs/applications/networking/p2p/libutp/3.3.nix
+++ b/pkgs/applications/networking/p2p/libutp/3.3.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "libutp";
+  version = "unstable-2017-01-02";
+
+  src = fetchFromGitHub {
+    # Use transmission fork from post-3.3-transmission branch
+    owner = "transmission";
+    repo = pname;
+    rev = "fda9f4b3db97ccb243fcbed2ce280eb4135d705b";
+    sha256 = "CvuZLOBksIl/lS6LaqOIuzNvX3ihlIPjI3Eqwo7YJH0=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "uTorrent Transport Protocol library";
+    homepage = "https://github.com/transmission/libutp";
+    license = licenses.mit;
+    maintainers = with maintainers; [ emilytrau ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/networking/p2p/libutp/default.nix
+++ b/pkgs/applications/networking/p2p/libutp/default.nix
@@ -1,18 +1,31 @@
-{ stdenv, lib, fetchFromGitHub, cmake }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, unstableGitUpdater
+}:
 
 stdenv.mkDerivation rec {
   pname = "libutp";
-  version = "unstable-2017-01-02";
+  version = "unstable-2023-03-05";
 
   src = fetchFromGitHub {
-    # Use transmission fork from post-3.3-transmission branch
+    # Use transmission fork from post-3.4-transmission branch
     owner = "transmission";
-    repo = pname;
-    rev = "fda9f4b3db97ccb243fcbed2ce280eb4135d705b";
-    sha256 = "CvuZLOBksIl/lS6LaqOIuzNvX3ihlIPjI3Eqwo7YJH0=";
+    repo = "libutp";
+    rev = "9cb9f9c4f0073d78b08d6542cebaea6564ecadfe";
+    sha256 = "dpbX1h/gpuVIAXC4hwwuRwQDJ0pwVVEsgemOVN0Dv9Q=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  passthru = {
+    updateScript = unstableGitUpdater {
+      branch = "post-3.4-transmission";
+    };
+  };
 
   meta = with lib; {
     description = "uTorrent Transport Protocol library";

--- a/pkgs/applications/networking/p2p/torrential/default.nix
+++ b/pkgs/applications/networking/p2p/torrential/default.nix
@@ -17,7 +17,7 @@
 , libevent
 , libgee
 , libnatpmp
-, libtransmission
+, transmission_3
 , libutp_3_3
 , miniupnpc
 , openssl
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     libevent
     libgee
     libnatpmp
-    libtransmission
+    transmission_3
     libutp_3_3
     miniupnpc
     openssl

--- a/pkgs/applications/networking/p2p/torrential/default.nix
+++ b/pkgs/applications/networking/p2p/torrential/default.nix
@@ -18,7 +18,7 @@
 , libgee
 , libnatpmp
 , libtransmission
-, libutp
+, libutp_3_3
 , miniupnpc
 , openssl
 , pantheon
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     libgee
     libnatpmp
     libtransmission
-    libutp
+    libutp_3_3
     miniupnpc
     openssl
     pantheon.granite7

--- a/pkgs/applications/networking/p2p/transmission/3.x.nix
+++ b/pkgs/applications/networking/p2p/transmission/3.x.nix
@@ -1,0 +1,79 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchurl
+, cmake
+, pkg-config
+, openssl
+, curl
+, libevent
+, inotify-tools
+, zlib
+, pcre
+, libb64
+, libutp
+, miniupnpc
+, dht
+, libnatpmp
+, libiconv
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "transmission3";
+  version = "3.00";
+
+  src = fetchFromGitHub {
+    owner = "transmission";
+    repo = "transmission";
+    rev = finalAttrs.version;
+    sha256 = "0ccg0km54f700x9p0jsnncnwvfnxfnxf7kcm7pcx1cj0vw78924z";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # fix build with openssl 3.0
+    (fetchurl {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/net-p2p/transmission/files/transmission-3.00-openssl-3.patch";
+      hash = "sha256-peVrkGck8AfbC9uYNfv1CIu1alIewpca7A6kRXjVlVs=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
+
+  buildInputs = [
+    openssl
+    curl
+    libevent
+    zlib
+    pcre
+    libb64
+    libutp
+    miniupnpc
+    dht
+    libnatpmp
+  ] ++ lib.optionals stdenv.isLinux [
+    inotify-tools
+  ] ++ lib.optionals stdenv.isDarwin [
+    libiconv
+  ];
+
+  cmakeFlags = [
+    "-DENABLE_MAC=OFF" # requires xcodebuild
+    "-DENABLE_GTK=OFF"
+    "-DENABLE_QT=OFF"
+    "-DENABLE_DAEMON=ON"
+    "-DENABLE_CLI=OFF"
+    "-DINSTALL_LIB=ON"
+  ];
+
+  meta = {
+    description = "Old version of libtransmission library for apps that depend on it";
+    homepage = "http://www.transmissionbt.com/";
+    license = lib.licenses.gpl2Plus; # parts are under MIT
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/applications/networking/p2p/transmission/3.x.nix
+++ b/pkgs/applications/networking/p2p/transmission/3.x.nix
@@ -11,7 +11,7 @@
 , zlib
 , pcre
 , libb64
-, libutp
+, libutp_3_3
 , miniupnpc
 , dht
 , libnatpmp
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
     pcre
     libb64
-    libutp
+    libutp_3_3
     miniupnpc
     dht
     libnatpmp

--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -12,7 +12,7 @@
 , zlib
 , pcre
 , libb64
-, libutp
+, libutp_3_3
 , miniupnpc
 , dht
 , libnatpmp
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
     pcre
     libb64
-    libutp
+    libutp_3_3
     miniupnpc
     dht
     libnatpmp

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -907,6 +907,7 @@ mapAliases ({
   libtorrentRasterbar = libtorrent-rasterbar; # Added 2020-12-20
   libtorrentRasterbar-1_2_x = libtorrent-rasterbar-1_2_x; # Added 2020-12-20
   libtorrentRasterbar-2_0_x = libtorrent-rasterbar-2_0_x; # Added 2020-12-20
+  libtransmission = transmission_3;
   libtxc_dxtn = throw "libtxc_dxtn was removed 2020-03-16, now integrated in Mesa";
   libtxc_dxtn_s2tc = throw "libtxc_dxtn_s2tc was removed 2020-03-16, now integrated in Mesa";
   libudev = throw "'libudev' has been renamed to/replaced by 'udev'"; # Converted to throw 2022-02-22
@@ -1687,6 +1688,7 @@ mapAliases ({
   torchPackages = throw "torchPackages has been removed, as the upstream project has been abandoned"; # Added 2020-03-28
   trang = throw "'trang' has been renamed to/replaced by 'jing-trang'"; # Converted to throw 2022-02-22
   transfig = fig2dev; # Added 2022-02-15
+  transmission = transmission_3;
   transmission-remote-cli = throw "transmission-remote-cli has been removed, as the upstream project has been abandoned. Please use tremc instead"; # Added 2020-10-14
   transmission_gtk = throw "'transmission_gtk' has been renamed to/replaced by 'transmission-gtk'"; # Converted to throw 2022-02-22
   transmission_remote_gtk = throw "'transmission_remote_gtk' has been renamed to/replaced by 'transmission-remote-gtk'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34991,15 +34991,18 @@ with pkgs;
 
   transcribe = callPackage ../applications/audio/transcribe { };
 
-  transmission = callPackage ../applications/networking/p2p/transmission { };
   transmission_3 = callPackage ../applications/networking/p2p/transmission/3.x.nix { };
-  libtransmission = transmission.override {
+  transmission-gtk = transmission_3.override { enableGTK3 = true; };
+  transmission-qt = transmission_3.override { enableQt = true; };
+
+  transmission_4 = callPackage ../applications/networking/p2p/transmission { };
+  transmission_4-gtk = transmission_4.override { enableGTK3 = true; };
+  transmission_4-qt = transmission_4.override { enableQt = true; };
+  libtransmission_4 = transmission_4.override {
     installLib = true;
     enableDaemon = false;
     enableCli = false;
   };
-  transmission-gtk = transmission.override { enableGTK3 = true; };
-  transmission-qt = transmission.override { enableQt = true; };
 
   transmission-remote-gtk = callPackage ../applications/networking/p2p/transmission-remote-gtk { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32469,6 +32469,8 @@ with pkgs;
 
   libutp = callPackage ../applications/networking/p2p/libutp { };
 
+  libutp_3_3 = callPackage ../applications/networking/p2p/libutp/3.3.nix { };
+
   lifelines = callPackage ../applications/misc/lifelines { };
 
   liferea = callPackage ../applications/networking/newsreaders/liferea { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34992,6 +34992,7 @@ with pkgs;
   transcribe = callPackage ../applications/audio/transcribe { };
 
   transmission = callPackage ../applications/networking/p2p/transmission { };
+  transmission_3 = callPackage ../applications/networking/p2p/transmission/3.x.nix { };
   libtransmission = transmission.override {
     installLib = true;
     enableDaemon = false;


### PR DESCRIPTION
###### Description of changes
https://github.com/transmission/transmission/releases/tag/4.0.0

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).