### PR TITLE
python3Packages.qtile-extras: init at 0.22.1

### DIFF
--- a/pkgs/development/python-modules/qtile-extras/default.nix
+++ b/pkgs/development/python-modules/qtile-extras/default.nix
@@ -1,0 +1,84 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools-scm
+, pytestCheckHook
+, xorgserver
+, pulseaudio
+, pytest-asyncio
+, qtile
+, keyring
+, requests
+, stravalib
+}:
+
+buildPythonPackage rec {
+  pname = "qtile-extras";
+  version = "0.22.1";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "elParaguayo";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-2dMpGLtwIp7+aoOgYav2SAjaKMiXHmmvsWTBEIMKEW4=";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    xorgserver
+  ];
+  checkInputs = [
+    pytest-asyncio
+    qtile.unwrapped
+    pulseaudio
+    keyring
+    requests
+    stravalib
+  ];
+  disabledTests = [
+    # AttributeError: 'ImgMask' object has no attribute '_default_size'. Did you mean: 'default_size'?
+    # cairocffi.pixbuf.ImageLoadingError: Pixbuf error: Unrecognized image file format
+    "test_draw"
+    "test_icons"
+    "1-x11-GithubNotifications-kwargs3"
+    "1-x11-SnapCast-kwargs8"
+    "1-x11-TVHWidget-kwargs10"
+    "test_tvh_widget_not_recording"
+    "test_tvh_widget_recording"
+    "test_tvh_widget_popup"
+    "test_snapcast_options"
+    # ValueError: Namespace Gdk not available
+    # AssertionError: Window never appeared...
+    "test_gloabl_menu"
+    "test_statusnotifier_menu"
+    # AttributeError: 'str' object has no attribute 'canonical'
+    "test_strava_widget_display"
+    "test_strava_widget_popup"
+    # Needs a running DBUS
+    "test_brightness_power_saving"
+    "test_upower_all_batteries"
+    "test_upower_named_battery"
+    "test_upower_low_battery"
+    "test_upower_critical_battery"
+    "test_upower_charging"
+    "test_upower_show_text"
+  ];
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  pythonImportsCheck = [ "qtile_extras" ];
+
+  meta = with lib; {
+    description = "Extra modules and widgets for the Qtile tiling window manager";
+    homepage = "https://github.com/elParaguayo/qtile-extras";
+    changelog = "https://github.com/elParaguayo/qtile-extras/blob/${src.rev}/CHANGELOG";
+    license = licenses.mit;
+    maintainers = with maintainers; [ arjan-s ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9806,6 +9806,8 @@ self: super: with self; {
 
   qtconsole = callPackage ../development/python-modules/qtconsole { };
 
+  qtile-extras = callPackage ../development/python-modules/qtile-extras { };
+
   qtpy = callPackage ../development/python-modules/qtpy { };
 
   quadprog = callPackage ../development/python-modules/quadprog { };


### PR DESCRIPTION
###### Description of changes
https://github.com/elParaguayo/qtile-extras
Package contains extra modules and widgets for use within the Qtile tiling window manager.
To use it in Qtile, add it to its `propagatedBuildInputs` using an overlay, something like this example (untested):
```
self: super: {
  qtile = super.qtile.unwrapped.override (old: rec {
    propagatedBuildInputs =
      (old.propagatedBuildInputs or [])
      ++ [ super.pkgs.python3Packages.qtile-extras ];
  });
}
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
