### PR TITLE
mariadb: unlink withNuma from withEmbedded

### DIFF
--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -179,8 +179,7 @@ let
         ++ lib.optionals withStorageMroonga [ kytea libsodium msgpack zeromq ]
         ++ lib.optionals (lib.versionAtLeast common.version "10.7") [ fmt_8 ];
 
-      propagatedBuildInputs = lib.optionals withEmbedded
-        (lib.optional withNuma numactl);
+      propagatedBuildInputs = lib.optional withNuma numactl;
 
       postPatch = ''
         substituteInPlace scripts/galera_new_cluster.sh \


### PR DESCRIPTION
mariadb: unlink withNuma from withEmbedded

- Numa and Embedded is/seems unrelated.
  - https://dev.mysql.com/doc/refman/8.0/en/source-configuration-options.html#option_cmake_with_numa
- Embedded was deprecated.
  - I'm not removing it because as ajs124 said, `amarok` is still using it.

This PR targets staging because it would conflict in staging if targeted master. (Another staging PR changed same parts of file.)