### PR TITLE
google-fonts: split into 1618 packages

### DIFF
--- a/pkgs/data/fonts/google-fonts/default.nix
+++ b/pkgs/data/fonts/google-fonts/default.nix
@@ -1,71 +1,47 @@
 { lib
 , stdenvNoCC
-, fetchFromGitHub
-, fonts ? []
+, fetchurl
 }:
 
-stdenvNoCC.mkDerivation {
-  pname = "google-fonts";
-  version = "unstable-2022-11-14";
+/*
+# Adobe Blank is split out in a separate output,
+# because it causes crashes with `libfontconfig`.
+# It has an absurd number of symbols
+outputs = [ "out" "adobeBlank" ];
+*/
 
-  # Adobe Blank is split out in a separate output,
-  # because it causes crashes with `libfontconfig`.
-  # It has an absurd number of symbols
-  outputs = [ "out" "adobeBlank" ];
+let
+  #version = "";
+  rev = "a7ca44cdf53d8597ac7425b67ac6ca5fa74177b7";
 
-  src = fetchFromGitHub {
-    owner = "google";
-    repo = "fonts";
-    rev = "83e116a566eda04a2469a11ee562cef1d7b33e4f";
-    sha256 = "sha256-sSabk+VWkoXj1Nzv9ufgIU/nkfKf4XkZU1SO+j+eSPA=";
+  # TODO use a more lightweight builder?
+  mkFont = fontName: license: files: stdenvNoCC.mkDerivation rec {
+    name = "google-fonts-${fontName}";
+    # no version to avoid rebuilds
+    # TODO add versions to srcs.nix - font version, not repo version
+    srcs = map (sha256_url: fetchurl {
+      url = "https://github.com/google/fonts/raw/${rev}/${builtins.elemAt sha256_url 1}";
+      sha256 = builtins.elemAt sha256_url 0;
+    }) files;
+    buildCommand = ''
+      urldecode() {
+        local s="''${1//+/ }"
+        printf '%b' "''${s//%/\x}"
+      }
+      mkdir -p $out/share/fonts/truetype
+      ${builtins.concatStringsSep "\n" (map (src: ''
+        cp -v ${src} $out/share/fonts/truetype/$(basename $(urldecode '${src.url}'))
+      '') srcs)}
+    '';
+    meta = with lib; {
+      #homepage = "https://fonts.google.com";
+      #description = "Font files available from Google Fonts"; # obvious from pname
+      license = licenses.${license};
+      platforms = platforms.all; # default?
+      hydraPlatforms = [];
+      #maintainers = with maintainers; [ manveru ]; # .maintainers is overrated ...
+    };
   };
+in
 
-  postPatch = ''
-    # These directories need to be removed because they contain
-    # older or duplicate versions of fonts also present in other
-    # directories. This causes non-determinism in the install since
-    # the installation order of font files with the same name is not
-    # fixed.
-    rm -rv ofl/cabincondensed \
-      ofl/signikanegative \
-      ofl/signikanegativesc \
-      axisregistry/tests/data
-
-    if find . -name "*.ttf" | sed 's|.*/||' | sort | uniq -c | sort -n | grep -v '^.*1 '; then
-      echo "error: duplicate font names"
-      exit 1
-    fi
-  '';
-
-  dontBuild = true;
-
-  # The font files are in the fonts directory and use two naming schemes:
-  # FamilyName-StyleName.ttf and FamilyName[param1,param2,...].ttf
-  # This installs all fonts if fonts is empty and otherwise only
-  # the specified fonts by FamilyName. To do this, it invokes
-  # `find` 2 times for every font, anyone is free to do this
-  # in a more efficient way.
-  fonts = map (font: builtins.replaceStrings [" "] [""] font) fonts;
-  installPhase = ''
-    adobeBlankDest=$adobeBlank/share/fonts/truetype
-    install -m 444 -Dt $adobeBlankDest ofl/adobeblank/AdobeBlank-Regular.ttf
-    rm -r ofl/adobeblank
-    dest=$out/share/fonts/truetype
-  '' + (if fonts == [] then ''
-    find . -name '*.ttf' -exec install -m 444 -Dt $dest '{}' +
-  '' else ''
-    for font in $fonts; do
-      find . -name "$font-*.ttf" -exec install -m 444 -Dt $dest '{}' +
-      find . -name "$font[*.ttf" -exec install -m 444 -Dt $dest '{}' +
-    done
-  '');
-
-  meta = with lib; {
-    homepage = "https://fonts.google.com";
-    description = "Font files available from Google Fonts";
-    license = with licenses; [ asl20 ofl ufl ];
-    platforms = platforms.all;
-    hydraPlatforms = [];
-    maintainers = with maintainers; [ manveru ];
-  };
-}
+(import ./srcs.nix { inherit mkFont; })

--- a/pkgs/data/fonts/google-fonts/readme.md
+++ b/pkgs/data/fonts/google-fonts/readme.md
@@ -1,0 +1,101 @@
+# google-fonts
+
+## total size
+
+```
+uncompressed: 2 GB
+tar.gz: 1 GB
+.git: 1 GB
+.git + files: 3 GB
+```
+
+## file count
+
+```
+find * -name "*.ttf" | wc -l
+3460
+```
+
+## folder count
+
+```
+find * -name "*.ttf" | xargs dirname | sort | uniq | wc -l
+1621
+```
+
+## unique folders
+
+```
+find * -name "*.ttf" | xargs dirname | xargs basename -a | sort | uniq | wc -l
+1619
+```
+
+folder names are NOT unique
+
+```
+find * -name "*.ttf" | xargs dirname | sort | uniq | xargs basename -a | sort >dirsfull.txt
+
+cat dirsfull.txt | uniq >dirsnames.txt
+
+diff dirsnames.txt dirsfull.txt | grep '^> '
+> nunito
+> static
+```
+
+```
+find * -name "*.ttf" | xargs dirname | sort | uniq | grep -w -e static -e nunito
+apache/roboto/static
+lang/data/test/nunito
+ofl/inconsolata/static
+ofl/nunito
+```
+
+lang: python module
+
+apache/roboto/static = roboto
+
+ofl/inconsolata/static = inconsolata
+
+## extra folders
+
+### catalog
+
+metadata
+
+### python modules
+
+find . -name "*.py"
+
+```
+axisregistry
+lang
+```
+
+todo: ignore these folders
+
+## filesystem schema
+
+google-fonts/README.md
+
+> The top-level directories indicate the license of all files found within them.
+> Subdirectories are named according to the family name of the fonts within.
+
+
+```
+${license}/${fontFamily}/**.ttf
+```
+
+## fonts with no ttf files
+
+```
+find google-fonts/cc-by-sa/knowledge -name "*.ttf" | wc -l
+0
+```
+
+TODO use other font formats?
+
+## unique font filenames?
+
+TODO
+
+at least per family, filenames should be unique

--- a/pkgs/data/fonts/google-fonts/srcs.nix
+++ b/pkgs/data/fonts/google-fonts/srcs.nix
@@ -1,0 +1,6690 @@
+{ mkFont }:
+{
+abeezee = mkFont "abeezee" "ofl" [
+  ["OJK7dFeCB+1u2uBAoIaeVNyuE6Rm0AVGBXCUcGITfdg=" "ofl/abeezee/ABeeZee-Italic.ttf"]
+  ["KQHI3yVmSMwrsuOvs4HLjSjmXtPb4R3iBpWuTV/97ak=" "ofl/abeezee/ABeeZee-Regular.ttf"]
+];
+abel = mkFont "abel" "ofl" [
+  ["iAncrSUxgiUFL4gzPiCMWq1K3LeyyTTBNXNewZqkELQ=" "ofl/abel/Abel-Regular.ttf"]
+];
+abhayalibre = mkFont "abhayalibre" "ofl" [
+  ["JU13PYDs04L15NgYQYrVIapajWnMmW0KwKHD8EF/q8A=" "ofl/abhayalibre/AbhayaLibre-SemiBold.ttf"]
+  ["qNBdqHZqm8VA4OpbY/NqFB1imQfo8GxMKyO7C9dBsuE=" "ofl/abhayalibre/AbhayaLibre-ExtraBold.ttf"]
+  ["1CedOKABL6VNNAl5aU5w4yNSZiIN7cDXAAExNF+zO9Q=" "ofl/abhayalibre/AbhayaLibre-Regular.ttf"]
+  ["AftM10hBxfEINyc3p0z+3q8KciyiPiJ13Gn0EdwK1aY=" "ofl/abhayalibre/AbhayaLibre-Bold.ttf"]
+  ["09QFGHfclTinFyDV/bpBGM3NRnCWlyxSSp//nEUmn0s=" "ofl/abhayalibre/AbhayaLibre-Medium.ttf"]
+];
+aboreto = mkFont "aboreto" "ofl" [
+  ["/HAtU1hX+ivagCZHudVfgqB1AtSs39lbRyebO/R56qE=" "ofl/aboreto/Aboreto-Regular.ttf"]
+];
+abrilfatface = mkFont "abrilfatface" "ofl" [
+  ["WXHUo3WKkiqf7cf2+4JaljQaLnGMRaSyyaa0F8jE2+k=" "ofl/abrilfatface/AbrilFatface-Regular.ttf"]
+];
+abyssinicasil = mkFont "abyssinicasil" "ofl" [
+  ["82i6afq8GuuPGljtHKZWxQbFUl6UA0Ipr209IYmAMlM=" "ofl/abyssinicasil/AbyssinicaSIL-Regular.ttf"]
+];
+aclonica = mkFont "aclonica" "asl20" [
+  ["d0pJNRzGKkabVpcul2lnnOgYo94VtAmtXxtiRO6E2Fs=" "apache/aclonica/Aclonica-Regular.ttf"]
+];
+acme = mkFont "acme" "ofl" [
+  ["dv21gvVGU8JydNXNmG+ZTCjX+n0yPn657hTOiHXTncQ=" "ofl/acme/Acme-Regular.ttf"]
+];
+actor = mkFont "actor" "ofl" [
+  ["p89il1peyqijvi4pE/+0ozWDExVHi5O+xyKtmCMI6jg=" "ofl/actor/Actor-Regular.ttf"]
+];
+adamina = mkFont "adamina" "ofl" [
+  ["5xCM/uCnGNWIX8jQ8DVV+m4MS2MJ5LFeqZGq3YJMNLc=" "ofl/adamina/Adamina-Regular.ttf"]
+];
+adobeblank = mkFont "adobeblank" "ofl" [
+  ["O0aPbvq+knToBO3xBHfIva8nyyp29Qpd18yjRZn4uRg=" "ofl/adobeblank/AdobeBlank-Regular.ttf"]
+];
+adventpro = mkFont "adventpro" "ofl" [
+  ["CRel1lWJAl8qdSsbBWj5JNrEmgZaJbTWARazxtTZ664=" "ofl/adventpro/AdventPro-Italic%5Bwdth,wght%5D.ttf"]
+  ["tgqykguJvcS32t+ygsraxuA4M+eoCET56sCWNZsrl2Y=" "ofl/adventpro/AdventPro%5Bwdth,wght%5D.ttf"]
+];
+aguafinascript = mkFont "aguafinascript" "ofl" [
+  ["VfZdhNhpNteqrf+kwXhzkj+6JsB41Cqk5uLxvov7X24=" "ofl/aguafinascript/AguafinaScript-Regular.ttf"]
+];
+akayakanadaka = mkFont "akayakanadaka" "ofl" [
+  ["eJGED4wUMmIgqv1z9Zn1kr9Exg5PiIK898V0JtYulCc=" "ofl/akayakanadaka/AkayaKanadaka-Regular.ttf"]
+];
+akayatelivigala = mkFont "akayatelivigala" "ofl" [
+  ["5XSYEzkS9aurFlGsRGVP1n6+/rtIkFJ0hYe0ujPhgsI=" "ofl/akayatelivigala/AkayaTelivigala-Regular.ttf"]
+];
+akronim = mkFont "akronim" "ofl" [
+  ["tVKLornWC5DLvgblh2VXYtxRhhbSYTy99hZ1G+r34vg=" "ofl/akronim/Akronim-Regular.ttf"]
+];
+aksarabaligalang = mkFont "aksarabaligalang" "ofl" [
+  ["JEm7nP+eYFCMWwNGqzDnDoT5WWQ/gUQq2zU0uvfiVTc=" "ofl/aksarabaligalang/AksaraBaliGalang-Regular.ttf"]
+];
+akshar = mkFont "akshar" "ofl" [
+  ["Uoj5cAdvV/FY26dn9Ersj46FKSDxo8wgoyaEIK2ewlE=" "ofl/akshar/Akshar%5Bwght%5D.ttf"]
+];
+aladin = mkFont "aladin" "ofl" [
+  ["x+5X4ZsbLIn414YRXcaSJQkf92ZfMP6nkIvC+yfRM5g=" "ofl/aladin/Aladin-Regular.ttf"]
+];
+alata = mkFont "alata" "ofl" [
+  ["qdXLJ6noHWpgSsZ31NimIoesdmDnbdOCJqQspPxKpR8=" "ofl/alata/Alata-Regular.ttf"]
+];
+alatsi = mkFont "alatsi" "ofl" [
+  ["DwEFnX/3TZWhh6rHVY/PANk54l/FWWC0jrdwxRiQecs=" "ofl/alatsi/Alatsi-Regular.ttf"]
+];
+albertsans = mkFont "albertsans" "ofl" [
+  ["Fusykfc4kEXpCgCrtmo9K8odAzh7fru8KwzZoJT4YiY=" "ofl/albertsans/AlbertSans-Italic%5Bwght%5D.ttf"]
+  ["j+XUz1gi1wltTReteByQ+Xx0WsE6Ir5hnbdJZvukX9o=" "ofl/albertsans/AlbertSans%5Bwght%5D.ttf"]
+];
+aldrich = mkFont "aldrich" "ofl" [
+  ["vKvY5ts+jLWSQujb3vML/ZslvmAOLo9QZhgAj5kTjUc=" "ofl/aldrich/Aldrich-Regular.ttf"]
+];
+alef = mkFont "alef" "ofl" [
+  ["Xa4NeyNlKI2KNPX7Az1CeL6WzvJUeGLLk864Nz4QvPE=" "ofl/alef/Alef-Bold.ttf"]
+  ["oyrcyVOsNWkGkBd4RgCD3CB9RWDLWG/Z6iTsWxhpae0=" "ofl/alef/Alef-Regular.ttf"]
+];
+alegreya = mkFont "alegreya" "ofl" [
+  ["+pFe7HYieTXcX7Z4lTyUtxKHw2CSgBPP20Qd/lL1o5E=" "ofl/alegreya/Alegreya-Italic%5Bwght%5D.ttf"]
+  ["ulVkY0uTqPi6V7SM1PGudBfStGVvusd5AoZ5sA3jzxI=" "ofl/alegreya/Alegreya%5Bwght%5D.ttf"]
+];
+alegreyasans = mkFont "alegreyasans" "ofl" [
+  ["j6tjQZYAevyoOfHlpvswCXba/1XYUotZDvAy8BsU6hA=" "ofl/alegreyasans/AlegreyaSans-Regular.ttf"]
+  ["PtngKCQajBEZggBvpenCzLH31Gg3idIZyzDoAQdGw34=" "ofl/alegreyasans/AlegreyaSans-ExtraBoldItalic.ttf"]
+  ["S1LW4thfTmMQvFDUWmrOqDB37IzYf2O3ToUzFLyqsSg=" "ofl/alegreyasans/AlegreyaSans-LightItalic.ttf"]
+  ["TGCoRMYYUC6VEXQmEndGN4v1rDd24Et6tl7T1dw64IE=" "ofl/alegreyasans/AlegreyaSans-Light.ttf"]
+  ["owVaGJN1m9vXUEuyKrxYN2nnl0xJNTF26sCwN5LJ+44=" "ofl/alegreyasans/AlegreyaSans-Bold.ttf"]
+  ["EKnTjqwGv11GkwUpslShvPI1ws7Xyo+khDf7fd9FtnQ=" "ofl/alegreyasans/AlegreyaSans-Thin.ttf"]
+  ["lfBt0/bkUp8Xazceib4dWJTD7QYGwxsddrCSoTCMH8A=" "ofl/alegreyasans/AlegreyaSans-Black.ttf"]
+  ["DHnaRirmN9f5X0KMk1ysepwiy5llXFzTe4cICGHdc+w=" "ofl/alegreyasans/AlegreyaSans-MediumItalic.ttf"]
+  ["vsxQRw48aymELaNpSFz0dSMmm7JFiCDcjOeBf6R1QEE=" "ofl/alegreyasans/AlegreyaSans-ThinItalic.ttf"]
+  ["uVqGedMp7Hm17shODeAPPYj/ecSh3q69rXfPTMuFEoI=" "ofl/alegreyasans/AlegreyaSans-BlackItalic.ttf"]
+  ["9J9vK92E34ULJbD4GF2KBR4dHrLdCOL5G4x7htmp4aY=" "ofl/alegreyasans/AlegreyaSans-Italic.ttf"]
+  ["alVQ8OTDAh5+LoOsSBToxkmg/iA4VInOdgnwCAIJe00=" "ofl/alegreyasans/AlegreyaSans-BoldItalic.ttf"]
+  ["OGHwinfVwbOzEQVZE0Q7BzN6S3q6/yGozbUfwK6YC54=" "ofl/alegreyasans/AlegreyaSans-ExtraBold.ttf"]
+  ["S4n+eAT9FIXsJ1d5WlP/22bhIG3Vb4RMLXKzyUSBW0M=" "ofl/alegreyasans/AlegreyaSans-Medium.ttf"]
+];
+alegreyasanssc = mkFont "alegreyasanssc" "ofl" [
+  ["uzNzuAuIA6BHdgQV6lFfqgkk22M2USZTvDKyrD1/cc4=" "ofl/alegreyasanssc/AlegreyaSansSC-MediumItalic.ttf"]
+  ["Qwl4gpvjR8ezDr4lINFREKNafQo4QIquSlrWkqpiW5E=" "ofl/alegreyasanssc/AlegreyaSansSC-LightItalic.ttf"]
+  ["FLjfPSldameyijEkn0P0+JHrkc9b3T1AggsyJnPMBxo=" "ofl/alegreyasanssc/AlegreyaSansSC-Thin.ttf"]
+  ["L85g/xfpnRvkvz8BDXGxKeYy0EfbJIufkvsv0TZMBKU=" "ofl/alegreyasanssc/AlegreyaSansSC-BlackItalic.ttf"]
+  ["eGIJuDGJ55D5UJSiT5kVN9jO9bmF7O+Ya+M7iLr97ZY=" "ofl/alegreyasanssc/AlegreyaSansSC-Black.ttf"]
+  ["ZAiLg68itY6UX1bElOOf/9m0Vl7Svdu9hJljrivdpOM=" "ofl/alegreyasanssc/AlegreyaSansSC-Light.ttf"]
+  ["ZueapwuDdbrH30rLBUXEt5A0fOckVG6vBJUnMj5NTNs=" "ofl/alegreyasanssc/AlegreyaSansSC-BoldItalic.ttf"]
+  ["Uyx9xLwP6BCdLF8Xgp2ZhVl6rLhugAECPgRdTuAPNWo=" "ofl/alegreyasanssc/AlegreyaSansSC-Medium.ttf"]
+  ["9eIx3YcM/LFyqQ5OVoZpClnX8wKA+rim6J4wn8A/XgY=" "ofl/alegreyasanssc/AlegreyaSansSC-Italic.ttf"]
+  ["+ecqPKgZwaCHgkyV+DDKn6VqNn1yB4215X5i5+CRepM=" "ofl/alegreyasanssc/AlegreyaSansSC-ExtraBold.ttf"]
+  ["tidaxeieFPjM5fs0VxpbxEpO1gcP8gmyX3DAOOcORjQ=" "ofl/alegreyasanssc/AlegreyaSansSC-ExtraBoldItalic.ttf"]
+  ["ksDsvB89UndPVXsJqc2k+k42PpPi9/e7mDGr9/Y9GPQ=" "ofl/alegreyasanssc/AlegreyaSansSC-ThinItalic.ttf"]
+  ["H38cozxK4BOpTTdBBv1ARIILPZFef3oiGC3a9JuceRI=" "ofl/alegreyasanssc/AlegreyaSansSC-Bold.ttf"]
+  ["DF1KvN2Drwzp9dTKSfImwrMDDSqDrfkstaXCY4yOaLA=" "ofl/alegreyasanssc/AlegreyaSansSC-Regular.ttf"]
+];
+alegreyasc = mkFont "alegreyasc" "ofl" [
+  ["Homo/XyjlvX3hivm0TxX/Si7O3HzKUIWsLX9UEfq2bg=" "ofl/alegreyasc/AlegreyaSC-Italic.ttf"]
+  ["PvlsvzvnuE2d/5saoeKsQO7AzzI8zQY4OVze+cWpFSg=" "ofl/alegreyasc/AlegreyaSC-Bold.ttf"]
+  ["PZnrmPZa9ClcOItbpn1gagr9KenA/nVvySm/SxfHNYY=" "ofl/alegreyasc/AlegreyaSC-ExtraBoldItalic.ttf"]
+  ["1IXh/qIiMB+GANqnC+RAJ/OXlRJ8nF+3emvZ9auo2/c=" "ofl/alegreyasc/AlegreyaSC-ExtraBold.ttf"]
+  ["+oliIhFcyaQcBpWj7m/q+6upeTLpu2JAUgs/7rVg6iw=" "ofl/alegreyasc/AlegreyaSC-Medium.ttf"]
+  ["f3UgTOiAJf1CtvVQUdUsyzIYEnu2UtqXa2GtnSkKSY0=" "ofl/alegreyasc/AlegreyaSC-MediumItalic.ttf"]
+  ["DV2cijbpRY9VmNETbXE4euMqWrlPBoM+rcNBVV0KTpE=" "ofl/alegreyasc/AlegreyaSC-Black.ttf"]
+  ["XI+6gAuEi4UeMI39/cVztkE15JjbQcvQtteLqdJn2aE=" "ofl/alegreyasc/AlegreyaSC-Regular.ttf"]
+  ["6oFYLvw/A0EcgzELfGr5UmkPUK0uKK+LbCa5bp13vAc=" "ofl/alegreyasc/AlegreyaSC-BlackItalic.ttf"]
+  ["8NV3MB3vyutcTPPXr9iNh4r/1nSVOeYUtdbQipLGbio=" "ofl/alegreyasc/AlegreyaSC-BoldItalic.ttf"]
+];
+aleo = mkFont "aleo" "ofl" [
+  ["K1rfMGKyiXxLCutjhP2QCs7oJHC0+FqC026MKLlbP7k=" "ofl/aleo/Aleo-Italic.ttf"]
+  ["VRKBztT0+u8ypCXbyzcV/JvL85dTBbcCCE0lcVxGv+4=" "ofl/aleo/Aleo-LightItalic.ttf"]
+  ["la4UPzvddEHvy0W11Z2cmPDHH6dzuP0uSkhf2C+FedY=" "ofl/aleo/Aleo-Bold.ttf"]
+  ["RJ5e/x1e46HrAAfVz6a01gy6+Ko+nyfNgibd1eCEf3c=" "ofl/aleo/Aleo-Light.ttf"]
+  ["w9G3SDfIeDuQIcBVBCO7fuf8U/ZVS31jb6tShNUBv1g=" "ofl/aleo/Aleo-BoldItalic.ttf"]
+  ["/6FLgaLXeA3UeQ3BiVaPYCWU4uOaIrcF9W6GhJ4ymS0=" "ofl/aleo/Aleo-Regular.ttf"]
+];
+alexandria = mkFont "alexandria" "ofl" [
+  ["24rgO2LVWmWqTgQweHjfjADW5TiOSABjXL4OIrZBG2Q=" "ofl/alexandria/Alexandria%5Bwght%5D.ttf"]
+];
+alexbrush = mkFont "alexbrush" "ofl" [
+  ["33AgONjid5cjDHeVnBOe7qOMrAyvU+GepbUT07DTNi0=" "ofl/alexbrush/AlexBrush-Regular.ttf"]
+];
+alfaslabone = mkFont "alfaslabone" "ofl" [
+  ["KGZK+mmKM5O9Winux1AjCgZFxTAdYiAOXy06An+yKZ0=" "ofl/alfaslabone/AlfaSlabOne-Regular.ttf"]
+];
+alice = mkFont "alice" "ofl" [
+  ["ghLEDxCzBq+bgicq5oMU3mlkUittq/ar2v9kfnSsi1g=" "ofl/alice/Alice-Regular.ttf"]
+];
+alikeangular = mkFont "alikeangular" "ofl" [
+  ["C0WHCACol3Ezcqtuuf9MCWFSgH7WI+FnySsnkGYPaL4=" "ofl/alikeangular/AlikeAngular-Regular.ttf"]
+];
+alike = mkFont "alike" "ofl" [
+  ["HHl92oKew+8HfcnRU4qVBU2D8jPzia3r+qOalrILnfw=" "ofl/alike/Alike-Regular.ttf"]
+];
+alkalami = mkFont "alkalami" "ofl" [
+  ["UwOga3tn7aVGyGhtqlCGzDaXSteHLBK9yw7CBb4mt8s=" "ofl/alkalami/Alkalami-Regular.ttf"]
+];
+allan = mkFont "allan" "ofl" [
+  ["xNN4EjO4c97TllIA1Oo7l47eLXMA0CxSjaeprZ55Rso=" "ofl/allan/Allan-Bold.ttf"]
+  ["EhZjPzD1Xc++J/HzqIKnQq2pSEom7SbLzyCPiOMVuJY=" "ofl/allan/Allan-Regular.ttf"]
+];
+allerta = mkFont "allerta" "ofl" [
+  ["nHpj94+UQ1O0Iqu7ZBxHlQP1KSo50eqTLcQYb9grl08=" "ofl/allerta/Allerta-Regular.ttf"]
+];
+allertastencil = mkFont "allertastencil" "ofl" [
+  ["jFBNG+IHaJQasEJRo4mtgtV4LWR/ocQCnIEdxbwqvVk=" "ofl/allertastencil/AllertaStencil-Regular.ttf"]
+];
+allison = mkFont "allison" "ofl" [
+  ["mQdQvJcEcoCM7y/OrtNCTJIueBrumeV5B6aKmTLToGY=" "ofl/allison/Allison-Regular.ttf"]
+];
+allura = mkFont "allura" "ofl" [
+  ["nBQrLlFYMsDfxP+LjqGPQDFJQ7+Te3LisjxGYbrBTMY=" "ofl/allura/Allura-Regular.ttf"]
+];
+almarai = mkFont "almarai" "ofl" [
+  ["n49y8csG23h6WzLjFKEJJn5TxQXJ+asNrVqo/4shmgc=" "ofl/almarai/Almarai-ExtraBold.ttf"]
+  ["pXvKJwNAICooiZ90iO527ZuTEVuJ16gduS1o4pmT2lo=" "ofl/almarai/Almarai-Light.ttf"]
+  ["BkATkbWzn7zyvAxqbgP6+ZJDXnsBEYOhhhc36ROvhhM=" "ofl/almarai/Almarai-Bold.ttf"]
+  ["W1ytM8jlkiCDco0nHNzakflropHxMH7MxPTvcy3BliI=" "ofl/almarai/Almarai-Regular.ttf"]
+];
+almendradisplay = mkFont "almendradisplay" "ofl" [
+  ["BLVDqee/45Ji5H1Hrn7GoEFmzi0FODqRGyVs/LeDOD8=" "ofl/almendradisplay/AlmendraDisplay-Regular.ttf"]
+];
+almendra = mkFont "almendra" "ofl" [
+  ["WJXvBNDVbGAIPsMC5y25m5UrBEqytEDuEig2SbXtyXE=" "ofl/almendra/Almendra-Bold.ttf"]
+  ["EOCn3UufWtfVG+f47kLXaRnDIty7dzPbrUj0rHUcsQU=" "ofl/almendra/Almendra-BoldItalic.ttf"]
+  ["ly65XdAwWSdVBkw16OOUt1Qjlz0Lfb/XWcfjbvgLt8s=" "ofl/almendra/Almendra-Italic.ttf"]
+  ["sSemEhIJNTtT2pznO/nTUPdBkNg4TCjt4Xnk+5RA+UY=" "ofl/almendra/Almendra-Regular.ttf"]
+];
+almendrasc = mkFont "almendrasc" "ofl" [
+  ["3KcztbA+TqUsZmNld3yPazYNVd4E78nYNM+fgraDCL4=" "ofl/almendrasc/AlmendraSC-Regular.ttf"]
+];
+alumnisanscollegiateone = mkFont "alumnisanscollegiateone" "ofl" [
+  ["m9SLKAOReUx6WuqXR2slBRtHBceWPktjsshIdtsxtZs=" "ofl/alumnisanscollegiateone/AlumniSansCollegiateOne-Regular.ttf"]
+  ["qh7DyvqUkmsA5h2gKcSCceaEVAAWfBD4tlm5ONqdVO4=" "ofl/alumnisanscollegiateone/AlumniSansCollegiateOne-Italic.ttf"]
+];
+alumnisansinlineone = mkFont "alumnisansinlineone" "ofl" [
+  ["upj+GpqnD2BBeFGzV4guAnWj9Yb/QDnI8li0r2OBcf8=" "ofl/alumnisansinlineone/AlumniSansInlineOne-Italic.ttf"]
+  ["53qdteY/kxaEDKtZ0TZM1AM01s1EHAtD/ioYslIeDn4=" "ofl/alumnisansinlineone/AlumniSansInlineOne-Regular.ttf"]
+];
+alumnisans = mkFont "alumnisans" "ofl" [
+  ["klXVIBx6ulvxveHoUh8P7mkfBYi4P0DbIopfm7qs+8Q=" "ofl/alumnisans/AlumniSans%5Bwght%5D.ttf"]
+  ["KtKTZMCEHCBX7uRLPRPesq900/E+FLxRmo39QULBrVQ=" "ofl/alumnisans/AlumniSans-Italic%5Bwght%5D.ttf"]
+];
+alumnisanspinstripe = mkFont "alumnisanspinstripe" "ofl" [
+  ["wAvI1kHy3cREu7mgcSX06x5u2gOEqJYZatDHvgqc/uo=" "ofl/alumnisanspinstripe/AlumniSansPinstripe-Regular.ttf"]
+  ["Vjng1b/sNxnxJxOdIyxgxCqjrmYbWA5AXmqbBgAqtr4=" "ofl/alumnisanspinstripe/AlumniSansPinstripe-Italic.ttf"]
+];
+amarante = mkFont "amarante" "ofl" [
+  ["3l63zCsTYy/j+f7b5Nw0Vxp2dYz7Urcf2s6PxKdjii8=" "ofl/amarante/Amarante-Regular.ttf"]
+];
+amaranth = mkFont "amaranth" "ofl" [
+  ["LKn5NJmtOvVnmv4pMBcP0AxQwv2vAkDH3pduI75Xkdw=" "ofl/amaranth/Amaranth-Bold.ttf"]
+  ["SdYFh9sESvUViv43O/piBNjczmR8zU8fHGH1YJgFVOw=" "ofl/amaranth/Amaranth-Regular.ttf"]
+  ["bJa9okjI7T69pjOCz8wjOiYhPYfUV6UiS3mgRSr/J+o=" "ofl/amaranth/Amaranth-Italic.ttf"]
+  ["6PwVFFOAbGqu1ypAusrz/POAzNXYUt4IvWhuVa5wRks=" "ofl/amaranth/Amaranth-BoldItalic.ttf"]
+];
+amaticsc = mkFont "amaticsc" "ofl" [
+  ["UTp2+W05pTZr0nwlhnSq6jXuUcQrjzBgOH90ZJ7oyKo=" "ofl/amaticsc/AmaticSC-Regular.ttf"]
+  ["02e+re5m77tlfSTT2PMPO2BjPp1cje1zhVQc93XKu00=" "ofl/amaticsc/AmaticSC-Bold.ttf"]
+];
+amethysta = mkFont "amethysta" "ofl" [
+  ["XhkgA+yLlVlcJ3N+KiuzydsuRosktXKpGDsvAAMUPxw=" "ofl/amethysta/Amethysta-Regular.ttf"]
+];
+amiko = mkFont "amiko" "ofl" [
+  ["cNKi6e7ulQxmb1yUg26fzT/TKX0ZdclS2yUY0OXrye8=" "ofl/amiko/Amiko-Bold.ttf"]
+  ["QC1NlgNHYv7mhRj9lbd4z2qdcMq4OPoagXy3g9OWOaQ=" "ofl/amiko/Amiko-Regular.ttf"]
+  ["3fwOU8zcTxPKxFmfl9V3W+dLLh4Hc88b3OcUg6R2+/Y=" "ofl/amiko/Amiko-SemiBold.ttf"]
+];
+amiri = mkFont "amiri" "ofl" [
+  ["ZBGRA75lZW0m5aCa7TNNAxr7y/s0ysxoMUMtKz5IG9U=" "ofl/amiri/Amiri-BoldItalic.ttf"]
+  ["J3XfTE21rrBz1IWgJ/+5YK/VksjyPfhlM4evgGlrE9Q=" "ofl/amiri/Amiri-Italic.ttf"]
+  ["0mWFL6UteIYh1rZf7+XgFh7qDYCMqILTjq77rSwhNrA=" "ofl/amiri/Amiri-Regular.ttf"]
+  ["77R1kdp+pM2HEDexqItVcj/Gl1dFTIBpseEx1XLDQTA=" "ofl/amiri/Amiri-Bold.ttf"]
+];
+amiriqurancolored = mkFont "amiriqurancolored" "ofl" [
+  ["W36O3E9dV34eOvlbuIiSZZZTlAG2bN5PxoG9+3c233c=" "ofl/amiriqurancolored/AmiriQuranColored-Regular.ttf"]
+];
+amiriquran = mkFont "amiriquran" "ofl" [
+  ["6hiz7KnP6caWUUfSoOBou1F9zhiItHuuJEHMPz1HzAc=" "ofl/amiriquran/AmiriQuran-Regular.ttf"]
+];
+amita = mkFont "amita" "ofl" [
+  ["VRNp6mqMrqqdLcMXGVZLojeaRF0W5plLx62/lEaitj0=" "ofl/amita/Amita-Regular.ttf"]
+  ["Lj2woYNJXMVbgTRjEbwsIt3g5LZZmp+KdGm1/v/b8Og=" "ofl/amita/Amita-Bold.ttf"]
+];
+amstelvaralpha = mkFont "amstelvaralpha" "ofl" [
+  ["gGTbCo2DmuQSliUikay45N7/q2Td37VUhbAYBCBWhiY=" "ofl/amstelvaralpha/AmstelvarAlpha-VF.ttf"]
+];
+anaheim = mkFont "anaheim" "ofl" [
+  ["7DBL1lSVlnzCM599jzw3R1tJ2F9/EUDueJ8wfScG2qY=" "ofl/anaheim/Anaheim-Regular.ttf"]
+];
+andadapro = mkFont "andadapro" "ofl" [
+  ["hUSr6t7tqA1wIB9ERiFnjt4a6xQKltJs1xE72nce+DE=" "ofl/andadapro/AndadaPro-Italic%5Bwght%5D.ttf"]
+  ["TzeDScXnpsDm2T/zy6kqLs8iF0B6C2M6tqyAfICrIKM=" "ofl/andadapro/AndadaPro%5Bwght%5D.ttf"]
+];
+andika = mkFont "andika" "ofl" [
+  ["akoN0m0o9Xe1Hdavtaz2/ZGrIWlOJWScJwoyF5u1KmI=" "ofl/andika/Andika-Italic.ttf"]
+  ["Q2ESYYmi0ODaZpmTUttYqvG0ypQPr4qCOdcl+DA9iQ0=" "ofl/andika/Andika-Bold.ttf"]
+  ["ICuWsfF0pKQ7rv6IW0DaysuBeGdV79CO1LdwTnnEVRU=" "ofl/andika/Andika-Regular.ttf"]
+  ["LQAPh5GhgnwMTUEen0WTxPwtsP27houx+GNZOz05aOY=" "ofl/andika/Andika-BoldItalic.ttf"]
+];
+anekbangla = mkFont "anekbangla" "ofl" [
+  ["i07C6vdADqmQNxikrd8xNUdSkubgsE23c10PmZKJ2Rk=" "ofl/anekbangla/AnekBangla%5Bwdth,wght%5D.ttf"]
+];
+anekdevanagari = mkFont "anekdevanagari" "ofl" [
+  ["uIzw/1cFWZsvFvzkupziAp92EG3STwQZl2xBfYnyCIg=" "ofl/anekdevanagari/AnekDevanagari%5Bwdth,wght%5D.ttf"]
+];
+anekgujarati = mkFont "anekgujarati" "ofl" [
+  ["fWjPkIBOac0jcX+fVIX0rBC2YAlqsLQG6G8y4J2WAps=" "ofl/anekgujarati/AnekGujarati%5Bwdth,wght%5D.ttf"]
+];
+anekgurmukhi = mkFont "anekgurmukhi" "ofl" [
+  ["QNchKeszLXxPr9JegKMNKsEfReFKFmDW97rL+cgA19U=" "ofl/anekgurmukhi/AnekGurmukhi%5Bwdth,wght%5D.ttf"]
+];
+anekkannada = mkFont "anekkannada" "ofl" [
+  ["aAh4PsuV7dlIySj/OUlTJW7teL23HdH9luzKpNoFozA=" "ofl/anekkannada/AnekKannada%5Bwdth,wght%5D.ttf"]
+];
+aneklatin = mkFont "aneklatin" "ofl" [
+  ["73B3q/IWat1qtqZLSkpEB4Wb9PnluQWLUawBraE2spU=" "ofl/aneklatin/AnekLatin%5Bwdth,wght%5D.ttf"]
+];
+anekmalayalam = mkFont "anekmalayalam" "ofl" [
+  ["MZzNPcYa/OKl8uXzzhb1VcHzhTkOgNEq97nQF91Jk/4=" "ofl/anekmalayalam/AnekMalayalam%5Bwdth,wght%5D.ttf"]
+];
+anekodia = mkFont "anekodia" "ofl" [
+  ["Zzu25Rtxrx3h8R+aVHo6WMUKb6MtSAlY4e8PBpgMpF8=" "ofl/anekodia/AnekOdia%5Bwdth,wght%5D.ttf"]
+];
+anektamil = mkFont "anektamil" "ofl" [
+  ["Syu32RoAEYC4iGIXfvKQHgJ+ZCjex/jiaUE9tR9VABM=" "ofl/anektamil/AnekTamil%5Bwdth,wght%5D.ttf"]
+];
+anektelugu = mkFont "anektelugu" "ofl" [
+  ["JZgZaKij+quXWZOlTuxFWCkhQ5CCEDf7Ok1sRH0uEXk=" "ofl/anektelugu/AnekTelugu%5Bwdth,wght%5D.ttf"]
+];
+angkor = mkFont "angkor" "ofl" [
+  ["7zqEY3DPCl9tVxgWLLkTOhqSQ1hvMvr2zbxElZSj3Bw=" "ofl/angkor/Angkor-Regular.ttf"]
+];
+annieuseyourtelescope = mkFont "annieuseyourtelescope" "ofl" [
+  ["IhtUBirbDfNtS48NL5iu9Pgn/DS5dMriziMqXiMxSbk=" "ofl/annieuseyourtelescope/AnnieUseYourTelescope-Regular.ttf"]
+];
+anonymouspro = mkFont "anonymouspro" "ofl" [
+  ["vBOsNOmZQSjGG1S/TniorbQ5tUPqCxl2HRWTQlmfRBo=" "ofl/anonymouspro/AnonymousPro-Italic.ttf"]
+  ["Rti5pfSzj8nTDzzdZ21Mb3ipvvlJuxqDBCFsxzHrh/g=" "ofl/anonymouspro/AnonymousPro-Regular.ttf"]
+  ["UolWV+fUiGAInr+sY6JyRPN6IhjsnFAZoLN/6IXA/Aw=" "ofl/anonymouspro/AnonymousPro-Bold.ttf"]
+  ["ToEeHjtg/HY/skrNJ3geciQag4C+sP+l4HryuHEzSW0=" "ofl/anonymouspro/AnonymousPro-BoldItalic.ttf"]
+];
+anticdidone = mkFont "anticdidone" "ofl" [
+  ["Y6VgeS8MtTQsDad1nJ3y4c4DJKivRq6XbZRY+8zLtEA=" "ofl/anticdidone/AnticDidone-Regular.ttf"]
+];
+antic = mkFont "antic" "ofl" [
+  ["xUUikvxDVnM697LXXToizk94KlGfzhrpIplH8aXjnIk=" "ofl/antic/Antic-Regular.ttf"]
+];
+anticslab = mkFont "anticslab" "ofl" [
+  ["vqWDGkEszxi/NGEqV12Qi3iSxGafqRuAQFy6UI/DKlY=" "ofl/anticslab/AnticSlab-Regular.ttf"]
+];
+antonio = mkFont "antonio" "ofl" [
+  ["npWiJY7N8+RccsW76hxM01Do9768h8nbpTspsYkLiQM=" "ofl/antonio/Antonio%5Bwght%5D.ttf"]
+];
+anton = mkFont "anton" "ofl" [
+  ["pLo6kjUOuwMdoMtHYwrEnrJlCCyhvARQRC9Kg6uUfKs=" "ofl/anton/Anton-Regular.ttf"]
+];
+anybody = mkFont "anybody" "ofl" [
+  ["8K5lsNSyHemLRFfW9XZ7idI5e70HKOxkTntD40i2Vu4=" "ofl/anybody/Anybody-Italic%5Bwdth,wght%5D.ttf"]
+  ["XtaaqMmpR3N625H0tfa0SPNHJXcM267BDozniC8IUXk=" "ofl/anybody/Anybody%5Bwdth,wght%5D.ttf"]
+];
+aoboshione = mkFont "aoboshione" "ofl" [
+  ["PRl0VAJu6zTuQJ0Nftp1qMfuZUqN+pwac62i2eUlt7E=" "ofl/aoboshione/AoboshiOne-Regular.ttf"]
+];
+arapey = mkFont "arapey" "ofl" [
+  ["XaRSWJmidwgkGkEI521r/Qh3ZqZtFZ2A3PmGgBv7EJI=" "ofl/arapey/Arapey-Regular.ttf"]
+  ["MFPmKlvx/g8I2Blr8x3jEt733qewQV1rIDhcql0zOwo=" "ofl/arapey/Arapey-Italic.ttf"]
+];
+arbutus = mkFont "arbutus" "ofl" [
+  ["bIbouGye6825Y/g7OC5bqSdks0xTzZ3ZagDsXTxaz9s=" "ofl/arbutus/Arbutus-Regular.ttf"]
+];
+arbutusslab = mkFont "arbutusslab" "ofl" [
+  ["9PVabpWqDcrUAHfUtOn30Cae0spEgTSRfJfVnEdOURw=" "ofl/arbutusslab/ArbutusSlab-Regular.ttf"]
+];
+architectsdaughter = mkFont "architectsdaughter" "ofl" [
+  ["YVlxigiJjjS8HLc1QIYUGl+acLc+VNvsJ+rQ1Zppc1k=" "ofl/architectsdaughter/ArchitectsDaughter-Regular.ttf"]
+];
+archivoblack = mkFont "archivoblack" "ofl" [
+  ["3ZqJoBm0hJ9mq3VFX+e9+TExEELLsPD5eswGFTlwMYA=" "ofl/archivoblack/ArchivoBlack-Regular.ttf"]
+];
+archivonarrow = mkFont "archivonarrow" "ofl" [
+  ["FHwJIUvghr8ccDEf+2b09aJS5I+Cjx1J41rlaVEBbMY=" "ofl/archivonarrow/ArchivoNarrow-Italic%5Bwght%5D.ttf"]
+  ["rb4Cf2Jcg5OuD24XTjLiM92khbw+2lFTzkKCdTlO+X8=" "ofl/archivonarrow/ArchivoNarrow%5Bwght%5D.ttf"]
+];
+archivo = mkFont "archivo" "ofl" [
+  ["DglKfTx8TCXPExDEswAU8drpMyIgscLIj0+plvCwUFM=" "ofl/archivo/Archivo%5Bwdth,wght%5D.ttf"]
+  ["MF0TtOuA5i99UX9418BFJQ2XdVKkIPLb7ZBvMU52EwU=" "ofl/archivo/Archivo-Italic%5Bwdth,wght%5D.ttf"]
+];
+arefruqaaink = mkFont "arefruqaaink" "ofl" [
+  ["BBXCQQseRT9dDqDbEU+5XQH2W6Lp4txK5nxftzwz6GM=" "ofl/arefruqaaink/ArefRuqaaInk-Regular.ttf"]
+  ["YBtcYH5+IOeVdnO5KUfTXrh2IM1AYhQDehQGlSIcMbQ=" "ofl/arefruqaaink/ArefRuqaaInk-Bold.ttf"]
+];
+arefruqaa = mkFont "arefruqaa" "ofl" [
+  ["JHBxAVt+79Y/lNbkeUnF0QKU7TG9Qy+Am6miGdk/kbs=" "ofl/arefruqaa/ArefRuqaa-Bold.ttf"]
+  ["zreG2DupLzXpbvzYYjwoWNKI4MVDyHYbo1sQIJiUZPk=" "ofl/arefruqaa/ArefRuqaa-Regular.ttf"]
+];
+areyouserious = mkFont "areyouserious" "ofl" [
+  ["4vYaFm84LXAxznUP4x2abQCafci2Oq/k/v9l5ctLOHQ=" "ofl/areyouserious/AreYouSerious-Regular.ttf"]
+];
+arimamadurai = mkFont "arimamadurai" "ofl" [
+  ["rjOy17Q0waLwWMcjwF7L1cEZ+ENbLFdPfn/AUZRgTj4=" "ofl/arimamadurai/ArimaMadurai-Thin.ttf"]
+  ["k1AC09pzANubdEbJBu+6r7HTZCDMPfMqCceWbNkzlkc=" "ofl/arimamadurai/ArimaMadurai-ExtraBold.ttf"]
+  ["blpKbbjr/GoX5DaM3IzbT/K8jHWBGYvv1w87AcpygI0=" "ofl/arimamadurai/ArimaMadurai-Bold.ttf"]
+  ["OazwZNK2rSvWJPwYqY73HrMdseFug3AIFGr9cgBjSCM=" "ofl/arimamadurai/ArimaMadurai-Black.ttf"]
+  ["BxQpclyni4s3UGjAt3KpMLpyXuarM6zBvk9FUNdbMhE=" "ofl/arimamadurai/ArimaMadurai-Medium.ttf"]
+  ["BacbcriYxVUJjSFX7On/0Q2PMsV4E8Tod/ZShgnCudY=" "ofl/arimamadurai/ArimaMadurai-Light.ttf"]
+  ["sq45u3N0NGqX3ExEIS24gMjD1xt6MKTpGM4BXJI8wPU=" "ofl/arimamadurai/ArimaMadurai-Regular.ttf"]
+  ["iP33LwoYa0ZDK3UL70Msb20jZIHm6ftuTZtPIWdqydc=" "ofl/arimamadurai/ArimaMadurai-ExtraLight.ttf"]
+];
+arima = mkFont "arima" "ofl" [
+  ["obAdK4DCeMQpsPCZadoEgqJBRCYBSgNXRuxYG0Knank=" "ofl/arima/Arima%5Bwght%5D.ttf"]
+];
+arimo = mkFont "arimo" "asl20" [
+  ["vSSPadJUmH2lS9/hjSKcZopnNPXwmMXb/VhzVTk1uJs=" "apache/arimo/Arimo-Italic%5Bwght%5D.ttf"]
+  ["x1Jw36i1dHxmbZ4ZFbjJpstuLedNEDzQ9u4BBGdaNgQ=" "apache/arimo/Arimo%5Bwght%5D.ttf"]
+];
+arizonia = mkFont "arizonia" "ofl" [
+  ["jfHBC8FdCroUXUWZwlyvrYPbaG0s76QmGfBptvG7zmI=" "ofl/arizonia/Arizonia-Regular.ttf"]
+];
+armata = mkFont "armata" "ofl" [
+  ["7kpqBBC6/B0LRr1FUeU2DU73YD7qGpx4PUbpVpqTaQU=" "ofl/armata/Armata-Regular.ttf"]
+];
+arsenal = mkFont "arsenal" "ofl" [
+  ["7q+X+N+dW7acjbI/fSrOYbbk7u/ZnBoibwV3oLOiP+Q=" "ofl/arsenal/Arsenal-Bold.ttf"]
+  ["VEeE7MxUBVcMjZFBlzmhLCqe58/JR3Fc7lH6BgcBtMI=" "ofl/arsenal/Arsenal-Regular.ttf"]
+  ["PjimnOge2JuKH+IMse7LrXYqrVjBIuqEOL24vkDtVQw=" "ofl/arsenal/Arsenal-Italic.ttf"]
+  ["J2xyuqf8Zw4DwpUfsQvl11w+DIUhEaEKhMjgxzn+2Qw=" "ofl/arsenal/Arsenal-BoldItalic.ttf"]
+];
+artifika = mkFont "artifika" "ofl" [
+  ["UdXjtZyQeTjhGWQwbc0T5OTNQTrKx9zM5PgYYNHtn4Y=" "ofl/artifika/Artifika-Regular.ttf"]
+];
+arvo = mkFont "arvo" "ofl" [
+  ["/Cnlf1VYhz5Byp/5qcd1IVZfEsaXJ1bQ+8xZLh8PTts=" "ofl/arvo/Arvo-BoldItalic.ttf"]
+  ["Yjmy7e52LbCrmTQxN8m6Fa6B/IQ9oudqCjlXgXSMwh8=" "ofl/arvo/Arvo-Bold.ttf"]
+  ["9BvUFHHsLbcUA1G93mFNpTQVJFA1mP9/5588icE7YF4=" "ofl/arvo/Arvo-Regular.ttf"]
+  ["outjoHcbjRPY5Uv2UKAq74E+6qLhD2KYNY5rFdJsZoY=" "ofl/arvo/Arvo-Italic.ttf"]
+];
+arya = mkFont "arya" "ofl" [
+  ["lkSdDsX0UvVsBf0wchFUNfQe0/eNNiREt5qDed4kefQ=" "ofl/arya/Arya-Bold.ttf"]
+  ["sCvazv4xvVRPkzK5tCRBaOwj4YvjlaVz4I9ITCp3iHk=" "ofl/arya/Arya-Regular.ttf"]
+];
+asapcondensed = mkFont "asapcondensed" "ofl" [
+  ["4wUDxgwbCYrgZX0VJ8pZZxVJHbAS4t/5Qzph9s+ndGo=" "ofl/asapcondensed/AsapCondensed-ExtraLight.ttf"]
+  ["ktHrJXn6mGihw2dr21EHnVwTRpqmGhIWTiXcRsJL264=" "ofl/asapcondensed/AsapCondensed-SemiBold.ttf"]
+  ["dbnjnLQEpUvGYMgI0/ZecBfD4KgLYqHj6fINJhVhRR8=" "ofl/asapcondensed/AsapCondensed-ExtraBoldItalic.ttf"]
+  ["bJBKJFu50EsLKxzEQcd8HSw3EK2HLPvDfLZEzChX6GA=" "ofl/asapcondensed/AsapCondensed-ExtraBold.ttf"]
+  ["l4qOoT8pTclEHZhxZTmhXw/WbzW0YbtxgCevUXKjHw8=" "ofl/asapcondensed/AsapCondensed-ExtraLightItalic.ttf"]
+  ["XA7+xbxO32q3I8fpruAcancoakewnsK7IkLBMBtdP38=" "ofl/asapcondensed/AsapCondensed-Light.ttf"]
+  ["lNUfEt3Y6US6HROMC5OU/hDuApXooeeLEx5P97FdElA=" "ofl/asapcondensed/AsapCondensed-MediumItalic.ttf"]
+  ["kaTIo6MZnXVTqptyAzbPP+9QtdusHRH4pTJBgI1y+qA=" "ofl/asapcondensed/AsapCondensed-Medium.ttf"]
+  ["KXCCshoVCVxOY/Z9y1QwSaO6yrlhiR2oLTBUAHTpOcs=" "ofl/asapcondensed/AsapCondensed-SemiBoldItalic.ttf"]
+  ["MOOy+MUVT9dUBX4aBnoOAO5n7+QOIXivFrzyRNHQR0o=" "ofl/asapcondensed/AsapCondensed-Black.ttf"]
+  ["MDWUIfappOIn7eFIleaGwniBRJL/hkF0Ea9nZGSsiwA=" "ofl/asapcondensed/AsapCondensed-LightItalic.ttf"]
+  ["DtS08poKvtOlBJJw8o2OEceX7cfAJwzFFJXAV4Yi+Co=" "ofl/asapcondensed/AsapCondensed-Bold.ttf"]
+  ["5KIOGr8V7T1YlcWSne3TdihshbjL1MnksY9xlhpg+7Y=" "ofl/asapcondensed/AsapCondensed-BlackItalic.ttf"]
+  ["pn1EWXYDhq0DO0UqEAj180pbIce3NEUDhYmhdsAJgqA=" "ofl/asapcondensed/AsapCondensed-BoldItalic.ttf"]
+  ["49JL1lMospBtPwdrhMcpHoZ5n6XnZ4kOdSAwPnHig1M=" "ofl/asapcondensed/AsapCondensed-Italic.ttf"]
+  ["KXM2q6Zk4Wwsaq22Smb7MdY/BI6uPSJAlJLNLxtM3aA=" "ofl/asapcondensed/AsapCondensed-Regular.ttf"]
+];
+asap = mkFont "asap" "ofl" [
+  ["bOoOPqhSdhUDwl81BaMoqfTAZKM9KKuXx4Uz8JPmq3Q=" "ofl/asap/Asap-Italic%5Bwdth,wght%5D.ttf"]
+  ["o5OLII16RtiPryLS1CIehxqyzGhsDlVaJzsqEmor0yE=" "ofl/asap/Asap%5Bwdth,wght%5D.ttf"]
+];
+asapvfbeta = mkFont "asapvfbeta" "ofl" [
+  ["8ocdEbgkjTQeUpoKEU0eFX5V812Oso8qhaidn879bSk=" "ofl/asapvfbeta/AsapVFBeta-Italic.ttf"]
+  ["HqYXr4xDsS4wAUJvq8Zho6r36RcBOZVb8FXLPpA2jw0=" "ofl/asapvfbeta/AsapVFBeta.ttf"]
+  ["y+c2qiyuwy5Iq41XoBfE2EUJaDBF5qQgnzE29U38BSw=" "ofl/asapvfbeta/AsapVFBeta-Condensed.ttf"]
+];
+asar = mkFont "asar" "ofl" [
+  ["i0FHNUrwCYNtAx9Qrz4EUHaNeLHg4CgcffF80mRAzC4=" "ofl/asar/Asar-Regular.ttf"]
+];
+asset = mkFont "asset" "ofl" [
+  ["TH7WP8rkyTS1yLAUHrbSJXLDW708cdf27NaHpl+35Tc=" "ofl/asset/Asset-Regular.ttf"]
+];
+assistant = mkFont "assistant" "ofl" [
+  ["HDs5OIT4+xM6Gxf0HSYXitrhBQpPhtekKdG1ZYwxT6M=" "ofl/assistant/Assistant%5Bwght%5D.ttf"]
+];
+astloch = mkFont "astloch" "ofl" [
+  ["G2+Y5MOR2nDZFmGCNp+QFkywKHCtIQxLMofzX/KCJ/A=" "ofl/astloch/Astloch-Regular.ttf"]
+  ["3ulftS+bJK/HAemZEggnX2VBYIcNsGvshM7LJeEPvu4=" "ofl/astloch/Astloch-Bold.ttf"]
+];
+asul = mkFont "asul" "ofl" [
+  ["K9YUrwWUyWV8xvmG9gKylNKpA7OnzhN5QqNawBtvH3Y=" "ofl/asul/Asul-Regular.ttf"]
+  ["Cupcj18EybLyUutbPX9tLugMvvYTUm67wzDFkpALvP4=" "ofl/asul/Asul-Bold.ttf"]
+];
+athiti = mkFont "athiti" "ofl" [
+  ["LnbKy6WaPp05zqUiktLoqK2aZFkzargRurDxQRA1RPM=" "ofl/athiti/Athiti-SemiBold.ttf"]
+  ["Fkqq8cBG6DT0GLx5ul/+Y2x5wqJuyRRuHq+Uh8vuqDM=" "ofl/athiti/Athiti-Bold.ttf"]
+  ["Zm9UdCWMv/1Te0lOLWpEHuhJd44hdaTiItTWJcbv4OU=" "ofl/athiti/Athiti-Regular.ttf"]
+  ["EnN806t0O6pCPOFN3oBmchgcU67KP8WWlm2jpUydtuk=" "ofl/athiti/Athiti-ExtraLight.ttf"]
+  ["ctJldxaxYjPIsJOSTVhARKuRqe2Ze8ct7hUsojxzG8k=" "ofl/athiti/Athiti-Medium.ttf"]
+  ["8Kcy4jNilrFsXVLN3WQJArrJSmW0jXMulk9vWiqWJ9Y=" "ofl/athiti/Athiti-Light.ttf"]
+];
+atkinsonhyperlegible = mkFont "atkinsonhyperlegible" "ofl" [
+  ["ekbxsO8vZLYQZcGmtaEfy5sBm0QGLYi6EhoIPMOehr8=" "ofl/atkinsonhyperlegible/AtkinsonHyperlegible-BoldItalic.ttf"]
+  ["WjsMjMjKVFFVFQtFEqH6JIKY3xIcUNZVfmUeYfvauS8=" "ofl/atkinsonhyperlegible/AtkinsonHyperlegible-Bold.ttf"]
+  ["f7kXyJAZiW0LUu6Et8uzMEwYy5CxmmL14ycSvSPpdmk=" "ofl/atkinsonhyperlegible/AtkinsonHyperlegible-Regular.ttf"]
+  ["AhvtpNPG7fx4hy5DbXQAn5obyylDMZCP5XR8YdPcxRQ=" "ofl/atkinsonhyperlegible/AtkinsonHyperlegible-Italic.ttf"]
+];
+atma = mkFont "atma" "ofl" [
+  ["Pd2eArS2B3slwH9dH0QRyQceUDCkEk133NWgT6KSuSE=" "ofl/atma/Atma-Regular.ttf"]
+  ["RNKfGIcXOSgolwmkfva2tSWSCawjSahiKSIxaml/SXw=" "ofl/atma/Atma-Light.ttf"]
+  ["Fbk1pXKQpnU5HGymusS9f8dG6tRONUldbcJWKyJloo8=" "ofl/atma/Atma-SemiBold.ttf"]
+  ["1VOZ9bzbePYNp9vWxav9ySUQFUNhWGrRsHvKfuc526Y=" "ofl/atma/Atma-Bold.ttf"]
+  ["Np2XiMkm6m82UJmWF76zSCOPNw1ls9XRgNY4yC6j2Co=" "ofl/atma/Atma-Medium.ttf"]
+];
+atomicage = mkFont "atomicage" "ofl" [
+  ["XqYREYCviCsHmaHhwEt6zFV4B/924MwkJYslmgb2ftI=" "ofl/atomicage/AtomicAge-Regular.ttf"]
+];
+aubrey = mkFont "aubrey" "ofl" [
+  ["Dl1bys2jjWDSWyxhorcTCpHSDwyrKAcvzPKRhfwsMXY=" "ofl/aubrey/Aubrey-Regular.ttf"]
+];
+audiowide = mkFont "audiowide" "ofl" [
+  ["x8DysPb62MYj4xdyznn5Sk7bkyH/zp/Ol46oktIK5zA=" "ofl/audiowide/Audiowide-Regular.ttf"]
+];
+autourone = mkFont "autourone" "ofl" [
+  ["aj9b8n6TmMJb2MTtrui9UD2AdFU1N6K/Ox1yQ1OqslI=" "ofl/autourone/AutourOne-Regular.ttf"]
+];
+average = mkFont "average" "ofl" [
+  ["+e/MIaIihwF4yG0tR9OGGkAoTSWs0oZXVU9kb2iQLjQ=" "ofl/average/Average-Regular.ttf"]
+];
+averagesans = mkFont "averagesans" "ofl" [
+  ["+Xi7DrWtk7AvOo5O8O1SWhGStAduio0Ls3slRqKXdi4=" "ofl/averagesans/AverageSans-Regular.ttf"]
+];
+averiagruesalibre = mkFont "averiagruesalibre" "ofl" [
+  ["3wgMbJnGlLPXQYNZV+Trw31kCpxU9Aec64xyEePy4gk=" "ofl/averiagruesalibre/AveriaGruesaLibre-Regular.ttf"]
+];
+averialibre = mkFont "averialibre" "ofl" [
+  ["N09nori4x+RaVD7GVY4DQ36MakRQzHJKXXDK6Jq6Z50=" "ofl/averialibre/AveriaLibre-Bold.ttf"]
+  ["PdppXgYBL4mznqzNd/u88iEzoXsAzl3fPk6amWVGuGU=" "ofl/averialibre/AveriaLibre-Regular.ttf"]
+  ["NIcbFKvOpsudzuZatjW+ZdCLD4Jc2I1wpE7VIXu5pSQ=" "ofl/averialibre/AveriaLibre-LightItalic.ttf"]
+  ["mhM3AHjWviwHd40rA+7i4XKu/GQMRTJzFqnr9cUNQak=" "ofl/averialibre/AveriaLibre-BoldItalic.ttf"]
+  ["t00rLa3+e/J6vx8luxsyRQTlLY9kUuuzSlZy+84S/wU=" "ofl/averialibre/AveriaLibre-Light.ttf"]
+  ["XltNM/CRH9Gi0j0gllM5M/Ex3SWPjDGW4WleZCVqcgI=" "ofl/averialibre/AveriaLibre-Italic.ttf"]
+];
+averiasanslibre = mkFont "averiasanslibre" "ofl" [
+  ["N/ff3y4quC1zy4Z3lhmh3+SVgjyCQl+Jgnd/pMEqjJw=" "ofl/averiasanslibre/AveriaSansLibre-LightItalic.ttf"]
+  ["hgPSljYY27Ru7TtGscf3BFSvex1WB6Tm6cagBknCPk8=" "ofl/averiasanslibre/AveriaSansLibre-Italic.ttf"]
+  ["4PpTFl4OfM02UQc2GXYrZhEN0K3cNoJFWGwIwC68LWA=" "ofl/averiasanslibre/AveriaSansLibre-BoldItalic.ttf"]
+  ["g0qajvOjfaAWUnTQNFg2tDDlTvFebr8HCufFgFA077w=" "ofl/averiasanslibre/AveriaSansLibre-Regular.ttf"]
+  ["xUzJOLNl+kRCud5NtgPyZZbp7z0/66MRz5hrbhMQeGM=" "ofl/averiasanslibre/AveriaSansLibre-Bold.ttf"]
+  ["A3JfdLhPUg2PJ9KdVCwxsiE8DgbK/1Y6Q3RZUOiGScc=" "ofl/averiasanslibre/AveriaSansLibre-Light.ttf"]
+];
+averiaseriflibre = mkFont "averiaseriflibre" "ofl" [
+  ["P21v6EA/IIDGOkjbC/hiJDxsKHhaEz2iqSc5BusGTNY=" "ofl/averiaseriflibre/AveriaSerifLibre-BoldItalic.ttf"]
+  ["z9RSrZC931m14g2ea2I/zhdr1/pL9TGA6Vxq2dXLQbw=" "ofl/averiaseriflibre/AveriaSerifLibre-LightItalic.ttf"]
+  ["xkVFvOZr4dc3gyM3wRiAFfmsrMUjDMvrTOZGoOqiUto=" "ofl/averiaseriflibre/AveriaSerifLibre-Regular.ttf"]
+  ["l0mG0KdLsqiI5/0T5VVjiK3TzM7rp3xpnkO7MSH6zxg=" "ofl/averiaseriflibre/AveriaSerifLibre-Light.ttf"]
+  ["xTLw9qtOmAVJQvVt4lNhUFx8cDLDk/K1zi2MgsIrJJk=" "ofl/averiaseriflibre/AveriaSerifLibre-Italic.ttf"]
+  ["pPScnfE1G2FRlpc3STRG+hrdFu0aIvqLmkrsvf/rGzs=" "ofl/averiaseriflibre/AveriaSerifLibre-Bold.ttf"]
+];
+azeretmono = mkFont "azeretmono" "ofl" [
+  ["8TliwmwbqoZK/3doNkAB+bym5Qb0G5owN8DWox4spzY=" "ofl/azeretmono/AzeretMono%5Bwght%5D.ttf"]
+  ["2P7yZtEZZLZCDInrt2cGoAr6McgOWNBRDbkoploF3kU=" "ofl/azeretmono/AzeretMono-Italic%5Bwght%5D.ttf"]
+];
+b612mono = mkFont "b612mono" "ofl" [
+  ["uYy5bMimIG2uCMBj1gkC335tQPhhOevblyVnBCU8nGk=" "ofl/b612mono/B612Mono-Regular.ttf"]
+  ["kaaoU1/GE1SixZpk6iBaT2lXwuCaxP+Rofxh00bABOE=" "ofl/b612mono/B612Mono-BoldItalic.ttf"]
+  ["1Y+oB+adGBWaQNV5DSV3IjnfIBZ7UKD4QOn+slMALJw=" "ofl/b612mono/B612Mono-Italic.ttf"]
+  ["tGex0Z/avtQr5R2H44yGZFzu/y+CjylHdRiNANH9aMo=" "ofl/b612mono/B612Mono-Bold.ttf"]
+];
+b612 = mkFont "b612" "ofl" [
+  ["E53OZZEAqDv5W0hHRpbkSL7pVjHvhP09BDfO0r8zz3M=" "ofl/b612/B612-Regular.ttf"]
+  ["WRH+CuaSZPt0spVvxmxhZYDNOStH8pM1+mjOXbR6TS8=" "ofl/b612/B612-BoldItalic.ttf"]
+  ["V/2KDTyLrwZvIcCjA0ryd4h6Cxe4wYy7zBxkJkDdFJ8=" "ofl/b612/B612-Italic.ttf"]
+  ["kXSVQax7LDKLWIMrfixN+AnX4ro41io6WqP444snGBQ=" "ofl/b612/B612-Bold.ttf"]
+];
+babylonica = mkFont "babylonica" "ofl" [
+  ["0DOxi6ZogeDwZuvGa0V5RODcUemB+b5hyDZdS8/bFlw=" "ofl/babylonica/Babylonica-Regular.ttf"]
+];
+badscript = mkFont "badscript" "ofl" [
+  ["o03EplTeo/9kr8XkXswZB5ozPXYGgf67eDJKVt0cd1M=" "ofl/badscript/BadScript-Regular.ttf"]
+];
+bahiana = mkFont "bahiana" "ofl" [
+  ["dXYOlVM5zXABLIvZV303P4vdQlanP1cfYaQvWOom/pw=" "ofl/bahiana/Bahiana-Regular.ttf"]
+];
+bahianita = mkFont "bahianita" "ofl" [
+  ["Ml8h/HI8li5Y+JWWHHftFRUguqpW42bE3K98j8t1Ewo=" "ofl/bahianita/Bahianita-Regular.ttf"]
+];
+baijamjuree = mkFont "baijamjuree" "ofl" [
+  ["luX4b0lEL2D9cs/Hco/edAhwzM07i8ijDnXdjZ/Es7Q=" "ofl/baijamjuree/BaiJamjuree-Italic.ttf"]
+  ["2kn50e/W8ZCsRErwKiVgbAzTj8eNT8HkWdjgFxtlrxE=" "ofl/baijamjuree/BaiJamjuree-ExtraLight.ttf"]
+  ["2qpovHIeiThh+Uj0BUK58eqElqP+QlCg/8htqwrujzw=" "ofl/baijamjuree/BaiJamjuree-SemiBold.ttf"]
+  ["crWjDLeJZoI+sybAm5AEsNA7S93N/P0bjNv/tsQUVH0=" "ofl/baijamjuree/BaiJamjuree-Regular.ttf"]
+  ["zcnNPC8WjReRhxtytdYr/teluH7+wbsLo1b3+tbWI/0=" "ofl/baijamjuree/BaiJamjuree-SemiBoldItalic.ttf"]
+  ["r+76h2ZnOOyGibsBjfyXGlMsj9noy6ZJ0b4BdnWdk8E=" "ofl/baijamjuree/BaiJamjuree-BoldItalic.ttf"]
+  ["lXgvPD4HhmdJ+yjh0aNW44Po8r3Me4jU46P8VGYTE38=" "ofl/baijamjuree/BaiJamjuree-Medium.ttf"]
+  ["833DzLZZfoUefCP+2U5qsN+WaPtcXRZjYOgcAN2EsLw=" "ofl/baijamjuree/BaiJamjuree-MediumItalic.ttf"]
+  ["jbQdk3K3Ql58cXunvTiDllutpkJBK8zAVFEC+QJNass=" "ofl/baijamjuree/BaiJamjuree-Light.ttf"]
+  ["dHhEEVBKKVpSVec24Kg4mJKvLIoU6RTT4ZQym1knkiM=" "ofl/baijamjuree/BaiJamjuree-Bold.ttf"]
+  ["TfrGiIcEFyyhDuGYbW3oneggopMQtIkoK4ebafAwQSg=" "ofl/baijamjuree/BaiJamjuree-ExtraLightItalic.ttf"]
+  ["eOCS2cFEU45XXagkKIjeJV4CiX6rCobXXkvB5rM9gvs=" "ofl/baijamjuree/BaiJamjuree-LightItalic.ttf"]
+];
+bakbakone = mkFont "bakbakone" "ofl" [
+  ["I43Sz3bw+jPgLqZ8L5aXcxN4rVZ1A8prH3eHeAk/+E8=" "ofl/bakbakone/BakbakOne-Regular.ttf"]
+];
+ballet = mkFont "ballet" "ofl" [
+  ["ZQC2q7bdMcM4no8yohrjxm4yV9Cv7+z3aIqiP3Qstnc=" "ofl/ballet/Ballet%5Bopsz%5D.ttf"]
+];
+baloo2 = mkFont "baloo2" "ofl" [
+  ["1HpoUlSAWbHbSaExnQbUmdVGw/oiN8+e7pxDyKuwJcI=" "ofl/baloo2/Baloo2%5Bwght%5D.ttf"]
+];
+baloobhai2 = mkFont "baloobhai2" "ofl" [
+  ["uFto+Fy4KSSxZHs+t068dTAa7kg564fujwPWANRGswQ=" "ofl/baloobhai2/BalooBhai2%5Bwght%5D.ttf"]
+];
+baloobhaijaan2 = mkFont "baloobhaijaan2" "ofl" [
+  ["Pp8H+8eWwN3LPm4Kom+chnQdn1t/XLcvTtPAblWhkzY=" "ofl/baloobhaijaan2/BalooBhaijaan2%5Bwght%5D.ttf"]
+];
+baloobhaina2 = mkFont "baloobhaina2" "ofl" [
+  ["0ikEtzN3IyAckQ7fcL4t5hNuxlvjZvKw5kiYYPE0PwQ=" "ofl/baloobhaina2/BalooBhaina2%5Bwght%5D.ttf"]
+];
+baloochettan2 = mkFont "baloochettan2" "ofl" [
+  ["jw3k+BtA0xShKcVaOp5YQRhoyppFLttXU3SIhT9G24Y=" "ofl/baloochettan2/BalooChettan2%5Bwght%5D.ttf"]
+];
+balooda2 = mkFont "balooda2" "ofl" [
+  ["i2KoxNvmWb5eTUDBm3swEhIDNbMzIFxaoQG0XNtEnP8=" "ofl/balooda2/BalooDa2%5Bwght%5D.ttf"]
+];
+baloopaaji2 = mkFont "baloopaaji2" "ofl" [
+  ["RPcMdgsQDDBz4uEofU4edFqW9OQILmcjaIL/qMdzZS4=" "ofl/baloopaaji2/BalooPaaji2%5Bwght%5D.ttf"]
+];
+balootamma2 = mkFont "balootamma2" "ofl" [
+  ["Nk57M/r+P5TrEhtNs2Qj4bD77yeK8LGo02Q8ZVZ7nTw=" "ofl/balootamma2/BalooTamma2%5Bwght%5D.ttf"]
+];
+balootammudu2 = mkFont "balootammudu2" "ofl" [
+  ["R3GhxQQjoH82kZ+sTYgswKxD5FH68EPIVY16IJKY1Ww=" "ofl/balootammudu2/BalooTammudu2%5Bwght%5D.ttf"]
+];
+baloothambi2 = mkFont "baloothambi2" "ofl" [
+  ["ZzmhHTVXt0JvD0POOiL/b7/uLTvlb/tN8JPTXTRgv3M=" "ofl/baloothambi2/BalooThambi2%5Bwght%5D.ttf"]
+];
+balsamiqsans = mkFont "balsamiqsans" "ofl" [
+  ["ufO5/dus+K0DGjQJQwFAeLDJ6mAojCFDQKpu1HmAmaA=" "ofl/balsamiqsans/BalsamiqSans-Italic.ttf"]
+  ["KrEKaiyR/hOTSHfXWQq8r5DRRYxU5k6YgwS2yazo1I0=" "ofl/balsamiqsans/BalsamiqSans-Regular.ttf"]
+  ["DvFIkrbkRYVZSnEdqliLp597dn7PDz9lWdOPahY1kX8=" "ofl/balsamiqsans/BalsamiqSans-BoldItalic.ttf"]
+  ["7XXMPW0NR4zlXlmOu/x2YkiIPUV9EHS5liOdWw0q9lg=" "ofl/balsamiqsans/BalsamiqSans-Bold.ttf"]
+];
+balthazar = mkFont "balthazar" "ofl" [
+  ["tJWFa2k0WKmaT8/kIJRLYDSv6CPrFZ6EN7Tokp1azqo=" "ofl/balthazar/Balthazar-Regular.ttf"]
+];
+bangers = mkFont "bangers" "ofl" [
+  ["vt0r4J9sNQMDT3YXTQ5uFE/VukDUvexnBJrPqsk662w=" "ofl/bangers/Bangers-Regular.ttf"]
+];
+barlowcondensed = mkFont "barlowcondensed" "ofl" [
+  ["3IPLu3VFoRernkwQ7QfTXu9vVjt3YhodNX8loxlJh9E=" "ofl/barlowcondensed/BarlowCondensed-SemiBoldItalic.ttf"]
+  ["GePEqB3H/O6MOKtr44GfzEXT84IvARrHtL1VDmUCuA8=" "ofl/barlowcondensed/BarlowCondensed-ExtraLight.ttf"]
+  ["5HZWLsnB4WzxZHWJW1EfCMgE9DjMmp+ApE6lCg7rW2U=" "ofl/barlowcondensed/BarlowCondensed-Bold.ttf"]
+  ["LDfh5rX+tx04pC5hgNLi9MoarSLP7L0BdDDzhj3rpn0=" "ofl/barlowcondensed/BarlowCondensed-Light.ttf"]
+  ["MxeD2unsDDmPTTLJ/VpW1MYCyqDBYowrnL/pP0jraMk=" "ofl/barlowcondensed/BarlowCondensed-ExtraBoldItalic.ttf"]
+  ["2GlPZc1ww+XmAOrTdleqsK219jsnXQwfb0pwRt4iIUU=" "ofl/barlowcondensed/BarlowCondensed-BoldItalic.ttf"]
+  ["50t1DfWCxgjzXbRntxGytg0iF2GOheYLcrQt/QBEbKs=" "ofl/barlowcondensed/BarlowCondensed-Black.ttf"]
+  ["WDzsXaO4S8TcfJxy4qVlyU005DFRixnX4lC3gwrV+ZY=" "ofl/barlowcondensed/BarlowCondensed-Regular.ttf"]
+  ["BjYV2gpk8xg5feKvrDMN+/u/TNtWKpmHy3K/3L03unw=" "ofl/barlowcondensed/BarlowCondensed-Italic.ttf"]
+  ["pYwXxZwibrDvQRtzaW95N00XDycIrMbXLY24wH8zMoY=" "ofl/barlowcondensed/BarlowCondensed-ExtraLightItalic.ttf"]
+  ["aK/jObhQOp10ssO1sMUh6lMzRh8prq98aAFBSCEU2Fo=" "ofl/barlowcondensed/BarlowCondensed-Thin.ttf"]
+  ["4e1dflDGpEmEVNQFCc4jYjhKLHhw3zQY/b0BD4Hf+tM=" "ofl/barlowcondensed/BarlowCondensed-BlackItalic.ttf"]
+  ["ckycJZUtX0othxhdl2eqAGFExfDZRNwFv31dYDVRwmA=" "ofl/barlowcondensed/BarlowCondensed-ExtraBold.ttf"]
+  ["Ww/4dOOuZOKz3Cx2HYui6z6uMk0mlEH23gBi6Pv/C44=" "ofl/barlowcondensed/BarlowCondensed-ThinItalic.ttf"]
+  ["FKq8STbFSjquZmq8y8S+YS5KM1AclIP35OuySTWdAXE=" "ofl/barlowcondensed/BarlowCondensed-LightItalic.ttf"]
+  ["e2GdFLwjJ1CanvMrCJD3CWJvfsyf9hGRwqQxTFSZ0tk=" "ofl/barlowcondensed/BarlowCondensed-SemiBold.ttf"]
+  ["JivRQyks5HnuDNCaQrR6sXP8qOnG617QtcioRbw3HRc=" "ofl/barlowcondensed/BarlowCondensed-Medium.ttf"]
+  ["4DZIi/4+oenznwBrEjfCkx58/qfZ7NzN8XUHpZhvc9k=" "ofl/barlowcondensed/BarlowCondensed-MediumItalic.ttf"]
+];
+barlow = mkFont "barlow" "ofl" [
+  ["hOak1h58PiHzxQ6mpPflMDo0Z4ZMA4vm6jdZurjVR/k=" "ofl/barlow/Barlow-Bold.ttf"]
+  ["B53O5KU1RBd/OxY1Sye0C1IeIoYaQAhKtNBS8Cie2eg=" "ofl/barlow/Barlow-BoldItalic.ttf"]
+  ["hQHLfa/IpZQfpVmFSi5TyoIguye+KQcee1dnJA2sF38=" "ofl/barlow/Barlow-ExtraLightItalic.ttf"]
+  ["2/bS3xNIxKkYdKFbvns/PYk9SRvSrnM3B5Wv4VfJk7k=" "ofl/barlow/Barlow-MediumItalic.ttf"]
+  ["TpSBA7G/BWSbqupkdH5BDcIWca1W6v1d0+byBitf810=" "ofl/barlow/Barlow-ThinItalic.ttf"]
+  ["cM9Fw1SvOeVQgv1QbnSMxqChgSlJh1+Z3tP3a/aR5Mo=" "ofl/barlow/Barlow-Italic.ttf"]
+  ["hld8sy+KvjZz21PKD0Ih5oVnUaT2cwyGfgD3IPi7H8U=" "ofl/barlow/Barlow-SemiBold.ttf"]
+  ["UjTZEDDhu4lSXLrMxDhoksP+AFoFgscFJkzjVy2WoaE=" "ofl/barlow/Barlow-ExtraBold.ttf"]
+  ["ILE3XAxmBnAYZ780x8yX9ECHhQVno2WH0lq7lRCxg8w=" "ofl/barlow/Barlow-Light.ttf"]
+  ["vUfbFMYwXrtkej8MavwDcP/U4zaPEkBcjNFBaDpMKwU=" "ofl/barlow/Barlow-ExtraLight.ttf"]
+  ["laoCx8QwluDdRNeHumIWhkpnFX5AKtq1mzVXLgwVd+o=" "ofl/barlow/Barlow-Regular.ttf"]
+  ["J3tF/AufBmv3fojl0Ue6ro0a10Qc7e4dwwX8PcboTOc=" "ofl/barlow/Barlow-SemiBoldItalic.ttf"]
+  ["EJrTtP/1v9M40PvJCOaNYBiTuXubHYrmmKqrIgn2phg=" "ofl/barlow/Barlow-BlackItalic.ttf"]
+  ["EDZx5aja8cAqwss1xh+jAIjgVeX/cY1RtPsgASWB0lI=" "ofl/barlow/Barlow-Thin.ttf"]
+  ["Vn8gD91T6EjMWWb4vz/lrvxutaXxUUmkdBJ3e4zEwgM=" "ofl/barlow/Barlow-LightItalic.ttf"]
+  ["WnjW9rcoGsOK8kedhyCXEkV6kUeAGflUKr/Xj+i9szI=" "ofl/barlow/Barlow-ExtraBoldItalic.ttf"]
+  ["/E906EdbGBAD91l0UMYtYwYitBfjZ6aEKXKyhsSflEA=" "ofl/barlow/Barlow-Black.ttf"]
+  ["+JBvdiy3PcpEHaA0vDY7LY4uaLwQ1cBeWHF2RsIMxLQ=" "ofl/barlow/Barlow-Medium.ttf"]
+];
+barlowsemicondensed = mkFont "barlowsemicondensed" "ofl" [
+  ["vSmfS8W0TTC+jULputOl331mrxzVXQ7XKouJFjYKFCQ=" "ofl/barlowsemicondensed/BarlowSemiCondensed-SemiBold.ttf"]
+  ["zW9Tv4c/1VAbJYKAXQvxqbRqykD0z44BxhhvUYgcHZo=" "ofl/barlowsemicondensed/BarlowSemiCondensed-MediumItalic.ttf"]
+  ["jQa5+6nuoOT07d/IGvH4h4GwdU6GSDI95XPoUEC1ndo=" "ofl/barlowsemicondensed/BarlowSemiCondensed-SemiBoldItalic.ttf"]
+  ["TUAwu0zI7ATuAXw8n+038GnDV+qwf5cgKO+v4eetFLE=" "ofl/barlowsemicondensed/BarlowSemiCondensed-LightItalic.ttf"]
+  ["MLhzuGAGKs8q1Mnf8kwOd5PKneJuwHGjjFh1NJdIZa4=" "ofl/barlowsemicondensed/BarlowSemiCondensed-BlackItalic.ttf"]
+  ["W9Z1fkWaEQ2oG0RTLw9DBY4tqyQBaIq8qE8v294ZPLs=" "ofl/barlowsemicondensed/BarlowSemiCondensed-Bold.ttf"]
+  ["qAltDcP/IuoBXWP0NqaFamnkAsEtqZkfSkDywL7fRO4=" "ofl/barlowsemicondensed/BarlowSemiCondensed-ExtraBold.ttf"]
+  ["SZi2k6GQt28rETFYRDRahUbB4uajIJBVB6nu0E7fi0g=" "ofl/barlowsemicondensed/BarlowSemiCondensed-Medium.ttf"]
+  ["6MckL2ErE9Am4YqUtjsP0HnpGj+vAJ0baYHbtfFtEVM=" "ofl/barlowsemicondensed/BarlowSemiCondensed-Regular.ttf"]
+  ["ZScLoCLgVgdLC49KnlGgOw3y4Q0EcA3NCnkuUkqHvO0=" "ofl/barlowsemicondensed/BarlowSemiCondensed-BoldItalic.ttf"]
+  ["Amq8xZY09uEY3Sn65yeIK7/o6sXneqZxqk9NSTVbClc=" "ofl/barlowsemicondensed/BarlowSemiCondensed-ExtraLightItalic.ttf"]
+  ["Q5NaiYnDorwOV8PUkatN/SIhf+83Pq4GnfMOYQ4yt+w=" "ofl/barlowsemicondensed/BarlowSemiCondensed-ThinItalic.ttf"]
+  ["zEoa09aOwBenmwmCKOdsci7ZLl55GXhGfHZDcYbyKgM=" "ofl/barlowsemicondensed/BarlowSemiCondensed-Light.ttf"]
+  ["4f/aYLwlp/NoJ4XCh7GhZ4OOeG/AGBMPemkHoV5NDRQ=" "ofl/barlowsemicondensed/BarlowSemiCondensed-ExtraLight.ttf"]
+  ["FxUCWWtYSGKmUUJgEPFIeNj3qH5qCApiHAsc1Eel/vw=" "ofl/barlowsemicondensed/BarlowSemiCondensed-Black.ttf"]
+  ["bOKCBMikg2nyVAVfzPF4T+EOx/zCb4SjANUWXd/Aywo=" "ofl/barlowsemicondensed/BarlowSemiCondensed-Italic.ttf"]
+  ["8sol7a0lgBnYiHmpqK4alSp6f2ja3vlFlUxjus2ggCY=" "ofl/barlowsemicondensed/BarlowSemiCondensed-Thin.ttf"]
+  ["ufXIefqVKytTViAKB5s/YA9T0nPE28CIWFZ41sdFauc=" "ofl/barlowsemicondensed/BarlowSemiCondensed-ExtraBoldItalic.ttf"]
+];
+barriecito = mkFont "barriecito" "ofl" [
+  ["/zKgmbaODrXiNq3LmlgUHQD73xllhuQh0cag0YWfdbg=" "ofl/barriecito/Barriecito-Regular.ttf"]
+];
+barrio = mkFont "barrio" "ofl" [
+  ["b4Ykn77U0NYgvP79pkoAgeFc8MjF/SrRfbFXuYtVi8U=" "ofl/barrio/Barrio-Regular.ttf"]
+];
+basic = mkFont "basic" "ofl" [
+  ["B39yRfZFkEVJWxygST8rQmxCHSES0QtIo4/4hYoHOXo=" "ofl/basic/Basic-Regular.ttf"]
+];
+baskervville = mkFont "baskervville" "ofl" [
+  ["bizMyM3iIYbTXSSZsB99wo+CA5/XcCVsWQ+6QAVXQO8=" "ofl/baskervville/Baskervville-Italic.ttf"]
+  ["TJUpVSwwaDzdny17bhSqzv+ihs68O6n6vD+YHri0Gx8=" "ofl/baskervville/Baskervville-Regular.ttf"]
+];
+battambang = mkFont "battambang" "ofl" [
+  ["KCYm3w75nNuo4lGeY3Bd5iHRzynD0yOh2OQk3xyupe0=" "ofl/battambang/Battambang-Light.ttf"]
+  ["H9PrmWCRE5bLeVXyxor+XuIcLBT4CX6UXQW3aO1N6UI=" "ofl/battambang/Battambang-Regular.ttf"]
+  ["jgLOtZEEeRGR1zcDJKdcTnToViNpEnJQf4vePIPXqNk=" "ofl/battambang/Battambang-Thin.ttf"]
+  ["TNEPelan2dH7QYSyIZgh+K1vQlvikCQ+9zxO86gMhv8=" "ofl/battambang/Battambang-Bold.ttf"]
+  ["RCYzKlQfbMhUiYE7EdmbihqspTsxP43rIbQDo9WCht0=" "ofl/battambang/Battambang-Black.ttf"]
+];
+baumans = mkFont "baumans" "ofl" [
+  ["/CJL8wHBySBKuJ//WoliRyrqJa8BogIj2P4qpp0G1rk=" "ofl/baumans/Baumans-Regular.ttf"]
+];
+bayon = mkFont "bayon" "ofl" [
+  ["/963rVyhq9N2MbCmN6qhss1pX4XlgvXHXMzia9qvUbY=" "ofl/bayon/Bayon-Regular.ttf"]
+];
+beaurivage = mkFont "beaurivage" "ofl" [
+  ["akB60kGKXinOtEfeSfsR5hRhXeSUMpLjhiNH+gEOe7o=" "ofl/beaurivage/BeauRivage-Regular.ttf"]
+];
+bebasneue = mkFont "bebasneue" "ofl" [
+  ["CORiOAUQLYGfWGAeRuNFZIhGB142OyzrIzE8LRyD7HM=" "ofl/bebasneue/BebasNeue-Regular.ttf"]
+];
+belgrano = mkFont "belgrano" "ofl" [
+  ["W/CV37xWcYvqfXTAsww2QTcUqviDPSywErYEtk/Tg9k=" "ofl/belgrano/Belgrano-Regular.ttf"]
+];
+bellefair = mkFont "bellefair" "ofl" [
+  ["XAzU1Sbm38sYkQava15uyZpU77bUWN/WFibObcDwMCY=" "ofl/bellefair/Bellefair-Regular.ttf"]
+];
+belleza = mkFont "belleza" "ofl" [
+  ["qI6w/fTnhoekDTR44ckNTTB56MDX06JFJIijuoBb/x0=" "ofl/belleza/Belleza-Regular.ttf"]
+];
+bellota = mkFont "bellota" "ofl" [
+  ["1GgG+cX9Rs1r8cJhv6RrLSJQMTDVhUUdx4Y9jOgFJPw=" "ofl/bellota/Bellota-Regular.ttf"]
+  ["GNGE81mLroMAggQc9/tJok0N7mBd4rUuSuaL3taY3wo=" "ofl/bellota/Bellota-Light.ttf"]
+  ["b2EETarAE5m9fR/QDCzP62uRbxD0yWowPhoQB7tI4X0=" "ofl/bellota/Bellota-LightItalic.ttf"]
+  ["jhrk2fpOBV6fwgK+WG+KmlvvgdhzG91AvYYt8gce25k=" "ofl/bellota/Bellota-Italic.ttf"]
+  ["gsqvpp7XzYqzcjssju20Q76Qj5CI5X/83gtfDTjcNwg=" "ofl/bellota/Bellota-BoldItalic.ttf"]
+  ["ISCptcPJLn/nz06WTpJawEywE8Y6xy2kp1aubthy6Xs=" "ofl/bellota/Bellota-Bold.ttf"]
+];
+bellotatext = mkFont "bellotatext" "ofl" [
+  ["/fJ0BPO2ZaoL34sZx/1CXZTOAT70E5Reu9ZrckQldc0=" "ofl/bellotatext/BellotaText-Light.ttf"]
+  ["KvVNBdpKlRLjpQ+SgNWq8cnVD2aGWNGy6CBoLMU2Bcg=" "ofl/bellotatext/BellotaText-BoldItalic.ttf"]
+  ["e1IJW2OEWUWL1yhfXlVlHzAVEeGlE225LLHtkV+MYaQ=" "ofl/bellotatext/BellotaText-LightItalic.ttf"]
+  ["McQcF9VxkAQ3sZQwC1qdo4TjZuIkWdaY+r6fC+Q1XvU=" "ofl/bellotatext/BellotaText-Bold.ttf"]
+  ["sQpYYFdHuF9zjju/mlVxEB7P8KOY72Yg356bTuHzP4M=" "ofl/bellotatext/BellotaText-Regular.ttf"]
+  ["TgSUPmOrJWAmzy0OUG0WzGqn1diR5jWCrMJQ/ECZK9w=" "ofl/bellotatext/BellotaText-Italic.ttf"]
+];
+benchnine = mkFont "benchnine" "ofl" [
+  ["saCqX9WbCa/x45b7YXx8qSI8OeG7vBGZ2WeEqM5weHg=" "ofl/benchnine/BenchNine-Light.ttf"]
+  ["XTxEUYRWn0JO1tQ0ytFr3aEwxaOV954mdPRHzVSVy5c=" "ofl/benchnine/BenchNine-Bold.ttf"]
+  ["q8Hh38/Pj+zzIthb1GHzCKaNMTqyqC9PGS2VgKgrsNc=" "ofl/benchnine/BenchNine-Regular.ttf"]
+];
+benne = mkFont "benne" "ofl" [
+  ["aBo6rb3kD0EbNL9vtVWXGx1sHpea337qV5P5vdXsfz0=" "ofl/benne/Benne-Regular.ttf"]
+];
+bentham = mkFont "bentham" "ofl" [
+  ["a11qwRtJAvxpEsOvuZUg4pD1mlYkUijKdSn+OTfLp5M=" "ofl/bentham/Bentham-Regular.ttf"]
+];
+berkshireswash = mkFont "berkshireswash" "ofl" [
+  ["8MgIN9xvMribEIlKfjkpXbSgCraXytpoKj9ZQsNC/gA=" "ofl/berkshireswash/BerkshireSwash-Regular.ttf"]
+];
+besley = mkFont "besley" "ofl" [
+  ["3lAqGrawamOYLc6Mnliz7uiq2hdeeNWk3Ap7NyHyZWI=" "ofl/besley/Besley-Italic%5Bwght%5D.ttf"]
+  ["cfNS2IWceHYxoJeBYdSEl6csqmncrmmW1nEqVk34bB4=" "ofl/besley/Besley%5Bwght%5D.ttf"]
+];
+bethellen = mkFont "bethellen" "ofl" [
+  ["yklHGuyQoZ32P1g/WmDVFPASVZqKLRf2L4o4n+kHJtc=" "ofl/bethellen/BethEllen-Regular.ttf"]
+];
+bevan = mkFont "bevan" "ofl" [
+  ["vfZ0Tho5jCu/gOlKgZUgl1mZKyXQmGPu+sxC3kycr2s=" "ofl/bevan/Bevan-Italic.ttf"]
+  ["jRbAkgMw8d74TjQs5wYmwn+/F5tClOY5GxkwH/WHNGk=" "ofl/bevan/Bevan-Regular.ttf"]
+];
+bevietnampro = mkFont "bevietnampro" "ofl" [
+  ["8LcUPtrD/ZmWAxJwbPpRy6/sKOevptSvvQinO7JGrxM=" "ofl/bevietnampro/BeVietnamPro-Light.ttf"]
+  ["f3OP5cQ8iHKAeyDi0w1CFjYY3opNr39IqTmtrDLBaEc=" "ofl/bevietnampro/BeVietnamPro-Bold.ttf"]
+  ["zR726dfbKK1c24imXMvmk4cOYNNAt5HzSdJINCtP5MM=" "ofl/bevietnampro/BeVietnamPro-Regular.ttf"]
+  ["/EQQ8Ko5QwRj8QNGPSe+VIbCAY0RhU8XM90nvnNItBw=" "ofl/bevietnampro/BeVietnamPro-ExtraLightItalic.ttf"]
+  ["1VJmxhTR+wE6ZmHFzR2Y8x8uA0GNg+kPUJshD0UsDN8=" "ofl/bevietnampro/BeVietnamPro-BlackItalic.ttf"]
+  ["uurfFI7itmQNeRDrq5mwGqr16wCUY730ZqsrQxCDif0=" "ofl/bevietnampro/BeVietnamPro-LightItalic.ttf"]
+  ["oz67P2jg4mCn04dNZCWa0wmXGi2vlp585fRE1wvOU18=" "ofl/bevietnampro/BeVietnamPro-Italic.ttf"]
+  ["RNv6AVU9InvsdrpkRsVhiHCnakoyl/QWMN3oWdBlDQI=" "ofl/bevietnampro/BeVietnamPro-ExtraBold.ttf"]
+  ["tVRKULdMMVP3qmhhTPrrvqkkhp5tb9/U7IDez91/9M0=" "ofl/bevietnampro/BeVietnamPro-ExtraBoldItalic.ttf"]
+  ["t9Q6X5QwSPfU5JoIAFKszhkC8eqwf0FgKZ2Eq6uBGfo=" "ofl/bevietnampro/BeVietnamPro-MediumItalic.ttf"]
+  ["oqZb35slG+s9ZYrmkYidcc5jwCkJQMh8pgtEnOsL2u4=" "ofl/bevietnampro/BeVietnamPro-BoldItalic.ttf"]
+  ["3Q7EYXgtp/Slhpi0MaZ8RVztfAneucQNe0fmGXXT/9s=" "ofl/bevietnampro/BeVietnamPro-Black.ttf"]
+  ["P/fK4L3Usgh/4kWD0RN9wKbs/tlsYu45lVmS+hYpF2w=" "ofl/bevietnampro/BeVietnamPro-Thin.ttf"]
+  ["FMUOPWyJgGVmge3kgGjRKuZFxxseqkD/FCZ9VKScXFo=" "ofl/bevietnampro/BeVietnamPro-ThinItalic.ttf"]
+  ["tggyv6D80BUVgRLGTX4/2tOwxih9GCP4WjEDY26EUmg=" "ofl/bevietnampro/BeVietnamPro-Medium.ttf"]
+  ["PfFlA5n9iRlnCCvS944dh/5OuC/Hvbt6uUuovahIyqE=" "ofl/bevietnampro/BeVietnamPro-ExtraLight.ttf"]
+  ["vY4n6wJyC52R5Z5PEKkIeGQyGfJc5qjZpPBqiojTu3E=" "ofl/bevietnampro/BeVietnamPro-SemiBold.ttf"]
+  ["99v4pj9LSm99fx9PJ0Q0ldAUdWY7uP5csab8Z0DoKic=" "ofl/bevietnampro/BeVietnamPro-SemiBoldItalic.ttf"]
+];
+bhavuka = mkFont "bhavuka" "ofl" [
+  ["FTgGJXeC6buZ9FBGWRdaS6J6WTMpFwKWNBbJiHCzeqk=" "ofl/bhavuka/Bhavuka-Regular.ttf"]
+];
+bhutukaexpandedone = mkFont "bhutukaexpandedone" "ofl" [
+  ["ZrUvEBO/l3VxwIIX/IUbmYjyZLBlvmEYgLkJCfs8J00=" "ofl/bhutukaexpandedone/BhuTukaExpandedOne-Regular.ttf"]
+];
+bigelowrules = mkFont "bigelowrules" "ofl" [
+  ["ts73ulHB+8qSC1MaOawsNIAjtbnk010bykPsgB7rX8s=" "ofl/bigelowrules/BigelowRules-Regular.ttf"]
+];
+bigshotone = mkFont "bigshotone" "ofl" [
+  ["P4fJaWMtypMqduh1u2kx4yoANXdDb+HxTszvsnTPKt4=" "ofl/bigshotone/BigshotOne-Regular.ttf"]
+];
+bigshouldersdisplay = mkFont "bigshouldersdisplay" "ofl" [
+  ["YOII3CdqHDX8W2LpT5+5WcQMEXg6nrdUgXXBSx++tyA=" "ofl/bigshouldersdisplay/BigShouldersDisplay%5Bwght%5D.ttf"]
+];
+bigshouldersinlinedisplay = mkFont "bigshouldersinlinedisplay" "ofl" [
+  ["sLGN5GBdtPufjrVMAOiT6ANC+qjw6Vt4EmR0zDLL32I=" "ofl/bigshouldersinlinedisplay/BigShouldersInlineDisplay%5Bwght%5D.ttf"]
+];
+bigshouldersinlinetext = mkFont "bigshouldersinlinetext" "ofl" [
+  ["4doqqGf7dW2yKLptDplU4QdnBqTqqUcf7o8lWkwwoT8=" "ofl/bigshouldersinlinetext/BigShouldersInlineText%5Bwght%5D.ttf"]
+];
+bigshouldersstencildisplay = mkFont "bigshouldersstencildisplay" "ofl" [
+  ["k7vvufOkl/z+7F0ayFxKlHoyuOW8rzt7Xv/1LxsRsOQ=" "ofl/bigshouldersstencildisplay/BigShouldersStencilDisplay%5Bwght%5D.ttf"]
+];
+bigshouldersstenciltext = mkFont "bigshouldersstenciltext" "ofl" [
+  ["WD40I+YruFO0lw17ENRDhNF52G4+lqC8VBA8+/uWoSI=" "ofl/bigshouldersstenciltext/BigShouldersStencilText%5Bwght%5D.ttf"]
+];
+bigshoulderstext = mkFont "bigshoulderstext" "ofl" [
+  ["/ObFz07eycnfs+eg9gvvknyIHqtyyhfVD930tV8zTtU=" "ofl/bigshoulderstext/BigShouldersText%5Bwght%5D.ttf"]
+];
+bilbo = mkFont "bilbo" "ofl" [
+  ["9HlQXIOdsMeovnEI0Easyj1AmgNLd3UUJBzGovnYGPw=" "ofl/bilbo/Bilbo-Regular.ttf"]
+];
+bilboswashcaps = mkFont "bilboswashcaps" "ofl" [
+  ["NuCm2fM8V3lzQKZch4knIkf40rC5UhqSES6qE8d6Q1Q=" "ofl/bilboswashcaps/BilboSwashCaps-Regular.ttf"]
+];
+biorhymeexpanded = mkFont "biorhymeexpanded" "ofl" [
+  ["51p8mWyIhNPSbAgj58+/PPQE0no23f9xX239lTia/6c=" "ofl/biorhymeexpanded/BioRhymeExpanded-Regular.ttf"]
+  ["uQE2VEpGJQ0sNm2P2zJoQZ8EM7pqbJaZi6r+DRcxmnc=" "ofl/biorhymeexpanded/BioRhymeExpanded-Bold.ttf"]
+  ["OWqTS8/NKQCUMvKBxb5u4tHtlVLKRerlCa8/kHbVEcs=" "ofl/biorhymeexpanded/BioRhymeExpanded-Light.ttf"]
+  ["FroS+ouUcSOD5aTqxR0RrduiqM5EoMI57hNYPNfDL8E=" "ofl/biorhymeexpanded/BioRhymeExpanded-ExtraLight.ttf"]
+  ["O5FogPp0yAQVMFF0U3aYjoVgKchr7R9/rNUyzr7uAA0=" "ofl/biorhymeexpanded/BioRhymeExpanded-ExtraBold.ttf"]
+];
+biorhyme = mkFont "biorhyme" "ofl" [
+  ["igYrChzufPz397dTocQeosloo+oBPXCOeIkc8j9q4Xg=" "ofl/biorhyme/BioRhyme-ExtraBold.ttf"]
+  ["K2IaiK7U3EsgptJC6z0GIEnvFfk8ffwXfy/wnQLLCz0=" "ofl/biorhyme/BioRhyme-Bold.ttf"]
+  ["Gy989ySsKCqSWiq6tO8R4hz8ByPTnBeaCBv+P+tfyn0=" "ofl/biorhyme/BioRhyme-Light.ttf"]
+  ["3Xleflk/BXNRM6SOjEDXghn7NQjw0RvRS/RrDHw6bac=" "ofl/biorhyme/BioRhyme-ExtraLight.ttf"]
+  ["kq2AGu/zE2GLHZmQ7a9t3E77k0nLnriSD9QN2dIIcnY=" "ofl/biorhyme/BioRhyme-Regular.ttf"]
+];
+birthstonebounce = mkFont "birthstonebounce" "ofl" [
+  ["7YoPGtX/gtYXKI4VJo1jZUEuO3k9FyMGEENbCUdLMbw=" "ofl/birthstonebounce/BirthstoneBounce-Medium.ttf"]
+  ["oDthRll9Rn55T91NYReNcvCD65Pp6GBAoQUwqqEwfvk=" "ofl/birthstonebounce/BirthstoneBounce-Regular.ttf"]
+];
+birthstone = mkFont "birthstone" "ofl" [
+  ["zQS7N/A9Loyuuu4vJrCdMkS6t4EPo0jYrLLmpSKNh4M=" "ofl/birthstone/Birthstone-Regular.ttf"]
+];
+biryani = mkFont "biryani" "ofl" [
+  ["gyOOMoVKxIngInauvKkNTGdeqVpEE8POPQElgcZ/6os=" "ofl/biryani/Biryani-Light.ttf"]
+  ["C4RrT4YA55Q6Ooai984Ewg2qfSza10yVHtzI4Hw2cRY=" "ofl/biryani/Biryani-Regular.ttf"]
+  ["i7XXj7KPonkJOU88NUjOVEN24jRI/xX7t8si7mULDl0=" "ofl/biryani/Biryani-SemiBold.ttf"]
+  ["8qlZCM8TaEf6qdvagibR0vRc/K3xdpbQggEEBFCd13A=" "ofl/biryani/Biryani-ExtraLight.ttf"]
+  ["XhsMxgy/R5oc5Bxrdk/LJRYHJkhcZnbbjnie1Lq0PkM=" "ofl/biryani/Biryani-Bold.ttf"]
+  ["6prnB5hd4/Ixj7K6gS+s7zElPCfhsDm66SLc7RXyJzo=" "ofl/biryani/Biryani-ExtraBold.ttf"]
+  ["RdeWPuYXtFCPFtGC4Ot67rtkMWFKBkHMyNRTTzZzuvo=" "ofl/biryani/Biryani-Black.ttf"]
+];
+bitter = mkFont "bitter" "ofl" [
+  ["SRu6t4pjr2KtdQ5vjw0fBZlyFaW+JAMcPcsnCwYsYmc=" "ofl/bitter/Bitter-Italic%5Bwght%5D.ttf"]
+  ["I4+kulFAJJT/V9OrRrS6DoRij3YkahCTniSu6r9qwmA=" "ofl/bitter/Bitter%5Bwght%5D.ttf"]
+];
+bizudgothic = mkFont "bizudgothic" "ofl" [
+  ["cJ/NQeMgn7dl2nUEcvVczfklZT6fp+HrAHy2XI90nHU=" "ofl/bizudgothic/BIZUDGothic-Regular.ttf"]
+  ["mKUotrY4RjBBloeDzA9jra9M3Cb1OYr+1ourcS0RE/M=" "ofl/bizudgothic/BIZUDGothic-Bold.ttf"]
+];
+bizudmincho = mkFont "bizudmincho" "ofl" [
+  ["Ro7m2bFJyhRICeA4Qb8YdA7PAU4FWgDabsrxqvQWWvI=" "ofl/bizudmincho/BIZUDMincho-Regular.ttf"]
+  ["Hwd/j4TB4J1cSs3WgoBIGAwvczrlrhMnH0jPAb7kroM=" "ofl/bizudmincho/BIZUDMincho-Bold.ttf"]
+];
+bizudpgothic = mkFont "bizudpgothic" "ofl" [
+  ["kebmeEGgRTPok4hd42QzM6gD41JC2LYONDEH9QasW/o=" "ofl/bizudpgothic/BIZUDPGothic-Bold.ttf"]
+  ["qOc93VogiyvvYsKEaofBc816rhAXJQRNnnI9NhCT19s=" "ofl/bizudpgothic/BIZUDPGothic-Regular.ttf"]
+];
+bizudpmincho = mkFont "bizudpmincho" "ofl" [
+  ["286gRXisHp00hFJehwzkkb0ENhdo9NK6S4J9luIPiR0=" "ofl/bizudpmincho/BIZUDPMincho-Regular.ttf"]
+  ["mWGOObiBWX78A9WHBr0ZR1fJaMG/enAXqJPv6taxsmA=" "ofl/bizudpmincho/BIZUDPMincho-Bold.ttf"]
+];
+blackandwhitepicture = mkFont "blackandwhitepicture" "ofl" [
+  ["TXLNbeHyELRGyG8GtOE9dkHLz7GzdcaSc0E4iqjggFY=" "ofl/blackandwhitepicture/BlackAndWhitePicture-Regular.ttf"]
+];
+blackhansans = mkFont "blackhansans" "ofl" [
+  ["rKjM9zmzMJ4fLCm8WKzaBGXDkqstJU9iTkX/2rdXcGw=" "ofl/blackhansans/BlackHanSans-Regular.ttf"]
+];
+blackopsone = mkFont "blackopsone" "ofl" [
+  ["KCqCW18pQ3c4fjlp92VAgVfb6o2g9dCq5oxrxwSxRbM=" "ofl/blackopsone/BlackOpsOne-Regular.ttf"]
+];
+blakahollow = mkFont "blakahollow" "ofl" [
+  ["UlUYl6G/7HYwOyd/BJnF2Mz4A0CeD19JdZoogXTkU0U=" "ofl/blakahollow/BlakaHollow-Regular.ttf"]
+];
+blakaink = mkFont "blakaink" "ofl" [
+  ["YCg6+s2wqLb5+dS6LKhxRyBNCYnn7sTdMmgzSvz/cnQ=" "ofl/blakaink/BlakaInk-Regular.ttf"]
+];
+blaka = mkFont "blaka" "ofl" [
+  ["9UxlAG3/gf4yytN4UcKLqWhC0XPS9/04q2Qo6ZE9o7U=" "ofl/blaka/Blaka-Regular.ttf"]
+];
+blinker = mkFont "blinker" "ofl" [
+  ["mQcN6Xefct9Og2uN/3erodthAsQfCT0gDF138zaxYXQ=" "ofl/blinker/Blinker-ExtraLight.ttf"]
+  ["qacB6xjL1feG8o+YbBaJX/wNAzfkqaYxMbYZ2VQuB9Q=" "ofl/blinker/Blinker-SemiBold.ttf"]
+  ["2nw+QrUCtURSY9SSta3N/wHmVth77d+MxbrlZXiYZko=" "ofl/blinker/Blinker-Bold.ttf"]
+  ["Kq2zv4hMD2DB/M+GHMxMMa5P9CyHsjREzZeSRtaGMSk=" "ofl/blinker/Blinker-ExtraBold.ttf"]
+  ["a4o4IYFVsfs3v9wQ1f8u+BU3Ltma7vPE5a67OeyNRx0=" "ofl/blinker/Blinker-Light.ttf"]
+  ["Ly2jmIyEN48RVoiFyXDEQqcmO85je9W9SwLsBkxXU8A=" "ofl/blinker/Blinker-Regular.ttf"]
+  ["lARyPzoaLGAMKxyoujvaofzDSM3KqUMBGB+X42jP/0k=" "ofl/blinker/Blinker-Black.ttf"]
+  ["PgYIfg9iSWrJnxTectS+5xjvKLmtgk68HXn8iVbTAog=" "ofl/blinker/Blinker-Thin.ttf"]
+];
+bodonimoda = mkFont "bodonimoda" "ofl" [
+  ["r3U5DBP2cxZT7ME1pfZQZ8IjlF7a3Mi0C4J9OVWVnhs=" "ofl/bodonimoda/BodoniModa-Italic%5Bopsz,wght%5D.ttf"]
+  ["WuIkHWMirYF4aospdaPjF6KnVVF+sb4mtmBQmJYOLjU=" "ofl/bodonimoda/BodoniModa%5Bopsz,wght%5D.ttf"]
+];
+bokor = mkFont "bokor" "ofl" [
+  ["ZA1HWr3RCb/YDS7viS/hxj0+wPrdzRX4GcXxcpcSw3A=" "ofl/bokor/Bokor-Regular.ttf"]
+];
+bonanova = mkFont "bonanova" "ofl" [
+  ["xZzLO6jwFRI2sbQntYvuDJBgfILvdHzG4Z1eIBODhd0=" "ofl/bonanova/BonaNova-Bold.ttf"]
+  ["DWHBYKUhsHLRrxnpaDdU8/V2G7zjX3P98JHs30lbxsI=" "ofl/bonanova/BonaNova-Italic.ttf"]
+  ["1y93Fba2YJbgzClx5JVPi+M73O0fFD+cVzmgPNtgvt4=" "ofl/bonanova/BonaNova-Regular.ttf"]
+];
+bonbon = mkFont "bonbon" "ofl" [
+  ["cYdT9xRGjoeLKvHILsZbaMYM6BcyMIlXw+kNWbznzpg=" "ofl/bonbon/Bonbon-Regular.ttf"]
+];
+bonheurroyale = mkFont "bonheurroyale" "ofl" [
+  ["w38oR8LXJuJUdir+JjVO1tm5rIjKpMNHOonu81n9KHg=" "ofl/bonheurroyale/BonheurRoyale-Regular.ttf"]
+];
+boogaloo = mkFont "boogaloo" "ofl" [
+  ["w4/r93C+wrjjDqa8Hds5ybDODoYl2Uzur7468ccJbZ0=" "ofl/boogaloo/Boogaloo-Regular.ttf"]
+];
+bowlbyone = mkFont "bowlbyone" "ofl" [
+  ["xGqAbXtR/UmH5fC+RJ/kCpRMtAfkMpDOHN7tApqM3B0=" "ofl/bowlbyone/BowlbyOne-Regular.ttf"]
+];
+bowlbyonesc = mkFont "bowlbyonesc" "ofl" [
+  ["3J8jJftrqzJ8JmGadSsnS48PQCJ1bYlkUJEeiFYJ8HE=" "ofl/bowlbyonesc/BowlbyOneSC-Regular.ttf"]
+];
+brawler = mkFont "brawler" "ofl" [
+  ["X3/O5m74TIsn+St825cwOaYZSrPvzOSzKOR1XMtnaDE=" "ofl/brawler/Brawler-Regular.ttf"]
+  ["hg2fUJTEa9UIvAR32nM0Yb9euPRmCAkJo9Qv/LZ5I64=" "ofl/brawler/Brawler-Bold.ttf"]
+];
+breeserif = mkFont "breeserif" "ofl" [
+  ["/QgFgtcBEu9Hm6Td1yQH+aT8vOxMqn0p3iWbE+619DE=" "ofl/breeserif/BreeSerif-Regular.ttf"]
+];
+brunoace = mkFont "brunoace" "ofl" [
+  ["i397eKg7DtZVtHnmpsyOGxM/Jx4vEIgtvC4FAXlOxx4=" "ofl/brunoace/BrunoAce-Regular.ttf"]
+];
+brunoacesc = mkFont "brunoacesc" "ofl" [
+  ["pfCYFhVAhZe0zEjRnFHWiAavLoMc3AsdWJx8WIKHQ7E=" "ofl/brunoacesc/BrunoAceSC-Regular.ttf"]
+];
+brygada1918 = mkFont "brygada1918" "ofl" [
+  ["k6I+fG3l4sVEEBFqvO7SlKBbcaoDr1L7qpLCzHkAPU0=" "ofl/brygada1918/Brygada1918%5Bwght%5D.ttf"]
+  ["xpTwdakkDEfHKiKYrPnBT3mr33uugk7KlreAmdvtk8U=" "ofl/brygada1918/Brygada1918-Italic%5Bwght%5D.ttf"]
+];
+bubblegumsans = mkFont "bubblegumsans" "ofl" [
+  ["240cccOYJm7KvprkkjxP6xMjRBpPBWqTOeQdj4R70MA=" "ofl/bubblegumsans/BubblegumSans-Regular.ttf"]
+];
+bubblerone = mkFont "bubblerone" "ofl" [
+  ["eZTGN5wEBaups0WfOvoHWVkpfipbPggntBqCxTUw1Ow=" "ofl/bubblerone/BubblerOne-Regular.ttf"]
+];
+buda = mkFont "buda" "ofl" [
+  ["HIqbtS9p26O2aWG3ksA+VAf0gHC/n/hDYQMIL23WpyA=" "ofl/buda/Buda-Light.ttf"]
+];
+buenard = mkFont "buenard" "ofl" [
+  ["UL8DfWiwjNmzK4fl9bUexJDxlv+bJbnPtnM9JO3WhXc=" "ofl/buenard/Buenard-Regular.ttf"]
+  ["xxvwj+YtVvdL/Ws1xFWPV2hHNexrnP/G9rQMz5sGkfA=" "ofl/buenard/Buenard-Bold.ttf"]
+];
+bungeecolor = mkFont "bungeecolor" "ofl" [
+  ["zyGnhuVPQ2lPTtu1Gjj4EzGkw0FCF8UkyMstCRqn/WM=" "ofl/bungeecolor/BungeeColor-Regular.ttf"]
+];
+bungeehairline = mkFont "bungeehairline" "ofl" [
+  ["pfsld4u/wWnqgJqHtLp0hlvThgGd94Wgd3tEvLaz/cM=" "ofl/bungeehairline/BungeeHairline-Regular.ttf"]
+];
+bungeeinline = mkFont "bungeeinline" "ofl" [
+  ["9JhUm6hk2oOt768TDtbxzUW6QbI3R5mpAYFPwfshiHY=" "ofl/bungeeinline/BungeeInline-Regular.ttf"]
+];
+bungee = mkFont "bungee" "ofl" [
+  ["2qXG3tPwMEO6HbNDup+Qo/xkef5H+w0+aN2vVLFx/Zw=" "ofl/bungee/Bungee-Regular.ttf"]
+];
+bungeeoutline = mkFont "bungeeoutline" "ofl" [
+  ["sPtCsKDs2DO31HRxhGMaWWj1ogJXIdJkwO8Tq1WApsw=" "ofl/bungeeoutline/BungeeOutline-Regular.ttf"]
+];
+bungeeshade = mkFont "bungeeshade" "ofl" [
+  ["zE4I2ViIU5D6EF/Lx/YUrY1IAwPpeO9jyCxTE5gMJ8E=" "ofl/bungeeshade/BungeeShade-Regular.ttf"]
+];
+bungeespice = mkFont "bungeespice" "ofl" [
+  ["gYWuM1zBEVbjD9RkTgYLs2bzc/co2JZWOWO8Gd1kYfc=" "ofl/bungeespice/BungeeSpice-Regular.ttf"]
+];
+butcherman = mkFont "butcherman" "ofl" [
+  ["uM7l4s3HH0TmgG3A2xCQo84uSMpycHIHNwC/ZGsM5rU=" "ofl/butcherman/Butcherman-Regular.ttf"]
+];
+butterflykids = mkFont "butterflykids" "ofl" [
+  ["ShMfScPZDoFuZEfSRAkOssNs2/Jr5TJUJxzN8tjREbk=" "ofl/butterflykids/ButterflyKids-Regular.ttf"]
+];
+cabincondensed = mkFont "cabincondensed" "ofl" [
+  ["Vcd1nN5iRF/mDTbfgS+DrS9yCSligEDyoDbh6MbkhnE=" "ofl/cabincondensed/CabinCondensed-Bold.ttf"]
+  ["pzuJ11DwOvimzYeDZ4zRY+x4+eLGA9I4lUj7uN/F1is=" "ofl/cabincondensed/CabinCondensed-SemiBold.ttf"]
+  ["CEdcxzcFXxwI6x+8rQhKvZ1NA0LLVbOnbpEUyrma2eI=" "ofl/cabincondensed/CabinCondensed-Medium.ttf"]
+  ["060soYcrw6hmS6kTMUsvhf7wFdCnyzAHp8pkILhOV00=" "ofl/cabincondensed/CabinCondensed-Regular.ttf"]
+];
+cabin = mkFont "cabin" "ofl" [
+  ["8DPMQ5G9y7Z0FpyZfjyvvzQXsf15Ch2b0x6voMqK/qQ=" "ofl/cabin/Cabin-Italic%5Bwdth,wght%5D.ttf"]
+  ["oWV25s7AHPmUxGg47RwX/9tiz22oQw7fvLAR9X3WJFc=" "ofl/cabin/Cabin%5Bwdth,wght%5D.ttf"]
+];
+cabinsketch = mkFont "cabinsketch" "ofl" [
+  ["pvmJ/MkQyjIeBs1qINvKsg+eQbzghJEUMoV8/ihjVec=" "ofl/cabinsketch/CabinSketch-Regular.ttf"]
+  ["CWFogDe5eUdJXC415uWpPysjRJBRTjM0ZgX/7fnH5r4=" "ofl/cabinsketch/CabinSketch-Bold.ttf"]
+];
+caesardressing = mkFont "caesardressing" "ofl" [
+  ["AJ3qJKTUo6fgLWgwh7q7FziswLlJzOOMSF+rMlyekpU=" "ofl/caesardressing/CaesarDressing-Regular.ttf"]
+];
+cagliostro = mkFont "cagliostro" "ofl" [
+  ["DSBemps0aR3KUAZOpoFAQVfxdH45tZL86XiyoyvV+2E=" "ofl/cagliostro/Cagliostro-Regular.ttf"]
+];
+cairo = mkFont "cairo" "ofl" [
+  ["qCR4OOEIcyF/Fm3NPrEMng2Abrq8QaVgBgc6PIoKFTE=" "ofl/cairo/Cairo%5Bslnt,wght%5D.ttf"]
+];
+cairoplay = mkFont "cairoplay" "ofl" [
+  ["ZMBB8tX/e8cp43opUmkcTcYYQeBpNF/UqYa/H0uh3IY=" "ofl/cairoplay/CairoPlay%5Bslnt,wght%5D.ttf"]
+];
+caladea = mkFont "caladea" "ofl" [
+  ["rjyy3LySWAndKdKkTpgCIRyrZr5UG6y/ycCMdLJ8N0I=" "ofl/caladea/Caladea-Bold.ttf"]
+  ["zKuqe34v3yU9Kxpfppndij342DWp6yha2CYxpnfrdsA=" "ofl/caladea/Caladea-BoldItalic.ttf"]
+  ["Q1mo4k90i2RHsf9tehdP6+cJYdKfi7hjS1bazXQKPes=" "ofl/caladea/Caladea-Italic.ttf"]
+  ["8eiZJ4t7RJGrpbaoJTxLBMBQzFmyGGW+XDdVmndRU80=" "ofl/caladea/Caladea-Regular.ttf"]
+];
+calistoga = mkFont "calistoga" "ofl" [
+  ["Ok7zhGOMnLalGwFtJI6Mxf2+gf6HRJvVlE3SABsTFxw=" "ofl/calistoga/Calistoga-Regular.ttf"]
+];
+calligraffitti = mkFont "calligraffitti" "asl20" [
+  ["1sBGToxT3Y/vyn7jrxqiwgxs9qQORTfSzUNTv/OhaNA=" "apache/calligraffitti/Calligraffitti-Regular.ttf"]
+];
+cambay = mkFont "cambay" "ofl" [
+  ["Rz+vcWMKobQR+piHlR0beyZ076E35ml81xr8K/F9TVU=" "ofl/cambay/Cambay-Regular.ttf"]
+  ["SlMQqNh/eQn6RleU+rYNw3qrXt6CFP9+6pXzbHoriXQ=" "ofl/cambay/Cambay-BoldItalic.ttf"]
+  ["4pRodEgb9ePyjG7GWpK8UprZyieHb+e8yosPBLVBC7M=" "ofl/cambay/Cambay-Italic.ttf"]
+  ["dbiDUyfbd42iOgKa0Hgr3p+CVn+QL5zwzR4Y76D6lrw=" "ofl/cambay/Cambay-Bold.ttf"]
+];
+cambo = mkFont "cambo" "ofl" [
+  ["UmyAqNAGeD6JlTcxSXKsQ0SbUg9TuWvvwXxHF16bLio=" "ofl/cambo/Cambo-Regular.ttf"]
+];
+candal = mkFont "candal" "ofl" [
+  ["z0/0JcSasuFn+30Wa6V/KSW232Fhoih4aykeo4dfHrU=" "ofl/candal/Candal.ttf"]
+];
+cantarell = mkFont "cantarell" "ofl" [
+  ["ETeXAHoLqp6romiN5AtR8dkH9cTyrdYc/SWl5iYVNhM=" "ofl/cantarell/Cantarell-Italic.ttf"]
+  ["hAolV3kliisktePR8yqCHtZB/dXvHkfE3BgAZNucz6E=" "ofl/cantarell/Cantarell-Regular.ttf"]
+  ["GxXUrNIN9jZ1W6+h4CbnP7J3dAqidEIZh5X88NHLmBg=" "ofl/cantarell/Cantarell-Bold.ttf"]
+  ["kT30l13l4wSiOVx+G5yZTa1LyT8egLlOyGYhE9h9Pjs=" "ofl/cantarell/Cantarell-BoldItalic.ttf"]
+];
+cantataone = mkFont "cantataone" "ofl" [
+  ["4S3zWuiKPgiYQiEQMB4Lf/TFSkwSm5IHeuf0VvRbo9s=" "ofl/cantataone/CantataOne-Regular.ttf"]
+];
+cantoraone = mkFont "cantoraone" "ofl" [
+  ["eOkXT2fbPgwe++C1cMNUa8gF7UOg+y2+xKyngxyvHxU=" "ofl/cantoraone/CantoraOne-Regular.ttf"]
+];
+capriola = mkFont "capriola" "ofl" [
+  ["Sm4ae2s0hSZ07w/9L3BJqQPmi0nTUztvZRytA530Iog=" "ofl/capriola/Capriola-Regular.ttf"]
+];
+caramel = mkFont "caramel" "ofl" [
+  ["NqRg+EGNX5cQ2kNAR3b8kU/hH/XsZJ6ci8tnDGArkr4=" "ofl/caramel/Caramel-Regular.ttf"]
+];
+carattere = mkFont "carattere" "ofl" [
+  ["LuB1tQp1rq6g2XbZFrU1+81COmhOl/6FNv2Pnv6QWuY=" "ofl/carattere/Carattere-Regular.ttf"]
+];
+cardo = mkFont "cardo" "ofl" [
+  ["vLgfN28cOJLHAm2r8r6vvRp+6K6V0TLufU/318OYgmE=" "ofl/cardo/Cardo-Regular.ttf"]
+  ["bJODsUcZNu6DsItnv3nw7ZK+49XoNj7DuiEwnVonLjY=" "ofl/cardo/Cardo-Bold.ttf"]
+  ["UsUc/eOoJ92UKFEcSpaGmZUripF8Xw6Xvngsv6GID5w=" "ofl/cardo/Cardo-Italic.ttf"]
+];
+carme = mkFont "carme" "ofl" [
+  ["K+Muvo9ilEsd8PG/DHaVe9o2lWe5lFTXSeURkqOT25A=" "ofl/carme/Carme-Regular.ttf"]
+];
+carroisgothic = mkFont "carroisgothic" "ofl" [
+  ["X6OIheqfnqLUIxnR6IzpFw1nuFjaemeidARg0V1/z/g=" "ofl/carroisgothic/CarroisGothic-Regular.ttf"]
+];
+carroisgothicsc = mkFont "carroisgothicsc" "ofl" [
+  ["Pfxf55erPgQycofZ264xOEdiNnBBfoUNOeJGYgcfHJg=" "ofl/carroisgothicsc/CarroisGothicSC-Regular.ttf"]
+];
+carterone = mkFont "carterone" "ofl" [
+  ["kmezLlcZJLWXejv7BocmYDoe7PKvja28QmLpQ7U5Wcg=" "ofl/carterone/CarterOne.ttf"]
+];
+castoro = mkFont "castoro" "ofl" [
+  ["rgeh+iSVQ4v97/HzATwQly7wbuRe5QREdWz2bxxhF6s=" "ofl/castoro/Castoro-Regular.ttf"]
+  ["hotabxokoWLmWZk2H9Hdb/gr8UsOYDoqck5acqQiliQ=" "ofl/castoro/Castoro-Italic.ttf"]
+];
+catamaran = mkFont "catamaran" "ofl" [
+  ["9u4zHDgfRBRUIlGW15MNTQoxVU1/H5yMWBScqeEispQ=" "ofl/catamaran/Catamaran%5Bwght%5D.ttf"]
+];
+caudex = mkFont "caudex" "ofl" [
+  ["/6R/Yl10bnt1wjBrdXLyJWHh1zMSo3V3IyXJghPgpPk=" "ofl/caudex/Caudex-Italic.ttf"]
+  ["iA+2eQHOlFc+0CYtFSuHEVoI+SjHL8bBEBN1oSI9OQo=" "ofl/caudex/Caudex-Bold.ttf"]
+  ["27ST4a3FCq7FIHFTXm/M9Bdnk8eVRfVNlagSy/uFFps=" "ofl/caudex/Caudex-Regular.ttf"]
+  ["eEQOirZzBYGscf54CtL6FboV0kAxMChnjkBKzk5w6yA=" "ofl/caudex/Caudex-BoldItalic.ttf"]
+];
+caveatbrush = mkFont "caveatbrush" "ofl" [
+  ["5WW9e//Ylcpk+NHLd8gWubONnAECRjhqB8lkhZL28oI=" "ofl/caveatbrush/CaveatBrush-Regular.ttf"]
+];
+caveat = mkFont "caveat" "ofl" [
+  ["C9trZgSC0xUxs5RYSfulkWs++GldpwJKnmue48QVeYg=" "ofl/caveat/Caveat%5Bwght%5D.ttf"]
+];
+cedarvillecursive = mkFont "cedarvillecursive" "ofl" [
+  ["X4bXHQimhgXVkSuby2OaBgzpwN69fgtxX14mjUpLwxc=" "ofl/cedarvillecursive/Cedarville-Cursive.ttf"]
+];
+cevicheone = mkFont "cevicheone" "ofl" [
+  ["NmJJyRHmic1eo9V2wOugw3qTjgpYch/ONzOkJE3ZqzI=" "ofl/cevicheone/CevicheOne-Regular.ttf"]
+];
+chakrapetch = mkFont "chakrapetch" "ofl" [
+  ["1ID0+XQF+sNgBlLi4U/QsUM5AxwK9NoRWCmUh48E2Rk=" "ofl/chakrapetch/ChakraPetch-Medium.ttf"]
+  ["Z+QmSI4iHV2eWjtio0tF8fU02r0QeL3Hf83+Q2MMvuA=" "ofl/chakrapetch/ChakraPetch-LightItalic.ttf"]
+  ["OpGFtnNYl66zj90TKq52GpCSABx2FayeIjgTG/mwme0=" "ofl/chakrapetch/ChakraPetch-MediumItalic.ttf"]
+  ["Ou6kjw/6sNatjTzQy5wM65jsvPNjUhzlb87qUey7HR8=" "ofl/chakrapetch/ChakraPetch-Italic.ttf"]
+  ["vwEs4YlP/PfTLT5lSLkN98QPMBYbXMKV61T/YcIfqxk=" "ofl/chakrapetch/ChakraPetch-BoldItalic.ttf"]
+  ["Zfv3bZVlFpcnXhnbTXF8DpWnid3TR2R4sFKSEE2yeKA=" "ofl/chakrapetch/ChakraPetch-Bold.ttf"]
+  ["G7r49vnzLcq7cjBxrn/KcvXGahBvJhPyvZIQci3r7DY=" "ofl/chakrapetch/ChakraPetch-ExtraLight.ttf"]
+  ["+Sfj1NmsQBZfMCOAefqIcFZpGsOz3VxqH0teUMMyCog=" "ofl/chakrapetch/ChakraPetch-ExtraLightItalic.ttf"]
+  ["RSZN4yBN29X7PhSiQCrNXGMNFmUK5fwiHSxS2kamc0s=" "ofl/chakrapetch/ChakraPetch-SemiBold.ttf"]
+  ["ThHBvscVEbvqijvD9M6/9Hm7loGWHWkaNvmeUjTY/ok=" "ofl/chakrapetch/ChakraPetch-SemiBoldItalic.ttf"]
+  ["mPzWOLqlyB/wMWt1OM4zDuOyOxMCcm3jUm1ZM6js+YY=" "ofl/chakrapetch/ChakraPetch-Regular.ttf"]
+  ["E6EGo2e5A/tQntEefJIViaDULCJUBRDTyo9sc0O+92s=" "ofl/chakrapetch/ChakraPetch-Light.ttf"]
+];
+changa = mkFont "changa" "ofl" [
+  ["fE96FNS3CsiBbqjfOgsSeu5MX1r3I5rKKv7MhN3H9NM=" "ofl/changa/Changa%5Bwght%5D.ttf"]
+];
+changaone = mkFont "changaone" "ofl" [
+  ["esTSajpFtHMZBLWcu4qcwVt7cNRH/Ctd2kDvF8XS4W0=" "ofl/changaone/ChangaOne-Regular.ttf"]
+  ["tiKPUPcgZReVyYqiTPk78GL+5YmQhKnmDxFas4hvVYM=" "ofl/changaone/ChangaOne-Italic.ttf"]
+];
+chango = mkFont "chango" "ofl" [
+  ["PlZvS4gfJBmP4bZSWq6XD5IAB4E240FqvHugJy0vgNk=" "ofl/chango/Chango-Regular.ttf"]
+];
+charissil = mkFont "charissil" "ofl" [
+  ["rN9txUwO5eA8rjOY9kEzwzUITNHsq2VfKoY2xdVqzts=" "ofl/charissil/CharisSIL-BoldItalic.ttf"]
+  ["NGM3N0qjR9ZO4BWybUQfGXDYYxkU4vOUGwDhxHYeKMU=" "ofl/charissil/CharisSIL-Regular.ttf"]
+  ["aEYNK3bI94G0n5Fo8sfcPJ97eIo6G48mfF+mu0fVxk0=" "ofl/charissil/CharisSIL-Bold.ttf"]
+  ["53bilhEXs5z5JMATneAXSKd7L8uZxDeyx3vdlAFgbBM=" "ofl/charissil/CharisSIL-Italic.ttf"]
+];
+charm = mkFont "charm" "ofl" [
+  ["bh+pL9p6t0/M6O1dep3hCg+0PXd1kOjvn2kx2m6TJIE=" "ofl/charm/Charm-Bold.ttf"]
+  ["2q4QLkESQzdwFtvrjLnVMIfRMHQGT+eWWK+pZqmsMw4=" "ofl/charm/Charm-Regular.ttf"]
+];
+charmonman = mkFont "charmonman" "ofl" [
+  ["fsVXXGyHpr5p3ng5s+zRAnt7plEK0+SbwwtzzJ7hvOA=" "ofl/charmonman/Charmonman-Regular.ttf"]
+  ["i/T4IpiZcBBmLeNc7FBMBQRFblHT2ammtPN4jksEq+4=" "ofl/charmonman/Charmonman-Bold.ttf"]
+];
+chathura = mkFont "chathura" "ofl" [
+  ["/6YmZCamM50ty5rnzNDQb1Ng6RyaZ9sll9cLC9LhCq0=" "ofl/chathura/Chathura-Thin.ttf"]
+  ["Ckk8ladMwT9nZtvy3kxH3aDERsX8DWV2uXDXiQzp+ao=" "ofl/chathura/Chathura-Bold.ttf"]
+  ["r/Oqsj8gIJLUEdrlSmEpaN7jnPQRwNgEnmqeqZ9+LBQ=" "ofl/chathura/Chathura-Regular.ttf"]
+  ["qZi6pYDiU0DhpEo0PGKg8Qb0dj5+DPFT8nn7bJZaEi0=" "ofl/chathura/Chathura-Light.ttf"]
+  ["gyOmipuZlAzlAJUDUDwKdbc5rC4edn4yxLNbILChY/w=" "ofl/chathura/Chathura-ExtraBold.ttf"]
+];
+chauphilomeneone = mkFont "chauphilomeneone" "ofl" [
+  ["K5//qpnyKEmO4QS6tSTXky6xxJ3WNea+KgYMjsmZycw=" "ofl/chauphilomeneone/ChauPhilomeneOne-Regular.ttf"]
+  ["SgEMyx8xc3ftn0tHYEECpds+UFM9N9gF0zIuVnlyGOA=" "ofl/chauphilomeneone/ChauPhilomeneOne-Italic.ttf"]
+];
+chelaone = mkFont "chelaone" "ofl" [
+  ["pWM/KJRfMaXklGg68sH5n5+RyWV4v0fcnDFevjBQyPU=" "ofl/chelaone/ChelaOne-Regular.ttf"]
+];
+chelseamarket = mkFont "chelseamarket" "ofl" [
+  ["ckO+KaLXTmqCbhCR90yJ5YzIAQBHxtuN4T9hboGx9fI=" "ofl/chelseamarket/ChelseaMarket-Regular.ttf"]
+];
+chenla = mkFont "chenla" "ofl" [
+  ["AXTNosdxjhKbnyWZzX3ZJlsBpjuaz2f5OYgvD93/Kbc=" "ofl/chenla/Chenla.ttf"]
+];
+cherish = mkFont "cherish" "ofl" [
+  ["XWWIpRaCBXMpVmuvEqEcQF3qdxqdzsYaxf6ag9nbaxM=" "ofl/cherish/Cherish-Regular.ttf"]
+];
+cherrybombone = mkFont "cherrybombone" "ofl" [
+  ["lZbGeT6wM1BX1lWxN1HOfMtQ7wzRXLUsWEZfti3iu48=" "ofl/cherrybombone/CherryBombOne-Regular.ttf"]
+];
+cherrycreamsoda = mkFont "cherrycreamsoda" "asl20" [
+  ["FYV3s4POl5g4RYC9QcNc0PtO1VCjL+Si5B9PJZQzc4U=" "apache/cherrycreamsoda/CherryCreamSoda-Regular.ttf"]
+];
+cherryswash = mkFont "cherryswash" "ofl" [
+  ["zpgkPUKBY74NWfwC0xM1B81a/njFAaoyDAnF3qp4pKM=" "ofl/cherryswash/CherrySwash-Regular.ttf"]
+  ["XMoyPCmoDhlACga+fAxG4Z24/ylmy7/34F6sMzVBJLo=" "ofl/cherryswash/CherrySwash-Bold.ttf"]
+];
+chewy = mkFont "chewy" "asl20" [
+  ["fPdeooj4L9ILreqKtNp6ZWqWpyd8FwgR6BOz09YpQUc=" "apache/chewy/Chewy-Regular.ttf"]
+];
+chicle = mkFont "chicle" "ofl" [
+  ["LIJJS4bT8DghKE1g8iCaMyGK3eDa1xM84+sGO0NjNys=" "ofl/chicle/Chicle-Regular.ttf"]
+];
+chilanka = mkFont "chilanka" "ofl" [
+  ["EN6TMK0LrnT3hqI7d2HVOHZ9cV97W5fTuH5f7lgAKsI=" "ofl/chilanka/Chilanka-Regular.ttf"]
+];
+chivomono = mkFont "chivomono" "ofl" [
+  ["5sPlRp2Z/uhkQUhF2V72qi+xZhIb3ddIbWlYxKVOOuo=" "ofl/chivomono/ChivoMono-Italic%5Bwght%5D.ttf"]
+  ["clJW8wt7GyXdABqW/41KI3cxl7uIbNhHqX/46rycHZ0=" "ofl/chivomono/ChivoMono%5Bwght%5D.ttf"]
+];
+chivo = mkFont "chivo" "ofl" [
+  ["UCM54c2nfiS1zUahqHXkxebyDqAZwkj1fyNCNScDD/M=" "ofl/chivo/Chivo-Italic%5Bwght%5D.ttf"]
+  ["gBZ0y+/3SQEaAYayyTLckVgYeoykymWY2yofXHxDQtE=" "ofl/chivo/Chivo%5Bwght%5D.ttf"]
+];
+chokokutai = mkFont "chokokutai" "ofl" [
+  ["xiK5cdG9stjNZPl4dG5tUtNhQXrkIiwnXLV1SeNOCX4=" "ofl/chokokutai/Chokokutai-Regular.ttf"]
+];
+chonburi = mkFont "chonburi" "ofl" [
+  ["qg2sTfCK8QeFuh3BASFJIif45CiPCiPRHdHR9af26/o=" "ofl/chonburi/Chonburi-Regular.ttf"]
+];
+cinzeldecorative = mkFont "cinzeldecorative" "ofl" [
+  ["psHrPiKPY5qYqv2KjooDVYLdUK1fioTp3LyGZOdFcRQ=" "ofl/cinzeldecorative/CinzelDecorative-Black.ttf"]
+  ["W4Yr4ykQOtKHoQ8KU+J6QOjMUZmZJT8aAiPi3DMLELg=" "ofl/cinzeldecorative/CinzelDecorative-Regular.ttf"]
+  ["6FTmijiKpQ10KkQVwa5cF6YX73lWyVpwAh0KSkTyBRg=" "ofl/cinzeldecorative/CinzelDecorative-Bold.ttf"]
+];
+cinzel = mkFont "cinzel" "ofl" [
+  ["9Ng9NNH2x0EZPkrPSz3/lTHlpntqplIo0Ap9typODzQ=" "ofl/cinzel/Cinzel%5Bwght%5D.ttf"]
+];
+clickerscript = mkFont "clickerscript" "ofl" [
+  ["AiHUN2/AoleVoy1+MJeYtmk7VvZcWFH5JSkEOyMKkRc=" "ofl/clickerscript/ClickerScript-Regular.ttf"]
+];
+climatecrisis = mkFont "climatecrisis" "ofl" [
+  ["pKgC7s6SsTEpajgXe1THTyWBrXJfLHP+UbhqMcjOUrY=" "ofl/climatecrisis/ClimateCrisis%5BYEAR%5D.ttf"]
+];
+codacaption = mkFont "codacaption" "ofl" [
+  ["wIxviFhkiWBHzivi4s50QGfjoNh/D3aSnvqp9w7q5XY=" "ofl/codacaption/CodaCaption-ExtraBold.ttf"]
+];
+coda = mkFont "coda" "ofl" [
+  ["9dMq6dXHjNq351pSvR2geuImRFlyMtCFpc580a80Hhc=" "ofl/coda/Coda-Regular.ttf"]
+  ["NZCeTGkH4TkdCbqpNMXnpKuyMt7epY5HrKpK7NFlxlw=" "ofl/coda/Coda-ExtraBold.ttf"]
+];
+codystar = mkFont "codystar" "ofl" [
+  ["+h/PTwDzw1uCIZMgojIvVhvJ5/Wube1JiiiVj1wHo8A=" "ofl/codystar/Codystar-Light.ttf"]
+  ["mfBZo+Ma/a8/6lPTm8YrFd84pdiCEErh0aXKLfVHwQo=" "ofl/codystar/Codystar-Regular.ttf"]
+];
+coiny = mkFont "coiny" "ofl" [
+  ["7wLXI6VKvkgZvqVOqLLs9y130lgBC7M2zUhio3cF6sc=" "ofl/coiny/Coiny-Regular.ttf"]
+];
+combo = mkFont "combo" "ofl" [
+  ["5xRnQRfChkv3QH4uv6+xHlgel0gChvoBtBmt2pTQhoY=" "ofl/combo/Combo-Regular.ttf"]
+];
+comfortaa = mkFont "comfortaa" "ofl" [
+  ["D8P0XcSLYU25w5GBUCVEs3IX7L+L7i+zWIaZK8lsW9M=" "ofl/comfortaa/Comfortaa%5Bwght%5D.ttf"]
+];
+comforterbrush = mkFont "comforterbrush" "ofl" [
+  ["e9NX3Iv4PXHyf9UVXs5cjBAKIELUUw5Eh2NUc8WDb5U=" "ofl/comforterbrush/ComforterBrush-Regular.ttf"]
+];
+comforter = mkFont "comforter" "ofl" [
+  ["KFLahbL7/TfM2HOH81eKJRy5qIFPurIsRIf3kpNqImc=" "ofl/comforter/Comforter-Regular.ttf"]
+];
+comicneue = mkFont "comicneue" "ofl" [
+  ["77kcBtzMJk8H+ADAaR1AyU6M/OYYPareBwkmi+wXj3Y=" "ofl/comicneue/ComicNeue-Light.ttf"]
+  ["Pn5fzP1+B4jzF7QzEhUcG9XPBYyWl6jYPqw5OQUL1h4=" "ofl/comicneue/ComicNeue-Bold.ttf"]
+  ["ptNrruCccCWRbdtReDVFjRXviQKRUHGXpUh1zMCWuSc=" "ofl/comicneue/ComicNeue-LightItalic.ttf"]
+  ["oO5aN8iyfE2wcAE32ShZix4jsAieFUaolhkJF2t3k2A=" "ofl/comicneue/ComicNeue-Regular.ttf"]
+  ["XDEsKi+mTu6C87h/z6uPOxKl5ZsEMSRAHTIusyPPvxY=" "ofl/comicneue/ComicNeue-BoldItalic.ttf"]
+  ["4Gv9FVL1yUZMVmVzP/1pI5sFk4hdu54FloilkA94z5g=" "ofl/comicneue/ComicNeue-Italic.ttf"]
+];
+comingsoon = mkFont "comingsoon" "asl20" [
+  ["z4E4j1h/9hIt4acF0QcLjwCrzNumYQhQmQi10QcVBow=" "apache/comingsoon/ComingSoon-Regular.ttf"]
+];
+commissioner = mkFont "commissioner" "ofl" [
+  ["2wEnmm64Z27mJnWk1+Xtv+Xwj7wQk1ji9JdgtwwER9M=" "ofl/commissioner/Commissioner%5BFLAR,VOLM,slnt,wght%5D.ttf"]
+];
+concertone = mkFont "concertone" "ofl" [
+  ["FlHgX7qadbEKXFxb2D3mQsvUfoIKljmj8VksjrXQNCw=" "ofl/concertone/ConcertOne-Regular.ttf"]
+];
+condiment = mkFont "condiment" "ofl" [
+  ["+xKXhzn+OCTpWz5fc5rmI/iI9xX+REgRF/s0Nr6aS10=" "ofl/condiment/Condiment-Regular.ttf"]
+];
+content = mkFont "content" "ofl" [
+  ["MkLWsiIB5pGceEptldAoS8Nu9rOHhf4AKoz6sYo/hB8=" "ofl/content/Content-Bold.ttf"]
+  ["tHDbnUzmFHID/5F8PrrfPTHrx4gBo1qsT3wJC/m2eAI=" "ofl/content/Content-Regular.ttf"]
+];
+contrailone = mkFont "contrailone" "ofl" [
+  ["p2Ze3bBoUHc29ZPKjrn1R9uKjWHqHPA+ByVUqrWg6LE=" "ofl/contrailone/ContrailOne-Regular.ttf"]
+];
+convergence = mkFont "convergence" "ofl" [
+  ["Thc1UihhAELmki238Z2dh+uZtPCbo6Er6KKAC60OmQQ=" "ofl/convergence/Convergence-Regular.ttf"]
+];
+cookie = mkFont "cookie" "ofl" [
+  ["na88yeXv4bZQlM3x8Ucp728Hpwwn7gZ5v39USoKLCA4=" "ofl/cookie/Cookie-Regular.ttf"]
+];
+copse = mkFont "copse" "ofl" [
+  ["uFLmgvDGbeTbGDX4VF/y6UdhVJmHpGB0R7Bp6XP1Cx0=" "ofl/copse/Copse-Regular.ttf"]
+];
+corben = mkFont "corben" "ofl" [
+  ["3Swml6j5NqQ7XworrhvILNr0D4pfwdFcHs1WKz6hYEQ=" "ofl/corben/Corben-Regular.ttf"]
+  ["H7WVloK4loBGerYo4vHmNZxgYqy7ftzqFP/MoRJNsPE=" "ofl/corben/Corben-Bold.ttf"]
+];
+corinthia = mkFont "corinthia" "ofl" [
+  ["hsWL+PanFg+ZFBYPs8jfv3XVsUXdCrlDoLgpE4NlFvk=" "ofl/corinthia/Corinthia-Bold.ttf"]
+  ["7irbFypBpSxfa33m3llTv46ea9+lvGQf3dvfTHN/yY4=" "ofl/corinthia/Corinthia-Regular.ttf"]
+];
+cormorantgaramond = mkFont "cormorantgaramond" "ofl" [
+  ["wgUJCJkm2dteVIf6HAa8qQ4lY9MdwtCWcLufQyBSiPI=" "ofl/cormorantgaramond/CormorantGaramond-Medium.ttf"]
+  ["0zYN3Z1+yqXsT7EsXgim0jJGiNiqzZd7D+JwBexJLhk=" "ofl/cormorantgaramond/CormorantGaramond-MediumItalic.ttf"]
+  ["qYv0v/9zty3fS2P0F7TlV6XQ0FL0sqjskcGERgB+qRE=" "ofl/cormorantgaramond/CormorantGaramond-LightItalic.ttf"]
+  ["PyCgeRTFbeFgpAV/j6SOxTctd+3zXBaP5LBUe2ZQIQY=" "ofl/cormorantgaramond/CormorantGaramond-Regular.ttf"]
+  ["omJpPyhye8LlCFn2o8yUmS6FtN8v/sfKO4Rra17wyYU=" "ofl/cormorantgaramond/CormorantGaramond-BoldItalic.ttf"]
+  ["pgJBsYyT9XAqOA4eE83I6ofES+bmP+mLkBhUyerfecs=" "ofl/cormorantgaramond/CormorantGaramond-SemiBoldItalic.ttf"]
+  ["UPzL3CmcIy0l3WaGiiorVf0OhdYjilhjiYbF9m3sob8=" "ofl/cormorantgaramond/CormorantGaramond-Italic.ttf"]
+  ["FZvae6xkyA8CYSwWO8IdoCjp+ZDLxNRpAF3mlEKK7oM=" "ofl/cormorantgaramond/CormorantGaramond-SemiBold.ttf"]
+  ["KIQEis+raCcP4uUWbb3aCtu7EDLzH+SSgRIWdFQ5U5g=" "ofl/cormorantgaramond/CormorantGaramond-Bold.ttf"]
+  ["ch18ra8BzGn46L7fdNmhpQ60F+KaUWhGSzGbVan/GU0=" "ofl/cormorantgaramond/CormorantGaramond-Light.ttf"]
+];
+cormorantinfant = mkFont "cormorantinfant" "ofl" [
+  ["CybipP43DWa5MaGlxeW1cRv6aGH1gktkJrK3tpf6YrE=" "ofl/cormorantinfant/CormorantInfant-SemiBoldItalic.ttf"]
+  ["DZwOQSKLLCasF3k/QkK+pS/ZN9Qlql3YwInQImEwSGc=" "ofl/cormorantinfant/CormorantInfant-Italic.ttf"]
+  ["dbg95qC7p1S1Dkn0xBCaNfgg59N/5K5h9WifvlyMIhg=" "ofl/cormorantinfant/CormorantInfant-Bold.ttf"]
+  ["QnChojXI5tfAJN+SxSTVt+LxNfZKkOqzZea66Gwab6c=" "ofl/cormorantinfant/CormorantInfant-Light.ttf"]
+  ["8bf6t1LVcOPJCHYEgoDxYsJ/xzkqqvWNEOvtNxMLiGk=" "ofl/cormorantinfant/CormorantInfant-Regular.ttf"]
+  ["DyF0ybxxX0fP4YhdZyIZkjqKg6+KLRJfsmwo3/GgfbY=" "ofl/cormorantinfant/CormorantInfant-SemiBold.ttf"]
+  ["iWbl5o7nHpv7Cp00Li5a0wtaPdGQZjFn2YX3Rc51AiI=" "ofl/cormorantinfant/CormorantInfant-BoldItalic.ttf"]
+  ["T9cVo+1zdrQfCj0wQjqnMtgYuJXeajETCj4dyzcq/Ug=" "ofl/cormorantinfant/CormorantInfant-LightItalic.ttf"]
+  ["11kvrLlfzCewutFunEglzJefMYTaFw5KyKCBX4U4X6Q=" "ofl/cormorantinfant/CormorantInfant-Medium.ttf"]
+  ["h2uQaMxHCY9p0Dhv9d5RiOnMk9MzHrrWUJnH/4K2u/Y=" "ofl/cormorantinfant/CormorantInfant-MediumItalic.ttf"]
+];
+cormorant = mkFont "cormorant" "ofl" [
+  ["LE4cQ/oSa1GoQWCBW5Jkr0QsbFMdE7/TwXI3A81IndI=" "ofl/cormorant/Cormorant-Italic%5Bwght%5D.ttf"]
+  ["jxLLIfBbYWSRkur/E+7rG1YZvFJP7q5nL7kWl0JZoHY=" "ofl/cormorant/Cormorant%5Bwght%5D.ttf"]
+];
+cormorantsc = mkFont "cormorantsc" "ofl" [
+  ["ZIzRyTKHHk6OHRR7WTMVQJ6OqCKC+I6Tl+LM6ug9Bls=" "ofl/cormorantsc/CormorantSC-SemiBold.ttf"]
+  ["pRmFoHXziE2NybLSA2fFG2sF5T/bkSlZrLeFCEV5rqo=" "ofl/cormorantsc/CormorantSC-Regular.ttf"]
+  ["ePcMebXAoeZmQdS0ouLtMuGkV3Sz3pTlb43mhRAhkXc=" "ofl/cormorantsc/CormorantSC-Bold.ttf"]
+  ["fsAua2wgaX/Y1QODSUUrbzxijBZECgQVZlDULj/vib8=" "ofl/cormorantsc/CormorantSC-Medium.ttf"]
+  ["09/L8aqSgXQ8sSMpKFGGK0QZYC778pxIZ+aA1Td0oq4=" "ofl/cormorantsc/CormorantSC-Light.ttf"]
+];
+cormorantunicase = mkFont "cormorantunicase" "ofl" [
+  ["uTTl6GXNAwHgvo7xX4UAbVR5+7L6+HUJPdw2STuOqEU=" "ofl/cormorantunicase/CormorantUnicase-Bold.ttf"]
+  ["j63wqd30t9IPvHwzCnQDeEaf5PRCLCJd0j5vxdwCiSE=" "ofl/cormorantunicase/CormorantUnicase-Regular.ttf"]
+  ["PPTxUgOo1u1VnHo6HqEJEO8EmjtIY7Cb2pLZVWFNybU=" "ofl/cormorantunicase/CormorantUnicase-Light.ttf"]
+  ["BXhwiU8WZQWmWHE156JYYlOg7pajUzJQficwrjbcoz8=" "ofl/cormorantunicase/CormorantUnicase-Medium.ttf"]
+  ["jnS0H1W8fg8Zm5EIaRatZO2DtyhDUtX0vTnRjvJ5I4s=" "ofl/cormorantunicase/CormorantUnicase-SemiBold.ttf"]
+];
+cormorantupright = mkFont "cormorantupright" "ofl" [
+  ["adb+oTOgfP3q4OkoFBgiMX3FpFIeVorzLcTtx0VrwdU=" "ofl/cormorantupright/CormorantUpright-Regular.ttf"]
+  ["WF6RBsQz8bTMXQIxAzBRI9knQVJqfifp/4ofW+/MkOY=" "ofl/cormorantupright/CormorantUpright-SemiBold.ttf"]
+  ["S2kUQaNaeOxpSQwEZZbzsyYjXjo/iKVtOyiLTyhEqm8=" "ofl/cormorantupright/CormorantUpright-Bold.ttf"]
+  ["RiOxe/aTaZQOGyEUoqgeWAJxDLPKhLG4Eh+5XY9TtPk=" "ofl/cormorantupright/CormorantUpright-Light.ttf"]
+  ["15MYIEqHvzH3UT/n9h3Rv+uIqpD3/UGWItSlDvhbr8I=" "ofl/cormorantupright/CormorantUpright-Medium.ttf"]
+];
+courgette = mkFont "courgette" "ofl" [
+  ["CZc50i5m7iuAZWu6Y4R/ntQZrX45abosHTxDfA0I8+M=" "ofl/courgette/Courgette-Regular.ttf"]
+];
+courierprime = mkFont "courierprime" "ofl" [
+  ["cveTN2+OKEFla/Idd6XeAQ8pKb1pVqIu6EitDH65eK8=" "ofl/courierprime/CourierPrime-Regular.ttf"]
+  ["M1UnPz6m1jYmWPlWT06D1Z4VbPGhguPBWStcWUNifcw=" "ofl/courierprime/CourierPrime-BoldItalic.ttf"]
+  ["8bmlgpeJ9+VkMqnzvHZl70Ux27ocESY55IvvOWIaAGs=" "ofl/courierprime/CourierPrime-Italic.ttf"]
+  ["/x84eGyEnRxB+o5EeWCr2yvXX9+wz83rUk+tZaWvNjg=" "ofl/courierprime/CourierPrime-Bold.ttf"]
+];
+cousine = mkFont "cousine" "asl20" [
+  ["aeHqWet3ABQgTlF0+AV1D5p5PbSiUx5lFrMLdGDUcLM=" "apache/cousine/Cousine-Regular.ttf"]
+  ["myuY5dOJ/nSWivKrtECsS2/NJOKhq6XtiVsDN7awteY=" "apache/cousine/Cousine-Italic.ttf"]
+  ["72W4Yk55k5d/65+boY9RSh+prcThxHN8iDlXRoXBiK4=" "apache/cousine/Cousine-BoldItalic.ttf"]
+  ["QtFLqvGAL47fdlk0aoV0tBxMeOJk64HNsIkcpmhjVM4=" "apache/cousine/Cousine-Bold.ttf"]
+];
+coustard = mkFont "coustard" "ofl" [
+  ["2OPgRtcXe2LZGghyMSLHygwizpV3JhqgnnYFxHlivj0=" "ofl/coustard/Coustard-Black.ttf"]
+  ["kKLjrpjVQCECN12IgZuDl2oBVTML1NGYJNQEcd1MP0c=" "ofl/coustard/Coustard-Regular.ttf"]
+];
+coveredbyyourgrace = mkFont "coveredbyyourgrace" "ofl" [
+  ["in5Wh6T5qtlSQ+sozcYkAJozXg3lF1ETvF8TSKTWf9c=" "ofl/coveredbyyourgrace/CoveredByYourGrace.ttf"]
+];
+craftygirls = mkFont "craftygirls" "asl20" [
+  ["X5L+1EH8cudf1SDuY7R4XJtldATFPh8mnJWmAWKY70U=" "apache/craftygirls/CraftyGirls-Regular.ttf"]
+];
+creepstercaps = mkFont "creepstercaps" "asl20" [
+  ["ZSgNoFpTziJAEncXD/E/IgoypAvYXWQn9nhmrzeLkT0=" "apache/creepstercaps/CreepsterCaps-Regular.ttf"]
+];
+creepster = mkFont "creepster" "ofl" [
+  ["QCrrc0WGx0rs09vcRUWJsfsS4uHHH3gv0BmuaAZtn0Q=" "ofl/creepster/Creepster-Regular.ttf"]
+];
+creteround = mkFont "creteround" "ofl" [
+  ["KwbudcNYBrn6s14FT7uXr5j7ayQZxhBWlzUdwaKzBsg=" "ofl/creteround/CreteRound-Regular.ttf"]
+  ["7uQS5D2EO4mjFwucXbrizl2pX/cpkW06LDRBrtNBG0I=" "ofl/creteround/CreteRound-Italic.ttf"]
+];
+crimsonpro = mkFont "crimsonpro" "ofl" [
+  ["FqqftzAKk2N9pR+sA6Bxsv8Itrv2X5nHlMJfBAtYr2o=" "ofl/crimsonpro/CrimsonPro%5Bwght%5D.ttf"]
+  ["p03BHc8vuxRSBk5COVpAqQfKYwtJz/hgEiI3heUrJVk=" "ofl/crimsonpro/CrimsonPro-Italic%5Bwght%5D.ttf"]
+];
+crimsontext = mkFont "crimsontext" "ofl" [
+  ["o6B2X8Xo0LSbVAojrv4BhIh9158GoL3023A1zqa++pM=" "ofl/crimsontext/CrimsonText-Bold.ttf"]
+  ["gC6EAAdA/sKp++CuCba2gRvYanigFzsV1ERQoVMOlBA=" "ofl/crimsontext/CrimsonText-SemiBold.ttf"]
+  ["j0oNstGBukSTpK1TBC7cO1erUP7dj6MseyrVcXMghUM=" "ofl/crimsontext/CrimsonText-SemiBoldItalic.ttf"]
+  ["TtFpmsfGTos9M/a7gyPD1yBrDXusue4tZcaX5gFNKd4=" "ofl/crimsontext/CrimsonText-Italic.ttf"]
+  ["RnAT6RPkYwR2BGHEZmHJlLKqF2nj+9MTcQJjADFRgbQ=" "ofl/crimsontext/CrimsonText-BoldItalic.ttf"]
+  ["SObF1a0dAVmdN07LgX4ViQ0f6zuKOojlJ9RMkDieHwY=" "ofl/crimsontext/CrimsonText-Regular.ttf"]
+];
+croissantone = mkFont "croissantone" "ofl" [
+  ["Vcy0YtB7q4Uygen9lkbwzCWL+xro/2RfhXuh+SH39p4=" "ofl/croissantone/CroissantOne-Regular.ttf"]
+];
+crushed = mkFont "crushed" "asl20" [
+  ["zpMKCufbIbxtb7CPyZZOhL8OyqYKb95WDT0qSuCUmho=" "apache/crushed/Crushed-Regular.ttf"]
+];
+cuprum = mkFont "cuprum" "ofl" [
+  ["vnVYWqV6XxwdEN5hMFu0Jm7/obkINyLSDCat+X6RFTQ=" "ofl/cuprum/Cuprum%5Bwght%5D.ttf"]
+  ["Gy+iRBtCHhYXbtOwNWlJ9AbvREl98Xsu55d6p/g4MSo=" "ofl/cuprum/Cuprum-Italic%5Bwght%5D.ttf"]
+];
+cutefont = mkFont "cutefont" "ofl" [
+  ["xAMif+YoiowUI8pI6T/X78geO4EFP30Xrc9lm9lfpMM=" "ofl/cutefont/CuteFont-Regular.ttf"]
+];
+cutivemono = mkFont "cutivemono" "ofl" [
+  ["VDx09hhVMa6/YVH7p8YY9a60OvjLawnXDpfjYRs1Hm4=" "ofl/cutivemono/CutiveMono-Regular.ttf"]
+];
+cutive = mkFont "cutive" "ofl" [
+  ["OZWDLpZmRMQE0OnoFcJYqrgJYTQsgHMYhL/ycxm4Tks=" "ofl/cutive/Cutive-Regular.ttf"]
+];
+damion = mkFont "damion" "ofl" [
+  ["neUUJyl9txcHKw062we3+QuPpNMaBGOtHqZ0+mDmdmY=" "ofl/damion/Damion-Regular.ttf"]
+];
+dancingscript = mkFont "dancingscript" "ofl" [
+  ["IYCGJVeP6NjNEMtoS+VG3KB3snzQOlOi8ewR3HQ8kkw=" "ofl/dancingscript/DancingScript%5Bwght%5D.ttf"]
+];
+dangrek = mkFont "dangrek" "ofl" [
+  ["19usKIFn75YOpnpdRYkLR0GeGMBG6Qxo7mVaAWjg0G0=" "ofl/dangrek/Dangrek-Regular.ttf"]
+];
+darkergrotesque = mkFont "darkergrotesque" "ofl" [
+  ["2ZAiHYMh8J6djsJ2dlHm7UZdZy1eAb8QnmvRYl9zwvw=" "ofl/darkergrotesque/DarkerGrotesque-Medium.ttf"]
+  ["BFrzYs/NRnhmiF2JEUM1JozWVPHtM9RnK7PokXSzLHQ=" "ofl/darkergrotesque/DarkerGrotesque-Regular.ttf"]
+  ["SybxZ5g9snDYXCSlNqdYLhafnJwh3dC9W8Qey2rhukU=" "ofl/darkergrotesque/DarkerGrotesque-ExtraBold.ttf"]
+  ["SYx72+75zrGRN/E6gPnodJbkE8RKFVzCuIveHBbVESE=" "ofl/darkergrotesque/DarkerGrotesque-Bold.ttf"]
+  ["2cZqjd8PrdSUjGSGUU7kpvhcrcOal4E3g3uO3NS0lXw=" "ofl/darkergrotesque/DarkerGrotesque-SemiBold.ttf"]
+  ["rKjWjE6/GOKBAqYdtcT1Gd8hQ+MFcxhcCj8rQI81w1k=" "ofl/darkergrotesque/DarkerGrotesque-Black.ttf"]
+  ["MkUXWg8VPo90+jN8KlbxInaydoQw4Mv/vji88iDtkCY=" "ofl/darkergrotesque/DarkerGrotesque-Light.ttf"]
+];
+darumadropone = mkFont "darumadropone" "ofl" [
+  ["vu9tkDGRiCMXbqD59ynLgRpfJQWY18jGhLPe4zOBBok=" "ofl/darumadropone/DarumadropOne-Regular.ttf"]
+];
+davidlibre = mkFont "davidlibre" "ofl" [
+  ["yLq0zJGOKBrCy2XnCsutB/mL6ri9WS/jQJEFCnENA8M=" "ofl/davidlibre/DavidLibre-Medium.ttf"]
+  ["sorg/ehBKWlN9cr6AUt0fRKWhSSPCFgGjGJL+VbnxTs=" "ofl/davidlibre/DavidLibre-Regular.ttf"]
+  ["3yiURaEh8sgBIGOwBu4hT8Sc3IpfSWHCTESdIAdRMBc=" "ofl/davidlibre/DavidLibre-Bold.ttf"]
+];
+dawningofanewday = mkFont "dawningofanewday" "ofl" [
+  ["Kyr6Yj27GSbjsCZgMoe00V7gV3gQbiansz75TUvincs=" "ofl/dawningofanewday/DawningofaNewDay.ttf"]
+];
+daysone = mkFont "daysone" "ofl" [
+  ["e1oObYhpbkPpX2MgYTkI5T02rYVLShjkobjRwZ/b8f4=" "ofl/daysone/DaysOne-Regular.ttf"]
+];
+decovaralpha = mkFont "decovaralpha" "ofl" [
+  ["OvFN+aBOq9GN3RQuhGp3OhFMh7Wz7liMHp7zlqDyLw4=" "ofl/decovaralpha/DecovarAlpha-VF.ttf"]
+];
+dekko = mkFont "dekko" "ofl" [
+  ["5rFRpb3FIYM865pPgBAZVRUlnpQWq/4FXP0WrbLhr0I=" "ofl/dekko/Dekko-Regular.ttf"]
+];
+delagothicone = mkFont "delagothicone" "ofl" [
+  ["T/h6CWXxsFBeWixYQkvGrTz/J+VqgvIcL8nWsOOFfuI=" "ofl/delagothicone/DelaGothicOne-Regular.ttf"]
+];
+delicioushandrawn = mkFont "delicioushandrawn" "ofl" [
+  ["EMSckC6hXNh7FqDs2bcJfMgqpkd0agL9fs/C6pMIgsc=" "ofl/delicioushandrawn/DeliciousHandrawn-Regular.ttf"]
+];
+delius = mkFont "delius" "ofl" [
+  ["wP1mYmkmtjfWTrE94BOzMY29cs35LDPkGimgOCi6tvY=" "ofl/delius/Delius-Regular.ttf"]
+];
+deliusswashcaps = mkFont "deliusswashcaps" "ofl" [
+  ["BMECRIAHJluKBnJZCQCRnTXf0mxiTlQ8jDv7q5U1tkI=" "ofl/deliusswashcaps/DeliusSwashCaps-Regular.ttf"]
+];
+deliusunicase = mkFont "deliusunicase" "ofl" [
+  ["JvtTtylygeSQff4lTMI8IG8oUQ9oPrcm5cUCTKNtyV0=" "ofl/deliusunicase/DeliusUnicase-Regular.ttf"]
+  ["L8j3KnJX2DeltxCo9sqea3oXn4CSQ+75OAuiGFuMKmc=" "ofl/deliusunicase/DeliusUnicase-Bold.ttf"]
+];
+dellarespira = mkFont "dellarespira" "ofl" [
+  ["gVGL5be69p21uOTP8aRHrC9r96YCnKSWOmfh+xsLkhg=" "ofl/dellarespira/DellaRespira-Regular.ttf"]
+];
+denkone = mkFont "denkone" "ofl" [
+  ["DS776JFsFPfOMK/tXNCaUD/Ws7FJi/qtQ27kfTvejsA=" "ofl/denkone/DenkOne-Regular.ttf"]
+];
+devonshire = mkFont "devonshire" "ofl" [
+  ["TADwA1cOWpk2HMgwF8sTFKoxcM+qU74poIxVW7tDRlc=" "ofl/devonshire/Devonshire-Regular.ttf"]
+];
+dhurjati = mkFont "dhurjati" "ofl" [
+  ["f4KrFBt30mP56psxtH+vUMETEPQvzm2d/+qqM0kJu/k=" "ofl/dhurjati/Dhurjati-Regular.ttf"]
+];
+dhyana = mkFont "dhyana" "ofl" [
+  ["p7JBxQnG857r7+ZJ0uAU0lGc1xWhICa7kK+ww7l8YmY=" "ofl/dhyana/Dhyana-Regular.ttf"]
+  ["4gktN7AtgcJEcbhxSz7vsQmOlvgPpljxEoS8DBixHo8=" "ofl/dhyana/Dhyana-Bold.ttf"]
+];
+didactgothic = mkFont "didactgothic" "ofl" [
+  ["uY+eCRtjN6hvTg9pyUwxkF4eKHeChT9HLhdrTijT+B8=" "ofl/didactgothic/DidactGothic-Regular.ttf"]
+];
+digitalnumbers = mkFont "digitalnumbers" "ofl" [
+  ["3p4M+4O8EKxvrYdvNdjzgaP/B/XKmSWRnp0y+YC8nUk=" "ofl/digitalnumbers/DigitalNumbers-Regular.ttf"]
+];
+diplomata = mkFont "diplomata" "ofl" [
+  ["oCrcPYeQ36wo4/+EGmNSkCTJMjP9as3t4LBEzhpCVHc=" "ofl/diplomata/Diplomata-Regular.ttf"]
+];
+diplomatasc = mkFont "diplomatasc" "ofl" [
+  ["1OA8UP0UyNG4m4NA01PIxWsir7sZ25de9Vmhn1A7IV4=" "ofl/diplomatasc/DiplomataSC-Regular.ttf"]
+];
+dmmono = mkFont "dmmono" "ofl" [
+  ["VbTJjxI9rrs+0nlHukeyrwBVT8YoTWOaVAvO9eYlitI=" "ofl/dmmono/DMMono-Regular.ttf"]
+  ["kCFhklVdVs1AhXJQu9bQ6BMN29AVmS1YQiXX85CElUQ=" "ofl/dmmono/DMMono-LightItalic.ttf"]
+  ["x7NkXcjSgjcxe00Be8R7n/CadmB1gSLay2lKWoJVLCQ=" "ofl/dmmono/DMMono-Light.ttf"]
+  ["/TJ9r0YduHtEqH3vR10lG/A7mX98B9loBZLXXbv6rQs=" "ofl/dmmono/DMMono-Medium.ttf"]
+  ["o7IhG7nPXE/BoLSHVT5nOnN8InDFm4a/HgtIx35YeqI=" "ofl/dmmono/DMMono-MediumItalic.ttf"]
+  ["MrW62cvOZOrG0FyKu+thkxf35Ms1Thwz23Ya2/quGxY=" "ofl/dmmono/DMMono-Italic.ttf"]
+];
+dmsans = mkFont "dmsans" "ofl" [
+  ["U5kgZvk3DOZzhVG3U+NHNz/28xjOfJ9/Wec/mc15lvM=" "ofl/dmsans/DMSans-Italic.ttf"]
+  ["nYAfipZqmGCp/SkhpUNip9cFjHgh4sr8f3XtBViEoDQ=" "ofl/dmsans/DMSans-Bold.ttf"]
+  ["T2qQnbheBU5TzRgP54HP4EhBbN2H9zZawoccjWRqkDM=" "ofl/dmsans/DMSans-Medium.ttf"]
+  ["N2hiKIbQmEzuF7JJ4zQGVbuGS4J9lwIBShYPvdWmuNY=" "ofl/dmsans/DMSans-MediumItalic.ttf"]
+  ["GtsJasqj0U9e1njpm4CLDIgA9iyzQvpcJ2KYrYAwtFg=" "ofl/dmsans/DMSans-Regular.ttf"]
+  ["NzZRKuQYkq3PJGuoMF8U4W4hV7VkNvLaSDfUgk5MBBg=" "ofl/dmsans/DMSans-BoldItalic.ttf"]
+];
+dmserifdisplay = mkFont "dmserifdisplay" "ofl" [
+  ["33TArDh7rq6w/k8jJOFmjmo+2MCc2Xlv4WLHF1PhnkU=" "ofl/dmserifdisplay/DMSerifDisplay-Italic.ttf"]
+  ["jMNkNTXt8DmqXZVECoVCc16Rl+T0uNkwPpgP779athY=" "ofl/dmserifdisplay/DMSerifDisplay-Regular.ttf"]
+];
+dmseriftext = mkFont "dmseriftext" "ofl" [
+  ["0Ba4HfXNdGIYiguhHcNDziiX3/o5+x/P8P7wu3aENk4=" "ofl/dmseriftext/DMSerifText-Italic.ttf"]
+  ["lLX6e6wPQGyzFJUSA3836iG1XOzXMsP9OgdiYEQTmc0=" "ofl/dmseriftext/DMSerifText-Regular.ttf"]
+];
+dohyeon = mkFont "dohyeon" "ofl" [
+  ["vV1eaFcqER1CdgCCscSymcC9IDc7FZx6IA19PIKSSOQ=" "ofl/dohyeon/DoHyeon-Regular.ttf"]
+];
+dokdo = mkFont "dokdo" "ofl" [
+  ["Wzo9jSivMfqa3sP8XagaiLUuH/Oe05MMHbeHqk55w20=" "ofl/dokdo/Dokdo-Regular.ttf"]
+];
+domine = mkFont "domine" "ofl" [
+  ["xjVSy2DGWOkMHaPoP5588gNWLDnNv1p4up32LY56Htc=" "ofl/domine/Domine%5Bwght%5D.ttf"]
+];
+donegalone = mkFont "donegalone" "ofl" [
+  ["H5sHu684ExAygYSPeC+udEmfXfw7O59OkOvqSqQvvHU=" "ofl/donegalone/DonegalOne-Regular.ttf"]
+];
+dongle = mkFont "dongle" "ofl" [
+  ["KWbnqdMSqGjitUd7+aPlm4zha+t25+UjBatYl9HOl0E=" "ofl/dongle/Dongle-Regular.ttf"]
+  ["lExJjA0aGDKrNvFzsbOqWud7KpFOAMTXngUzj642Ry0=" "ofl/dongle/Dongle-Bold.ttf"]
+  ["uwTgPb5E+wxhlDTzFWXmK1usZyKdXtcu6sacLnTppFw=" "ofl/dongle/Dongle-Light.ttf"]
+];
+doppioone = mkFont "doppioone" "ofl" [
+  ["Joak6t+tA5YfY+hHR5iotZHVMaqhveaSNIFWWDCxnZ4=" "ofl/doppioone/DoppioOne-Regular.ttf"]
+];
+dorsa = mkFont "dorsa" "ofl" [
+  ["0gTbXOstAoUp+XAfqxv5mn9rH1Vc2lv/5RBy7BQJ48c=" "ofl/dorsa/Dorsa-Regular.ttf"]
+];
+dosis = mkFont "dosis" "ofl" [
+  ["siOO7ws0ZJBP7Ql+8nTHBLxj0hQHNpt9elvnsIIaDoI=" "ofl/dosis/Dosis%5Bwght%5D.ttf"]
+];
+dotgothic16 = mkFont "dotgothic16" "ofl" [
+  ["OtmviHJtQrQPfzZfDcrHha9zzyDqbx1bROV8whFQuPE=" "ofl/dotgothic16/DotGothic16-Regular.ttf"]
+];
+drsugiyama = mkFont "drsugiyama" "ofl" [
+  ["hDbB6uOgYSam4KqFsd/7G1B9Oeq3tlEqm7GtxdUU2bk=" "ofl/drsugiyama/DrSugiyama-Regular.ttf"]
+];
+durusans = mkFont "durusans" "ofl" [
+  ["7dFaVZYxjsxjVIT3tPyzTG3Kp76PhcTS6Sc62Ntoj/A=" "ofl/durusans/DuruSans-Regular.ttf"]
+];
+dynalight = mkFont "dynalight" "ofl" [
+  ["Ng2l12e0jISdBqYIpGBdU8MqSf3hJ2A6qDsJa2tD0PE=" "ofl/dynalight/Dynalight-Regular.ttf"]
+];
+dynapuff = mkFont "dynapuff" "ofl" [
+  ["w3Uvxt2KqkaohjfwYamk5qtEwCxfCv1lUouRro/2+Ug=" "ofl/dynapuff/DynaPuff%5Bwdth,wght%5D.ttf"]
+];
+eaglelake = mkFont "eaglelake" "ofl" [
+  ["U6TpKcnqNYTyQyFX/VScdgTmvn5sSzmHPzT65/aCOSg=" "ofl/eaglelake/EagleLake-Regular.ttf"]
+];
+eastseadokdo = mkFont "eastseadokdo" "ofl" [
+  ["jOuznTdRNP287e+b9OxPbD8Cw57Qqs1ug/eg9DXlk7I=" "ofl/eastseadokdo/EastSeaDokdo-Regular.ttf"]
+];
+eater = mkFont "eater" "ofl" [
+  ["3ydErw9YWSxP8T6CBeYqVve9+RWz4xyd7wdWaMQqKz8=" "ofl/eater/Eater-Regular.ttf"]
+];
+ebgaramond = mkFont "ebgaramond" "ofl" [
+  ["O2gWIfnFLvPgE5VTBQCcXQD4WlDGEol6O08Yu85JBFg=" "ofl/ebgaramond/EBGaramond-Italic%5Bwght%5D.ttf"]
+  ["t/HdkWQ+T4H2DkP6nEuhF2Y6ABYhkT3P0hNwak2D5tk=" "ofl/ebgaramond/EBGaramond%5Bwght%5D.ttf"]
+];
+economica = mkFont "economica" "ofl" [
+  ["tlvVG3vmvQ3yC/mmUslq+w7NfMGGO9LD7o8A4uKTBPQ=" "ofl/economica/Economica-Bold.ttf"]
+  ["fV41me+ZVg9uyv0P5BdTSE7obyFaf2xQM8bAfWW117Q=" "ofl/economica/Economica-Regular.ttf"]
+  ["AKushnImlu3T5oHHGy7KHfUQ9U0/L7+gRxyNs4GQq0M=" "ofl/economica/Economica-BoldItalic.ttf"]
+  ["dSQwFVWRO8BCJyeygw2bboJpo2QzrMglaB7Za0CUiEM=" "ofl/economica/Economica-Italic.ttf"]
+];
+eczar = mkFont "eczar" "ofl" [
+  ["tSrzo7RX+bInhhK3PJfq8oJw/8kcmeTJBHHMFbuHSMY=" "ofl/eczar/Eczar%5Bwght%5D.ttf"]
+];
+edunswactfoundation = mkFont "edunswactfoundation" "ofl" [
+  ["WksizDnATZdHK75wW5cA6GRJK4U7SUFkXaYCAreWFGo=" "ofl/edunswactfoundation/EduNSWACTFoundation%5Bwght%5D.ttf"]
+];
+eduqldbeginner = mkFont "eduqldbeginner" "ofl" [
+  ["3pN7B5g8hvaQoRTQEsXTjMYHyxHNdaosv6Y41a4QnDk=" "ofl/eduqldbeginner/EduQLDBeginner%5Bwght%5D.ttf"]
+];
+edusabeginner = mkFont "edusabeginner" "ofl" [
+  ["HsDYtPOm/aAYB5+ihFcNLEo6UU42h9E5slsF27hsf/Q=" "ofl/edusabeginner/EduSABeginner%5Bwght%5D.ttf"]
+];
+edutasbeginner = mkFont "edutasbeginner" "ofl" [
+  ["F9yKTj44RCvYbkv/vjSBmxVsxkuTdQV9IbPQ+8NUasY=" "ofl/edutasbeginner/EduTASBeginner%5Bwght%5D.ttf"]
+];
+eduvicwantbeginner = mkFont "eduvicwantbeginner" "ofl" [
+  ["tcv1CdJFxW8KQsqn/tioZhrVkn122IuyAIyQNyCRVLM=" "ofl/eduvicwantbeginner/EduVICWANTBeginner%5Bwght%5D.ttf"]
+];
+ekmukta = mkFont "ekmukta" "ofl" [
+  ["r6vuMKEti9rDb8K2OeYPJub2Oy8RYTVHz8oNXkFntUo=" "ofl/ekmukta/EkMukta-Light.ttf"]
+  ["JthfMvCEp0s+uXbCj6FIODrJgisIbZSkG+9GWfPK1Wg=" "ofl/ekmukta/EkMukta-SemiBold.ttf"]
+  ["TXk+54HZm9lJjRCJ60Yb+4EzvxsF4KLaxlmQUgbAaDc=" "ofl/ekmukta/EkMukta-ExtraLight.ttf"]
+  ["qYt/rWz66ZxJizYAKykNr0xUDPsS26hrq3LxYymbD1Y=" "ofl/ekmukta/EkMukta-Medium.ttf"]
+  ["HWJDRiXKmeA6zSAHAu1f1NRyMdE0gJgHzdf7QZ9kCdE=" "ofl/ekmukta/EkMukta-Bold.ttf"]
+  ["np/+ajETtbRyC1YXW773aDapsOm7nv/k/JaLUNmPV1o=" "ofl/ekmukta/EkMukta-ExtraBold.ttf"]
+  ["0U9ApYiyMsrJ+zBjxwffk/wQ6NJlaU/Jn8+vzIq3s7Q=" "ofl/ekmukta/EkMukta-Regular.ttf"]
+];
+electrolize = mkFont "electrolize" "ofl" [
+  ["qoGrkBX8AZC7XmjFApBWXHpKcj3fMriHdKr/Bc3Wa8o=" "ofl/electrolize/Electrolize-Regular.ttf"]
+];
+elmessiri = mkFont "elmessiri" "ofl" [
+  ["XVjVJZ0qzMy6Oc/+EuEiboi2r8UVDjYF6yqcL+BsyrA=" "ofl/elmessiri/ElMessiri%5Bwght%5D.ttf"]
+];
+elsie = mkFont "elsie" "ofl" [
+  ["aTOfzRCl1cErcs9RJ7RL5aAUfSUxuvSUAEx62tSvYzg=" "ofl/elsie/Elsie-Black.ttf"]
+  ["mz/1BWhmZn+yn2C+tFIplK/dTV9YBibG/Z5vW/SfHqU=" "ofl/elsie/Elsie-Regular.ttf"]
+];
+elsieswashcaps = mkFont "elsieswashcaps" "ofl" [
+  ["K207Fx4RjUOB4DsoitN9sZp46sEuviCXU3XHASu+ESs=" "ofl/elsieswashcaps/ElsieSwashCaps-Black.ttf"]
+  ["jKHFROyybW2zSDUivkc+m8eONbmyEbPm4e5bF3i1dTc=" "ofl/elsieswashcaps/ElsieSwashCaps-Regular.ttf"]
+];
+emblemaone = mkFont "emblemaone" "ofl" [
+  ["Boq1hPuYaMKZd2rbhxz2k7IRI8z7btX6uY/4YdHUK+4=" "ofl/emblemaone/EmblemaOne-Regular.ttf"]
+];
+emilyscandy = mkFont "emilyscandy" "ofl" [
+  ["DPPKnb5xszWW6KHrErQN6sLmQU/lYW3aUMVUWAtuDGg=" "ofl/emilyscandy/EmilysCandy-Regular.ttf"]
+];
+encodesanscondensed = mkFont "encodesanscondensed" "ofl" [
+  ["do2WkSeVPIoufXVqdzXH+APgij+GvmDcrXe6//NxF4g=" "ofl/encodesanscondensed/EncodeSansCondensed-Regular.ttf"]
+  ["rlchRkpgyXR/f1+PLYJFdd0c+mNykFupDR/UjvHoGYc=" "ofl/encodesanscondensed/EncodeSansCondensed-Medium.ttf"]
+  ["NcREU2MK8rNVEgtzKF9C0aucxOKqDPkhHBv2AQkYQFM=" "ofl/encodesanscondensed/EncodeSansCondensed-Black.ttf"]
+  ["JkrcEXv8S2EAsqh/7+uPtx2Grp2sDJSkU7GWArvLUbQ=" "ofl/encodesanscondensed/EncodeSansCondensed-SemiBold.ttf"]
+  ["0RFTqi64nQD7ZaY/u1mmYGgdBmnpPPVZegRK7ZE9pLA=" "ofl/encodesanscondensed/EncodeSansCondensed-ExtraBold.ttf"]
+  ["nyF3lEQUr0P3vqFcfXaGkgCzPBIeMzPSD0A7k0/MNlY=" "ofl/encodesanscondensed/EncodeSansCondensed-Thin.ttf"]
+  ["polrKMyOFv6NEHPHZhJ6B6nInMj035/6w3akH/QFC18=" "ofl/encodesanscondensed/EncodeSansCondensed-Bold.ttf"]
+  ["3i0hw8jgHbBbubKR93Swn8MW96Fyf6JATvR9j+NaoGM=" "ofl/encodesanscondensed/EncodeSansCondensed-ExtraLight.ttf"]
+  ["O72t3Yd7y6hlzZCgknzd4SgeFE4uMCzoZnuiTxXyGSM=" "ofl/encodesanscondensed/EncodeSansCondensed-Light.ttf"]
+];
+encodesansexpanded = mkFont "encodesansexpanded" "ofl" [
+  ["q1PKPN1bkK6YA8vvbKsMILgIC6uzp/VFBVEuOWM6b5k=" "ofl/encodesansexpanded/EncodeSansExpanded-Light.ttf"]
+  ["8MOljsT9Zw3GrVvQANFZgJZ7tK5kofoRjn0XNj6Yc7E=" "ofl/encodesansexpanded/EncodeSansExpanded-ExtraLight.ttf"]
+  ["E5TKo7baJpR7N9AgDQK393v01jq0vvyltfHe7wxT0oQ=" "ofl/encodesansexpanded/EncodeSansExpanded-Medium.ttf"]
+  ["Ul91i/fV5WNORZ5j1KhXXKWF4u7tS+wm4tPpJaJmxu4=" "ofl/encodesansexpanded/EncodeSansExpanded-Regular.ttf"]
+  ["mFVryEBbcqtcuVyv6t1u7CfP9JKnyCjCrE7y8//1EFs=" "ofl/encodesansexpanded/EncodeSansExpanded-SemiBold.ttf"]
+  ["VlMYWqDfh+voSPXHb3Gnb2+U76XQesyHBYw6FzujDaw=" "ofl/encodesansexpanded/EncodeSansExpanded-Black.ttf"]
+  ["O8ghFL4P0HbCdGHLLF/cZ2BYRO/+Y+YELXaSyPxP2JA=" "ofl/encodesansexpanded/EncodeSansExpanded-ExtraBold.ttf"]
+  ["SVPOcLLX/LKcAc7DV7fIi1wHXWkHYFQuocp60Jfwn7I=" "ofl/encodesansexpanded/EncodeSansExpanded-Thin.ttf"]
+  ["AUh2QeFv2FpFfBEdlIihoQCQN0N6BLHTGM7FHAAoKuU=" "ofl/encodesansexpanded/EncodeSansExpanded-Bold.ttf"]
+];
+encodesans = mkFont "encodesans" "ofl" [
+  ["dzUyCrtjoQItCGyTiHLa4ydU23M+zU3NQC8qRFy+tD8=" "ofl/encodesans/EncodeSans%5Bwdth,wght%5D.ttf"]
+];
+encodesanssc = mkFont "encodesanssc" "ofl" [
+  ["/K0iw0QJkr9CIW5qCtboZA0tHf/x3cVXOTSTMVISO9A=" "ofl/encodesanssc/EncodeSansSC%5Bwdth,wght%5D.ttf"]
+];
+encodesanssemicondensed = mkFont "encodesanssemicondensed" "ofl" [
+  ["W2jx8QyvktdigaFP9bBY+npcyBqQlWdRsto1P5E9zGQ=" "ofl/encodesanssemicondensed/EncodeSansSemiCondensed-Medium.ttf"]
+  ["MmaZLuDKGWDTFkp7VfemuXg7Xo6xwrAq80rDvZFz2DM=" "ofl/encodesanssemicondensed/EncodeSansSemiCondensed-Light.ttf"]
+  ["obPr8dhAF8QTaHC2uDI/DuBVoiqanknljZ4mtnsO+GY=" "ofl/encodesanssemicondensed/EncodeSansSemiCondensed-Regular.ttf"]
+  ["CluNDdXj2au2iLK2DkQfOs71vT10T4cxU0bQNN8LX78=" "ofl/encodesanssemicondensed/EncodeSansSemiCondensed-Bold.ttf"]
+  ["VF25qqqG/DBRwoZgahpDVYQ95hPQR4lcGe8K8oAK6HY=" "ofl/encodesanssemicondensed/EncodeSansSemiCondensed-Thin.ttf"]
+  ["XYLEjbqa3vbBk9yRtiY0PK/SxE+jxAvH4hQPMytZ5Cc=" "ofl/encodesanssemicondensed/EncodeSansSemiCondensed-ExtraBold.ttf"]
+  ["X4yDJ2qvCufthz+5D8Rm7bqlBvDnjiz2AaMFw5wv58w=" "ofl/encodesanssemicondensed/EncodeSansSemiCondensed-ExtraLight.ttf"]
+  ["+bpEHTZ3wQCQ4VrUsdYKCCXEMCj6iSx2w9EKK0/d5Xw=" "ofl/encodesanssemicondensed/EncodeSansSemiCondensed-Black.ttf"]
+  ["+TnpVIGWeYmLFeSn9rrcHpaUlUHlwo77/lsCrYsht1o=" "ofl/encodesanssemicondensed/EncodeSansSemiCondensed-SemiBold.ttf"]
+];
+encodesanssemiexpanded = mkFont "encodesanssemiexpanded" "ofl" [
+  ["LWJmCvKxBvj/RTVtAJxNvEEHyVDlzjFFUisaETfD+Go=" "ofl/encodesanssemiexpanded/EncodeSansSemiExpanded-Thin.ttf"]
+  ["OI8Yy/C8xNyvyRbF8DmJvjDePv66tx74APNtH4a2WWI=" "ofl/encodesanssemiexpanded/EncodeSansSemiExpanded-Bold.ttf"]
+  ["qmm8sK34nReMguOBq2uVnspYyGFEBTLK+8wk4Dzc4P8=" "ofl/encodesanssemiexpanded/EncodeSansSemiExpanded-Regular.ttf"]
+  ["zrjNds7eyAIYkrxG3/EpzebEeuGc1dnPZ2BE/zN7Opg=" "ofl/encodesanssemiexpanded/EncodeSansSemiExpanded-Medium.ttf"]
+  ["uoFlej0o65IgdbZBnvebdAmPa/dHcHl/kODOWXlqUpo=" "ofl/encodesanssemiexpanded/EncodeSansSemiExpanded-ExtraLight.ttf"]
+  ["7SNdki4PhZrJy81VnQRB4yUG1E3a4krqiZJumIQfmCw=" "ofl/encodesanssemiexpanded/EncodeSansSemiExpanded-Light.ttf"]
+  ["XM+JWHjbIVS0oh3vdVlCWOiecSLQUTTVbNN5geoi/48=" "ofl/encodesanssemiexpanded/EncodeSansSemiExpanded-Black.ttf"]
+  ["G8bz9ao9tC1Pw32ST0si8xOmd/01df7IBfwRaQBuPh8=" "ofl/encodesanssemiexpanded/EncodeSansSemiExpanded-SemiBold.ttf"]
+  ["tQtlls6y5bpiwztGun5vOgqMx88rSR8Bv6TuMKoXeoU=" "ofl/encodesanssemiexpanded/EncodeSansSemiExpanded-ExtraBold.ttf"]
+];
+engagement = mkFont "engagement" "ofl" [
+  ["C/tmYAXA836cUSZcpd/4ErL8SSntMk81nKqS+Awl4Bo=" "ofl/engagement/Engagement-Regular.ttf"]
+];
+englebert = mkFont "englebert" "ofl" [
+  ["58XPT/pJupMomgQ099uL94SYOpdzRYiHHNk5Zc5e/TM=" "ofl/englebert/Englebert-Regular.ttf"]
+];
+enriqueta = mkFont "enriqueta" "ofl" [
+  ["uGaWeUilO9UW1EHAsE8LvEtFBhqNHVfnqJieqyvZzBg=" "ofl/enriqueta/Enriqueta-SemiBold.ttf"]
+  ["vnRV/gnbFbNu6FjWasWdCrMeN7BLQlMJn9hpJY+bVZI=" "ofl/enriqueta/Enriqueta-Medium.ttf"]
+  ["XjrKTG2vIhiKknF7ftUyIVGdqpa3+FEXYB6/GJBoZxY=" "ofl/enriqueta/Enriqueta-Regular.ttf"]
+  ["u0U3l7XjU5kMRWmZR1TCSWZA9CczHJ8ztRQU7VZ3dBI=" "ofl/enriqueta/Enriqueta-Bold.ttf"]
+];
+ephesis = mkFont "ephesis" "ofl" [
+  ["j7RympGPmSo3q0XxRmeDx46oyqd6ew5pVFMi4dvpxfk=" "ofl/ephesis/Ephesis-Regular.ttf"]
+];
+epilogue = mkFont "epilogue" "ofl" [
+  ["AS9lG0X0fBDHcUy34/L32cy38jWizHLGsnPdxzVwXGc=" "ofl/epilogue/Epilogue%5Bwght%5D.ttf"]
+  ["flJjv+W46p1GIB/D49WcNUYo3iIgw/P+gx+tlGoffbI=" "ofl/epilogue/Epilogue-Italic%5Bwght%5D.ttf"]
+];
+ericaone = mkFont "ericaone" "ofl" [
+  ["SxNfdZlpWdZdQltxdfCUQkP6vo6dYiOFVa2cmxmhfZM=" "ofl/ericaone/EricaOne-Regular.ttf"]
+];
+esteban = mkFont "esteban" "ofl" [
+  ["EX+AqCPRiZ34VwilnjnvDw2XSnQHqEVUMohhL4IU5o8=" "ofl/esteban/Esteban-Regular.ttf"]
+];
+estonia = mkFont "estonia" "ofl" [
+  ["Awh1l+okh5wZ1RykYi+MTpzYZ9CB560K0+fcz9sZM7I=" "ofl/estonia/Estonia-Regular.ttf"]
+];
+euphoriascript = mkFont "euphoriascript" "ofl" [
+  ["HKgVF6RQUGKQ4r4lZI4VPuTJz2rMRMHWELHm1+DmdIQ=" "ofl/euphoriascript/EuphoriaScript-Regular.ttf"]
+];
+ewert = mkFont "ewert" "ofl" [
+  ["in6yOtzlGTthvBhD11LzfCCMFj3W2y/BtkeReRlp9Ks=" "ofl/ewert/Ewert-Regular.ttf"]
+];
+exo2 = mkFont "exo2" "ofl" [
+  ["bcJos1E06gfbTqaxnJZbyC5lDO+9Hk+PsmW/xOYwyJc=" "ofl/exo2/Exo2%5Bwght%5D.ttf"]
+  ["a4CJwn4aKbPH4i6t5hkPXHVtCr3SCg1cc2r97G0pqUI=" "ofl/exo2/Exo2-Italic%5Bwght%5D.ttf"]
+];
+exo = mkFont "exo" "ofl" [
+  ["BirKmrmqSp4ATo1nnoSspu8M3Kuy+sOyenOAjgS+2bQ=" "ofl/exo/Exo-Italic%5Bwght%5D.ttf"]
+  ["Lwj4GPETWsV5gDDAvKJSwIRa9cVN/hcqXHT73WiENEU=" "ofl/exo/Exo%5Bwght%5D.ttf"]
+];
+expletussans = mkFont "expletussans" "ofl" [
+  ["M1CLO0d8VIrAAXnZfG3qyh6Y2rTMHYad7FgVkx51QPg=" "ofl/expletussans/ExpletusSans%5Bwght%5D.ttf"]
+  ["Xmn5hC7zvd+dtYFkIwYhb50lZJufneLoCUTmlKwYl5k=" "ofl/expletussans/ExpletusSans-Italic%5Bwght%5D.ttf"]
+];
+explora = mkFont "explora" "ofl" [
+  ["opobL1nqzquVX2Zn4SXfzUFAakHrwszj2DfEXQQFsSk=" "ofl/explora/Explora-Regular.ttf"]
+];
+fahkwang = mkFont "fahkwang" "ofl" [
+  ["zllu+doeQNiUofbbrKVKqzxpl2PicVpkmoFG5u8y+ys=" "ofl/fahkwang/Fahkwang-Regular.ttf"]
+  ["9EUSt42uZlKQ4Ly8C1GYRiaUyJTTMAAZtpow2HNB8EI=" "ofl/fahkwang/Fahkwang-Bold.ttf"]
+  ["BATQ5pxfIfi+W2X8LCFe4Ix96e6JRzgBwX+xpelaXaY=" "ofl/fahkwang/Fahkwang-MediumItalic.ttf"]
+  ["q/ZYPB+PBemgU+LPODLkooWdKHd9oNRSMvzsUZBV0Mo=" "ofl/fahkwang/Fahkwang-ExtraLight.ttf"]
+  ["PI6u5/E47+OyklVx+NmvknWvJWYqKout3w3DryeQ/eM=" "ofl/fahkwang/Fahkwang-SemiBold.ttf"]
+  ["dFUTFiiJSrqEiz/puowvqZ9svEH1I5GTTmMKSqiGD6s=" "ofl/fahkwang/Fahkwang-Italic.ttf"]
+  ["BQq6d2K2G4XzOSQjrb4iG3HIVDEsy1SHCcS8YeRRh0E=" "ofl/fahkwang/Fahkwang-Medium.ttf"]
+  ["wD66W69XbZghYCehsO7cQDXcE8568dRDFtgFOLylDBo=" "ofl/fahkwang/Fahkwang-ExtraLightItalic.ttf"]
+  ["ZmIjX6JpGdzNtlaXzEpmSBTh3KV0mMFoueJKCUiopJc=" "ofl/fahkwang/Fahkwang-SemiBoldItalic.ttf"]
+  ["KsVYb4Qph4AeX0o5HmzwydLyblO4o7wkQqdkASf9oCs=" "ofl/fahkwang/Fahkwang-Light.ttf"]
+  ["7/RBxHve9xJHf07Mn76MlmNVG8zKHxWLFnTcffZoVEo=" "ofl/fahkwang/Fahkwang-LightItalic.ttf"]
+  ["YHODx97OEzeyu1c6CRNiI63cilTV4KNNzRRigAUsSAU=" "ofl/fahkwang/Fahkwang-BoldItalic.ttf"]
+];
+familjengrotesk = mkFont "familjengrotesk" "ofl" [
+  ["LSX8QTIaBFYfqyCpD8i8ntTRwHQ/6Lp2zFHNNjITi4A=" "ofl/familjengrotesk/FamiljenGrotesk%5Bwght%5D.ttf"]
+  ["J4BHSSZDdWx1Uz0qy5DgZEq/5d97xrmfIc9yp1BYBjQ=" "ofl/familjengrotesk/FamiljenGrotesk-Italic%5Bwght%5D.ttf"]
+];
+fanwoodtext = mkFont "fanwoodtext" "ofl" [
+  ["I/UeL9okOodZ1cMv+KlNoj3Gl+jJoBTUcYqgq37TyAg=" "ofl/fanwoodtext/FanwoodText-Italic.ttf"]
+  ["mKqcv1xezjaFAdGIsVZa4+f2yZcO44I3abjmchncM8I=" "ofl/fanwoodtext/FanwoodText-Regular.ttf"]
+];
+farro = mkFont "farro" "ofl" [
+  ["7tWAfid5wfuhoWJ6HTSwRQ5PxqhyAFIuLz4/YXIhyCs=" "ofl/farro/Farro-Regular.ttf"]
+  ["DmbFgkPG9PexDqJotSaHxifWWNYHSThlruR0rPK11/s=" "ofl/farro/Farro-Light.ttf"]
+  ["pUR79RIumpgEAHxWNTZT7n8iMAgSDUKKUXagKOxpfIA=" "ofl/farro/Farro-Medium.ttf"]
+  ["dnGl0SLS4wPH7NvrDjzlUuyKtkRITVh+cqxxoG09mgc=" "ofl/farro/Farro-Bold.ttf"]
+];
+farsan = mkFont "farsan" "ofl" [
+  ["e7loRUot3ghMn7D5mpkh6aj5awzSje349UXsI9UsNVA=" "ofl/farsan/Farsan-Regular.ttf"]
+];
+fascinateinline = mkFont "fascinateinline" "ofl" [
+  ["QTEBgQ/kIFIBIogEBNH46JImnmpq+i4A6YD2XvYy7js=" "ofl/fascinateinline/FascinateInline-Regular.ttf"]
+];
+fascinate = mkFont "fascinate" "ofl" [
+  ["Lz1OHTsfWLpHAOugeMB9nwXZ85UT9tKbAwbdwAe9f+w=" "ofl/fascinate/Fascinate-Regular.ttf"]
+];
+fasterone = mkFont "fasterone" "ofl" [
+  ["wdbkuur4Kp+XH77LQ8KDY3Grtd1gT5vvfYn9tzfqoWE=" "ofl/fasterone/FasterOne-Regular.ttf"]
+];
+fasthand = mkFont "fasthand" "ofl" [
+  ["9KFR1NAastr1PmeQTv0rlDwXrHtzUd5Obue9p2l7ChM=" "ofl/fasthand/Fasthand-Regular.ttf"]
+];
+faunaone = mkFont "faunaone" "ofl" [
+  ["PGNgZzMehvvzSZJPPBlkFVuZByo5DKr/5gzmwIZjY/4=" "ofl/faunaone/FaunaOne-Regular.ttf"]
+];
+faustina = mkFont "faustina" "ofl" [
+  ["IVub9j2gyVhLWgqo4icNpqK2LBKB9cOQiWE8Oq7/or4=" "ofl/faustina/Faustina-Italic%5Bwght%5D.ttf"]
+  ["LOJgbw7h1JOHPCSBijkeAmBu52rJJLPZhcu4IMClPqU=" "ofl/faustina/Faustina%5Bwght%5D.ttf"]
+];
+federant = mkFont "federant" "ofl" [
+  ["1AywnIURTCsMlEJjZBLpl9glizg+HRpoTn4ysh0HpcI=" "ofl/federant/Federant-Regular.ttf"]
+];
+federo = mkFont "federo" "ofl" [
+  ["UoRijDgwnsUEamvyMeA46vhMRt8DYCaQYHr1bKwrm8c=" "ofl/federo/Federo-Regular.ttf"]
+];
+felipa = mkFont "felipa" "ofl" [
+  ["0/B+JmngRqzBAwE5pLCARtfsqHwLR3qMyZrBxGr4Ttw=" "ofl/felipa/Felipa-Regular.ttf"]
+];
+fenix = mkFont "fenix" "ofl" [
+  ["UQT180T2S1UyhQsTHXueAzwRL8+pff7wCmTApAva6RE=" "ofl/fenix/Fenix-Regular.ttf"]
+];
+festive = mkFont "festive" "ofl" [
+  ["NJQNTmj/267oDiXZrI75VusPSWXIBNBnBBNz3cpqnsg=" "ofl/festive/Festive-Regular.ttf"]
+];
+figtree = mkFont "figtree" "ofl" [
+  ["MseWooMsneLdKr8MalQ27GYHiDSULJ/8aV9nI7musU8=" "ofl/figtree/Figtree-Italic%5Bwght%5D.ttf"]
+  ["1dJ3peTejhfAUnoHTrL4lWAYjqEKgnxy/kBRgMM6QcA=" "ofl/figtree/Figtree%5Bwght%5D.ttf"]
+];
+fingerpaint = mkFont "fingerpaint" "ofl" [
+  ["/OAArgKLCcpTlJFyqDgoLGeHluFULSWebaNz4lc3f8g=" "ofl/fingerpaint/FingerPaint-Regular.ttf"]
+];
+finlandica = mkFont "finlandica" "ofl" [
+  ["gZLH+RatkpiQt5m9T+CXQgC+YuAkwmfHsjRjLKymZY4=" "ofl/finlandica/Finlandica%5Bwght%5D.ttf"]
+  ["cLe921tdAa64Rh5aTA0CLvvIkq2W9o630WPLNEA2ByU=" "ofl/finlandica/Finlandica-Italic%5Bwght%5D.ttf"]
+];
+firacode = mkFont "firacode" "ofl" [
+  ["kzWwgrPHhQ2YpktYTzQX9lNV80cSeLte64xsDoZXrus=" "ofl/firacode/FiraCode%5Bwght%5D.ttf"]
+];
+firamono = mkFont "firamono" "ofl" [
+  ["LgCwzzEGo9eS81cRt3InQLdsAu5zAOqMYPlAWEt6isk=" "ofl/firamono/FiraMono-Regular.ttf"]
+  ["pbwaLbL2WUYEneYV7MCGA9eI6wwCtSD07ZXwWlzFhTI=" "ofl/firamono/FiraMono-Medium.ttf"]
+  ["YfDKOucqg964BwQPMU4bi05AsIIT3yQ9uf1DAJXKswU=" "ofl/firamono/FiraMono-Bold.ttf"]
+];
+firasanscondensed = mkFont "firasanscondensed" "ofl" [
+  ["195fYuQF+Vh/YU/ej7WujfsFEfN7J77D+AZ+mtvGZc0=" "ofl/firasanscondensed/FiraSansCondensed-MediumItalic.ttf"]
+  ["uTcQUuWOxbcJFT3Q//xgtSBbTTQ1z5V8JSJwWzGw28w=" "ofl/firasanscondensed/FiraSansCondensed-Bold.ttf"]
+  ["C0PGkfmon+jQbDRYT/nuaXUwCEQDuFkNNFlNijZkT9E=" "ofl/firasanscondensed/FiraSansCondensed-Thin.ttf"]
+  ["xnYJ8U/J0yhEK//8wxmIsPduVXXPRg/MHz3Y5JEv4lc=" "ofl/firasanscondensed/FiraSansCondensed-Regular.ttf"]
+  ["Q0Aroj9y0LxUsVg+3b3SO1TTZ6vpeYWNuPk5jjhd2SM=" "ofl/firasanscondensed/FiraSansCondensed-ExtraLightItalic.ttf"]
+  ["YC0eC5YbLvwNqE0A6jNMD2/lAZEueWW27UgsYqZAbT8=" "ofl/firasanscondensed/FiraSansCondensed-LightItalic.ttf"]
+  ["UHuFkVHHDHoDg8U1tr/TZJcggj9KqcnAcYoXWnVWcCU=" "ofl/firasanscondensed/FiraSansCondensed-ThinItalic.ttf"]
+  ["V/Oyz7sHaYuWmeYTNp0z4GthuCdYa2M0HeqmxXPSZOI=" "ofl/firasanscondensed/FiraSansCondensed-Italic.ttf"]
+  ["Y4WWf+khpu6DciHN5GHmled/iTGjykvILHwcGl/kf4Y=" "ofl/firasanscondensed/FiraSansCondensed-Medium.ttf"]
+  ["rMtuW2O8tKuxF/Qw1Rb/tn4+3BZPQRn4qSZwPgjy6dA=" "ofl/firasanscondensed/FiraSansCondensed-ExtraLight.ttf"]
+  ["xPHRNz8c4fUhm9xv+b+WRpjOC9ydL2bg31N0Hz9MC+k=" "ofl/firasanscondensed/FiraSansCondensed-SemiBoldItalic.ttf"]
+  ["H979dvt3PpXREg22vCDFdv6sHpZNoo4o60NCyOdzDNo=" "ofl/firasanscondensed/FiraSansCondensed-Light.ttf"]
+  ["irLP5nNwt8w36K0kYZprBRDiRnoH1rxBxrINpMor+WM=" "ofl/firasanscondensed/FiraSansCondensed-BlackItalic.ttf"]
+  ["0eUYGmXgSXDvF7g/pRgndlghcIGgMsf2C3rA8QE0fPI=" "ofl/firasanscondensed/FiraSansCondensed-ExtraBold.ttf"]
+  ["Bx5sN+kKO6L7U+3p+I/XfQJHcFA2ZWlxhwEzlwArDGY=" "ofl/firasanscondensed/FiraSansCondensed-ExtraBoldItalic.ttf"]
+  ["WpWGvFSdVXxBWmo9yIZYsUU9HfZh7fgRlU69VXdsAc0=" "ofl/firasanscondensed/FiraSansCondensed-SemiBold.ttf"]
+  ["rr4y0tghiQ4NZkQ8otxZsjf/NKV1BIaWqWUW2FeuDaY=" "ofl/firasanscondensed/FiraSansCondensed-BoldItalic.ttf"]
+  ["RKE7AVcCAe8LpnpgPyJxZkhe+T0uG9XW4bYNC+FNCXU=" "ofl/firasanscondensed/FiraSansCondensed-Black.ttf"]
+];
+firasansextracondensed = mkFont "firasansextracondensed" "ofl" [
+  ["v9WejueROiwB5elx0bzFIyKqzhiLY7blufbpKyMbm9g=" "ofl/firasansextracondensed/FiraSansExtraCondensed-SemiBoldItalic.ttf"]
+  ["x8ohkUpuwoTkZOo/i7xxdGTtlU1vR0lW9NPkTuIyjIk=" "ofl/firasansextracondensed/FiraSansExtraCondensed-MediumItalic.ttf"]
+  ["vLNaDphKJN6i21FJW3Ja+ZJT28kIeBGuxLhQUy6RdtU=" "ofl/firasansextracondensed/FiraSansExtraCondensed-ThinItalic.ttf"]
+  ["HOs3c0T/H5GhCrGj7Ml2Bq3sMzkfNNUVhQzKWr6lUpA=" "ofl/firasansextracondensed/FiraSansExtraCondensed-Light.ttf"]
+  ["Pjhc+9k8ipJKxLM7DzOjndScORnf+i9mEJGj8hzEFQ4=" "ofl/firasansextracondensed/FiraSansExtraCondensed-Bold.ttf"]
+  ["3mw5QG1H3+mgQ5rLTjDtSr7zp+A4Ii5pQNQwACkujMc=" "ofl/firasansextracondensed/FiraSansExtraCondensed-ExtraLight.ttf"]
+  ["CI8cSMUCRHydXBf3D4CW/p5IB0ARw1APm+LHXysKm0c=" "ofl/firasansextracondensed/FiraSansExtraCondensed-Italic.ttf"]
+  ["EK1JfaCeMDUlhfr6/6XwMqBV0odn0o3DJs1THYCy+SA=" "ofl/firasansextracondensed/FiraSansExtraCondensed-ExtraBoldItalic.ttf"]
+  ["A3xym9YfhR8up63fstfD1AzvKtGLEz73T1aRbUV0xfU=" "ofl/firasansextracondensed/FiraSansExtraCondensed-BoldItalic.ttf"]
+  ["0bNhJFI5HdWAlm1yTF3WAqI5VeM7RmwiAg3L1Hg37iI=" "ofl/firasansextracondensed/FiraSansExtraCondensed-Medium.ttf"]
+  ["nKhmwa/xBq64UOItwVQeo1wM9oYrJYaaRSqDP+aCH7E=" "ofl/firasansextracondensed/FiraSansExtraCondensed-BlackItalic.ttf"]
+  ["FC9VwaRu+pkl+B6TNJuZLyCw8Zc7ozyDwGY1c6+tiOU=" "ofl/firasansextracondensed/FiraSansExtraCondensed-LightItalic.ttf"]
+  ["BWytKLNpe/Cgk+tJ5V0C6HOx3h607WRGfIyAsQxnUOk=" "ofl/firasansextracondensed/FiraSansExtraCondensed-ExtraBold.ttf"]
+  ["UfAZhcqNx0C5Ua/T0hR4zFHLHYVGE2ZDw7Axp0rdVHk=" "ofl/firasansextracondensed/FiraSansExtraCondensed-Regular.ttf"]
+  ["tiJCAyJiTyg7js+3/5aGz6X4yhkbzrQhAJ7OqKqEpi8=" "ofl/firasansextracondensed/FiraSansExtraCondensed-ExtraLightItalic.ttf"]
+  ["l5KHhInbl9BoqvEVyrUL2t0ehDJ0/1GzeGyoECuhaoc=" "ofl/firasansextracondensed/FiraSansExtraCondensed-Black.ttf"]
+  ["VPxCXAFmMfuqGuKqH1n1Pkbpw4Bfod9aIXYT2LYijsc=" "ofl/firasansextracondensed/FiraSansExtraCondensed-SemiBold.ttf"]
+  ["+Xi3Ud7T5xydCpC5kq3OIdGTAnRN7xa5zEsLtK920eU=" "ofl/firasansextracondensed/FiraSansExtraCondensed-Thin.ttf"]
+];
+firasans = mkFont "firasans" "ofl" [
+  ["9NZq8nyCiiadXfSDpIhARgWVfQ9K7q2Ou8miDa0ksRU=" "ofl/firasans/FiraSans-ExtraLightItalic.ttf"]
+  ["wpVWonGb9hPvPV4HDkDZA6iWXZwIG+yhN13B5uD5PCM=" "ofl/firasans/FiraSans-Regular.ttf"]
+  ["4hcvSiPpviL5d8NN44l9iQQBu8XpxH35aN+iwB+zIjU=" "ofl/firasans/FiraSans-Light.ttf"]
+  ["gbwPX6xbG6ViwWJTGWduggL+wBtH4eCbNduIIQwwz2g=" "ofl/firasans/FiraSans-BlackItalic.ttf"]
+  ["cnWHljCZD1vBOjw/zWjuockCqogndp3kmFOQEEpxoUk=" "ofl/firasans/FiraSans-ThinItalic.ttf"]
+  ["CibP+QTXkPet4r/68ie1/s2+/9rBaV/b1kDghv5OcVI=" "ofl/firasans/FiraSans-ExtraBold.ttf"]
+  ["9XVELYuGMIZZkgjJtp0ONFoJNvPsJ7ErP7xBUmtW6Dg=" "ofl/firasans/FiraSans-ExtraLight.ttf"]
+  ["zZ1YL/rhUbxhaybPhLPEkS0ENjucXhs+WZtm4OfVMqQ=" "ofl/firasans/FiraSans-Thin.ttf"]
+  ["G5bBbbmBm8qp1YgGi7OXu26XfEh0ll09UNeJoZQ3V+s=" "ofl/firasans/FiraSans-BoldItalic.ttf"]
+  ["y8GELL7YwdEUa6fJ25fY8oyb7f0l9BxbDhJZykhiIyg=" "ofl/firasans/FiraSans-Medium.ttf"]
+  ["ykIovdd3YeIp504+MPOjeGp1J1t35nXey3X301bX97Q=" "ofl/firasans/FiraSans-LightItalic.ttf"]
+  ["CrJ+kXjX90iY3SbjpfEOt5IrsqiKKQPgB5bE98fgjMA=" "ofl/firasans/FiraSans-Black.ttf"]
+  ["pNjhSezdSHSgcm6wr4lEiLOzHEI9awAXyPQV7Rt5W0U=" "ofl/firasans/FiraSans-Bold.ttf"]
+  ["pCBPmoApwcVdqlOFrJWTb3Sr6j4jJ3Dx+yhioZ0d+hM=" "ofl/firasans/FiraSans-Italic.ttf"]
+  ["l9xWlv4Kq8q/fgQVJ+DKOSFWYcuBdM0aksAdn+Ikxz0=" "ofl/firasans/FiraSans-SemiBoldItalic.ttf"]
+  ["6ybfGv7sH4F5d8hym0obpe8H18gh05y/9jSOSRx0j18=" "ofl/firasans/FiraSans-ExtraBoldItalic.ttf"]
+  ["2JK3puh02Dm8fnErHVfPZLz4ATrhQ8PqsJ4P2aBgRBE=" "ofl/firasans/FiraSans-MediumItalic.ttf"]
+  ["2wMh+D6z6fUnuK84Shs/79wQOc8rBv05s/YUkr2pVhw=" "ofl/firasans/FiraSans-SemiBold.ttf"]
+];
+fjallaone = mkFont "fjallaone" "ofl" [
+  ["i2cHX0eRw1uM2ImzCJ0NjcsPeBPN+9tP8amHEwRgKn8=" "ofl/fjallaone/FjallaOne-Regular.ttf"]
+];
+fjordone = mkFont "fjordone" "ofl" [
+  ["5YniJBK1OCwaTsSCryjFFdnHlM6L3ppMLbjvKmoGPYY=" "ofl/fjordone/FjordOne-Regular.ttf"]
+];
+flamenco = mkFont "flamenco" "ofl" [
+  ["bnVepMILhp3XRjwPKls3quC+axWNDvgoGwN0rzxRUhA=" "ofl/flamenco/Flamenco-Light.ttf"]
+  ["TeZ/nGskRK4gc8I28IKcldOAxe9Er/RTl1SIj8LjzyM=" "ofl/flamenco/Flamenco-Regular.ttf"]
+];
+flavors = mkFont "flavors" "ofl" [
+  ["TmUbzavpdTCSq4sahUh8k02TZQQBhTpZG720ZYv1Atg=" "ofl/flavors/Flavors-Regular.ttf"]
+];
+fleurdeleah = mkFont "fleurdeleah" "ofl" [
+  ["EfbBm9UoNcZs9s948GCkZ6kqhfHWZ0R+qP7v3ZvMun0=" "ofl/fleurdeleah/FleurDeLeah-Regular.ttf"]
+];
+flowblock = mkFont "flowblock" "ofl" [
+  ["Qd8q2V2a4tNXPn6VgYbgSoUqRKVo5cL8X70i5Ba1Csw=" "ofl/flowblock/FlowBlock-Regular.ttf"]
+];
+flowcircular = mkFont "flowcircular" "ofl" [
+  ["6ofVsdC+fFo89jBUrT4dXtVMynSR+SN6EibLcvY0Dng=" "ofl/flowcircular/FlowCircular-Regular.ttf"]
+];
+flowrounded = mkFont "flowrounded" "ofl" [
+  ["3TMZGIgAvrpPMDUy8lSID3fFE9+47lTkTNf6L96yUSM=" "ofl/flowrounded/FlowRounded-Regular.ttf"]
+];
+foldit = mkFont "foldit" "ofl" [
+  ["zQ8ZMu13Ys5nm0852vwYFmCIOxTZehJgwHSojTkVIS4=" "ofl/foldit/Foldit%5Bwght%5D.ttf"]
+];
+fondamento = mkFont "fondamento" "ofl" [
+  ["7gOnzLO3zfPNCV0Mw0+ecMFrF3nLx8Rmv5B3Mjpup2Q=" "ofl/fondamento/Fondamento-Regular.ttf"]
+  ["gwPHbM+vgaBlw2U6HVWfdugiOjIAp5RR1d7dM867754=" "ofl/fondamento/Fondamento-Italic.ttf"]
+];
+fontdinerswanky = mkFont "fontdinerswanky" "asl20" [
+  ["hHIp+/WMf3R5+T/Xz5/CabVMDJ9kZavLZaIG+yYb5Bs=" "apache/fontdinerswanky/FontdinerSwanky-Regular.ttf"]
+];
+forum = mkFont "forum" "ofl" [
+  ["XJ++nEznbQJp9QiNkh1X5YCC/ZwoQz6stt6Vuvk4rfg=" "ofl/forum/Forum-Regular.ttf"]
+];
+fragmentmono = mkFont "fragmentmono" "ofl" [
+  ["yd08eyTBG6BasabsOmWcgj8OFPsmwU3w6T6C67YPOiU=" "ofl/fragmentmono/FragmentMono-Italic.ttf"]
+  ["D+AR9CWHPC4PxzoYnjlONArUjSuamaV2ve7HXO4ABGA=" "ofl/fragmentmono/FragmentMono-Regular.ttf"]
+];
+francoisone = mkFont "francoisone" "ofl" [
+  ["cA+15KW27bFN3i3NSB5anKwUKBV5z0JQAXC6583dNgk=" "ofl/francoisone/FrancoisOne-Regular.ttf"]
+];
+frankruhllibre = mkFont "frankruhllibre" "ofl" [
+  ["SM6jv1rE42qO+sWq4nqvaFSNNv97FvyJafKAX6NRj5g=" "ofl/frankruhllibre/FrankRuhlLibre%5Bwght%5D.ttf"]
+];
+fraunces = mkFont "fraunces" "ofl" [
+  ["F3/2wPFOVVCjxiQkfNEYlhHU62XQALFJRMY9lnlYq7s=" "ofl/fraunces/Fraunces%5BSOFT,WONK,opsz,wght%5D.ttf"]
+  ["skRIxDcC+sTuhWeB1GGg37qNjllLbo4ZAjS3X+0sDgE=" "ofl/fraunces/Fraunces-Italic%5BSOFT,WONK,opsz,wght%5D.ttf"]
+];
+freckleface = mkFont "freckleface" "ofl" [
+  ["VLYan1usPrOj1/ePmdTZxdVoiphZ55u/hwSuecf48Pw=" "ofl/freckleface/FreckleFace-Regular.ttf"]
+];
+frederickathegreat = mkFont "frederickathegreat" "ofl" [
+  ["M9wIMrXpNPPbedxoPepQKcIutBgYO2lmmwRzVcDCRaI=" "ofl/frederickathegreat/FrederickatheGreat-Regular.ttf"]
+];
+fredoka = mkFont "fredoka" "ofl" [
+  ["K6AuaLFShorvm6KOJLNkjH1Ff+byXHYfLCxT+2GnP8g=" "ofl/fredoka/Fredoka%5Bwdth,wght%5D.ttf"]
+];
+fredokaone = mkFont "fredokaone" "ofl" [
+  ["ovuxQWUQ7+IDMCcrwYLWZ+/hUH21+uzeiTCE+xWVOXM=" "ofl/fredokaone/FredokaOne-Regular.ttf"]
+];
+freehand = mkFont "freehand" "ofl" [
+  ["Py8RVdhiMEzynMQlKqXfTUdGjRJ8PBLL8WiUsN2myDM=" "ofl/freehand/Freehand-Regular.ttf"]
+];
+fresca = mkFont "fresca" "ofl" [
+  ["9kNAAWqCAJMgLKavUz8jLuf+TD2ESGAaxCtAkSNrV3c=" "ofl/fresca/Fresca-Regular.ttf"]
+];
+frijole = mkFont "frijole" "ofl" [
+  ["4YK7rQ4bp+sG2T7bHJenH1t9VuJ0M/s3X19xODmatyw=" "ofl/frijole/Frijole-Regular.ttf"]
+];
+fruktur = mkFont "fruktur" "ofl" [
+  ["L8DLJvDRlFICtgIuporFZoJtGeZLRhtkDpoQVvH0Ahg=" "ofl/fruktur/Fruktur-Italic.ttf"]
+  ["3LqQG1/hHAtsPo1esQAzObLdAg4vw5SQFO0Nj/h3Fec=" "ofl/fruktur/Fruktur-Regular.ttf"]
+];
+fugazone = mkFont "fugazone" "ofl" [
+  ["FP1b7M6LCumH5Es/n6nj5sh0Y+lYWsFdtsgnFGIGimI=" "ofl/fugazone/FugazOne-Regular.ttf"]
+];
+fuggles = mkFont "fuggles" "ofl" [
+  ["LnOPoUNgHUQVyFjYyETxIzO0nEe6XBLHh6D2+hUOFSo=" "ofl/fuggles/Fuggles-Regular.ttf"]
+];
+fuzzybubbles = mkFont "fuzzybubbles" "ofl" [
+  ["QHgp8eC2tzqUgv/f0icCuxSaAg+tM/leswvJi/nUcdU=" "ofl/fuzzybubbles/FuzzyBubbles-Regular.ttf"]
+  ["8Y+ljGbPJUCADxCuTJrjFciRScQazio5TF78pzVMTqg=" "ofl/fuzzybubbles/FuzzyBubbles-Bold.ttf"]
+];
+gabriela = mkFont "gabriela" "ofl" [
+  ["E/zKd2T1ftEwgQBmkEUXzsEhiO31rj3nE8yRCQuj1lQ=" "ofl/gabriela/Gabriela-Regular.ttf"]
+];
+gaegu = mkFont "gaegu" "ofl" [
+  ["zDikr5UGpFJU0c4HxYnsRz2eXwvjGeWnexfCFJA/jBw=" "ofl/gaegu/Gaegu-Bold.ttf"]
+  ["2kStblgjgZWZ7ELhpRbyMALMDnL5aPk71J55M2DNd8o=" "ofl/gaegu/Gaegu-Light.ttf"]
+  ["qlLJgzb3xi4olvyLErVqddW0dtiKLxBLCYD0984K38M=" "ofl/gaegu/Gaegu-Regular.ttf"]
+];
+gafata = mkFont "gafata" "ofl" [
+  ["qBauH8aDqMCTZms7f13o6NvfymWEWaSEE45lN41DJrY=" "ofl/gafata/Gafata-Regular.ttf"]
+];
+gajrajone = mkFont "gajrajone" "ofl" [
+  ["65JPDhy58p8SmnZkXa3MNtDzqDEYWsUwprWvYHrgYjE=" "ofl/gajrajone/GajrajOne-Regular.ttf"]
+];
+galada = mkFont "galada" "ofl" [
+  ["rMIrQe5HDcVC4VtfiQfH++vvG5wB6yDkEnvb8FKwBu4=" "ofl/galada/Galada-Regular.ttf"]
+];
+galdeano = mkFont "galdeano" "ofl" [
+  ["7CN55q4RkkIOt6YzwXCJDPhZRKvHPm72xoNx0cBcZlI=" "ofl/galdeano/Galdeano-Regular.ttf"]
+];
+galindo = mkFont "galindo" "ofl" [
+  ["M1pz3vaokNOOh5OoEHeo4VmHsaTlNmhH4Ti1vrE78P4=" "ofl/galindo/Galindo-Regular.ttf"]
+];
+gamjaflower = mkFont "gamjaflower" "ofl" [
+  ["7OMoGe1YU2NVpJoJWwzf3TuO+QgcXtnKHO+PXZma4aw=" "ofl/gamjaflower/GamjaFlower-Regular.ttf"]
+];
+gantari = mkFont "gantari" "ofl" [
+  ["lo+apMam9+9PaZVTPJSSNntMe16LSRLbVVRz7P2iTg8=" "ofl/gantari/Gantari-Italic%5Bwght%5D.ttf"]
+  ["Frg+3WIO/UAceFXruWaUcYwp9V9BmJE9+tR5FZF5bnE=" "ofl/gantari/Gantari%5Bwght%5D.ttf"]
+];
+gayathri = mkFont "gayathri" "ofl" [
+  ["xPq12ZRRgkf3jZa/ISp9WzZWO2BmMTZ2X7rr0zp01Pk=" "ofl/gayathri/Gayathri-Regular.ttf"]
+  ["rWLUqymQ1bupIDwgVROo4WKkSgPFgmn5qLE4ytnA1eM=" "ofl/gayathri/Gayathri-Bold.ttf"]
+  ["XGCoiOpcDR0lmhgD/b6df6XI757c6VJILvqfWd3kUZ0=" "ofl/gayathri/Gayathri-Thin.ttf"]
+];
+gelasio = mkFont "gelasio" "ofl" [
+  ["X5lzNzPo7i2WQJ8o66eIjcX/dibrQPnffZs3sVZCtUQ=" "ofl/gelasio/Gelasio-Regular.ttf"]
+  ["C1gM0GtJ5fYcPD5c/RZL7W/XqqMeB5yKZjswjB/2i0Y=" "ofl/gelasio/Gelasio-Medium.ttf"]
+  ["/JeJD2sFmvtcPucq5YcHqJKBiZ7NbkrRG/kVdu5MHZU=" "ofl/gelasio/Gelasio-Bold.ttf"]
+  ["Dfk7TrNl2+k7SyLtve1FRgrdEN78l5YcV6+zUOBpoFs=" "ofl/gelasio/Gelasio-Italic.ttf"]
+  ["TS91hA3ATfo0iB3oP88+zvppXxppWZED2qTKhhQzd0g=" "ofl/gelasio/Gelasio-SemiBold.ttf"]
+  ["g53kPsVUI+1vWSFQobt2KbwNb4dGUv3Yag8BmjMqYLI=" "ofl/gelasio/Gelasio-BoldItalic.ttf"]
+  ["zr0TVwUbl8LDzrgReiO/bkK3gqb0MY+RHqgMjGlgR8I=" "ofl/gelasio/Gelasio-MediumItalic.ttf"]
+  ["MRdfPKLPhZxhKb8JrdQoSZq+O5+fmqkrdG+fv/YlLGg=" "ofl/gelasio/Gelasio-SemiBoldItalic.ttf"]
+];
+gemunulibre = mkFont "gemunulibre" "ofl" [
+  ["5yO39EsGskQ7ROtzTzJ5Tq5kkVAphC0rIYfq3XSzd6Y=" "ofl/gemunulibre/GemunuLibre%5Bwght%5D.ttf"]
+];
+genos = mkFont "genos" "ofl" [
+  ["iKMlidnYYVq3KJd9ZH9eUBDb94kFDUzyXWYHsU1JofE=" "ofl/genos/Genos%5Bwght%5D.ttf"]
+  ["iFkdU3S8jsHX5OEVHwKJvQCnGQOlKjgDeUka/XMKdz4=" "ofl/genos/Genos-Italic%5Bwght%5D.ttf"]
+];
+gentiumbookbasic = mkFont "gentiumbookbasic" "ofl" [
+  ["8OXC1IQIgEyvl3nuLgOWh7OsXPVu3/UVd/wK7cCQiZQ=" "ofl/gentiumbookbasic/GenBkBasR.ttf"]
+  ["3MvKVqDRvbzEQOOyBw7g72P9g0RUGWuuqoIm6tnILwc=" "ofl/gentiumbookbasic/GenBkBasBI.ttf"]
+  ["N/wlt5FuQFX//wub2iuanv59NAR3Mzn6jN4AoV1Viak=" "ofl/gentiumbookbasic/GenBkBasB.ttf"]
+  ["aHnkAaDETGRz+3lsKEES8xOb0gwonP+S5sSrtNq302k=" "ofl/gentiumbookbasic/GenBkBasI.ttf"]
+];
+gentiumbookplus = mkFont "gentiumbookplus" "ofl" [
+  ["5Vfden+Bj6SCw+Y8dXbG1FX28uO/nYTgoR0WF+K8E4M=" "ofl/gentiumbookplus/GentiumBookPlus-BoldItalic.ttf"]
+  ["s5w/sS4uFeIzby7G0FHHeGGOwl9zYLxHZb/nVbQIwBE=" "ofl/gentiumbookplus/GentiumBookPlus-Bold.ttf"]
+  ["/ntk7qzEMPz0aDam8N/gDSxaFUg+02aSoqGFyyPsKlw=" "ofl/gentiumbookplus/GentiumBookPlus-Regular.ttf"]
+  ["egq0vXhwH6RtMl42JlTEGkfioKXLSj7ryU3OicLuffE=" "ofl/gentiumbookplus/GentiumBookPlus-Italic.ttf"]
+];
+gentiumplus = mkFont "gentiumplus" "ofl" [
+  ["GN8fPd8Jz3IzjyXEXKDRki+16GzddIUi29a+3k+x+Z0=" "ofl/gentiumplus/GentiumPlus-Italic.ttf"]
+  ["NeetZZFpSoMt5Z3xiZvMyI4K+K1f/yBTO2N1F0eFHHE=" "ofl/gentiumplus/GentiumPlus-BoldItalic.ttf"]
+  ["cWxKFoh1ULE/QLQI312tbEEMcqAIZ8X+gCqe1IPj+40=" "ofl/gentiumplus/GentiumPlus-Bold.ttf"]
+  ["hF4Gu0ZzqQil87O0rJ84hBdQoH+qmqRb/LV5aJM0bws=" "ofl/gentiumplus/GentiumPlus-Regular.ttf"]
+];
+geo = mkFont "geo" "ofl" [
+  ["TwCDeCojiiwD+4hkEZsd9cDIOIogig8D16fBExPmefM=" "ofl/geo/Geo-Oblique.ttf"]
+  ["OGae13wP/hhZ9FFDxjYUwPGVMHQzFTbLNdPKypRL5gU=" "ofl/geo/Geo-Regular.ttf"]
+];
+georama = mkFont "georama" "ofl" [
+  ["Mhvg7YaI7Sei/9PoXvuePH2SKYQrfZupCZm/NuZy+wA=" "ofl/georama/Georama-Italic%5Bwdth,wght%5D.ttf"]
+  ["CmJBlwKrVX4GEKWgc6VvJG0Tp9sJTvl5RaCqVvrxSrE=" "ofl/georama/Georama%5Bwdth,wght%5D.ttf"]
+];
+geostarfill = mkFont "geostarfill" "ofl" [
+  ["8JrNwg+gLzIOlwRvYYy15CTRLZehnUdG8F6hU3HeEqg=" "ofl/geostarfill/GeostarFill-Regular.ttf"]
+];
+geostar = mkFont "geostar" "ofl" [
+  ["iRuSwSS75KwAbAuLdAIhVIa3y3lRSIF49BVpSliY0Ss=" "ofl/geostar/Geostar-Regular.ttf"]
+];
+germaniaone = mkFont "germaniaone" "ofl" [
+  ["PuPVZYS6uMnj9ZzDNgqoo24hnc8KnzyJKOPaWhknfj8=" "ofl/germaniaone/GermaniaOne-Regular.ttf"]
+];
+gfsdidot = mkFont "gfsdidot" "ofl" [
+  ["T8eEq4JOiGbu74rVWXa5Pn4XD7G4I3/U+HgbW03Sl/k=" "ofl/gfsdidot/GFSDidot-Regular.ttf"]
+];
+gfsneohellenic = mkFont "gfsneohellenic" "ofl" [
+  ["OSFLonrscoI4gb3JZ7a4kpB5YJdJ2xkR7aD3By5GFog=" "ofl/gfsneohellenic/GFSNeohellenicItalic.ttf"]
+  ["FNVN1/Nv3XFA0/Y1fJmo6tmIqAiymEceArosCZKqEQ0=" "ofl/gfsneohellenic/GFSNeohellenic.ttf"]
+  ["saOQD18zJ6t50Yx2L8oX5GwNs3oy+/NPfcpBRYvUb1M=" "ofl/gfsneohellenic/GFSNeohellenicBold.ttf"]
+  ["tIbDJardHH3E9ah8Qa6ciCPqcoXenXrY+Ppug21BytE=" "ofl/gfsneohellenic/GFSNeohellenicBoldItalic.ttf"]
+];
+gideonroman = mkFont "gideonroman" "ofl" [
+  ["jt2SNldSnkIDggFujwo5XS1SbDkTKPyXz01C7S0Yvc4=" "ofl/gideonroman/GideonRoman-Regular.ttf"]
+];
+gidugu = mkFont "gidugu" "ofl" [
+  ["L6789azc0uYWNI2pvHvBje8tag9+f201fKxcWxNMiIg=" "ofl/gidugu/Gidugu-Regular.ttf"]
+];
+gildadisplay = mkFont "gildadisplay" "ofl" [
+  ["jKVHVpJVLNTxSbzQAJnAmEU8ObhUH0q+IZL4StF6eqA=" "ofl/gildadisplay/GildaDisplay-Regular.ttf"]
+];
+girassol = mkFont "girassol" "ofl" [
+  ["hMIp3qJCi/JoCNmFpEJi/Vf0ehexciSXydTsW7qU+vw=" "ofl/girassol/Girassol-Regular.ttf"]
+];
+giveyouglory = mkFont "giveyouglory" "ofl" [
+  ["+3H5pGoyNMLZjbvkTnEfZWVDaAMcV7knv3Z5pG4njIA=" "ofl/giveyouglory/GiveYouGlory.ttf"]
+];
+glassantiqua = mkFont "glassantiqua" "ofl" [
+  ["r5P67dlb0upV/W9spiE2kztkFJdpPxWxn8NkLVS1tE4=" "ofl/glassantiqua/GlassAntiqua-Regular.ttf"]
+];
+glegoo = mkFont "glegoo" "ofl" [
+  ["I3yjIO+GdBbEbG/fpu3CrF9JoSE5atAnmi4Pjteqo7E=" "ofl/glegoo/Glegoo-Regular.ttf"]
+  ["itWSLbE0/pv58mkfxVVCk8BohM+Jgj9FL8dttrPef+8=" "ofl/glegoo/Glegoo-Bold.ttf"]
+];
+gloock = mkFont "gloock" "ofl" [
+  ["w6Z+AhL32gF2R5auchy5urPhItFCNU+Xz5xj+3Y+bXc=" "ofl/gloock/Gloock-Regular.ttf"]
+];
+gloriahallelujah = mkFont "gloriahallelujah" "ofl" [
+  ["61nydizoeFopK+uyrzs+aqIUVJE9eR9fJUQdHVfq2fw=" "ofl/gloriahallelujah/GloriaHallelujah.ttf"]
+];
+glory = mkFont "glory" "ofl" [
+  ["8k2qpGcXePB4hTVHH+mqagoJ7Ll+5kTZp7WAHen2y5Q=" "ofl/glory/Glory-Italic%5Bwght%5D.ttf"]
+  ["coIXgIDKT8X+yntv+WISrO5YRi79/4pDuA1nIE8QCDc=" "ofl/glory/Glory%5Bwght%5D.ttf"]
+];
+gluten = mkFont "gluten" "ofl" [
+  ["y0sB5HVONmFRJefLFv4eyCVdHbAtCyNtfJkkONwag+Q=" "ofl/gluten/Gluten%5Bslnt,wght%5D.ttf"]
+];
+goblinone = mkFont "goblinone" "ofl" [
+  ["JqFer9iRH1R+hGBmoe6gUhry2HDW8XuOzwdBdouZ0Jk=" "ofl/goblinone/GoblinOne.ttf"]
+];
+gochihand = mkFont "gochihand" "ofl" [
+  ["xGsCmrSEayk14wGvCyz4Wh100oWOajNjaj5kzzzEaWs=" "ofl/gochihand/GochiHand-Regular.ttf"]
+];
+goldman = mkFont "goldman" "ofl" [
+  ["PYdbwC153/hjaa2ltMTYwbexhLxwoyK2UapcOWk2MeM=" "ofl/goldman/Goldman-Bold.ttf"]
+  ["dH1OtUf/yhscTOtJ048Eos2HZ9XYZCW3EpBFarjrKAo=" "ofl/goldman/Goldman-Regular.ttf"]
+];
+golostext = mkFont "golostext" "ofl" [
+  ["F7tY+2muwt+wR6Lr9SU0Aj6baIyXpreseVsKcpEsIGM=" "ofl/golostext/GolosText%5Bwght%5D.ttf"]
+];
+gorditas = mkFont "gorditas" "ofl" [
+  ["JrglnC9h7xDfoqL+HR4RPfskHW94DOFYeNAF+GwUZcU=" "ofl/gorditas/Gorditas-Bold.ttf"]
+  ["lVQ6qkw+HcIrIgspvL2GGP90TZBO1MIxeatakR1VTuA=" "ofl/gorditas/Gorditas-Regular.ttf"]
+];
+gothica1 = mkFont "gothica1" "ofl" [
+  ["PeAee2vA/dSU+k3gZ35npzpq6QdTe7TF81XZyWbi6/0=" "ofl/gothica1/GothicA1-ExtraLight.ttf"]
+  ["LK7nfA22r+HNdZxUdTc2HOZpRefW/vDxSpo1+7RYG7Y=" "ofl/gothica1/GothicA1-Thin.ttf"]
+  ["N6ZTU6ZG/qWhrJBYXRu4+bmX7K4LecTx8YdWb5EOP50=" "ofl/gothica1/GothicA1-ExtraBold.ttf"]
+  ["IRFRvqmAmMV5YQqxEUuxv+kJBXIH21YfNXuJbQdsIaw=" "ofl/gothica1/GothicA1-Regular.ttf"]
+  ["fuMGPy1iaTbYpZ36IVJeftGbTono+7DqWpJMrZsMwfQ=" "ofl/gothica1/GothicA1-SemiBold.ttf"]
+  ["Log/oK5UgACZYli0EB8rtzKiixlyZPSWIaLLFtbp8SY=" "ofl/gothica1/GothicA1-Bold.ttf"]
+  ["yKDrVvprE0SGiP7QeZ1QP+U2qMa3rPr9/VgO25xMIZI=" "ofl/gothica1/GothicA1-Medium.ttf"]
+  ["Y5j/XGkjx0y0UzkIkty5guwKbEOzXahZCo8ycC2MB50=" "ofl/gothica1/GothicA1-Black.ttf"]
+  ["kngmseIzZjJ+vlPUZ1qHk47pC3cQTLeUCHtROFiLU/Q=" "ofl/gothica1/GothicA1-Light.ttf"]
+];
+gotu = mkFont "gotu" "ofl" [
+  ["dm+/sZ2KDDiBSyPEJRXtnepTj84Y10EiHsoyHQYEo/U=" "ofl/gotu/Gotu-Regular.ttf"]
+];
+goudybookletter1911 = mkFont "goudybookletter1911" "ofl" [
+  ["YtIZlC0uSjqEc8EWJUlm0wiCCuFyni+sNzDmbAc6VUg=" "ofl/goudybookletter1911/GoudyBookletter1911.ttf"]
+];
+gowunbatang = mkFont "gowunbatang" "ofl" [
+  ["RmxZPnFHQS50ivSFbVrRRwm1qGC99iucJUbyxYdOmEk=" "ofl/gowunbatang/GowunBatang-Regular.ttf"]
+  ["2/yqZG5YMedHhSSSTwKQb1UChaUFBpm044yZULPsS5Q=" "ofl/gowunbatang/GowunBatang-Bold.ttf"]
+];
+gowundodum = mkFont "gowundodum" "ofl" [
+  ["puRXkzInSDoRdY/QlHvHRCKhBtRvC/BX/apa+UowBn0=" "ofl/gowundodum/GowunDodum-Regular.ttf"]
+];
+graduate = mkFont "graduate" "ofl" [
+  ["IPdvQZOh3CDOZNcpHsC4jr/f3Szz6MuHqaP75TBzXVc=" "ofl/graduate/Graduate-Regular.ttf"]
+];
+grandhotel = mkFont "grandhotel" "ofl" [
+  ["7HrmXUnJNste0yU0q3Tb1AxWcz3lFFrDqunaNi4CtQ8=" "ofl/grandhotel/GrandHotel-Regular.ttf"]
+];
+grandstander = mkFont "grandstander" "ofl" [
+  ["+8fR2TTmqnhC9+hCDNgz7KnrEj1hiAB17saHUTaeLxM=" "ofl/grandstander/Grandstander%5Bwght%5D.ttf"]
+  ["IrpVZ1eUL9Kz2Hqgh86I1yIkksVEDE8AkUR3DctovQ0=" "ofl/grandstander/Grandstander-Italic%5Bwght%5D.ttf"]
+];
+grapenuts = mkFont "grapenuts" "ofl" [
+  ["1HcnJJMduvxQfGEPENjP+kYC+Ljoq/wL04SZaHWvQTQ=" "ofl/grapenuts/GrapeNuts-Regular.ttf"]
+];
+gravitasone = mkFont "gravitasone" "ofl" [
+  ["tA3EXzNU8oIQcoas8VQgctJYxxfI7fHRGO8BBfJeYns=" "ofl/gravitasone/GravitasOne.ttf"]
+];
+greatvibes = mkFont "greatvibes" "ofl" [
+  ["gm6zpeu73P9Awx9HXHSZq1NaZ3QNjxyFQZLenszSTK4=" "ofl/greatvibes/GreatVibes-Regular.ttf"]
+];
+grechenfuemen = mkFont "grechenfuemen" "ofl" [
+  ["AEjSzLP1jOiZSAS+V2TgdHcZd/St0vPdEt/ppljxrcA=" "ofl/grechenfuemen/GrechenFuemen-Regular.ttf"]
+];
+grenzegotisch = mkFont "grenzegotisch" "ofl" [
+  ["cBspnY3AAqK0vqL/DxJywOQIGig1kUNUgEVlxBDQxjc=" "ofl/grenzegotisch/GrenzeGotisch%5Bwght%5D.ttf"]
+];
+grenze = mkFont "grenze" "ofl" [
+  ["Ry8oLOv09mfprFkcFO2+jh5s4tayrVxE3YA9louaFNs=" "ofl/grenze/Grenze-Medium.ttf"]
+  ["ov2X5l08sa4WshwC9F8yDkmJUzN1TaJ7yS0jXuyEgy4=" "ofl/grenze/Grenze-Regular.ttf"]
+  ["tJuPlA76Ai6nM5wPFb9IYBD0fm7qh6G64P8r4fr5SAo=" "ofl/grenze/Grenze-Light.ttf"]
+  ["myF8Huqzeg4YEWCOslxb0wODTIZKhoqileSlGdWl8RE=" "ofl/grenze/Grenze-Thin.ttf"]
+  ["rLwGz2h+IZozMWJKMoBkuFqC0zyjkG67LUQl4egSZgc=" "ofl/grenze/Grenze-ExtraBold.ttf"]
+  ["GZ9aMevSSpE3bEOrnaw0gMa3pRWMEHfoRdZStsuUeug=" "ofl/grenze/Grenze-Black.ttf"]
+  ["cPu39WmWdH/t98N+N9QjLFYp6InYnu4xJfDH1Wvfm3s=" "ofl/grenze/Grenze-Italic.ttf"]
+  ["RIeAww3ReyQM88VeScXdPYWzNDu7uKczI5vwmM1YVP0=" "ofl/grenze/Grenze-ThinItalic.ttf"]
+  ["Lv6Q5CW8Ffh1l9LdbvCsWCDWeuqIIhunbKs1HX7luqI=" "ofl/grenze/Grenze-Bold.ttf"]
+  ["+Qfwxzcm75vZ05Swz5mgG5KTQl6l3eo35qqpXAn76V8=" "ofl/grenze/Grenze-SemiBoldItalic.ttf"]
+  ["+BlzVa5JT2dtLLbxRGaVXWfw+FbSVeqcFLe3XfmMFhM=" "ofl/grenze/Grenze-SemiBold.ttf"]
+  ["i7RMIb2Q5pzbK3aZVunh9wVos4pGeAyyQenIuEw9bEA=" "ofl/grenze/Grenze-ExtraLightItalic.ttf"]
+  ["4ozTp86R+6AYOZ9iC5BYID19WlBVwdTouYG8/rm8MRA=" "ofl/grenze/Grenze-ExtraLight.ttf"]
+  ["TtHA7+VJrt6sdVG4rDrGN75vuXJD63T9dcqjhTo2GYs=" "ofl/grenze/Grenze-ExtraBoldItalic.ttf"]
+  ["fXRWD4t88Z5LQ/nr0C29iFftyr3NvqQ49FgJRUFGfEI=" "ofl/grenze/Grenze-BoldItalic.ttf"]
+  ["RIzBir/ETqeeVhKDX6CaKaK0evamIGg4xnyAdepgf2w=" "ofl/grenze/Grenze-LightItalic.ttf"]
+  ["/CV9YU1ahUXdQ+B9rvLL+M7dXVjEejZx8WGZQe7tFU4=" "ofl/grenze/Grenze-BlackItalic.ttf"]
+  ["hOxjtAxkJzAWuEGiko6HfsF5G/X614xFxkLgrksv9pk=" "ofl/grenze/Grenze-MediumItalic.ttf"]
+];
+greyqo = mkFont "greyqo" "ofl" [
+  ["HtRwHCQUWio7QnHEj+J9OuCCuY78dhnB5+5bKf/izWc=" "ofl/greyqo/GreyQo-Regular.ttf"]
+];
+griffy = mkFont "griffy" "ofl" [
+  ["yInD+NFpYxOGopfq6LW977+NBqqfTzJfrsMbm1847rU=" "ofl/griffy/Griffy-Regular.ttf"]
+];
+gruppo = mkFont "gruppo" "ofl" [
+  ["K/ibSxDY1KCK7J9u0SS8pIrbEKi7oC0IBVkZXjnf+4A=" "ofl/gruppo/Gruppo-Regular.ttf"]
+];
+gudea = mkFont "gudea" "ofl" [
+  ["KxtWdj3VkPeCtlsHl4++b5qDul7P2vaYwOlCygYYEFk=" "ofl/gudea/Gudea-Bold.ttf"]
+  ["pLVBAJCoIeoXAhYnMSur3z2NsCcSF/2MTZ9invCi2Qs=" "ofl/gudea/Gudea-Regular.ttf"]
+  ["1Oerx25b82hkNpOIQJJ7NSL9cEwfkgUUsxtnmTQJ4nQ=" "ofl/gudea/Gudea-Italic.ttf"]
+];
+gugi = mkFont "gugi" "ofl" [
+  ["wLH5eZec/DCfskOPqUZPlhczU+DEhCzHpZGWWBhO2dM=" "ofl/gugi/Gugi-Regular.ttf"]
+];
+gulzar = mkFont "gulzar" "ofl" [
+  ["JGM3lzrGTotw/mEUBdzzKjlaiIXESX3EXbxJddOsCDE=" "ofl/gulzar/Gulzar-Regular.ttf"]
+];
+gupter = mkFont "gupter" "ofl" [
+  ["yth7bAasY+JPK5dBwMvkvPWUWCZpb0usphkzyVkFLPY=" "ofl/gupter/Gupter-Regular.ttf"]
+  ["j6uKhOWkfExaWkRJymLjpkkvvdrdd43p2fstOxs2mJw=" "ofl/gupter/Gupter-Bold.ttf"]
+  ["bKngwvp0y9K3Wg5psRYhhXCsdNgMHpLrzFm7a9yLsDI=" "ofl/gupter/Gupter-Medium.ttf"]
+];
+gurajada = mkFont "gurajada" "ofl" [
+  ["NTwSiab0unQxVMhwQYJyz2jg9jwMOFmO0zy6gU0xeOg=" "ofl/gurajada/Gurajada-Regular.ttf"]
+];
+gwendolyn = mkFont "gwendolyn" "ofl" [
+  ["3nzQgeYVBJqkuLTPK2/HCrcOanunssSYU6fylt4UHEA=" "ofl/gwendolyn/Gwendolyn-Bold.ttf"]
+  ["gfEUoP+prkYfqE7ckPD/UCtMfArv5tToQv/0eCFKYvw=" "ofl/gwendolyn/Gwendolyn-Regular.ttf"]
+];
+habibi = mkFont "habibi" "ofl" [
+  ["Za6QW/mK6MoOxneG0BzcGt1VdZ27i5nn2g02j56nRnE=" "ofl/habibi/Habibi-Regular.ttf"]
+];
+hachimarupop = mkFont "hachimarupop" "ofl" [
+  ["eECJEMjxovF0onnLwUhLSLcXgAOeuj/hviv8xdTfP5g=" "ofl/hachimarupop/HachiMaruPop-Regular.ttf"]
+];
+hahmlet = mkFont "hahmlet" "ofl" [
+  ["iSv/5TAlV3CnQ1ImFUoC9RkFX/a+32QlTzfyHRWlknk=" "ofl/hahmlet/Hahmlet%5Bwght%5D.ttf"]
+];
+halant = mkFont "halant" "ofl" [
+  ["HvRe9hE+aemO3dgJpO78GPYAV0POdxjvb9aR20MCm4I=" "ofl/halant/Halant-SemiBold.ttf"]
+  ["9kb/oc3y1Ks2MmlD00lMmEFiZPTfQPjnv4YhHeVx3wc=" "ofl/halant/Halant-Regular.ttf"]
+  ["moAvbsk/LbjRSC35YS2DlgWSqf6SzLgTwkKqinJgFDQ=" "ofl/halant/Halant-Light.ttf"]
+  ["7jPlrS+Lj/A++RsobqO/k1g8wWK2FHkOLdz9V3KTna8=" "ofl/halant/Halant-Bold.ttf"]
+  ["Gpvsf/JDPTr0Wv/2gftsPGeed6tE27TbLLuctV6beiM=" "ofl/halant/Halant-Medium.ttf"]
+];
+hammersmithone = mkFont "hammersmithone" "ofl" [
+  ["b69Omlmisl4QFsTkfPTaSklNB67hXcL3CKiMquAV/4o=" "ofl/hammersmithone/HammersmithOne-Regular.ttf"]
+];
+hanaleifill = mkFont "hanaleifill" "ofl" [
+  ["GRbyCKDowtG5U14m+Pd+RbZB6Y+b8W6AnN1Hg2e2Qds=" "ofl/hanaleifill/HanaleiFill-Regular.ttf"]
+];
+hanalei = mkFont "hanalei" "ofl" [
+  ["AA3dKmvlf1KqQYdsK6cTEOKnEfA0PBvdceQ8nxNwAPY=" "ofl/hanalei/Hanalei-Regular.ttf"]
+];
+handjet = mkFont "handjet" "ofl" [
+  ["kmJ0nouwtz68rg4gQoaJw8WVdu6+tsThAgMA0tQb300=" "ofl/handjet/Handjet%5BELGR,ELSH,wght%5D.ttf"]
+];
+handlee = mkFont "handlee" "ofl" [
+  ["e5nA8pG11S4GxmSYodDdbf9Foy4y0TvgicYNLY3ABEU=" "ofl/handlee/Handlee-Regular.ttf"]
+];
+hankengrotesk = mkFont "hankengrotesk" "ofl" [
+  ["gTs/j6CWVAVmmomzjlG779le72uOINHLLYwQzOBiZi8=" "ofl/hankengrotesk/HankenGrotesk%5Bwght%5D.ttf"]
+  ["rlcxcm/3UwGjy2Py6Y0bq8d9VasJ+44inKdfW9RvvjI=" "ofl/hankengrotesk/HankenGrotesk-Italic%5Bwght%5D.ttf"]
+];
+hanna = mkFont "hanna" "ofl" [
+  ["NLEFAibssFfebYOklO4BWy0MngI4+j1C2jewxVrsmoo=" "ofl/hanna/BM-HANNA.ttf"]
+];
+hannari = mkFont "hannari" "ofl" [
+  ["by7s4lo3ij6F+CxfGGLMiG37o+tnfTqcGMWkmTe7m1M=" "ofl/hannari/Hannari-Regular.ttf"]
+];
+hanuman = mkFont "hanuman" "ofl" [
+  ["UzTHK9V0ZdqeFlKAVVQMIMZ0dq4vp0ct1FBM6mc/4vc=" "ofl/hanuman/Hanuman-Thin.ttf"]
+  ["2YJFjlkwGPHxCnVDREGb950l12rcn/uqjWCeb/ROSQY=" "ofl/hanuman/Hanuman-Regular.ttf"]
+  ["aPnbhM4KeCBtvAcX9sjkNKfJwmlO3kMMMCxnzQoea9E=" "ofl/hanuman/Hanuman-Black.ttf"]
+  ["BXDWPBvBCRcL/hzIlgFVcOuJ2R9IaFbE39sOUCijAmQ=" "ofl/hanuman/Hanuman-Bold.ttf"]
+  ["ZwNn/xBgg4vmO3ifCLJT4jb4D1M9p5zM6pQguITCSts=" "ofl/hanuman/Hanuman-Light.ttf"]
+];
+happymonkey = mkFont "happymonkey" "ofl" [
+  ["FU0X79UEPp926kuKFXQ/4ZY0x62+NTHWr2i+yKDH+tM=" "ofl/happymonkey/HappyMonkey-Regular.ttf"]
+];
+harmattan = mkFont "harmattan" "ofl" [
+  ["IkMuzWSDTtG65ZxFeDa22XjhNk8qFIiDsGJDqwHK6nA=" "ofl/harmattan/Harmattan-Bold.ttf"]
+  ["aurrM6Hwd14fIGuGkqHysDGuCTqyZ8OCuZ1se/CF8us=" "ofl/harmattan/Harmattan-Regular.ttf"]
+];
+headlandone = mkFont "headlandone" "ofl" [
+  ["sJri3QiyluHg2a+T9cNImdagTWxXr/dmQJ+KltCF86Q=" "ofl/headlandone/HeadlandOne-Regular.ttf"]
+];
+heebo = mkFont "heebo" "ofl" [
+  ["qAWjb71FnYWC0jtFLHTM1m04059FozpwADBIitbsdhQ=" "ofl/heebo/Heebo%5Bwght%5D.ttf"]
+];
+hennypenny = mkFont "hennypenny" "ofl" [
+  ["nIVQZlgn29NB5dVOouaG+k9KneP4su0gK5akHierThk=" "ofl/hennypenny/HennyPenny-Regular.ttf"]
+];
+heptaslab = mkFont "heptaslab" "ofl" [
+  ["c3utx5RNW2+SwFkZmVJA1upw6Gvr5F0ZbmFnfnqQHyk=" "ofl/heptaslab/HeptaSlab%5Bwght%5D.ttf"]
+];
+hermeneusone = mkFont "hermeneusone" "ofl" [
+  ["U/+LZo/2A76zoVspjDXYCTL1ekfIiebpa7k9Q02iWAg=" "ofl/hermeneusone/HermeneusOne-Regular.ttf"]
+];
+herrvonmuellerhoff = mkFont "herrvonmuellerhoff" "ofl" [
+  ["uorBCAenlGK3yCZbLuu4QZ5QF/3BpYKLGgcdnoR4dy4=" "ofl/herrvonmuellerhoff/HerrVonMuellerhoff-Regular.ttf"]
+];
+himelody = mkFont "himelody" "ofl" [
+  ["Ng0sCogJGKpIMo0dkhn1OQeI0Jock1PhK0cd4BhnOuY=" "ofl/himelody/HiMelody-Regular.ttf"]
+];
+hinamincho = mkFont "hinamincho" "ofl" [
+  ["g5X6+gwnIbS1wnQDHhM2/qD3A9kIsXXuIfi6LxrVZqA=" "ofl/hinamincho/HinaMincho-Regular.ttf"]
+];
+hindcolombo = mkFont "hindcolombo" "ofl" [
+  ["l+GN8jYXsooADJg2qFeStnfqc17xBcHPXAn/x9uhovs=" "ofl/hindcolombo/HindColombo-Medium.ttf"]
+  ["t/ryj/JbiC4gJP332TPsqqKm5/smzvCbRaWp+r6CBRQ=" "ofl/hindcolombo/HindColombo-Regular.ttf"]
+  ["wygB3BnV9Q/Umm2HlP3Y6JMAz0YYaS6if+7BDxlSsrY=" "ofl/hindcolombo/HindColombo-Bold.ttf"]
+  ["4+R9TTNm9g/Tdl1uJxbwY+MMVOMsVyNObuQIeZNRcYY=" "ofl/hindcolombo/HindColombo-Light.ttf"]
+  ["mNNbKiehbjMVzQuoZ6on6VEoMckR5joGirI94+YqadM=" "ofl/hindcolombo/HindColombo-SemiBold.ttf"]
+];
+hindguntur = mkFont "hindguntur" "ofl" [
+  ["Nw0oOMxRy/AGDxZP/hHss1omGUUrjI0gC+zLUOPQIow=" "ofl/hindguntur/HindGuntur-Medium.ttf"]
+  ["wUOvqATGN9BcbDBULAUzggBG1S4sTDLde2qKUe8wdZQ=" "ofl/hindguntur/HindGuntur-SemiBold.ttf"]
+  ["3ThHtA0W7o+Qa0GSi18ONIDqkJJSS1xqlJ6xncRYyvk=" "ofl/hindguntur/HindGuntur-Light.ttf"]
+  ["4+iOh6RwlLNNGwvEqI9wDLHR013WKGvSJLw1zBcSsWc=" "ofl/hindguntur/HindGuntur-Bold.ttf"]
+  ["L5tNMVB8kv4dVOUlaQTkHZFpi5UskNZr/pJs0VbaxOs=" "ofl/hindguntur/HindGuntur-Regular.ttf"]
+];
+hindjalandhar = mkFont "hindjalandhar" "ofl" [
+  ["jyMWUbZ/j6Xb0+RkA2zg6er4ydEuNJRhlqe2p5zK3EQ=" "ofl/hindjalandhar/HindJalandhar-SemiBold.ttf"]
+  ["tP7CqO7bbs3SnteGK7dvhH4HdCTwM3x+rwkYWqFEfUc=" "ofl/hindjalandhar/HindJalandhar-Light.ttf"]
+  ["jRWj26nVmqdox41i2qJZEp45HKaJlNMqlUsZPnfCCN4=" "ofl/hindjalandhar/HindJalandhar-Medium.ttf"]
+  ["7DGiEERB7dVGB2EOfJwUoTy3/VfWPP8kMwoXNKTa1+E=" "ofl/hindjalandhar/HindJalandhar-Regular.ttf"]
+  ["QK6ei+6jG88n4KIjQkpbkE3nFvbTNDyUJaJop8BKwag=" "ofl/hindjalandhar/HindJalandhar-Bold.ttf"]
+];
+hindkochi = mkFont "hindkochi" "ofl" [
+  ["PFm27GAjyeS040c6CwBs4yzBUhyjjjXGGOEjHq/NTeU=" "ofl/hindkochi/HindKochi-Medium.ttf"]
+  ["vk71r1FXxkq4anWFgPnMQa3kRsJW/RUHCADrj8/Nxjk=" "ofl/hindkochi/HindKochi-Regular.ttf"]
+  ["ABXq7YBILjO5z0wYlB4yUJFcpbi+1Ci4sPnZUklvNyY=" "ofl/hindkochi/HindKochi-Bold.ttf"]
+  ["WObL4mtwggGMVbxyjEBWkT0jz7192dkUe6iuIZrEJL8=" "ofl/hindkochi/HindKochi-SemiBold.ttf"]
+  ["q4FNiPxgZS6WddkjWNZMEu9SFgMgCbONS2auSrozuAE=" "ofl/hindkochi/HindKochi-Light.ttf"]
+];
+hindmadurai = mkFont "hindmadurai" "ofl" [
+  ["hCCGxDEhAKAySU3LQ/p6/GmtV3L+AEhl4HYfkhZZEKE=" "ofl/hindmadurai/HindMadurai-Bold.ttf"]
+  ["Uiqubep/uanfvy6iW/Lr9dbwXE7Low/SpW0ippD0wHI=" "ofl/hindmadurai/HindMadurai-Medium.ttf"]
+  ["2+eiI000HoCzRdT/wgAuMIlJLNB81P9cOP4ty7/qVMw=" "ofl/hindmadurai/HindMadurai-Light.ttf"]
+  ["i9VtYALU/k9fN43Sn5rTgtu9A6K/FtokWZqr4z+bVbM=" "ofl/hindmadurai/HindMadurai-Regular.ttf"]
+  ["/OMs0VUTB0Ho265yVt3CyxlesH94FnRue8go4Dx7DOU=" "ofl/hindmadurai/HindMadurai-SemiBold.ttf"]
+];
+hindmysuru = mkFont "hindmysuru" "ofl" [
+  ["N+BJM2nbRPdNQu82wt2poZd/mnJOWsUaLKft04GJqig=" "ofl/hindmysuru/HindMysuru-Bold.ttf"]
+  ["QGNMW+s3AMDxtVbI3fTdon5qIPsbkNp6XK6FxTYoSIc=" "ofl/hindmysuru/HindMysuru-Light.ttf"]
+  ["zvciWNNJEx14yp1d4obU1UGZ0n5QYoetCDRbAWJsMkA=" "ofl/hindmysuru/HindMysuru-Medium.ttf"]
+  ["ep7tP0hq/7Dkaaz3XmBWJ0OhmTc395Y1vtdAqqjIKoQ=" "ofl/hindmysuru/HindMysuru-SemiBold.ttf"]
+  ["o4ozgG2fAI+98gTS9oToCyPOz8Qu4MKu2Bx7OoMz5/I=" "ofl/hindmysuru/HindMysuru-Regular.ttf"]
+];
+hind = mkFont "hind" "ofl" [
+  ["F0KhsKupe0naHT7jr1aPqZfFmjz+c4Kfe+wpP0FtJd0=" "ofl/hind/Hind-SemiBold.ttf"]
+  ["cPnBFYOQ0Mk6i8JLNbS+SyQ5ZTNyu85zgaMsaG+5Gpg=" "ofl/hind/Hind-Medium.ttf"]
+  ["wxuLYHOxT4kYdYb7H6OHENitrjQp70Hho5jay/6DnlE=" "ofl/hind/Hind-Light.ttf"]
+  ["MwxUOWvCdijDLmm4hlTkEGVyIYLG8zuTaipG1yydZ3Q=" "ofl/hind/Hind-Bold.ttf"]
+  ["Ad4VgCL1MHe1IwPkbeOwq1+yRSIqf/4loqV/3Z6WkWI=" "ofl/hind/Hind-Regular.ttf"]
+];
+hindsiliguri = mkFont "hindsiliguri" "ofl" [
+  ["0TV2V4HRpK68fdSiryIUJ+yGiQYBIdikixm8o+6zl34=" "ofl/hindsiliguri/HindSiliguri-Bold.ttf"]
+  ["RQcafakCp0h39DJyL1JdAFAtYa73H8pMqz2oojFWwz0=" "ofl/hindsiliguri/HindSiliguri-Regular.ttf"]
+  ["8nWcUw1kdyCk1OmfrvPC0VDhRSGTqcg/uByNKYBcE+o=" "ofl/hindsiliguri/HindSiliguri-Medium.ttf"]
+  ["kqmmgkCINGeDC4eyVoJCpZ5o1FNenhXwh2UOEsSqyoM=" "ofl/hindsiliguri/HindSiliguri-SemiBold.ttf"]
+  ["nVXQ3Mm1TLCHCuXVskyvjTyp8wTNkO5vT+HmyO+DPlo=" "ofl/hindsiliguri/HindSiliguri-Light.ttf"]
+];
+hindvadodara = mkFont "hindvadodara" "ofl" [
+  ["TyhUu1MiLrU1dHEeqmdbVbUT/faO6Tjb5rgDiaFjLjY=" "ofl/hindvadodara/HindVadodara-Light.ttf"]
+  ["Bk01EE4g5VCPLtQNBjTjD7X5kKoBHYhOC0VBwPudiB0=" "ofl/hindvadodara/HindVadodara-Regular.ttf"]
+  ["dW+91NTL7UZLFI7aY7cAjk8uBtiqFA0rWUQC7nCuuow=" "ofl/hindvadodara/HindVadodara-Bold.ttf"]
+  ["98QlD2ch9X7MRlrk8CcVGN1uL6sB1nPs56zvj9SnH/8=" "ofl/hindvadodara/HindVadodara-SemiBold.ttf"]
+  ["VtqZqX6tkAocTiYHJGN/zYsg6Nes/rcEWiRsghfzS8E=" "ofl/hindvadodara/HindVadodara-Medium.ttf"]
+];
+holtwoodonesc = mkFont "holtwoodonesc" "ofl" [
+  ["1zP7XfLPqLylsdm9sljHp3L3ep7lsglXNAKtHf2Fl6o=" "ofl/holtwoodonesc/HoltwoodOneSC.ttf"]
+];
+homemadeapple = mkFont "homemadeapple" "asl20" [
+  ["3RuqyjzeGx+EFa7TsK6mgIZVydnKWpnHKC2azMFsGlg=" "apache/homemadeapple/HomemadeApple-Regular.ttf"]
+];
+homenaje = mkFont "homenaje" "ofl" [
+  ["C/e65Ko+fCxnR4UyXSD0QFpT8lrOTOtHUs914nFyvko=" "ofl/homenaje/Homenaje-Regular.ttf"]
+];
+hubballi = mkFont "hubballi" "ofl" [
+  ["5RrXfUC1rczWxspTeGPvTjZL03TFZZPgB/v1QCqaHN0=" "ofl/hubballi/Hubballi-Regular.ttf"]
+];
+hurricane = mkFont "hurricane" "ofl" [
+  ["XqhrViylwrGJPCMzZ83hruDWd7ttMK+cP2mcJwiA2hM=" "ofl/hurricane/Hurricane-Regular.ttf"]
+];
+ibarrarealnova = mkFont "ibarrarealnova" "ofl" [
+  ["xierSNr2VECZAUtMXH+qTjuZPvXsd3Ccid0379QQfd0=" "ofl/ibarrarealnova/IbarraRealNova%5Bwght%5D.ttf"]
+  ["Lq1xBkRGCgQzmYuszaYHAgetgZwCfOxEJIlXi1gOH24=" "ofl/ibarrarealnova/IbarraRealNova-Italic%5Bwght%5D.ttf"]
+];
+ibmplexmono = mkFont "ibmplexmono" "ofl" [
+  ["K7TdGKuwPLigoa5poKELGU4CAnuBfHsTEm70ckp/XHM=" "ofl/ibmplexmono/IBMPlexMono-LightItalic.ttf"]
+  ["N4LwHxK0RMYr5xJnZkbFUvwjRD6P0C1bVhnGxLl1UW0=" "ofl/ibmplexmono/IBMPlexMono-ThinItalic.ttf"]
+  ["xEyCDBS08bgYNE5fXcGJzumLHV5WtOgAVUlsIo88x+o=" "ofl/ibmplexmono/IBMPlexMono-Thin.ttf"]
+  ["r04Fp2HpjBrfBkxIpjUsm+waatcJgs0qVEFJMjOR+Y4=" "ofl/ibmplexmono/IBMPlexMono-BoldItalic.ttf"]
+  ["gmt2W9UXO5fVIQUzMKZid+3CJPjMXx4ANd8dmV1fADw=" "ofl/ibmplexmono/IBMPlexMono-ExtraLight.ttf"]
+  ["iuInZglL0EwoCKPJ3sgS3PBheGwm69Je6iEa5oXrLDk=" "ofl/ibmplexmono/IBMPlexMono-ExtraLightItalic.ttf"]
+  ["OR7w4nPrUlcezKq2ptvd7sSOHSgst78VMENRK3l+1vA=" "ofl/ibmplexmono/IBMPlexMono-SemiBoldItalic.ttf"]
+  ["qbTEm7KZ4FtfbEgef7XniUPSeTJJoMiHSrV0otHqZ1U=" "ofl/ibmplexmono/IBMPlexMono-Medium.ttf"]
+  ["M2L8eRsGUhkzKLhiwcXyOnibxyiLFhf6YzAviGiaKjQ=" "ofl/ibmplexmono/IBMPlexMono-Italic.ttf"]
+  ["ajQS8FjH2N/ZFwxB6FreSOUVbsuJNWEQylegonc0r0Y=" "ofl/ibmplexmono/IBMPlexMono-Regular.ttf"]
+  ["eAvPZVCdcqNewRS1e8viINxrd9jqLpsl4pS+PFcMUCU=" "ofl/ibmplexmono/IBMPlexMono-Light.ttf"]
+  ["rCer1kUKZN2URnWAoC/mI1FW1bkvKSbrvI50id9k4L4=" "ofl/ibmplexmono/IBMPlexMono-Bold.ttf"]
+  ["08OOVcePWw8oAJ/dukg07FAyeJNqWYYDJCTJvS0jqkY=" "ofl/ibmplexmono/IBMPlexMono-SemiBold.ttf"]
+  ["3m4PgFoVoqFTi+XRB0dBKYoH/8um+h9M2TmD/3MVWn0=" "ofl/ibmplexmono/IBMPlexMono-MediumItalic.ttf"]
+];
+ibmplexsansarabic = mkFont "ibmplexsansarabic" "ofl" [
+  ["Iws9lX5szXu68g67ctv92CBPzaD5E4wPzto14oogi9E=" "ofl/ibmplexsansarabic/IBMPlexSansArabic-SemiBold.ttf"]
+  ["1/R9aRFG6rVLGxAyNRdFvrpjWfe0TqK9WWZF53nGL1s=" "ofl/ibmplexsansarabic/IBMPlexSansArabic-ExtraLight.ttf"]
+  ["el2l2hHskmx+ZCPhxt2Nz9KuYWlqFoQquNyDTBwmNpE=" "ofl/ibmplexsansarabic/IBMPlexSansArabic-Thin.ttf"]
+  ["3Rszi+BhCuumjoYNuoISDvts4/YpNT8o46zqffqlyOs=" "ofl/ibmplexsansarabic/IBMPlexSansArabic-Bold.ttf"]
+  ["HLQ7esEuxT7dFANftZ36Qj7znjIOHQr9tvib1ptD74c=" "ofl/ibmplexsansarabic/IBMPlexSansArabic-Medium.ttf"]
+  ["sH85203eweUXBu+TM33X72F8xonDaS6Xd93yt3BYfXE=" "ofl/ibmplexsansarabic/IBMPlexSansArabic-Light.ttf"]
+  ["gWAfnsfLNTm34G1FDTCelGFhybkkteyuKwsxDwdXQXw=" "ofl/ibmplexsansarabic/IBMPlexSansArabic-Regular.ttf"]
+];
+ibmplexsanscondensed = mkFont "ibmplexsanscondensed" "ofl" [
+  ["/mfhf9yLVXMdiNkilAMPfNgIbNvcN6qqmTsx0UfroPc=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-Thin.ttf"]
+  ["/hmDwHoIb77pOeXw+CblQo99AmZsjju7cpX7NQRZegc=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-BoldItalic.ttf"]
+  ["gSLHixn+pHWsmu1eXQ24MfdLggYEvXo4k1Peet8gy5c=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-ThinItalic.ttf"]
+  ["2Y2Ps4o81yVjKQAYixRsC6cuq9UVoDeIvYlbvzZQhq4=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-SemiBoldItalic.ttf"]
+  ["tlSS2GzdXNnUPSZxtV1dNv7DaFn8iwi8arp45EHWyEk=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-Bold.ttf"]
+  ["q3KUhaImVyKQgQEibSjC5mgc6YrQlhK5ZKAF5t2r7n0=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-ExtraLightItalic.ttf"]
+  ["oIHKYFSK6hQQB1ei1v5xymD9kOvOd5yaiuWgyPtFJtQ=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-SemiBold.ttf"]
+  ["q4kxxydK/1sDFbeYrGgUn5KmZ9lkfLnWJj9fREA+VFI=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-MediumItalic.ttf"]
+  ["oDIOYMF5JsTiEN/bOxo0aZHzX4O0cdr1VTfuecvLfH8=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-Italic.ttf"]
+  ["ODbtHh9chw3fn9ag7X10pDhaLKGU+mh4LGoQ5gk3nMg=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-Light.ttf"]
+  ["T/lonjuLPCUy5s5t/boLtb6z0HPDt7d1oHmwPMLlYfM=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-LightItalic.ttf"]
+  ["QmNQwpgnf3+dGpOVZXJ5nKPRbi1D5/YO7IOCvNeV7DA=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-Medium.ttf"]
+  ["SmupTgzHWQwnfV2RZ0cF3XO7toq5AW0UYMDisPnvM1A=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-ExtraLight.ttf"]
+  ["50N8By7vLvWSrm8r6wAARGKHOFkHq7V6wc8HvLqiqjM=" "ofl/ibmplexsanscondensed/IBMPlexSansCondensed-Regular.ttf"]
+];
+ibmplexsansdevanagari = mkFont "ibmplexsansdevanagari" "ofl" [
+  ["oRLzb5LstpZ+6CxkNUeYZGLR3c/yLCCtAkywkV3dK+4=" "ofl/ibmplexsansdevanagari/IBMPlexSansDevanagari-Medium.ttf"]
+  ["V/ACouCYRoQev8WfEtPzxTDQX/hWSNaFbf5E9THGyE0=" "ofl/ibmplexsansdevanagari/IBMPlexSansDevanagari-SemiBold.ttf"]
+  ["mjCXlv++O2gnWR605ufxPic8ONN7QNEqWsaVFyVx6Is=" "ofl/ibmplexsansdevanagari/IBMPlexSansDevanagari-Regular.ttf"]
+  ["0XSkuMnT3lvbvfylrch+31eLYfwgf1dq7Ef0QLjAslY=" "ofl/ibmplexsansdevanagari/IBMPlexSansDevanagari-Light.ttf"]
+  ["n9IVEsLcvRZ18JmRlaxtCQEaE/Yf5gd1rmpeAOV3weU=" "ofl/ibmplexsansdevanagari/IBMPlexSansDevanagari-ExtraLight.ttf"]
+  ["9BFEo7+RMLpirRDX4LD0JpW/dPc7AMYVSwP441qRltE=" "ofl/ibmplexsansdevanagari/IBMPlexSansDevanagari-Thin.ttf"]
+  ["jBpVUwpZ9NPfceNu1wkOeFEc8eA8MrkyxpOuasYDs48=" "ofl/ibmplexsansdevanagari/IBMPlexSansDevanagari-Bold.ttf"]
+];
+ibmplexsanshebrew = mkFont "ibmplexsanshebrew" "ofl" [
+  ["DX9jkqfz4UIqrPVuQ1sDD5aRtMh/TavnPPJh53/+97w=" "ofl/ibmplexsanshebrew/IBMPlexSansHebrew-Light.ttf"]
+  ["K40oH2PMe33q/nuDcFKfMhhhM4UWvs0rgj9lMtj00nU=" "ofl/ibmplexsanshebrew/IBMPlexSansHebrew-ExtraLight.ttf"]
+  ["RGilJvYGrHTo25Elt4WpMs9VomX441iFU3G+1hJqFjc=" "ofl/ibmplexsanshebrew/IBMPlexSansHebrew-Bold.ttf"]
+  ["FbXWsg9bQAfy1wn/eGJm/2K6mxO6TlrE0j831VTWhTQ=" "ofl/ibmplexsanshebrew/IBMPlexSansHebrew-Medium.ttf"]
+  ["ywXNkgapgFcqhtWF46Q3jRnCITvslbKLjwCFJCKq/6w=" "ofl/ibmplexsanshebrew/IBMPlexSansHebrew-Thin.ttf"]
+  ["wR30Kt9eLG535iPb7b6MwjunIZasmti+sCdU7r2cQAo=" "ofl/ibmplexsanshebrew/IBMPlexSansHebrew-Regular.ttf"]
+  ["PKOCmsvrWPCDLzMgpUurIzkEwH0NHcebfx/z82umiy0=" "ofl/ibmplexsanshebrew/IBMPlexSansHebrew-SemiBold.ttf"]
+];
+ibmplexsansjp = mkFont "ibmplexsansjp" "ofl" [
+  ["Ny+LupXzhoVq5DXcDmnwjbHKwpvtUT2ZFxoK4tMHuio=" "ofl/ibmplexsansjp/IBMPlexSansJP-Regular.ttf"]
+  ["dzBCv16PQo1G/PgbklXGpFHyDL05mD8wjpaAii4V4TQ=" "ofl/ibmplexsansjp/IBMPlexSansJP-Thin.ttf"]
+  ["g7Oo2WcpXBYpOJRtapOV1TnJX9U+Fh4OSwHl1/OaLqY=" "ofl/ibmplexsansjp/IBMPlexSansJP-ExtraLight.ttf"]
+  ["WYXCnS1dREBykVz1h03IDgo/X62/FKnjAToDqP5tf/U=" "ofl/ibmplexsansjp/IBMPlexSansJP-SemiBold.ttf"]
+  ["HQn14lsZ5UssVdpw3lj5liUSw+B+18PhybrXes5cIuY=" "ofl/ibmplexsansjp/IBMPlexSansJP-Medium.ttf"]
+  ["9jkCMbDOhIhm1VmXZYl9S4gtayncBITdTRpUNbBXYbo=" "ofl/ibmplexsansjp/IBMPlexSansJP-Light.ttf"]
+  ["vYqYubVcnqPw+h7QlMFZgXiMyaQbA1f0RTAU/R1E2hk=" "ofl/ibmplexsansjp/IBMPlexSansJP-Bold.ttf"]
+];
+ibmplexsanskr = mkFont "ibmplexsanskr" "ofl" [
+  ["gP5MXcL84XpxFahJZtpvXkQ+IfMy2y4d5TM59/kjV8Y=" "ofl/ibmplexsanskr/IBMPlexSansKR-Thin.ttf"]
+  ["IC0appKo0iICb5gXJUd99+qWMkbDxggMw7VWaUFPyGE=" "ofl/ibmplexsanskr/IBMPlexSansKR-ExtraLight.ttf"]
+  ["pE67RnJh4LsC9dXON1yl1nWnD4BH/Y1OjcVq3UvlDHs=" "ofl/ibmplexsanskr/IBMPlexSansKR-Light.ttf"]
+  ["nYKovlMw9te1MSEmKGe0ArrKZy62m4UpKPBtGF01f30=" "ofl/ibmplexsanskr/IBMPlexSansKR-Bold.ttf"]
+  ["gjwZVq31bCfAawYnJd/OI/Jm5P0TZikPKVfIQHSCqBc=" "ofl/ibmplexsanskr/IBMPlexSansKR-SemiBold.ttf"]
+  ["U3UDeScDEjaM92QZAfQ6mN2JLj2dV5jPJc3CRchcccA=" "ofl/ibmplexsanskr/IBMPlexSansKR-Regular.ttf"]
+  ["SnEw9WzlC/EPnTg/Yk5QutLIC+vGPlH0Jp7OLH2RkWY=" "ofl/ibmplexsanskr/IBMPlexSansKR-Medium.ttf"]
+];
+ibmplexsans = mkFont "ibmplexsans" "ofl" [
+  ["+c7ogJxUA/m6ihqxEFI5QWvY3k9NTdVShNF7R1oOsKw=" "ofl/ibmplexsans/IBMPlexSans-ThinItalic.ttf"]
+  ["WeIB2f+mHM4ZFT6UgUZ2tLoLvyOMrEQtdVI+oVpXibY=" "ofl/ibmplexsans/IBMPlexSans-BoldItalic.ttf"]
+  ["y2KpoNHYP/nwDRNnbfgk4bEXVjXUYx2nqxP6caiW59k=" "ofl/ibmplexsans/IBMPlexSans-ExtraLight.ttf"]
+  ["dr0EzzsjIVhuZo7K5gtz7LW4a03Gi7vNxnFaxmBfd4M=" "ofl/ibmplexsans/IBMPlexSans-SemiBold.ttf"]
+  ["dC6n/fTKqnkpzTGUdbJQPSe+Ro+Tv6HrFI4C2YsmbTI=" "ofl/ibmplexsans/IBMPlexSans-LightItalic.ttf"]
+  ["ogcC6rwG/uyv2N6e7EXsIpQ1MAbgwQGsw+bHD0pS2Zc=" "ofl/ibmplexsans/IBMPlexSans-Bold.ttf"]
+  ["J9YY0YLE+iINUg6DvwrrHJvs55xoUmKqYHD56y6sfXg=" "ofl/ibmplexsans/IBMPlexSans-ExtraLightItalic.ttf"]
+  ["+z3cL5h9xoP2nHEferHsKWQpTKmk/hTjK3lMMngoUQ8=" "ofl/ibmplexsans/IBMPlexSans-SemiBoldItalic.ttf"]
+  ["LzZRQA+FsdYEk1aGt4aGLZ+SeGBsBCYL1tY9aQ6xahA=" "ofl/ibmplexsans/IBMPlexSans-Light.ttf"]
+  ["yAEiVzVyvQQFbA+C6j4cix33kiYh86S0R5FdUZzPcGo=" "ofl/ibmplexsans/IBMPlexSans-Italic.ttf"]
+  ["eRcW0BS0k7UzpPrulHs772B48x7p2s7nGURTV6qcDhs=" "ofl/ibmplexsans/IBMPlexSans-Medium.ttf"]
+  ["9ekQNrbXk9M77M5MpAIYkg7uf8mmqNFWZ0mWwoaZD6s=" "ofl/ibmplexsans/IBMPlexSans-Thin.ttf"]
+  ["fyGNUb17p108UmsXL8K5X3iFBiNtCPtBn9vOR4peXBU=" "ofl/ibmplexsans/IBMPlexSans-MediumItalic.ttf"]
+  ["Urq9Eh/4J8T267sghE1RVpeV7uY3NYD8iXmvxUAEhZY=" "ofl/ibmplexsans/IBMPlexSans-Regular.ttf"]
+];
+ibmplexsansthailooped = mkFont "ibmplexsansthailooped" "ofl" [
+  ["HYrjOCPT55ezL12IT/BIebjR4mbaJOTpRlpQuyCdepY=" "ofl/ibmplexsansthailooped/IBMPlexSansThaiLooped-ExtraLight.ttf"]
+  ["AhnNbiHJuyJjePpg69c+JVCxrbJF/sghyBfise/LHwQ=" "ofl/ibmplexsansthailooped/IBMPlexSansThaiLooped-Medium.ttf"]
+  ["bXkQ0Tp6njOHLVUB/YGnH4TuUy9ym/tyxv+pTR8TAJ4=" "ofl/ibmplexsansthailooped/IBMPlexSansThaiLooped-Regular.ttf"]
+  ["kFNeAJaiWUB4hHPS9Ryi2+SiQEufrVcLktyAt5KrItE=" "ofl/ibmplexsansthailooped/IBMPlexSansThaiLooped-SemiBold.ttf"]
+  ["OtXDwqa5EHqBBSUMRQ4bK7qlOaQNpY4wXEthuFPjASY=" "ofl/ibmplexsansthailooped/IBMPlexSansThaiLooped-Thin.ttf"]
+  ["mCffkvxod02eUSA7EbuDE1G/57sRUJeIruyNyF73g2U=" "ofl/ibmplexsansthailooped/IBMPlexSansThaiLooped-Light.ttf"]
+  ["31PFx5S5EPaLuPMHWmyb9ZJhw62WS9K+Dd/xvUx5x6k=" "ofl/ibmplexsansthailooped/IBMPlexSansThaiLooped-Bold.ttf"]
+];
+ibmplexsansthai = mkFont "ibmplexsansthai" "ofl" [
+  ["7uBh0brDm+QPm7lEmImM0YlPXT2aLw7my9SKa9A9BSs=" "ofl/ibmplexsansthai/IBMPlexSansThai-Regular.ttf"]
+  ["sboMl9lZZXgywaCSnCdOTU2BKMosUtJMaDXPh/tKWgQ=" "ofl/ibmplexsansthai/IBMPlexSansThai-ExtraLight.ttf"]
+  ["nXUmoMjfrWPEmBXQzOnuoQJvAYRouBxXmZfpU2IKZ9M=" "ofl/ibmplexsansthai/IBMPlexSansThai-SemiBold.ttf"]
+  ["ZfLNTtbyMEhiK7oaEGLAXC/4DmA9IC/czzA889XQheU=" "ofl/ibmplexsansthai/IBMPlexSansThai-Thin.ttf"]
+  ["uOLaVuwR8ZZa9ZpxGe4Lm3h3Opyaia4Em0l1yRl7XI0=" "ofl/ibmplexsansthai/IBMPlexSansThai-Light.ttf"]
+  ["+I++CjcXyT3t30sT5QoFya3NOPWNZ12dXQuGmWGFFmc=" "ofl/ibmplexsansthai/IBMPlexSansThai-Bold.ttf"]
+  ["Rrobc2XMLFg5FPI5FMzkboNqcmYuNPbjApsVqqELeS4=" "ofl/ibmplexsansthai/IBMPlexSansThai-Medium.ttf"]
+];
+ibmplexserif = mkFont "ibmplexserif" "ofl" [
+  ["KjK3asGcGUK/WULbvSoVZuXxrpgz5CHrzzbTUicV4VM=" "ofl/ibmplexserif/IBMPlexSerif-BoldItalic.ttf"]
+  ["U0wCwpWZndhudwRX7OHUPbDeklbdmL90FCb2OukEIJ4=" "ofl/ibmplexserif/IBMPlexSerif-Bold.ttf"]
+  ["S3Wzi+RnNScjH0nEiBjQkMkT1QQt1cdHtSW/YYXSnss=" "ofl/ibmplexserif/IBMPlexSerif-Italic.ttf"]
+  ["FfTjl0uDskWaahslLKo1apoRMW3uukWtvIm0b7SquCA=" "ofl/ibmplexserif/IBMPlexSerif-SemiBoldItalic.ttf"]
+  ["MpJec+W0pEHfnSPoR/K4xARsH8PbCU6QutiIMVeBFQk=" "ofl/ibmplexserif/IBMPlexSerif-Medium.ttf"]
+  ["9FrKS0oUAsDAfEpGZbJ46wGs7ZC2txmvKeiuGiqL3EM=" "ofl/ibmplexserif/IBMPlexSerif-ExtraLightItalic.ttf"]
+  ["dyOXdl04QuN1cSondgl4PcHHU2UxV948gHxTkNahUT0=" "ofl/ibmplexserif/IBMPlexSerif-ThinItalic.ttf"]
+  ["aYutHV5SAEyx1QQkm9cEzwrtA3QNfvItelM9srwCD2k=" "ofl/ibmplexserif/IBMPlexSerif-Light.ttf"]
+  ["5wgBkm4W3XfEH0p8EJn2urcUD0ifA/uAhW7GeIIL5g0=" "ofl/ibmplexserif/IBMPlexSerif-ExtraLight.ttf"]
+  ["J85NEFWRtI9mayKOHjmYOKcEWU7+oitzAACVG+pwCmA=" "ofl/ibmplexserif/IBMPlexSerif-SemiBold.ttf"]
+  ["9OQ2To+2DZoKTtQeW751dnKwQs3yqWMhUDWVF4LegGA=" "ofl/ibmplexserif/IBMPlexSerif-LightItalic.ttf"]
+  ["o7XFspHbC4ir+DO9AoZK3KpLqZTZ99m3kPVS4v0Mur0=" "ofl/ibmplexserif/IBMPlexSerif-MediumItalic.ttf"]
+  ["G033MRba0kMvLRMzeuNH//caA7jBuis+HAbMmKrbpys=" "ofl/ibmplexserif/IBMPlexSerif-Thin.ttf"]
+  ["6ILvqcQZSaUorCNpB57F7wUMHJlrvQuszjwzJtRM+A0=" "ofl/ibmplexserif/IBMPlexSerif-Regular.ttf"]
+];
+iceberg = mkFont "iceberg" "ofl" [
+  ["274MT87r4uHJZjYunWRxBMdHluUtSUVU7qv01hBPsv8=" "ofl/iceberg/Iceberg-Regular.ttf"]
+];
+iceland = mkFont "iceland" "ofl" [
+  ["W1kZGJ5dAab6x5JRqvn6lWWnOMOZdMvhPemKwC7H//U=" "ofl/iceland/Iceland-Regular.ttf"]
+];
+imbue = mkFont "imbue" "ofl" [
+  ["v0X/HcAZdKzt9PEby/pzZQU9l/TVmN2v4YnSOKyApTQ=" "ofl/imbue/Imbue%5Bopsz,wght%5D.ttf"]
+];
+imfelldoublepica = mkFont "imfelldoublepica" "ofl" [
+  ["SBr6gqAGCzZJZo+mKUVcrupAeGTUwfbYFTgIZsUE3wc=" "ofl/imfelldoublepica/IMFELLDoublePica-Regular.ttf"]
+  ["AKwOc4VfFucZKna8KE+4b2my8sIbQF4pmR+Z7Og9Y5E=" "ofl/imfelldoublepica/IMFELLDoublePica-Italic.ttf"]
+];
+imfelldoublepicasc = mkFont "imfelldoublepicasc" "ofl" [
+  ["zeGx4gazbvL3TqSyvxl4bZnpPhxld1uSZwHhFBcm3oE=" "ofl/imfelldoublepicasc/IMFeDPsc28P.ttf"]
+];
+imfelldwpica = mkFont "imfelldwpica" "ofl" [
+  ["9l5UAW36tCIrpVLPuCJgsUp99lJ8zmZDD19mAirdsFI=" "ofl/imfelldwpica/IMFePIrm28P.ttf"]
+  ["4JoAZUtd0mau50PAxD0SnIQEotXg6/J+Wg5HK9GQC40=" "ofl/imfelldwpica/IMFePIit28P.ttf"]
+];
+imfelldwpicasc = mkFont "imfelldwpicasc" "ofl" [
+  ["f8AcBWsglWvy6EN1NApidDMrZ/eEXLu0ef4LkLQfhF0=" "ofl/imfelldwpicasc/IMFePIsc28P.ttf"]
+];
+imfellenglish = mkFont "imfellenglish" "ofl" [
+  ["R8113OVLHy4IMTWdItXmiPUZ1orkVwa2ZP0xD9DjzPc=" "ofl/imfellenglish/IMFeENit28P.ttf"]
+  ["/pcFu95Rr4AnGSRtRgjQjTe96VarmdmlkNqZalIhokw=" "ofl/imfellenglish/IMFeENrm28P.ttf"]
+];
+imfellenglishsc = mkFont "imfellenglishsc" "ofl" [
+  ["ECMk+1Q0u12nljUzQmsK1EyFu8nndVBnU1ydEUZKF2s=" "ofl/imfellenglishsc/IMFeENsc28P.ttf"]
+];
+imfellfrenchcanon = mkFont "imfellfrenchcanon" "ofl" [
+  ["P+p2kypi/5T/k/HPlbM4MwZ0347NFulhEWo0amSQDdM=" "ofl/imfellfrenchcanon/IMFeFCrm28P.ttf"]
+  ["xS4ewnJRtM1mY+OEFTgEBOzzmyzutVNdQFmFkKUR5Fk=" "ofl/imfellfrenchcanon/IMFeFCit28P.ttf"]
+];
+imfellfrenchcanonsc = mkFont "imfellfrenchcanonsc" "ofl" [
+  ["LuqxTjhLB/wnQ5+5kroWx3opluIifmfnYn7AfG/QHZ8=" "ofl/imfellfrenchcanonsc/IMFeFCsc28P.ttf"]
+];
+imfellgreatprimer = mkFont "imfellgreatprimer" "ofl" [
+  ["XG3jhqy4dVDe1Vj3AdKI7Bzn/6nsSxYK4G7jcooXhLI=" "ofl/imfellgreatprimer/IMFeGPrm28P.ttf"]
+  ["o8HNn8aU5vCQkjQj7Y5NwgPGzMdOokbuhieQaDAv4j0=" "ofl/imfellgreatprimer/IMFeGPit28P.ttf"]
+];
+imfellgreatprimersc = mkFont "imfellgreatprimersc" "ofl" [
+  ["eJUuWZDIMRbvAa10AvQ4SxubxcbDhpDSBI8WpTF/8MQ=" "ofl/imfellgreatprimersc/IMFeGPsc28P.ttf"]
+];
+imperialscript = mkFont "imperialscript" "ofl" [
+  ["+gQK5ZbN6CVZw7zwVqwhapTvqQS4SDgquFdA0430urc=" "ofl/imperialscript/ImperialScript-Regular.ttf"]
+];
+imprima = mkFont "imprima" "ofl" [
+  ["Bp89DIe65dIb47hvG1mq0xgBIaJvjbb1jn832cILbDI=" "ofl/imprima/Imprima-Regular.ttf"]
+];
+inconsolata = mkFont "inconsolata" "ofl" [
+  ["I97SW0RwdNAGWTkr+bESPYnfVcsHsK2b/vM2bRmbX8s=" "ofl/inconsolata/Inconsolata%5Bwdth,wght%5D.ttf"]
+  ["d9zF21uScBzYm/kWXzadTopd9UPPoa1zlqXLhsNPMLo=" "ofl/inconsolata/static/Inconsolata-ExtraExpandedBold.ttf"]
+  ["h7sF4W2uNyIKVyaKZfCi8L30ODYNtcPv5e3iR36atrg=" "ofl/inconsolata/static/Inconsolata-UltraExpandedRegular.ttf"]
+  ["LNBiJp8dgweQD9UyWlLb/vM4D3iw6MXUKvVvk5l2C/M=" "ofl/inconsolata/static/Inconsolata-CondensedMedium.ttf"]
+  ["1ibP2Um/gVuXJB0SuRY9X67+ps7qHOkPbMqtJc8OWxY=" "ofl/inconsolata/static/Inconsolata-CondensedExtraBold.ttf"]
+  ["FaSGZzsrrJT+hd4NJ3CzFn0ayslscJ8f4dORceAmpkw=" "ofl/inconsolata/static/Inconsolata-ExtraExpanded.ttf"]
+  ["29/Kr/1kixHF3NmalgANhvc6OZGWrw96+xnmHFuyKW8=" "ofl/inconsolata/static/Inconsolata-SemiCondensedBold.ttf"]
+  ["TJTAqVrZhmoa3YD64QdSKt7lvU4LylI0rKhdV45BqlQ=" "ofl/inconsolata/static/Inconsolata-ExpandedLight.ttf"]
+  ["7PWidOrNLM8Zm7PUuKqSfuScjISGsVqTDb5J05hJZyA=" "ofl/inconsolata/static/Inconsolata-ExtraExpandedRegular.ttf"]
+  ["3r20bBIkpCElI0n8dhamPMImsnYl/OSAe4sUTy9547g=" "ofl/inconsolata/static/Inconsolata-UltraCondensedRegular.ttf"]
+  ["n1CbVEBAwarov3SifSys/74LlcdTHSjS/1FMORvQPew=" "ofl/inconsolata/static/Inconsolata-ExtraCondensedBold.ttf"]
+  ["o51NOiVvsH7lbisuUI2vERPn8J9/Zbp7AS13gfQ6BNM=" "ofl/inconsolata/static/Inconsolata-CondensedRegular.ttf"]
+  ["cIEGOnJw3DFdRtVVZBZbLhNLGPX4LmHHuGk8gZo9TNo=" "ofl/inconsolata/static/Inconsolata-Condensed.ttf"]
+  ["FIpks5Wz4EkFxhJyIncbKuJYOJtrnk+B9w2ZnWr5QHQ=" "ofl/inconsolata/static/Ligconsolata-Bold.ttf"]
+  ["5A2i2IwlU4pHWSlswDyzeXMPNuCC/Y061gf2veAd2ls=" "ofl/inconsolata/static/Inconsolata-SemiExpandedExtraLight.ttf"]
+  ["Se30jhdp8pXkXNgLWOV/Ra+lhNglRZGcjQGs//jimy0=" "ofl/inconsolata/static/Inconsolata-UltraCondensedBlack.ttf"]
+  ["QmnIt/Hb0EnYKeQoGQ9fYsXAE44CoL4YSFdO5juqKQw=" "ofl/inconsolata/static/Inconsolata-ExtraCondensedRegular.ttf"]
+  ["kLoaVr3Qu1l0dkIAdwNSWj5S+l0seNFjcF82pVQ52v0=" "ofl/inconsolata/static/Inconsolata-Medium.ttf"]
+  ["UZrFYBYEWRaamPaH6pSZHtSjidO+0sdGDhOFkgh42Ss=" "ofl/inconsolata/static/Inconsolata-UltraExpandedLight.ttf"]
+  ["cVp80Yudaci1rBSGj7erKmwi8MFtgFSwGe2qRdIgQ4c=" "ofl/inconsolata/static/Inconsolata-SemiExpandedExtraBold.ttf"]
+  ["fBpu59HL7HFjBO7o6PL/emi2QjZQiqaL21FDI0mBibw=" "ofl/inconsolata/static/Inconsolata-SemiExpandedBlack.ttf"]
+  ["C8DiTGTx5J3nCCcYEud2kCyhp/+HwwsWQf1hpKyn5sY=" "ofl/inconsolata/static/Inconsolata-UltraCondensedExtraLight.ttf"]
+  ["SFwyEmUPh5nSTh3kKv88Xj82VZmUyV6K8or+KWUoIlA=" "ofl/inconsolata/static/Inconsolata-ExpandedBold.ttf"]
+  ["M4HEDT/41V+H32KsPPPGehTXRONr2di7Ik+HM/ETOpY=" "ofl/inconsolata/static/Inconsolata-ExtraLight.ttf"]
+  ["rNRyEpoJJBpAAgjX/vfnj3zOXj+RRBOnzyzdy2ZRyaY=" "ofl/inconsolata/static/Inconsolata-CondensedBold.ttf"]
+  ["kiwP2a0zPi9UOcbr+wVnC9m5EZscYJH0MpLqnP08J7A=" "ofl/inconsolata/static/Inconsolata-ExpandedExtraBold.ttf"]
+  ["sfyRc0ZH4GL3iH6HJAKgPzpvuF2GOsCzkwF8f+GarAw=" "ofl/inconsolata/static/Inconsolata-CondensedSemiBold.ttf"]
+  ["URBLkHHg/pq9+v4qD+hsrtWeaATr+A9Z3kvBV2hwixQ=" "ofl/inconsolata/static/Inconsolata-SemiCondensedRegular.ttf"]
+  ["RtZTU+PYZnuR/OgJ7BFhGZZcFWop/kOFfcPMkeotAio=" "ofl/inconsolata/static/Inconsolata-CondensedLight.ttf"]
+  ["sGt5j1VlVjXt8vvIf2/+9rRL/FuR1QEHcIiFgZZxfWY=" "ofl/inconsolata/static/Inconsolata-CondensedExtraLight.ttf"]
+  ["RicuvWmNUF2efiuhoQN4qQG8x52JzmJkFKvO2TDdx78=" "ofl/inconsolata/static/Inconsolata-SemiCondensed.ttf"]
+  ["TvpWeYWMj/8Ff2sYBTH8zy2KCU2YwrQb7rQ0Wf6IjzY=" "ofl/inconsolata/static/Inconsolata-ExtraExpandedSemiBold.ttf"]
+  ["lFRegxAWxTA0749K3EhpCFzH4Ys67JDp3dmzRbrDgTM=" "ofl/inconsolata/static/Inconsolata-UltraExpandedBlack.ttf"]
+  ["ZG56NjjwLnUqK6mxU635HZsvhIPXE2hFZBiZ5VbyGhc=" "ofl/inconsolata/static/Inconsolata-Expanded.ttf"]
+  ["/d9DLMGJUXQdRIJZ6esqrtJyH0D+yfBSKo1F+cqNdYg=" "ofl/inconsolata/static/Inconsolata-ExpandedBlack.ttf"]
+  ["3tHLDh7MXldJvZ0MHMWjSoa5lAgjfbLWIhbJTJlifuU=" "ofl/inconsolata/static/Inconsolata-ExtraCondensedSemiBold.ttf"]
+  ["eOhCQWQC6Et96aj+jwoqBzNWVjQqp7Hr0XfgApllDYU=" "ofl/inconsolata/static/Inconsolata-ExpandedSemiBold.ttf"]
+  ["lFcCUThWVQarto0PWJECrhBLYR6SUpUfZWCfTPoBJso=" "ofl/inconsolata/static/Inconsolata-ExtraExpandedMedium.ttf"]
+  ["gVLXzQU9xZTg6F8eh6oR0GKZfmf59VYGKvFKibY/axA=" "ofl/inconsolata/static/Inconsolata-SemiBold.ttf"]
+  ["yuTzhW/a7wcfNYYK9ttEsUbtv3zefXoUTckw1AC06RQ=" "ofl/inconsolata/static/Ligconsolata-Regular.ttf"]
+  ["Sc2K7/m03GnGW+6oBpfDE4+kkcQjeaWlLNGAGHIfywY=" "ofl/inconsolata/static/Inconsolata-CondensedBlack.ttf"]
+  ["1/uoG3JRaH2Xdj0DiSaBgEFPPXpoc48cjcGLukR2vEs=" "ofl/inconsolata/static/Inconsolata-ExpandedRegular.ttf"]
+  ["p4IQT5PPoLY7gTjvYSCjhsDeFWP5kNFvLzY11Ibphnk=" "ofl/inconsolata/static/Inconsolata-UltraExpandedMedium.ttf"]
+  ["Yhe7W1tzbKTk0NFTibvF8agvhtbwKoMEXg0gzn6oR6s=" "ofl/inconsolata/static/Inconsolata-UltraCondensed.ttf"]
+  ["k2ilmxOSLz3zioEvm3CBDLW3CvJGlgzsvkgebmqux7w=" "ofl/inconsolata/static/Inconsolata-SemiCondensedMedium.ttf"]
+  ["rWG0qjP2/77bq74a9OVY1m2cLXcEmnyKCgCIRnGE29s=" "ofl/inconsolata/static/Inconsolata-ExtraExpandedExtraLight.ttf"]
+  ["VwHhWbAdalv7OPKhIq5CxwsptuqRx5XGqo3nZ+2V9gI=" "ofl/inconsolata/static/Inconsolata-Black.ttf"]
+  ["mS2Kt+Cq+jFmyVsgFabcA1tiLp3WqAQ4f6dlfrKk/TM=" "ofl/inconsolata/static/Inconsolata-ExtraCondensedExtraBold.ttf"]
+  ["aNcFnGoUkAp9/5P6qj4ygfIU9SuMdjT5ZD0QPGOHmIg=" "ofl/inconsolata/static/Inconsolata-ExpandedMedium.ttf"]
+  ["/uhiugMTSgv+bQCfW1ViY8molCY3ixL/O5xvmhvrzQ0=" "ofl/inconsolata/static/Inconsolata-UltraCondensedSemiBold.ttf"]
+  ["HE34X5Z32JliP9hjZlIBzMBJbmhXeyR+kflV63BeyaE=" "ofl/inconsolata/static/Inconsolata-SemiExpandedSemiBold.ttf"]
+  ["c9GdqaRMJSJ1cXxHXKdNYqY7fd0uAFarDmiRtFtL8fI=" "ofl/inconsolata/static/Inconsolata-ExtraBold.ttf"]
+  ["4EVoEk4IlSgiHgnOVPvM6enuRWXvcvUqFKqqKdDpyQM=" "ofl/inconsolata/static/Inconsolata-ExtraCondensedMedium.ttf"]
+  ["2pz4mlDpIi3bPnhlt9a3uLE409aRPozrF5LYD6sm26c=" "ofl/inconsolata/static/Inconsolata-UltraCondensedExtraBold.ttf"]
+  ["FkRVuS8r1UmyjLyzRNl/8X959SBlSxn2U/nt9GoTyRM=" "ofl/inconsolata/static/Inconsolata-SemiExpanded.ttf"]
+  ["Bbp6BqTaND660gpGwpAgJJTDnUHIO5rNlBMGcixlKLA=" "ofl/inconsolata/static/Inconsolata-SemiExpandedBold.ttf"]
+  ["oqEJoMgG9WnaoUG0CHJ/ZXfclF9xLkA17avPhfEn/I0=" "ofl/inconsolata/static/Inconsolata-ExtraExpandedExtraBold.ttf"]
+  ["YQ4JW+EPhBxPPtDpeUgiQJGpFgn4bDo+W6D3O3k0StM=" "ofl/inconsolata/static/Inconsolata-UltraCondensedBold.ttf"]
+  ["Orx+8x0EqQHZDj1TpQg1WDOysOb7Wm+n4oF/YhSCV0c=" "ofl/inconsolata/static/Inconsolata-SemiCondensedSemiBold.ttf"]
+  ["on88jhvH6CtraC/EfkKTIskOYfmH69I6U6OBAj15qGA=" "ofl/inconsolata/static/Inconsolata-UltraCondensedLight.ttf"]
+  ["3vgfk25wy3UEXbbrwBZEiG/0nO3efLCwNHTNGkfBrX0=" "ofl/inconsolata/static/Inconsolata-SemiCondensedBlack.ttf"]
+  ["1MuJL+J3e60Q54IAMGFAv8EZrhKMlNB36qg2Ph0UaNk=" "ofl/inconsolata/static/Inconsolata-SemiExpandedLight.ttf"]
+  ["BnufiqLwDjAVE/kugOMcW6ZwtLQBJz0K6cAHjdg7w1Q=" "ofl/inconsolata/static/Inconsolata-SemiExpandedRegular.ttf"]
+  ["xculS1oBvZkqbcopEA6ferZL0aKtTlamNPBi9pTfBXs=" "ofl/inconsolata/static/Inconsolata-UltraExpandedBold.ttf"]
+  ["6igbtU53DppNkgf5sQh0++Brqva5iV96jQKGvvuGcF8=" "ofl/inconsolata/static/Inconsolata-ExtraCondensedLight.ttf"]
+  ["0i/J6MS8cEiTmjtjpvlFb5mDbZdiFNfcHHC1FK8VhHc=" "ofl/inconsolata/static/Inconsolata-UltraExpanded.ttf"]
+  ["JjPE60pWj/L9ittCL9ragEkMk3xYFln4CqXKjJ/w8cI=" "ofl/inconsolata/static/Inconsolata-ExtraExpandedBlack.ttf"]
+  ["OnDmWN+OO4Drw5NkO69Nclt1t4hFBLzZuCtxfCobuHQ=" "ofl/inconsolata/static/Inconsolata-UltraExpandedSemiBold.ttf"]
+  ["jKD4mk4c8V+BRqWlfXpryN6OooiqDLYaoaZBl2jYft4=" "ofl/inconsolata/static/Inconsolata-ExpandedExtraLight.ttf"]
+  ["lVF44F3QiBSIqVetq3+IeuWvaB3mEolHjrlGYvFDL5U=" "ofl/inconsolata/static/Inconsolata-SemiCondensedExtraBold.ttf"]
+  ["Ta2HAzc2gF5BNh+k21S0Xx4c6f3CwH4UIHgYdiznqQM=" "ofl/inconsolata/static/Inconsolata-ExtraCondensedExtraLight.ttf"]
+  ["CqpV6ylNonjLvUcbn/W/lZyE9cV/GkpFEY6DXueCO9g=" "ofl/inconsolata/static/Inconsolata-ExtraExpandedLight.ttf"]
+  ["N3Rq4qwdNEg8Q4yqd8uQwVFQ6UHXH4QMS6N87XiGR/Q=" "ofl/inconsolata/static/Inconsolata-UltraExpandedExtraLight.ttf"]
+  ["W1bSL8flNqPyky36cmzM+hJjK+b/3ML6l+BTr0mkuEQ=" "ofl/inconsolata/static/Inconsolata-Light.ttf"]
+  ["9z4hPKULUvwDFRzhpwDm2YF5mgga0Xu+R9fa220c+8U=" "ofl/inconsolata/static/Inconsolata-SemiCondensedExtraLight.ttf"]
+  ["4AZrB/CaXG8D0G1nVN5XXgpyb7Vw5QcV0hFK8BdfoeE=" "ofl/inconsolata/static/Inconsolata-UltraCondensedMedium.ttf"]
+  ["kshqczfQRDVMN/6uLpzXBEvvB9oBZKoPUpRwJRMpkkU=" "ofl/inconsolata/static/Inconsolata-SemiCondensedLight.ttf"]
+  ["GgT4tuSd2NnJ0Ofb2fJZQCh0IxxoX9mm+cP6/lHBt7w=" "ofl/inconsolata/static/Inconsolata-UltraExpandedExtraBold.ttf"]
+  ["0rJ9kZyg2VS+USebyw75u6L3i2+fc52CQjxrSIFdy5I=" "ofl/inconsolata/static/Inconsolata-ExtraCondensed.ttf"]
+  ["xDo9Nh+dZT/RPP9Ns53eUgAaVkA3Dd1QQWk1VuWpmYI=" "ofl/inconsolata/static/Inconsolata-SemiExpandedMedium.ttf"]
+  ["ad6002Jrzc4AMxRY5i3kngrlgjZiaEEBSTndjFEZq7Q=" "ofl/inconsolata/static/Inconsolata-Bold.ttf"]
+  ["DxGsQNFhjhqhrbcyKhSYCgsMlDQhEkAiBz+DI20V8NU=" "ofl/inconsolata/static/Inconsolata-Regular.ttf"]
+  ["FNqhCsPQsslkYdRGRfU8M6FL3Gut6vwne6zZhK2HHWA=" "ofl/inconsolata/static/Inconsolata-ExtraCondensedBlack.ttf"]
+];
+inder = mkFont "inder" "ofl" [
+  ["fpkidWxoecau1gsfiA/NMGfETI8zKIMJCdEJGxEWj8Y=" "ofl/inder/Inder-Regular.ttf"]
+];
+indieflower = mkFont "indieflower" "ofl" [
+  ["zMlLIrFW6cXf5Q/QUfAbCXYAslLCRHPmJLtDoUMUCpQ=" "ofl/indieflower/IndieFlower-Regular.ttf"]
+];
+ingriddarling = mkFont "ingriddarling" "ofl" [
+  ["8ItDQ41tx3QqnAQ05xmeAScqLBsrE1yaiG9lF8nlrk8=" "ofl/ingriddarling/IngridDarling-Regular.ttf"]
+];
+inika = mkFont "inika" "ofl" [
+  ["V8WzmKDXLIUoOkZAM3CRvJdKrp7wOxvRWVI7dHwRl/M=" "ofl/inika/Inika-Bold.ttf"]
+  ["P+lKZperq8O4tYDgBdJxiizg/ir+oIsWTuUlnZ6o2yU=" "ofl/inika/Inika-Regular.ttf"]
+];
+inknutantiqua = mkFont "inknutantiqua" "ofl" [
+  ["IiojPaUiVTVBk4+neA07zACK8Alnl5dliIXwBS/7du8=" "ofl/inknutantiqua/InknutAntiqua-Bold.ttf"]
+  ["LsVjz338FulE/2+zQR3X/EneE1FdOZNYckPwLnbkv5g=" "ofl/inknutantiqua/InknutAntiqua-Medium.ttf"]
+  ["1Gx0ILHl/twghsjOiSdabtE8Z3iCnAYX9W34w73daG8=" "ofl/inknutantiqua/InknutAntiqua-Regular.ttf"]
+  ["J53i2bPyF5aio2fMVdhlTu6VNKTzKdXUQilNgqMzw2E=" "ofl/inknutantiqua/InknutAntiqua-Black.ttf"]
+  ["ifYs+o5y+OyazFoKrgiKtLBP7Zw9uqrQ0v22VjpBy6Q=" "ofl/inknutantiqua/InknutAntiqua-ExtraBold.ttf"]
+  ["9NMa0B8kriazDIYQ9bPhq5ODh28e+YzApBGAJJKEVvQ=" "ofl/inknutantiqua/InknutAntiqua-SemiBold.ttf"]
+  ["aWHE5rPf/9JAhBfVtYmUiCgGrpWeAFMJoAloabq9gNw=" "ofl/inknutantiqua/InknutAntiqua-Light.ttf"]
+];
+inriasans = mkFont "inriasans" "ofl" [
+  ["SCxknB9qDp5qH1TVYD+J4lTIzYsgr57c6NuBmb36m8k=" "ofl/inriasans/InriaSans-Italic.ttf"]
+  ["wCWk/BUwMfGwc3w0ESFZAtm+5uKgCEP2Y0NIPfjgbsg=" "ofl/inriasans/InriaSans-LightItalic.ttf"]
+  ["4hNgfeuc9Wh1VAg5odl5RLK/m6SfClEO82jx2HhI0yc=" "ofl/inriasans/InriaSans-Regular.ttf"]
+  ["P6PEKMWP63oXPraww21LaNjKbLjCRuXiTdPmuvkzhk4=" "ofl/inriasans/InriaSans-Light.ttf"]
+  ["u0FYGHyUPlZfIPwbgdiDNbqEfcMYseEsXYok+w5GG/o=" "ofl/inriasans/InriaSans-Bold.ttf"]
+  ["EJeITACc/G8YOk7eRta4Zhw0o+Ehs/f/0B4f0X0PIio=" "ofl/inriasans/InriaSans-BoldItalic.ttf"]
+];
+inriaserif = mkFont "inriaserif" "ofl" [
+  ["dtrSUCaRmoTZtl03WPUwmcGRfPFcxF4OdFuRohXunzc=" "ofl/inriaserif/InriaSerif-LightItalic.ttf"]
+  ["V2uid+PqG7feQ3JNFMmJ3pLjXuriBCELDCqeexDcI/w=" "ofl/inriaserif/InriaSerif-Regular.ttf"]
+  ["Nf+Y4MWMsnpuwEWyUHLZneV9bqA/EsjcCWP8vtDfLZE=" "ofl/inriaserif/InriaSerif-Bold.ttf"]
+  ["q4xIeDZhRVmPZCHclw70DeJ9Je3wL6lii18s2T5NVPM=" "ofl/inriaserif/InriaSerif-Italic.ttf"]
+  ["ZAdy2S35E1AflhOCIVs0Tq5xwdVKGgL9FQiY/l3ka/0=" "ofl/inriaserif/InriaSerif-BoldItalic.ttf"]
+  ["hN4Jui+2Fr45AhSlKDqq9VuJ5QWUvX78xDiv9pxOmSc=" "ofl/inriaserif/InriaSerif-Light.ttf"]
+];
+inspiration = mkFont "inspiration" "ofl" [
+  ["QwgEDGmToWdy+2oJ2LOOCuAiLIHGBhXPTYCq0OPfq/Y=" "ofl/inspiration/Inspiration-Regular.ttf"]
+];
+inter = mkFont "inter" "ofl" [
+  ["v/9WY8hLIg88bbsOUiXGbqs9eeDWc1G7rBUbUQnHii0=" "ofl/inter/Inter%5Bslnt,wght%5D.ttf"]
+];
+intertight = mkFont "intertight" "ofl" [
+  ["FdPt8MPSVgZYUpuMTHOY0GxzCkaVSExoC2ycqeQ4W+I=" "ofl/intertight/InterTight-Italic%5Bwght%5D.ttf"]
+  ["uBtz3LZN88IwyrreffbFdzv4YyM/JMnuUQh1GfH4i28=" "ofl/intertight/InterTight%5Bwght%5D.ttf"]
+];
+irishgrover = mkFont "irishgrover" "asl20" [
+  ["2JS+TpBLvQip1GZwtPYx6Et95dcO3iyJ6CF5WMoy7sQ=" "apache/irishgrover/IrishGrover-Regular.ttf"]
+];
+islandmoments = mkFont "islandmoments" "ofl" [
+  ["aI5MU2i1Gw0RIsT7TCyPicaF9mvsSJv+B8syh3csS3E=" "ofl/islandmoments/IslandMoments-Regular.ttf"]
+];
+istokweb = mkFont "istokweb" "ofl" [
+  ["VG8bAWRBdszxNLl/dMtLzIMHq/77Cwbd8QNT2rEpagg=" "ofl/istokweb/IstokWeb-BoldItalic.ttf"]
+  ["2LYXKfXXHrnbfWRXP5AD/Yk9+59vyPul2RXuwCuoUoM=" "ofl/istokweb/IstokWeb-Italic.ttf"]
+  ["oTxObLqPbSSr+WVC2QKM6kdBGsZcAeb4U0nXQF3uU8Y=" "ofl/istokweb/IstokWeb-Regular.ttf"]
+  ["6Mrh6abp9FIFk0JUeujr9Y8E+FwE9Z1DgxCUkP70XWk=" "ofl/istokweb/IstokWeb-Bold.ttf"]
+];
+italiana = mkFont "italiana" "ofl" [
+  ["CtJx2c1CpXzVxfpIOuJAaoE4uVrLKkPrc6jTe3KR/uk=" "ofl/italiana/Italiana-Regular.ttf"]
+];
+italianno = mkFont "italianno" "ofl" [
+  ["9q6W3qDaRsczcOsFdYSKsO2hkDFb39o/WyUruj3JFzw=" "ofl/italianno/Italianno-Regular.ttf"]
+];
+itim = mkFont "itim" "ofl" [
+  ["kWTX65LKcXtTsHGT40RclngiItJCFRUbjShRtXaxdkU=" "ofl/itim/Itim-Regular.ttf"]
+];
+jacquesfrancois = mkFont "jacquesfrancois" "ofl" [
+  ["M6o9dC7mLyNQFt1j9+HtajRQ4NUnoOlRux1BCkesaM0=" "ofl/jacquesfrancois/JacquesFrancois-Regular.ttf"]
+];
+jacquesfrancoisshadow = mkFont "jacquesfrancoisshadow" "ofl" [
+  ["OUeCehlqPBLOtHHtWJFoqbVyhdtyWOtGioP0wXlFeEw=" "ofl/jacquesfrancoisshadow/JacquesFrancoisShadow-Regular.ttf"]
+];
+jaldi = mkFont "jaldi" "ofl" [
+  ["VRju8nurFG+VfHD+UO8Qvqj+Nj06x1zHl6qIKnImvZk=" "ofl/jaldi/Jaldi-Bold.ttf"]
+  ["JvNMSLe6qDjdRZtfXbAm6Uk7tGjvwpVnYcUhNNR40uI=" "ofl/jaldi/Jaldi-Regular.ttf"]
+];
+jejugothic = mkFont "jejugothic" "ofl" [
+  ["iJk/FYoRC5BTwUsJtvfIRAxgP2/pL/OC+z24OvEdzoc=" "ofl/jejugothic/JejuGothic-Regular.ttf"]
+];
+jejuhallasan = mkFont "jejuhallasan" "ofl" [
+  ["cdEZjCfXF37WoXjFEx2soRmW8gdJA2RVAxfZZm5HSOk=" "ofl/jejuhallasan/JejuHallasan-Regular.ttf"]
+];
+jejumyeongjo = mkFont "jejumyeongjo" "ofl" [
+  ["Qd/gg1e/O1cGjgeluj7Y0xjisZcyTB4UfLV9Q+ECi/c=" "ofl/jejumyeongjo/JejuMyeongjo-Regular.ttf"]
+];
+jetbrainsmono = mkFont "jetbrainsmono" "ofl" [
+  ["SHFaQuwkLCHp8CaSiR4UfQIimaUuSNXkE+GpQhk//to=" "ofl/jetbrainsmono/JetBrainsMono%5Bwght%5D.ttf"]
+  ["ha4qXNP1a68c4cIahRMixY49j76OitSk0JCoIN1/5Vg=" "ofl/jetbrainsmono/JetBrainsMono-Italic%5Bwght%5D.ttf"]
+];
+jimnightshade = mkFont "jimnightshade" "ofl" [
+  ["rUmp9lLLHXznEdfM37WSLjlh+HFwXoj7Dl0DPg5wcQM=" "ofl/jimnightshade/JimNightshade-Regular.ttf"]
+];
+joan = mkFont "joan" "ofl" [
+  ["6JRiVy4RoYuA0pgm3PP7feu6iy4NINDP9Q1FweXN8mY=" "ofl/joan/Joan-Regular.ttf"]
+];
+jockeyone = mkFont "jockeyone" "ofl" [
+  ["YzGj6Z4kDEXkteuZhF9XJJMhV9akdm8rSDb3WCiRrEo=" "ofl/jockeyone/JockeyOne-Regular.ttf"]
+];
+jollylodger = mkFont "jollylodger" "ofl" [
+  ["ZNPmKK4vPryzTu0CnpDLZnTp507U525y7/v1O5Oy2/k=" "ofl/jollylodger/JollyLodger-Regular.ttf"]
+];
+jomhuria = mkFont "jomhuria" "ofl" [
+  ["F7SwRTrNqvuUCovorMzJaHE+Ij5dA5QjR/ZWLKOx3sM=" "ofl/jomhuria/Jomhuria-Regular.ttf"]
+];
+jomolhari = mkFont "jomolhari" "ofl" [
+  ["RQdZesbY+q05CMBqRpgWf4IEoRAdOL8ysEWCzC0i6Gw=" "ofl/jomolhari/Jomolhari-Regular.ttf"]
+];
+josefinsans = mkFont "josefinsans" "ofl" [
+  ["witCymkL5+oH0EQVrHC0hgPf+I6FRzjLpL2HAnuQXvE=" "ofl/josefinsans/JosefinSans-Italic%5Bwght%5D.ttf"]
+  ["klWr2185O8UeEBq70Hpxapd/0+FUcrG4SyYPQmo0K/0=" "ofl/josefinsans/JosefinSans%5Bwght%5D.ttf"]
+];
+josefinslab = mkFont "josefinslab" "ofl" [
+  ["uROZkrJmgg1ibIA1/jCA26aNZ81504CfSq0KHMS45bE=" "ofl/josefinslab/JosefinSlab-Italic%5Bwght%5D.ttf"]
+  ["LRMW+VyxHa1uc7H7EAbA7LO9laQFg8GUbSeGinVnKxs=" "ofl/josefinslab/JosefinSlab%5Bwght%5D.ttf"]
+];
+jost = mkFont "jost" "ofl" [
+  ["Y0O3CXEACwTF1AHJauCM43EIYTXpmdXh4UEwOcAhMHY=" "ofl/jost/Jost%5Bwght%5D.ttf"]
+  ["Fab34+Efno4zilg6b+A+j2sdnOh376P+V5KCtsHLFf4=" "ofl/jost/Jost-Italic%5Bwght%5D.ttf"]
+];
+jotione = mkFont "jotione" "ofl" [
+  ["bTE5nJrKYua/R9fylJ4adySVALoBVwNzRr1h3bW8vwA=" "ofl/jotione/JotiOne-Regular.ttf"]
+];
+jsmathcmbx10 = mkFont "jsmathcmbx10" "asl20" [
+  ["5KpUXiOR+Q+cbII+Z6sLaCpqjhcR9yov/BIEWLUZ+sQ=" "apache/jsmathcmbx10/jsMath-cmbx10.ttf"]
+];
+jsmathcmex10 = mkFont "jsmathcmex10" "asl20" [
+  ["u4iAw5kilfrNCh9+gBkDny5x+Tm31aMjgLcRtOLA8lk=" "apache/jsmathcmex10/jsMath-cmex10.ttf"]
+];
+jsmathcmmi10 = mkFont "jsmathcmmi10" "asl20" [
+  ["+PVp4JWvFdpWGQgCY1OnP+fRdvJ22Gv39v7glLrlvIc=" "apache/jsmathcmmi10/jsMath-cmmi10.ttf"]
+];
+jsmathcmr10 = mkFont "jsmathcmr10" "asl20" [
+  ["m9W66Takr3FS8yDj/ufxTru3eBAZA+nIssyJAfQLd4s=" "apache/jsmathcmr10/jsMath-cmr10.ttf"]
+];
+jsmathcmsy10 = mkFont "jsmathcmsy10" "asl20" [
+  ["lpjo+YgJzhq5uIF5MJtCfHpKF4lOTm5DKGIMBCJeLEM=" "apache/jsmathcmsy10/jsMath-cmsy10.ttf"]
+];
+jsmathcmti10 = mkFont "jsmathcmti10" "asl20" [
+  ["GZ+T52rUq/xFgqNVned2vllYNbBOAyf815tMq6oev8M=" "apache/jsmathcmti10/jsMath-cmti10.ttf"]
+];
+jua = mkFont "jua" "ofl" [
+  ["MIDTUCimVc8gttvQcU+oFwYFuTPkohHBri5PRCA5+vY=" "ofl/jua/Jua-Regular.ttf"]
+];
+judson = mkFont "judson" "ofl" [
+  ["c3kL95GX5bvyQXjfOEH/J/svygXdHxf8EEbku+Fsr5U=" "ofl/judson/Judson-Regular.ttf"]
+  ["K92u0hjq0oRZn83MKInftZ6AT4nbSHeeBcDuhyFv3Y8=" "ofl/judson/Judson-Italic.ttf"]
+  ["B+dzkMNT1+TmmGK5Hgp59ndLGdFgK19KUE7RXvbxAjw=" "ofl/judson/Judson-Bold.ttf"]
+];
+julee = mkFont "julee" "ofl" [
+  ["eI9qAX95jtoe5lQgrZO34JZpU+vVhcU7mIibYYJiaN4=" "ofl/julee/Julee-Regular.ttf"]
+];
+juliussansone = mkFont "juliussansone" "ofl" [
+  ["tUC8rZKD9YlVqNuC2BA7H9NWN49V7HZM2yDZ9a50nyM=" "ofl/juliussansone/JuliusSansOne-Regular.ttf"]
+];
+junge = mkFont "junge" "ofl" [
+  ["RnHGWg5sAshmNik46Wjgg9FxdE5MkPos+ouAnMn3IH4=" "ofl/junge/Junge-Regular.ttf"]
+];
+jura = mkFont "jura" "ofl" [
+  ["GItBXUSBDWi01rSowoH4ZBhMK47cXojmNXyJ97RAdb8=" "ofl/jura/Jura%5Bwght%5D.ttf"]
+];
+justanotherhand = mkFont "justanotherhand" "asl20" [
+  ["8c0QLrrNtjiMh5ydSB1jkI7g1ZOaMBQVp4zf3HUveeo=" "apache/justanotherhand/JustAnotherHand-Regular.ttf"]
+];
+justmeagaindownhere = mkFont "justmeagaindownhere" "ofl" [
+  ["BBKqHkYGZtM5c4mRtI6fS9UeELbwTi4TQfzk0rMkTDE=" "ofl/justmeagaindownhere/JustMeAgainDownHere.ttf"]
+];
+k2d = mkFont "k2d" "ofl" [
+  ["YSi2LT2mqN/bulVKdFOK/Oe74I6YgRCFlvjvqEhefXg=" "ofl/k2d/K2D-BoldItalic.ttf"]
+  ["5COmVU55DO+mhBry7jSDdGX5MT/V5qEHT5t5XXBztQQ=" "ofl/k2d/K2D-Italic.ttf"]
+  ["fWIlpJEQ6ZgdJLvMrwauV3S2QSl+3vFv+is3JJeEDQc=" "ofl/k2d/K2D-SemiBold.ttf"]
+  ["V9iQWIdD8WGxZE///BiQfEkRW2TNMtLpvMX28MmTJuo=" "ofl/k2d/K2D-SemiBoldItalic.ttf"]
+  ["DqmpKk0AX2mmz1Ox6u0kT3CBekd9zWa8Bv7x9NmCF5U=" "ofl/k2d/K2D-Medium.ttf"]
+  ["RqqE7V/6j3weFW3f+FRB67wZE7iqM0m/PNci57l992E=" "ofl/k2d/K2D-ExtraBold.ttf"]
+  ["9pZk+0ISGthVVYItghv9bM3mTyAZhNW2iMIvMAoe+z0=" "ofl/k2d/K2D-Light.ttf"]
+  ["M8phRZR3+RrHJuVR657LTUcK9Br8M93LXMGpheSGmts=" "ofl/k2d/K2D-Thin.ttf"]
+  ["OzxySwriWeGxY+n0RR9sJZA7E/OiBJ6nO+p/Y10XHcQ=" "ofl/k2d/K2D-ExtraLight.ttf"]
+  ["v6sRk7k7kgBFURnJaPDMrCS2jSQI0mqBI6TDwB+xGCE=" "ofl/k2d/K2D-Regular.ttf"]
+  ["VtLxFx3GJ3DDZolk8jFWL64NiCkUYJEz/KkUzYK+ogM=" "ofl/k2d/K2D-LightItalic.ttf"]
+  ["wYE6ZLh5AnKdcw9Xo7uSByer+LHiWjVhD54hOyN7V5E=" "ofl/k2d/K2D-ThinItalic.ttf"]
+  ["Kc2mC/2hNBMv3HLLAqdGBP/pEgy6HwOO0lIu3+IQvFw=" "ofl/k2d/K2D-MediumItalic.ttf"]
+  ["+wyWXZaSHYUkJkJnCTRNrN2BB9L0BVE6CSYBsAd7Tok=" "ofl/k2d/K2D-ExtraBoldItalic.ttf"]
+  ["zjossBqRNzPeLYUVnNG3V8dm+nmgJmNj8cYLSJ4/suk=" "ofl/k2d/K2D-ExtraLightItalic.ttf"]
+  ["CHaIKQirtO47z59zAHEo3d1St3/jZBQQH7EtoKZ+2z0=" "ofl/k2d/K2D-Bold.ttf"]
+];
+kadwa = mkFont "kadwa" "ofl" [
+  ["LXJv6t+tzx4esx1ENVa4MNpmutuwYp6YRBnY3at+bp0=" "ofl/kadwa/Kadwa-Regular.ttf"]
+  ["TcpKeSgOzBkR3rg8wEQdvVPWWvEKQrBxV8ep8t4eJcw=" "ofl/kadwa/Kadwa-Bold.ttf"]
+];
+kaiseidecol = mkFont "kaiseidecol" "ofl" [
+  ["+5ICuXlE+gC18UWtRwHe9cMGvNDSZAeRe6754BsEIFY=" "ofl/kaiseidecol/KaiseiDecol-Regular.ttf"]
+  ["bbUnPWgH9PV1Iipw6/O7VIFz3N2i8i2b8nLW0OcWGqE=" "ofl/kaiseidecol/KaiseiDecol-Medium.ttf"]
+  ["DjptpRRf27oyz7HIBoEtlUV1BuFpj11h6Pg0+4R/DW8=" "ofl/kaiseidecol/KaiseiDecol-Bold.ttf"]
+];
+kaiseiharunoumi = mkFont "kaiseiharunoumi" "ofl" [
+  ["FXVRn9D7BgkrSmXSzY6cBX46Q1LG8cuoViRQsHSwaYA=" "ofl/kaiseiharunoumi/KaiseiHarunoUmi-Medium.ttf"]
+  ["oQuqNtWHJFIZJp6EANpcFUBGPIAja5Uta2zQSFozf0o=" "ofl/kaiseiharunoumi/KaiseiHarunoUmi-Bold.ttf"]
+  ["F24trD/7FlndhckGZqPuGdK7T86KiiMV/mMGJaxatqc=" "ofl/kaiseiharunoumi/KaiseiHarunoUmi-Regular.ttf"]
+];
+kaiseiopti = mkFont "kaiseiopti" "ofl" [
+  ["SOCm41kD7q6iuVWaxiy+g9rHAbLJNVx8/4knciyWWsw=" "ofl/kaiseiopti/KaiseiOpti-Bold.ttf"]
+  ["X7ZwVdTT5gYltu4QyT+ofjSLfZnyv9JjK99OQ8ltVNo=" "ofl/kaiseiopti/KaiseiOpti-Medium.ttf"]
+  ["mQz7H7APMRyJdcLF9HeLL+VGL9XqvwiEgooyPa0/GMA=" "ofl/kaiseiopti/KaiseiOpti-Regular.ttf"]
+];
+kaiseitokumin = mkFont "kaiseitokumin" "ofl" [
+  ["RUD2tcMnJKzJxLp3aSGVB43kOk7nYtQ2450y+o0ac8k=" "ofl/kaiseitokumin/KaiseiTokumin-Bold.ttf"]
+  ["P72+xTk2mu0Rux+gzdodGeokbnlRBzVzg9+lYYSKQn0=" "ofl/kaiseitokumin/KaiseiTokumin-Regular.ttf"]
+  ["v0S7PiPMcDv7GREYM/eOZRmY0KKxhj7/nojOyziovFM=" "ofl/kaiseitokumin/KaiseiTokumin-ExtraBold.ttf"]
+  ["/FisCBRoyjoGyfi4kHf7vwHFdynB1Xh8x/M62z5A1vM=" "ofl/kaiseitokumin/KaiseiTokumin-Medium.ttf"]
+];
+kalam = mkFont "kalam" "ofl" [
+  ["L2V2YB2wFdT2wIZ4EgJ3/IUQuYwG6TLOemqcv/TL3e0=" "ofl/kalam/Kalam-Bold.ttf"]
+  ["K48sAgjTl6GCNoh4PaMxfWrxjqAHqaG1bdsX4nggUH4=" "ofl/kalam/Kalam-Light.ttf"]
+  ["V87LY9RggBk3GVQnSuHYw5d2TevVsZ1KM8HvpNySPAs=" "ofl/kalam/Kalam-Regular.ttf"]
+];
+kameron = mkFont "kameron" "ofl" [
+  ["gXNk5YkbrbqIeg2DRlREMdAFCdLrIRiYAOXeQmil6aY=" "ofl/kameron/Kameron-Bold.ttf"]
+  ["WK4ayhACxJ5Nrum/JD1YtFhGzFdKpGzwXpcAhHlBrqo=" "ofl/kameron/Kameron-Regular.ttf"]
+];
+kanit = mkFont "kanit" "ofl" [
+  ["+Q5EC0EXDy918pMNMnPb6e16WsSffb3DdbpfjS4iR0U=" "ofl/kanit/Kanit-ExtraLight.ttf"]
+  ["cAgocNH1u2rp+qcIVyssNt48B2yq4YftrnU/cJ0N6YQ=" "ofl/kanit/Kanit-ExtraBold.ttf"]
+  ["JxcMBJZgsvli0+0oRB/SD0x0NQPKAx/snCtFQtbFJzY=" "ofl/kanit/Kanit-Regular.ttf"]
+  ["5iMFVlRx9u8ROVgeKvvNCxCPwqixQAUs0G7ChSqtnPk=" "ofl/kanit/Kanit-ExtraLightItalic.ttf"]
+  ["f+Px2H4z4WXq4tZk5Cox+vVC0k5DGi59o29OTu5fhSk=" "ofl/kanit/Kanit-BlackItalic.ttf"]
+  ["fASwvmAReC/MTAMvQDPvb2uh/vmbE1uh7mi4AMUwF+w=" "ofl/kanit/Kanit-Light.ttf"]
+  ["6HSpbeZrU0AXTd+cYhWTKAoh6a244HuxWHES3idKytU=" "ofl/kanit/Kanit-ExtraBoldItalic.ttf"]
+  ["dA2KTZLdrjlNE6PK6oRcBIttYrWPn7ku1KwBGO04wIM=" "ofl/kanit/Kanit-Thin.ttf"]
+  ["3x9jXzAiMGp/Ye0DzcGpA2TzHhlFS9KHz/5F+YyoBdA=" "ofl/kanit/Kanit-SemiBoldItalic.ttf"]
+  ["GU0mupC3gkZb1GU8xaHN96m+17nicd9Pb7QbXbo1nXg=" "ofl/kanit/Kanit-BoldItalic.ttf"]
+  ["b2GmOLoCW0lfvyOgX5avMa4+nKcQUG2hI+PWOr3PfUA=" "ofl/kanit/Kanit-ThinItalic.ttf"]
+  ["5c0KfOnOZbe+WShzINJHt2J7CkN6ajvRF0RAzu1K8cY=" "ofl/kanit/Kanit-LightItalic.ttf"]
+  ["XexbCA2rE96dIpVDfA/z7AXJ51WH38MTWMAF6076XnA=" "ofl/kanit/Kanit-Bold.ttf"]
+  ["JmqAROWZzi/u99/6jjznZIyUkn2rogxIOGKQVGM8+MQ=" "ofl/kanit/Kanit-MediumItalic.ttf"]
+  ["Z+ZLrxp+bgdkNVGP8Oa/JcTXS5gUPNGiaI25BsCrzhE=" "ofl/kanit/Kanit-SemiBold.ttf"]
+  ["UKI3A0JEAmp8Y/5V4k4LQpi6vjY83gQ+AyB1t2TFRaI=" "ofl/kanit/Kanit-Medium.ttf"]
+  ["XSkMLMmSZ2S9eCqmq8R6j1W9ZGQdCvtW4RXuUiaY7n4=" "ofl/kanit/Kanit-Black.ttf"]
+  ["fL5pOTp7+UjdSeV1NpNEqQfwawGC56YYwDPGcgirsn0=" "ofl/kanit/Kanit-Italic.ttf"]
+];
+kantumruy = mkFont "kantumruy" "ofl" [
+  ["CyATTTrlr6vv3CZ2zJsVenaIlAAvvZEGI1R8LkXePsU=" "ofl/kantumruy/Kantumruy-Bold.ttf"]
+  ["x30R8i65Ij+YuMWaLzJcBt76s1RlhMZpX50YyH3Ekio=" "ofl/kantumruy/Kantumruy-Regular.ttf"]
+  ["IRJAQvBixgGis1xoiqmnzspIlkC5RZxQo78km6pQYXI=" "ofl/kantumruy/Kantumruy-Light.ttf"]
+];
+kantumruypro = mkFont "kantumruypro" "ofl" [
+  ["YTvBscpOJvX4rJjSI7dvXtDLeefD+mVYwr1pKe/gQ64=" "ofl/kantumruypro/KantumruyPro%5Bwght%5D.ttf"]
+  ["eZEuD5psd2gL8yBjOtodiksB8ucO2fJqeZIjKTkU1LA=" "ofl/kantumruypro/KantumruyPro-Italic%5Bwght%5D.ttf"]
+];
+kapakana = mkFont "kapakana" "ofl" [
+  ["WjzUyOiKvHds65K1vfKeYdca1dWUyuiWy11c5XHX/jI=" "ofl/kapakana/Kapakana%5Bwght%5D.ttf"]
+];
+karantina = mkFont "karantina" "ofl" [
+  ["Mob/w5ADYhh0rSrC1sqTdNJyhENGXE32Ii3/QlgUVg0=" "ofl/karantina/Karantina-Light.ttf"]
+  ["oe+O5Rck8BgvB9BgtjBHVAoLypbbENM/pqC1OfmQGb8=" "ofl/karantina/Karantina-Regular.ttf"]
+  ["/Ame5yqEP7W01XSr0JngR+7Ez0dqGixl/lIOHNzIl74=" "ofl/karantina/Karantina-Bold.ttf"]
+];
+karla = mkFont "karla" "ofl" [
+  ["7COdKaN0xDXi1NC0+DVoP4xzO0Mg7c65U741SBKZKds=" "ofl/karla/Karla-Italic%5Bwght%5D.ttf"]
+  ["Os+N8vzVMRP5poXq9FfmxfzDnKqo7XYoyeZRm/xvspI=" "ofl/karla/Karla%5Bwght%5D.ttf"]
+];
+karlatamilinclined = mkFont "karlatamilinclined" "ofl" [
+  ["V3iP5G+ptwHPKEEEwJRsby72act+OfvKQEpB4xXu0OU=" "ofl/karlatamilinclined/KarlaTamilInclined-Bold.ttf"]
+  ["1WOs46dMoc6cAs0y+23KXeeXT1PeMwSsc0mA4Cuk8ck=" "ofl/karlatamilinclined/KarlaTamilInclined-Regular.ttf"]
+];
+karlatamilupright = mkFont "karlatamilupright" "ofl" [
+  ["fXnuJtNR7PA8vrEp7wocKXebWN7EWhUykfGjxskm5Q8=" "ofl/karlatamilupright/KarlaTamilUpright-Regular.ttf"]
+  ["ASHTDvTXs7j4vdYvPtIQjTcTXagCGnN9X8SXbDPxE5Y=" "ofl/karlatamilupright/KarlaTamilUpright-Bold.ttf"]
+];
+karma = mkFont "karma" "ofl" [
+  ["zDRX0oZ7Z+6VbZUgbbyDHleyaXUhnT1OaNYPUfZ7S1U=" "ofl/karma/Karma-Regular.ttf"]
+  ["5BifEcd5Q1jhTWbjZhxYXOG1UEA7Mnq8TqTSQNzcURY=" "ofl/karma/Karma-SemiBold.ttf"]
+  ["KO8hg0pIaq/uhsvfrRuJ1+vRdcDVi88HCZ98q8O8lAY=" "ofl/karma/Karma-Medium.ttf"]
+  ["OBnO2qjvckeqrncRPLubIrIH9f5sBFrg4UQqe2tpMo4=" "ofl/karma/Karma-Bold.ttf"]
+  ["imF0JExRn0GQ95la5k5StCA7ARVjJ9AsoHxURa0u2j0=" "ofl/karma/Karma-Light.ttf"]
+];
+katibeh = mkFont "katibeh" "ofl" [
+  ["M07q21jrRCc0/n3qh0Esu9jD/QApQlJyOq3xmoUM8R8=" "ofl/katibeh/Katibeh-Regular.ttf"]
+];
+kaushanscript = mkFont "kaushanscript" "ofl" [
+  ["bY03nZu6mBeL7kdtaBFMj4OBLBgAXszPZ55w9g4D2PY=" "ofl/kaushanscript/KaushanScript-Regular.ttf"]
+];
+kavivanar = mkFont "kavivanar" "ofl" [
+  ["qzc6IY7oRk/ubtFO6GTVpsUUbKBFjwphZ4oYif5EtxA=" "ofl/kavivanar/Kavivanar-Regular.ttf"]
+];
+kavoon = mkFont "kavoon" "ofl" [
+  ["2WAOBcI7ughyFx8JTP/piFH1LTzh00PxdB0yv8vN/6I=" "ofl/kavoon/Kavoon-Regular.ttf"]
+];
+kdamthmorpro = mkFont "kdamthmorpro" "ofl" [
+  ["88DrIy7ByomRV2zZPrYEhogw3CAb9x8x+3+6jPREEiY=" "ofl/kdamthmorpro/KdamThmorPro-Regular.ttf"]
+];
+keaniaone = mkFont "keaniaone" "ofl" [
+  ["Vca+PQzcgWxGK8y8yTXvIPVgvXrsvxs4yu1HUrUsFMA=" "ofl/keaniaone/KeaniaOne-Regular.ttf"]
+];
+kellyslab = mkFont "kellyslab" "ofl" [
+  ["y/mL3bU0xS0vEVCu0jPFPl46eWa3vhq4YFUMI/mTDCc=" "ofl/kellyslab/KellySlab-Regular.ttf"]
+];
+kenia = mkFont "kenia" "ofl" [
+  ["QFLgPNq9Ne+fc5/fFGKxsmwWsiOLonIjI4YkortVZbk=" "ofl/kenia/Kenia-Regular.ttf"]
+];
+khand = mkFont "khand" "ofl" [
+  ["HhZsra8ER2XcQfmThnVjdti2SMceGYEzZTwUKk6aCG4=" "ofl/khand/Khand-Bold.ttf"]
+  ["+ytgSoD5/W41MrHyXJZL9WACJA4toOp6cmXux7tLxRk=" "ofl/khand/Khand-Regular.ttf"]
+  ["kYy5dQnJn+CprLhX36kOVST8IxeR/t125rwfnZT6A44=" "ofl/khand/Khand-SemiBold.ttf"]
+  ["UkKc/0jooqd6Y5QMp/eVff1ATCN1aRJy/Ho4bjP+AFU=" "ofl/khand/Khand-Light.ttf"]
+  ["QEBdasRc7GFFW5YLwTo1NTa5eH3/OOgHCtO5zBioBjk=" "ofl/khand/Khand-Medium.ttf"]
+];
+khmer = mkFont "khmer" "ofl" [
+  ["zIjq5H/nh19qCtITXgHlkQ2s6+0DRFxPjRlR+c9p49E=" "ofl/khmer/Khmer.ttf"]
+];
+khula = mkFont "khula" "ofl" [
+  ["glR308mVmX69QSRfxBd78Wgb/WVGZ04NZ6KaCUx4ZE8=" "ofl/khula/Khula-Regular.ttf"]
+  ["kjyv53z0gGbhUfkTWIAL2eA2scQXufzDJto50oG4f+c=" "ofl/khula/Khula-Bold.ttf"]
+  ["gFvsdkcQ0uGFkMO3g9C6JB52NopxgQft4xj4S5QOUHU=" "ofl/khula/Khula-Light.ttf"]
+  ["sSxIldoaDn7MwYyES6oQVP1R6rcNOmV4bnyEN/6lGYY=" "ofl/khula/Khula-SemiBold.ttf"]
+  ["unHWFqQoSIBxA3+6b6ZgOW8KGJ/FRc9gt6DecJB1lH8=" "ofl/khula/Khula-ExtraBold.ttf"]
+];
+khyay = mkFont "khyay" "ofl" [
+  ["/g3Scn+Yia4xCxsehWWpB48YW8tl0+BUF5SGZ6hCb5g=" "ofl/khyay/Khyay-Regular.ttf"]
+];
+kings = mkFont "kings" "ofl" [
+  ["gN2nOxMlTVAXOvHbrT9zIbmcph15HruM1fuL4IRsObs=" "ofl/kings/Kings-Regular.ttf"]
+];
+kiranghaerang = mkFont "kiranghaerang" "ofl" [
+  ["G851vNaKgtsYg3L7GRmqn7sAnavSczU9UCDcYPk+KMM=" "ofl/kiranghaerang/KirangHaerang-Regular.ttf"]
+];
+kiteone = mkFont "kiteone" "ofl" [
+  ["ZWo2ohEybexqruKMN20MtpCu23WDw36z9JZ+NoMtamc=" "ofl/kiteone/KiteOne-Regular.ttf"]
+];
+kiwimaru = mkFont "kiwimaru" "ofl" [
+  ["MPhWvJRJEbAlv79kC/a5/+GKnHsGsg1O8m/lzJs4Gfg=" "ofl/kiwimaru/KiwiMaru-Light.ttf"]
+  ["sMMQOyY59pDB/LROBgBYODF0v9LrcuZjW8mGmzdN7oc=" "ofl/kiwimaru/KiwiMaru-Regular.ttf"]
+  ["smWfMAp9SMPynrJz/8XhsmzEFqyMN/9rsvPkPC9NI1o=" "ofl/kiwimaru/KiwiMaru-Medium.ttf"]
+];
+kleeone = mkFont "kleeone" "ofl" [
+  ["v0Bj8DDMKuat8KEUJKGIjlwOtEOPH20C9SKUr4aOmzo=" "ofl/kleeone/KleeOne-Regular.ttf"]
+  ["sDHsQmwjyhFD7x99WL7np57+EZ7WVBUvEhySIgKzA/0=" "ofl/kleeone/KleeOne-SemiBold.ttf"]
+];
+knewave = mkFont "knewave" "ofl" [
+  ["7Tusdh11W4mrMILIRNSmI9Y8fW7vhdIroftsaA5qRDY=" "ofl/knewave/Knewave-Regular.ttf"]
+];
+#knowledge = null; # no ttf files
+kodchasan = mkFont "kodchasan" "ofl" [
+  ["sMi8p1JRvjdf3VDEj6eC+o1+vF9ngJ91WaLH1fRJgkE=" "ofl/kodchasan/Kodchasan-SemiBold.ttf"]
+  ["P0giWmq1g8hjoGzjEenHme7UaaoSnDpv+O/Ph9KCIxg=" "ofl/kodchasan/Kodchasan-Medium.ttf"]
+  ["rt5ZvdtCw7sc9G5vSmMcqfQVWL55Z+FGjreMbBwPWZQ=" "ofl/kodchasan/Kodchasan-Italic.ttf"]
+  ["FMNQf5Ctig+d5eu1OZfsgRFBagaYOrHZ2DpYQngI9vc=" "ofl/kodchasan/Kodchasan-Regular.ttf"]
+  ["6cHVA3liOajTwkIH14iyKSIUW73NGjMM3zzpEwicNlo=" "ofl/kodchasan/Kodchasan-BoldItalic.ttf"]
+  ["MeeAgfMqcmE7PWBALNg2gBQnWCJXmR6gQMbNfy/M4ZQ=" "ofl/kodchasan/Kodchasan-Light.ttf"]
+  ["d2InvpyvHltneUoXpZPBqiJCXluaKktursu5YHbRB5s=" "ofl/kodchasan/Kodchasan-MediumItalic.ttf"]
+  ["KNyjZxoKzCNY971pnquAQ0te9SgcKR8MDCdoful7ByE=" "ofl/kodchasan/Kodchasan-LightItalic.ttf"]
+  ["WZqrcEbBolk9+7I3592qHFMOwvPbLukMSCq5PRpqr0Q=" "ofl/kodchasan/Kodchasan-SemiBoldItalic.ttf"]
+  ["k0+lX/59pO0w0IGddhW0KhbVtJdVLUJOrmGDE9Z52j0=" "ofl/kodchasan/Kodchasan-ExtraLightItalic.ttf"]
+  ["giQhu9rLk9MbXyT1kharzqWCj5xaPFsdSM4snmZXUjU=" "ofl/kodchasan/Kodchasan-ExtraLight.ttf"]
+  ["LNk9oX+5juqDRhzeO0/ZnwvDPHo996XI1mjWS9HG8iM=" "ofl/kodchasan/Kodchasan-Bold.ttf"]
+];
+koho = mkFont "koho" "ofl" [
+  ["3pjKgLNpbEsYK94gTWOjCl1KBx5LcHj5QzBkvz0kxHg=" "ofl/koho/KoHo-ExtraLight.ttf"]
+  ["cjeVn6o3f0E9PRDe0iUheraqYLGlVOvq5SIq6a2rAlk=" "ofl/koho/KoHo-ExtraLightItalic.ttf"]
+  ["FNi7pokEFFQEyI1uHAEXtRL40Ik0DbS1bMZhZpH2ZAA=" "ofl/koho/KoHo-MediumItalic.ttf"]
+  ["U5bXoludVxxrpVBUUsRt/aKZUTxL//nHJ6wsMJrAuE8=" "ofl/koho/KoHo-SemiBold.ttf"]
+  ["2d/rf2J8fOPtlDfIEwUE2vJkTs5fVKJ7n3kw291FrTA=" "ofl/koho/KoHo-Regular.ttf"]
+  ["rWa2Kt74iDngKSu/Sh37XZNFgmoZo//XgNNPe8Zp4bE=" "ofl/koho/KoHo-Bold.ttf"]
+  ["4EAYN4k0ngm0S9mAWGh+WXk82M2lw7KqbTx/pDGaN/A=" "ofl/koho/KoHo-BoldItalic.ttf"]
+  ["Ir42j88Kcp2V/qGmbTWjzszxOQq0PTd7uhLtYzkNNRU=" "ofl/koho/KoHo-SemiBoldItalic.ttf"]
+  ["jDLmf1dLFQFk/2FiCegjkZKUm7GPPpTgGskftUGShrk=" "ofl/koho/KoHo-Medium.ttf"]
+  ["XPuaFXV89F9aCxo33IzAmRqPP5Vwx02PzenmapQFNcY=" "ofl/koho/KoHo-Light.ttf"]
+  ["Q2vkGQbcgHhjWNdUbtJ5tQUf+z4Q2rhhVNCxANietqA=" "ofl/koho/KoHo-Italic.ttf"]
+  ["8V5bZERGaZe7p7QKveQHhjqU24n7agAeQlJNrAzafc8=" "ofl/koho/KoHo-LightItalic.ttf"]
+];
+kohsantepheap = mkFont "kohsantepheap" "ofl" [
+  ["exUDs21lp8UddNCJ1zFTQBATyWATXwaXvqVg845OHLk=" "ofl/kohsantepheap/KohSantepheap-Bold.ttf"]
+  ["NAxyCatV/mC5RQbPWYlM3qrMoZToHl3riAfRK4m+U4M=" "ofl/kohsantepheap/KohSantepheap-Light.ttf"]
+  ["78Y2CXjx8KztuEEWyn2QRHy4++0Faza4mxCbzmmKFE4=" "ofl/kohsantepheap/KohSantepheap-Thin.ttf"]
+  ["0Sb2gNgIHbQ5CXJSvb6IRgGfGmZzcpXVN3XE9W4iVMI=" "ofl/kohsantepheap/KohSantepheap-Regular.ttf"]
+  ["j1X+/RCaqHyrhL770ZJ5Vm32t7UAAJqHYCddOF7vWJg=" "ofl/kohsantepheap/KohSantepheap-Black.ttf"]
+];
+kokoro = mkFont "kokoro" "ofl" [
+  ["stupaZipKtVpJ7LOtZJU9BEDpQeU1CsCDjAMYBJtXpU=" "ofl/kokoro/Kokoro-Regular.ttf"]
+];
+kolkerbrush = mkFont "kolkerbrush" "ofl" [
+  ["wJFIErxbIkzA6DId5wAhozoadmue+vUl90YyAPgjAPQ=" "ofl/kolkerbrush/KolkerBrush-Regular.ttf"]
+];
+konkhmersleokchher = mkFont "konkhmersleokchher" "ofl" [
+  ["Fs+EjlZwsVZc/3ehgnNHpW7gheC1VvH25m3o07oO8N8=" "ofl/konkhmersleokchher/KonkhmerSleokchher-Regular.ttf"]
+];
+kopubbatang = mkFont "kopubbatang" "ofl" [
+  ["4h8SAgYs+Kdhc8zlq6B6iLeawht4qohdxcnijcG2cqw=" "ofl/kopubbatang/KoPubBatang-Bold.ttf"]
+  ["S0ixjoHsxQtUpdNOYlrCGlqbawQ+P2urbNhyeaZFWHs=" "ofl/kopubbatang/KoPubBatang-Light.ttf"]
+  ["5+UcbY0RMdjasgetjaZL6GEHBwCyCxn8tM0TVW0Mwnw=" "ofl/kopubbatang/KoPubBatang-Regular.ttf"]
+];
+kosugi = mkFont "kosugi" "asl20" [
+  ["9egdamuGXZuIxU0tPBa8qjsjnfzvrypil2rJ3HV0urc=" "apache/kosugi/Kosugi-Regular.ttf"]
+];
+kosugimaru = mkFont "kosugimaru" "asl20" [
+  ["S40AIsja3QkO9nzR9x8TBxR2eveAbLoutOvksCccHWg=" "apache/kosugimaru/KosugiMaru-Regular.ttf"]
+];
+kottaone = mkFont "kottaone" "ofl" [
+  ["F7Hddcnr1jK13ysFL+WugxOVFqVug2fFAn27/UrFsYQ=" "ofl/kottaone/KottaOne-Regular.ttf"]
+];
+koulen = mkFont "koulen" "ofl" [
+  ["ThmwuDxTdUew8f8fs52vtVzvv26VfvS8kA3MueQiARc=" "ofl/koulen/Koulen-Regular.ttf"]
+];
+kranky = mkFont "kranky" "asl20" [
+  ["K0BUiyqE49qpIvdwZXrvyG1M4T0VW5aRK+otULywnMQ=" "apache/kranky/Kranky-Regular.ttf"]
+];
+kreon = mkFont "kreon" "ofl" [
+  ["P9spuhb+GQd0fEC0cG07j5Gp6VFxYJGUvBDL0W2YKUM=" "ofl/kreon/Kreon%5Bwght%5D.ttf"]
+];
+kristi = mkFont "kristi" "ofl" [
+  ["ZyW3oo2b2HYeKDSmqzgLq+BzZ4xvQgF/5XYRa51v0qA=" "ofl/kristi/Kristi-Regular.ttf"]
+];
+kronaone = mkFont "kronaone" "ofl" [
+  ["JzRjkW+WpHB+aX4wE9lVzegVS05tY1pVEy56EvJ2U0w=" "ofl/kronaone/KronaOne-Regular.ttf"]
+];
+krub = mkFont "krub" "ofl" [
+  ["mjQD2tRUxFzE8fvgv8AAHIQjAt3aUUxHKFklt5IfVgI=" "ofl/krub/Krub-SemiBold.ttf"]
+  ["OxuaF0Dg7gloBsXYKGfT4ogWV1v/+weIXYT3tNn+KTc=" "ofl/krub/Krub-Italic.ttf"]
+  ["v2E5iCtfPbv6AAhEFF7lHffOO7SzMJQ2AglFWKGPy6Y=" "ofl/krub/Krub-ExtraLightItalic.ttf"]
+  ["zfcnSkgiyeDuvBtQNlCrNwO8loCCp+u6r2mjv7YF1Hc=" "ofl/krub/Krub-Medium.ttf"]
+  ["a1sywHHXtmVvKjSliseJkcXcpWefMA7lnhKm7kNP3jc=" "ofl/krub/Krub-ExtraLight.ttf"]
+  ["u1N5FMctW7swXRYVRtw8zM/de+9pxZ4nzkt0C56jm/M=" "ofl/krub/Krub-Light.ttf"]
+  ["b0BZNmFT+jn2UassCxk7egMP2uMF6prlh3aB0JmoeQQ=" "ofl/krub/Krub-MediumItalic.ttf"]
+  ["60KQ5xdKN/DMcbkJaBOi2KnHEZyTRnq298ACiVXYAik=" "ofl/krub/Krub-LightItalic.ttf"]
+  ["wnPxbOlo1AK/FE5buC4HTmr5vCYcIAw3TVfRO/B3r04=" "ofl/krub/Krub-SemiBoldItalic.ttf"]
+  ["C4wmhHNnQuGB9I7X2bCu0QrC1OHjoCyDRuUwCkoH8QA=" "ofl/krub/Krub-Bold.ttf"]
+  ["JOXECE7p6HjVTnC/5fzszzrkb9Sq5zp5TATfQJH15p0=" "ofl/krub/Krub-Regular.ttf"]
+  ["tDY7pTadx80TgJMtfkrc3ODyGQrmrWWd6jfLekVEjSU=" "ofl/krub/Krub-BoldItalic.ttf"]
+];
+kufam = mkFont "kufam" "ofl" [
+  ["8XqJtRjIM94olZjQZiu5oH0JzH11tweaFfEwX2JLvNo=" "ofl/kufam/Kufam%5Bwght%5D.ttf"]
+  ["N8XPKctRUJl4NGEFHPLJJ/wYYFs+fgCI+b0hUK7XVqk=" "ofl/kufam/Kufam-Italic%5Bwght%5D.ttf"]
+];
+kulimpark = mkFont "kulimpark" "ofl" [
+  ["bWSN8cRTWxzZb01tek2dcT5jV0xMY1+gC093FtGOXBs=" "ofl/kulimpark/KulimPark-BoldItalic.ttf"]
+  ["hmdP7o04f8gZ2l79OHJfa6HyBeNpI+XOeZ/ppggJRxQ=" "ofl/kulimpark/KulimPark-Light.ttf"]
+  ["t7aQO504Jy66HGOsHJWCcNW87YSThSpCEH7m++NSpiM=" "ofl/kulimpark/KulimPark-Bold.ttf"]
+  ["irE+2y6QuRf0T08BIjWfug4ooJh1QJ1iN7GL1Yl2vFo=" "ofl/kulimpark/KulimPark-ExtraLight.ttf"]
+  ["vynAkRAvV0WyBkM9nG/97WYe1jyV81q9nnfwHbRz79g=" "ofl/kulimpark/KulimPark-Italic.ttf"]
+  ["RneIPOgvJrTq+dzSeeUcIgfqJ/ehNKznbRrlS7/iRYU=" "ofl/kulimpark/KulimPark-ExtraLightItalic.ttf"]
+  ["KcR3eyS9B90X+m/+ebjTDYWdwrmU0NYqM885JRhASgI=" "ofl/kulimpark/KulimPark-Regular.ttf"]
+  ["DE41JLMB488A1HHwFgEIJW1B+aqSoytQl3ILejqipeQ=" "ofl/kulimpark/KulimPark-LightItalic.ttf"]
+  ["b4TE7oW1GRy+91pHUQyKCxm7c7eIsQtXJh4OnfIv6Uc=" "ofl/kulimpark/KulimPark-SemiBold.ttf"]
+  ["G3K7THVi82i6bqyv/XLr4hWuQAwwvOfLpOIZo235lcY=" "ofl/kulimpark/KulimPark-SemiBoldItalic.ttf"]
+];
+kumarone = mkFont "kumarone" "ofl" [
+  ["BNZHlyFjnw0AqjTPqhjZQOrPhAYLQnQz7bcBALbQEQA=" "ofl/kumarone/KumarOne-Regular.ttf"]
+];
+kumbhsans = mkFont "kumbhsans" "ofl" [
+  ["q3GEhktGXyVt53MoI42x/rDkF8FMhtZt5rKw7Sez4Ms=" "ofl/kumbhsans/KumbhSans%5BYOPQ,wght%5D.ttf"]
+];
+kurale = mkFont "kurale" "ofl" [
+  ["04+VdYU18Ibm4D07FRn9fnGMSguszas+HfT3ja/29tY=" "ofl/kurale/Kurale-Regular.ttf"]
+];
+labelleaurore = mkFont "labelleaurore" "ofl" [
+  ["7WdGKZngXwzayS9oY3RmHk1oxW/c19BXJcbfe0HqvSo=" "ofl/labelleaurore/LaBelleAurore.ttf"]
+];
+labrada = mkFont "labrada" "ofl" [
+  ["1dSR9NbFMHB+LMaJpL5KmyjEXpgBLs9uBAsKw47ptCg=" "ofl/labrada/Labrada-Italic%5Bwght%5D.ttf"]
+  ["A3RynHMtpSrYaBvAqEp+mSzvNNv8X2gd/b33xd4lYXs=" "ofl/labrada/Labrada%5Bwght%5D.ttf"]
+];
+lacquer = mkFont "lacquer" "ofl" [
+  ["FAwh9xkHoWlSkm7jVMgQgQkskNWZyJ/otFV7rq67voM=" "ofl/lacquer/Lacquer-Regular.ttf"]
+];
+laila = mkFont "laila" "ofl" [
+  ["zqsIKcUoGqf26Blu5rgFLHzWIn3Tbl5BM25MfdYbXzM=" "ofl/laila/Laila-Medium.ttf"]
+  ["O1Cq4JBB4JQeQwm6HLxLrNhY+IUrXnbiQBV65ufah7M=" "ofl/laila/Laila-Bold.ttf"]
+  ["8qSj+ayNjV40AFD6P0Jhji5toK3rz4OJqPpv67ztMfI=" "ofl/laila/Laila-Regular.ttf"]
+  ["35FvvGZLvz4lcCsw/g2UcSIX4JRo74deQ+Thg+cZq2Y=" "ofl/laila/Laila-SemiBold.ttf"]
+  ["U+N9+zsdWpeahQYmTfbG7zU4/pzyUDXRcF9xBTsn6GM=" "ofl/laila/Laila-Light.ttf"]
+];
+lakkireddy = mkFont "lakkireddy" "ofl" [
+  ["8BxavndSQ/0qdUjCxQF4+HuSb/xMfGtnV3WkCTH4Cgs=" "ofl/lakkireddy/LakkiReddy-Regular.ttf"]
+];
+lalezar = mkFont "lalezar" "ofl" [
+  ["e4CAe8gx8UHeD33PaBZBK/DFSJaNVIxRVso4hzM5Dqk=" "ofl/lalezar/Lalezar-Regular.ttf"]
+];
+lancelot = mkFont "lancelot" "ofl" [
+  ["vsqSUHnfwWdBb9r+lTYTahT2bcXLBtlJSfbpX7pJZ0w=" "ofl/lancelot/Lancelot-Regular.ttf"]
+];
+langar = mkFont "langar" "ofl" [
+  ["s8VVlIDyyFh73CSBb5LtOtkG0dLMwilNLgUdxOoP6AY=" "ofl/langar/Langar-Regular.ttf"]
+];
+laomuangdon = mkFont "laomuangdon" "ofl" [
+  ["A5R6nGTA8nwt+xxqTsqwn3myaWsaTYKKND27QgfvRH8=" "ofl/laomuangdon/LaoMuangDon-Regular.ttf"]
+];
+laomuangkhong = mkFont "laomuangkhong" "ofl" [
+  ["tfufcMgX9kS+bjIfpVbhrTkcLI9p83zIJjWauZKMXzs=" "ofl/laomuangkhong/LaoMuangKhong-Regular.ttf"]
+];
+laosanspro = mkFont "laosanspro" "ofl" [
+  ["G5pk4R0IEshkHiMGLvCAXfmhpK6NsUFFlsgvxB+OWeo=" "ofl/laosanspro/LaoSansPro-Regular.ttf"]
+];
+lateef = mkFont "lateef" "ofl" [
+  ["1hhoPCsg/aAU1z+5i6XvrixAVVt2Ia/nkKjC6sIygnQ=" "ofl/lateef/Lateef-Medium.ttf"]
+  ["4VjjdbNQ9U9gNYrvyw7RSNH6iAvLRc8irPIwxmUnM8o=" "ofl/lateef/Lateef-ExtraBold.ttf"]
+  ["EahkxnvumRFFy3LZmD6nxWsEbuvt1X5Q9UfdgWADpdI=" "ofl/lateef/Lateef-ExtraLight.ttf"]
+  ["ynQZT4BMMponRoPrLUgpttz+tMXgRhDmWEsOgKwZXww=" "ofl/lateef/Lateef-Regular.ttf"]
+  ["BgKreXEl2ysSeIHuMIQTpIhWXPVJ9WLkSPn+CnCForU=" "ofl/lateef/Lateef-Light.ttf"]
+  ["2+BUTwQZYrWkQwnLvSYTU9YdkigU8/lrUwiKvT1GzHc=" "ofl/lateef/Lateef-Bold.ttf"]
+  ["8P/bros4Nc5ruL4y9v905EIky4KTj7zmMVcr4pjrwjE=" "ofl/lateef/Lateef-SemiBold.ttf"]
+];
+lato = mkFont "lato" "ofl" [
+  ["cA5nIv0UoQ52RjR6axTEhtTDZKNzumHHDgtczueBFjU=" "ofl/lato/Lato-LightItalic.ttf"]
+  ["pCs4S5w3kTphAj46R8B/6tJud2Enu8nmoMlv5BMIk3Q=" "ofl/lato/Lato-ExtraBoldItalic.ttf"]
+  ["06wYKmgz4AV0XddWefutCBwLElNd9Ok62O1XgXoxozg=" "ofl/lato/Lato-Medium.ttf"]
+  ["mJmJtIHbXfCCfZDFH9CNAk/nvE42cEbiWEoNOwSHk20=" "ofl/lato/Lato-ExtraLight.ttf"]
+  ["Wt62szTY+5nvBTvAUrlSdz1UQxXg4dZooSwM6L1RN1w=" "ofl/lato/Lato-SemiBoldItalic.ttf"]
+  ["YsG38NLnS0WWAVTDUg78M3tVPbCWG/3JUNVhgzRZbMg=" "ofl/lato/Lato-BoldItalic.ttf"]
+  ["YQGN5iva+Q1KyAsdU8XBMHVsjpIZrqPSdz/JvVhpr5c=" "ofl/lato/Lato-ExtraBold.ttf"]
+  ["45nETv4ThxAFMdJsfkgAxdEiUbiQ1mVKMJjHxnnLF4Y=" "ofl/lato/Lato-Italic.ttf"]
+  ["/FZSYlC5tkzgkIxSNQsD6RuEr+ywj9KDShLle5Gr2zE=" "ofl/lato/Lato-ExtraLightItalic.ttf"]
+  ["igqs510zeU7s5LKBh7/B3wu9KIi12KVuAXiMjWXRa+E=" "ofl/lato/Lato-Bold.ttf"]
+  ["gIxig5xi28595omvdgNmb8f4uB4N9TfYpSEsh1gNQzc=" "ofl/lato/Lato-Black.ttf"]
+  ["MhT3W/lng6VxvSUzjIZ8Zp58XnwIoifxintjdm1ubL4=" "ofl/lato/Lato-BlackItalic.ttf"]
+  ["1jbkaDIx+THtoiLViOlE0IK/0726AvkovuRhwPGFslE=" "ofl/lato/Lato-Regular.ttf"]
+  ["zyp3RQO69BjVhPSZZ70WDh4D8IfBOyVgLygCTsd4jwg=" "ofl/lato/Lato-Light.ttf"]
+  ["ZjxVv+mjgnD/9E2ic79NeS6vw+fhIB9iwwZMrYDF1ec=" "ofl/lato/Lato-Thin.ttf"]
+  ["cbi33svnWoge0me+U51AK9HpQgt5lliq2k4NG9WvgDw=" "ofl/lato/Lato-SemiBold.ttf"]
+  ["5ehuIZzmmHsXVHDZTVd1Ojh9GGC2NdpjJ6YOjRmjO+s=" "ofl/lato/Lato-ThinItalic.ttf"]
+  ["7Lzmz/pC2KZ6/rJ6nW6F1RXoFIHUss7OmJ6DOkgEhAU=" "ofl/lato/Lato-MediumItalic.ttf"]
+];
+lavishlyyours = mkFont "lavishlyyours" "ofl" [
+  ["SgelACpPhSlSgY7r3PAI5I6n1TdUHMj/frhCCIhCMT4=" "ofl/lavishlyyours/LavishlyYours-Regular.ttf"]
+];
+leaguegothic = mkFont "leaguegothic" "ofl" [
+  ["Ow6ZjJoANCIjlP/s3Tg+aUglmtA3uVVVsTmiF2Kc4dA=" "ofl/leaguegothic/LeagueGothic%5Bwdth%5D.ttf"]
+];
+leaguescript = mkFont "leaguescript" "ofl" [
+  ["QsOkkwKK7DoiZuVAoSZPe14m7v0XIZ3amxZbkomGMIo=" "ofl/leaguescript/LeagueScript-Regular.ttf"]
+];
+leaguespartan = mkFont "leaguespartan" "ofl" [
+  ["LbtikLOat8SKQLGPdMpZ70immgFcPqBUJwPwxs5R1hc=" "ofl/leaguespartan/LeagueSpartan%5Bwght%5D.ttf"]
+];
+leckerlione = mkFont "leckerlione" "ofl" [
+  ["PzjtmaB6tCbqpkx9V3OFCl3I5nGbAxJe/OLPvIKwg9c=" "ofl/leckerlione/LeckerliOne-Regular.ttf"]
+];
+ledger = mkFont "ledger" "ofl" [
+  ["DZ5AhiCNWu6IE64RhQEMWPovB5M/tcGh0JUPQr2XYnI=" "ofl/ledger/Ledger-Regular.ttf"]
+];
+lekton = mkFont "lekton" "ofl" [
+  ["zLtGXSVaS9AkKvWV1fVBDmNb0Nvy9LYSs5DlCKk9ejo=" "ofl/lekton/Lekton-Regular.ttf"]
+  ["mqtaKB80KNiC5n2alFkwgiOA9bKK0A9fv3niHa3uN18=" "ofl/lekton/Lekton-Bold.ttf"]
+  ["q1+1M/TvIRkaUitckuK7zK1s9G2Sej/cdhczSmiXdCc=" "ofl/lekton/Lekton-Italic.ttf"]
+];
+lemonada = mkFont "lemonada" "ofl" [
+  ["hBNOnh2n1ZODkHMVeYCk04KW0r4QthRpqPMWkgSVmtk=" "ofl/lemonada/Lemonada%5Bwght%5D.ttf"]
+];
+lemonadavfbeta = mkFont "lemonadavfbeta" "ofl" [
+  ["vbArhhF2NuG55QL4yHQF6/RCHsVzIX+3V/iS79PseCE=" "ofl/lemonadavfbeta/LemonadaVFBeta.ttf"]
+];
+lemon = mkFont "lemon" "ofl" [
+  ["fe2T/eRYnDzDIFLaGH0Ly/Aj37U68ai0zoR9R62a3TM=" "ofl/lemon/Lemon-Regular.ttf"]
+];
+lexenddeca = mkFont "lexenddeca" "ofl" [
+  ["0RwSKY9DHX5Bah5hXTPywrmL2iMYoMGGyMlPCMLZDOg=" "ofl/lexenddeca/LexendDeca%5Bwght%5D.ttf"]
+];
+lexendexa = mkFont "lexendexa" "ofl" [
+  ["0Dpe9881KlUIxqZNx7e55Qu3r926GpDXkqgBpvQhpjw=" "ofl/lexendexa/LexendExa%5Bwght%5D.ttf"]
+];
+lexendgiga = mkFont "lexendgiga" "ofl" [
+  ["piyVjomJlaIXf5aD49rSqNqYtXGgRgGhW0ssS7OQxvE=" "ofl/lexendgiga/LexendGiga%5Bwght%5D.ttf"]
+];
+lexendmega = mkFont "lexendmega" "ofl" [
+  ["yvIHplioUZNlqJJ0tk2L6jbs9ZJ0U9OIlleJznviXfk=" "ofl/lexendmega/LexendMega%5Bwght%5D.ttf"]
+];
+lexend = mkFont "lexend" "ofl" [
+  ["Ot1T5kH7yB2mTaS7JUKF4oMbUrApUnvAcU4rlhCDLuY=" "ofl/lexend/Lexend%5Bwght%5D.ttf"]
+];
+lexendpeta = mkFont "lexendpeta" "ofl" [
+  ["SL11PCFr2xmkaaZXCodW8jBFweRvjUmPbPEDjLzcE1s=" "ofl/lexendpeta/LexendPeta%5Bwght%5D.ttf"]
+];
+lexendtera = mkFont "lexendtera" "ofl" [
+  ["FTxiPes5pKefJpcuGnthZRwW+dVn1K+DvilCMDMH36w=" "ofl/lexendtera/LexendTera%5Bwght%5D.ttf"]
+];
+lexendzetta = mkFont "lexendzetta" "ofl" [
+  ["cFui+A+NrzyTua7CeY0FTl8xyxve0A8XBoAFSfR8Nd8=" "ofl/lexendzetta/LexendZetta%5Bwght%5D.ttf"]
+];
+librebarcode128 = mkFont "librebarcode128" "ofl" [
+  ["vs5rhpXPKfBM4ccG8PUIplVF87YkCgPO8wK3D4RmMKc=" "ofl/librebarcode128/LibreBarcode128-Regular.ttf"]
+];
+librebarcode128text = mkFont "librebarcode128text" "ofl" [
+  ["Doomh0nnfIvxZEoZzdZeg69khrytwGIl5IbN9WnVj1g=" "ofl/librebarcode128text/LibreBarcode128Text-Regular.ttf"]
+];
+librebarcode39extended = mkFont "librebarcode39extended" "ofl" [
+  ["T9JFaL2jDyjPQw9am6KqP8zjZ34I8wbt8wq0L9YYdTU=" "ofl/librebarcode39extended/LibreBarcode39Extended-Regular.ttf"]
+];
+librebarcode39extendedtext = mkFont "librebarcode39extendedtext" "ofl" [
+  ["17UBAfFsTcPq4L0bqyVMH9praaE5bbcrF2e+IpoM7Cs=" "ofl/librebarcode39extendedtext/LibreBarcode39ExtendedText-Regular.ttf"]
+];
+librebarcode39 = mkFont "librebarcode39" "ofl" [
+  ["DIkH8odl5vAh86kQ0ZPk4C9RgGX73LvHd8GVhyi8xqU=" "ofl/librebarcode39/LibreBarcode39-Regular.ttf"]
+];
+librebarcode39text = mkFont "librebarcode39text" "ofl" [
+  ["Bv/g9yQJspEmc+LQC0iOSodL2l14Rey1cTu8nQkUg68=" "ofl/librebarcode39text/LibreBarcode39Text-Regular.ttf"]
+];
+librebarcodeean13text = mkFont "librebarcodeean13text" "ofl" [
+  ["Snx8gwqY6dxolrgOn257xuwKD6uUK8Sky+min1vNPAI=" "ofl/librebarcodeean13text/LibreBarcodeEAN13Text-Regular.ttf"]
+];
+librebaskerville = mkFont "librebaskerville" "ofl" [
+  ["iZ0hIuadhptex0dLMW3bW+gE8gXWs+Zoqdi56gntb28=" "ofl/librebaskerville/LibreBaskerville-Bold.ttf"]
+  ["9NJ7KwR2enPIZEtb1EmPLDNS8n/DKUkAPkOXIf4fHWA=" "ofl/librebaskerville/LibreBaskerville-Italic.ttf"]
+  ["/WRAnEI49MkOr8iQDkGSS7w+hqhvSKrKZva00BsKzrc=" "ofl/librebaskerville/LibreBaskerville-Regular.ttf"]
+];
+librebodoni = mkFont "librebodoni" "ofl" [
+  ["U99Bs3C7Z0ViHqspCnLqQuQjf8wwPIdfVQ1bt7xEZZU=" "ofl/librebodoni/LibreBodoni-Italic%5Bwght%5D.ttf"]
+  ["60CBKy/bJQ49rZw4+LK//kxm93ihKZ7DJiIAX/TwmW0=" "ofl/librebodoni/LibreBodoni%5Bwght%5D.ttf"]
+];
+librecaslondisplay = mkFont "librecaslondisplay" "ofl" [
+  ["I0DElxgelEb8uyNeHDeAVY3GKHn/4O9HkG0/fzXPXzU=" "ofl/librecaslondisplay/LibreCaslonDisplay-Regular.ttf"]
+];
+librecaslontext = mkFont "librecaslontext" "ofl" [
+  ["wRgJ2/1URYhik9ibMr/CWEB1yA53dQzxwoQRPja4s/Q=" "ofl/librecaslontext/LibreCaslonText%5Bwght%5D.ttf"]
+  ["YMoaOq3mHIw4GADKhbmy8Ps0HYnr4GXhLNbsLuLlPlQ=" "ofl/librecaslontext/LibreCaslonText-Italic%5Bwght%5D.ttf"]
+];
+librefranklin = mkFont "librefranklin" "ofl" [
+  ["JmvUhZ5bXLvR+BWta8XRxCWt+znih8GtwXTZV4WEVnM=" "ofl/librefranklin/LibreFranklin-Italic%5Bwght%5D.ttf"]
+  ["diXwhDRHYowsJjxGOpcM88U9oyr1ejeoc+ooP0QxHcA=" "ofl/librefranklin/LibreFranklin%5Bwght%5D.ttf"]
+];
+licorice = mkFont "licorice" "ofl" [
+  ["xy2MsvVuaZWzaC2GIOLWArrPeLZxIc37+s6azEInUNg=" "ofl/licorice/Licorice-Regular.ttf"]
+];
+lifesavers = mkFont "lifesavers" "ofl" [
+  ["xdC6iMqRFxVzvA6j7q0inaiSyCe+i2Jzj5yXXA3Bi1I=" "ofl/lifesavers/LifeSavers-ExtraBold.ttf"]
+  ["nVU0+a1BoUeUvkJ2i64RT90+9k/qumUAihe/IoIdGwE=" "ofl/lifesavers/LifeSavers-Bold.ttf"]
+  ["Tkv+vfBXN90g2CwmXd8Si329livVOUEHWmqlbN4w6MM=" "ofl/lifesavers/LifeSavers-Regular.ttf"]
+];
+lilitaone = mkFont "lilitaone" "ofl" [
+  ["9bZBxFxp13LuTtpoe8n9pBHVytawtFNxSR2kWAy8jVk=" "ofl/lilitaone/LilitaOne-Regular.ttf"]
+];
+lilyscriptone = mkFont "lilyscriptone" "ofl" [
+  ["GRyOO/1lOuAgzyPNW0xaai3nQSRkopDlFGHdCEqmJ2U=" "ofl/lilyscriptone/LilyScriptOne-Regular.ttf"]
+];
+limelight = mkFont "limelight" "ofl" [
+  ["9b+KkVmt/FucdWyF2BKk/RKZuJFv7985rUskrebY0M8=" "ofl/limelight/Limelight-Regular.ttf"]
+];
+lindenhill = mkFont "lindenhill" "ofl" [
+  ["7tP95sSV3VWLiKoNNIZRbdTZlWpJfDNdt76qnCnQUIo=" "ofl/lindenhill/LindenHill-Regular.ttf"]
+  ["YHHry6UyQhZ8/jjf0K4QgSUFVAX7G07NBGjih6nnx0M=" "ofl/lindenhill/LindenHill-Italic.ttf"]
+];
+literata = mkFont "literata" "ofl" [
+  ["kTA4yTE6mn0v3DDvimCI3vuxBrshSUhv2M/Z8weIQ5I=" "ofl/literata/Literata-Italic%5Bopsz,wght%5D.ttf"]
+  ["smeRTJB0cP36oo5ib6ETZszsmxuvps03sSePJyVqYfQ=" "ofl/literata/Literata%5Bopsz,wght%5D.ttf"]
+];
+liujianmaocao = mkFont "liujianmaocao" "ofl" [
+  ["yrOWuRpbfAtABaNYkRgNBuZ1H1rCYf5oCuxlwa4gkDM=" "ofl/liujianmaocao/LiuJianMaoCao-Regular.ttf"]
+];
+livvic = mkFont "livvic" "ofl" [
+  ["87qqM6xQvnQXZc+R5w2Eg17emmjclaNXQN6a/94RNGE=" "ofl/livvic/Livvic-Light.ttf"]
+  ["d451d8+O2PCpfrZXu/TU8FvAxujrCshFjyWg6qbKFug=" "ofl/livvic/Livvic-Regular.ttf"]
+  ["yxXZ2xspzYgnfsvcd3YXMOOSLi58I7Xa4E4Aqww7ZMQ=" "ofl/livvic/Livvic-LightItalic.ttf"]
+  ["g+ZsBQeGBZrqvrX7ad76slk9+Tyu3eEXRtxid/v45SM=" "ofl/livvic/Livvic-BlackItalic.ttf"]
+  ["pLYrLGaXK8P69yp/Y1CF1p6w5z/mxZWiV0oqyLjS/Wc=" "ofl/livvic/Livvic-ExtraLightItalic.ttf"]
+  ["Tsvco1cyAKOPkrOWT59RWWYJaRAOLgewuW9EFCiMRiw=" "ofl/livvic/Livvic-ThinItalic.ttf"]
+  ["F+IudxOWe+vXg7G4dFZJovxU6e4JbYrTgSn1O0fJSu8=" "ofl/livvic/Livvic-Thin.ttf"]
+  ["k88GLPKM//A1nzjdk6dfRtz1ulFEg7tVcGmom3s8Tgw=" "ofl/livvic/Livvic-SemiBold.ttf"]
+  ["sP33AQJnXuGsgcw4oPDkBpSmQDqLoybMYumb4LrUzt0=" "ofl/livvic/Livvic-BoldItalic.ttf"]
+  ["8uOllSwP5GV3ii65OopP0fJ/tqn4CA+aosfwhSEtzz8=" "ofl/livvic/Livvic-Bold.ttf"]
+  ["ePknfei4c0zxciiPtE81nIXzo4pvmPIzP44QPOGs3PQ=" "ofl/livvic/Livvic-Medium.ttf"]
+  ["emnT+u2t5LTuI4Bp/nAxY4QvIjC1BQV1Y4gs7GWcWcY=" "ofl/livvic/Livvic-ExtraLight.ttf"]
+  ["aVIueEpIcZGUX6n52S1n5kzVpLxuhJrkLV9KeZqNm2A=" "ofl/livvic/Livvic-Black.ttf"]
+  ["olLtZIjYn0IAtUF0wAKEZCSqW6tFQiDmxo9qtK0Du84=" "ofl/livvic/Livvic-Italic.ttf"]
+  ["hKivXEDulvDphzuOM6nWXDoIzDvbWwzU6D6BdNErreA=" "ofl/livvic/Livvic-SemiBoldItalic.ttf"]
+  ["IpPpfvTgEtx0p6RT0yYREt5LULi2UH+Fh+vJXkiUkLk=" "ofl/livvic/Livvic-MediumItalic.ttf"]
+];
+lobster = mkFont "lobster" "ofl" [
+  ["1laOaX/VDO3AvgTYquQSf+la3WB+e/+VTKiGBL6AwgU=" "ofl/lobster/Lobster-Regular.ttf"]
+];
+lobstertwo = mkFont "lobstertwo" "ofl" [
+  ["xyeuHZ4eFmp8Bnn895wv8MIbxUg+4lP9/uL1eSwL69k=" "ofl/lobstertwo/LobsterTwo-Italic.ttf"]
+  ["mA7gh0VfHwqW+y6nS+9EGivykEjixznRFoPTMM/Bkyk=" "ofl/lobstertwo/LobsterTwo-BoldItalic.ttf"]
+  ["UlWzg/yKpDLk5+X4AFIQR3wJgzcK3GrWIFyb0s0c63Y=" "ofl/lobstertwo/LobsterTwo-Bold.ttf"]
+  ["vj2M4YGIvFWd435DVfX5ArSWCntlqZ77eMA7tlu3guY=" "ofl/lobstertwo/LobsterTwo-Regular.ttf"]
+];
+lohitbengali = mkFont "lohitbengali" "ofl" [
+  ["YJrvs0TXx+Wwgvfa1QHFR59miJYIipOxmGdb9iE+juE=" "ofl/lohitbengali/Lohit-Bengali.ttf"]
+];
+lohitdevanagari = mkFont "lohitdevanagari" "ofl" [
+  ["4vpwzdbNZjhVTcJ4aZsM+q1/lCH6Ba6OA7tiFkBpvSE=" "ofl/lohitdevanagari/Lohit-Devanagari.ttf"]
+];
+lohittamil = mkFont "lohittamil" "ofl" [
+  ["Mg0JWcBlCZjNLlibM2itMxmg0Qa+y4G4DCcqAdxI/hQ=" "ofl/lohittamil/Lohit-Tamil.ttf"]
+];
+londrinaoutline = mkFont "londrinaoutline" "ofl" [
+  ["dzxlW8ai6baZz6jEpfYVxjSGhtAYKBu45s3EcLLwX00=" "ofl/londrinaoutline/LondrinaOutline-Regular.ttf"]
+];
+londrinashadow = mkFont "londrinashadow" "ofl" [
+  ["vcSmYhPCvtOg5YkSuy5H97DqUbB9KRpDiW7tXIfgGiE=" "ofl/londrinashadow/LondrinaShadow-Regular.ttf"]
+];
+londrinasketch = mkFont "londrinasketch" "ofl" [
+  ["HTt77tpwFQFEEskW4gUBbtZtH4KYqX3ODKOuLRMnHJ8=" "ofl/londrinasketch/LondrinaSketch-Regular.ttf"]
+];
+londrinasolid = mkFont "londrinasolid" "ofl" [
+  ["d3YdgD6TfsQqf0s76AyhUhKn1ZLcEAIoONwR344V/bU=" "ofl/londrinasolid/LondrinaSolid-Thin.ttf"]
+  ["6CubPuIczxU9z2fl9CJqIQR0WRpq0xtfF/LxTcJSRRQ=" "ofl/londrinasolid/LondrinaSolid-Regular.ttf"]
+  ["jGOhXj+jTgs2Kr65A5RKK9RecbHvoSJIbApH4pXq4G8=" "ofl/londrinasolid/LondrinaSolid-Black.ttf"]
+  ["/G8lctAIB4lawv/ixc/7n7EHzLdc22K10VnXycgVkaE=" "ofl/londrinasolid/LondrinaSolid-Light.ttf"]
+];
+longcang = mkFont "longcang" "ofl" [
+  ["5b8sPyTvIyfG8TbY9z4vnf30SJb9vrNalRX0R3e7kbw=" "ofl/longcang/LongCang-Regular.ttf"]
+];
+lora = mkFont "lora" "ofl" [
+  ["P+SZUQfj/iktQ/FxG5rgxAbJttPnft/Smlp2PVRobbA=" "ofl/lora/Lora-Italic%5Bwght%5D.ttf"]
+  ["mDltJJM68ViciwVYt0fA7ygnm942CBtsEXSJRjKfSsY=" "ofl/lora/Lora%5Bwght%5D.ttf"]
+];
+lovedbytheking = mkFont "lovedbytheking" "ofl" [
+  ["HS/OcFyQKgxHJkmS5pjOdjNgE0WPBhLMaJFwJcpvz7M=" "ofl/lovedbytheking/LovedbytheKing.ttf"]
+];
+lovelight = mkFont "lovelight" "ofl" [
+  ["IDZ5DuIR+EYWGX1b25DNUZ1RogAT3y/7jJ89+Zbx4BY=" "ofl/lovelight/LoveLight-Regular.ttf"]
+];
+loversquarrel = mkFont "loversquarrel" "ofl" [
+  ["qFbNWjbQUKbn+0uXYUPm3a2Ccb3uv7LC7+x4qw+FabY=" "ofl/loversquarrel/LoversQuarrel-Regular.ttf"]
+];
+loveyalikeasister = mkFont "loveyalikeasister" "ofl" [
+  ["T74sH6ZH3lpBWsrHsrZJFUL+l2e2GZcZo713p8816w0=" "ofl/loveyalikeasister/LoveYaLikeASister.ttf"]
+];
+luckiestguy = mkFont "luckiestguy" "asl20" [
+  ["z73WigOfkt9RzzchUGr2JC5kWUxjJf4L7b7/P+OF2YA=" "apache/luckiestguy/LuckiestGuy-Regular.ttf"]
+];
+lusitana = mkFont "lusitana" "ofl" [
+  ["fOiv/mqc+YME0zRD8msXLyQjDcK5bYgPmGeXgOLhga0=" "ofl/lusitana/Lusitana-Bold.ttf"]
+  ["WC74Ge/+0ljCNvSSTieZMj89R0Ry1Qk5uBf5ECLtHmA=" "ofl/lusitana/Lusitana-Regular.ttf"]
+];
+lustria = mkFont "lustria" "ofl" [
+  ["i1B1N3nRUWdNzHS9+c3eHniNj7K5rOj7GDoN7w9zYc4=" "ofl/lustria/Lustria-Regular.ttf"]
+];
+luxuriousroman = mkFont "luxuriousroman" "ofl" [
+  ["MNa8SyXPB1Vg8N2Qp3qO2BZb0oCoY94cOrQp+/ms5Ys=" "ofl/luxuriousroman/LuxuriousRoman-Regular.ttf"]
+];
+luxuriousscript = mkFont "luxuriousscript" "ofl" [
+  ["2xoRijTrg195YKCdi+Rytllx13mHcoQtw803qGQUkek=" "ofl/luxuriousscript/LuxuriousScript-Regular.ttf"]
+];
+macondo = mkFont "macondo" "ofl" [
+  ["GRD+KbYFiHmUdOpigbWeEx4z6Wx3v7gHIqTH+BM9tKo=" "ofl/macondo/Macondo-Regular.ttf"]
+];
+macondoswashcaps = mkFont "macondoswashcaps" "ofl" [
+  ["d2yVrVIOR3akWt2NhpPmk7Vmvp8mzSBQUlbI6UTcB+o=" "ofl/macondoswashcaps/MacondoSwashCaps-Regular.ttf"]
+];
+mada = mkFont "mada" "ofl" [
+  ["w+cL9xqwVX3dgpBnJsNtieGZeS2xmXBAsVmfYeAKzXg=" "ofl/mada/Mada-Medium.ttf"]
+  ["d0akyhxnZ6lxwNsx7BhZT6UhGtzDGOKT0ntV78Nr3tk=" "ofl/mada/Mada-Black.ttf"]
+  ["SYdCX95F6NpF7eP61AmwrADjLKAlWmC0S44fcBdkNGw=" "ofl/mada/Mada-Light.ttf"]
+  ["no9O3Ht0aXiD1DggAFAtdClIH3zMWbZaxiwo6ZSBy8M=" "ofl/mada/Mada-ExtraLight.ttf"]
+  ["uU4fnJF65A5ea42V/iTeGBfjeUKq+5uTENXg1LBJIho=" "ofl/mada/Mada-Bold.ttf"]
+  ["njwkq4MDem1PxbctBoyqpqB2dBS9INfe/jHFYs7W1uc=" "ofl/mada/Mada-Regular.ttf"]
+  ["BS4ODxdOno/2O/KoX3DbbMWdM5GgFqMazo4gxJ0PoNY=" "ofl/mada/Mada-SemiBold.ttf"]
+];
+magra = mkFont "magra" "ofl" [
+  ["1ND+Qh0ySzp4hsrExsIGn05nGuGFlGPxSvFIitJ/IV4=" "ofl/magra/Magra-Regular.ttf"]
+  ["PpkQEsKQvs/rKZQ/hjkaQ1uLvx/IU9yDmcy/zOa1aoE=" "ofl/magra/Magra-Bold.ttf"]
+];
+maidenorange = mkFont "maidenorange" "asl20" [
+  ["/WPkQmk1Cpdh25qI25owHIJnESPHqVUPpABLJrXRYgA=" "apache/maidenorange/MaidenOrange-Regular.ttf"]
+];
+maitree = mkFont "maitree" "ofl" [
+  ["0WBUW1uAJlhDHRe6w38BbH6muKFq6M7Nf5OJ2lJYEhY=" "ofl/maitree/Maitree-SemiBold.ttf"]
+  ["YxT9qNlaL2nxa2Po7KSkqC4bHKUZ7HA5+ZVl1dKzThY=" "ofl/maitree/Maitree-Medium.ttf"]
+  ["ZAlrIst5aVg5HHBJktDPaY3rNHjUr2wTHxtaQ16FHgg=" "ofl/maitree/Maitree-Light.ttf"]
+  ["Cxdfm0aJYdN/ryG/vycgfFrtqfKwKYQbzK8nR8LCab4=" "ofl/maitree/Maitree-Regular.ttf"]
+  ["qqMQ+byROIKGOx05vXCXi30Gisgx7zeJvZIfeBOSND0=" "ofl/maitree/Maitree-ExtraLight.ttf"]
+  ["WYmRaNBEFDEIsY/ORgA8Z3QhcBmkh41DE/Z5O50X+/I=" "ofl/maitree/Maitree-Bold.ttf"]
+];
+majormonodisplay = mkFont "majormonodisplay" "ofl" [
+  ["Py7nHCuEZPBlv5YKFIvoHWj8wTOF34dzeSj5SCCN/8Y=" "ofl/majormonodisplay/MajorMonoDisplay-Regular.ttf"]
+];
+mako = mkFont "mako" "ofl" [
+  ["/AAKIarS88fWg2mj96yCXIl9IZEUmp+Rb5qTbJ//6Rs=" "ofl/mako/Mako-Regular.ttf"]
+];
+mali = mkFont "mali" "ofl" [
+  ["R+WKvDe70CedLjSZVqUpoGn8CIZrLNuX4XExrrBdOaM=" "ofl/mali/Mali-LightItalic.ttf"]
+  ["HuXqiD/eeOTsi2a6NgY0jNSBccxCByCQ3491AKguPzM=" "ofl/mali/Mali-ExtraLight.ttf"]
+  ["/rKAi704J5SbXtqTF51YILD7uyv9YVSGaw0F4bjyX4w=" "ofl/mali/Mali-Italic.ttf"]
+  ["qjMghF4oHeBdcHau2b5aCd9L8R5sRhZQJ6C1egyPXck=" "ofl/mali/Mali-Medium.ttf"]
+  ["4yEvD5vhMHQ9MqTxdLfXlijapdsNcspMY8eZrkZVl7s=" "ofl/mali/Mali-Regular.ttf"]
+  ["Pi9CEDbD+R617zRlClzSEWxzelQhR3aUN6mFakVdRGI=" "ofl/mali/Mali-Bold.ttf"]
+  ["OoOlPyuI6EZKCfh4jNStTpauMAjjuyEo3jRpO9KtbtE=" "ofl/mali/Mali-SemiBoldItalic.ttf"]
+  ["C6bZK0Y2nsUEDRGfh6F1hr6WNk+sdD+/UQtUo+rRrcw=" "ofl/mali/Mali-SemiBold.ttf"]
+  ["DNNlw2G0o5RYN0auIisTbKYns0SjXPhMamXCz0unqXw=" "ofl/mali/Mali-Light.ttf"]
+  ["7VHR+nIeTcSkPbo0kmRCoAf4owBUPBFxiHgQpUflsjs=" "ofl/mali/Mali-BoldItalic.ttf"]
+  ["LDfXjM9+YJVSbxPuAgx+SMFekc9CqLEVoiRn/2j8Lso=" "ofl/mali/Mali-MediumItalic.ttf"]
+  ["ApWslLlBye4AmXqvg0WfEAqZmGs/Ti8sGdIRlh45hrQ=" "ofl/mali/Mali-ExtraLightItalic.ttf"]
+];
+mallanna = mkFont "mallanna" "ofl" [
+  ["c+V2klNWWyhK3tXZ2h+YxqELDaW6dbQLPCNiOfzCP3Y=" "ofl/mallanna/Mallanna-Regular.ttf"]
+];
+mandali = mkFont "mandali" "ofl" [
+  ["i6RmPRFK/2OeSXS2V5U1PBkycgJjCGCNlXcKqqav2AY=" "ofl/mandali/Mandali-Regular.ttf"]
+];
+manjari = mkFont "manjari" "ofl" [
+  ["8Z/vaVso5USK6HRR37q0JmdsrfS1k0BVihV8AHG2nSY=" "ofl/manjari/Manjari-Bold.ttf"]
+  ["Dqsv1IKysObNRpxT0JUTojA/+RyG3IwbpCrPxzJCvXI=" "ofl/manjari/Manjari-Thin.ttf"]
+  ["FkYJJGlr/qKi9xtCAdh4aGfGQTtUjsvSK8a/5VvpD5U=" "ofl/manjari/Manjari-Regular.ttf"]
+];
+manrope = mkFont "manrope" "ofl" [
+  ["0GOb5F0K8255gXJBnXvRc8S9Tynit2y7adsdEb+LCkA=" "ofl/manrope/Manrope%5Bwght%5D.ttf"]
+];
+mansalva = mkFont "mansalva" "ofl" [
+  ["YTyilPCjZP0oKgbV6KZdtdjyu4uDT4shQ3pTz3Da+4o=" "ofl/mansalva/Mansalva-Regular.ttf"]
+];
+manuale = mkFont "manuale" "ofl" [
+  ["GeoJrS+/Mhz4+UrD9mVHvJsr3zcjovBzYV6qAv4X3tY=" "ofl/manuale/Manuale%5Bwght%5D.ttf"]
+  ["E+sg8i6LaijrqTZwIZy0cpgOj9AGMZqRcxZDTi7Rlho=" "ofl/manuale/Manuale-Italic%5Bwght%5D.ttf"]
+];
+marcellus = mkFont "marcellus" "ofl" [
+  ["HPDNELF9NehScplizB/6/+2UUUiVlyRYNF4t80q7L4E=" "ofl/marcellus/Marcellus-Regular.ttf"]
+];
+marcellussc = mkFont "marcellussc" "ofl" [
+  ["AwRKtlIosFVMmlweY98p1OWKcYV+ISgBqvdo39EGvfA=" "ofl/marcellussc/MarcellusSC-Regular.ttf"]
+];
+marckscript = mkFont "marckscript" "ofl" [
+  ["UE3ozG+RkWO8mvtnubwgjSWCMMXo0Ay4LsUkdPn6/Ds=" "ofl/marckscript/MarckScript-Regular.ttf"]
+];
+margarine = mkFont "margarine" "ofl" [
+  ["VAQ9PYV69Fz+QNJD388Ti9Rff7RSNkpwklmJOEGY1/M=" "ofl/margarine/Margarine-Regular.ttf"]
+];
+marhey = mkFont "marhey" "ofl" [
+  ["GcMGhhV+yWV5f66Mj+t7sUKwgiFyJ1YtGoCcBn30R+k=" "ofl/marhey/Marhey%5Bwght%5D.ttf"]
+];
+markazitext = mkFont "markazitext" "ofl" [
+  ["QktzMWgRYP8qSyCb/DVuqVZNQpp9rqQ+5Nwo3o/0+f4=" "ofl/markazitext/MarkaziText%5Bwght%5D.ttf"]
+];
+markazitextvfbeta = mkFont "markazitextvfbeta" "ofl" [
+  ["ln5CB3bk2gucAJjq5GqvMjCwVPjrTR6K/K6MZRo8QG8=" "ofl/markazitextvfbeta/MarkaziText-VF.ttf"]
+];
+markoone = mkFont "markoone" "ofl" [
+  ["ZRQBk3PavbXZGrPT1+l9lqZWc4xjT7rgR9u4FDgVOV0=" "ofl/markoone/MarkoOne-Regular.ttf"]
+];
+marmelad = mkFont "marmelad" "ofl" [
+  ["qtzqepcthClKtTmbmWVFBlWdMo4DFpojUYVMcEa3f8Y=" "ofl/marmelad/Marmelad-Regular.ttf"]
+];
+martel = mkFont "martel" "ofl" [
+  ["a+l5MjIlzZ0aOWRAOydxgW4AdhDuaNjUvwinXy5+CL8=" "ofl/martel/Martel-DemiBold.ttf"]
+  ["W8R8DUIyQvHcn34zJGzyZMcvsGcuvHbUd0SU/nHM+aQ=" "ofl/martel/Martel-ExtraBold.ttf"]
+  ["WJU3JAo9LAZ5PF59X4X8YKTOupuV41IG86e12Q9vaTg=" "ofl/martel/Martel-Light.ttf"]
+  ["BytyWQYamRKOUAVrCBAkl138bkwLJlq5n3W/Zr1Qwzg=" "ofl/martel/Martel-Bold.ttf"]
+  ["tzPlYUQRXV2mpkFdKXGrl7cmKUjRcuJzCa0AzpCWuHY=" "ofl/martel/Martel-Regular.ttf"]
+  ["d1+gdWGwVbMSl60vBb9fRe3cFkUxjtLEGXJKQbCc8BA=" "ofl/martel/Martel-UltraLight.ttf"]
+  ["YSL8YV0uoxpEOAc3xnnWGTot5aJj9r1rMpZ5tPZAYJ4=" "ofl/martel/Martel-Heavy.ttf"]
+];
+martelsans = mkFont "martelsans" "ofl" [
+  ["pri7MLpRzw6K+6pH6hV7+VKh7nmtiedyp9/2QEorZLQ=" "ofl/martelsans/MartelSans-Bold.ttf"]
+  ["3DU7jnkChrinIaNx458uLrN6zhN1akWArcp+bYVD5Gw=" "ofl/martelsans/MartelSans-ExtraLight.ttf"]
+  ["4cVHNq4ieZ+8K8ENLHU7MZ2H3ZNG676G++C4xZAJrKo=" "ofl/martelsans/MartelSans-Light.ttf"]
+  ["iHoCmS+zVg2lhkEdmb5+oZiNisaBDKiBFB+P2nrF5Ko=" "ofl/martelsans/MartelSans-Black.ttf"]
+  ["XDZYgOXHl2PHRcoTIElRjmmHPPPab37pFxHcUisCEQA=" "ofl/martelsans/MartelSans-Regular.ttf"]
+  ["7s7RrKsqsuvC7rnPgPFiWDwbNvqy4fZb2xTEpoveaGg=" "ofl/martelsans/MartelSans-ExtraBold.ttf"]
+  ["kgyzmAFwh7I2mgNt9nYzWjKjr3HEVg294OIZmgBMn8E=" "ofl/martelsans/MartelSans-SemiBold.ttf"]
+];
+martianmono = mkFont "martianmono" "ofl" [
+  ["w0Z4Q+wcJXSwX7z9cUfHv7z2Pdyo/CvLnRF/G/sbIuc=" "ofl/martianmono/MartianMono%5Bwdth,wght%5D.ttf"]
+];
+marvel = mkFont "marvel" "ofl" [
+  ["gmxBixHhlPxCYziqbaO3Qgy8KoCJ0beFGY/gcudRXRA=" "ofl/marvel/Marvel-Regular.ttf"]
+  ["01lctfaH5ZPO/ukwJ9sSeDonAagd/0YKgqY3NyTCu8Q=" "ofl/marvel/Marvel-Italic.ttf"]
+  ["LxVNwwJSXSYvOlkw7WnB/9vibug3yv6aLMEkuDLS7Zw=" "ofl/marvel/Marvel-Bold.ttf"]
+  ["TRRT/VzlA6/gsW9Kx152QvKgB6VbqvWJpH7JUqxzv64=" "ofl/marvel/Marvel-BoldItalic.ttf"]
+];
+mashanzheng = mkFont "mashanzheng" "ofl" [
+  ["PxUWwU8ldrkHDvXasxRdLYJDqrcXmr6riVO6obslOvo=" "ofl/mashanzheng/MaShanZheng-Regular.ttf"]
+];
+mate = mkFont "mate" "ofl" [
+  ["TkNgpZlJ+0j4v0tSzsyjzec2E4v/2ZCMQ6Hp1RY6zCU=" "ofl/mate/Mate-Regular.ttf"]
+  ["N4TfnSnvKP3jY10vnWr4QrnN+umqlX+ZvWXJYgtpUNE=" "ofl/mate/Mate-Italic.ttf"]
+];
+matesc = mkFont "matesc" "ofl" [
+  ["NLRar15ig2sU2u9YZ6rfPTeOFmXzv+UOmb4gKE4cWHU=" "ofl/matesc/MateSC-Regular.ttf"]
+];
+mavenpro = mkFont "mavenpro" "ofl" [
+  ["K9BWjEmr5KK+M4IDUVvzbbG95c9SQ0cNgdtbimohAnI=" "ofl/mavenpro/MavenPro%5Bwght%5D.ttf"]
+];
+mavenprovfbeta = mkFont "mavenprovfbeta" "ofl" [
+  ["6F+zn26Bf1g1IgWZWivV6yqn97HbbF98Pwnce7P30mo=" "ofl/mavenprovfbeta/MavenProVFBeta.ttf"]
+];
+mclaren = mkFont "mclaren" "ofl" [
+  ["MWTg29qnYemmvB3/NTKjs/YxtvITfAmEeyp1FOS9xO8=" "ofl/mclaren/McLaren-Regular.ttf"]
+];
+meaculpa = mkFont "meaculpa" "ofl" [
+  ["xaKTFReTgg0l/xCETxQYFwrnVfph0KEmzvoem4LyHOU=" "ofl/meaculpa/MeaCulpa-Regular.ttf"]
+];
+meddon = mkFont "meddon" "ofl" [
+  ["yYPpmP9+ASQlRGWclxv0BVv7Q6n8Wg3YPKfa/RBflNo=" "ofl/meddon/Meddon.ttf"]
+];
+medievalsharp = mkFont "medievalsharp" "ofl" [
+  ["dMsuZzi9dwOt8SCAL2j7oMnduRR6COaEfxAFseVd9aU=" "ofl/medievalsharp/MedievalSharp.ttf"]
+];
+medulaone = mkFont "medulaone" "ofl" [
+  ["7Jb8tkaIeNbOFzNCFEIfTAG7l+vgqJvubiI1KSn2Dyo=" "ofl/medulaone/MedulaOne-Regular.ttf"]
+];
+meerainimai = mkFont "meerainimai" "ofl" [
+  ["Pf+pUBrHkLXhw+vs26TyyQphen0xMfrRKYk5KbxWcI4=" "ofl/meerainimai/MeeraInimai-Regular.ttf"]
+];
+megrim = mkFont "megrim" "ofl" [
+  ["iNMFRKYxIasCH0z2D1clfIHKrt3usutNbsGmAK53nP0=" "ofl/megrim/Megrim.ttf"]
+];
+meiescript = mkFont "meiescript" "ofl" [
+  ["AGxmul2N4Lgkgh2URLqXsUniZxWUTBqKtCe7s1cE5sA=" "ofl/meiescript/MeieScript-Regular.ttf"]
+];
+meowscript = mkFont "meowscript" "ofl" [
+  ["IOWLhFWhnxjGh9Z+Lt+gtivXtm0Yrmj19H4LYDwZd3Y=" "ofl/meowscript/MeowScript-Regular.ttf"]
+];
+mergeone = mkFont "mergeone" "ofl" [
+  ["k60oV51KvzvsmtmWH9IJEuzqYK+tHXfD7L05NJuI2Wc=" "ofl/mergeone/MergeOne-Regular.ttf"]
+];
+merienda = mkFont "merienda" "ofl" [
+  ["qR5NiKULT4DHsfMf5G43brh7ciR9KiFvXlvhiBNA3uo=" "ofl/merienda/Merienda%5Bwght%5D.ttf"]
+];
+meriendaone = mkFont "meriendaone" "ofl" [
+  ["b6jrJW4Dhy8Pi0GzF+s+uwCKuqu62eg+DNEjTYmcVUM=" "ofl/meriendaone/MeriendaOne-Regular.ttf"]
+];
+merriweather = mkFont "merriweather" "ofl" [
+  ["QDsb7OPXBCDmXGcDFWk+m8olXpyViE2csrM0g45ntQk=" "ofl/merriweather/Merriweather-BoldItalic.ttf"]
+  ["vDj+dWs+JZJIGD/At1rYGwJ3Tzymjl5UTpJYJ7AYbUA=" "ofl/merriweather/Merriweather-Regular.ttf"]
+  ["/IDbrAyp2olK4YAd+avlj23MoXnsT49vfqgP0TodOH0=" "ofl/merriweather/Merriweather-Italic.ttf"]
+  ["0+zEa6sSjtBzrZGJvX790t9FXYlC7AVvFBKb81vOp+U=" "ofl/merriweather/Merriweather-Light.ttf"]
+  ["VROXaahwhb/3d/aOPs+SRQwhoExd3R6elSiWC6QIjJ8=" "ofl/merriweather/Merriweather-Bold.ttf"]
+  ["hSHI61Qq3xeLGceregIQ+0cV/mi7bqV4vhKSd7ZCwfA=" "ofl/merriweather/Merriweather-LightItalic.ttf"]
+  ["3/EEhJmiwkVxPfpB42g8/s/RXfdXzEyyD4W866e/1Ys=" "ofl/merriweather/Merriweather-Black.ttf"]
+  ["QrXN2AspOssdehWViiwvi2uVITcJEQd3SGdjx1vIPr8=" "ofl/merriweather/Merriweather-BlackItalic.ttf"]
+];
+merriweathersans = mkFont "merriweathersans" "ofl" [
+  ["vvkNIn7rW1jifQpCHfbF2N8uam1oqgi9xR+qVPHZl9w=" "ofl/merriweathersans/MerriweatherSans%5Bwght%5D.ttf"]
+  ["iC5nY/ofNdwDzWHB4xhtuiQIgoyAeJXfoWh1sSQq1Z0=" "ofl/merriweathersans/MerriweatherSans-Italic%5Bwght%5D.ttf"]
+];
+mervalescript = mkFont "mervalescript" "ofl" [
+  ["UlIsSWW4S/XlYBW/kZsWW37tuu2wjX0NdHfDgUHJU9Y=" "ofl/mervalescript/MervaleScript-Regular.ttf"]
+];
+metalmania = mkFont "metalmania" "ofl" [
+  ["S5Xw5VspGZDCantogYsgwbcoqL4Fo0mCt7tHNsRsGeo=" "ofl/metalmania/MetalMania-Regular.ttf"]
+];
+metal = mkFont "metal" "ofl" [
+  ["NxgJb/9c9qdgBf3LeGx/Mh9Jb+bVb7y39mTBLEM9hBM=" "ofl/metal/Metal-Regular.ttf"]
+];
+metamorphous = mkFont "metamorphous" "ofl" [
+  ["VZOaVmTgaAfof6SvZPUgOerRLwAt2oMXOT/c4vf/V/4=" "ofl/metamorphous/Metamorphous-Regular.ttf"]
+];
+metrophobic = mkFont "metrophobic" "ofl" [
+  ["NOSsMlcwfCjm3RT113uyliEfDd0hdgciilN1QW7YrFg=" "ofl/metrophobic/Metrophobic-Regular.ttf"]
+];
+miama = mkFont "miama" "ofl" [
+  ["Lf/4TrDUascn6ZQ4QX4kTTqS5NCbJsMDm0DWQPB6ums=" "ofl/miama/Miama-Regular.ttf"]
+];
+michroma = mkFont "michroma" "ofl" [
+  ["zZP/XjqjRFFPNcLRvpI5JormZ/mDWjqgHeYaIJYni3w=" "ofl/michroma/Michroma.ttf"]
+];
+milonga = mkFont "milonga" "ofl" [
+  ["ICzjN/rRiz1UKvBObb12oZtHwAyI0Vt1Vc71ThgY44M=" "ofl/milonga/Milonga-Regular.ttf"]
+];
+miltonian = mkFont "miltonian" "ofl" [
+  ["vUraN2Tmd0lk7+CXRjUzsnWXVeOQ9o49FpdCZPjdLZg=" "ofl/miltonian/Miltonian-Regular.ttf"]
+];
+miltoniantattoo = mkFont "miltoniantattoo" "ofl" [
+  ["tOn0wmP8HnvrFLCVcuyyG6iTzo1eXOweVyfHnVyFg9w=" "ofl/miltoniantattoo/MiltonianTattoo-Regular.ttf"]
+];
+mina = mkFont "mina" "ofl" [
+  ["6xJYaeANXi+jO6oDNEkjFB8xpfEOGuP6ZRQ8snOfwxg=" "ofl/mina/Mina-Bold.ttf"]
+  ["HKj1+2N+If1s581MwjC3KEqQUkzpOmlrg4u+Pt0lq3w=" "ofl/mina/Mina-Regular.ttf"]
+];
+mingzat = mkFont "mingzat" "ofl" [
+  ["Y7jJ6pzrmVOmrq+U5wvj1TTJMHAkfJRVEsHngtrOlho=" "ofl/mingzat/Mingzat-Regular.ttf"]
+];
+miniver = mkFont "miniver" "ofl" [
+  ["Bjf/ZTqRExidGWQ08gVTiGOAg93jl5ZLg6osGADVtbc=" "ofl/miniver/Miniver-Regular.ttf"]
+];
+miriamlibre = mkFont "miriamlibre" "ofl" [
+  ["J36qJZ5u9ZJS4IJ/zwc48j9G5a8omyQ6GH+g947HkX8=" "ofl/miriamlibre/MiriamLibre-Regular.ttf"]
+  ["2IwxXrC4yD8tspKXArCGBjpwckSKXMz3ivR6nS3UhPg=" "ofl/miriamlibre/MiriamLibre-Bold.ttf"]
+];
+mirza = mkFont "mirza" "ofl" [
+  ["QjUyQHzIMu+EzI8IozWfJrUOchyKoOACIeQhXMg0QLM=" "ofl/mirza/Mirza-Medium.ttf"]
+  ["MGtBKjnZ+TyoQME8piMA61x3EuKvqUvX7yJytRExvm0=" "ofl/mirza/Mirza-Bold.ttf"]
+  ["QiUhXQ30rTicSsKdSP3cUxcDd2WRreZMI/b5lWadQHg=" "ofl/mirza/Mirza-SemiBold.ttf"]
+  ["WxrGyyhco0kuMTpT1SUrl4S/dgfyg1otRMs8utAWhTk=" "ofl/mirza/Mirza-Regular.ttf"]
+];
+missfajardose = mkFont "missfajardose" "ofl" [
+  ["924PJF54GnXqn6UocGtBcXP3dBQ5NpwH0VASdhcKtwk=" "ofl/missfajardose/MissFajardose-Regular.ttf"]
+];
+mitr = mkFont "mitr" "ofl" [
+  ["JX6GEpI+0Tg4svCg+bJVJ6qDUTxlffBJpe5gjm1KBZ0=" "ofl/mitr/Mitr-SemiBold.ttf"]
+  ["kjScBc1qNVSdD7PpsNfXMFlxfiEsvaGC7ijlkXFQvDQ=" "ofl/mitr/Mitr-Bold.ttf"]
+  ["hHNAkzQk1HO/9tARvAhUOiotKmcJhak+NDHjrIkmBo8=" "ofl/mitr/Mitr-Medium.ttf"]
+  ["N2OSPKjYYPnAb0g/ZjzT2NlOntjC81p841u2sT4SGf0=" "ofl/mitr/Mitr-Regular.ttf"]
+  ["3D5qA2A7sNs9xoMwQuIYqRfSEdUtk7ykJqpgbxKdRIg=" "ofl/mitr/Mitr-ExtraLight.ttf"]
+  ["DdsvQ7wHHNFUbRq9sER8SkEeBkUOadl8g4wnJfyAZKY=" "ofl/mitr/Mitr-Light.ttf"]
+];
+mochiypopone = mkFont "mochiypopone" "ofl" [
+  ["ngCUMOExbCcaXzR1nGtl/DQ8ToBvGTBCUoiH5yNaksY=" "ofl/mochiypopone/MochiyPopOne-Regular.ttf"]
+];
+mochiypoppone = mkFont "mochiypoppone" "ofl" [
+  ["ADEkOqEpDGPHVR+M3waxYxpccgM9ErK3xZXmBmAAclI=" "ofl/mochiypoppone/MochiyPopPOne-Regular.ttf"]
+];
+modak = mkFont "modak" "ofl" [
+  ["mpa6BW3cu30Mk3xS90T/XXEASpdomx/Szb1njzFNskU=" "ofl/modak/Modak-Regular.ttf"]
+];
+modernantiqua = mkFont "modernantiqua" "ofl" [
+  ["Ns4NcGBLWJFaKRiQZaG4OD1Rl7oReZTIfL/U82CDHv0=" "ofl/modernantiqua/ModernAntiqua-Regular.ttf"]
+];
+mogra = mkFont "mogra" "ofl" [
+  ["HXEz9ZJs9ecEK1h7g4vFxbz+bIaxkVev1UTHGmMBWdg=" "ofl/mogra/Mogra-Regular.ttf"]
+];
+mohave = mkFont "mohave" "ofl" [
+  ["hg1ih18PPfkjswo8L+gSMjfvS12qrwioBZTW/mZ/wOM=" "ofl/mohave/Mohave%5Bwght%5D.ttf"]
+  ["623Za1sMH4ixRfbC0EHZpIrtwd5tyE8cnND4L8YSMak=" "ofl/mohave/Mohave-Italic%5Bwght%5D.ttf"]
+];
+molengo = mkFont "molengo" "ofl" [
+  ["F5skcrvIPJD/46ZOMefOaRXSIXPuUHPMTnhun8d5LXY=" "ofl/molengo/Molengo-Regular.ttf"]
+];
+molle = mkFont "molle" "ofl" [
+  ["VpOgmnflr9KDgNJp4s8DynjE/ZKous0kiRAiHL/i71g=" "ofl/molle/Molle-Regular.ttf"]
+];
+monda = mkFont "monda" "ofl" [
+  ["6DtZ6iZRPJEoQ1IiBP+exbXspGQpBh4ZICtii/8ckzE=" "ofl/monda/Monda-Regular.ttf"]
+  ["VGbFnjUqGOEoNTSZSjqW/UTGwAwjdFOjS2m+6IPST5s=" "ofl/monda/Monda-Bold.ttf"]
+];
+monofett = mkFont "monofett" "ofl" [
+  ["BcIlqyZT1i6a7vanhpPWyZA4PTJT2uzovtxZZCMdXFI=" "ofl/monofett/Monofett.ttf"]
+];
+monomaniacone = mkFont "monomaniacone" "ofl" [
+  ["QEXStBkmjvzhse8zAEYDx0wEWAQTdpPx+5jHlXbzHG8=" "ofl/monomaniacone/MonomaniacOne-Regular.ttf"]
+];
+monoton = mkFont "monoton" "ofl" [
+  ["lRxM6mX/7eeEp8lnL+7F0ymn4eEiFsQtU+zzbJDQTeo=" "ofl/monoton/Monoton-Regular.ttf"]
+];
+monsieurladoulaise = mkFont "monsieurladoulaise" "ofl" [
+  ["3T4E++Zhp6cP+HtWtEbleiYF3lZZyE0171j0YG7mj60=" "ofl/monsieurladoulaise/MonsieurLaDoulaise-Regular.ttf"]
+];
+montaga = mkFont "montaga" "ofl" [
+  ["L4TEqe5JId1imtVcAAPl8VRIc3iE3qHD/9mqyvO0dqA=" "ofl/montaga/Montaga-Regular.ttf"]
+];
+montaguslab = mkFont "montaguslab" "ofl" [
+  ["Jv4l5vUiH6SLl4B9lma78250hrx4U2drJLtjE3PopQU=" "ofl/montaguslab/MontaguSlab%5Bopsz,wght%5D.ttf"]
+];
+montecarlo = mkFont "montecarlo" "ofl" [
+  ["EdOXIScitd3R4xkMOBITkDXnrP+wHajOrslur5heErU=" "ofl/montecarlo/MonteCarlo-Regular.ttf"]
+];
+montez = mkFont "montez" "asl20" [
+  ["9Y/HkPIM9hI5Nze7kMSsQY7qchR+mIGC9Ot+5X9GOfM=" "apache/montez/Montez-Regular.ttf"]
+];
+montserratalternates = mkFont "montserratalternates" "ofl" [
+  ["/lBeTsLWpYY6sbtC4+ch2VqYfdk6vRDTzf1MU1lOPTE=" "ofl/montserratalternates/MontserratAlternates-BlackItalic.ttf"]
+  ["b6S/h++JJ3kMwRzIe4vK3v4tihMmZkttdQ9bTl4s+UM=" "ofl/montserratalternates/MontserratAlternates-Black.ttf"]
+  ["cCiOC9qbhoDCsvrkw8ZpC7l8shlqYzX/Ymsv4y1QcOk=" "ofl/montserratalternates/MontserratAlternates-Light.ttf"]
+  ["ZtzX76flaBE6lYhk5o9F7Ri8lurMFrXSwahf/u2538Y=" "ofl/montserratalternates/MontserratAlternates-ExtraBold.ttf"]
+  ["Hi5l4pzoTecV/krKibW27wy6gjxMfmj1We+F9kgTUYY=" "ofl/montserratalternates/MontserratAlternates-MediumItalic.ttf"]
+  ["7aOFOQ4xSfsxOPJQqUm87EEnk0hKqZUIFIMi7v24JdY=" "ofl/montserratalternates/MontserratAlternates-Italic.ttf"]
+  ["iy+aSmlP2fpIetOH2PluPnTV5GKpMK9+qgoiyEPhSOA=" "ofl/montserratalternates/MontserratAlternates-SemiBoldItalic.ttf"]
+  ["u/agJEiGXSCFYB7yud4lceTHf7uaK9PP//w1mB5qEaU=" "ofl/montserratalternates/MontserratAlternates-ExtraLightItalic.ttf"]
+  ["ZvVirV/4vmU9344ZTbZpuajlZXHCTWU5/pLReLHX4Ho=" "ofl/montserratalternates/MontserratAlternates-ThinItalic.ttf"]
+  ["30F0pINqj3Ex+bKkb0p6ERpAWiioo4GdpSTJYJMhbSE=" "ofl/montserratalternates/MontserratAlternates-LightItalic.ttf"]
+  ["O3xWPyCHiIJ5/bfCHMV7Bzuhkx2+QT4SAkhbRuv7fq0=" "ofl/montserratalternates/MontserratAlternates-Regular.ttf"]
+  ["UcbmXjBeq16a5H7mM0xs9hXmZBjf2xaBKKcAzWWmupc=" "ofl/montserratalternates/MontserratAlternates-Thin.ttf"]
+  ["mPNThrwgMGdAeyD/HyLu/XUMn/PmN6a/s2sqLvO4+7A=" "ofl/montserratalternates/MontserratAlternates-Bold.ttf"]
+  ["EQBNPSNb2lgP5e1+cNbGF5Gc6R5VIfZzSSmohEplobQ=" "ofl/montserratalternates/MontserratAlternates-BoldItalic.ttf"]
+  ["DKy/LC+6r/G2qG22yVVPDQu1RgsujiN1j6XYWd+FT8E=" "ofl/montserratalternates/MontserratAlternates-ExtraBoldItalic.ttf"]
+  ["rNC46Mp1W0MEysz50shDLCtg6KTykkFejEaO0SyXR3k=" "ofl/montserratalternates/MontserratAlternates-Medium.ttf"]
+  ["YaUAjmVk5CdZPTXheZ2fIwwz9QL5Yy519Fk1+Os0XgI=" "ofl/montserratalternates/MontserratAlternates-ExtraLight.ttf"]
+  ["hZbfa0yMUdInrXvtemnW17vU/LOIoxjgr9jikTXH2Qk=" "ofl/montserratalternates/MontserratAlternates-SemiBold.ttf"]
+];
+montserrat = mkFont "montserrat" "ofl" [
+  ["lwp1lfVGjoe+YQf/yGuT1K8h7VApOyVxGG9sib7OnR8=" "ofl/montserrat/Montserrat-Italic%5Bwght%5D.ttf"]
+  ["+qyDRTCBxih2Gf/7tB5BwKcsIfP7b7zUPX1qT2IhvO0=" "ofl/montserrat/Montserrat%5Bwght%5D.ttf"]
+];
+montserratsubrayada = mkFont "montserratsubrayada" "ofl" [
+  ["4vgq0gF2qr7OAXUbhPWoV7RqbMTKuReDD9HLbhQf97M=" "ofl/montserratsubrayada/MontserratSubrayada-Bold.ttf"]
+  ["N6XmTgwPu0FIw39zHFLGPB78cfNlZKJ1cNUiLlmVpfE=" "ofl/montserratsubrayada/MontserratSubrayada-Regular.ttf"]
+];
+moolahlah = mkFont "moolahlah" "ofl" [
+  ["En/i5nh4Es/9YX6joRT5RekS1VCrpUks8PO4ANChkC8=" "ofl/moolahlah/MooLahLah-Regular.ttf"]
+];
+moondance = mkFont "moondance" "ofl" [
+  ["8l5oMLDBuV34VEb8BkzAvI2xWIYAomCkQbAwERiegzU=" "ofl/moondance/MoonDance-Regular.ttf"]
+];
+moul = mkFont "moul" "ofl" [
+  ["wERehnZ+3xv7CKb+Zb0481C1iMZBr34uiKWdcszs2cM=" "ofl/moul/Moul-Regular.ttf"]
+];
+moulpali = mkFont "moulpali" "ofl" [
+  ["VV+hW4WnCzsYwYLM0mok8uG6uvZPtTujG7+RMnp7MbQ=" "ofl/moulpali/Moulpali-Regular.ttf"]
+];
+mountainsofchristmas = mkFont "mountainsofchristmas" "asl20" [
+  ["TGEm9DxlDIHSNv0E/8L8y8PzdDjDBMr61olKg1wiUO8=" "apache/mountainsofchristmas/MountainsofChristmas-Bold.ttf"]
+  ["OFUwO+a4hwfAC7Jx+clemWYF6ajmVrOjBoaGI1KxBS4=" "apache/mountainsofchristmas/MountainsofChristmas-Regular.ttf"]
+];
+mousememoirs = mkFont "mousememoirs" "ofl" [
+  ["G7f0usy0Y3XFaSMnr4MT/cJCuealhNQ8Y3NXo96ZiDQ=" "ofl/mousememoirs/MouseMemoirs-Regular.ttf"]
+];
+mplus1code = mkFont "mplus1code" "ofl" [
+  ["WouQxNDkbA39EeuVEwPdxqtfuh93ov8RhBM+7ScflyM=" "ofl/mplus1code/MPLUS1Code%5Bwght%5D.ttf"]
+];
+mplus1 = mkFont "mplus1" "ofl" [
+  ["IHhZMhArDpgJQisvMcxrVRg9AoXHr2PVNzEBIIJnvcY=" "ofl/mplus1/MPLUS1%5Bwght%5D.ttf"]
+];
+mplus1p = mkFont "mplus1p" "ofl" [
+  ["0X90VxJmiw3NleQrNjSpCnYZUijUq/iKC+jpjdvEQbI=" "ofl/mplus1p/MPLUS1p-ExtraBold.ttf"]
+  ["KLL1KkCumIBkgQtx1n4SffdaFuCNffThktEAbkB1OU8=" "ofl/mplus1p/MPLUS1p-Medium.ttf"]
+  ["qgk/5EvrdA0nMOBDe90L/rV7Um0w6LJBDinsZQNDTdY=" "ofl/mplus1p/MPLUS1p-Thin.ttf"]
+  ["LylK1JZDKxYI8HDTEOOqKtzx3kr0KfSQHfl+xL02HtE=" "ofl/mplus1p/MPLUS1p-Regular.ttf"]
+  ["gVghpizgheRTrzGMoAR2jjNjKdWn1ve+0nLpfnhi1D4=" "ofl/mplus1p/MPLUS1p-Black.ttf"]
+  ["45+jn4VWw/30fgH2iRXY0Xk2EH8z++rWsbQPz2BcEYw=" "ofl/mplus1p/MPLUS1p-Light.ttf"]
+  ["dusHewoxyjPKQCOOR9paF+J4Z0FgfOwJZ419Llqxr8E=" "ofl/mplus1p/MPLUS1p-Bold.ttf"]
+];
+mplus2 = mkFont "mplus2" "ofl" [
+  ["g33ZzI7oEuVBAl9gI2KuF9V6WUKrgb6lzGAkLo9tP2Y=" "ofl/mplus2/MPLUS2%5Bwght%5D.ttf"]
+];
+mpluscodelatin = mkFont "mpluscodelatin" "ofl" [
+  ["x1XRGzctfi7R96EGQMb/Okc8ZmtKjgtPgJ5A59S0xfU=" "ofl/mpluscodelatin/MPLUSCodeLatin%5Bwdth,wght%5D.ttf"]
+];
+mrbedfort = mkFont "mrbedfort" "ofl" [
+  ["FVEyEVGoGM/F+fFjAudrjKhvFr74/nR4/+rGkhG73Mk=" "ofl/mrbedfort/MrBedfort-Regular.ttf"]
+];
+mrdafoe = mkFont "mrdafoe" "ofl" [
+  ["pCo8ZqcJkn81gkP9/LxDe9jrGI4u5qaAxS9b4SxnD9I=" "ofl/mrdafoe/MrDafoe-Regular.ttf"]
+];
+mrdehaviland = mkFont "mrdehaviland" "ofl" [
+  ["EM2ONLF6QnItxJ0tYrf+d0WVq+NMyJ7h15Zj32jqYIk=" "ofl/mrdehaviland/MrDeHaviland-Regular.ttf"]
+];
+mrssaintdelafield = mkFont "mrssaintdelafield" "ofl" [
+  ["Z6erwpjOnTaLLAD8v/UuxUvpSIibilkDKugMozIuWzQ=" "ofl/mrssaintdelafield/MrsSaintDelafield-Regular.ttf"]
+];
+mrssheppards = mkFont "mrssheppards" "ofl" [
+  ["D6XygqKtUS09XSdvxtR5b+T9oPwGEthocRPVQjyMM9g=" "ofl/mrssheppards/MrsSheppards-Regular.ttf"]
+];
+msmadi = mkFont "msmadi" "ofl" [
+  ["CN/pWQd0kNEaTdDTCXtI2q/ezvgh4pDJc80Yk1lcwgg=" "ofl/msmadi/MsMadi-Regular.ttf"]
+];
+muktamahee = mkFont "muktamahee" "ofl" [
+  ["EA6zW/epZpeJe+x0e0IwNKfDIujOMUYopQppk24nZuI=" "ofl/muktamahee/MuktaMahee-Regular.ttf"]
+  ["wWgVA9yAWjA7klIhyYRxN3IbimXlYUu9SVwvtx65ipc=" "ofl/muktamahee/MuktaMahee-Medium.ttf"]
+  ["89WOvV8o05E7y/wusbUS+LGdez6C7rY63qxMNUFMKbw=" "ofl/muktamahee/MuktaMahee-Bold.ttf"]
+  ["qBi8XTZRCcmDCI3NpUn3XQYzR3oQVSCgzE6kEblsgWw=" "ofl/muktamahee/MuktaMahee-ExtraBold.ttf"]
+  ["ngvD8C6CuVaD29JZOw1E9qJ6fQbD4lclAd+foZOyv6c=" "ofl/muktamahee/MuktaMahee-SemiBold.ttf"]
+  ["yCwdrDaGBQ4NklT8sKcaCyoBHCO7hevRhfrNQVtMrGA=" "ofl/muktamahee/MuktaMahee-Light.ttf"]
+  ["Z4ACC3WL/xJqp2cPe0Sm6G85nRklakpoMTCOV2T07rg=" "ofl/muktamahee/MuktaMahee-ExtraLight.ttf"]
+];
+muktamalar = mkFont "muktamalar" "ofl" [
+  ["2gbivvDtEphJmATDxT+L4NbBOBd8Trn/fou6tcn1Pl4=" "ofl/muktamalar/MuktaMalar-SemiBold.ttf"]
+  ["2bibiI1ejC5eF4EY+v/t41E+10ljyyMnpjgevmzEnEw=" "ofl/muktamalar/MuktaMalar-Bold.ttf"]
+  ["ERsOHsB4NLbjpFiegRr/z1IXQFib1AvSwnmuERoHGso=" "ofl/muktamalar/MuktaMalar-ExtraBold.ttf"]
+  ["JKY8gb8XqQplkxkL+ce2dhg/WUO0pSnbGk7y6wxxgF8=" "ofl/muktamalar/MuktaMalar-Medium.ttf"]
+  ["UZBAQSYIVe9Lor+EXJvGUR6jMBV7cEpEyFsCkZXTKnM=" "ofl/muktamalar/MuktaMalar-Regular.ttf"]
+  ["wp3gvGW+msAT2dOt2PqakLCErSwkHImRwc+bY5ZvtWY=" "ofl/muktamalar/MuktaMalar-Light.ttf"]
+  ["s1CfVVNvWuZ3iwX0GbaZ/zFb7Uchikt7vISJCaRHow4=" "ofl/muktamalar/MuktaMalar-ExtraLight.ttf"]
+];
+mukta = mkFont "mukta" "ofl" [
+  ["9Df7CY+PKay4YoYXyyaC8HgO8i+osEQ94fZgkMNuUQo=" "ofl/mukta/Mukta-SemiBold.ttf"]
+  ["Fh8vItM6HHXZ+zfXTqmejbvhGc1cECyDFG+wMqVS6PI=" "ofl/mukta/Mukta-Light.ttf"]
+  ["TbGL2PGVgmB+imrwxL8Vi0szeLQm5CrTnURNIWxwB0w=" "ofl/mukta/Mukta-Medium.ttf"]
+  ["Mo7uv/4G+sYNYLRv5gw5lakI0jR+nChfHu8aDJ1z4AQ=" "ofl/mukta/Mukta-ExtraBold.ttf"]
+  ["/zJg5v1md5ewvrgEMLDaMYzNrHPA+Q/oKMLdWgkyZaE=" "ofl/mukta/Mukta-ExtraLight.ttf"]
+  ["fSKJHNV1B7BK+Vpn/69Ztwc7NZWifRz7vO+0GN6CChI=" "ofl/mukta/Mukta-Bold.ttf"]
+  ["KVjkr1ZFB98qhWFk32+ZeNrLA/mZpPNKDCadyKTelog=" "ofl/mukta/Mukta-Regular.ttf"]
+];
+muktavaani = mkFont "muktavaani" "ofl" [
+  ["YQenLlHM9KdHomTSHegQaaYUAF/Kj4cnP7yw9k1tRBM=" "ofl/muktavaani/MuktaVaani-ExtraLight.ttf"]
+  ["Qn9soLAIkU1ODKJ3+rf9Y9PEOYY2YfCOOfT8zH4aSI0=" "ofl/muktavaani/MuktaVaani-ExtraBold.ttf"]
+  ["KW8AhpAsefQi2cSpoDtuQkM6XnteIT5+APLRyP1PJmw=" "ofl/muktavaani/MuktaVaani-Regular.ttf"]
+  ["foayIMzuAQSM3mrIeCRFlHXFeLqElKg98/reIRHJ118=" "ofl/muktavaani/MuktaVaani-SemiBold.ttf"]
+  ["4R8zDSGQEME7heO8VoNmujJUTxxK5/nEl2eS7SkYrFE=" "ofl/muktavaani/MuktaVaani-Bold.ttf"]
+  ["Wxm478sKBC5+3uwUvvqjplPie0iq6NtsVyNG3q4CCZA=" "ofl/muktavaani/MuktaVaani-Medium.ttf"]
+  ["o1hbBARco/32QrFH4DL7ArYdilNytyFrjBfW7tthIBc=" "ofl/muktavaani/MuktaVaani-Light.ttf"]
+];
+mulish = mkFont "mulish" "ofl" [
+  ["T01fl7UwUAIy2dSHEBuCg4QBaNz+e4uaKFr2Xw+oqqs=" "ofl/mulish/Mulish-Italic%5Bwght%5D.ttf"]
+  ["APEQV5YpGi/doReg/H8l2OaPgBDNuzSkEfYLO9V3F6w=" "ofl/mulish/Mulish%5Bwght%5D.ttf"]
+];
+murecho = mkFont "murecho" "ofl" [
+  ["Oic8LxHgFk+Cm8FcBonlh/400Uk/8WfVr/+P5xop5mc=" "ofl/murecho/Murecho%5Bwght%5D.ttf"]
+];
+museomoderno = mkFont "museomoderno" "ofl" [
+  ["/xI5iabBdc0/zms97LowLThB1l2YOewJ3QyFC+ohK1Y=" "ofl/museomoderno/MuseoModerno-Italic%5Bwght%5D.ttf"]
+  ["0DsCfPXPctAUyKQFqM64PqHV2K4sZKf2ArEx2Zc+NQM=" "ofl/museomoderno/MuseoModerno%5Bwght%5D.ttf"]
+];
+myanmarsanspro = mkFont "myanmarsanspro" "ofl" [
+  ["vSIFLTGFKQfzWlaQwZrSC+3FBcR80JEgFiUIn/wpu5c=" "ofl/myanmarsanspro/MyanmarSansPro-Regular.ttf"]
+];
+mynerve = mkFont "mynerve" "ofl" [
+  ["GERwawAg508cw4gQJm+MRXQb0Nm3vusFpYTK7hHbxj4=" "ofl/mynerve/Mynerve-Regular.ttf"]
+];
+mysoul = mkFont "mysoul" "ofl" [
+  ["KLywUMEiAUX9av9vbxOxuPSpYIOIwMNOT/lEUuXmRE8=" "ofl/mysoul/MySoul-Regular.ttf"]
+];
+mysteryquest = mkFont "mysteryquest" "ofl" [
+  ["/D+6Yb6Y194DlktBF17lYpvMaViyUfgDfvE+q7VDHrI=" "ofl/mysteryquest/MysteryQuest-Regular.ttf"]
+];
+nabla = mkFont "nabla" "ofl" [
+  ["5FzsYOsgmbS0/+6OvgBdHTBgdxBx7eHK7usS43osAK4=" "ofl/nabla/Nabla%5BEDPT,EHLT%5D.ttf"]
+];
+nanumbrushscript = mkFont "nanumbrushscript" "ofl" [
+  ["J86vV4yW9ZTN8H/gGBslF5Csu3RqFk5FwfZHP4mRGjE=" "ofl/nanumbrushscript/NanumBrushScript-Regular.ttf"]
+];
+nanumgothiccoding = mkFont "nanumgothiccoding" "ofl" [
+  ["eH7/1+/tKryoit4jH6qBkfTp/PhbGAWhPuHcNyS3IIk=" "ofl/nanumgothiccoding/NanumGothicCoding-Regular.ttf"]
+  ["d6bel8F2t275poO1ZaHm9M5AtJnHKilyxLW998a456A=" "ofl/nanumgothiccoding/NanumGothicCoding-Bold.ttf"]
+];
+nanumgothic = mkFont "nanumgothic" "ofl" [
+  ["+WKY+fsY42TSNw9MPOlIrGeithr5ktcjS8FcQrAzxnQ=" "ofl/nanumgothic/NanumGothic-Bold.ttf"]
+  ["dvRe9Ka8/zRMg3yVp9zCbgF+OLWEbVrgzctbhr4uLTE=" "ofl/nanumgothic/NanumGothic-Regular.ttf"]
+  ["XEVo5SlajFK8MOfvoeptLeQ1ViaO9C2rqTVAoezmka4=" "ofl/nanumgothic/NanumGothic-ExtraBold.ttf"]
+];
+nanummyeongjo = mkFont "nanummyeongjo" "ofl" [
+  ["QuYsom6G9HZ5f5KqhU6npm9WOKBYc7TN3Pd8ojmEUnA=" "ofl/nanummyeongjo/NanumMyeongjo-Regular.ttf"]
+  ["cIGSW6brJo4l+4iRhV7mc7T/xNnOy1LEzT4NkO9kbZ4=" "ofl/nanummyeongjo/NanumMyeongjo-ExtraBold.ttf"]
+  ["jF4MkKLWUR8/Mm0vDcMa27yPJuEJNmi98Appkf6Asjg=" "ofl/nanummyeongjo/NanumMyeongjo-Bold.ttf"]
+];
+nanumpenscript = mkFont "nanumpenscript" "ofl" [
+  ["bw0aspx4lAENyIgx+3oKUe23kTbkUDRBg95bGotSvUM=" "ofl/nanumpenscript/NanumPenScript-Regular.ttf"]
+];
+nats = mkFont "nats" "ofl" [
+  ["DmYKmUWcVckDH5xVuLUDjeutrsVrq0hJ2Dj35BHy/Ls=" "ofl/nats/NATS-Regular.ttf"]
+];
+neonderthaw = mkFont "neonderthaw" "ofl" [
+  ["FacqtjDrc+6SKtZTeDuBBTzzge9TvMF6U288f6gJcYQ=" "ofl/neonderthaw/Neonderthaw-Regular.ttf"]
+];
+nerkoone = mkFont "nerkoone" "ofl" [
+  ["VWldfXdxK5g5c+KYTYAUxQYK7PsulEk2cfpPD/w4dsc=" "ofl/nerkoone/NerkoOne-Regular.ttf"]
+];
+neucha = mkFont "neucha" "ofl" [
+  ["eSe9bOCQ+gMoV9y8OtDot2XEYtCnKod5BoEySWtOCH0=" "ofl/neucha/Neucha.ttf"]
+];
+neuton = mkFont "neuton" "ofl" [
+  ["W1kJA9c5GA7byjwgNjRmNYgk5840iVgppTSV7ZESKmU=" "ofl/neuton/Neuton-ExtraBold.ttf"]
+  ["tcZqUC7Wm0iTAIh7cBmSPnmSX5Dxvtks67w5jsVLUZk=" "ofl/neuton/Neuton-Italic.ttf"]
+  ["Dd5BBpazP1VGvzl1zszl0AgQ3DZ/udYsToxN7abITrY=" "ofl/neuton/Neuton-ExtraLight.ttf"]
+  ["BVWC5Lr9sTdZ6fm/wLiNZMV8OVxBSyweRShmzNH1750=" "ofl/neuton/Neuton-Light.ttf"]
+  ["bpWUtO+udQjUNKzYY+DF/SJQLudnmOcqLnmpSkJV+nQ=" "ofl/neuton/Neuton-Bold.ttf"]
+  ["KK5B/Q/xiSXBqCk1i3vTNOJ5lNoj1qvdcur/ZGysrbY=" "ofl/neuton/Neuton-Regular.ttf"]
+];
+newrocker = mkFont "newrocker" "ofl" [
+  ["KKSZzluLzwZS+LLiUTUYPq3fDDyMPiUSWbB1xx0e8Uw=" "ofl/newrocker/NewRocker-Regular.ttf"]
+];
+newscycle = mkFont "newscycle" "ofl" [
+  ["l/czo6QUzvbETWpP3oziVD+sv9H1o1roDb/Wkaid1jI=" "ofl/newscycle/NewsCycle-Bold.ttf"]
+  ["hlPMzgbSbc8ZpocEoWBjg1/J/qA2Y4wvy9W9yMlOTpU=" "ofl/newscycle/NewsCycle-Regular.ttf"]
+];
+newsreader = mkFont "newsreader" "ofl" [
+  ["eWZoYR+Atk1a3xgv3jtvKe2DtOfL7HuWk36ErAE2R5I=" "ofl/newsreader/Newsreader-Italic%5Bopsz,wght%5D.ttf"]
+  ["igjRP4psDVG+N5pgr4T5RfZTaaZ+UJ7jw73MQhJU18E=" "ofl/newsreader/Newsreader%5Bopsz,wght%5D.ttf"]
+];
+newtegomin = mkFont "newtegomin" "ofl" [
+  ["vK6HdfD5uI4S5AQ0kYxWgX6W46KR4qZZWjT7OP4+WPs=" "ofl/newtegomin/NewTegomin-Regular.ttf"]
+];
+nicomoji = mkFont "nicomoji" "ofl" [
+  ["x08vjMgyUq3IarKKQHDTPRytruMv9MMUtHM4q1OuE/E=" "ofl/nicomoji/NicoMoji-Regular.ttf"]
+];
+niconne = mkFont "niconne" "ofl" [
+  ["3HBYCiWRSu7DmpRgt4WO4I60rQu7zR18nLiIpuqYmic=" "ofl/niconne/Niconne-Regular.ttf"]
+];
+nikukyu = mkFont "nikukyu" "ofl" [
+  ["4hAhOzSpzJuGp0NNSS2oiVp5VZmI1LKdKHR8ai8DBWY=" "ofl/nikukyu/Nikukyu-Regular.ttf"]
+];
+niramit = mkFont "niramit" "ofl" [
+  ["WMsS437s3VkHa1//AP1w8iNH47vVCI9afQuPfiqD1fk=" "ofl/niramit/Niramit-BoldItalic.ttf"]
+  ["s3xenQFZLjwdjjgZF/5uLpaqv6EGTNBeTxs600nujnw=" "ofl/niramit/Niramit-SemiBold.ttf"]
+  ["9FKDIhhyLcdBYLaxeCKyYCnbsfnTiM6vKnWFgaUTc+g=" "ofl/niramit/Niramit-Italic.ttf"]
+  ["v431tIRSH1c933RTRe0Djc97xAoCEXfQ0R0EyYpM35Y=" "ofl/niramit/Niramit-ExtraLightItalic.ttf"]
+  ["PjAA0sA6CSIoJ4Wxay/nR7s1mdNyge8647xQDeci+PM=" "ofl/niramit/Niramit-ExtraLight.ttf"]
+  ["ukAJ/1Qa7EcSVuKo6PSTNSXVINyY3wX+b8gy7/hKaG8=" "ofl/niramit/Niramit-SemiBoldItalic.ttf"]
+  ["g3fTXTMKog2y9gyWx8GQIVu/VD+idVoqOsnvNN/w/54=" "ofl/niramit/Niramit-Light.ttf"]
+  ["qUwFEpZuicotTv5ZbVBDib+rhi0BjKmiMPwp3K0rV5E=" "ofl/niramit/Niramit-LightItalic.ttf"]
+  ["BBSPrWSwVfagYmBMmDviZAm/0+ThOQJ5KIpOuDmQnOA=" "ofl/niramit/Niramit-Regular.ttf"]
+  ["LseuFxN6C6BgF2deOCgCiaZxam9txqwhDwtUslY+rGQ=" "ofl/niramit/Niramit-Bold.ttf"]
+  ["PQgbPddd4hhJPS17iqIHm+qqhB7PkgFbhwUZ4fI5+lY=" "ofl/niramit/Niramit-Medium.ttf"]
+  ["2sR6I7qRWxhmFRDAoX/tU1RM8b7u9re/jWmS6iBVRJ0=" "ofl/niramit/Niramit-MediumItalic.ttf"]
+];
+nixieone = mkFont "nixieone" "ofl" [
+  ["aQMOsJbSWQ0A9Kx5/voebpwS8tOWo3UnoffWwEfND10=" "ofl/nixieone/NixieOne-Regular.ttf"]
+];
+nobile = mkFont "nobile" "ofl" [
+  ["3fxYlkdA0osz6sYu3eO1gH/68/GBmcowZnmI06FezK0=" "ofl/nobile/Nobile-BoldItalic.ttf"]
+  ["IbxdxhAHxEeL4/VBI4w4Y3Q0spq+OcgAztxhFcheQKE=" "ofl/nobile/Nobile-Italic.ttf"]
+  ["CSbvBV52N90j7rFxekW27vTlxcG9malRbSdw5YeuRSQ=" "ofl/nobile/Nobile-Medium.ttf"]
+  ["/C6rJOo9vn9dgDJPpcXT6lCYF1dVwyGOPVTOxDVZh/I=" "ofl/nobile/Nobile-Regular.ttf"]
+  ["rI59kJOAzhXkmiIJ937FXxMIjxxxskpP8cwDQLiNSK8=" "ofl/nobile/Nobile-MediumItalic.ttf"]
+  ["18hl7r7wfyiPoniFKAI1N8tqFV/ImvNSywsUQfdEdVg=" "ofl/nobile/Nobile-Bold.ttf"]
+];
+nokora = mkFont "nokora" "ofl" [
+  ["UMQz6AjjdKnsFYJp7rbydmojn86XbC6d3shndLo8WF0=" "ofl/nokora/Nokora-Thin.ttf"]
+  ["JRf+E7fz7PxvzLnrTx3yiw8CtQUfP3AvpafjKHZh9wU=" "ofl/nokora/Nokora-Bold.ttf"]
+  ["cEH1plJBqsh69NW1rjTrHfMmUFJslaNlumLa/+/5HBE=" "ofl/nokora/Nokora-Black.ttf"]
+  ["s8ufNlB/mGZ6U+/uJd4eryxpUvPzI9nsk8rVoLBHVvU=" "ofl/nokora/Nokora-Light.ttf"]
+  ["Xq2Zdu/X+00xFDbvpW5SDq3iO9zGA5LYv80EnLyXTaM=" "ofl/nokora/Nokora-Regular.ttf"]
+];
+norican = mkFont "norican" "ofl" [
+  ["+PiYjPfMK/pAk8aqL/l+Sw4PPh5vZHUMyKlEJsZGqVE=" "ofl/norican/Norican-Regular.ttf"]
+];
+nosifercaps = mkFont "nosifercaps" "ofl" [
+  ["Gh1P6Pk8MkCNxtBo9D5Zqqo/rk4s/3Tcz7tk3lAF2cE=" "ofl/nosifercaps/NosiferCaps-Regular.ttf"]
+];
+nosifer = mkFont "nosifer" "ofl" [
+  ["CcWsNeNNx6OX1faYtwPFZAtZz5PU00Prrk8W84WdCbg=" "ofl/nosifer/Nosifer-Regular.ttf"]
+];
+notable = mkFont "notable" "ofl" [
+  ["/lEFoeC1xNrx6hBzCqwvu+rsOmQx5n64J79W46lm08Y=" "ofl/notable/Notable-Regular.ttf"]
+];
+nothingyoucoulddo = mkFont "nothingyoucoulddo" "ofl" [
+  ["Ha+M95B2v1nFqRF7Xv1uzqNeV6Be8Sf+T5WwcrilJF0=" "ofl/nothingyoucoulddo/NothingYouCouldDo.ttf"]
+];
+noticiatext = mkFont "noticiatext" "ofl" [
+  ["PrETOeWmrNetjG0HU7F1visS9sUQVWLVxDstyADWiPg=" "ofl/noticiatext/NoticiaText-Regular.ttf"]
+  ["qbHJfWf5PXrVI2VrU0OlqAbksVUBowUyZ3AAPNVUi10=" "ofl/noticiatext/NoticiaText-Bold.ttf"]
+  ["Keas2D6LJM/cDTBeBjfJZmXHp1mFBZ1wYVxl1jxP8lM=" "ofl/noticiatext/NoticiaText-Italic.ttf"]
+  ["KE45zZIgcuPED3g0Dd4vomlCqHPx5BwUJZ9jWzIPlio=" "ofl/noticiatext/NoticiaText-BoldItalic.ttf"]
+];
+notocoloremojicompattest = mkFont "notocoloremojicompattest" "ofl" [
+  ["blSXWaRHb7JQsPeH/YRon47e7xXuvId51c5RWVNNtss=" "ofl/notocoloremojicompattest/NotoColorEmojiCompatTest-Regular.ttf"]
+];
+notocoloremoji = mkFont "notocoloremoji" "ofl" [
+  ["7HNah2W1WlQHaeoxeD8n3MCx4aQDvcjCCeRc6uP9Oc4=" "ofl/notocoloremoji/NotoColorEmoji-Regular.ttf"]
+];
+notokufiarabic = mkFont "notokufiarabic" "ofl" [
+  ["4xWyoif/7RT51Yhgx4S4LPiOqQgCyQLaEfmstlsl2r0=" "ofl/notokufiarabic/NotoKufiArabic%5Bwght%5D.ttf"]
+];
+notomusic = mkFont "notomusic" "ofl" [
+  ["FVdrAW39v8maNm4cKAYbud9uRu5iM9hdaNYZkZZKNP4=" "ofl/notomusic/NotoMusic-Regular.ttf"]
+];
+notonaskharabic = mkFont "notonaskharabic" "ofl" [
+  ["g0h+L+8n3zg3HP3O7FxTY1is7wkja421iHRlzkldQBg=" "ofl/notonaskharabic/NotoNaskhArabic%5Bwght%5D.ttf"]
+];
+notonaskharabicui = mkFont "notonaskharabicui" "ofl" [
+  ["a89p+4Z6dzCEuvKXNrZBD/eg/WfIIScf5uuH7SKSsc0=" "ofl/notonaskharabicui/NotoNaskhArabicUI%5Bwght%5D.ttf"]
+];
+notonastaliqurdu = mkFont "notonastaliqurdu" "ofl" [
+  ["3ME91NS92CTYwZ1y4Gv8iKFytTJmb9dVFXtx/Y3AREU=" "ofl/notonastaliqurdu/NotoNastaliqUrdu%5Bwght%5D.ttf"]
+];
+notorashihebrew = mkFont "notorashihebrew" "ofl" [
+  ["YvwC9CAgMlh8nreGlF4G5YUNsI5ma4YK+Jq/D6cGytE=" "ofl/notorashihebrew/NotoRashiHebrew%5Bwght%5D.ttf"]
+];
+notosansadlam = mkFont "notosansadlam" "ofl" [
+  ["/amO7butUdbIAxkGW7GTobPJQQqDCfCQYwgrdopUFZ8=" "ofl/notosansadlam/NotoSansAdlam%5Bwght%5D.ttf"]
+];
+notosansadlamunjoined = mkFont "notosansadlamunjoined" "ofl" [
+  ["ap3WoJkdqfZAPEBHgwrL2HpvPR980v/vHbfuJPopCtg=" "ofl/notosansadlamunjoined/NotoSansAdlamUnjoined%5Bwght%5D.ttf"]
+];
+notosansanatolianhieroglyphs = mkFont "notosansanatolianhieroglyphs" "ofl" [
+  ["var/+1Mt8sIAAWbctCULHEhjXEHZUC4iPZ1RkippJyg=" "ofl/notosansanatolianhieroglyphs/NotoSansAnatolianHieroglyphs-Regular.ttf"]
+];
+notosansarabic = mkFont "notosansarabic" "ofl" [
+  ["ADTAGRpA/5PQNAnmZr5Zwdu1t6VPDjAKhktYi6hQrVs=" "ofl/notosansarabic/NotoSansArabic%5Bwdth,wght%5D.ttf"]
+];
+notosansarabicui = mkFont "notosansarabicui" "ofl" [
+  ["LUcJD3o94v0Buor/mndSY7OrcKRs0qa/49HD4d2J/+U=" "ofl/notosansarabicui/NotoSansArabicUI%5Bwdth,wght%5D.ttf"]
+];
+notosansarmenian = mkFont "notosansarmenian" "ofl" [
+  ["x7kjWFUHeYDSJjbSeAyGwpQg+aoObUBYh5aY1E0KpOY=" "ofl/notosansarmenian/NotoSansArmenian%5Bwdth,wght%5D.ttf"]
+];
+notosansavestan = mkFont "notosansavestan" "ofl" [
+  ["srzLpL2CNejSverzzxlPnvTHJpxmX/C8Gk2r+FHpdeg=" "ofl/notosansavestan/NotoSansAvestan-Regular.ttf"]
+];
+notosansbalinese = mkFont "notosansbalinese" "ofl" [
+  ["moDjsqBRayoDzD/ptbHamEm6T2Xkxu8aLZObmMcuxVo=" "ofl/notosansbalinese/NotoSansBalinese%5Bwght%5D.ttf"]
+];
+notosansbamum = mkFont "notosansbamum" "ofl" [
+  ["rJxJjyAwGSBA4sVUEwLtQoqBGE/0Y1+qzTJBeljYPlM=" "ofl/notosansbamum/NotoSansBamum%5Bwght%5D.ttf"]
+];
+notosansbassavah = mkFont "notosansbassavah" "ofl" [
+  ["tsBluQXUyiKFgAJxZPIQL652IVckxDo26Ovzx+6BuPs=" "ofl/notosansbassavah/NotoSansBassaVah%5Bwght%5D.ttf"]
+];
+notosansbatak = mkFont "notosansbatak" "ofl" [
+  ["i4SLa6VNfkmlJA05gJM1x0BmkJZFkwdLQaWyj7i4u40=" "ofl/notosansbatak/NotoSansBatak-Regular.ttf"]
+];
+notosansbengali = mkFont "notosansbengali" "ofl" [
+  ["g8JRYrkvIu9Y3oS+xEh8TsTnBNKa2hJ6YfAsHAmmPT0=" "ofl/notosansbengali/NotoSansBengali%5Bwdth,wght%5D.ttf"]
+];
+notosansbengaliui = mkFont "notosansbengaliui" "ofl" [
+  ["FQD9ApreIEJJvCdmFb6YP4FE5FrHWBKtX+3BoPc1JAw=" "ofl/notosansbengaliui/NotoSansBengaliUI%5Bwdth,wght%5D.ttf"]
+];
+notosansbhaiksuki = mkFont "notosansbhaiksuki" "ofl" [
+  ["wrcpgvxMKCh6Xfbcz77GXSp04/dSbkoIMZUWDWIR+A0=" "ofl/notosansbhaiksuki/NotoSansBhaiksuki-Regular.ttf"]
+];
+notosansbrahmi = mkFont "notosansbrahmi" "ofl" [
+  ["DJ6dfrwguB//fPW8/E7VVSrZezpYPG4zuqLTiVIYLQU=" "ofl/notosansbrahmi/NotoSansBrahmi-Regular.ttf"]
+];
+notosansbuginese = mkFont "notosansbuginese" "ofl" [
+  ["rx7QKvnv9I6HLD/PkiunIFO3dsLw0aDUyzblfV41CLU=" "ofl/notosansbuginese/NotoSansBuginese-Regular.ttf"]
+];
+notosansbuhid = mkFont "notosansbuhid" "ofl" [
+  ["cECNvPDaM9EtO1gjBQV6Y6PqEytL8xMCeDTluban2IY=" "ofl/notosansbuhid/NotoSansBuhid-Regular.ttf"]
+];
+notosanscanadianaboriginal = mkFont "notosanscanadianaboriginal" "ofl" [
+  ["urXtBpBBl4/J0hZ419+nWWZWiMYjS9RLIBkzT26khJg=" "ofl/notosanscanadianaboriginal/NotoSansCanadianAboriginal%5Bwght%5D.ttf"]
+];
+notosanscarian = mkFont "notosanscarian" "ofl" [
+  ["liuseI9Ks4xh9t6G1bjBvKKxBdiKURwQuakFjGsSkao=" "ofl/notosanscarian/NotoSansCarian-Regular.ttf"]
+];
+notosanscaucasianalbanian = mkFont "notosanscaucasianalbanian" "ofl" [
+  ["D67v4VbGlS5DLq2SYp6juDWwYPRaATEawn8wOMAYiNk=" "ofl/notosanscaucasianalbanian/NotoSansCaucasianAlbanian-Regular.ttf"]
+];
+notosanschakma = mkFont "notosanschakma" "ofl" [
+  ["DlYMYc/g83g3d0F3DTi1+AJFdFXdeKr0uJYUCCZZ+6U=" "ofl/notosanschakma/NotoSansChakma-Regular.ttf"]
+];
+notosanscham = mkFont "notosanscham" "ofl" [
+  ["L6AakqhVRgKFShFga2czg/mHMPlVekh057w7jXrCxUw=" "ofl/notosanscham/NotoSansCham%5Bwght%5D.ttf"]
+];
+notosanscherokee = mkFont "notosanscherokee" "ofl" [
+  ["hl2eZE9QEfICChAyW3JC+FycjvDt7OAOXtdD5d+ydf0=" "ofl/notosanscherokee/NotoSansCherokee%5Bwght%5D.ttf"]
+];
+notosanscoptic = mkFont "notosanscoptic" "ofl" [
+  ["JhB3j3dt+xrXOvcPU3b66HQE98kjcz86RMvJFQJu6BU=" "ofl/notosanscoptic/NotoSansCoptic-Regular.ttf"]
+];
+notosanscuneiform = mkFont "notosanscuneiform" "ofl" [
+  ["ETiBX6vEcHU+CYdsbe60oAYhm3Vuay2b/g6RqkvMIeE=" "ofl/notosanscuneiform/NotoSansCuneiform-Regular.ttf"]
+];
+notosanscypriot = mkFont "notosanscypriot" "ofl" [
+  ["TSpH38AMz4lxo/InPSx2ghKLqwPech8O6SOaV3fpeN8=" "ofl/notosanscypriot/NotoSansCypriot-Regular.ttf"]
+];
+notosansdeseret = mkFont "notosansdeseret" "ofl" [
+  ["NaTTMadgc+7/U5RCssO0nvtYuqDTTR2g9oX2pLmNHi8=" "ofl/notosansdeseret/NotoSansDeseret-Regular.ttf"]
+];
+notosansdevanagari = mkFont "notosansdevanagari" "ofl" [
+  ["ArBT6WRGNiLHU/R0kYhGND60VAdUXuue1ResATarIRs=" "ofl/notosansdevanagari/NotoSansDevanagari%5Bwdth,wght%5D.ttf"]
+];
+notosansdevanagariui = mkFont "notosansdevanagariui" "ofl" [
+  ["wLEF0kgzdDW4dtOj0Zs4DJeC5FKxXxQqDPexD10pooA=" "ofl/notosansdevanagariui/NotoSansDevanagariUI-Regular.ttf"]
+  ["dKZA3XJ4WFVQUzLI4C8kmVh/icbDGcmElZDTzk9pGVg=" "ofl/notosansdevanagariui/NotoSansDevanagariUI-Thin.ttf"]
+  ["D2bCSf7tHi0WTH0ZS3MHDatxWamjKdHAIV6WEjPSmT4=" "ofl/notosansdevanagariui/NotoSansDevanagariUI-Light.ttf"]
+  ["VEVgBhRJRRRGYQQJ5tOjD75tNBMT6PAImDmow43Gy7c=" "ofl/notosansdevanagariui/NotoSansDevanagariUI-Black.ttf"]
+  ["RLnMB6dqqMSqwYG5P0SxUF9YDOIYO2Aez3m29tvgzbg=" "ofl/notosansdevanagariui/NotoSansDevanagariUI-ExtraLight.ttf"]
+  ["Zgs2miORTycKm3P/fbfY1zwdHIVBQdjKEK7xeyWHaPA=" "ofl/notosansdevanagariui/NotoSansDevanagariUI-SemiBold.ttf"]
+  ["/TYkWqhTXZULiiL6UuFhZGhVs2M4z/xKAzNhDuevEmc=" "ofl/notosansdevanagariui/NotoSansDevanagariUI-ExtraBold.ttf"]
+  ["wqZIAl0Ts1Z0zjnYhrF5/62nICCXtCvUY0vymPCPZU4=" "ofl/notosansdevanagariui/NotoSansDevanagariUI-Bold.ttf"]
+  ["o7pxWygi8bdvI7diOO9KpaQX1N9JgVwZebVq855iQM4=" "ofl/notosansdevanagariui/NotoSansDevanagariUI-Medium.ttf"]
+];
+notosansdisplay = mkFont "notosansdisplay" "ofl" [
+  ["3qpoFB+lrSG9F9fBH6eRg87aGbMuQP9cM4dNQvNjbd4=" "ofl/notosansdisplay/NotoSansDisplay%5Bwdth,wght%5D.ttf"]
+  ["gTdLN16UduL6WzGp7kvKtSSjBycN1b8DM0bHupMvIms=" "ofl/notosansdisplay/NotoSansDisplay-Italic%5Bwdth,wght%5D.ttf"]
+];
+notosansduployan = mkFont "notosansduployan" "ofl" [
+  ["4Y7l/9akVlQbtvHE20ptOfiewdK6yyGY9lPaDXmw3Is=" "ofl/notosansduployan/NotoSansDuployan-Regular.ttf"]
+];
+notosansegyptianhieroglyphs = mkFont "notosansegyptianhieroglyphs" "ofl" [
+  ["rVDlNVAKzIi5WCxkjMhMqaRnnBgQpCaqhbe6i62orxU=" "ofl/notosansegyptianhieroglyphs/NotoSansEgyptianHieroglyphs-Regular.ttf"]
+];
+notosanselbasan = mkFont "notosanselbasan" "ofl" [
+  ["a05VSCcVTL6tawDIsmHN3pRThF4zhx/wga1o9YxlFm0=" "ofl/notosanselbasan/NotoSansElbasan-Regular.ttf"]
+];
+notosanselymaic = mkFont "notosanselymaic" "ofl" [
+  ["R3YKQao21ptEKjmI4SuQQpDCTntU/xF2LYJuhKoMHno=" "ofl/notosanselymaic/NotoSansElymaic-Regular.ttf"]
+];
+notosansethiopic = mkFont "notosansethiopic" "ofl" [
+  ["DbzMALItGA69akvYpzORiinnCfpnmAI63D5s1A2mUHc=" "ofl/notosansethiopic/NotoSansEthiopic%5Bwdth,wght%5D.ttf"]
+];
+notosansgeorgian = mkFont "notosansgeorgian" "ofl" [
+  ["+Wq7SGhDlTGMPQ/FJd0WldL6ZFkolTPz5mI6wUOD//Q=" "ofl/notosansgeorgian/NotoSansGeorgian%5Bwdth,wght%5D.ttf"]
+];
+notosansglagolitic = mkFont "notosansglagolitic" "ofl" [
+  ["VSbmQLIFvvovWbPEZRP8lL6JahPEQo+EAA6yL4qPOjI=" "ofl/notosansglagolitic/NotoSansGlagolitic-Regular.ttf"]
+];
+notosansgothic = mkFont "notosansgothic" "ofl" [
+  ["yF53gMOt2pD1ZZGRTYnD7U3J6hsj1+OkYvzTnoiOxw8=" "ofl/notosansgothic/NotoSansGothic-Regular.ttf"]
+];
+notosansgrantha = mkFont "notosansgrantha" "ofl" [
+  ["A8FJcXq71MP/FAEtlyD2DMgkNX3UCIR8DK98fDcTrio=" "ofl/notosansgrantha/NotoSansGrantha-Regular.ttf"]
+];
+notosansgujarati = mkFont "notosansgujarati" "ofl" [
+  ["yvWX+nY/Jwdsd0iiTzMWh6roGA9wO6R3ke3KeJMlKMc=" "ofl/notosansgujarati/NotoSansGujarati%5Bwdth,wght%5D.ttf"]
+];
+notosansgujaratiui = mkFont "notosansgujaratiui" "ofl" [
+  ["g+PkE1jDjJK6iDdHgE7EMYqAlXqbsdWf3SXkAlr6GhU=" "ofl/notosansgujaratiui/NotoSansGujaratiUI-ExtraLight.ttf"]
+  ["GU5nsDUY/SY6+pCsbGNmsR3fE03rNRNV0cRJEAlK8g4=" "ofl/notosansgujaratiui/NotoSansGujaratiUI-Medium.ttf"]
+  ["WcNhGkH2jFWiKWP7+6lInNpPBto6A7Ht5l63YHPsdYQ=" "ofl/notosansgujaratiui/NotoSansGujaratiUI-Regular.ttf"]
+  ["sanzARPlJTpfy5ou3XxwMv/3dsLkrCuAOrkAOS2wlpU=" "ofl/notosansgujaratiui/NotoSansGujaratiUI-Black.ttf"]
+  ["9YQmBmtFTjLfWG47UEeNOArh0MZoOlD+oIeC4fmGx2Y=" "ofl/notosansgujaratiui/NotoSansGujaratiUI-ExtraBold.ttf"]
+  ["TFE7S+glwnbowylm67IDRAjpk6yfLupCrJjWcHNX+/8=" "ofl/notosansgujaratiui/NotoSansGujaratiUI-Thin.ttf"]
+  ["LJHY4p/euuizpQwNMhL1E+Uk256x0Qo09ynCXEpc1vk=" "ofl/notosansgujaratiui/NotoSansGujaratiUI-Bold.ttf"]
+  ["vzWhu00kTVSXqb/fQlQBxqa3zzqZqNltDPsD7pcVwhA=" "ofl/notosansgujaratiui/NotoSansGujaratiUI-Light.ttf"]
+  ["A1ucu/PhdiwFE4NRz9m5OiH3/c+VJ1Fi8BZFwRpbXQ4=" "ofl/notosansgujaratiui/NotoSansGujaratiUI-SemiBold.ttf"]
+];
+notosansgunjalagondi = mkFont "notosansgunjalagondi" "ofl" [
+  ["ELd0S/0VHkrYRBVc79D2ADKwBSac80c4/qArD/Xaz5w=" "ofl/notosansgunjalagondi/NotoSansGunjalaGondi-Regular.ttf"]
+];
+notosansgurmukhi = mkFont "notosansgurmukhi" "ofl" [
+  ["DYjKFjmVeUPNCXcK+aSYYPfrETgP2wHnN5f5BgPfVIo=" "ofl/notosansgurmukhi/NotoSansGurmukhi%5Bwdth,wght%5D.ttf"]
+];
+notosansgurmukhiui = mkFont "notosansgurmukhiui" "ofl" [
+  ["NhWvxDOG92isFTNTSei/gQu4EWFPa0IlLsofw0hJaSs=" "ofl/notosansgurmukhiui/NotoSansGurmukhiUI%5Bwdth,wght%5D.ttf"]
+];
+notosanshanifirohingya = mkFont "notosanshanifirohingya" "ofl" [
+  ["FP4jHLlJ9wb2PasT2XtGHohU47znyRu6u9oHIbELRkk=" "ofl/notosanshanifirohingya/NotoSansHanifiRohingya%5Bwght%5D.ttf"]
+];
+notosanshanunoo = mkFont "notosanshanunoo" "ofl" [
+  ["ce4OQs7Dd/MW4/ULpXonrAtbClnCcSgLSKUAPMod9E4=" "ofl/notosanshanunoo/NotoSansHanunoo-Regular.ttf"]
+];
+notosanshatran = mkFont "notosanshatran" "ofl" [
+  ["tMLO41LCGKR/ZMGGY2vSjvdkYValFxyjSPL7+Hc+g/o=" "ofl/notosanshatran/NotoSansHatran-Regular.ttf"]
+];
+notosanshebrew = mkFont "notosanshebrew" "ofl" [
+  ["fhl9Iy5QSRgmhiwNjis5zRKpzg7cLFoNYNDpu5+4VvU=" "ofl/notosanshebrew/NotoSansHebrew%5Bwdth,wght%5D.ttf"]
+];
+notosanshk = mkFont "notosanshk" "ofl" [
+  ["dgmO547CNM1PjJUHQrP3Zv6i+LQ9UYDZAQSPT8hsaEk=" "ofl/notosanshk/NotoSansHK%5Bwght%5D.ttf"]
+];
+notosansimperialaramaic = mkFont "notosansimperialaramaic" "ofl" [
+  ["oeqlSE6lC6zlftWepk5jCr8ZbX6vVeJrDtKZIjpRAMM=" "ofl/notosansimperialaramaic/NotoSansImperialAramaic-Regular.ttf"]
+];
+notosansindicsiyaqnumbers = mkFont "notosansindicsiyaqnumbers" "ofl" [
+  ["HV/QI4cKyF0LFqesi39nnbLEdeJxmElnDKwCnW0uxDs=" "ofl/notosansindicsiyaqnumbers/NotoSansIndicSiyaqNumbers-Regular.ttf"]
+];
+notosansinscriptionalpahlavi = mkFont "notosansinscriptionalpahlavi" "ofl" [
+  ["9c9+DTSe20WpVzrp0d1oOXfw7vF5QGb6mim9u2Wrz3Q=" "ofl/notosansinscriptionalpahlavi/NotoSansInscriptionalPahlavi-Regular.ttf"]
+];
+notosansinscriptionalparthian = mkFont "notosansinscriptionalparthian" "ofl" [
+  ["Y4mzWt5tucRpMJ2EA0BXxnOKAyq+E/TrJDXP2G7RDMQ=" "ofl/notosansinscriptionalparthian/NotoSansInscriptionalParthian-Regular.ttf"]
+];
+notosansjavanese = mkFont "notosansjavanese" "ofl" [
+  ["3LZYiAXK5nQas2Dk9siFk6rlSG068uOd3ZAahRUEvFk=" "ofl/notosansjavanese/NotoSansJavanese%5Bwght%5D.ttf"]
+];
+notosansjp = mkFont "notosansjp" "ofl" [
+  ["wvO01GNQCi3c04Sc3tH87rn9bRwy5svs1WhFO6UPxo8=" "ofl/notosansjp/NotoSansJP%5Bwght%5D.ttf"]
+];
+notosanskaithi = mkFont "notosanskaithi" "ofl" [
+  ["0hfIvIWFlLEuE9DUrMznVChMj4C1UxMT3dHcI1ngPw8=" "ofl/notosanskaithi/NotoSansKaithi-Regular.ttf"]
+];
+notosanskannada = mkFont "notosanskannada" "ofl" [
+  ["qz8v+eXJO45lOj0WCIuQ2uG2NsY3MzVpdZTXShP3ZS4=" "ofl/notosanskannada/NotoSansKannada%5Bwdth,wght%5D.ttf"]
+];
+notosanskannadaui = mkFont "notosanskannadaui" "ofl" [
+  ["oLNcP/Yos9o98QSh1cg0CO1QzjMWiXZwSimJNqKQAyk=" "ofl/notosanskannadaui/NotoSansKannadaUI%5Bwdth,wght%5D.ttf"]
+];
+notosanskayahli = mkFont "notosanskayahli" "ofl" [
+  ["R34S7RoCVei1H0Io0Ppm/HQKC1RtYyqC0wgMN/3Qh/U=" "ofl/notosanskayahli/NotoSansKayahLi%5Bwght%5D.ttf"]
+];
+notosanskharoshthi = mkFont "notosanskharoshthi" "ofl" [
+  ["3rv0mTSOWorI4pL+9stKniRDjvir/E9Qo9Mih+SkZtM=" "ofl/notosanskharoshthi/NotoSansKharoshthi-Regular.ttf"]
+];
+notosanskhmer = mkFont "notosanskhmer" "ofl" [
+  ["A7n479+1/cmyPSuk41fryeholo3OM3OaiySNro+xrdA=" "ofl/notosanskhmer/NotoSansKhmer%5Bwdth,wght%5D.ttf"]
+];
+notosanskhmerui = mkFont "notosanskhmerui" "ofl" [
+  ["FGehgov7/mWYEnSC58PT18gr7SE9TVTjBm3OXZgNt3s=" "ofl/notosanskhmerui/NotoSansKhmerUI%5Bwdth,wght%5D.ttf"]
+];
+notosanskhojki = mkFont "notosanskhojki" "ofl" [
+  ["VwYNgTCuE8MHdLrUoTp3W2zTXad96CRoGj0Zq6t8qIk=" "ofl/notosanskhojki/NotoSansKhojki-Regular.ttf"]
+];
+notosanskhudawadi = mkFont "notosanskhudawadi" "ofl" [
+  ["b1PHXqVHf0rWjTLv+NLMDQ7CFgB0TAgE88atTykAZUE=" "ofl/notosanskhudawadi/NotoSansKhudawadi-Regular.ttf"]
+];
+notosanskr = mkFont "notosanskr" "ofl" [
+  ["GUAY5rKyk6eWTwN7JcAknOFBi8mrPJcQYKA6pXhh4lI=" "ofl/notosanskr/NotoSansKR%5Bwght%5D.ttf"]
+];
+notosanslaolooped = mkFont "notosanslaolooped" "ofl" [
+  ["qq1ULVRhv58Eh5+Kw+UoJE+N8HvR5iCDn8tDlt0x/ao=" "ofl/notosanslaolooped/NotoSansLaoLooped%5Bwdth,wght%5D.ttf"]
+];
+notosanslao = mkFont "notosanslao" "ofl" [
+  ["GgdIukrgtfvcpsHx/9cxtgIPV/fx+J2wETPBOUr+nEw=" "ofl/notosanslao/NotoSansLao%5Bwdth,wght%5D.ttf"]
+];
+notosanslaoui = mkFont "notosanslaoui" "ofl" [
+  ["vqvXgw/m1rHn9iK3ISWVqlgFz9f0/Gmip2k2KzCGt9Y=" "ofl/notosanslaoui/NotoSansLaoUI%5Bwdth,wght%5D.ttf"]
+];
+notosanslepcha = mkFont "notosanslepcha" "ofl" [
+  ["liSTGuj5qKKkUjPlSG+sGoDzM6Czol+E0OJIQ2ORT4Q=" "ofl/notosanslepcha/NotoSansLepcha-Regular.ttf"]
+];
+notosanslimbu = mkFont "notosanslimbu" "ofl" [
+  ["mFdfu22N4Ylb7BDLWZAVaiUpJa42Wnbekvm/Ox38bfw=" "ofl/notosanslimbu/NotoSansLimbu-Regular.ttf"]
+];
+notosanslineara = mkFont "notosanslineara" "ofl" [
+  ["Iw2qJXjwStijhEHxzxKNcNZNyQ/KiR/T6TwVaTcBVk4=" "ofl/notosanslineara/NotoSansLinearA-Regular.ttf"]
+];
+notosanslinearb = mkFont "notosanslinearb" "ofl" [
+  ["Ffrz/5tdA0Ptt+1OVbLJ9bqQdHMZfWXwc53Do02b8zQ=" "ofl/notosanslinearb/NotoSansLinearB-Regular.ttf"]
+];
+notosanslisu = mkFont "notosanslisu" "ofl" [
+  ["ZpWS79NYxJUACueSAdvsc22HfQT6v038TfuIfNnurEA=" "ofl/notosanslisu/NotoSansLisu%5Bwght%5D.ttf"]
+];
+notosanslycian = mkFont "notosanslycian" "ofl" [
+  ["51KE34XI6ktVAj051UUriohV9foCpJcIfu6zCjIAimI=" "ofl/notosanslycian/NotoSansLycian-Regular.ttf"]
+];
+notosanslydian = mkFont "notosanslydian" "ofl" [
+  ["oBzI70zmLDTRJqDGi0KUTaP15FzejhMAVocvKT3KueE=" "ofl/notosanslydian/NotoSansLydian-Regular.ttf"]
+];
+notosansmahajani = mkFont "notosansmahajani" "ofl" [
+  ["FGAjWBhqI2HVdwcQW56jWskP8jVZjyqJDPplvvFjSVg=" "ofl/notosansmahajani/NotoSansMahajani-Regular.ttf"]
+];
+notosansmalayalam = mkFont "notosansmalayalam" "ofl" [
+  ["EekqLMWvsg6rgQOtQNEJtgghMS37SWc/5C/ZVUDjguU=" "ofl/notosansmalayalam/NotoSansMalayalam%5Bwdth,wght%5D.ttf"]
+];
+notosansmalayalamui = mkFont "notosansmalayalamui" "ofl" [
+  ["aYDZ5pr1haM0biHNry4g/L0pLiTbBD2med3yvyrLiEw=" "ofl/notosansmalayalamui/NotoSansMalayalamUI%5Bwdth,wght%5D.ttf"]
+];
+notosansmandaic = mkFont "notosansmandaic" "ofl" [
+  ["pQ1p3FKZhhjznkkEI6tZQ9ZFb1Ct5Ia1TDOeBtU6LDo=" "ofl/notosansmandaic/NotoSansMandaic-Regular.ttf"]
+];
+notosansmanichaean = mkFont "notosansmanichaean" "ofl" [
+  ["UP2X0gMGQxJx4jUjqNPlchDRBa3Tw0Dv0u5fd7Y6x1Y=" "ofl/notosansmanichaean/NotoSansManichaean-Regular.ttf"]
+];
+notosansmarchen = mkFont "notosansmarchen" "ofl" [
+  ["lbxh/T+iD7Q6oHBHNyM03/jbX2zaml7nVnhLmdp+wFY=" "ofl/notosansmarchen/NotoSansMarchen-Regular.ttf"]
+];
+notosansmasaramgondi = mkFont "notosansmasaramgondi" "ofl" [
+  ["pga0sizE5WJHPG3vycV7ZFXdcWPIfObmV6PNDFBgwhQ=" "ofl/notosansmasaramgondi/NotoSansMasaramGondi-Regular.ttf"]
+];
+notosansmath = mkFont "notosansmath" "ofl" [
+  ["gkK9HlU2iyfjJFUmB1TPmqWPOtfqgGZLZsIfGwmRDWw=" "ofl/notosansmath/NotoSansMath-Regular.ttf"]
+];
+notosansmayannumerals = mkFont "notosansmayannumerals" "ofl" [
+  ["WDIFC+iTPru+MuDsJQCtJ8rOR6LL4KQ+JQze8KRUuto=" "ofl/notosansmayannumerals/NotoSansMayanNumerals-Regular.ttf"]
+];
+notosansmedefaidrin = mkFont "notosansmedefaidrin" "ofl" [
+  ["U44xM38Jzq8pDjdMLopkkhG6VlI0gsL2Z04oaLVVVUY=" "ofl/notosansmedefaidrin/NotoSansMedefaidrin%5Bwght%5D.ttf"]
+];
+notosansmeeteimayek = mkFont "notosansmeeteimayek" "ofl" [
+  ["1W621UrYqtNXC37gf2SGaDKgTym85uXxg5GMnq8Aj6w=" "ofl/notosansmeeteimayek/NotoSansMeeteiMayek%5Bwght%5D.ttf"]
+];
+notosansmendekikakui = mkFont "notosansmendekikakui" "ofl" [
+  ["Hw1OWVfy10/9LvSFC1EuUSBmxYNlMI5DOYXDhC8td58=" "ofl/notosansmendekikakui/NotoSansMendeKikakui-Regular.ttf"]
+];
+notosansmeroitic = mkFont "notosansmeroitic" "ofl" [
+  ["ScdvXaRLkyJJxhUPQdIOj0pAXijYgjpv1ySwW8ECk3U=" "ofl/notosansmeroitic/NotoSansMeroitic-Regular.ttf"]
+];
+notosansmiao = mkFont "notosansmiao" "ofl" [
+  ["rrehfdROjiAn1xfOwrFGKfgst0Gn0abksyXpnLaQc6s=" "ofl/notosansmiao/NotoSansMiao-Regular.ttf"]
+];
+notosansmodi = mkFont "notosansmodi" "ofl" [
+  ["4B/h1DugXc3tlIKK2OChEo4msLRoQXakmqETHKeyjxQ=" "ofl/notosansmodi/NotoSansModi-Regular.ttf"]
+];
+notosansmongolian = mkFont "notosansmongolian" "ofl" [
+  ["DqaqAwdyWXjqHRhdlQvoA0R2U8jfKQXCVaSY/MzEG+0=" "ofl/notosansmongolian/NotoSansMongolian-Regular.ttf"]
+];
+notosansmono = mkFont "notosansmono" "ofl" [
+  ["SVYub6Q2FzV+zBCts+8/Z1BKQrRB1uwTqgii/9B9B94=" "ofl/notosansmono/NotoSansMono%5Bwdth,wght%5D.ttf"]
+];
+notosansmro = mkFont "notosansmro" "ofl" [
+  ["/gX7z2WqOkL0RkN6bi206czyodL9hf3f2Trz3x1ynPk=" "ofl/notosansmro/NotoSansMro-Regular.ttf"]
+];
+notosansmultani = mkFont "notosansmultani" "ofl" [
+  ["/jnXik8KyujlAzrFmqevP4ZkQQwEijtYtddupEVIwJA=" "ofl/notosansmultani/NotoSansMultani-Regular.ttf"]
+];
+notosansmyanmar = mkFont "notosansmyanmar" "ofl" [
+  ["eru/viUUEF186Uk3ruP+srqJtzolbIt3tYZr2bg+Muw=" "ofl/notosansmyanmar/NotoSansMyanmar%5Bwdth,wght%5D.ttf"]
+];
+notosansmyanmarui = mkFont "notosansmyanmarui" "ofl" [
+  ["KsRANSOsKUL6OVlXVaVvn6NlutPMQ9Rf1/17YgNIETk=" "ofl/notosansmyanmarui/NotoSansMyanmarUI-Light.ttf"]
+  ["KceTkbqEcRNSSEULj3qrYC+UHaxD3CypAK8XfwGpn8M=" "ofl/notosansmyanmarui/NotoSansMyanmarUI-Medium.ttf"]
+  ["XF8e/uPUqHfjwy0CNukYeslJ3pGcR79vDP0vbMJ3FEM=" "ofl/notosansmyanmarui/NotoSansMyanmarUI-Bold.ttf"]
+  ["r2uo9Ab2/o4ya3iGAnm/LZoTL4C3ObXhqMGyCfb6EwM=" "ofl/notosansmyanmarui/NotoSansMyanmarUI-Regular.ttf"]
+  ["U0RwfUZmf/P89s3EtM7hfjSGwIQ90maWecpiFhopkww=" "ofl/notosansmyanmarui/NotoSansMyanmarUI-Thin.ttf"]
+  ["/DWwlu/oYKZN3jDRXQBJ4hocns2PLH2nGVBUQEDprn8=" "ofl/notosansmyanmarui/NotoSansMyanmarUI-Black.ttf"]
+  ["SgSt8YiMHHlO4gcISBMG0m/rXRoeu6+aXDoxUEPAtnU=" "ofl/notosansmyanmarui/NotoSansMyanmarUI-ExtraLight.ttf"]
+  ["jyl6EatE/JWSprZvbG261KFo4HYe07im7A8dVcqBehU=" "ofl/notosansmyanmarui/NotoSansMyanmarUI-SemiBold.ttf"]
+  ["478s4y1Fkx9tm3+x75Lrd+w98e/9e6E5bnonMy7BZR4=" "ofl/notosansmyanmarui/NotoSansMyanmarUI-ExtraBold.ttf"]
+];
+notosansnabataean = mkFont "notosansnabataean" "ofl" [
+  ["rBfhZv9daAmNx2a+cEcv5Ncw1W4ABmqSCsSUTYw5uLk=" "ofl/notosansnabataean/NotoSansNabataean-Regular.ttf"]
+];
+notosansnewa = mkFont "notosansnewa" "ofl" [
+  ["Wmfy4qlOtJMHbbtwipHuTUjNIExgj1MQd618YktSTp4=" "ofl/notosansnewa/NotoSansNewa-Regular.ttf"]
+];
+notosansnewtailue = mkFont "notosansnewtailue" "ofl" [
+  ["H5wSoCZE4fxNIZU7S4EPDZbUSgqkblz3LGO8HeiJ8tA=" "ofl/notosansnewtailue/NotoSansNewTaiLue%5Bwght%5D.ttf"]
+];
+notosansnko = mkFont "notosansnko" "ofl" [
+  ["ZYhyAhtdbuOcNvDMLHlpvYFjEbFARni1/oregCT+qM8=" "ofl/notosansnko/NotoSansNKo-Regular.ttf"]
+];
+notosansnko_todelist = mkFont "notosansnko_todelist" "ofl" [
+  ["OJ9AgolL8YM9xfFAooJJYRQ2a0EHefuxazSG9GYOkxM=" "ofl/notosansnko_todelist/NotoSansNKo-Regular.ttf"]
+];
+notosansnushu = mkFont "notosansnushu" "ofl" [
+  ["mlnGp2R0CgCKrRjqSVwnGFF25IQM+hPISPOobHB6+I8=" "ofl/notosansnushu/NotoSansNushu-Regular.ttf"]
+];
+notosans = mkFont "notosans" "ofl" [
+  ["DXO1sjDP+sTLoYNXG/3VLD9N/EnPwbVEfbmdU9K0cRE=" "ofl/notosans/NotoSans-Bold.ttf"]
+  ["Qzvo+bCPeJ0BWSijuZdvCMC99k+5NGvD1BaN09doP5I=" "ofl/notosans/NotoSans-ThinItalic.ttf"]
+  ["o9a30d7DSy3gSQr2/SRiWpdvK0p4jt2hp+SDQ8X8950=" "ofl/notosans/NotoSans-Medium.ttf"]
+  ["ICEwsKPjiVkHNcXOCDOdxLDK/BlTIpKbI4OgEeX9INA=" "ofl/notosans/NotoSans-SemiBold.ttf"]
+  ["71SubitishdGdCmMfi7HWp4zwQ7c/qZeMLi7ko+CG78=" "ofl/notosans/NotoSans-LightItalic.ttf"]
+  ["kWM5H298+RZFRyDjO/15d7pJUOpcTNB3U8vbx33OLck=" "ofl/notosans/NotoSans-Thin.ttf"]
+  ["RN9yjEA7z1LB1wU3iYaSPUtymF5F2uyEdUl9T4Yi/mQ=" "ofl/notosans/NotoSans-Black.ttf"]
+  ["tAyc0B080hjgW9LrxBVL7QscN94t6flpqWqvULCxM34=" "ofl/notosans/NotoSans-ExtraLight.ttf"]
+  ["SwjBJ+0DmdppE9k4+OP0Wl2H8Ze2NvPSl4xlFfDOvYY=" "ofl/notosans/NotoSans-BoldItalic.ttf"]
+  ["Na0i1n7Ky1V7NOXQ6Z2PL02lGjRTgG5m2aCJnKrHM6k=" "ofl/notosans/NotoSans-SemiBoldItalic.ttf"]
+  ["bAaBVY0RIT31+XnLZ39jrOxAp3RJfum+4EjFPrSFV0w=" "ofl/notosans/NotoSans-Italic.ttf"]
+  ["kEY964pgRjJeJ0Vn4XqjwhWbEuA5AzkzsDVgOZteNYc=" "ofl/notosans/NotoSans-Light.ttf"]
+  ["0H3Nl2CG60yd8DW6B9aL2fv0p0uM7p3J9ber9w3lMyc=" "ofl/notosans/NotoSans-ExtraBold.ttf"]
+  ["o8SxQgE1TnbzYDAMzPaIFiKAuQ6hY5CS8ednBqBA+rQ=" "ofl/notosans/NotoSans-Regular.ttf"]
+  ["JocSG1GHiS29342MzCvV8jLIAgAbThnrLbnswwel/E4=" "ofl/notosans/NotoSans-MediumItalic.ttf"]
+  ["u9xaa2JGwThiR91WiZLHoabrhdGEJPCM+PaYlIx8xWs=" "ofl/notosans/NotoSans-ExtraLightItalic.ttf"]
+  ["zio8qFYh5tJXjFTSw37ThnSMRZD7B4yIrEG6hEdQLZw=" "ofl/notosans/NotoSans-BlackItalic.ttf"]
+  ["3kFAVzKFmpW12mUbu4Zb0NX0ukuYtGPoIHeQHEPIxCc=" "ofl/notosans/NotoSans-ExtraBoldItalic.ttf"]
+];
+notosansogham = mkFont "notosansogham" "ofl" [
+  ["BlboxqGt7tuiagTNNTcHKSTF4RS1dD4hHh5eUvvdzts=" "ofl/notosansogham/NotoSansOgham-Regular.ttf"]
+];
+notosansolchiki = mkFont "notosansolchiki" "ofl" [
+  ["ycMZiGVvSezOyViIJas7UEUJnC+FDvmPNW+XbopZa00=" "ofl/notosansolchiki/NotoSansOlChiki%5Bwght%5D.ttf"]
+];
+notosansoldhungarian = mkFont "notosansoldhungarian" "ofl" [
+  ["/XJrHfWgPHkMk7K+Tjl/UDGbHgTmropnE4ZEbjyOmIg=" "ofl/notosansoldhungarian/NotoSansOldHungarian-Regular.ttf"]
+];
+notosansolditalic = mkFont "notosansolditalic" "ofl" [
+  ["cyRilmtOeDRodeY7eMZglNZL8qOppW1AhPYjpUL3SQQ=" "ofl/notosansolditalic/NotoSansOldItalic-Regular.ttf"]
+];
+notosansoldnortharabian = mkFont "notosansoldnortharabian" "ofl" [
+  ["kGhoDTLWvBSQm9GRfQJwzoPmVfXk12yUrFX8mgoW0X8=" "ofl/notosansoldnortharabian/NotoSansOldNorthArabian-Regular.ttf"]
+];
+notosansoldpermic = mkFont "notosansoldpermic" "ofl" [
+  ["dS0lGdS7wflh8vefKJYmfhj1d1Ux+gFxjWfB0uy7fxI=" "ofl/notosansoldpermic/NotoSansOldPermic-Regular.ttf"]
+];
+notosansoldpersian = mkFont "notosansoldpersian" "ofl" [
+  ["zagaPQMHhJiCCfn7fN+bioztZvO9WSORhNU+IVgimJM=" "ofl/notosansoldpersian/NotoSansOldPersian-Regular.ttf"]
+];
+notosansoldsogdian = mkFont "notosansoldsogdian" "ofl" [
+  ["AzdTQySXWQdYitvIZV5MpiKgy//Ek4TrdBCqRDqHr6o=" "ofl/notosansoldsogdian/NotoSansOldSogdian-Regular.ttf"]
+];
+notosansoldsoutharabian = mkFont "notosansoldsoutharabian" "ofl" [
+  ["5sx28JP3rjA3NwHxjwYb15QYQfs3dQQcnDQ7R+lsXQU=" "ofl/notosansoldsoutharabian/NotoSansOldSouthArabian-Regular.ttf"]
+];
+notosansoldturkic = mkFont "notosansoldturkic" "ofl" [
+  ["faWWMG64jNq0O7RNRdC1uxJhRIi+bk7sMcyEE8Phh3M=" "ofl/notosansoldturkic/NotoSansOldTurkic-Regular.ttf"]
+];
+notosansoriya = mkFont "notosansoriya" "ofl" [
+  ["qxOOAU2vYvB3s3SAdin3ubv8NO3ODDKjiX3VqR4/Ryc=" "ofl/notosansoriya/NotoSansOriya%5Bwdth,wght%5D.ttf"]
+];
+notosansoriyaui = mkFont "notosansoriyaui" "ofl" [
+  ["ulF0v9MyeNPSjPCSrmTjve3roK2M+M+mtDOLNVZxK4s=" "ofl/notosansoriyaui/NotoSansOriyaUI-Black.ttf"]
+  ["LRUaXCyfsBpsvnZ/IAsmPQkNiL9qdIgPQ+2BwhHlH7I=" "ofl/notosansoriyaui/NotoSansOriyaUI-Regular.ttf"]
+  ["f+oYcLiFNqDm77ZtyGKZNikDYzS0JeiWbBs87iHZ+Ic=" "ofl/notosansoriyaui/NotoSansOriyaUI-Thin.ttf"]
+  ["AIPmTAtnEWuOzJIMAoQwGXHJCZvzOjg+s4/ULilHb6Q=" "ofl/notosansoriyaui/NotoSansOriyaUI-Bold.ttf"]
+];
+notosansosage = mkFont "notosansosage" "ofl" [
+  ["+39/7TEFaMzt3z0Iz7sTzN57hLHd2T+UMMuRwr3UFy0=" "ofl/notosansosage/NotoSansOsage-Regular.ttf"]
+];
+notosansosmanya = mkFont "notosansosmanya" "ofl" [
+  ["iDISXxBqC+nUt+ZEJJOpby1mJrjtsswg9TxI6bc/1ac=" "ofl/notosansosmanya/NotoSansOsmanya-Regular.ttf"]
+];
+notosanspahawhhmong = mkFont "notosanspahawhhmong" "ofl" [
+  ["i1ddgvN9ERnH+20PVp+v6lcr3f64OGHIUB1KtaX675I=" "ofl/notosanspahawhhmong/NotoSansPahawhHmong-Regular.ttf"]
+];
+notosanspalmyrene = mkFont "notosanspalmyrene" "ofl" [
+  ["+NF6RLCpDnQtQhP7upXKYfXMHAt+FBJ+k6jn6G2XVxg=" "ofl/notosanspalmyrene/NotoSansPalmyrene-Regular.ttf"]
+];
+notosanspaucinhau = mkFont "notosanspaucinhau" "ofl" [
+  ["FI9q0R5xxYpMVXr39JKmR4s+lnACAqYucBPdcDEFeoM=" "ofl/notosanspaucinhau/NotoSansPauCinHau-Regular.ttf"]
+];
+notosansphagspa = mkFont "notosansphagspa" "ofl" [
+  ["JuEQAANYWuNvPohWlibk4Nma8/g1yxGP4nkZ12NRBHs=" "ofl/notosansphagspa/NotoSansPhagsPa-Regular.ttf"]
+];
+notosansphoenician = mkFont "notosansphoenician" "ofl" [
+  ["p50sTwtMBM+43JfJEUXSnciZZfOvw5hffEAGzL3lje8=" "ofl/notosansphoenician/NotoSansPhoenician-Regular.ttf"]
+];
+notosanspsalterpahlavi = mkFont "notosanspsalterpahlavi" "ofl" [
+  ["kIeMMas37bX3XEh+GmHvUIKs/swqdHmPOEmcurN0bbs=" "ofl/notosanspsalterpahlavi/NotoSansPsalterPahlavi-Regular.ttf"]
+];
+notosansrejang = mkFont "notosansrejang" "ofl" [
+  ["GVYDu2VlmAO3XTeDQylFbQxnpZmAVZOea4K/We2WTIo=" "ofl/notosansrejang/NotoSansRejang-Regular.ttf"]
+];
+notosansrunic = mkFont "notosansrunic" "ofl" [
+  ["SeVAeY3tzPJDAUN/tepcij9CFDsbbBCMHUjHikHEzg8=" "ofl/notosansrunic/NotoSansRunic-Regular.ttf"]
+];
+notosanssamaritan = mkFont "notosanssamaritan" "ofl" [
+  ["SHjdmin40kuhhpyFrlw7cFbmd6FLNVE18zWbkLFOHsw=" "ofl/notosanssamaritan/NotoSansSamaritan-Regular.ttf"]
+];
+notosanssaurashtra = mkFont "notosanssaurashtra" "ofl" [
+  ["0t+ItOKTY20Ew2OxPcXG+I/KDpo7b+zlLxLBHXfp5WY=" "ofl/notosanssaurashtra/NotoSansSaurashtra-Regular.ttf"]
+];
+notosanssc = mkFont "notosanssc" "ofl" [
+  ["owQYEaeMNhsd5Q+VPIBeAkSVHCHFvUEvcjLvDYma8No=" "ofl/notosanssc/NotoSansSC%5Bwght%5D.ttf"]
+];
+notosanssharada = mkFont "notosanssharada" "ofl" [
+  ["LM+45ydz0xjAO4QUrYJobJfuZamCX9saOI43bE3xM3I=" "ofl/notosanssharada/NotoSansSharada-Regular.ttf"]
+];
+notosansshavian = mkFont "notosansshavian" "ofl" [
+  ["wBNReSJfHNDSUIn1yrLjTXG0PMHExBPhU3ZOjTreGiA=" "ofl/notosansshavian/NotoSansShavian-Regular.ttf"]
+];
+notosanssiddham = mkFont "notosanssiddham" "ofl" [
+  ["v/jbMFuerL71EvhZdH/PsJQiedvjXm75F1qipLjGBcA=" "ofl/notosanssiddham/NotoSansSiddham-Regular.ttf"]
+];
+notosanssignwriting = mkFont "notosanssignwriting" "ofl" [
+  ["VgSoXJeEWUGwgF5OcqPcJeO1BEm3W8+HTpYY+4D3RwM=" "ofl/notosanssignwriting/NotoSansSignWriting-Regular.ttf"]
+];
+notosanssinhala = mkFont "notosanssinhala" "ofl" [
+  ["m9k+QHongHW+QDMkBjvJSn4wbETeTfgSFOkyMwwi7s8=" "ofl/notosanssinhala/NotoSansSinhala%5Bwdth,wght%5D.ttf"]
+];
+notosanssinhalaui = mkFont "notosanssinhalaui" "ofl" [
+  ["Pa8eyYEIoHBbTRl0JEktCVU4apvHang47J8x20fB/DI=" "ofl/notosanssinhalaui/NotoSansSinhalaUI%5Bwdth,wght%5D.ttf"]
+];
+notosanssogdian = mkFont "notosanssogdian" "ofl" [
+  ["SiS5btKQXXJXgY49sCowCig+kJRIzPln76Q05eRbreg=" "ofl/notosanssogdian/NotoSansSogdian-Regular.ttf"]
+];
+notosanssorasompeng = mkFont "notosanssorasompeng" "ofl" [
+  ["H+ZvSQTpYHBbaMYPfpKuV574C6sw8puJTUTu0e3DBuA=" "ofl/notosanssorasompeng/NotoSansSoraSompeng%5Bwght%5D.ttf"]
+];
+notosanssoyombo = mkFont "notosanssoyombo" "ofl" [
+  ["1sureqetFUeWti6zuxJRcIRunIxutVYIBkJTd/82Ijw=" "ofl/notosanssoyombo/NotoSansSoyombo-Regular.ttf"]
+];
+notosanssundanese = mkFont "notosanssundanese" "ofl" [
+  ["vZ/74Qvjpx8CI4epEZ+e7qyzJ1SDK7b1cbSvhBgI9CE=" "ofl/notosanssundanese/NotoSansSundanese%5Bwght%5D.ttf"]
+];
+notosanssylotinagri = mkFont "notosanssylotinagri" "ofl" [
+  ["QcQrFH+HcL9EB42ROYlyqh9JcrTjyj1LpVZ5hZJDvjc=" "ofl/notosanssylotinagri/NotoSansSylotiNagri-Regular.ttf"]
+];
+notosanssymbols2 = mkFont "notosanssymbols2" "ofl" [
+  ["aQ+FpU0CalSdXVT4yeDaU020y8mKPo9NsGpH5N30QNk=" "ofl/notosanssymbols2/NotoSansSymbols2-Regular.ttf"]
+];
+notosanssymbols = mkFont "notosanssymbols" "ofl" [
+  ["d50umYNExLRf9Pn6vifX7/pjuEU8h5SimOZPyyiND28=" "ofl/notosanssymbols/NotoSansSymbols%5Bwght%5D.ttf"]
+];
+notosanssyriac = mkFont "notosanssyriac" "ofl" [
+  ["SZF7RHLpHfs3KR709IIZV/QiXtrdthALHYc23zkQsjc=" "ofl/notosanssyriac/NotoSansSyriac-Regular.ttf"]
+  ["1I8fJ6gZKqZ1pG3jsub2MIqKeeYbLTjEgb6OikwP9XE=" "ofl/notosanssyriac/NotoSansSyriac-Black.ttf"]
+  ["ot0bKmfFJsbYWNubLbbFWxrGt2q5kdHPwp6TCG9J8fU=" "ofl/notosanssyriac/NotoSansSyriac-Thin.ttf"]
+];
+notosanstagalog = mkFont "notosanstagalog" "ofl" [
+  ["GVrfim2RNZqHvwBkefKD/5k0JIKmV3SwhZf3vXr05YQ=" "ofl/notosanstagalog/NotoSansTagalog-Regular.ttf"]
+];
+notosanstagbanwa = mkFont "notosanstagbanwa" "ofl" [
+  ["n5KIAk4+3f0853CIxIBuBRXUeqCTsaBLx7wkvf1dmYo=" "ofl/notosanstagbanwa/NotoSansTagbanwa-Regular.ttf"]
+];
+notosanstaile = mkFont "notosanstaile" "ofl" [
+  ["7rTEHY4aYHX35YDMFZ3/Qk4vYeZPXtzVe16MpX1Youo=" "ofl/notosanstaile/NotoSansTaiLe-Regular.ttf"]
+];
+notosanstaitham = mkFont "notosanstaitham" "ofl" [
+  ["oFO5n8XtCj5fsU7su/E3JFywuMNMLLT/0Ictswl7zQo=" "ofl/notosanstaitham/NotoSansTaiTham%5Bwght%5D.ttf"]
+];
+notosanstaiviet = mkFont "notosanstaiviet" "ofl" [
+  ["mbZL/NKucfRY/RJbTuoA7Lk3SHyJdlSVsJkM5sRRZT4=" "ofl/notosanstaiviet/NotoSansTaiViet-Regular.ttf"]
+];
+notosanstakri = mkFont "notosanstakri" "ofl" [
+  ["ShLDg8Bilc44MAh85EPC5NqhO3xgwfDWtgfpm7K+6+c=" "ofl/notosanstakri/NotoSansTakri-Regular.ttf"]
+];
+notosanstamil = mkFont "notosanstamil" "ofl" [
+  ["dkUdX2Dl65YbrhiwFPBkBnm3XatOwSgDRG9LdQm0SB4=" "ofl/notosanstamil/NotoSansTamil%5Bwdth,wght%5D.ttf"]
+];
+notosanstamilsupplement = mkFont "notosanstamilsupplement" "ofl" [
+  ["D63DDDw/14RuYHo8Dqrcr8fHZXmUO8jn4oVsItUztoA=" "ofl/notosanstamilsupplement/NotoSansTamilSupplement-Regular.ttf"]
+];
+notosanstamilui = mkFont "notosanstamilui" "ofl" [
+  ["Ztq7qv2VzxSCe2m1raavG9zeI3tQXjasIVeX8NybwoE=" "ofl/notosanstamilui/NotoSansTamilUI%5Bwdth,wght%5D.ttf"]
+];
+notosanstangsa = mkFont "notosanstangsa" "ofl" [
+  ["+7f8bO0B4KsB8TInVmvum8ZRqZSaW5SpTub4bYQO+N8=" "ofl/notosanstangsa/NotoSansTangsa%5Bwght%5D.ttf"]
+];
+notosanstc = mkFont "notosanstc" "ofl" [
+  ["hkcn0hDVTyU3u+I7OoOUNsOZKvct6TIq9ScIlyRr1E8=" "ofl/notosanstc/NotoSansTC%5Bwght%5D.ttf"]
+];
+notosanstelugu = mkFont "notosanstelugu" "ofl" [
+  ["ycFfNOExzCBPw7D03A7axrONnjFycyZRTLPXwkSLyhc=" "ofl/notosanstelugu/NotoSansTelugu%5Bwdth,wght%5D.ttf"]
+];
+notosansteluguui = mkFont "notosansteluguui" "ofl" [
+  ["lGTgylXHMQ+8kpn5r66zcg7+6bPZGBOZmvfa4nbMH8A=" "ofl/notosansteluguui/NotoSansTeluguUI%5Bwdth,wght%5D.ttf"]
+];
+notosansthaana = mkFont "notosansthaana" "ofl" [
+  ["QLZ2qcfaSSDF+OOsVLm0iena+YFQym5p/PXuz3d69oo=" "ofl/notosansthaana/NotoSansThaana%5Bwght%5D.ttf"]
+];
+notosansthailooped = mkFont "notosansthailooped" "ofl" [
+  ["lsrpMj8puiSiBXhZpLFfL0GZP6iZE3GSlK0drIQXUFI=" "ofl/notosansthailooped/NotoSansThaiLooped-Bold.ttf"]
+  ["29H0YcYBQy6K80n/GD0xvr7LEZe/MiNHfbwyK/ldvWM=" "ofl/notosansthailooped/NotoSansThaiLooped-Light.ttf"]
+  ["raOESA9g0KWa4ctylAdtCDloQH15gAem7/XJntR15Yc=" "ofl/notosansthailooped/NotoSansThaiLooped-Medium.ttf"]
+  ["hla866McdazaQUsTU1tw4dDAOPu1Kixw716PZ5xNStw=" "ofl/notosansthailooped/NotoSansThaiLooped-Black.ttf"]
+  ["/hQRoo8+2YhLSjLlXUxSoHEGSn9/kWWrp59ybtyLpuQ=" "ofl/notosansthailooped/NotoSansThaiLooped-SemiBold.ttf"]
+  ["ieR8UfTVCnN/ACO1qZ+Z35vpyGYynYBODw0JxvsF1n8=" "ofl/notosansthailooped/NotoSansThaiLooped-ExtraLight.ttf"]
+  ["R4gWrrDNNiIziR+ztPGHXJVXx4FQPkpSCJk7X56HBwg=" "ofl/notosansthailooped/NotoSansThaiLooped-ExtraBold.ttf"]
+  ["68k5ggLiYKtkGIJ7+Ll6eY9eK1NV3UYZAhdXF0Hz+IU=" "ofl/notosansthailooped/NotoSansThaiLooped-Thin.ttf"]
+  ["HUdch1WPjDzi4ddWdavxCY4Zbs7IRq7ShNEEqzk9pXM=" "ofl/notosansthailooped/NotoSansThaiLooped-Regular.ttf"]
+];
+notosansthai = mkFont "notosansthai" "ofl" [
+  ["2yvBxi+uLfgU7f93Bd21YNR9dCJ07ZlHt93xpsscF7Y=" "ofl/notosansthai/NotoSansThai%5Bwdth,wght%5D.ttf"]
+];
+notosansthaiui = mkFont "notosansthaiui" "ofl" [
+  ["Pt3w7FIlIluc/Z5kkxS4g9IJztvFk/+W5IVVcpY1M4k=" "ofl/notosansthaiui/NotoSansThaiUI%5Bwdth,wght%5D.ttf"]
+];
+notosanstifinagh = mkFont "notosanstifinagh" "ofl" [
+  ["cbFPpdIvBPVsqYrPeI39mm2E6zWn94wmeMKKpOU3qeE=" "ofl/notosanstifinagh/NotoSansTifinagh-Regular.ttf"]
+];
+notosanstirhuta = mkFont "notosanstirhuta" "ofl" [
+  ["bCtSWTfqR6CJiippZ12EZz8VTwbTau9Vc/dn69vf76A=" "ofl/notosanstirhuta/NotoSansTirhuta-Regular.ttf"]
+];
+notosansugaritic = mkFont "notosansugaritic" "ofl" [
+  ["T+KFRqSE+7eN92qjSbmf1z35O8jixIbJkGrQteicsMg=" "ofl/notosansugaritic/NotoSansUgaritic-Regular.ttf"]
+];
+notosansvai = mkFont "notosansvai" "ofl" [
+  ["HuY9r8LSpxxC17sGJZrhco2P0VW8dSJUocxacALhOo0=" "ofl/notosansvai/NotoSansVai-Regular.ttf"]
+];
+notosanswancho = mkFont "notosanswancho" "ofl" [
+  ["pcuLNNockbVaeJ79eRiMEDw03Z1VIY1ACHr9OFDpfzE=" "ofl/notosanswancho/NotoSansWancho-Regular.ttf"]
+];
+notosanswarangciti = mkFont "notosanswarangciti" "ofl" [
+  ["9MbsVFi4Xh19lFL7QEvwxHYumKx+6pWqan5XmMtv/bo=" "ofl/notosanswarangciti/NotoSansWarangCiti-Regular.ttf"]
+];
+notosansyi = mkFont "notosansyi" "ofl" [
+  ["7k3jdqHk88S8fhFvT0ZTg0hxa4QIuGoPwYwcYSjS5W0=" "ofl/notosansyi/NotoSansYi-Regular.ttf"]
+];
+notosanszanabazarsquare = mkFont "notosanszanabazarsquare" "ofl" [
+  ["ep6VyeIG7P8ceeZYY9I7RQc6XK12JhOaXyihtBUnzbE=" "ofl/notosanszanabazarsquare/NotoSansZanabazarSquare-Regular.ttf"]
+];
+notoserifahom = mkFont "notoserifahom" "ofl" [
+  ["yQ9DRLdpEwLFR823rQpVU5qRXoumPzJ2bO7Vi2fnvh4=" "ofl/notoserifahom/NotoSerifAhom-Regular.ttf"]
+];
+notoserifarmenian = mkFont "notoserifarmenian" "ofl" [
+  ["dMc75b/OGPXynNEVbl/bbD8014bSa1KSo/i+x+XaYVY=" "ofl/notoserifarmenian/NotoSerifArmenian%5Bwdth,wght%5D.ttf"]
+];
+notoserifbalinese = mkFont "notoserifbalinese" "ofl" [
+  ["9sWmc2He+hgwzRT5CfhJ2NJS5QwXATjSFgaqR8rHhaQ=" "ofl/notoserifbalinese/NotoSerifBalinese-Regular.ttf"]
+];
+notoserifbengali = mkFont "notoserifbengali" "ofl" [
+  ["DToGdwSaLgnhhrWmGghGXh9D0awBcjl9BaCq5+OuSEg=" "ofl/notoserifbengali/NotoSerifBengali%5Bwdth,wght%5D.ttf"]
+];
+notoserifdevanagari = mkFont "notoserifdevanagari" "ofl" [
+  ["RBgB9109Tdvxu2O9o9kbgkvtH1ugLHAdjzsytx7thzY=" "ofl/notoserifdevanagari/NotoSerifDevanagari%5Bwdth,wght%5D.ttf"]
+];
+notoserifdisplay = mkFont "notoserifdisplay" "ofl" [
+  ["2q1NMUcIg5pcND8m51Rn7fbAWjpyZQLJiXTdPiQOZRY=" "ofl/notoserifdisplay/NotoSerifDisplay-Italic%5Bwdth,wght%5D.ttf"]
+  ["S2Ya3Pal04v1vv3E2XbopyOKSutX5iwcGmd3U4Cgnfk=" "ofl/notoserifdisplay/NotoSerifDisplay%5Bwdth,wght%5D.ttf"]
+];
+notoserifdogra = mkFont "notoserifdogra" "ofl" [
+  ["+1VRTOjmP5ctppx37R9hQac9xvxexL75XwI+gDPvbKs=" "ofl/notoserifdogra/NotoSerifDogra-Regular.ttf"]
+];
+notoserifethiopic = mkFont "notoserifethiopic" "ofl" [
+  ["SdXapsNHekJ/XU+KWunqfwoE6n+GX8Iffgj8Su1w2So=" "ofl/notoserifethiopic/NotoSerifEthiopic%5Bwdth,wght%5D.ttf"]
+];
+notoserifgeorgian = mkFont "notoserifgeorgian" "ofl" [
+  ["/Rj50dHt/VQ3nGL4BkgMVaytq5oBXqkjCrzDSO+rbU0=" "ofl/notoserifgeorgian/NotoSerifGeorgian%5Bwdth,wght%5D.ttf"]
+];
+notoserifgrantha = mkFont "notoserifgrantha" "ofl" [
+  ["KRRZirxC1sDLN8fmk9bTMlNdDwR5Ec0V0FyM5L3Hn28=" "ofl/notoserifgrantha/NotoSerifGrantha-Regular.ttf"]
+];
+notoserifgujarati = mkFont "notoserifgujarati" "ofl" [
+  ["G7FXNZD8jx6FgU/7CtLj5R/fYtlD5ezQM8pp9zO1/6o=" "ofl/notoserifgujarati/NotoSerifGujarati%5Bwght%5D.ttf"]
+];
+notoserifgurmukhi = mkFont "notoserifgurmukhi" "ofl" [
+  ["lJEq8d4oNferkonJ+WUpw5bRkKJOJK5Hjmmfl7FxboI=" "ofl/notoserifgurmukhi/NotoSerifGurmukhi%5Bwght%5D.ttf"]
+];
+notoserifhebrew = mkFont "notoserifhebrew" "ofl" [
+  ["GKty2MqkIrIo6CJlwjn+z5x6uDxCc0070pDAhvTqhX4=" "ofl/notoserifhebrew/NotoSerifHebrew%5Bwdth,wght%5D.ttf"]
+];
+notoserifhk = mkFont "notoserifhk" "ofl" [
+  ["cH7hU8trhMEK6Y2o5NaAiStgRmfM66w+kzwm7RQA1x0=" "ofl/notoserifhk/NotoSerifHK%5Bwght%5D.ttf"]
+];
+notoserifjp = mkFont "notoserifjp" "ofl" [
+  ["TGtGcLc9CEPHstMLni+8+llq72/Tk3+JSSmrC41lnR4=" "ofl/notoserifjp/NotoSerifJP%5Bwght%5D.ttf"]
+];
+notoserifkannada = mkFont "notoserifkannada" "ofl" [
+  ["mv9d3YFUWx64q33Rx1Q9v18TmQuU82dWLLFqeuLLuyU=" "ofl/notoserifkannada/NotoSerifKannada%5Bwght%5D.ttf"]
+];
+notoserifkhmer = mkFont "notoserifkhmer" "ofl" [
+  ["qs5T8KVcgNg/sLIFiU5qwst75exojlVEUtlJfpfzBms=" "ofl/notoserifkhmer/NotoSerifKhmer%5Bwdth,wght%5D.ttf"]
+];
+notoserifkhojki = mkFont "notoserifkhojki" "ofl" [
+  ["eIiDntzvAo+xst6CNfuMomlzjTBw5D3Bp/RpOefnl+8=" "ofl/notoserifkhojki/NotoSerifKhojki%5Bwght%5D.ttf"]
+];
+notoserifkr = mkFont "notoserifkr" "ofl" [
+  ["1HdZJMFs6OzFY8vBqeN5T9Id+F7a4vvRhJe3vWebVN0=" "ofl/notoserifkr/NotoSerifKR%5Bwght%5D.ttf"]
+];
+notoseriflao = mkFont "notoseriflao" "ofl" [
+  ["8l+xcXJNtmpXXOXhuvd2XVJE92IPWUH2p19pfQWtEMI=" "ofl/notoseriflao/NotoSerifLao%5Bwdth,wght%5D.ttf"]
+];
+notoserifmalayalam = mkFont "notoserifmalayalam" "ofl" [
+  ["XwgdxgMLb4ktuYQpm/5suuuOvartbTW0PeDqdtDhqUU=" "ofl/notoserifmalayalam/NotoSerifMalayalam%5Bwght%5D.ttf"]
+];
+notoserifmyanmar = mkFont "notoserifmyanmar" "ofl" [
+  ["O8EHProp9OqG0FkiyuiCFuCsNhcGFPpemUh+vHC9CHk=" "ofl/notoserifmyanmar/NotoSerifMyanmar-Black.ttf"]
+  ["QYgYbaFp9V32y6ewG54IyfRFFuCtZnZvyLRugGtCOn4=" "ofl/notoserifmyanmar/NotoSerifMyanmar-Bold.ttf"]
+  ["REAl/T0p59ikVOYyqOz9AkaNfFI2w5x19q0gZ85+a20=" "ofl/notoserifmyanmar/NotoSerifMyanmar-ExtraLight.ttf"]
+  ["XILhwngKjOG8SavuT6U5K8OTM6ZazVr//3WJ35NKTJA=" "ofl/notoserifmyanmar/NotoSerifMyanmar-SemiBold.ttf"]
+  ["AHwIpddVTIKmtvw0guiXYlz4Z8fcIuf5t+v1XJRRuw0=" "ofl/notoserifmyanmar/NotoSerifMyanmar-Medium.ttf"]
+  ["kdfDqUAqPtGObAh6URt1QqCWgB6thmkCfw36YX9QRm8=" "ofl/notoserifmyanmar/NotoSerifMyanmar-Thin.ttf"]
+  ["aLT3dBlVIPC26bpUqmrpUe6pqab2ump2beEe7QClcKA=" "ofl/notoserifmyanmar/NotoSerifMyanmar-Light.ttf"]
+  ["+I0dpadajgn/Cwc/48hh0JWnLpT+oyNfCfgObFssmTM=" "ofl/notoserifmyanmar/NotoSerifMyanmar-Regular.ttf"]
+  ["dKAGvqotZNUgSmIFMMVkNmsxbctEOiJ4A5mXo0l48OA=" "ofl/notoserifmyanmar/NotoSerifMyanmar-ExtraBold.ttf"]
+];
+notoserifnphmong = mkFont "notoserifnphmong" "ofl" [
+  ["aRfyn9y3Zmi4rUyFA41UgVtYmcSSQsgrdsOz3MK7IW8=" "ofl/notoserifnphmong/NotoSerifNPHmong%5Bwght%5D.ttf"]
+];
+notoserifnyiakengpuachuehmong = mkFont "notoserifnyiakengpuachuehmong" "ofl" [
+  ["gCuDjeHK5ZQBxRQGIEee5txOqijYd9T8xbedkui0NVU=" "ofl/notoserifnyiakengpuachuehmong/NotoSerifNyiakengPuachueHmong%5Bwght%5D.ttf"]
+];
+notoserif = mkFont "notoserif" "ofl" [
+  ["SlrjCTGnWQviMK4YZ2UGefgDGIxSEUk70aXj/ArHgYE=" "ofl/notoserif/NotoSerif-Italic.ttf"]
+  ["yNfp6aWGzV9nH8JnkGyHOb5w+16SBp/YkeEXfh0lX+E=" "ofl/notoserif/NotoSerif-BoldItalic.ttf"]
+  ["N16D6t5g/8HC9RaokXU1i6X8t4WpvbaMajvhtkcHBN0=" "ofl/notoserif/NotoSerif-Regular.ttf"]
+  ["WN4QNAlZ7hq9cV+2+KZw9EyjrfxdnH4J5I169KH/QZI=" "ofl/notoserif/NotoSerif-Bold.ttf"]
+];
+notoseriforiya = mkFont "notoseriforiya" "ofl" [
+  ["n6KgjLamd9FVqCO8WLTFh2E3gL1DAT/TYjacJRABUCo=" "ofl/notoseriforiya/NotoSerifOriya%5Bwght%5D.ttf"]
+];
+notoserifsc = mkFont "notoserifsc" "ofl" [
+  ["A6e8VDZMVwLnDpK2h32nT08MWiI2KRDGZoS8wtwD09E=" "ofl/notoserifsc/NotoSerifSC%5Bwght%5D.ttf"]
+];
+notoserifsinhala = mkFont "notoserifsinhala" "ofl" [
+  ["JJfTHyZHOUzYAwh/hwyRRcMuZ3PPSgL5gCpXAoled/Q=" "ofl/notoserifsinhala/NotoSerifSinhala%5Bwdth,wght%5D.ttf"]
+];
+notoseriftamil = mkFont "notoseriftamil" "ofl" [
+  ["gdZKKRZ8LkjIbbLHwm358pN3vldXO5ZvtwuG6lM2eNw=" "ofl/notoseriftamil/NotoSerifTamil-Italic%5Bwdth,wght%5D.ttf"]
+  ["6FD9C2b0sEJ8JBRrwuUbNdb5gv9bRVfR27S0hDrOHD8=" "ofl/notoseriftamil/NotoSerifTamil%5Bwdth,wght%5D.ttf"]
+];
+notoseriftangut = mkFont "notoseriftangut" "ofl" [
+  ["DbXbBJLQScW8qjkQ7OfbORdHWm6RtsdLUSV2CwGz710=" "ofl/notoseriftangut/NotoSerifTangut-Regular.ttf"]
+];
+notoseriftc = mkFont "notoseriftc" "ofl" [
+  ["G2CQ7n1aVbREKBukWgmdCKS9yC9IEoZu1zSxabxI6Jo=" "ofl/notoseriftc/NotoSerifTC%5Bwght%5D.ttf"]
+];
+notoseriftelugu = mkFont "notoseriftelugu" "ofl" [
+  ["xHBlsB596WT+KuHEvhRp6+Tyct/HXpYBo64Ho+vuxb8=" "ofl/notoseriftelugu/NotoSerifTelugu%5Bwght%5D.ttf"]
+];
+notoserifthai = mkFont "notoserifthai" "ofl" [
+  ["BPPaqi6JJZrZ5LZax37x60EOPbdLvCgMJ9EgZungZ3A=" "ofl/notoserifthai/NotoSerifThai%5Bwdth,wght%5D.ttf"]
+];
+notoseriftibetan = mkFont "notoseriftibetan" "ofl" [
+  ["Bg7AIrBMMG3j9Y0FH7Dhz4GlthDFkQ+/xDu6FUwFfNo=" "ofl/notoseriftibetan/NotoSerifTibetan%5Bwght%5D.ttf"]
+];
+notoseriftoto = mkFont "notoseriftoto" "ofl" [
+  ["zijvb2QU8uIzgPm0W3Q0+FmIOroYiPVzJpzrw/O5nhk=" "ofl/notoseriftoto/NotoSerifToto%5Bwght%5D.ttf"]
+];
+notoserifyezidi = mkFont "notoserifyezidi" "ofl" [
+  ["ztjNtal7wGRml/uDSlugmMq4a6UK6/dyepFdSvdu6Ro=" "ofl/notoserifyezidi/NotoSerifYezidi%5Bwght%5D.ttf"]
+];
+nototraditionalnushu = mkFont "nototraditionalnushu" "ofl" [
+  ["BLL+GER+h5TqUiaxR5B0vMuGz45EY5//QenVpfNFeZk=" "ofl/nototraditionalnushu/NotoTraditionalNushu-Regular.ttf"]
+];
+novacut = mkFont "novacut" "ofl" [
+  ["CbQjgxJ3D7akQFAn3DP+7xuxySg9PJB/5ygpYNpOtfc=" "ofl/novacut/NovaCut.ttf"]
+];
+novaflat = mkFont "novaflat" "ofl" [
+  ["3jApMs3KbSdPf3kbmAXW4PhOxErm7WMPGx6MYW/ATEI=" "ofl/novaflat/NovaFlat.ttf"]
+];
+novamono = mkFont "novamono" "ofl" [
+  ["ZI6ttmSMCAGxhtPc72DuaqhKeRseCccmk1wHElCLSAc=" "ofl/novamono/NovaMono.ttf"]
+];
+novaoval = mkFont "novaoval" "ofl" [
+  ["KukGicF6/ctp/UUyX8Zc2Yyo1TemPtLDPu2YJ6xqFvY=" "ofl/novaoval/NovaOval.ttf"]
+];
+novaround = mkFont "novaround" "ofl" [
+  ["n0J6COY2f4R9S5RSq1YlLZlDa2pWcgbBc01ctN6JXZU=" "ofl/novaround/NovaRound.ttf"]
+];
+novascript = mkFont "novascript" "ofl" [
+  ["RwpLLKMXtJ+L/CHSuPcNUGsmUmQ2ZOHDiYhS5yEioo0=" "ofl/novascript/NovaScript-Regular.ttf"]
+];
+novaslim = mkFont "novaslim" "ofl" [
+  ["eM8YgBfyEfZOoU/RyUbMFdz97IZ/R1mlCv8LQ1Djju0=" "ofl/novaslim/NovaSlim.ttf"]
+];
+novasquare = mkFont "novasquare" "ofl" [
+  ["v32HJeL+0ZhMrby05U1nzYmPBC4RwU6cMAdLFNq2lj8=" "ofl/novasquare/NovaSquare.ttf"]
+];
+ntr = mkFont "ntr" "ofl" [
+  ["xZAAuaACwpNbGa/c6qOqybDt78/SE+P2TeCxcv2lCx0=" "ofl/ntr/NTR-Regular.ttf"]
+];
+numans = mkFont "numans" "ofl" [
+  ["0zHvNHNXL16w3QW23iOLZbTYdescUpbhgiWntOZENvM=" "ofl/numans/Numans-Regular.ttf"]
+];
+nunito = mkFont "nunito" "ofl" [
+  ["u1WlylwgQjNbOZGvJ8TQcF0O9BysYWSsc3/Y8qHoUgc=" "ofl/nunito/Nunito%5Bwght%5D.ttf"]
+  ["tSDMhxhosKz8ob7ah1339KROvOkU+Kifg5d/ycCVKcg=" "ofl/nunito/Nunito-Italic%5Bwght%5D.ttf"]
+];
+nunitosans = mkFont "nunitosans" "ofl" [
+  ["0+aEU7x+834caEy0CNDTg4be1QrwZYQ8y76T7yaESRM=" "ofl/nunitosans/NunitoSans-ExtraLight.ttf"]
+  ["5R5m1qPlGfcLdqFWBmGCQG5GSx6HMfuijRY3K2sD+rA=" "ofl/nunitosans/NunitoSans-SemiBold.ttf"]
+  ["DFhbTvnIBJuukIthZW0oYE9cSWT8Qc5LduxX73subv0=" "ofl/nunitosans/NunitoSans-SemiBoldItalic.ttf"]
+  ["knYoZoO63inh8DvVX5a4f/3XONr1KfAZH/K9pp0ydNo=" "ofl/nunitosans/NunitoSans-LightItalic.ttf"]
+  ["T08QQ/H+LES7ANMF36cIS+/QjiXWvjnmsjg+G4uHR5E=" "ofl/nunitosans/NunitoSans-Bold.ttf"]
+  ["PfGsVo8dn0oa/3HwxyvzQMGPmiR2SL9HDNUoo7jr/bc=" "ofl/nunitosans/NunitoSans-Light.ttf"]
+  ["UmINPdgPDb1aTh7CL0KSWeWlJvd4xqepueRa51Y4DzA=" "ofl/nunitosans/NunitoSans-ExtraBoldItalic.ttf"]
+  ["RWIU8qJ0NxTYA2e+Q6AN7fRQGOIVwjL7kgTo3eULoKA=" "ofl/nunitosans/NunitoSans-Italic.ttf"]
+  ["kwbpBxYct/6zNYYSsbiljE392lisij3vRkBuv1jasNc=" "ofl/nunitosans/NunitoSans-Black.ttf"]
+  ["qipcHLVbFoHql4rmw+nRlOU1IjDo5Jdho6lfnbqFrUQ=" "ofl/nunitosans/NunitoSans-ExtraBold.ttf"]
+  ["j58J8vrTaMteqctf+P+eCiNQTv55DM8OnupTCIi+5Ds=" "ofl/nunitosans/NunitoSans-ExtraLightItalic.ttf"]
+  ["K6XaXsMHlSVyiqk429nNtavdyUmL8d+PKrlPNr5cBag=" "ofl/nunitosans/NunitoSans-BlackItalic.ttf"]
+  ["sm0Wd/d3bIoH/YeoPbOm/cdIa7YnMyxz7ItsN9lBaDQ=" "ofl/nunitosans/NunitoSans-Regular.ttf"]
+  ["2/pfkbaXU/mLaii0zJrAx5VL8EpV2AYdmdgFdXC4OFE=" "ofl/nunitosans/NunitoSans-BoldItalic.ttf"]
+];
+nuosusil = mkFont "nuosusil" "ofl" [
+  ["PKTjAYC3V15yRVTF188yS8i+PdVsXvHeBifGg5UgMs0=" "ofl/nuosusil/NuosuSIL-Regular.ttf"]
+];
+odibeesans = mkFont "odibeesans" "ofl" [
+  ["TkAGxxP1UJ93L2ThbIoIIa0mQRpp9ojHGxJ1aDVVIOg=" "ofl/odibeesans/OdibeeSans-Regular.ttf"]
+];
+odormeanchey = mkFont "odormeanchey" "ofl" [
+  ["KcsuCUp+jtndVwH0il70LE4V24rNhep44igErmcYj74=" "ofl/odormeanchey/OdorMeanChey-Regular.ttf"]
+];
+offside = mkFont "offside" "ofl" [
+  ["mW0etS1JItn9q3u20LNSXpk5YlTUp+HVw7GCxr9UUKk=" "ofl/offside/Offside-Regular.ttf"]
+];
+oflsortsmillgoudytt = mkFont "oflsortsmillgoudytt" "ofl" [
+  ["fLFkfGRueft/QpUYH8F25cWySPGWftS7n0jkpcV8Ris=" "ofl/oflsortsmillgoudytt/OFLGoudyStMTT-Italic.ttf"]
+  ["HxaH5XNpiH7nhb55E4srmNNtxfEGQek2u8kWQ79nu3o=" "ofl/oflsortsmillgoudytt/OFLGoudyStMTT.ttf"]
+];
+oi = mkFont "oi" "ofl" [
+  ["/PXtlgTkyZIlTvHz13UxarmBlhQXB9Om4lWTtbs2aHE=" "ofl/oi/Oi-Regular.ttf"]
+];
+oldenburg = mkFont "oldenburg" "ofl" [
+  ["tPgV3lYrX7eIGwM4UTv/+vgS9rB10a3gG3W010aZiCM=" "ofl/oldenburg/Oldenburg-Regular.ttf"]
+];
+oldstandardtt = mkFont "oldstandardtt" "ofl" [
+  ["fYMenXma0j7pjoiTganbKig7Lax/Io3VwGBx3sucVNs=" "ofl/oldstandardtt/OldStandard-Bold.ttf"]
+  ["QnF6EoC1I6UGyisChcyjgOd/4hSx9uPXWouSUAXxnqw=" "ofl/oldstandardtt/OldStandard-Regular.ttf"]
+  ["S5Ui9HETF/wG4kE6WLRmLCSctwffGT1oK51kDjZe9WQ=" "ofl/oldstandardtt/OldStandard-Italic.ttf"]
+];
+ole = mkFont "ole" "ofl" [
+  ["YHFSdIYJa+cUxkqLBBgfeFVsuhSpX1ljI8DTVg5AbnM=" "ofl/ole/Ole-Regular.ttf"]
+];
+oleoscript = mkFont "oleoscript" "ofl" [
+  ["GqADrJOK35vqZExAbOkO6xkTE4qh10kiQsDKlIwPSKw=" "ofl/oleoscript/OleoScript-Regular.ttf"]
+  ["fkhDyddCM/AKKBWVQXfjN1jBxCoI0hixHBMc99gY8dU=" "ofl/oleoscript/OleoScript-Bold.ttf"]
+];
+oleoscriptswashcaps = mkFont "oleoscriptswashcaps" "ofl" [
+  ["uIEcgDICu8gOYSQgBmYICmK2PfO1LhgzRWGJ7B95jDE=" "ofl/oleoscriptswashcaps/OleoScriptSwashCaps-Regular.ttf"]
+  ["DWIsal24UH7LqqhEZy6FU/JiScahVmsJj1QpWnfrQqI=" "ofl/oleoscriptswashcaps/OleoScriptSwashCaps-Bold.ttf"]
+];
+ooohbaby = mkFont "ooohbaby" "ofl" [
+  ["kE0beQk9oa5LdDasIZDd9QSOPLg5stwMBRbQ9YocJe4=" "ofl/ooohbaby/OoohBaby-Regular.ttf"]
+];
+opensanshebrew = mkFont "opensanshebrew" "asl20" [
+  ["VknQ6EK3ryZDfrrAv4zF4rwxD+H7rLjYKnfZa49sKwY=" "apache/opensanshebrew/OpenSansHebrew-Light.ttf"]
+  ["vi97YNAAD6Oe+edTcb7TY9nRntz7N5EM0wWUQ+KijHs=" "apache/opensanshebrew/OpenSansHebrew-ExtraBoldItalic.ttf"]
+  ["DPYcJuAmSeRK6aRPOULGEdaXImpu1LBhwM+a7JNEc0Q=" "apache/opensanshebrew/OpenSansHebrew-Italic.ttf"]
+  ["VMd7nOjWnwQfTlPvZ6zLgPBOakVvwUPrXUmp2nyMJwI=" "apache/opensanshebrew/OpenSansHebrew-BoldItalic.ttf"]
+  ["B9ir/N/TOhw7+amBHOtN21aYlRpfz8kk8rPqR9aoMKA=" "apache/opensanshebrew/OpenSansHebrew-Bold.ttf"]
+  ["L4wXJe17HyXjjHT/I1Q/oN59xN/3Mq7HZgKbXmM1LKw=" "apache/opensanshebrew/OpenSansHebrew-Regular.ttf"]
+  ["n4N0q50LQAoPJTPXWnggclggkfGHusCdsc3vHGM6kqI=" "apache/opensanshebrew/OpenSansHebrew-ExtraBold.ttf"]
+  ["bAP+sJ7Rw2sJtEK5yn2lTm/9b2Iz7gp7TSPmINxwlL4=" "apache/opensanshebrew/OpenSansHebrew-LightItalic.ttf"]
+];
+opensanshebrewcondensed = mkFont "opensanshebrewcondensed" "asl20" [
+  ["0SPoPL+QZx2Q7BUxu8c3FbUxiFEEVNKWEyL0jKBbNaE=" "apache/opensanshebrewcondensed/OpenSansHebrewCondensed-Regular.ttf"]
+  ["/MomCtL+z3jOUeU+OicQHg8QrTJFtJMT3fluzTBWT7A=" "apache/opensanshebrewcondensed/OpenSansHebrewCondensed-ExtraBoldItalic.ttf"]
+  ["qwFrkpJFZbNT3B4CA5Wrfyv7nVuLZ0eMm9B/3TS4DLk=" "apache/opensanshebrewcondensed/OpenSansHebrewCondensed-ExtraBold.ttf"]
+  ["CLsGIb/1X8YDjKn6zWFppEaD8QaXJQuxXUpQOS4+byg=" "apache/opensanshebrewcondensed/OpenSansHebrewCondensed-Light.ttf"]
+  ["oK28OR2E9eIavFMipRs4cDmAxIKkM9RkxKTz+hA6L9I=" "apache/opensanshebrewcondensed/OpenSansHebrewCondensed-LightItalic.ttf"]
+  ["r6IpRmIgQgnj2lPXYX1NX2g5PvSrniwpXLKfZxdcFzo=" "apache/opensanshebrewcondensed/OpenSansHebrewCondensed-Bold.ttf"]
+  ["0INbePjp35BMPdeOJJtfoZ16OwvKfduqLR5HniNQnuU=" "apache/opensanshebrewcondensed/OpenSansHebrewCondensed-Italic.ttf"]
+  ["kEN/2S0y1IhDkdekd/YdWem9H3ttATRzkUP1arIAKq8=" "apache/opensanshebrewcondensed/OpenSansHebrewCondensed-BoldItalic.ttf"]
+];
+opensans = mkFont "opensans" "ofl" [
+  ["qqm9oScGtaxMHn+TfINyX0mYBhE6JnKk54g6hvwm9Mw=" "ofl/opensans/OpenSans%5Bwdth,wght%5D.ttf"]
+  ["CK1VgrNlJyrVyerHzTMqcfbyvvLGk1HRugcsUPYEl1M=" "ofl/opensans/OpenSans-Italic%5Bwdth,wght%5D.ttf"]
+];
+oranienbaum = mkFont "oranienbaum" "ofl" [
+  ["0MJSfxBt2vU7684I6QO1hdH9HYMO3dI+1yPDE7T+LGw=" "ofl/oranienbaum/Oranienbaum-Regular.ttf"]
+];
+orbitron = mkFont "orbitron" "ofl" [
+  ["9C2y3RbmQiWONXgpFuzrHc2+oG+5WNd61x3FljWH6P0=" "ofl/orbitron/Orbitron%5Bwght%5D.ttf"]
+];
+oregano = mkFont "oregano" "ofl" [
+  ["DC6u2YGu76hEXEqTd5T9HsfdWltA/2Awell3XMI5sYc=" "ofl/oregano/Oregano-Regular.ttf"]
+  ["Xk32eZeGnU5o26GjhGOnDIZ50py3rGeHeWMduTgvVTg=" "ofl/oregano/Oregano-Italic.ttf"]
+];
+orelegaone = mkFont "orelegaone" "ofl" [
+  ["34Ny3KaNGlvEx3E1lOwnXRQZLyJgudXGfEJtMAUFtwQ=" "ofl/orelegaone/OrelegaOne-Regular.ttf"]
+];
+orienta = mkFont "orienta" "ofl" [
+  ["pav4GKT9/N7qEJ47uLS9HJTkyRTcp2qwTQEYP7ohedo=" "ofl/orienta/Orienta-Regular.ttf"]
+];
+originalsurfer = mkFont "originalsurfer" "ofl" [
+  ["7kpCggsiShk08roJl5WNeWWtNHYtiCRPv/3bCwrkiOQ=" "ofl/originalsurfer/OriginalSurfer-Regular.ttf"]
+];
+oswald = mkFont "oswald" "ofl" [
+  ["CPPxKWEUVjJSrk/Dyjjc1DLLRhqjKxGaT0mrp+qPN8w=" "ofl/oswald/Oswald%5Bwght%5D.ttf"]
+];
+otomanopeeone = mkFont "otomanopeeone" "ofl" [
+  ["HBAgf6+16ufHuFVUckZT48NxikU9sx2fpV37GHLMxSM=" "ofl/otomanopeeone/OtomanopeeOne-Regular.ttf"]
+];
+outfit = mkFont "outfit" "ofl" [
+  ["Y791n7nV+W7faQmtv9PI5tRPfRaBBk1gZd0tHSWEaOc=" "ofl/outfit/Outfit%5Bwght%5D.ttf"]
+];
+overlock = mkFont "overlock" "ofl" [
+  ["p94k+G+BcLL5I6zkUuKInXTngfgokOEOjCMTWwPMzJE=" "ofl/overlock/Overlock-BlackItalic.ttf"]
+  ["hgL8g7Ny1aCed0BU+t7kBWoncODzuQANomPSIdDYBKU=" "ofl/overlock/Overlock-Italic.ttf"]
+  ["GqDPBw/Hb95jvD6xRO2DhzCrzzO8ZYEbDOmyOt7HaR4=" "ofl/overlock/Overlock-BoldItalic.ttf"]
+  ["A6xM4H69bokKr5Bx+Mdb+LcGDznUQzUlDdJrz8ihYyk=" "ofl/overlock/Overlock-Bold.ttf"]
+  ["V+mpmCB15yp4AMDEw3xP8jIdys7FtmYixKPhFMXSX3s=" "ofl/overlock/Overlock-Black.ttf"]
+  ["4n7CbcsFXm04Q8UQb8rLxU4MUKzMBAmTXHqqFjJ7ySo=" "ofl/overlock/Overlock-Regular.ttf"]
+];
+overlocksc = mkFont "overlocksc" "ofl" [
+  ["NUMmI6QAoHTjkxt8SVjgBHnL36hISiP2+7qN/JSXZnU=" "ofl/overlocksc/OverlockSC-Regular.ttf"]
+];
+overpassmono = mkFont "overpassmono" "ofl" [
+  ["SfIw4QJRYI8K4aLORr52jXud3L5c3KLp9rdi/Lzhrk8=" "ofl/overpassmono/OverpassMono%5Bwght%5D.ttf"]
+];
+overpass = mkFont "overpass" "ofl" [
+  ["O0WsQZOTC760kbXHYiev1ZkWB3EvDRbWvF1022u9gXI=" "ofl/overpass/Overpass-Italic%5Bwght%5D.ttf"]
+  ["lwcX3xen+ZEd7kX2BpXQW/qddF+goR/Fw0g3H6IfAHM=" "ofl/overpass/Overpass%5Bwght%5D.ttf"]
+];
+overtherainbow = mkFont "overtherainbow" "ofl" [
+  ["YqIyzKo/GgtXWUeojRNVxeTFX14M5lMHq5HqlYkVw9M=" "ofl/overtherainbow/OvertheRainbow.ttf"]
+];
+ovo = mkFont "ovo" "ofl" [
+  ["jU8ROtp0j0TQBTcb7laS5YlQqE5gaLdPVHEOKAop84k=" "ofl/ovo/Ovo-Regular.ttf"]
+];
+oxanium = mkFont "oxanium" "ofl" [
+  ["LOAdlG4eH/yNfuz/+9qGI77dY+r4EaIEiMS2mvRbq7A=" "ofl/oxanium/Oxanium%5Bwght%5D.ttf"]
+];
+oxygenmono = mkFont "oxygenmono" "ofl" [
+  ["3MZx2pP3/DHy56SnwFjIFcHq7Go9J3kuGO3/TTv1OfA=" "ofl/oxygenmono/OxygenMono-Regular.ttf"]
+];
+oxygen = mkFont "oxygen" "ofl" [
+  ["2G2aEa0aokLb9Q0qKjKVuqsqETSdz221vSjjYDa39sA=" "ofl/oxygen/Oxygen-Bold.ttf"]
+  ["AUtETDBzvPQzV3zKCqoXezWrG5pGraVicQAGyzUShAk=" "ofl/oxygen/Oxygen-Light.ttf"]
+  ["oyi4+jZr3ZT1B60C4nIaxJy0JXqe8eSVYLIwB5OGAQ4=" "ofl/oxygen/Oxygen-Regular.ttf"]
+];
+pacifico = mkFont "pacifico" "ofl" [
+  ["W2wNUzSnv3fepSuXXFoMQIh4wPcRXtW2+xUfY0t79wE=" "ofl/pacifico/Pacifico-Regular.ttf"]
+];
+padauk = mkFont "padauk" "ofl" [
+  ["nbtGdFrk7ULZAwIQ5j96pTKBhhx/oL4HKYAWH5SScRU=" "ofl/padauk/Padauk-Bold.ttf"]
+  ["yJz1blcqvallLZ5UIDvXKbDFlUHEtWkEa5thrNC1MvM=" "ofl/padauk/Padauk-Regular.ttf"]
+];
+padyakkeexpandedone = mkFont "padyakkeexpandedone" "ofl" [
+  ["/Nxss/wneJXJj8EgrK8S1CHJEbunaOuiiRBJtd8iUDI=" "ofl/padyakkeexpandedone/PadyakkeExpandedOne-Regular.ttf"]
+];
+palanquindark = mkFont "palanquindark" "ofl" [
+  ["i/NZHHWKOjWXe5r3LGqWOapgxmUnQ925zcWdwaMPeXE=" "ofl/palanquindark/PalanquinDark-Bold.ttf"]
+  ["RymuTmDMIMvB7JQrAzNUaDM5/Xep3PVfmY6RU8ttMDY=" "ofl/palanquindark/PalanquinDark-SemiBold.ttf"]
+  ["MrLwZy6xWXVWxx0AK1nbr/da6yDj0v3pKGxxs3k7SD8=" "ofl/palanquindark/PalanquinDark-Medium.ttf"]
+  ["3nuhDXA48Txne2pX4BxLIILdSWAqFUBhNddhKWyUkoQ=" "ofl/palanquindark/PalanquinDark-Regular.ttf"]
+];
+palanquin = mkFont "palanquin" "ofl" [
+  ["OHwymJAwcEQHyLbnEbBSaLZ92T4PAz+O690wCpxPCAk=" "ofl/palanquin/Palanquin-Thin.ttf"]
+  ["M8QP8H+SWiYkCnbeGsOlfAhqOIE4xElm8OovVlIok9A=" "ofl/palanquin/Palanquin-Light.ttf"]
+  ["CM8AEbxatjLnXKefLfHzeVb8O5PRMFtGEX3xf7WMtBQ=" "ofl/palanquin/Palanquin-SemiBold.ttf"]
+  ["9PnPQVJ5tGaxxN9haCg/lfqIRAsnuzTohK6wOkMrAvA=" "ofl/palanquin/Palanquin-Regular.ttf"]
+  ["mv3SBVitYkxKReydRFCYAyDEkJO+OXyD0zAz5BPcxMQ=" "ofl/palanquin/Palanquin-Medium.ttf"]
+  ["HpLurwAIHpMgu8vaThxUy6pMgUjcamolwa0LPxR08Zg=" "ofl/palanquin/Palanquin-ExtraLight.ttf"]
+  ["uf+H1XQ8F50TAOy725fFPnoa2y9UxEbCGs7FDivHes8=" "ofl/palanquin/Palanquin-Bold.ttf"]
+];
+palettemosaic = mkFont "palettemosaic" "ofl" [
+  ["YCneapRnBpW2ILPfZleU49riE9i3rtisAyey2lZ5sAQ=" "ofl/palettemosaic/PaletteMosaic-Regular.ttf"]
+];
+pangolin = mkFont "pangolin" "ofl" [
+  ["z08KRnBMeFnUlDMg/ObG0GzH3EUO+XHDZ27zb59IIpk=" "ofl/pangolin/Pangolin-Regular.ttf"]
+];
+paprika = mkFont "paprika" "ofl" [
+  ["pTu6VJibVAHWERUzKtJVTDzGt6uC4CywvRq8TUitY8s=" "ofl/paprika/Paprika-Regular.ttf"]
+];
+parisienne = mkFont "parisienne" "ofl" [
+  ["vJ7hfwIuILxwB5fl9VfRS/pDrwyY2ebJxcHKTseqzVc=" "ofl/parisienne/Parisienne-Regular.ttf"]
+];
+passeroone = mkFont "passeroone" "ofl" [
+  ["tRcOzIVSANNp+KYPyMDDUcyMteyfq5qDjVon804BmC0=" "ofl/passeroone/PasseroOne-Regular.ttf"]
+];
+passionone = mkFont "passionone" "ofl" [
+  ["hv6lAB5ddRz1aW8OzUdU24CRituxJlit2Vn1vNySsJs=" "ofl/passionone/PassionOne-Regular.ttf"]
+  ["OnJJkJsuVugx+KNXpO5UnpxZRc0APw5eO9h5GnbZi34=" "ofl/passionone/PassionOne-Bold.ttf"]
+  ["yVTbrIg1vxb5OPjZf+FifUeqEi1gJGFp/1XOx3KUnpY=" "ofl/passionone/PassionOne-Black.ttf"]
+];
+passionsconflict = mkFont "passionsconflict" "ofl" [
+  ["b6kIDIpVd4A8PmBz6SpUdYkw6MwxES9lAJAb401fxVo=" "ofl/passionsconflict/PassionsConflict-Regular.ttf"]
+];
+pathwaygothicone = mkFont "pathwaygothicone" "ofl" [
+  ["2Dg2lBPHoWQGbfQKuykEP6vsz0hXukfZ0fFQunarNEA=" "ofl/pathwaygothicone/PathwayGothicOne-Regular.ttf"]
+];
+patrickhand = mkFont "patrickhand" "ofl" [
+  ["Dxc7Pmy20a8lur9/AFfFrE7hH5mSsEabuBfpZ+9K0Pw=" "ofl/patrickhand/PatrickHand-Regular.ttf"]
+];
+patrickhandsc = mkFont "patrickhandsc" "ofl" [
+  ["g+/4jPo8TlAeJfM0wKGojrTUrx6p1MMpAO3y+xeCRNw=" "ofl/patrickhandsc/PatrickHandSC-Regular.ttf"]
+];
+pattaya = mkFont "pattaya" "ofl" [
+  ["Ard/f1tS5xipEjDI6hU7/nRuHXSNq97U5B1+Z2X6mIk=" "ofl/pattaya/Pattaya-Regular.ttf"]
+];
+patuaone = mkFont "patuaone" "ofl" [
+  ["o/qoue/dnYmYC1b6KwgGadZvP5d/B6KmKVSY2+fCanw=" "ofl/patuaone/PatuaOne-Regular.ttf"]
+];
+pavanam = mkFont "pavanam" "ofl" [
+  ["0oBb/cpX99egxp7fNaX5jUYFr2YD3MqUPbXRHqUxwvM=" "ofl/pavanam/Pavanam-Regular.ttf"]
+];
+paytoneone = mkFont "paytoneone" "ofl" [
+  ["HAcHOwtXgZm1THhm1V4rYx0oXoqku0+8CICdmAzUmxQ=" "ofl/paytoneone/PaytoneOne-Regular.ttf"]
+];
+pecita = mkFont "pecita" "ofl" [
+  ["MzBrPlqvRkSNsMK6E+JBtoNJjJgYwUaATB//oSGVFqI=" "ofl/pecita/Pecita.ttf"]
+];
+peddana = mkFont "peddana" "ofl" [
+  ["GsouUNOo3UMlC/lCBJrhi4/aVC8EaUNOs1yKU7EVeDY=" "ofl/peddana/Peddana-Regular.ttf"]
+];
+peralta = mkFont "peralta" "ofl" [
+  ["K71Itk/0nKGRSLvD1thZXwJi2M85gJ9ENSh1QpXFbCs=" "ofl/peralta/Peralta-Regular.ttf"]
+];
+permanentmarker = mkFont "permanentmarker" "asl20" [
+  ["KPgsinlDy46dWZ+FVNodT8ddvPabmIWtbAYR0gxpRsU=" "apache/permanentmarker/PermanentMarker-Regular.ttf"]
+];
+petemoss = mkFont "petemoss" "ofl" [
+  ["wVMVu6OMG0/cxqrdpbt67LnTQRIbvA6i4j8Fv2+2FMQ=" "ofl/petemoss/Petemoss-Regular.ttf"]
+];
+petitformalscript = mkFont "petitformalscript" "ofl" [
+  ["m4CgUXC6x/Nyt+ALx2L+FLr9Sr3rATdHsYn2ZSXP/ok=" "ofl/petitformalscript/PetitFormalScript-Regular.ttf"]
+];
+petrona = mkFont "petrona" "ofl" [
+  ["9K1ZkJPSmmaOL5ReAntHuu6EdmR9kryMI6ibD4bAgHg=" "ofl/petrona/Petrona-Italic%5Bwght%5D.ttf"]
+  ["Dt53+/cmVBz5Ps57chp7Bp8ATLQTqyBfdJY1YAFasHU=" "ofl/petrona/Petrona%5Bwght%5D.ttf"]
+];
+phetsarath = mkFont "phetsarath" "ofl" [
+  ["DQMowgNjGaBq5OAJPR6jK22EkGn2JM9t1n4fbrxGNag=" "ofl/phetsarath/Phetsarath-Regular.ttf"]
+  ["O4zO1lqbSknaSHxKu2w2ydr7LBHjx1oWt9oyoovC7Ks=" "ofl/phetsarath/Phetsarath-Bold.ttf"]
+];
+philosopher = mkFont "philosopher" "ofl" [
+  ["5bYLNEjA5X3JbiW0HoYKvigKZief+2QgSAQRIYVrCXQ=" "ofl/philosopher/Philosopher-Regular.ttf"]
+  ["hw3TKu8RW7S5jSMjdlJAKVSQ94Kpg1bT8dFEzP+urBY=" "ofl/philosopher/Philosopher-Italic.ttf"]
+  ["ueOPfEJP8SfoKY7rkCt7GsBpqtm0S21G9iNbDq6EtPk=" "ofl/philosopher/Philosopher-BoldItalic.ttf"]
+  ["5GZn1++UTZ0KlMVqrkTZPAHKCUn3w0eRYHIImyRCAYI=" "ofl/philosopher/Philosopher-Bold.ttf"]
+];
+phudu = mkFont "phudu" "ofl" [
+  ["Vt+xL197aoUfNjjPl113M/vKugqPgYZVE/Alcw41NqA=" "ofl/phudu/Phudu%5Bwght%5D.ttf"]
+];
+piazzolla = mkFont "piazzolla" "ofl" [
+  ["/+s40MmzMvbvaFNSv7rl5ld1zNwq4UL0msjtLX0hUmg=" "ofl/piazzolla/Piazzolla-Italic%5Bopsz,wght%5D.ttf"]
+  ["trZFHaupOktx+Iyo43pmw/0rTlfsVKQHzd9q5ltix7c=" "ofl/piazzolla/Piazzolla%5Bopsz,wght%5D.ttf"]
+];
+piedra = mkFont "piedra" "ofl" [
+  ["Lp0A+U09ePOGGCUNA9PovMylQclW1eCkN8YtcI72wdo=" "ofl/piedra/Piedra-Regular.ttf"]
+];
+pinyonscript = mkFont "pinyonscript" "ofl" [
+  ["qoUMH8wyeXxa3B+1w5w4oz3J6fOsCrryjBr1653PKgA=" "ofl/pinyonscript/PinyonScript-Regular.ttf"]
+];
+pirataone = mkFont "pirataone" "ofl" [
+  ["U0ei4VVYns9mfUt2ZhPI7gA+3en4Nxf9JMCVmaSx7MA=" "ofl/pirataone/PirataOne-Regular.ttf"]
+];
+plaster = mkFont "plaster" "ofl" [
+  ["+LLX0dVqvU8grpYrnwVZ6QcqCSa1lj2e7QQJKcoH3C0=" "ofl/plaster/Plaster-Regular.ttf"]
+];
+playball = mkFont "playball" "ofl" [
+  ["EwZU3RkvTM0cT6LcUW0DzKk9yOza8w1FgoPlTcrvj0A=" "ofl/playball/Playball-Regular.ttf"]
+];
+playfairdisplay = mkFont "playfairdisplay" "ofl" [
+  ["peJtxeLnf7KAOgvwL9T4HuE27I3qhjzNsMWaJjshN4s=" "ofl/playfairdisplay/PlayfairDisplay-Italic%5Bwght%5D.ttf"]
+  ["xA8ik3ZqUDvHDM6eUS74RKTMt8vN55L+LqMdGRkX2NY=" "ofl/playfairdisplay/PlayfairDisplay%5Bwght%5D.ttf"]
+];
+playfairdisplaysc = mkFont "playfairdisplaysc" "ofl" [
+  ["nZx4CA3bUdsmkFa9DYThEAfm9uGYDsFedXFYr7tvOtQ=" "ofl/playfairdisplaysc/PlayfairDisplaySC-Italic.ttf"]
+  ["tYqWjPybTpbmhXogbhsELcP9vl3DHNdYJdhk+ArH6RU=" "ofl/playfairdisplaysc/PlayfairDisplaySC-Bold.ttf"]
+  ["a+ppu9u8k63dmb0SR2Ph/IoxydclE+LSIIfQRnbhVG8=" "ofl/playfairdisplaysc/PlayfairDisplaySC-BlackItalic.ttf"]
+  ["P+jdp8sU7O1s1W/i636ui+5dcMqjAedaI/HOGfprgss=" "ofl/playfairdisplaysc/PlayfairDisplaySC-BoldItalic.ttf"]
+  ["Vd8J8KSZBaD15HhZe1s/x4rPBRLOtWhQTzzcRllmLkc=" "ofl/playfairdisplaysc/PlayfairDisplaySC-Regular.ttf"]
+  ["mlCCKUAeKl3rUv+cEfAERqSCvSUCmDalQCdxYxDP4LA=" "ofl/playfairdisplaysc/PlayfairDisplaySC-Black.ttf"]
+];
+play = mkFont "play" "ofl" [
+  ["7tDaeQBcqzXW7Q6sq1lO1nzGQ74LJjL6nkQLO8UHjcQ=" "ofl/play/Play-Regular.ttf"]
+  ["RcVy7M2kzzNRZbdQNFJY51MDW/SO4v3zf6oHx9uIvOA=" "ofl/play/Play-Bold.ttf"]
+];
+plusjakartasans = mkFont "plusjakartasans" "ofl" [
+  ["kX7lqBznYtB1bAVBsWnP1ZIVT3GNtz5cFnlF+wRnDyk=" "ofl/plusjakartasans/PlusJakartaSans%5Bwght%5D.ttf"]
+  ["QixZP9Dia/euz5ttOZbnZGeJQknNycL0upRTscSdjwM=" "ofl/plusjakartasans/PlusJakartaSans-Italic%5Bwght%5D.ttf"]
+];
+podkova = mkFont "podkova" "ofl" [
+  ["p75nMqSJscXHw3pcLoFvrZAVY8zYgum7xW0T7uv0pOc=" "ofl/podkova/Podkova%5Bwght%5D.ttf"]
+];
+podkovavfbeta = mkFont "podkovavfbeta" "ofl" [
+  ["yB+GByxuJDbZ5iZIF3thGVCrkHcQI2Rwm28csiOK+GM=" "ofl/podkovavfbeta/PodkovaVFBeta.ttf"]
+];
+poetsenone = mkFont "poetsenone" "ofl" [
+  ["YZQ4IVNPO6Q4pQ6Exu/pAgerwDJi+uBLUuTR3+o+qyY=" "ofl/poetsenone/PoetsenOne-Regular.ttf"]
+];
+poiretone = mkFont "poiretone" "ofl" [
+  ["RX8tAyY/WOWm28wbYHsQ3/ZYHnz5xOvfMw7D5ncqNVg=" "ofl/poiretone/PoiretOne-Regular.ttf"]
+];
+pollerone = mkFont "pollerone" "ofl" [
+  ["ScUSjLVQFW6ThEU5BrhpuDCq+s/DqTMsz5icjtFG13M=" "ofl/pollerone/PollerOne.ttf"]
+];
+poly = mkFont "poly" "ofl" [
+  ["HhqNeZHV9PIiaMln/m5/TeLgBsenDC2dP71DtVY+kYE=" "ofl/poly/Poly-Regular.ttf"]
+  ["yD6J1G2Y3asa14l9826T9IiezONYvQsZd6cKEcUwOCM=" "ofl/poly/Poly-Italic.ttf"]
+];
+pompiere = mkFont "pompiere" "ofl" [
+  ["EWEL3jdJcKbKARNv2+qCD3lfzq6MOZxmTmnxJ3wbxSM=" "ofl/pompiere/Pompiere-Regular.ttf"]
+];
+ponnala = mkFont "ponnala" "ofl" [
+  ["f+vE9/OG6P5EhadXnrra+4xdXusFZgvzXtoz0R8u2B4=" "ofl/ponnala/Ponnala-Regular.ttf"]
+];
+pontanosans = mkFont "pontanosans" "ofl" [
+  ["2C2rMxgXbWlnB932aHu1yn6XArVCns0vMECHxvvT+bQ=" "ofl/pontanosans/PontanoSans-Regular.ttf"]
+];
+poorstory = mkFont "poorstory" "ofl" [
+  ["gxq4f3tUY/nNg6wkm/OGgW86R48dImQnyIyskHrbfuI=" "ofl/poorstory/PoorStory-Regular.ttf"]
+];
+poppins = mkFont "poppins" "ofl" [
+  ["FrsRiqIyyaE/ojgCfSTXhU3RodnLr5mxf+xDiNVrQyw=" "ofl/poppins/Poppins-SemiBoldItalic.ttf"]
+  ["kDc+fYONMkaEOPw+FS3KC9sS7cq5nqY58Vh5Cxuh/QU=" "ofl/poppins/Poppins-Medium.ttf"]
+  ["078b2vBVDoPamsCx0dn+bbCGg1qDqihXjmCaOUuaAoY=" "ofl/poppins/Poppins-SemiBold.ttf"]
+  ["ZQulf6mdEuxAwxzPtoC+ZWvkSX++FBZGF9Z+Mv/pzUY=" "ofl/poppins/Poppins-Light.ttf"]
+  ["2Cqq+YqSg/mo7dJOURczN9jq8J4lzT2Ygx+OyEYXSKE=" "ofl/poppins/Poppins-Black.ttf"]
+  ["T6dq51tA+SZCBRQERyLLl/Mhhsr9OzgmPMNNrXF01G0=" "ofl/poppins/Poppins-Italic.ttf"]
+  ["uPnFvllyP6345UR/oSRcLFO2CjRkok1uzp7jwoPYkXs=" "ofl/poppins/Poppins-LightItalic.ttf"]
+  ["bY5dnSkUDMk+MhdF+hJDxniJ5rw2Oew022Tz2npJY1I=" "ofl/poppins/Poppins-Thin.ttf"]
+  ["cXGhfkzaj23teKepMfm384mHBX8//R/genFSitDwHkk=" "ofl/poppins/Poppins-ExtraLightItalic.ttf"]
+  ["9IUsqJwp9p2ADhTwl+1NHwoMxFTp931zv9bbH3HCh6A=" "ofl/poppins/Poppins-BlackItalic.ttf"]
+  ["3ACi65iDc+n06Zv4/3bGMV7iHTazQcu/8CTkwYzHrAM=" "ofl/poppins/Poppins-ExtraBoldItalic.ttf"]
+  ["NXKsgRagrHMX00ImKymTe8uvlNjwP5Dfb+Zm+n4vtDo=" "ofl/poppins/Poppins-BoldItalic.ttf"]
+  ["dlrd9sfBHsPFQyXKzWjKvQXfjktkVTAtgSqbm6/RxhQ=" "ofl/poppins/Poppins-MediumItalic.ttf"]
+  ["Rt+ArJcPXoSCm4aNKDh4tNl+KJx7EkVUHYu/ZrXWcKg=" "ofl/poppins/Poppins-ThinItalic.ttf"]
+  ["mDZ2UWFndIt03m9Hcfs4TGZP2ROsuLRxEi7Kz12l6mw=" "ofl/poppins/Poppins-Bold.ttf"]
+  ["fmUgHpt5FZ4jACZ8yIXhbI3O8kJM36CaKb+wmAqUp7o=" "ofl/poppins/Poppins-Regular.ttf"]
+  ["8qsXwaY6DswSwkYYSPyKRpOV480tZBgD6InGQ9n5WOE=" "ofl/poppins/Poppins-ExtraBold.ttf"]
+  ["VcAzFMx1Tib3Qfl4kOXpy+OzJ4/jq87P7K/WARGyZD0=" "ofl/poppins/Poppins-ExtraLight.ttf"]
+];
+portersansblock = mkFont "portersansblock" "ofl" [
+  ["dglD0bCJ83yNB58+A0fisIWMhZiJTywEt9xSy9KrTf0=" "ofl/portersansblock/PorterSansBlock-Regular.ttf"]
+];
+portlligatsans = mkFont "portlligatsans" "ofl" [
+  ["iTdMdbi4bDY0q7A3mXSDcIYRzdJfqj2pVku2ip4WJ1c=" "ofl/portlligatsans/PortLligatSans-Regular.ttf"]
+];
+portlligatslab = mkFont "portlligatslab" "ofl" [
+  ["cO2wLXw4zeCbN5+RATIvuTGJo1J2556xXCQHgL07Svc=" "ofl/portlligatslab/PortLligatSlab-Regular.ttf"]
+];
+postnobillscolombo = mkFont "postnobillscolombo" "ofl" [
+  ["AQnIRn0bfb7D/YwGdA6CBE/Z9QCEl0nEizUn9iIGoXw=" "ofl/postnobillscolombo/PostNoBillsColombo-Light.ttf"]
+  ["BJNMOMM/K2VpEgv4GsHcaXhjBf5yeaOQzJuT8IVvY0A=" "ofl/postnobillscolombo/PostNoBillsColombo-Medium.ttf"]
+  ["LZFFKsVij0N6skmsYccQvErcfz2nXouHVb69f1vNb9U=" "ofl/postnobillscolombo/PostNoBillsColombo-ExtraBold.ttf"]
+  ["+5loYPI1HN63q2bzHN5aeSnoXLjQcLf8BGKqaKswlCo=" "ofl/postnobillscolombo/PostNoBillsColombo-Regular.ttf"]
+  ["N9U7GgVrCwlsxa1d4kKr06LifcFL6liz1DLbcmcT/7c=" "ofl/postnobillscolombo/PostNoBillsColombo-SemiBold.ttf"]
+  ["vsooa92yijh9LFQEVXS96L191J6xqyQr4t8uMk+G2ek=" "ofl/postnobillscolombo/PostNoBillsColombo-Bold.ttf"]
+];
+postnobillsjaffna = mkFont "postnobillsjaffna" "ofl" [
+  ["KBm3G0tao8zv5CQc2srHwuPHhRQjzJRrMAY2LmjK5UA=" "ofl/postnobillsjaffna/PostNoBillsJaffna-Regular.ttf"]
+  ["5o2qESjYGs468LcFOQ1cb16vYMqAUnRY9v8pdHclO68=" "ofl/postnobillsjaffna/PostNoBillsJaffna-SemiBold.ttf"]
+  ["Z816jbKyg9xrp7NHGldXXOaiyewsBNKRJ9H8wWXOmAQ=" "ofl/postnobillsjaffna/PostNoBillsJaffna-Medium.ttf"]
+  ["mQhvkAssURVhaq8+9eDGoMKDznDNhxMiigw9hFNBUn0=" "ofl/postnobillsjaffna/PostNoBillsJaffna-Bold.ttf"]
+  ["EsUUW+6a/PFEi2eHuOmwsrLJg5wFEIR/nnbynKS8EDw=" "ofl/postnobillsjaffna/PostNoBillsJaffna-Light.ttf"]
+  ["nfUGggIb8QFPLCM+3LlksIC+H80qolcDNLk11kOsqag=" "ofl/postnobillsjaffna/PostNoBillsJaffna-ExtraBold.ttf"]
+];
+pottaone = mkFont "pottaone" "ofl" [
+  ["vehDhotW5CnhyGPaLvp231MxYrIm2ZDvy5bVM7DKKpM=" "ofl/pottaone/PottaOne-Regular.ttf"]
+];
+pragatinarrow = mkFont "pragatinarrow" "ofl" [
+  ["jhUckwcZTm/daVA5mfIVDgZtxenNsqlmyGHsUyhvyGM=" "ofl/pragatinarrow/PragatiNarrow-Bold.ttf"]
+  ["wA0ojMebzjhOhRYaJWVw0ni/JVmPgJyXGKT1lCFRapQ=" "ofl/pragatinarrow/PragatiNarrow-Regular.ttf"]
+];
+praise = mkFont "praise" "ofl" [
+  ["H56IAxY4x/PCOPW0Sp10UEGxYgIIp37L77YrELD/shQ=" "ofl/praise/Praise-Regular.ttf"]
+];
+prata = mkFont "prata" "ofl" [
+  ["OyuIBze+O9pfA1VCl7dYUWh2FXyI+eOzuuj6H8lqLCw=" "ofl/prata/Prata-Regular.ttf"]
+];
+preahvihear = mkFont "preahvihear" "ofl" [
+  ["6jBr6OKGvDvXW5y0l8qji9zQbo1lQaU+Lhp38W1+1SI=" "ofl/preahvihear/Preahvihear-Regular.ttf"]
+];
+pressstart2p = mkFont "pressstart2p" "ofl" [
+  ["A0x38fBeyJQh5KY/DjpMoez4UsxtK/YR8SbydXKOAX0=" "ofl/pressstart2p/PressStart2P-Regular.ttf"]
+];
+pridi = mkFont "pridi" "ofl" [
+  ["EvLtnNJYtYUIO+Gm+qSQxuQZF9laT74EX9tDgZ7tipw=" "ofl/pridi/Pridi-ExtraLight.ttf"]
+  ["04ym3ZH47eUct5PcBcVsI4GkkzqISd3AkoHstQlDKUs=" "ofl/pridi/Pridi-Medium.ttf"]
+  ["zFouqWYNePxkyQnClYKri9cZUSj4G+2CXXzumFNppNo=" "ofl/pridi/Pridi-Regular.ttf"]
+  ["PzKM/frOQgAyAt820nWw00mMdITdOErdP7sGbFgp2rA=" "ofl/pridi/Pridi-Light.ttf"]
+  ["r7meiRqyraUHKUAZN2a/+1OoNvfnXNjshSE6Ye3eTOQ=" "ofl/pridi/Pridi-SemiBold.ttf"]
+  ["ftFvlGKQxZ8zbBywMagKX9SuYObCYb/6ngbJLfaGX/Q=" "ofl/pridi/Pridi-Bold.ttf"]
+];
+princesssofia = mkFont "princesssofia" "ofl" [
+  ["K13zCnuGbNdkzE/1htyMKOFpZwmdUKtYLwA/+8cijuU=" "ofl/princesssofia/PrincessSofia-Regular.ttf"]
+];
+prociono = mkFont "prociono" "ofl" [
+  ["z8ZBEX/nSNmVjZiRcCaS2mG/hpF95QOaCzHTD3jOQno=" "ofl/prociono/Prociono-Regular.ttf"]
+];
+prompt = mkFont "prompt" "ofl" [
+  ["4s9Bbutc0fL1fdqrewW52ugReKrI9Dv4p3Jj9SF6EEw=" "ofl/prompt/Prompt-MediumItalic.ttf"]
+  ["VJL0jHRqb3Ja0hp4e7SexOlI2+16P6HjV7Dvwe742IE=" "ofl/prompt/Prompt-ExtraLight.ttf"]
+  ["8Bg4xDP2CBPfvc1/LJNRaQESmPDWIcMYyo41LXdsg1Q=" "ofl/prompt/Prompt-SemiBoldItalic.ttf"]
+  ["eUEs9e9/YNfx3/TheHB7C8Zi3XZghpeno2tHaUVPi4I=" "ofl/prompt/Prompt-Light.ttf"]
+  ["T7tj+Qzp6kIURhlCtSGxP20vcZSmfehINj2CnD/fPmY=" "ofl/prompt/Prompt-Black.ttf"]
+  ["sbJyFe+mpFHCoVScXeTJa7OJz4noaSGz7kiN22cC4Jo=" "ofl/prompt/Prompt-BlackItalic.ttf"]
+  ["GSNsHjiTh5nDJs63itVXErbxO8ys3QVhKSqDaIA/A7E=" "ofl/prompt/Prompt-ExtraLightItalic.ttf"]
+  ["o4nwd7FbPq5mgdSCTuBLwIHb4OvcwWCrZaMoIXFgix4=" "ofl/prompt/Prompt-Thin.ttf"]
+  ["akJFG+aS66Rzxjn0vNxsbZFgo9YyMZpkKH4+0frhXWs=" "ofl/prompt/Prompt-Medium.ttf"]
+  ["29SXgDzsPK/7xrf1mcpv7YvuoO1+CtHgmBMMXrvE/UI=" "ofl/prompt/Prompt-Regular.ttf"]
+  ["wRiBdt5J43aZDf+CnBvA1oaxfflt1GX56TaMyy8og80=" "ofl/prompt/Prompt-Italic.ttf"]
+  ["0cJgaM0SkdI4wEoGThac6GcxWqsla/e9Esvglpuzazo=" "ofl/prompt/Prompt-BoldItalic.ttf"]
+  ["MoXJ5qTrxICmR2oaJrRNbrD5h0Al+pbkKv1SFyt/Ark=" "ofl/prompt/Prompt-SemiBold.ttf"]
+  ["8Z6+p0CUDWxusIDV7eHHjl5ovVsfqjTvusJRu4R0AQA=" "ofl/prompt/Prompt-ExtraBold.ttf"]
+  ["XDwopyEEMP9Fcnm0y1fQ1ETQ0LIdVGXlVuagaKnYYws=" "ofl/prompt/Prompt-ThinItalic.ttf"]
+  ["I1YKuOkIwQQb76CsaHP7qnEN5tCuIbxgxbL97dg+64Y=" "ofl/prompt/Prompt-ExtraBoldItalic.ttf"]
+  ["WKZObS06Ljfw9Ij2iZX0WKXitsFfoLLNB+Wzj7YT9F8=" "ofl/prompt/Prompt-LightItalic.ttf"]
+  ["AoE8pPk8HfJ+Jx8Q/vPbbjTmZ1GuH0o+2CrgbLIBUOo=" "ofl/prompt/Prompt-Bold.ttf"]
+];
+prostoone = mkFont "prostoone" "ofl" [
+  ["dFl0pMQEzB/WRtQTSUDtNZZX1sKGNLVE+cvA+DB5HqY=" "ofl/prostoone/ProstoOne-Regular.ttf"]
+];
+prozalibre = mkFont "prozalibre" "ofl" [
+  ["CoUI8L0U3A1azNPwaHNWD7vvwWlWwTVSCVLeGvDf4WI=" "ofl/prozalibre/ProzaLibre-Regular.ttf"]
+  ["pQgVTBqiLf/8UbIahWioUJ7dtTI2jann364qhdQfjss=" "ofl/prozalibre/ProzaLibre-BoldItalic.ttf"]
+  ["DUDJGhy1Dm7aiFAiXWiNF4QJpee/r2TP/rdnOMNKaMo=" "ofl/prozalibre/ProzaLibre-ExtraBoldItalic.ttf"]
+  ["sh0vdWmS1uPgSft5ydiJrGcOl1rRYT/hzqKtkdhWVY0=" "ofl/prozalibre/ProzaLibre-Italic.ttf"]
+  ["FV8TXaSFmSL4QGIMKZg32IrNbGJzICsbCODbujqIONE=" "ofl/prozalibre/ProzaLibre-Bold.ttf"]
+  ["PZPksrpsxfvvi+09eGW0IVNJRxDeuwWYJE7v+5gmVIQ=" "ofl/prozalibre/ProzaLibre-Medium.ttf"]
+  ["e4hDL87/PJSDH8YgVLvEL0rmTeDZbdjrnAIpdfF1tYw=" "ofl/prozalibre/ProzaLibre-ExtraBold.ttf"]
+  ["RSxb80L5cswx7ZeFbNHW3nkmr3yNwApHvRakuFD6YHk=" "ofl/prozalibre/ProzaLibre-SemiBoldItalic.ttf"]
+  ["URqDwAsFcUs/aTp50glxWL11I0u690tIi72RClqhunI=" "ofl/prozalibre/ProzaLibre-MediumItalic.ttf"]
+  ["LlC8DnLYtfZRfxGzvNNaA/ThyLRSs7tkl+vJjy1rtN0=" "ofl/prozalibre/ProzaLibre-SemiBold.ttf"]
+];
+ptmono = mkFont "ptmono" "ofl" [
+  ["y+cys7j9IR/Zhuvfybhw3eyk+qsLtUJfxQmzf5tKyAQ=" "ofl/ptmono/PTM55FT.ttf"]
+];
+ptsanscaption = mkFont "ptsanscaption" "ofl" [
+  ["kddj3Z6ChJOL6BS3aRmwvZdRDsNCQ05+x6Vvn8WLNsQ=" "ofl/ptsanscaption/PT_Sans-Caption-Web-Regular.ttf"]
+  ["9JMJwgTMYoKDG1RdaPuMWMXpiJ6T3S/EX8X73eFki9U=" "ofl/ptsanscaption/PT_Sans-Caption-Web-Bold.ttf"]
+];
+ptsansnarrow = mkFont "ptsansnarrow" "ofl" [
+  ["5p2DvPW9ZHiStOKyL1CY2r1VyYlBNRMZdyL8FW+58A4=" "ofl/ptsansnarrow/PT_Sans-Narrow-Web-Bold.ttf"]
+  ["QQLt2gMFkWN3GGnSWN9UrIVjxAj6bp73Wy3cheq+pvQ=" "ofl/ptsansnarrow/PT_Sans-Narrow-Web-Regular.ttf"]
+];
+ptsans = mkFont "ptsans" "ofl" [
+  ["MSi9Xs8BgW5Zoj1UxXp6axRhWwfbU/8nfHc3YBAmWwU=" "ofl/ptsans/PT_Sans-Web-Bold.ttf"]
+  ["gawiHN0CvM+mecdK2xIkeOnQkuZaci4xyhFGmWFIN4U=" "ofl/ptsans/PT_Sans-Web-BoldItalic.ttf"]
+  ["nMgxSQUyAJuuKzzg05xirfyIkGC+tCFZO/2dI5bQ8Qo=" "ofl/ptsans/PT_Sans-Web-Regular.ttf"]
+  ["WpD+LQzXmHAJNSQFgL3MEsD/yRAsDHFjs0GOE7wh3r0=" "ofl/ptsans/PT_Sans-Web-Italic.ttf"]
+];
+ptserifcaption = mkFont "ptserifcaption" "ofl" [
+  ["r+aSM0mGdsQYODud79qKrOQH7KDob0SZ2bpOn0lPnaU=" "ofl/ptserifcaption/PT_Serif-Caption-Web-Italic.ttf"]
+  ["0X1H9E6EDu4Bf4ObJ9/zyUx6/ndD7/MI1L0R9wGLaa8=" "ofl/ptserifcaption/PT_Serif-Caption-Web-Regular.ttf"]
+];
+ptserif = mkFont "ptserif" "ofl" [
+  ["pJUfreBv+PCbdnOqgf+2WozUCeJNMomm3GcLxN2iVXo=" "ofl/ptserif/PT_Serif-Web-Regular.ttf"]
+  ["9X6V/53IVpGjsuGT8gKNs29mY5OaRsD8TyhtYYuAt84=" "ofl/ptserif/PT_Serif-Web-Italic.ttf"]
+  ["A4unM2vX6hTxKtFVvtUaQ0XKxRUyddUh3sO6BAIcUm4=" "ofl/ptserif/PT_Serif-Web-Bold.ttf"]
+  ["8AN4i6CJgesJiLNVem8iSlPatJwg4oPot01a88Rm+L4=" "ofl/ptserif/PT_Serif-Web-BoldItalic.ttf"]
+];
+publicsans = mkFont "publicsans" "ofl" [
+  ["bOKSsFqoxmvGRL7f+DS00N3umvdcVfmNyyj6oyqBBW8=" "ofl/publicsans/PublicSans-Italic%5Bwght%5D.ttf"]
+  ["11p9waJ+ueM21bM/VUidLstWIb9pTVxDskFbziyoMKg=" "ofl/publicsans/PublicSans%5Bwght%5D.ttf"]
+];
+puppiesplay = mkFont "puppiesplay" "ofl" [
+  ["EE/SDdxPePJW3V46d9LP2w71sm5GdAQ3f3vQr6u7JMA=" "ofl/puppiesplay/PuppiesPlay-Regular.ttf"]
+];
+puritan = mkFont "puritan" "ofl" [
+  ["ZObRNYLBvC3KtF8ve+RjYqEdEI2oS0SA4DOe+ck0htE=" "ofl/puritan/Puritan-Bold.ttf"]
+  ["LLjj0psI8hppOs4rpD3q8DD5GRIF4Gep+CU110LBj54=" "ofl/puritan/Puritan-Italic.ttf"]
+  ["wbsjOTpLR87ikNSzcdwq2BLiyAZ2e619LdLwjG2fde0=" "ofl/puritan/Puritan-Regular.ttf"]
+  ["EhcA4akqMHtKrx6Qi9cTzJr+lQDTO120+B0NE98fZLQ=" "ofl/puritan/Puritan-BoldItalic.ttf"]
+];
+purplepurse = mkFont "purplepurse" "ofl" [
+  ["nF1yifIr2x7yCuDEf7iWwA+LNbv54RStb9JShIU4Des=" "ofl/purplepurse/PurplePurse-Regular.ttf"]
+];
+pushster = mkFont "pushster" "ofl" [
+  ["1laOaX/VDO3AvgTYquQSf+la3WB+e/+VTKiGBL6AwgU=" "ofl/pushster/Pushster-Regular.ttf"]
+];
+qahiri = mkFont "qahiri" "ofl" [
+  ["aOMaJFqGE9i0nVX3zv/diLJvKrrOKp3QlKB2149TogM=" "ofl/qahiri/Qahiri-Regular.ttf"]
+];
+quando = mkFont "quando" "ofl" [
+  ["HGurG0s78xowXThmw4JuBCN+janZrPqE9JqxODlOiQk=" "ofl/quando/Quando-Regular.ttf"]
+];
+quantico = mkFont "quantico" "ofl" [
+  ["5HYfwE1FrIHLF8wSzCMa9mbTm3OduhwcvOraOt6L4AE=" "ofl/quantico/Quantico-Italic.ttf"]
+  ["46iKGMhb+owIV3q7B+PUkOkmT8CcPGkMbeOCyGKJAf8=" "ofl/quantico/Quantico-Bold.ttf"]
+  ["fyffsGWJFKxXC/HaNqJSfxDu/UHSWo+WA9UpV9YcB10=" "ofl/quantico/Quantico-Regular.ttf"]
+  ["iKRMvFvWQPSUCjxCsS1CxgIOvPcRl4dbj1U4lMpOIJw=" "ofl/quantico/Quantico-BoldItalic.ttf"]
+];
+quattrocento = mkFont "quattrocento" "ofl" [
+  ["V9yNr/kSG+guVM8SIWWLe6TxgBISgXrq0tGEpWYPvLk=" "ofl/quattrocento/Quattrocento-Regular.ttf"]
+  ["WUXee21sfJ/vu2e8NOxg9kp90b1kX7J3HsdyjAq2fJ0=" "ofl/quattrocento/Quattrocento-Bold.ttf"]
+];
+quattrocentosans = mkFont "quattrocentosans" "ofl" [
+  ["juVcSpmMB5784NuWowUgoSHSu5D+Vo9qnlzvVMyCrVk=" "ofl/quattrocentosans/QuattrocentoSans-Regular.ttf"]
+  ["QQfyrV1Jk+dk3zNt+daRnOXPNgDF/ERIjh1yQRb5kRQ=" "ofl/quattrocentosans/QuattrocentoSans-Italic.ttf"]
+  ["PF/L+gEIxrjV8YL7unmNg49r5CwMprSzRi6IonVoLrU=" "ofl/quattrocentosans/QuattrocentoSans-Bold.ttf"]
+  ["+WQY7/Mcwz4caOaBA8EDEABygNwGtzTL+TZYTVMuwp4=" "ofl/quattrocentosans/QuattrocentoSans-BoldItalic.ttf"]
+];
+questrial = mkFont "questrial" "ofl" [
+  ["Dufy3rq7E3c/04Rosxgg4R/KICqPmMTYC2/8t5aJm28=" "ofl/questrial/Questrial-Regular.ttf"]
+];
+quicksand = mkFont "quicksand" "ofl" [
+  ["Ocm2QiNWH1aq/2BipvBAY8T8hoCa1naHIsBmFNl34cw=" "ofl/quicksand/Quicksand%5Bwght%5D.ttf"]
+];
+quintessential = mkFont "quintessential" "ofl" [
+  ["c9GS8Q2/xxYhSq4oKvuTA28SQV0WrcnW0OmB802CnTI=" "ofl/quintessential/Quintessential-Regular.ttf"]
+];
+qwigley = mkFont "qwigley" "ofl" [
+  ["agGNhy+orWE6caSDg7Pw+Yeg580wVnjKOnyHZI5s27I=" "ofl/qwigley/Qwigley-Regular.ttf"]
+];
+qwitchergrypen = mkFont "qwitchergrypen" "ofl" [
+  ["VPh3qTjEXlX0Q0Sm/hQ/g/YM7bxlPcLjGGF6nfl+lk4=" "ofl/qwitchergrypen/QwitcherGrypen-Regular.ttf"]
+  ["pINUqkLcpt+vFnALRT0Dxz7zTmFosFwQDt17lX6zrdc=" "ofl/qwitchergrypen/QwitcherGrypen-Bold.ttf"]
+];
+racingsansone = mkFont "racingsansone" "ofl" [
+  ["i1ytqD4+RpL2JPG1g6Bps05FfgekIQzt27ETOzODZz4=" "ofl/racingsansone/RacingSansOne-Regular.ttf"]
+];
+radiocanada = mkFont "radiocanada" "ofl" [
+  ["1E2Qo+jQew+Vqp9KdCGJgQh4+sWivyjqQxb2MfHoxXI=" "ofl/radiocanada/RadioCanada%5Bwdth,wght%5D.ttf"]
+  ["Zg/1DnNwPkn6+hV3NIMr+jow0gm8ZKhe5lpNYbgXUw4=" "ofl/radiocanada/RadioCanada-Italic%5Bwdth,wght%5D.ttf"]
+];
+radley = mkFont "radley" "ofl" [
+  ["Mb4qC7ricurirhJeBZxn4ROZBiDaQZDPlm1+IYIVK88=" "ofl/radley/Radley-Italic.ttf"]
+  ["IgEskiT9Lm/oe76mVkgGOlpW38oXKC1lpMHbT9hj26c=" "ofl/radley/Radley-Regular.ttf"]
+];
+rajdhani = mkFont "rajdhani" "ofl" [
+  ["lLvSWhjKZlmZ/rBaU33p/SuGDc+3i76coAJwglvyNdo=" "ofl/rajdhani/Rajdhani-SemiBold.ttf"]
+  ["bh/CKKgxglGm5WlQLsV7rB5GVsWC+S9ZzOzEaI4Dm5g=" "ofl/rajdhani/Rajdhani-Regular.ttf"]
+  ["aRRw3TKGoU6Wd5QNC/dXlheYQbpSFcvaGiyJEKMiav0=" "ofl/rajdhani/Rajdhani-Bold.ttf"]
+  ["FA6fE69pU4FhxXgPz3+BWUwGmuqIfnv/1BeuHGQSE8M=" "ofl/rajdhani/Rajdhani-Light.ttf"]
+  ["Ev99z+TCBuOHWsU7F2LqtX3movp/WobCa5e4jWWR6sI=" "ofl/rajdhani/Rajdhani-Medium.ttf"]
+];
+rakkas = mkFont "rakkas" "ofl" [
+  ["VCeIguR3TBTVDDtVXxJ9D+WGNm1beHMW67y9gQiCnmA=" "ofl/rakkas/Rakkas-Regular.ttf"]
+];
+ralewaydots = mkFont "ralewaydots" "ofl" [
+  ["o1WCwR4p1dQL9e0mP0vhjEImQ3a1G2uKeht5JSuFPgk=" "ofl/ralewaydots/RalewayDots-Regular.ttf"]
+];
+raleway = mkFont "raleway" "ofl" [
+  ["i7zD64J1w4j0vNmYgy+KS5Q+rbr2pZUgUxJ3S1lRrvs=" "ofl/raleway/Raleway%5Bwght%5D.ttf"]
+  ["lmKcryICGD+rRscCNwVafWfmpUALhUE9Rad+1vKgdww=" "ofl/raleway/Raleway-Italic%5Bwght%5D.ttf"]
+];
+ramabhadra = mkFont "ramabhadra" "ofl" [
+  ["aMV3ic3zWNcPp/H7p/m5OglUEBgnjcL92Yq4LRSo/60=" "ofl/ramabhadra/Ramabhadra-Regular.ttf"]
+];
+ramaraja = mkFont "ramaraja" "ofl" [
+  ["lUDiptYRsPfghS1kISCRyteo8K8hKMvzke5mjFaZFI8=" "ofl/ramaraja/Ramaraja-Regular.ttf"]
+];
+rambla = mkFont "rambla" "ofl" [
+  ["ULabk4kh1BqGjoz7zHGkEeBMrxTtrWoVMiL8A9MW7Zc=" "ofl/rambla/Rambla-Regular.ttf"]
+  ["NZ4syOk1q5u9F3NMd0yghrjcejDznLVEBCnSmKRDkKY=" "ofl/rambla/Rambla-Italic.ttf"]
+  ["bNUaGYcuNzbJLg0N1I++8xTfIAtbFpt9V7n/3MRvkqM=" "ofl/rambla/Rambla-BoldItalic.ttf"]
+  ["DlrwnVz0x/BKla4DT+1FuNN9xafz9UkpYbtOyzoqo1k=" "ofl/rambla/Rambla-Bold.ttf"]
+];
+rammettoone = mkFont "rammettoone" "ofl" [
+  ["LkLAOy3wgjkuXf4/y3TSW2tBXu3IN5TWGpfkN3II250=" "ofl/rammettoone/RammettoOne-Regular.ttf"]
+];
+rampartone = mkFont "rampartone" "ofl" [
+  ["pMYO6DUXX6FH60g/rA3Y/5AHw3iE73evhrCoaPpVTUk=" "ofl/rampartone/RampartOne-Regular.ttf"]
+];
+ranchers = mkFont "ranchers" "ofl" [
+  ["GVaKuollZk0bxvWkjCTSacl1Ae7YevJrkS9CtubyKtw=" "ofl/ranchers/Ranchers-Regular.ttf"]
+];
+rancho = mkFont "rancho" "asl20" [
+  ["Gt1+4amKzo1oeTWyoXNeHFPvyKIQi3PIgo2y34ojEwY=" "apache/rancho/Rancho-Regular.ttf"]
+];
+ranga = mkFont "ranga" "ofl" [
+  ["5RpomONNEr2bkFcALmRfF20w9eghv6oczE5WKUr3CZo=" "ofl/ranga/Ranga-Regular.ttf"]
+  ["xcdjYo6AWirzyd62ir0LcCJ6mJEfe6VvT4wqPowoa5Y=" "ofl/ranga/Ranga-Bold.ttf"]
+];
+rasa = mkFont "rasa" "ofl" [
+  ["ENL3Wq97PyMslIw0WExJyvDN0XpMk+t6Wus0OO/ULhk=" "ofl/rasa/Rasa%5Bwght%5D.ttf"]
+  ["7Op3Pt0eh8MxCg+4EexhAq6nHaI1+TvCziUG6Bs8Iac=" "ofl/rasa/Rasa-Italic%5Bwght%5D.ttf"]
+];
+rationale = mkFont "rationale" "ofl" [
+  ["dE4WPHNKBr0g2jc30MxM643FqMCf39Tp/qy+3dIIHFw=" "ofl/rationale/Rationale-Regular.ttf"]
+];
+raviprakash = mkFont "raviprakash" "ofl" [
+  ["9Tm9smc7Phtponnadj0Xim5LTK/loSyFvg9eA7VH/LY=" "ofl/raviprakash/RaviPrakash-Regular.ttf"]
+];
+readexpro = mkFont "readexpro" "ofl" [
+  ["XswAPb2SLV4xmXnhykJUcG7d5iryhzUMpWUcmoDfSQk=" "ofl/readexpro/ReadexPro%5BHEXP,wght%5D.ttf"]
+];
+recursive = mkFont "recursive" "ofl" [
+  ["ZTIhykZ/RzL+aFasST9sQJ6fVqdnSr42sjZKzIl5b3w=" "ofl/recursive/Recursive%5BCASL,CRSV,MONO,slnt,wght%5D.ttf"]
+];
+redacted = mkFont "redacted" "ofl" [
+  ["ONjFKciplUJsjsddC51GUpblQVh2MtoDjkpdAwtNEGk=" "ofl/redacted/Redacted-Regular.ttf"]
+];
+redactedscript = mkFont "redactedscript" "ofl" [
+  ["X/Ede5UQqQy+4VJVZEV7aZGmXgpBPsxP293ml0Uv5mU=" "ofl/redactedscript/RedactedScript-Light.ttf"]
+  ["SK1qdr5vCUiTVBiY0cmgTj3r5IZFwxTPB63ZLAGeeYM=" "ofl/redactedscript/RedactedScript-Bold.ttf"]
+  ["HrqrlkKi9D+jP0SXYEaZAxQ/0dCLJDPrbBXihgLZNg0=" "ofl/redactedscript/RedactedScript-Regular.ttf"]
+];
+redhatdisplay = mkFont "redhatdisplay" "ofl" [
+  ["5+jjqVeeVh4n3Nmo3w6LfnmZmrEUUb/ZMw9tsX9R8jg=" "ofl/redhatdisplay/RedHatDisplay%5Bwght%5D.ttf"]
+  ["pyKGWFq2RJjppkekACg77zJwUAHEJDdpr2cc3FC1qrQ=" "ofl/redhatdisplay/RedHatDisplay-Italic%5Bwght%5D.ttf"]
+];
+redhatmono = mkFont "redhatmono" "ofl" [
+  ["tTTAIBYBp0YCru/WLea9GueDNVTy9NbO0+QMEAAof2E=" "ofl/redhatmono/RedHatMono%5Bwght%5D.ttf"]
+  ["Mbk2yTTP74nvd8XAD1c9udRi0FsrWTTObBz753L+96M=" "ofl/redhatmono/RedHatMono-Italic%5Bwght%5D.ttf"]
+];
+redhattext = mkFont "redhattext" "ofl" [
+  ["oKvdix2+2Cg5FzqB81veyyi5ISfkbM4sHjGsjC1rN5E=" "ofl/redhattext/RedHatText%5Bwght%5D.ttf"]
+  ["/MUJPN62seNXp8xtSvCvzHR8tE85h18BVLrDL7CSPHQ=" "ofl/redhattext/RedHatText-Italic%5Bwght%5D.ttf"]
+];
+redressed = mkFont "redressed" "asl20" [
+  ["5wY/Gr01wEitIsXlIjLZUD8xBjdvPefzgSXDpUO6ZZg=" "apache/redressed/Redressed-Regular.ttf"]
+];
+redrose = mkFont "redrose" "ofl" [
+  ["4oEaUhVkeogc+ehMAwzYHHtFKpnlZ2UvhTHod9euhto=" "ofl/redrose/RedRose%5Bwght%5D.ttf"]
+];
+reemkufifun = mkFont "reemkufifun" "ofl" [
+  ["/apeicv3nTGY1vGbUgJKUkGWPnZ/pyIbqD2hKuALqus=" "ofl/reemkufifun/ReemKufiFun%5Bwght%5D.ttf"]
+];
+reemkufiink = mkFont "reemkufiink" "ofl" [
+  ["ZDtROIo1k0eSuKyYA8tH7K98XFfNDzWJI0gQDVD43QE=" "ofl/reemkufiink/ReemKufiInk-Regular.ttf"]
+];
+reemkufi = mkFont "reemkufi" "ofl" [
+  ["369Q4Zy5+qKzXP8+iKq20o0KptApiz9d3DmLng6HMqs=" "ofl/reemkufi/ReemKufi%5Bwght%5D.ttf"]
+];
+reeniebeanie = mkFont "reeniebeanie" "ofl" [
+  ["DqYIqjJb+eEclZDMC2Pc980hXicHhPHrvm+tSSezH/g=" "ofl/reeniebeanie/ReenieBeanie.ttf"]
+];
+reggaeone = mkFont "reggaeone" "ofl" [
+  ["rr5iWYcy12A28w7BG7DsX2iTjjc6BtG0zra5zxq/PbI=" "ofl/reggaeone/ReggaeOne-Regular.ttf"]
+];
+revalia = mkFont "revalia" "ofl" [
+  ["qTE/unu+tfneZXLD4VylPy9gi6v/QM+p6QCP/wwePIA=" "ofl/revalia/Revalia-Regular.ttf"]
+];
+rhodiumlibre = mkFont "rhodiumlibre" "ofl" [
+  ["0Gi+gGD9dxNb18lO42gi1pAq7Tvw04LYvN/Lta0bgoM=" "ofl/rhodiumlibre/RhodiumLibre-Regular.ttf"]
+];
+ribeyemarrow = mkFont "ribeyemarrow" "ofl" [
+  ["SxnVS4agaLtbigYJONh9HmAo1WbI77aPqcfeuqGZh9A=" "ofl/ribeyemarrow/RibeyeMarrow-Regular.ttf"]
+];
+ribeye = mkFont "ribeye" "ofl" [
+  ["w4SwCdunuclzQCQncWzPKlfcXkSzDP2kX8Dsxc8ji8s=" "ofl/ribeye/Ribeye-Regular.ttf"]
+];
+righteous = mkFont "righteous" "ofl" [
+  ["L/s/5cJ9fmVxIQuABEjE4jTmUbRsa0QmwbtWflNBNIo=" "ofl/righteous/Righteous-Regular.ttf"]
+];
+risque = mkFont "risque" "ofl" [
+  ["hLPXZ0GifmPGavgMJN7iXtWBcnUdD8s6X0vVgmdr+r0=" "ofl/risque/Risque-Regular.ttf"]
+];
+roadrage = mkFont "roadrage" "ofl" [
+  ["sluBEzQL2DUg+SoyoT2NLjnEb8xZXPOeiunppLYzLrg=" "ofl/roadrage/RoadRage-Regular.ttf"]
+];
+roboto = mkFont "roboto" "asl20" [
+  ["2x69i4IRWqvZb228NjHbQEt5j+mCyPQk14OnygpY8Vc=" "apache/roboto/Roboto-Italic%5Bwdth,wght%5D.ttf"]
+  ["q0j/Rs4cwHXRKnIGaGlqIOOEf2TZ0rv7udmTsFn39ro=" "apache/roboto/Roboto%5Bwdth,wght%5D.ttf"]
+  ["VjhFOZpLVcwcP6nJScVb+mhrHEkE5cqYP2wtq8vxjHQ=" "apache/roboto/static/Roboto-ThinItalic.ttf"]
+  ["V8ubFD7nha5fxqu8jBKtFSTDSnB68Q6HWqJ8kXO6004=" "apache/roboto/static/RobotoCondensed-BoldItalic.ttf"]
+  ["vEImAywpYc019iQDstTlKvdUPM4j/divlguXIIUEvC4=" "apache/roboto/static/Roboto-Thin.ttf"]
+  ["+c7ZrHblbajMoQSLIeDH2oN0ApapSeGZeuXbBNexjOw=" "apache/roboto/static/Roboto-Regular.ttf"]
+  ["ogJNLosyCpo/3J+SHJvicKaAvbCxN+/6nX+C8udCsAA=" "apache/roboto/static/RobotoCondensed-Bold.ttf"]
+  ["qPGzKE8hhz0sin4F09+61THeIGwrZjq6/axMrsRrV/w=" "apache/roboto/static/Roboto-Black.ttf"]
+  ["7czH83TjrGswsaSj3dHY0eU73+oVPUScTfN1vnIlvT0=" "apache/roboto/static/Roboto-Medium.ttf"]
+  ["BFJdnbLgsP94uaA++1pf408YNBPFwxd/MmsoAIRPCcY=" "apache/roboto/static/RobotoCondensed-LightItalic.ttf"]
+  ["ClcavqGb4wGovYUfj3Cq1EjoE/AGsB0MVYPkGclkC4U=" "apache/roboto/static/Roboto-Italic.ttf"]
+  ["3/Om0dnYJVRqgBhe/n2CuXyn5nsM1HbLVIjufb3zCaA=" "apache/roboto/static/Roboto-MediumItalic.ttf"]
+  ["uoLAgj/eWHJ6yXwsbO7JZ5aaEILxQXrvfU/6Xlyu+DQ=" "apache/roboto/static/Roboto-Bold.ttf"]
+  ["wnCBv9txL4V0Ojgw9vci2d8/6Cb3zswnugCJTJwgGis=" "apache/roboto/static/RobotoCondensed-MediumItalic.ttf"]
+  ["lMbTx72TcEAil69B7XNEt4Tj2xlCUHFVMls6R6aC8Ok=" "apache/roboto/static/RobotoCondensed-Regular.ttf"]
+  ["mkW0+mAT+ZcIhGnurlO0D6ccXFzDfznhvXCEQ9ilZzY=" "apache/roboto/static/RobotoCondensed-Medium.ttf"]
+  ["uGt4wPd1t8eTYHKDVKPP5OjldXfh79/+zvM1mJ0S0Vc=" "apache/roboto/static/Roboto-BlackItalic.ttf"]
+  ["C8oq+TPLZlwCVK9FRFxUW8KvqJNMaTpOyVKT1bTRrIk=" "apache/roboto/static/Roboto-Light.ttf"]
+  ["xUox5N+Rlvr2YmHwJeFriGgPCbfTrE/lGXvmfl7TH/k=" "apache/roboto/static/Roboto-LightItalic.ttf"]
+  ["GYF0WX/vAB4+EzJ5rzhCzwuJ+C8LSPWD5A4l2AOoAFQ=" "apache/roboto/static/Roboto-BoldItalic.ttf"]
+  ["55EpovLBAKaJf2mZNXuDuu3GVo/83mytd5urXto5xtQ=" "apache/roboto/static/RobotoCondensed-Italic.ttf"]
+  ["vWKMjRcpGCTSEQ1plfz4FgFStqIWtWvaqADZ9R+G4kU=" "apache/roboto/static/RobotoCondensed-Light.ttf"]
+];
+robotoflex = mkFont "robotoflex" "ofl" [
+  ["qGY+xCnTan8kMxQolmXaEbpbanyLAysCvoU2ZFHYgUI=" "ofl/robotoflex/RobotoFlex%5BGRAD,XOPQ,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght%5D.ttf"]
+];
+robotomono = mkFont "robotomono" "asl20" [
+  ["WetkzU3EXZw0lpiLCnNcFmSvLVHKDGGpgEUg/hIdKAw=" "apache/robotomono/RobotoMono-Italic%5Bwght%5D.ttf"]
+  ["fZM4QcEIbEfa2RsvJJsfjsq84NeEaSQui7Uu9Dzckls=" "apache/robotomono/RobotoMono%5Bwght%5D.ttf"]
+];
+robotoserif = mkFont "robotoserif" "ofl" [
+  ["Lk6gRn/bIw1yXWUsrF/+wi9MM+389IWUgAYoUGwy7IU=" "ofl/robotoserif/RobotoSerif%5BGRAD,opsz,wdth,wght%5D.ttf"]
+  ["Pd2GvGf26GXx4r8jA7uVFJt4afXQZOTrNOfLO4EDwr8=" "ofl/robotoserif/RobotoSerif-Italic%5BGRAD,opsz,wdth,wght%5D.ttf"]
+];
+robotoslab = mkFont "robotoslab" "asl20" [
+  ["GBN2KLJzGsjQk8VSs6cav8lYvbEy7PKacWFDCcgoNtk=" "apache/robotoslab/RobotoSlab%5Bwght%5D.ttf"]
+];
+rochester = mkFont "rochester" "asl20" [
+  ["OGV99eNX6EGjmZVZKXCsFOqWoTdvF48NjgIx/V1jCys=" "apache/rochester/Rochester-Regular.ttf"]
+];
+rock3d = mkFont "rock3d" "ofl" [
+  ["yV5nF0M18SZ4/DCeMhrU5AmelBG1p6Lt+7UBERYSPxY=" "ofl/rock3d/Rock3D-Regular.ttf"]
+];
+rocknrollone = mkFont "rocknrollone" "ofl" [
+  ["3A9f+XWFGCf2Pyxr/tEo/7yhS2OZoQ+14XESFcAQhSY=" "ofl/rocknrollone/RocknRollOne-Regular.ttf"]
+];
+rocksalt = mkFont "rocksalt" "asl20" [
+  ["xUIdHO0ZSUiPKdEbdbfvlnq+LYcPgWJGvxj9wPPinJY=" "apache/rocksalt/RockSalt-Regular.ttf"]
+];
+rokkitt = mkFont "rokkitt" "ofl" [
+  ["rNI2WJp/tCtgc1w3pNDW3NIr2tNk6VA75Cj13Z6GFdU=" "ofl/rokkitt/Rokkitt-Italic%5Bwght%5D.ttf"]
+  ["c3sogdLpj4VCS0c6sEnaMhYomh+EJmvsuXLIdmTeK0A=" "ofl/rokkitt/Rokkitt%5Bwght%5D.ttf"]
+];
+rokkittvfbeta = mkFont "rokkittvfbeta" "ofl" [
+  ["IZVbj7XNj/4Beb8q6/NdkT6VfJFP4WiyYlQp7fvjJzc=" "ofl/rokkittvfbeta/RokkittVFBeta.ttf"]
+];
+romanesco = mkFont "romanesco" "ofl" [
+  ["Kvgi4ulyplUlcmZ/c/7iOttPFG25f4nt/mrXItDBYHY=" "ofl/romanesco/Romanesco-Regular.ttf"]
+];
+ropasans = mkFont "ropasans" "ofl" [
+  ["x6jTjfJHwh+1XuRSYZsa5cRSdxxQGXLb0xeg8HyhcG0=" "ofl/ropasans/RopaSans-Italic.ttf"]
+  ["SgvDQp9nLKtPmtXlgEfZ58y2rRbbFVq5LFbRrvzdqPE=" "ofl/ropasans/RopaSans-Regular.ttf"]
+];
+rosario = mkFont "rosario" "ofl" [
+  ["QqQYpUcuYGcUMtiYH43v/UCQcGqUGjOofgd8cD6TBMU=" "ofl/rosario/Rosario-Italic%5Bwght%5D.ttf"]
+  ["6+qq5FyIQPUFTcS/yiEBvtPXRLQDaFl81od5gPIb/kg=" "ofl/rosario/Rosario%5Bwght%5D.ttf"]
+];
+rosarivo = mkFont "rosarivo" "ofl" [
+  ["i2UDtnxcCAu++M68WfRmW3xtRUKcZ36/+g2+eXpNxNA=" "ofl/rosarivo/Rosarivo-Regular.ttf"]
+  ["qYZdjtX3mExplLhjCm7p+ik5WhOnK14lezRhE54wW0c=" "ofl/rosarivo/Rosarivo-Italic.ttf"]
+];
+rougescript = mkFont "rougescript" "ofl" [
+  ["md4MqWnZiYaHMFo29+bd5tMIBqt6Rj67QGjdndKlT9Y=" "ofl/rougescript/RougeScript-Regular.ttf"]
+];
+roundedmplus1c = mkFont "roundedmplus1c" "ofl" [
+  ["jnwVkB3Kh/FFGzVt2llPfQkrolKl3MR9p0UjokJJPDY=" "ofl/roundedmplus1c/RoundedMplus1c-ExtraBold.ttf"]
+  ["t1cItT5FsG0X1HCu7KW3ZuPRs5mfA/E+xOuGPKhGwUw=" "ofl/roundedmplus1c/RoundedMplus1c-Regular.ttf"]
+  ["reXGc6XQl7Wce8WxpsHjfT3WPDrJhGimR9irI5K5i0k=" "ofl/roundedmplus1c/RoundedMplus1c-Light.ttf"]
+  ["1ZgaWczF8A2hvTrkZ1D6lc0WWw5rOl/HoZRflMWUSeM=" "ofl/roundedmplus1c/RoundedMplus1c-Black.ttf"]
+  ["GAwJWf/1ryFjfDiHwOxH34Fkh3IY736GanoifyweGp8=" "ofl/roundedmplus1c/RoundedMplus1c-Thin.ttf"]
+  ["rf3htrrlhxnE4BRGEqlCMucvxcplXEciFl/ojQZSGnA=" "ofl/roundedmplus1c/RoundedMplus1c-Medium.ttf"]
+  ["w1hjBYTo4tj71hIdD0aTJV/+9tHm1PNEH9blqWOhH54=" "ofl/roundedmplus1c/RoundedMplus1c-Bold.ttf"]
+];
+rowdies = mkFont "rowdies" "ofl" [
+  ["KcmEEtGm4ZkepsvTa1/Xz1edacG6FLqFehbH6N2dAKQ=" "ofl/rowdies/Rowdies-Regular.ttf"]
+  ["+jaO9atjRDhzi5MNzSSELWcmyyAzOfoeVPzFLP0IG2U=" "ofl/rowdies/Rowdies-Light.ttf"]
+  ["5WrD/jDlYkNIMIOmuicTh+My93kg6FDOfcG66tT77eI=" "ofl/rowdies/Rowdies-Bold.ttf"]
+];
+rozhaone = mkFont "rozhaone" "ofl" [
+  ["hJG4OMMfMCcqptpn5HSa+rq4KX24KgVf0tCqaJ9QDuM=" "ofl/rozhaone/RozhaOne-Regular.ttf"]
+];
+rubik80sfade = mkFont "rubik80sfade" "ofl" [
+  ["2hRnmuFsqvStMq7OmnNX3N6gLF18mx0pb6uobhmGLT8=" "ofl/rubik80sfade/Rubik80sFade-Regular.ttf"]
+];
+rubikbeastly = mkFont "rubikbeastly" "ofl" [
+  ["hUxfS9BarnbXgw6HHiyZDqMJpDYHLY8LZ6eWqA7Byxg=" "ofl/rubikbeastly/RubikBeastly-Regular.ttf"]
+];
+rubikbubbles = mkFont "rubikbubbles" "ofl" [
+  ["IXFSHasrGzZ1u7euzTSxwWkWfDYONkfa20k5kQSQyXQ=" "ofl/rubikbubbles/RubikBubbles-Regular.ttf"]
+];
+rubikburned = mkFont "rubikburned" "ofl" [
+  ["FJcFF3t/41K1QiewUSHAMFIKVeHMikzdf40K8yTm8A0=" "ofl/rubikburned/RubikBurned-Regular.ttf"]
+];
+rubikdirt = mkFont "rubikdirt" "ofl" [
+  ["nePZKOQ0pH7IXXWQEsig6/6rCGAHbupOOYmkfF4hMSM=" "ofl/rubikdirt/RubikDirt-Regular.ttf"]
+];
+rubikdistressed = mkFont "rubikdistressed" "ofl" [
+  ["ZKmWLIYkUVB7XY28HEvwI928rXAbxz0nfq5GcjcYMno=" "ofl/rubikdistressed/RubikDistressed-Regular.ttf"]
+];
+rubikgemstones = mkFont "rubikgemstones" "ofl" [
+  ["PzCKWzdEwnJ/h/+imh5sjmOtZetbSjZYS93sCKiEaPo=" "ofl/rubikgemstones/RubikGemstones-Regular.ttf"]
+];
+rubikglitch = mkFont "rubikglitch" "ofl" [
+  ["JgJFASSD1WlWJpEA6+znR6qVtLZ+WpQRqBo26R9V5lM=" "ofl/rubikglitch/RubikGlitch-Regular.ttf"]
+];
+rubikiso = mkFont "rubikiso" "ofl" [
+  ["s9d06IeYsgKjVLy+fxQYDCx2WWuqDxu4RFxTaD6KURs=" "ofl/rubikiso/RubikIso-Regular.ttf"]
+];
+rubikmarkerhatch = mkFont "rubikmarkerhatch" "ofl" [
+  ["jZHkAd+vXJOyb8cXsnwmLIKb5oBPe+em23og9P8JwJs=" "ofl/rubikmarkerhatch/RubikMarkerHatch-Regular.ttf"]
+];
+rubikmaze = mkFont "rubikmaze" "ofl" [
+  ["W8TDM+a108rwhdRLYzsoptKrxA+pM7e8ehly7wGf9dk=" "ofl/rubikmaze/RubikMaze-Regular.ttf"]
+];
+rubikmicrobe = mkFont "rubikmicrobe" "ofl" [
+  ["ryNgqhPOOgaBQt7d7TnS2DFhXYu+NwvAhulRkvLlKNc=" "ofl/rubikmicrobe/RubikMicrobe-Regular.ttf"]
+];
+rubikmonoone = mkFont "rubikmonoone" "ofl" [
+  ["siYktqNuVD6UIQbt/M0ZjFC1e2W5JL/gKm8KVplCnms=" "ofl/rubikmonoone/RubikMonoOne-Regular.ttf"]
+];
+rubikmoonrocks = mkFont "rubikmoonrocks" "ofl" [
+  ["Of9NlrkG6Mwv16NQqhNiDV7/GNd2/ttcmMEsv24fLB4=" "ofl/rubikmoonrocks/RubikMoonrocks-Regular.ttf"]
+];
+rubik = mkFont "rubik" "ofl" [
+  ["C6Zbqoxo2fPigN391YnOGLfRcsBpBl4nqQjQQbKGCaY=" "ofl/rubik/Rubik-Italic%5Bwght%5D.ttf"]
+  ["h2B2IMWTdqGTd/NvqBU4e6HUFvW5AWYukr6PlB7/9Es=" "ofl/rubik/Rubik%5Bwght%5D.ttf"]
+];
+rubikone = mkFont "rubikone" "ofl" [
+  ["/O0YznIg11BKuhWt69WPY9KeylVBgKp06nVFyeB+ZUg=" "ofl/rubikone/RubikOne-Regular.ttf"]
+];
+rubikpuddles = mkFont "rubikpuddles" "ofl" [
+  ["rGkLB5C4kKJMVJl8/Ga94U1GSMsakU6bh1TpAjuw00I=" "ofl/rubikpuddles/RubikPuddles-Regular.ttf"]
+];
+rubikspraypaint = mkFont "rubikspraypaint" "ofl" [
+  ["5givk8UU8rp4yez7COkKIGpvX9T8OvvS2x5lvGUSnKE=" "ofl/rubikspraypaint/RubikSprayPaint-Regular.ttf"]
+];
+rubikstorm = mkFont "rubikstorm" "ofl" [
+  ["DMx7WQHGrWkI38ASXxLvDcJkfIuGQcbdcDKN+GEIIpw=" "ofl/rubikstorm/RubikStorm-Regular.ttf"]
+];
+rubikvinyl = mkFont "rubikvinyl" "ofl" [
+  ["ZPHRY2hR2BSpAxqUW8bKa3vCaikAnrMWF20n8A8rfU4=" "ofl/rubikvinyl/RubikVinyl-Regular.ttf"]
+];
+rubikwetpaint = mkFont "rubikwetpaint" "ofl" [
+  ["PzXRx3IZxSGYJrI8Lwxy3Q7tRkJaDU//IbiCfNzmFpM=" "ofl/rubikwetpaint/RubikWetPaint-Regular.ttf"]
+];
+ruda = mkFont "ruda" "ofl" [
+  ["rMbkEsdFRfk0vthWT4ZQ8RPUbSIPDzqUSE5qZVjLQPA=" "ofl/ruda/Ruda%5Bwght%5D.ttf"]
+];
+rufina = mkFont "rufina" "ofl" [
+  ["CybhOI6Cevp8QOPsJoyFAQ3aDHWb4KFpAlUJtZsaSxw=" "ofl/rufina/Rufina-Regular.ttf"]
+  ["ZndFH0fY/VKLhgczWtO65S2zT3dVWfw9uZ3HKB9YBeA=" "ofl/rufina/Rufina-Bold.ttf"]
+];
+rugeboogie = mkFont "rugeboogie" "ofl" [
+  ["r/4lskMezULLjG7rLeVrsmTWZuaksrJ7asPiJXQ27tA=" "ofl/rugeboogie/RugeBoogie-Regular.ttf"]
+];
+ruluko = mkFont "ruluko" "ofl" [
+  ["xCbbE3N1XTugBFbezlz1rRyAI5ePYMv+e34larHInD8=" "ofl/ruluko/Ruluko-Regular.ttf"]
+];
+rumraisin = mkFont "rumraisin" "ofl" [
+  ["H7dBATwFmV6kiqscFrzRQcAE6lyPlGbfmg4TF9BXQS4=" "ofl/rumraisin/RumRaisin-Regular.ttf"]
+];
+ruserius = mkFont "ruserius" "ofl" [
+  ["UkI5YKc3gp68hRoY+2NiuM9F7g4sE5ZwbKGhyioFkP0=" "ofl/ruserius/RUSerius-Regular.ttf"]
+];
+ruslandisplay = mkFont "ruslandisplay" "ofl" [
+  ["bRI/cLoUvpmX/W3MBdXAtuoS1hQd41YY3nqmr5cL1MQ=" "ofl/ruslandisplay/RuslanDisplay.ttf"]
+];
+russoone = mkFont "russoone" "ofl" [
+  ["vAq8xmC9i3rTAA7LKJiifFiimlD37IFlL6EudRSNCd8=" "ofl/russoone/RussoOne-Regular.ttf"]
+];
+ruthie = mkFont "ruthie" "ofl" [
+  ["+X6ZkQ55psrrzBjcyjBZaaCrQllfzmdnE58mDBk9owI=" "ofl/ruthie/Ruthie-Regular.ttf"]
+];
+rye = mkFont "rye" "ofl" [
+  ["t+3uXmFa4bawfp0DDBMJFSvzZyoOiipGKT4nNzD1rbo=" "ofl/rye/Rye-Regular.ttf"]
+];
+sacramento = mkFont "sacramento" "ofl" [
+  ["k0H9oQrb/rfvyUMCs0UHo+In1+f1xDLfP1rIdT/3PSQ=" "ofl/sacramento/Sacramento-Regular.ttf"]
+];
+sahitya = mkFont "sahitya" "ofl" [
+  ["n+sntdKYC3QTVbtiQNDwtE0PTP2xXBGYAEn0dQ/KqIo=" "ofl/sahitya/Sahitya-Bold.ttf"]
+  ["9D5Xyes8k24ZUAmldVkG00zf+35axNClHSYBUPEY7mI=" "ofl/sahitya/Sahitya-Regular.ttf"]
+];
+sail = mkFont "sail" "ofl" [
+  ["Dsmp6E9VcCWNMZomvOkq2txJmM6sxNlbY2h8naQWT2U=" "ofl/sail/Sail-Regular.ttf"]
+];
+sairacondensed = mkFont "sairacondensed" "ofl" [
+  ["mu8uT2ICXp2nW9y1uGW/a7TVgVfbphDTLBW6iIEuIPk=" "ofl/sairacondensed/SairaCondensed-ExtraLight.ttf"]
+  ["Pt9fLwJ+LVIDIY9bVs2mUrKvkljAwIvn+4dPP4zyZq4=" "ofl/sairacondensed/SairaCondensed-Black.ttf"]
+  ["VgKX5LzPuMbmQwlecWteouqdcomAHd15q5AWmP+w3uY=" "ofl/sairacondensed/SairaCondensed-Bold.ttf"]
+  ["MPjtTQeCEQA6lxXIDFHOAxurXJoX6HcRguTEWZIFY0s=" "ofl/sairacondensed/SairaCondensed-SemiBold.ttf"]
+  ["+8Jxu7wQ5EfFP0Npa/KOggA8f/Tirk5Gk2Jv364h8SE=" "ofl/sairacondensed/SairaCondensed-Thin.ttf"]
+  ["FoXlK++z/MaUM1NSRD9BelGi2QU3d1sac1ORY45ic2o=" "ofl/sairacondensed/SairaCondensed-Light.ttf"]
+  ["iCHKu8i7OwcnvgqC0ZLJa6rbr2CAEq/1V+qs7RiXroQ=" "ofl/sairacondensed/SairaCondensed-ExtraBold.ttf"]
+  ["jybt2fIneUgYtm+TYDfcNb0iZ0socIfV0ZqT1VTZpvY=" "ofl/sairacondensed/SairaCondensed-Regular.ttf"]
+  ["oC2P5FuLfZUssN00FoOwLdwbVdvQ7YnZ1DiGi+YUtm8=" "ofl/sairacondensed/SairaCondensed-Medium.ttf"]
+];
+sairaextracondensed = mkFont "sairaextracondensed" "ofl" [
+  ["NXPWMZjGs0bosoGpmMNiaq4SWOAiTY9GAp25JLt77ro=" "ofl/sairaextracondensed/SairaExtraCondensed-Medium.ttf"]
+  ["DLsS7xrAs70asT824d4V7zekKjQjqXGKg5PYeXlliIw=" "ofl/sairaextracondensed/SairaExtraCondensed-Black.ttf"]
+  ["/fjt4FQFIekswg0XIwMDQvpsdd4pKDK7BLdJzHNPmSk=" "ofl/sairaextracondensed/SairaExtraCondensed-Thin.ttf"]
+  ["XpJg8pteuqMjDfCTd4OhuYDY8oX7Tpgr1y5VnOmQ7GE=" "ofl/sairaextracondensed/SairaExtraCondensed-Regular.ttf"]
+  ["wAhLDhY+xzaZONblEi1kiqcZuQIClyjalTt43hGEWFY=" "ofl/sairaextracondensed/SairaExtraCondensed-Light.ttf"]
+  ["oYXQ6wMgVh02QnNmDruqQdQ6U3/7DCMI29cO2yiRGWg=" "ofl/sairaextracondensed/SairaExtraCondensed-Bold.ttf"]
+  ["oOW89B6m7JOlXeKI9PDbjAGkwfEmAgzVfbFH6mzTuu4=" "ofl/sairaextracondensed/SairaExtraCondensed-SemiBold.ttf"]
+  ["DigtANgDbIoJV240hbhU360PqLEBnf9BcS3zfP4QJZQ=" "ofl/sairaextracondensed/SairaExtraCondensed-ExtraBold.ttf"]
+  ["wsh/+/ZYD0DlY0Siqu9MH8iYU7mBJFeXr7kjoqR+LYo=" "ofl/sairaextracondensed/SairaExtraCondensed-ExtraLight.ttf"]
+];
+saira = mkFont "saira" "ofl" [
+  ["nQUPxaAchfdMQlfCB9ULVdHkDDcwjGQvl0osUAMjHd4=" "ofl/saira/Saira%5Bwdth,wght%5D.ttf"]
+  ["lllywlQ7cpSK7bVfrjbiMXVmHQ+dLY1/FKEAnkZpEvg=" "ofl/saira/Saira-Italic%5Bwdth,wght%5D.ttf"]
+];
+sairasemicondensed = mkFont "sairasemicondensed" "ofl" [
+  ["vYhr1vYytJBqT0acgcyzex8NaNTBdb73J3yK3bhs/y0=" "ofl/sairasemicondensed/SairaSemiCondensed-Medium.ttf"]
+  ["na0P6iQF68dACSoMo041CsI1wKBACVBo4AVLM3Ug+To=" "ofl/sairasemicondensed/SairaSemiCondensed-Regular.ttf"]
+  ["RK+Jg1HyiE5gPHzmCJG+R+fe+Ykdf9v/lcGSv4mW+08=" "ofl/sairasemicondensed/SairaSemiCondensed-Light.ttf"]
+  ["hxY+D1JHFi/z8OtIl/rHzkYedW266QK9lAqEYPZzDWg=" "ofl/sairasemicondensed/SairaSemiCondensed-Thin.ttf"]
+  ["KrejX3mOFJ2xkI3a6EQCS8uXW9zL/IHbrDQp0PYnCxQ=" "ofl/sairasemicondensed/SairaSemiCondensed-Bold.ttf"]
+  ["YahB5OfL+iH+PS6X+Ndf6IgFXVxufT/f2xrQhoGY3q0=" "ofl/sairasemicondensed/SairaSemiCondensed-ExtraLight.ttf"]
+  ["OjlKW0img4xsIALwxYWvaQ5BriOoqNkj4CAJ0J+vut0=" "ofl/sairasemicondensed/SairaSemiCondensed-ExtraBold.ttf"]
+  ["96Mq3tYH+zZKlAygi02+UUNGtPv6a7F3fHHt9tfw/lY=" "ofl/sairasemicondensed/SairaSemiCondensed-SemiBold.ttf"]
+  ["6rq0I5OThTYl+mUi20gF8uvpfnRah152+C7LbmWegaQ=" "ofl/sairasemicondensed/SairaSemiCondensed-Black.ttf"]
+];
+sairastencilone = mkFont "sairastencilone" "ofl" [
+  ["eBSW/a+OBM9nQbMQJfa0uoT2YCGwl6jg2Fy+ohgM8iM=" "ofl/sairastencilone/SairaStencilOne-Regular.ttf"]
+];
+salsa = mkFont "salsa" "ofl" [
+  ["PmnAcxpRBNTyVHeqLN+dfpxUsgHGDpnDc4Dr0FCXkww=" "ofl/salsa/Salsa-Regular.ttf"]
+];
+sanchez = mkFont "sanchez" "ofl" [
+  ["UJeDaYgIZuQVNLzbIV6+2bYy764x1DSyUqYHaIv0vAU=" "ofl/sanchez/Sanchez-Italic.ttf"]
+  ["dZ5zutC3joRVUhX9mmhjfPRF1B0p4OmDT17p3EP6doQ=" "ofl/sanchez/Sanchez-Regular.ttf"]
+];
+sancreek = mkFont "sancreek" "ofl" [
+  ["5gRO1zPcDVsADPo1zq0rgAvB+FDlqSuz9TKyj4KB7o0=" "ofl/sancreek/Sancreek-Regular.ttf"]
+];
+sansation = mkFont "sansation" "ofl" [
+  ["73eY8tCjQ1eXeTrItwO9MTHlpbHsXMvRXzl/EabOGBE=" "ofl/sansation/Sansation-Light.ttf"]
+  ["Qo6y8R4bEsVVBbxarwV55zVDkSB99HTYj0RRfffUhwk=" "ofl/sansation/Sansation-BoldItalic.ttf"]
+  ["33n1lhgyXYkKphH/h0LjE7G88KWvxhK0vi+dhwdC3Fc=" "ofl/sansation/Sansation-Italic.ttf"]
+  ["bUcDnuZmXXixQ6GyZKvAIBejP/pSpOn2ZFzjV/ktTwk=" "ofl/sansation/Sansation-Regular.ttf"]
+  ["lu7zr6smqaAYQV2ld8cdvOquSPn0sqsm8PfUEsHdCNE=" "ofl/sansation/Sansation-LightItalic.ttf"]
+  ["jsdMligXntldB1RAuk0BCR+ADKm+BF3cJZgr2Lwhr/8=" "ofl/sansation/Sansation-Bold.ttf"]
+];
+sansita = mkFont "sansita" "ofl" [
+  ["vTX4yXFzG8vJY7dunbRRHnzZ5bijCs2UqM1tEGIE88o=" "ofl/sansita/Sansita-BoldItalic.ttf"]
+  ["9RP9X1xF9HVy4X2Emv/T5Ihnb6SEcoF9w4BpuCBANIA=" "ofl/sansita/Sansita-ExtraBold.ttf"]
+  ["EL1cYUqo0X5+4np4g0K4NbyzVdFKSb3BnW7ffs3ZSFg=" "ofl/sansita/Sansita-Italic.ttf"]
+  ["A9cOQr3AHBz7Q9oKVN3yHm92jdu8fL+GE0vNvCqGAXQ=" "ofl/sansita/Sansita-Bold.ttf"]
+  ["OS55ebFmdwTC7Zrr8/vwFMH5J6NyqzH9BbGbKR3E0ks=" "ofl/sansita/Sansita-Black.ttf"]
+  ["9KnxrUEmUHpNfzOHWv1fx5kS5kpYrwNleTlSilnO1QM=" "ofl/sansita/Sansita-ExtraBoldItalic.ttf"]
+  ["5TcpNpfctJBa0FqQy+XKvDUszdMdVO9wsJJ+pRuRmSU=" "ofl/sansita/Sansita-BlackItalic.ttf"]
+  ["GyUXGmeo+yaXL4vavjHtPM03206o99gX/DfVcgJCCK0=" "ofl/sansita/Sansita-Regular.ttf"]
+];
+sansitaone = mkFont "sansitaone" "ofl" [
+  ["jL6IFX01CnoV+q2w5o7ucxDLGDMLnSX/LWSx0y8xha0=" "ofl/sansitaone/SansitaOne-Regular.ttf"]
+];
+sansitaswashed = mkFont "sansitaswashed" "ofl" [
+  ["pv9mGfItAeuVgvsAo4BS16+6QE/1hovpvd834oiKHGo=" "ofl/sansitaswashed/SansitaSwashed%5Bwght%5D.ttf"]
+];
+sarabun = mkFont "sarabun" "ofl" [
+  ["wLsFfYbkoSCX1wGsCVNZfjFXiNR6RG9bY6ZgSrIdzro=" "ofl/sarabun/Sarabun-SemiBold.ttf"]
+  ["+lXqszLpmKy0u2TEPZvRzveR2I1dFdY1cPQ3QWiNcFc=" "ofl/sarabun/Sarabun-Thin.ttf"]
+  ["XvG5MPmjr+1eyDN0tWF8rTqJ2RqPxeNy3AKMKqKVD40=" "ofl/sarabun/Sarabun-BoldItalic.ttf"]
+  ["Jj5rtR2AwijCAaB3DmEAGBEVEZ/cp5aERdRNL7lKsAk=" "ofl/sarabun/Sarabun-MediumItalic.ttf"]
+  ["S2mfCuAYpY3wS9Kip8N9ccKcU1nLnfSKvHAhC6JWTvk=" "ofl/sarabun/Sarabun-ExtraBoldItalic.ttf"]
+  ["Im1PNo+8BFeZDd7yaSZ5ut/SwaTonlrE1DwQundDsvE=" "ofl/sarabun/Sarabun-Regular.ttf"]
+  ["wtqS6uRnRYm/t+wE7LUEHAu+d2it9l/d3PwcmvO7uy8=" "ofl/sarabun/Sarabun-ExtraLightItalic.ttf"]
+  ["04MIyifQZ7mht5AGM3wfmmbCmqAW2WqdiNOAHaf6g7k=" "ofl/sarabun/Sarabun-Bold.ttf"]
+  ["zHwwFtqrMyFnT99uLvWYUNwMB1A94cvbi5D+gICtorQ=" "ofl/sarabun/Sarabun-Medium.ttf"]
+  ["xSDQBGdNJX9OU5kmwE7Jt3y6siOaqitGjflpOjabuIQ=" "ofl/sarabun/Sarabun-ThinItalic.ttf"]
+  ["UMEqZP9/tn+nylJcLtLe+WYMl8PKRDrOpiLjW+7pfDM=" "ofl/sarabun/Sarabun-LightItalic.ttf"]
+  ["nv115eu213Vcyj+qWQbHeku9OcmqwO0jv39LozsC9og=" "ofl/sarabun/Sarabun-Light.ttf"]
+  ["WVqWjpeouBeaa94tdNT5GxFHXc+2zycAN9dtjtcRYOo=" "ofl/sarabun/Sarabun-Italic.ttf"]
+  ["H0ug2q1jyALYJYhTQb1/HwVDBqZp6isYPysg7mWgoEM=" "ofl/sarabun/Sarabun-ExtraBold.ttf"]
+  ["iqn7qIhVVFRce84/HbXv2RTHTAzorljp5MtHe1gk/p0=" "ofl/sarabun/Sarabun-ExtraLight.ttf"]
+  ["mCvVbUaDxg5+TJzYS/r657cAxLUU2WVbiBC7dHgGPlw=" "ofl/sarabun/Sarabun-SemiBoldItalic.ttf"]
+];
+sarala = mkFont "sarala" "ofl" [
+  ["nn40M17+rsgeeRt2Emo9JqdyMLyp5YCqFljM9yzrzns=" "ofl/sarala/Sarala-Regular.ttf"]
+  ["sIzKsqIrPc+tapuI1bcAy4MMdVeuE+kmTmHNapbswmg=" "ofl/sarala/Sarala-Bold.ttf"]
+];
+sarina = mkFont "sarina" "ofl" [
+  ["icbhTXY45IRjzGxhsuRj49zFeAomGXvPf0QS1wBIpKY=" "ofl/sarina/Sarina-Regular.ttf"]
+];
+sarpanch = mkFont "sarpanch" "ofl" [
+  ["X/sSUDPUZ/r9eeixPcEfqIw84xeEDWBCr7VtO7lNwys=" "ofl/sarpanch/Sarpanch-ExtraBold.ttf"]
+  ["oeH4GtuEBN5XgDvNQgluxnAr+Fv7lSQEnwPybPz093E=" "ofl/sarpanch/Sarpanch-Black.ttf"]
+  ["wj+WwV0dB1szm7el7eNCWR0TiZJDMUZLmFhIZdiMjr8=" "ofl/sarpanch/Sarpanch-Bold.ttf"]
+  ["ztdzvCp1l+waUUX/zm36zsB2JVIEzwLxMDkHqCxhAvI=" "ofl/sarpanch/Sarpanch-SemiBold.ttf"]
+  ["KCgoewglsIx7LLuhV3n9izuFwZB9+Lmph/CISM1pR/Q=" "ofl/sarpanch/Sarpanch-Regular.ttf"]
+  ["nxq18bqW31qWjF9/Aru1YLGvG92Su6ijPvCThMxBt74=" "ofl/sarpanch/Sarpanch-Medium.ttf"]
+];
+sassyfrass = mkFont "sassyfrass" "ofl" [
+  ["kfxuD0Oid921kPr4qX/TAW9PElGp3qLer2WLGBLEKJk=" "ofl/sassyfrass/SassyFrass-Regular.ttf"]
+];
+satisfy = mkFont "satisfy" "asl20" [
+  ["VbsUGgojoyJ41fp/0uhTgk+qFzuUd0Zg6+3bEGvgfIA=" "apache/satisfy/Satisfy-Regular.ttf"]
+];
+sawarabigothic = mkFont "sawarabigothic" "ofl" [
+  ["BPL5ERu2nLjTcGwntEh5wsD6xZOhHt9c/ozsHvySx4k=" "ofl/sawarabigothic/SawarabiGothic-Regular.ttf"]
+];
+sawarabimincho = mkFont "sawarabimincho" "ofl" [
+  ["hjc8YZcQ0VKKrDpNR86Wg0EBuziwVyNbOeR7YboUPG0=" "ofl/sawarabimincho/SawarabiMincho-Regular.ttf"]
+];
+scada = mkFont "scada" "ofl" [
+  ["OgCFQAz8IpvEMp533VoR63nn/IgfXChfgTslETPd0JU=" "ofl/scada/Scada-Bold.ttf"]
+  ["P0edv+gO100/+IAHZGj5gY7dKP+ZCeXyLOaYIkoIXB8=" "ofl/scada/Scada-Italic.ttf"]
+  ["SujxCLjOAWAXov5A/2XsYT62pBSc47mp/mDOoRe1UDY=" "ofl/scada/Scada-Regular.ttf"]
+  ["xQmXb8gogNZym/ak2xl4by6vht/kzPNgYK+z2HHm9Uc=" "ofl/scada/Scada-BoldItalic.ttf"]
+];
+scheherazadenew = mkFont "scheherazadenew" "ofl" [
+  ["38oJn+3PKcanw0OoNGxuJKouz/kb0qdUYx1MYaY65yI=" "ofl/scheherazadenew/ScheherazadeNew-Bold.ttf"]
+  ["Bn3bW2HBZLs1PAbs0lbXyQ/UNetCEUSPZlIJUlBCS/Q=" "ofl/scheherazadenew/ScheherazadeNew-Regular.ttf"]
+];
+schoolbell = mkFont "schoolbell" "asl20" [
+  ["AP9mVaXrHrcNMvK3NR0bzz9F8/nKQP1cDSXaeff4KlA=" "apache/schoolbell/Schoolbell-Regular.ttf"]
+];
+scopeone = mkFont "scopeone" "ofl" [
+  ["PqkNbCRjIazCYmAlXyQJXMH5H8MzgLvJKD399bdxGM0=" "ofl/scopeone/ScopeOne-Regular.ttf"]
+];
+seaweedscript = mkFont "seaweedscript" "ofl" [
+  ["SKfwHOPzB7UyycX4WCqO2HiDOJkzsxG443BOh5i6S8c=" "ofl/seaweedscript/SeaweedScript-Regular.ttf"]
+];
+secularone = mkFont "secularone" "ofl" [
+  ["J8wkVDShmCBhFwubzgl7Rz4BZVZwMFUtfCRR7AEmJ0g=" "ofl/secularone/SecularOne-Regular.ttf"]
+];
+sedan = mkFont "sedan" "ofl" [
+  ["06d7kHgE0cpL+VMqMiXbWI0V/XXPnTwR8wXdaTyF8C4=" "ofl/sedan/Sedan-Regular.ttf"]
+  ["mSkM09zRpWoPozYHJ+wtrCuysd2wcI+hxsyOXSRsMPg=" "ofl/sedan/Sedan-Italic.ttf"]
+];
+sedansc = mkFont "sedansc" "ofl" [
+  ["jv1ESJsvqVDoTCDk9Aq2/bOV0wHYtBr6cs3SSSD5zXc=" "ofl/sedansc/SedanSC-Regular.ttf"]
+];
+sedgwickavedisplay = mkFont "sedgwickavedisplay" "ofl" [
+  ["O5wpWhRrr7k8ihLB3eOKL+R1End9rxRYgl4pF1JGmjg=" "ofl/sedgwickavedisplay/SedgwickAveDisplay-Regular.ttf"]
+];
+sedgwickave = mkFont "sedgwickave" "ofl" [
+  ["nDYz5WqKEE4NEN67cJB7Zrs88ysDE3+ufVOScSslPvo=" "ofl/sedgwickave/SedgwickAve-Regular.ttf"]
+];
+sendflowers = mkFont "sendflowers" "ofl" [
+  ["TGZ+Y5+cijfD1GZjvgiFJFw7D7woMTjPpdgxNfM4bJE=" "ofl/sendflowers/SendFlowers-Regular.ttf"]
+];
+sen = mkFont "sen" "ofl" [
+  ["xNnxBKrXcJV8QcxF4odvvSjhzhQ+A4e8K05uvxIJyQY=" "ofl/sen/Sen-Bold.ttf"]
+  ["AIzkIflqcvvjCq7WH9CVGUIIaqgNlfhhNktrtptfPI4=" "ofl/sen/Sen-ExtraBold.ttf"]
+  ["Kb5DbSAtQ7UgtPt1kqt5TwHoSurxrDcPhufFRYJk3g0=" "ofl/sen/Sen-Regular.ttf"]
+];
+seoulhangangcondensed = mkFont "seoulhangangcondensed" "ofl" [
+  ["c+wSaVARWnJaGJM7NNfDe0OlgntXMauZIYKmlpF7NGI=" "ofl/seoulhangangcondensed/SeoulHangangCondensed-Medium.ttf"]
+  ["qsktQMOg85jMu0Sp09UTDdLXZyiWFOQVTxpfETEWC/E=" "ofl/seoulhangangcondensed/SeoulHangangCondensed-BoldL.ttf"]
+  ["/h2wc2MP/L+2zHamAFpVETi87UFW3CRE8GoR8tjyj70=" "ofl/seoulhangangcondensed/SeoulHangangCondensed-ExtraBold.ttf"]
+  ["s19zXCkYtNngS9Xx4+aUEUbFnrAGmH+4x0MBanUGJ1E=" "ofl/seoulhangangcondensed/SeoulHangangCondensed-Light.ttf"]
+  ["zvwCX9V5GX/nmI9YICeCLvevRsu+mM2TMVHTR7iE0Mk=" "ofl/seoulhangangcondensed/SeoulHangangCondensed-Bold.ttf"]
+];
+seoulhangang = mkFont "seoulhangang" "ofl" [
+  ["IKeoDMxFCqyXYJ45YJ3FTZvE/wwMPpYGvsTIM08oBWI=" "ofl/seoulhangang/SeoulHangang-Medium.ttf"]
+  ["2x1hvF+5a85prY2EmT3I5r6cgPM3QlWLxSrOnLxBfV0=" "ofl/seoulhangang/SeoulHangang-ExtraBold.ttf"]
+  ["7p9ADYHmjy/TFf2rgerd/BcG2u+bCDBsKqiTkoE17uE=" "ofl/seoulhangang/SeoulHangang-Bold.ttf"]
+  ["dfi3bNvk64XQj0paws8Ol/x79Y5HTr1q9IKDjIpY92s=" "ofl/seoulhangang/SeoulHangang-Light.ttf"]
+];
+seoulnamsancondensed = mkFont "seoulnamsancondensed" "ofl" [
+  ["q0VucCRlJnuLmPetrq33FW04kVHbd+aZIvJ2J0f0rUs=" "ofl/seoulnamsancondensed/SeoulNamsanCondensed-Light.ttf"]
+  ["SzY56X3wV9NI7kYwtLjUUkvB0+XcrwsEZ7wYYvAv2qw=" "ofl/seoulnamsancondensed/SeoulNamsanCondensed-Bold.ttf"]
+  ["OHZNntrsTh2vOoRh6y6W2NjmvrHUHmt3+jkMq54+mvM=" "ofl/seoulnamsancondensed/SeoulNamsanCondensed-ExtraBold.ttf"]
+  ["YfZrC9ifYz9R7ZctAEHKMQBFaH3xmfaf4GjMM06hRkg=" "ofl/seoulnamsancondensed/SeoulNamsanCondensed-Black.ttf"]
+  ["MLr+60QY5PkQCrLYnHQIb9I4JPtJp7EK4awrHH79OVg=" "ofl/seoulnamsancondensed/SeoulNamsanCondensed-Medium.ttf"]
+];
+seoulnamsan = mkFont "seoulnamsan" "ofl" [
+  ["8hef6+ZXhRTrEQN1YOsX8wKVDAV0hgIxLg9Sng1p4Rk=" "ofl/seoulnamsan/SeoulNamsan-ExtraBold.ttf"]
+  ["Bzr+zi1Py3b+/0CGjeoBrDLKBW0Y5QDqBJTVMSccbZA=" "ofl/seoulnamsan/SeoulNamsan-Medium.ttf"]
+  ["H6x6J87zL3B/2xne0B7LiE2DhD5ILfj1ex0Qj1Fy18I=" "ofl/seoulnamsan/SeoulNamsan-Bold.ttf"]
+  ["GVlLuDSy7HpcUYdaS4N5urKohipO1xVAX2sAjZIMSOE=" "ofl/seoulnamsan/SeoulNamsan-Light.ttf"]
+];
+seoulnamsanvertical = mkFont "seoulnamsanvertical" "ofl" [
+  ["//P1FhHcUL7jJZ5kU6J47TP//fByiSPwWkhI5zzC+yM=" "ofl/seoulnamsanvertical/SeoulNamsanVertical-Regular.ttf"]
+];
+sevillana = mkFont "sevillana" "ofl" [
+  ["JImvCOkdKpvv3jo6K2E4dJ/2XddOKvDLm8P/UtOP0g8=" "ofl/sevillana/Sevillana-Regular.ttf"]
+];
+seymourone = mkFont "seymourone" "ofl" [
+  ["Y4PcEqly7Lxk78YNlXbI1nHqxN2MmNCyNwguDvDNpJ4=" "ofl/seymourone/SeymourOne-Regular.ttf"]
+];
+shadowsintolight = mkFont "shadowsintolight" "ofl" [
+  ["E0eGMVGs3AD6KB2quho1Q9vOWHC1X5z3R5oVu4QAdoE=" "ofl/shadowsintolight/ShadowsIntoLight.ttf"]
+];
+shadowsintolighttwo = mkFont "shadowsintolighttwo" "ofl" [
+  ["0lQBcLGx3zCU3kM7RjJ1W6key2ViYgKjyK/9IkXghAU=" "ofl/shadowsintolighttwo/ShadowsIntoLightTwo-Regular.ttf"]
+];
+shalimar = mkFont "shalimar" "ofl" [
+  ["ALChHHuhLY8UN9tqlZd+zVRTdJ8Rm5PPJQLQpB4Flhw=" "ofl/shalimar/Shalimar-Regular.ttf"]
+];
+shantellsans = mkFont "shantellsans" "ofl" [
+  ["t5w+TtswecD0ASWD6QQAVnyYSSq09vaiMDPoPC6dKUs=" "ofl/shantellsans/ShantellSans%5BBNCE,INFM,SPAC,wght%5D.ttf"]
+  ["8I+mvEt0vW8JXOmDIEv0mO3G19tJBd1yan+nhHpXR3E=" "ofl/shantellsans/ShantellSans-Italic%5BBNCE,INFM,SPAC,wght%5D.ttf"]
+];
+shanti = mkFont "shanti" "ofl" [
+  ["j5RU34dTQjOyH8/Fbtdul0nGJ8rpq3reGWf8HcCEzmI=" "ofl/shanti/Shanti-Regular.ttf"]
+];
+share = mkFont "share" "ofl" [
+  ["7xw1IsEmKPGRdPvbKTmi29A8g9JJjkqMDHTGpMqpkUs=" "ofl/share/Share-Regular.ttf"]
+  ["ZX1EnDIFzWsHKrjincX7FcHYMgsRG9Q6AWhSFx4LaJI=" "ofl/share/Share-Italic.ttf"]
+  ["CMwy+KCb2f9DNszmQor2j4/CFA0lU1/RDWT/UkSorYI=" "ofl/share/Share-BoldItalic.ttf"]
+  ["lBn/J/ZF/iWuRlNC13yC/NKj9rl6f/CQUUMuZPLfdYE=" "ofl/share/Share-Bold.ttf"]
+];
+sharetechmono = mkFont "sharetechmono" "ofl" [
+  ["nOqx+HQUgpryWcD1N1c64D733TFHwLJ6NqGgvrZzJnc=" "ofl/sharetechmono/ShareTechMono-Regular.ttf"]
+];
+sharetech = mkFont "sharetech" "ofl" [
+  ["LR3EJjHCLOmShaOnwdDKnguunmeqHKAaUBCB8nogPfQ=" "ofl/sharetech/ShareTech-Regular.ttf"]
+];
+shipporiantiqueb1 = mkFont "shipporiantiqueb1" "ofl" [
+  ["C1UUIQC1j2vSIbIikTLMLjRNHTyAOtr+s3ZiTG44GcQ=" "ofl/shipporiantiqueb1/ShipporiAntiqueB1-Regular.ttf"]
+];
+shipporiantique = mkFont "shipporiantique" "ofl" [
+  ["uI/VE4x3wTWUBgUXhtRciKs04gQMbfo4XwCk4X7aq1I=" "ofl/shipporiantique/ShipporiAntique-Regular.ttf"]
+];
+shipporiminchob1 = mkFont "shipporiminchob1" "ofl" [
+  ["0g85ga+4vO2l/fjw+ym6UeshUYZEYSzNihg+W9Qz4lo=" "ofl/shipporiminchob1/ShipporiMinchoB1-Bold.ttf"]
+  ["vumaJC8yEo6NakrP8rPxdCzULqkHSHWObhBFaHGIfnY=" "ofl/shipporiminchob1/ShipporiMinchoB1-ExtraBold.ttf"]
+  ["BxI0gSRynjBQep7Z18iTkSXxNgWVRZas/g7EpjQeO50=" "ofl/shipporiminchob1/ShipporiMinchoB1-Medium.ttf"]
+  ["LQ3862YtUiyd1kP2gi6a8t72sKAYbtXLMDRj0u2PXAY=" "ofl/shipporiminchob1/ShipporiMinchoB1-SemiBold.ttf"]
+  ["iUA+SyqcoNufgyuJPPv9kFBsfGdM1kC6ig7hKMNN56Q=" "ofl/shipporiminchob1/ShipporiMinchoB1-Regular.ttf"]
+];
+shipporimincho = mkFont "shipporimincho" "ofl" [
+  ["Y7xO3cdHk/Zxw6uCfFF153P/vladC/UO5lN16p47woY=" "ofl/shipporimincho/ShipporiMincho-Bold.ttf"]
+  ["dptSafD5vGU0s1LA5r2FalZuA/94jxBxkcLYNYY1cLI=" "ofl/shipporimincho/ShipporiMincho-Regular.ttf"]
+  ["vHklVEiUqRRmRJrbc8bZQ/UMPlPrHHTQZz/i26/NTS0=" "ofl/shipporimincho/ShipporiMincho-SemiBold.ttf"]
+  ["cA5QWvxM3tIzjropR4oEHgTBwupRFPuz4LBOdsMCxdg=" "ofl/shipporimincho/ShipporiMincho-Medium.ttf"]
+  ["vbeHZEtLNH6afv3VdvDRbuRSjMm1yG0j4G+hoUrgREw=" "ofl/shipporimincho/ShipporiMincho-ExtraBold.ttf"]
+];
+shizuru = mkFont "shizuru" "ofl" [
+  ["WVRWLl+7QP/+Y2HLvKwNSkycXiiX17IIdvKU+8wkP38=" "ofl/shizuru/Shizuru-Regular.ttf"]
+];
+shojumaru = mkFont "shojumaru" "ofl" [
+  ["hgcRDvRdpmSGHHLZX7gEw2CRaev9KjgMtHs1OnskHHU=" "ofl/shojumaru/Shojumaru-Regular.ttf"]
+];
+shortstack = mkFont "shortstack" "ofl" [
+  ["nw4W6Gg7Lc5m7dfDNANitVQyZzn7rFlMq8HpRCz16Mw=" "ofl/shortstack/ShortStack-Regular.ttf"]
+];
+shrikhand = mkFont "shrikhand" "ofl" [
+  ["i6MvbWqW+428kvwaz7xNISPVNIBj2JssPdeE56/Lga8=" "ofl/shrikhand/Shrikhand-Regular.ttf"]
+];
+siemreap = mkFont "siemreap" "ofl" [
+  ["RkdgxtBvw/FT8uAF6xsNM9W9Z+dfLRxjP1hMJKwAZYg=" "ofl/siemreap/Siemreap.ttf"]
+];
+sigmarone = mkFont "sigmarone" "ofl" [
+  ["CBfraYpcSqwsB7uEvh6tgGSUxInaRo2yP1/9m88/CXA=" "ofl/sigmarone/SigmarOne-Regular.ttf"]
+];
+signikanegative = mkFont "signikanegative" "ofl" [
+  ["LREbH3YP34Rzk3HxHIjUfUf2Qq1kMDnT5jlGZgalzew=" "ofl/signikanegative/SignikaNegative%5Bwght%5D.ttf"]
+];
+signikanegativesc = mkFont "signikanegativesc" "ofl" [
+  ["lxAj47/vsAF2up3oN0+55wMBNT/lunQPQEHjVE2X1ok=" "ofl/signikanegativesc/SignikaNegativeSC-Light.ttf"]
+  ["dKEoKM0cAElAxX1mtRwoX+UD3duOGi4OOIUIx6BAHnY=" "ofl/signikanegativesc/SignikaNegativeSC-SemiBold.ttf"]
+  ["QHUaqSJIy7R56oXX1wZSIlZmLIh9OZvQqHsCD6WIeRg=" "ofl/signikanegativesc/SignikaNegativeSC-Bold.ttf"]
+  ["9tIez+CPK6WfgZkHGRyIgO4a6jYMyVR+qczvjpB7Q3s=" "ofl/signikanegativesc/SignikaNegativeSC-Regular.ttf"]
+];
+signika = mkFont "signika" "ofl" [
+  ["vmsuekapAdSDy5zl34gKkeY9XnCUUb04AFHgSuLEnIk=" "ofl/signika/Signika%5Bwght%5D.ttf"]
+];
+signikasc = mkFont "signikasc" "ofl" [
+  ["D/0VatVgC/4XSY7/0Mae3B1ssJ/b/aGpT5zrD4tAMiI=" "ofl/signikasc/SignikaSC%5Bwght%5D.ttf"]
+];
+silkscreen = mkFont "silkscreen" "ofl" [
+  ["doR2qnEtT1w+GNO86A+YCovT9ytwlNIuxedo3zrP7WE=" "ofl/silkscreen/Silkscreen-Bold.ttf"]
+  ["yEVHMzC5TCB5zprwHFGsi6LZnCT00UwDmEO7uOZC69g=" "ofl/silkscreen/Silkscreen-Regular.ttf"]
+];
+simonetta = mkFont "simonetta" "ofl" [
+  ["ltFNn4yK+FfcZL6vTO4pfyLXmSpGPP/z4wkotdVXLvY=" "ofl/simonetta/Simonetta-Regular.ttf"]
+  ["xZEqM8QZBIxv4LxEMDu6Oph6Eiv7THM3UNcdr9CEGxs=" "ofl/simonetta/Simonetta-Black.ttf"]
+  ["kktrf4JVLBFXkDe7aQa7vPeD0BSI3pJ4l3y75LRJSKc=" "ofl/simonetta/Simonetta-BlackItalic.ttf"]
+  ["iRZGec9Cb7UBhb4U2Wc8jKNeQpoDCPBjk5iMINz7nCA=" "ofl/simonetta/Simonetta-Italic.ttf"]
+];
+singleday = mkFont "singleday" "ofl" [
+  ["cW/2eksGdbNcJtYKS7gxc/fRU6t1RHTtNsM2lZPKHKg=" "ofl/singleday/SingleDay-Regular.ttf"]
+];
+sintony = mkFont "sintony" "ofl" [
+  ["sXgdoO+yjBZoqg6LMxhoobsu7xoCln4B5qFm86rjSVg=" "ofl/sintony/Sintony-Regular.ttf"]
+  ["8JHUkutLWUDjBnmiBLDlRltbNcemBLPaMw6FDpNAK+8=" "ofl/sintony/Sintony-Bold.ttf"]
+];
+sirinstencil = mkFont "sirinstencil" "ofl" [
+  ["DiMcYiB4cXlYj+ixyJIb/3Agfx9Vam73415GrgQ1Ky0=" "ofl/sirinstencil/SirinStencil-Regular.ttf"]
+];
+sitara = mkFont "sitara" "ofl" [
+  ["bBBiYXveiouRVsXBnsFkWwLhX3rTVoDaj/i2i3GGRBk=" "ofl/sitara/Sitara-Bold.ttf"]
+  ["2wErk7yVuwbD0iMWWshSpwoIFTiR8C3G2LvdLwRiReA=" "ofl/sitara/Sitara-Regular.ttf"]
+  ["+ycyiiAnUK3rFwXh67wQwmM9ozNMSZM7Z/zwUwiO7x4=" "ofl/sitara/Sitara-Italic.ttf"]
+  ["csdehDeZJwcka9O1NA9lGrczWpyMPzjZNzDhJw91IsM=" "ofl/sitara/Sitara-BoldItalic.ttf"]
+];
+sixcaps = mkFont "sixcaps" "ofl" [
+  ["e1SkZnFyL7ZwZHycOVHm5hi2qdh2/F2a4039MRYorlo=" "ofl/sixcaps/SixCaps.ttf"]
+];
+skranji = mkFont "skranji" "ofl" [
+  ["z+LjhH1MTWPvsgdTNTmTOxrKqn6nHo34Z1jAG33m6as=" "ofl/skranji/Skranji-Bold.ttf"]
+  ["daJbxW8EYG3U4FBoaDGmWH1ppTZecAG8hisIz4bdTqE=" "ofl/skranji/Skranji-Regular.ttf"]
+];
+slabo13px = mkFont "slabo13px" "ofl" [
+  ["e4btw8lgX54NmXZYc1t1rh1eEWBqkQm4zJlSHrKz9AY=" "ofl/slabo13px/Slabo13px-Regular.ttf"]
+];
+slabo27px = mkFont "slabo27px" "ofl" [
+  ["dhWp41clQB2JwPsCqWy85DtJ762lGxgddASayNSdS1U=" "ofl/slabo27px/Slabo27px-Regular.ttf"]
+];
+slackey = mkFont "slackey" "asl20" [
+  ["C+JTzerc0eqQ/1lU6GZBs8y+8nFSYI4mavkWGc0wjrI=" "apache/slackey/Slackey-Regular.ttf"]
+];
+slacksideone = mkFont "slacksideone" "ofl" [
+  ["wy1n2SHP3i+J0v4StueKWGGKQXdKfLGw4yHV0a6aMko=" "ofl/slacksideone/SlacksideOne-Regular.ttf"]
+];
+smokum = mkFont "smokum" "asl20" [
+  ["37Bulee5lyTi5QiXm91nnCoanIQTx/aWFlYJf9OMmmM=" "apache/smokum/Smokum-Regular.ttf"]
+];
+smooch = mkFont "smooch" "ofl" [
+  ["pqkKRhPTUyKOtWqLJXh5Nl+SghBZiZl/krOTDy/FXYQ=" "ofl/smooch/Smooch-Regular.ttf"]
+];
+smoochsans = mkFont "smoochsans" "ofl" [
+  ["bYL0gNcTZdnGxPlq0fPKtEBT6j8LY2ULHg5TnZFa/0k=" "ofl/smoochsans/SmoochSans%5Bwght%5D.ttf"]
+];
+smythe = mkFont "smythe" "ofl" [
+  ["USB6u+TvLVdrMDPpX8W9MCgsDbdmgH4biuPxnSVA4Rw=" "ofl/smythe/Smythe-Regular.ttf"]
+];
+sniglet = mkFont "sniglet" "ofl" [
+  ["+5KhGOFLS94QGgFDiV9XClSwcKMHs1lRC3cDtalLsYw=" "ofl/sniglet/Sniglet-ExtraBold.ttf"]
+  ["KFapdbnArAQC6EAqxL0SbNl9bJBJBDW2GY135jhK5PA=" "ofl/sniglet/Sniglet-Regular.ttf"]
+];
+snippet = mkFont "snippet" "ofl" [
+  ["ZqzvZydTaAVwhddH5ojl3NSIB9mPtqPKmpQkc0vaE1M=" "ofl/snippet/Snippet.ttf"]
+];
+snowburstone = mkFont "snowburstone" "ofl" [
+  ["7egRC1kitxjJuAcXpMXcwrSoYnZ9gxmHeYN3PJALsA8=" "ofl/snowburstone/SnowburstOne-Regular.ttf"]
+];
+sofadione = mkFont "sofadione" "ofl" [
+  ["6I+iBnmp41aLZu4LuXO8i+v3O7hoKXot/9MKmTVMCi8=" "ofl/sofadione/SofadiOne-Regular.ttf"]
+];
+sofia = mkFont "sofia" "ofl" [
+  ["VjTE7PBm+6L6EWRaPFtB6DDKJA4e6rgeELnUdhAbHuo=" "ofl/sofia/Sofia-Regular.ttf"]
+];
+sofiasanscondensed = mkFont "sofiasanscondensed" "ofl" [
+  ["MoLE4aCdFOkcX9sQqt7pMEjQF/oA+Ff0P9zCnJiSIf0=" "ofl/sofiasanscondensed/SofiaSansCondensed%5Bwght%5D.ttf"]
+  ["WDLRDHJ3twuvlUw6n14jXaB12qGH36WchrjmJkn4ElA=" "ofl/sofiasanscondensed/SofiaSansCondensed-Italic%5Bwght%5D.ttf"]
+];
+sofiasansextracondensed = mkFont "sofiasansextracondensed" "ofl" [
+  ["abQsiDrTNN70mwRP/6U5E1j2saZoJZ8Y/c3Av+hU/EU=" "ofl/sofiasansextracondensed/SofiaSansExtraCondensed%5Bwght%5D.ttf"]
+  ["RCwsPZ5QIp8curSYEkHnIgTJdEla/4cilqleDLkBPzA=" "ofl/sofiasansextracondensed/SofiaSansExtraCondensed-Italic%5Bwght%5D.ttf"]
+];
+sofiasans = mkFont "sofiasans" "ofl" [
+  ["wOaRFtNBACEogbX5kyJf8MPqI+LBR/TAhTOJkjyatqU=" "ofl/sofiasans/SofiaSans-Italic%5Bwght%5D.ttf"]
+  ["o+EBm4hn4ht10mp7WdTrLIHRrPa2m5rmztyiafto4pE=" "ofl/sofiasans/SofiaSans%5Bwght%5D.ttf"]
+];
+sofiasanssemicondensed = mkFont "sofiasanssemicondensed" "ofl" [
+  ["eULhwLNwy1/o2/NYSj84qROthKJ+E+dMzQ5UfkPVeh8=" "ofl/sofiasanssemicondensed/SofiaSansSemiCondensed%5Bwght%5D.ttf"]
+  ["rH9PjlzunGPHIsUubLc8l6eJSZJ0bpCg7oKGKR5N+v8=" "ofl/sofiasanssemicondensed/SofiaSansSemiCondensed-Italic%5Bwght%5D.ttf"]
+];
+solitreo = mkFont "solitreo" "ofl" [
+  ["C232byFF6P0BPXMktqVca8DIPEeGpsfc51Bf2+tlKVs=" "ofl/solitreo/Solitreo-Regular.ttf"]
+];
+solway = mkFont "solway" "ofl" [
+  ["TSp0WNYTujMWzZwct6Gsidrsw0xzrtEA1yxRcNsahtg=" "ofl/solway/Solway-ExtraBold.ttf"]
+  ["PEdkO0tIyCXmXkSvk1a7c5LuY8fE5yEeb40eG5a2M/A=" "ofl/solway/Solway-Medium.ttf"]
+  ["GSmurgg2eZoIRyAmr/eXp2jxwFHbYpqFPTVYm6Xlrh4=" "ofl/solway/Solway-Bold.ttf"]
+  ["p6UQNQmmSIQUm5S1AAA9Pe7MKJy5TyVWyBlFyiiw2lU=" "ofl/solway/Solway-Regular.ttf"]
+  ["fVgZ/9pXjGE2N3l4mqI60mKFpERydDqKsw4X3xXIgDM=" "ofl/solway/Solway-Light.ttf"]
+];
+sometypemono = mkFont "sometypemono" "ofl" [
+  ["Ey7zxlOdGFOOnb4uWTQGQPpPvkDgbtBa/6k9Rhlj4NQ=" "ofl/sometypemono/SometypeMono-Regular.ttf"]
+  ["bOIW1wbd6rPS3seyw9lbnFyLEl61lMl/2p8RoRc2EYA=" "ofl/sometypemono/SometypeMono-BoldItalic.ttf"]
+  ["b3B6xZPqLnP1rUTvR4EpXvBAp70Eqqp467XKEYo1iR4=" "ofl/sometypemono/SometypeMono-MediumItalic.ttf"]
+  ["JriWctSvlK7EJfEYd1Jkx3/VxCIy+mYGvZD4zhmFIsk=" "ofl/sometypemono/SometypeMono-Bold.ttf"]
+  ["ks9nZ/d4ijjA6FkVz8mAO25DsXuQqyF0MftLE7oOF3U=" "ofl/sometypemono/SometypeMono-Italic.ttf"]
+  ["wLezBICpyds96LeEDMR/WTBABjfBF5m4UTsiNvlELuY=" "ofl/sometypemono/SometypeMono-Medium.ttf"]
+];
+songmyung = mkFont "songmyung" "ofl" [
+  ["f5CrICUJEVYCEsxYGceyBfnGZEu5a2UJXYn8rglrv1g=" "ofl/songmyung/SongMyung-Regular.ttf"]
+];
+sono = mkFont "sono" "ofl" [
+  ["JHymQcpwZuOt3ICB2JYTwGp55Cds1PIWTQemSTUwAQ8=" "ofl/sono/Sono%5BMONO,wght%5D.ttf"]
+];
+sonsieone = mkFont "sonsieone" "ofl" [
+  ["r5J+Yn9UBmOQ1kM2MRBt7+w4VBJVCD6jbkxNon2tdSU=" "ofl/sonsieone/SonsieOne-Regular.ttf"]
+];
+sora = mkFont "sora" "ofl" [
+  ["hP9wlq4+xsi+R9kG0aC6TefyznjGFSdcdzAZZKMW4Ww=" "ofl/sora/Sora%5Bwght%5D.ttf"]
+];
+sortsmillgoudy = mkFont "sortsmillgoudy" "ofl" [
+  ["encgcDdJx0tlf1NA7aU3TQuHqWU4VdXNLyPMEIPZsPk=" "ofl/sortsmillgoudy/SortsMillGoudy-Italic.ttf"]
+  ["Oh/cDRUbKcVirT87fXyr8Ad4O6TcaURNOphma7YUNS0=" "ofl/sortsmillgoudy/SortsMillGoudy-Regular.ttf"]
+];
+souliyo = mkFont "souliyo" "ofl" [
+  ["ZwsyISpAXJh+jwoxuse1Htc/pD8aLVdQvIM8ANWzUsw=" "ofl/souliyo/Souliyo-Regular.ttf"]
+];
+sourcecodepro = mkFont "sourcecodepro" "ofl" [
+  ["F6FOJGDYcfblU2Gxa+Fz8oRIsa+SQeJ4GuYM9XqkCBI=" "ofl/sourcecodepro/SourceCodePro-Italic%5Bwght%5D.ttf"]
+  ["voii48NoMRxv+PYrBDuxGt3WlgSFgnGSU7aBuMgCmu8=" "ofl/sourcecodepro/SourceCodePro%5Bwght%5D.ttf"]
+];
+sourcesans3 = mkFont "sourcesans3" "ofl" [
+  ["MUY6mPm813yKFFGQaCMFTYIecLJcxsTsjT7/Zw/8OFU=" "ofl/sourcesans3/SourceSans3-Italic%5Bwght%5D.ttf"]
+  ["i5XvAGGo6ynsg1icMOnEzqJ5WQeCrFiWOrXt/KmlFJM=" "ofl/sourcesans3/SourceSans3%5Bwght%5D.ttf"]
+];
+sourcesanspro = mkFont "sourcesanspro" "ofl" [
+  ["N7tHL0fTOgT1YWxukSByPtlEwxMGg47NaS/rfGkITaI=" "ofl/sourcesanspro/SourceSansPro-SemiBold.ttf"]
+  ["DeZNovi4WZIMtg6OphcnS58cnbpCd3O+YTB9ecmCIEo=" "ofl/sourcesanspro/SourceSansPro-BlackItalic.ttf"]
+  ["dAeYlHqgFRxr7EUIunPrfLIvnvLkNUMU/GOPZuqi8HI=" "ofl/sourcesanspro/SourceSansPro-Italic.ttf"]
+  ["YFQl3Gh+zHvc6TKcD8l26jjrOKkQwkFEztYNc/NehV4=" "ofl/sourcesanspro/SourceSansPro-LightItalic.ttf"]
+  ["cZMZ5/4e0GprxeZqHP6oxSJQ7v7lAtF1eAz0Vx3cW/A=" "ofl/sourcesanspro/SourceSansPro-Light.ttf"]
+  ["jhE2wcE1Jho4kRj5dY1HfTWCyd2hD+xrdRHifoZq37w=" "ofl/sourcesanspro/SourceSansPro-SemiBoldItalic.ttf"]
+  ["PS6WJZnUvYO3l6uBPyAX8sf35+Di6OOkl/TnE6Czyck=" "ofl/sourcesanspro/SourceSansPro-Regular.ttf"]
+  ["CtQsziPtYaranmoVa/pBH9AzVAZ3EeBLO7PIRw+C2MY=" "ofl/sourcesanspro/SourceSansPro-BoldItalic.ttf"]
+  ["ekTDDpLtoJY2Mzd/9YTdg1BfVuZebBGMXKMnGQ20Lc0=" "ofl/sourcesanspro/SourceSansPro-ExtraLight.ttf"]
+  ["4ayXHntisq0LC7n1W8FfYhXfivW/aeiUkFNBz9+lGuo=" "ofl/sourcesanspro/SourceSansPro-Bold.ttf"]
+  ["YJ1kwEj0n/xStfHW9M0vP4eEDAY5s1ZK2vLkcJegHvM=" "ofl/sourcesanspro/SourceSansPro-ExtraLightItalic.ttf"]
+  ["UfsCkRwZGZ0rCzV4nvUrAXk4DnKUq6rJOFW/0bCxtwQ=" "ofl/sourcesanspro/SourceSansPro-Black.ttf"]
+];
+sourceserif4 = mkFont "sourceserif4" "ofl" [
+  ["FfvH5GeUiaUBmYw2aScmN6ZkY4jvfkvXfuu1v5Z6H0I=" "ofl/sourceserif4/SourceSerif4-Italic%5Bopsz,wght%5D.ttf"]
+  ["l7LU2m48tJS1oeZq4XaRTYUsyr70ngwCwN8l8+Oaygs=" "ofl/sourceserif4/SourceSerif4%5Bopsz,wght%5D.ttf"]
+];
+sourceserifpro = mkFont "sourceserifpro" "ofl" [
+  ["DenxzLJ0Wwdh8iAHSfj+WPaNJy9QyEV0ezUfyU2k7fo=" "ofl/sourceserifpro/SourceSerifPro-SemiBold.ttf"]
+  ["XKNo1WIppgboQKRDKAgXTb9fPBa/KDjSqwRZ64YUNIw=" "ofl/sourceserifpro/SourceSerifPro-BoldItalic.ttf"]
+  ["qMzFXtKnMEoD0AHUi3M4L3OeD+X4BVM/VKOtsyBJyCo=" "ofl/sourceserifpro/SourceSerifPro-Italic.ttf"]
+  ["jmiheFQXLF8WgwseC66f0gkFUJwmHIJG9y2gB3hSIAw=" "ofl/sourceserifpro/SourceSerifPro-LightItalic.ttf"]
+  ["Y83OJvSzF72fB15im/VL3C1FPX75O8CZPICpDauRebg=" "ofl/sourceserifpro/SourceSerifPro-ExtraLightItalic.ttf"]
+  ["iUzlM3m68sADbvYFKNvQrrpWjZwNePQ0F88XX7UmVcg=" "ofl/sourceserifpro/SourceSerifPro-Bold.ttf"]
+  ["TrDTRt6O8JKADba0mkJq+4q9lch11qOS419Tq4JU6mI=" "ofl/sourceserifpro/SourceSerifPro-Regular.ttf"]
+  ["NEW1JT3ofEZqj3E3GCy0VIYlIDBYaP17pWjo6XLD+JU=" "ofl/sourceserifpro/SourceSerifPro-Black.ttf"]
+  ["1GwOAwoPCP0Yxw5ixZUKs3UANj512bkMe3QkGSKUghE=" "ofl/sourceserifpro/SourceSerifPro-SemiBoldItalic.ttf"]
+  ["H99WYK0EIJpnQ9XxBiye2bd3oUgdku1PBd2brYtWQBY=" "ofl/sourceserifpro/SourceSerifPro-BlackItalic.ttf"]
+  ["gDoZOuPuLHzSjFjJTUUSfMQbJbAqBOfRhDQa3nrY5cg=" "ofl/sourceserifpro/SourceSerifPro-ExtraLight.ttf"]
+  ["QjCzMhZM+U1NUVDFeczHpXFSWw2K5IJFLt/R+50foNs=" "ofl/sourceserifpro/SourceSerifPro-Light.ttf"]
+];
+spacegrotesk = mkFont "spacegrotesk" "ofl" [
+  ["rK1t4fyTQ29cDx9BN3Ue8E8a6jBj5wNlNZcP/PvXn3I=" "ofl/spacegrotesk/SpaceGrotesk%5Bwght%5D.ttf"]
+];
+spacemono = mkFont "spacemono" "ofl" [
+  ["kDGbnTq4fAq5w6+RnlDaz3NSGrqAcy8eeQW+aGCKQqU=" "ofl/spacemono/SpaceMono-Bold.ttf"]
+  ["PnxjPdoRgL+6Df+WWamIP646H/WGYUjd1jOJKgO8saM=" "ofl/spacemono/SpaceMono-BoldItalic.ttf"]
+  ["+lgCu6IDEcyiZz083B6Js0t9RP5vLXML1sXUIpGZrjk=" "ofl/spacemono/SpaceMono-Regular.ttf"]
+  ["44OBPblfoahrjycg3WrAGmUzqcjqhd3xxj1/k4z4FzI=" "ofl/spacemono/SpaceMono-Italic.ttf"]
+];
+specialelite = mkFont "specialelite" "asl20" [
+  ["p3b8tM64vfA+KWdojr2tQmgN5bkafmLBfnGK4hLRS8Q=" "apache/specialelite/SpecialElite-Regular.ttf"]
+];
+spectral = mkFont "spectral" "ofl" [
+  ["M7bSAb5ed4vdXizXQUqQqoQVVjzTSMwWvGuswqWPtMw=" "ofl/spectral/Spectral-MediumItalic.ttf"]
+  ["aO/RlNcU8UcaOM1UUdqkdRbDnlAxAZGgth5UJS+ioB8=" "ofl/spectral/Spectral-Light.ttf"]
+  ["mfOF9N9TGkgc7eIWbzlvi8EwvzwJGceU7DCsQ3xjiUo=" "ofl/spectral/Spectral-ExtraBold.ttf"]
+  ["i9k29cBG9RacFgHmaeX/u/ttj5+QBMQPU6RSOUJJ+Ps=" "ofl/spectral/Spectral-ExtraBoldItalic.ttf"]
+  ["0Nio8AKePlhBlTMfiY8SskNSH+Y7GO0w7JvFV8Hhjhw=" "ofl/spectral/Spectral-SemiBoldItalic.ttf"]
+  ["ED8UlUtPxEysmNkN3Seq5eczs6Rl+t0fbgwJdqvaKPk=" "ofl/spectral/Spectral-LightItalic.ttf"]
+  ["+xR61u+I36OdBuNo8IrISoYnS7BZBGavFG/gbNSih6I=" "ofl/spectral/Spectral-Regular.ttf"]
+  ["yIAYEmT+7RAZXPK7SkOVUamsyj4ZAlajC+k5pItOxOY=" "ofl/spectral/Spectral-ExtraLightItalic.ttf"]
+  ["N2q7AlP6blF8i31cg8/ek8StoHhYFDkn5iwzC8CE/Xc=" "ofl/spectral/Spectral-SemiBold.ttf"]
+  ["whDxU2WnvI4fC5mR6+iMxmI3/XFZ0pdYJvQnppx+aAg=" "ofl/spectral/Spectral-Medium.ttf"]
+  ["oU0QvGmLtVYcHuUJfbuOV8xSG6lpmo+i9v5bsvkyXSU=" "ofl/spectral/Spectral-Italic.ttf"]
+  ["UbBoRgRp+5vp/4GjUBArju99OeDR86zofZouUY8Of2g=" "ofl/spectral/Spectral-ExtraLight.ttf"]
+  ["X5Ps2ZZqOhWBqUnJ+ILs7V+TAVEE598eqAw3/9mYbzE=" "ofl/spectral/Spectral-Bold.ttf"]
+  ["zi5uh+3VScXWtPcsqvLX5N9R0QFzOy5cGbF+Xi5UWa4=" "ofl/spectral/Spectral-BoldItalic.ttf"]
+];
+spectralsc = mkFont "spectralsc" "ofl" [
+  ["QkEnxWQPu8rFvL6sS4Ga5vFWAaXXOfzjXgwVR3V+K+A=" "ofl/spectralsc/SpectralSC-ExtraBold.ttf"]
+  ["yRbRO/kY4c0REwreEG2zVx8Vkook8W7kemg8oI0j+m8=" "ofl/spectralsc/SpectralSC-BoldItalic.ttf"]
+  ["UeUAodp1WuAvBnGlsgqfLK9x6OGcvmMQqkNRARvAZN8=" "ofl/spectralsc/SpectralSC-Regular.ttf"]
+  ["wVYrUCOg3S8LK7tVyxiIKGFYUlfV4lJv/iVzKjF73o4=" "ofl/spectralsc/SpectralSC-Bold.ttf"]
+  ["g5rGkbbcjEX7MGTsdvuhQkYO9ka2YGQoJBk05A1KkBg=" "ofl/spectralsc/SpectralSC-ExtraLight.ttf"]
+  ["3ZUi6fmw/bi/ooE1UgTHeziQIciUPdnZPhpLXbmHmlM=" "ofl/spectralsc/SpectralSC-ExtraBoldItalic.ttf"]
+  ["LjAhHRh5MfSWGTDPzebr3blpxIrS/j78uryYM2N6PSE=" "ofl/spectralsc/SpectralSC-SemiBold.ttf"]
+  ["tdnwgkybgTTYaRVp5+95MujLTtDNkWfOW8hvKVxqVkQ=" "ofl/spectralsc/SpectralSC-LightItalic.ttf"]
+  ["9gvt1yFnfitBiqFtinQmGnbRjbQ4WeMcNP68oFVdqaI=" "ofl/spectralsc/SpectralSC-SemiBoldItalic.ttf"]
+  ["pPT5W7kVcNoLGEkRx6ahFAZm+6tWYnbza5pRWsY9JnE=" "ofl/spectralsc/SpectralSC-Medium.ttf"]
+  ["BdTL5BMlnqYZHJ9bohhUOWrCsp10WFZ7hCCcZha+8xE=" "ofl/spectralsc/SpectralSC-MediumItalic.ttf"]
+  ["5R0gCpT/i4V6jQJdJB4JDYKCputVC7tXAmx2QggBuLI=" "ofl/spectralsc/SpectralSC-ExtraLightItalic.ttf"]
+  ["epT6BfwZfMhH9S29CtdKN8xJa/20dtt7zQEWdaOh6sg=" "ofl/spectralsc/SpectralSC-Light.ttf"]
+  ["bIKGE5Rmcl28V5jO3c23kdlTtj/sHDMbWAXrw5iiXJ4=" "ofl/spectralsc/SpectralSC-Italic.ttf"]
+];
+spicyrice = mkFont "spicyrice" "ofl" [
+  ["8zn5sLPVhZdOwio3TX4JOLQpwincDzs7FvNMZQqwgGg=" "ofl/spicyrice/SpicyRice-Regular.ttf"]
+];
+spinnaker = mkFont "spinnaker" "ofl" [
+  ["+JhS+xy/QV6sGJPZiXjXe5NEddU9RoOP0UaSSk0uE/w=" "ofl/spinnaker/Spinnaker-Regular.ttf"]
+];
+spirax = mkFont "spirax" "ofl" [
+  ["5QmXXAaA5EfmvolGf38L6+xtTLCot117a7bW/X4tW2U=" "ofl/spirax/Spirax-Regular.ttf"]
+];
+splash = mkFont "splash" "ofl" [
+  ["QsLdwRkXMzvNJKPrC8ffUgUngibi9lIUWThEefG2Z1w=" "ofl/splash/Splash-Regular.ttf"]
+];
+splinesansmono = mkFont "splinesansmono" "ofl" [
+  ["Bz8RHzeobMbZUreHCzwa67/Hj0BW3TmW2yi7xxZmZ6Y=" "ofl/splinesansmono/SplineSansMono-Italic%5Bwght%5D.ttf"]
+  ["4gwd8yqi+IboKM/MgcpcQF0/OxYJkPa4kpI+LkSb9SU=" "ofl/splinesansmono/SplineSansMono%5Bwght%5D.ttf"]
+];
+splinesans = mkFont "splinesans" "ofl" [
+  ["ZSUJOd4KtBLSsjScnLhTBKWRn8PF1OdHE6LYofRfKUc=" "ofl/splinesans/SplineSans%5Bwght%5D.ttf"]
+];
+squadaone = mkFont "squadaone" "ofl" [
+  ["WzShYz28SNs4NdioR7xHXm4CZxIdNDWFRym6S0B6Bd8=" "ofl/squadaone/SquadaOne-Regular.ttf"]
+];
+squarepeg = mkFont "squarepeg" "ofl" [
+  ["7sEDJo4W8fNISCaHlk5cFUXJxYiAUstI0aqNyfJ6N/w=" "ofl/squarepeg/SquarePeg-Regular.ttf"]
+];
+sreekrushnadevaraya = mkFont "sreekrushnadevaraya" "ofl" [
+  ["O49bAaCPulr1N2DidNbNfqZRTsJljZxIDq/MiRfX4ss=" "ofl/sreekrushnadevaraya/SreeKrushnadevaraya-Regular.ttf"]
+];
+sriracha = mkFont "sriracha" "ofl" [
+  ["wxKMMMsh6HJLeSWGyHBZ0bXs6uENmVe6KrJsgLvtNmk=" "ofl/sriracha/Sriracha-Regular.ttf"]
+];
+srisakdi = mkFont "srisakdi" "ofl" [
+  ["wBcnD2i6x8OygsnYDmZl9WrU9dZw21kKKFHcucCnX1c=" "ofl/srisakdi/Srisakdi-Bold.ttf"]
+  ["Bz0WlL2lz0IIJXSkt9V98pjX8s/J7pl/j1q5shTPcsk=" "ofl/srisakdi/Srisakdi-Regular.ttf"]
+];
+staatliches = mkFont "staatliches" "ofl" [
+  ["g5UhKqTGw1NL05p0XZVjBf8IDD8+1zumHk+6rpUeVcw=" "ofl/staatliches/Staatliches-Regular.ttf"]
+];
+stalemate = mkFont "stalemate" "ofl" [
+  ["NrjC8nd8/MoXgV5jY290mzmAYjEMCJ5sn+KmUpDH5Xk=" "ofl/stalemate/Stalemate-Regular.ttf"]
+];
+stalinistone = mkFont "stalinistone" "ofl" [
+  ["c8xI7voBVDsJ/T35uravKjAuUuKSuGJfS2LIaLwVLus=" "ofl/stalinistone/StalinistOne-Regular.ttf"]
+];
+stardosstencil = mkFont "stardosstencil" "ofl" [
+  ["axX1Cxs1hRLZIrXxGTevF+kHBFh+HX+wCfFxXS1d+nQ=" "ofl/stardosstencil/StardosStencil-Bold.ttf"]
+  ["IIsT0VOHwoKhwMQ5qOTDiAkkPRXDYbMdpECyWn5POa4=" "ofl/stardosstencil/StardosStencil-Regular.ttf"]
+];
+sticknobills = mkFont "sticknobills" "ofl" [
+  ["R1TTN/vwz/rHRLWDFsPQkberxmjXuftd8ILhkFsnwCc=" "ofl/sticknobills/StickNoBills%5Bwght%5D.ttf"]
+];
+stick = mkFont "stick" "ofl" [
+  ["DlgtcrUSXHhH0cRrZYMzGU96P3C/ohDS+MrhpZaheFc=" "ofl/stick/Stick-Regular.ttf"]
+];
+stintultracondensed = mkFont "stintultracondensed" "ofl" [
+  ["HDK3elDpYPnojinhxloKFf/id2gazg2/IH+vp74jWR4=" "ofl/stintultracondensed/StintUltraCondensed-Regular.ttf"]
+];
+stintultraexpanded = mkFont "stintultraexpanded" "ofl" [
+  ["grDsUGROiCQQCjIIXHE2rrebLcmoGASu/ILDyTN/im8=" "ofl/stintultraexpanded/StintUltraExpanded-Regular.ttf"]
+];
+stixtwomath = mkFont "stixtwomath" "ofl" [
+  ["ViVRsVuDbm4B0bc1CQm688jI2DJgwRkPv0VEMz5pNt4=" "ofl/stixtwomath/STIXTwoMath-Regular.ttf"]
+];
+stixtwotext = mkFont "stixtwotext" "ofl" [
+  ["iMDi4xbq/1bt3J5R5IUDF+Kh5JC791iy3sR5Ou26nHQ=" "ofl/stixtwotext/STIXTwoText-Italic%5Bwght%5D.ttf"]
+  ["eWK4t4EeaolsmpGgvMu1JBBHdw6yTUmXxctf4h1cDfI=" "ofl/stixtwotext/STIXTwoText%5Bwght%5D.ttf"]
+];
+stoke = mkFont "stoke" "ofl" [
+  ["bXZXhF8gA7cRm7mB1PI2MYLHfzog0aOjsrRGWBTp37g=" "ofl/stoke/Stoke-Light.ttf"]
+  ["2lDRdGwpAQaT/yCDKusMqpSzsFZkQwVzQebfPHFd+LI=" "ofl/stoke/Stoke-Regular.ttf"]
+];
+strait = mkFont "strait" "ofl" [
+  ["ZI+E1MWU7hyFftUvKNqU0zU539zC+wPUwcoK9LngHA4=" "ofl/strait/Strait-Regular.ttf"]
+];
+strong = mkFont "strong" "ofl" [
+  ["TK5SeMs3LQ7CD+ewCpaal2a17KufGhbD2dMfL6jAtGE=" "ofl/strong/Strong-Regular.ttf"]
+];
+stylescript = mkFont "stylescript" "ofl" [
+  ["Tyhap7Lofenqj8PTpXHMQoJXxCrHe194bZnZlJrE7Zo=" "ofl/stylescript/StyleScript-Regular.ttf"]
+];
+stylish = mkFont "stylish" "ofl" [
+  ["PqLkydAYP9zBNiA5MF7zD6i7UVTwMLMDoCkFmkSoUWw=" "ofl/stylish/Stylish-Regular.ttf"]
+];
+sueellenfrancisco = mkFont "sueellenfrancisco" "ofl" [
+  ["1tcuBG6OkvZZ6s+3RXz34fIULBEsPYxDwLWjkEpchiE=" "ofl/sueellenfrancisco/SueEllenFrancisco-Regular.ttf"]
+];
+suezone = mkFont "suezone" "ofl" [
+  ["PvhoRKrQz5233L2jJvPS9UzEzP5W25SengxgoXAxvUE=" "ofl/suezone/SuezOne-Regular.ttf"]
+];
+sulphurpoint = mkFont "sulphurpoint" "ofl" [
+  ["XTqoJ7X9FURxIIH0UJ3xRRw2sdEBkSkYYpAqUcf3iAE=" "ofl/sulphurpoint/SulphurPoint-Light.ttf"]
+  ["RtbVSWDHdwB0NOKpkrDs9jyfVUwrJ/BZMh9CBGYty2o=" "ofl/sulphurpoint/SulphurPoint-Regular.ttf"]
+  ["bEhmN0IbO3UHredXlcpRq9UGP7dPKBFhjzk/rm2c6Ms=" "ofl/sulphurpoint/SulphurPoint-Bold.ttf"]
+];
+sumana = mkFont "sumana" "ofl" [
+  ["5xvhvlX4lw7yTuOq95DDTK0/W2xdUY5ByGUcWW4QLsQ=" "ofl/sumana/Sumana-Regular.ttf"]
+  ["4yFQw2ztEIBNB33EFxTfflyEcUCLzMcDb7owMUqRTnk=" "ofl/sumana/Sumana-Bold.ttf"]
+];
+sunflower = mkFont "sunflower" "ofl" [
+  ["3Z+5eqnsH9tl4DKFE9nFTBFPukHezKHTKh4e2ZLiVcU=" "ofl/sunflower/Sunflower-Light.ttf"]
+  ["biFtay93qFD2tzviVjPQngM4Xfpjo6Yy+efYOpDqf3k=" "ofl/sunflower/Sunflower-Medium.ttf"]
+  ["awM2J4F/ZhlDOv6CAoAT3EWnj/gkBrHb5bFuG7w3Dgo=" "ofl/sunflower/Sunflower-Bold.ttf"]
+];
+sunshiney = mkFont "sunshiney" "asl20" [
+  ["L0HLxiY8AzwY8dt65lI6ietQzVZlsLdjXMOkycmg/k0=" "apache/sunshiney/Sunshiney-Regular.ttf"]
+];
+supermercadoone = mkFont "supermercadoone" "ofl" [
+  ["c+H2xG5PlJSd+DlKXcIHpa5MdblNGbASx7jqpn3KN1A=" "ofl/supermercadoone/SupermercadoOne-Regular.ttf"]
+];
+suranna = mkFont "suranna" "ofl" [
+  ["Zq1BlPki4LIw4S01BwyFLThXOtQK1OmTy+fWnfNEsXc=" "ofl/suranna/Suranna-Regular.ttf"]
+];
+sura = mkFont "sura" "ofl" [
+  ["PwWpznXx2Or48txXaE/IqoSoH6cqQ3WDhJ7rhPVwies=" "ofl/sura/Sura-Bold.ttf"]
+  ["3zW9+IPvbNoXPz516IlwoleuaeqpS5NlVFHzO5+WAjQ=" "ofl/sura/Sura-Regular.ttf"]
+];
+suravaram = mkFont "suravaram" "ofl" [
+  ["Z8jg2eeMPu8pJL/lS3Ri6Ydf9C/jervj5gGtapraD5w=" "ofl/suravaram/Suravaram-Regular.ttf"]
+];
+suwannaphum = mkFont "suwannaphum" "ofl" [
+  ["8Q5nuyVseMEmrJ3vViqTOsRKUeX6DOvqKmI0+qVd5KU=" "ofl/suwannaphum/Suwannaphum-Regular.ttf"]
+  ["TGPYvmXlWpt1U4XGEU2eQN09AFQst1gdMh5BsCmCa+k=" "ofl/suwannaphum/Suwannaphum-Light.ttf"]
+  ["ivoRVLd96b4oJIOVFgz1+UzaeEesoSOXGvIS4HTW+D0=" "ofl/suwannaphum/Suwannaphum-Bold.ttf"]
+  ["p2IqOZKTw2NSoYLYKdcbkL+OcRQWye1VFDShVFGTN2Y=" "ofl/suwannaphum/Suwannaphum-Thin.ttf"]
+  ["xoESqYoUMWXc8jGwSjNUl/bAKCFABrDhrVkF1l0KKQY=" "ofl/suwannaphum/Suwannaphum-Black.ttf"]
+];
+swankyandmoomoo = mkFont "swankyandmoomoo" "ofl" [
+  ["p0Xv+olheQcXlm98adlnVqer4tM0oIvjM6ZWt8VLYn8=" "ofl/swankyandmoomoo/SwankyandMooMoo.ttf"]
+];
+syncopate = mkFont "syncopate" "asl20" [
+  ["/LsQeYuAyYGvq6oQVb3i7imygwabRM38aEV+kDoFasE=" "apache/syncopate/Syncopate-Regular.ttf"]
+  ["xx9aQKgxFVGEQ8E0dOUTKAT0qRzibib9lxjNOBStSy4=" "apache/syncopate/Syncopate-Bold.ttf"]
+];
+synemono = mkFont "synemono" "ofl" [
+  ["sUKwiGgHkXJYScx0xU15N8mB3iN4WDvecvgmvT6yZ9w=" "ofl/synemono/SyneMono-Regular.ttf"]
+];
+syne = mkFont "syne" "ofl" [
+  ["zlrHcUKmXKsiSKGi67dAsdTZwgtSSIh30/9mTRNWEEo=" "ofl/syne/Syne%5Bwght%5D.ttf"]
+];
+synetactile = mkFont "synetactile" "ofl" [
+  ["1H7DaTqPen/fcs3uDkXI+g4IvAtBukG4zzFQkGX/BiA=" "ofl/synetactile/SyneTactile-Regular.ttf"]
+];
+taiheritagepro = mkFont "taiheritagepro" "ofl" [
+  ["3S6dUYWEsiFHYqtN5XLFvS05VcDTK3RzmlxHFBLiu6w=" "ofl/taiheritagepro/TaiHeritagePro-Regular.ttf"]
+  ["ZYul1lWULgE5IzzI6KfgRSmXbDjdmr2AoJPc7MrUL/Q=" "ofl/taiheritagepro/TaiHeritagePro-Bold.ttf"]
+];
+tajawal = mkFont "tajawal" "ofl" [
+  ["qybtPgxa8scbRptXgN7P+AiNKQq5GqKbBzIVgBNugTo=" "ofl/tajawal/Tajawal-Light.ttf"]
+  ["H/i9lDomHJ3XkGvbGZPKuHttklp/tfhIzbUe0wFTEJA=" "ofl/tajawal/Tajawal-Medium.ttf"]
+  ["oS/7+q7DCrgULtxg+kcnsQSpDrVMaiAKdpiKHsLsEdw=" "ofl/tajawal/Tajawal-ExtraLight.ttf"]
+  ["aIKJLaPgNSfV2yu6s7SL3m7y6HikP1ItGk7r2pABChk=" "ofl/tajawal/Tajawal-Regular.ttf"]
+  ["2lgqV50yAIaVNdyZTSNJYIqFggQvh3azZ5sVcBXbKHw=" "ofl/tajawal/Tajawal-Black.ttf"]
+  ["A0Kra3S2vRtLW/e+2kWpc0orMUejHoo6RbajQXpS2dc=" "ofl/tajawal/Tajawal-Bold.ttf"]
+  ["PRKYt0fCJXn54b3rDUFlBkyxf35mFF4vQ/nesSrXos8=" "ofl/tajawal/Tajawal-ExtraBold.ttf"]
+];
+tangerine = mkFont "tangerine" "ofl" [
+  ["P122AQ3kj3Fzk58WYhwODnlLWJ7sBOOwTgqBvoSN+rk=" "ofl/tangerine/Tangerine-Regular.ttf"]
+  ["o1NoyBTHHBWSj/xgy6wyvIFGHwO4laSmB9+cZLPRVIs=" "ofl/tangerine/Tangerine-Bold.ttf"]
+];
+tapestry = mkFont "tapestry" "ofl" [
+  ["FDSi57o2+1JmqO94ietOhztktYAH6JwAyvWALKvf/28=" "ofl/tapestry/Tapestry-Regular.ttf"]
+];
+taprom = mkFont "taprom" "ofl" [
+  ["2JxS6a0yaT/72GRuJ3DjMdg8MQBWut8yzjsSs+G1tFo=" "ofl/taprom/Taprom-Regular.ttf"]
+];
+tauri = mkFont "tauri" "ofl" [
+  ["/KifxnW4k2PlULEwju7ef6D19OHrK/m5u11DLAGBejk=" "ofl/tauri/Tauri-Regular.ttf"]
+];
+taviraj = mkFont "taviraj" "ofl" [
+  ["EmoO0GH/lsSZsxS9zaz6HCzNFT/NeOT7s1dciOmNrj0=" "ofl/taviraj/Taviraj-Medium.ttf"]
+  ["M7F4kgx0Knn8XatLVVhbYeoKCZzhUsj6ut3Mwvi+Eeg=" "ofl/taviraj/Taviraj-BlackItalic.ttf"]
+  ["MNRd5SN0zsOgfmAoQeeq2/RTFvzVu4GRv5wjN8cXWqs=" "ofl/taviraj/Taviraj-BoldItalic.ttf"]
+  ["O7w3ZE+e2iR1vVYneYsNl8dlz2aCl5c6If6CZsNRBx4=" "ofl/taviraj/Taviraj-Thin.ttf"]
+  ["gfPIEVVzOnPEtZFNfWhXgy59ytW15j95kteXkH4yehc=" "ofl/taviraj/Taviraj-Black.ttf"]
+  ["nqWCJJuE8g8716XXgt6Gq/huz63fISBEXgzh0ZnmyO4=" "ofl/taviraj/Taviraj-LightItalic.ttf"]
+  ["B35imXEf3cqXP51DRVlJAYRZwtKcbnkGZtQQF+4aJ9U=" "ofl/taviraj/Taviraj-Regular.ttf"]
+  ["+x03vVVtsRnUtG4m8iv2aMusurIO03SBcAkKFrmnUPo=" "ofl/taviraj/Taviraj-SemiBoldItalic.ttf"]
+  ["7OVjHcONiiKRSOyHgw+hCqS6jYZBxxnqJe7yw3R0uiE=" "ofl/taviraj/Taviraj-Bold.ttf"]
+  ["QYDalodxRCcGwqiLA00E3vz3Hl/hW4NcDX5OHNQlIyI=" "ofl/taviraj/Taviraj-ThinItalic.ttf"]
+  ["V2cKu0GPZ/kAMesHPnr7admOBBt++CSg1omBEE8Tvu0=" "ofl/taviraj/Taviraj-Light.ttf"]
+  ["ecxVI0/IuFEhuz5FY92ONa98gF1Djs401IT3Bm2osA4=" "ofl/taviraj/Taviraj-ExtraLight.ttf"]
+  ["Hu1b8LMs2NcSO4H8GQ0aJpUZnidS7wcWtmdaoegOmoc=" "ofl/taviraj/Taviraj-ExtraBoldItalic.ttf"]
+  ["lkupVtiVOsQkJHHX8gyJjCZsjyz3yYOlEAi+Cs+z7xk=" "ofl/taviraj/Taviraj-ExtraBold.ttf"]
+  ["1NOV+crRs0wpDrpsk9qF6pmpDouliErfekUE/88LgDM=" "ofl/taviraj/Taviraj-MediumItalic.ttf"]
+  ["+hzJ+JTZf0pAoLAkONw7UVVw59PbKW0qUDuj0yzGxhM=" "ofl/taviraj/Taviraj-Italic.ttf"]
+  ["f0eA4YqCO0ZEIawtoWsZDOPPYXfngUWhAFIo792+Yiw=" "ofl/taviraj/Taviraj-SemiBold.ttf"]
+  ["5Zxciu6VRQFKkKjAC1+XSrEHjwY1o73/ZaLKesO/R7c=" "ofl/taviraj/Taviraj-ExtraLightItalic.ttf"]
+];
+teko = mkFont "teko" "ofl" [
+  ["WXkrFlzGlTGrhzBHksQCH2gnGyT7OGYLll6EoMqmTmU=" "ofl/teko/Teko-Bold.ttf"]
+  ["w0Pnu4YkhoCHCOqiwBkceA7lgE4L9YJCSiZ7m34nmjs=" "ofl/teko/Teko-Light.ttf"]
+  ["M8W2fp5JKUsivnhhGh4QSO/Oz0qe+X6gx7zgyFPN0LM=" "ofl/teko/Teko-Regular.ttf"]
+  ["IPq71ZlnAg+TMerLo5yHPqyFmItQIWpWrNUMK/vfGVg=" "ofl/teko/Teko-Medium.ttf"]
+  ["rjbiwtp89D+N6a2nNCMzhmnBGYhuO+Iph63xXK41Vgc=" "ofl/teko/Teko-SemiBold.ttf"]
+];
+telex = mkFont "telex" "ofl" [
+  ["7qotF9EFtrRuU2js2ZD1sZxQEx/5Itv3m/ubtFwkmHE=" "ofl/telex/Telex-Regular.ttf"]
+];
+tenaliramakrishna = mkFont "tenaliramakrishna" "ofl" [
+  ["Jw3iQrOnEnW+WRnNHVrvonKuSpltReg7lnLhUVLKpLg=" "ofl/tenaliramakrishna/TenaliRamakrishna-Regular.ttf"]
+];
+tenorsans = mkFont "tenorsans" "ofl" [
+  ["NQyIL6nxmSftEINxaR05PV3Bwgnt3oRyyriqgBMkE2Y=" "ofl/tenorsans/TenorSans-Regular.ttf"]
+];
+textmeone = mkFont "textmeone" "ofl" [
+  ["n+hQI5hXFcBa8SGip2QxymUat34l4y2PswecXyOBiEk=" "ofl/textmeone/TextMeOne-Regular.ttf"]
+];
+texturina = mkFont "texturina" "ofl" [
+  ["1YJ+ZTFRDpteKpXzBC7nRjsLHzIPmkFGFZpVNIL24zk=" "ofl/texturina/Texturina-Italic%5Bopsz,wght%5D.ttf"]
+  ["R4oV1xRc+UVlz8GuszWWrrARjH2GqE0GHd9G3j19/aM=" "ofl/texturina/Texturina%5Bopsz,wght%5D.ttf"]
+];
+thabit = mkFont "thabit" "ofl" [
+  ["jd7VZKH23GoiMRK2byDRKiIa12p/aI3VcM73lJQN0SQ=" "ofl/thabit/Thabit-Bold.ttf"]
+  ["3Iyiy83Z0ZJTlLImG7Rol3UrIKGQzn0QjiC1a0Zc5oY=" "ofl/thabit/Thabit-Oblique.ttf"]
+  ["U3XtnQ1epunpgGu93R3IYLGFcBjTIp0Q+UTKOeBDGP8=" "ofl/thabit/Thabit-BoldOblique.ttf"]
+  ["P+b0I9dRkZ1kEbONbeL/gjJSKS7vnoYMSlMvr3ebZ0o=" "ofl/thabit/Thabit.ttf"]
+];
+tharlon = mkFont "tharlon" "ofl" [
+  ["rzLLzNUNiz7KRdmV/FbmkEEZeRN22ZEVf0czaFIhyHQ=" "ofl/tharlon/Tharlon-Regular.ttf"]
+];
+thasadith = mkFont "thasadith" "ofl" [
+  ["EQrMx9+QvjmOr+RpGLx7Vjo04R67qk/kBH4HCh4Ul08=" "ofl/thasadith/Thasadith-Bold.ttf"]
+  ["VjhYpwC0y/0zSHSeHJqOAOAwFX/f1TistiV3AjA+FIs=" "ofl/thasadith/Thasadith-BoldItalic.ttf"]
+  ["gvFt5RKHIz77JxE4ZUIQXkt9Xb8df0YP76hwCz/O9es=" "ofl/thasadith/Thasadith-Regular.ttf"]
+  ["C/hQYd8X8nXRDb9gD8mLPDp8Mzkn5MQ2g+tQo28GN1Q=" "ofl/thasadith/Thasadith-Italic.ttf"]
+];
+thegirlnextdoor = mkFont "thegirlnextdoor" "ofl" [
+  ["NTKecSWOSDmGQ/H5QXWqDJqNGL0XmRjZrE89SXtlV6E=" "ofl/thegirlnextdoor/TheGirlNextDoor.ttf"]
+];
+thenautigal = mkFont "thenautigal" "ofl" [
+  ["1RiY2pAJbO/S7fxapP6ivd47rQErod4IrmWfBrtCDm8=" "ofl/thenautigal/TheNautigal-Bold.ttf"]
+  ["xyObmZwNgSdoMRbIVjMH8K29Y/exazQsGA+BlpQeymc=" "ofl/thenautigal/TheNautigal-Regular.ttf"]
+];
+tienne = mkFont "tienne" "ofl" [
+  ["SRwdrnnClvMA3RirWV64ppOiMSY78aAD3Ci9L+rFRio=" "ofl/tienne/Tienne-Black.ttf"]
+  ["L6kENYO76UlnRLnj4aHUczecdzZjV/a8hTyUrVPYwxw=" "ofl/tienne/Tienne-Regular.ttf"]
+  ["+QN/7xmgdcrHA5EMPHGtdHrdugqgCPtm1pdp95pBMgo=" "ofl/tienne/Tienne-Bold.ttf"]
+];
+tillana = mkFont "tillana" "ofl" [
+  ["dsU7iWNDJBgIf6N0jRS+JfCQ/YnNcJ9sFLY2ecTHIkQ=" "ofl/tillana/Tillana-Bold.ttf"]
+  ["i/4UvHa4vLLdY7kt90jjSVrw5+7ucdtJNgNOb+1xGcY=" "ofl/tillana/Tillana-SemiBold.ttf"]
+  ["ZulvnMqGSWn98SMRy3FXurYNbH2aR9gD/wakDv19ziU=" "ofl/tillana/Tillana-ExtraBold.ttf"]
+  ["v/MIUXQsktiUo1jOeIZpeCqr7pWp9Rw5838sK4U/Rug=" "ofl/tillana/Tillana-Medium.ttf"]
+  ["/ZBxAPoMEx25mZYLt6xxJD5RXDMO4W4Y8o+olYvRgRs=" "ofl/tillana/Tillana-Regular.ttf"]
+];
+tiltneon = mkFont "tiltneon" "ofl" [
+  ["wiMz39HNFMKmErNuocUOoT5ekkQYHlEppjyUShZYI6A=" "ofl/tiltneon/TiltNeon%5BXROT,YROT%5D.ttf"]
+];
+tiltprism = mkFont "tiltprism" "ofl" [
+  ["KOljUXU+F33G4Jf38InGlCzfJkFuhh9KudbuC8V8dRU=" "ofl/tiltprism/TiltPrism%5BXROT,YROT%5D.ttf"]
+];
+tiltwarp = mkFont "tiltwarp" "ofl" [
+  ["5lAyDkBcIghTGE+iCmCoEvPwJ1w6Gy0XaUCa0ctL/KU=" "ofl/tiltwarp/TiltWarp%5BXROT,YROT%5D.ttf"]
+];
+timmana = mkFont "timmana" "ofl" [
+  ["WIKWiwYfw/RcD/KGi8S+zRax1fOF7KGmPkh6+GttY8Y=" "ofl/timmana/Timmana-Regular.ttf"]
+];
+tinos = mkFont "tinos" "asl20" [
+  ["UsTYepiOsfHCXh/Ll5cNRWovslLg+iEW4rS7M+eCS9o=" "apache/tinos/Tinos-BoldItalic.ttf"]
+  ["agr+hwaLpd3rapu3udDcQWZpZsBEdn32nePvt+M/Wvg=" "apache/tinos/Tinos-Bold.ttf"]
+  ["EGE5WsZ3XzzqJ9ye89ejucw0wrSi2XqmSUESlNUWWZA=" "apache/tinos/Tinos-Regular.ttf"]
+  ["dRyXkEPJZB2tOJq5xoDCyf+woMc1IVP0i569lY6JY9g=" "apache/tinos/Tinos-Italic.ttf"]
+];
+tirobangla = mkFont "tirobangla" "ofl" [
+  ["p2NSPcP5CnGWLLjZQAuPCoa0CyywFnbxZRAaKWcSeuQ=" "ofl/tirobangla/TiroBangla-Regular.ttf"]
+  ["3rgzClZpfPq++P85PG02r2BTEimxOL+aP/6DQzDLA+E=" "ofl/tirobangla/TiroBangla-Italic.ttf"]
+];
+tirodevanagarihindi = mkFont "tirodevanagarihindi" "ofl" [
+  ["7tB6ynKR40+ixPPki+MlsmH2BRbs+DVhD+4w2t4PeOw=" "ofl/tirodevanagarihindi/TiroDevanagariHindi-Italic.ttf"]
+  ["0qvLTTUvC/q5FjLfXZyBc4ggc8GC5mL6cxpac45mgdc=" "ofl/tirodevanagarihindi/TiroDevanagariHindi-Regular.ttf"]
+];
+tirodevanagarimarathi = mkFont "tirodevanagarimarathi" "ofl" [
+  ["jh1O35JMBoXxOD0NN6p8RmIQPS5IXlO1NbRSivWs2WY=" "ofl/tirodevanagarimarathi/TiroDevanagariMarathi-Regular.ttf"]
+  ["/6I4PUV+Ro23V3XPGZEKSBfD4lDabPooo8aZSVSrfUw=" "ofl/tirodevanagarimarathi/TiroDevanagariMarathi-Italic.ttf"]
+];
+tirodevanagarisanskrit = mkFont "tirodevanagarisanskrit" "ofl" [
+  ["lkGRQDIVTqaKfK7RADIM9UfWOJGh45YgM7qR3JwzrCs=" "ofl/tirodevanagarisanskrit/TiroDevanagariSanskrit-Italic.ttf"]
+  ["da6HPl4/nDD7lio9KDufXnvFvKV4IqKqkmdTspexUMo=" "ofl/tirodevanagarisanskrit/TiroDevanagariSanskrit-Regular.ttf"]
+];
+tirogurmukhi = mkFont "tirogurmukhi" "ofl" [
+  ["AdKysT0YWQBch78pyGOJ8sfKvLVnLlTQNEeZC9O6e3E=" "ofl/tirogurmukhi/TiroGurmukhi-Italic.ttf"]
+  ["SdaVlHTSMnY+1bFseGyef/BYfHDBQe/njAcOcJAUpX0=" "ofl/tirogurmukhi/TiroGurmukhi-Regular.ttf"]
+];
+tirokannada = mkFont "tirokannada" "ofl" [
+  ["VUN3np6uz1/K/CJ1s3zd1w7dtzUq812gKKuCKLRZMFA=" "ofl/tirokannada/TiroKannada-Regular.ttf"]
+  ["4iuWFAhCvNt8RT1ovRj5auxTUYL4tZ5QccgnnGvnPCY=" "ofl/tirokannada/TiroKannada-Italic.ttf"]
+];
+tirotamil = mkFont "tirotamil" "ofl" [
+  ["9K0mqTiTpF/LRL8ReUDUYsWu8Yh1Q+m4vxUHZ+WXp28=" "ofl/tirotamil/TiroTamil-Regular.ttf"]
+  ["lXHwBIufJUEf8CDsA30sfiV8X8KwQ8GFM+MF6kqhk+Y=" "ofl/tirotamil/TiroTamil-Italic.ttf"]
+];
+tirotelugu = mkFont "tirotelugu" "ofl" [
+  ["rv1yoxsanXJgR9PcNFaPCqzDpQSJcfc9MijU0qYIckA=" "ofl/tirotelugu/TiroTelugu-Regular.ttf"]
+  ["jxVIm1d95vE1ET3xhsoJRAreuiM5ma00XPFvf8G9dms=" "ofl/tirotelugu/TiroTelugu-Italic.ttf"]
+];
+titanone = mkFont "titanone" "ofl" [
+  ["Vj/23hebvUS819KmxEjW3Dv5NYNCN88SUOUG5lzYb/E=" "ofl/titanone/TitanOne-Regular.ttf"]
+];
+titilliumweb = mkFont "titilliumweb" "ofl" [
+  ["3MON/q0+EUmSkiywaETUZ85c/mK6uoQf9AU8JQ3LQek=" "ofl/titilliumweb/TitilliumWeb-SemiBoldItalic.ttf"]
+  ["fJLxUwLXrBg2AVy5z0BoeWQGZnswSgYbdd+OEfFkjIE=" "ofl/titilliumweb/TitilliumWeb-SemiBold.ttf"]
+  ["e2tEUsZcyLhSLpLn1NTC5tdnU0HOr9BBu2vTApdRfqU=" "ofl/titilliumweb/TitilliumWeb-Regular.ttf"]
+  ["zEjCXQHjakFIZN4j4iMUXpt2I04qEr7qyNIEyDzK/EU=" "ofl/titilliumweb/TitilliumWeb-LightItalic.ttf"]
+  ["4ujhgSBB4sWGjx0DrCSZQxIFLFOBzKLoB0jwjLfhMJM=" "ofl/titilliumweb/TitilliumWeb-Bold.ttf"]
+  ["ONMQr2bAFQFsOUVbD955nYOYC4RP0fXUxF71WObXAKI=" "ofl/titilliumweb/TitilliumWeb-ExtraLight.ttf"]
+  ["dEBo7g8WI8YVZ7CYHVHEntugEtdMW6cwdoR8AUMoSiU=" "ofl/titilliumweb/TitilliumWeb-BoldItalic.ttf"]
+  ["TwjmgcGzj4JRJaGlqcijjQ65TupRsEzbKhfL7Ef5CDM=" "ofl/titilliumweb/TitilliumWeb-Italic.ttf"]
+  ["bgZHccKa7kx5ya671WDbefqnH0wZROon8S2CvooEscs=" "ofl/titilliumweb/TitilliumWeb-Black.ttf"]
+  ["MWDAJD20unCKWm/63omEfVBqX+eszAZCPdFwWmpHrrs=" "ofl/titilliumweb/TitilliumWeb-ExtraLightItalic.ttf"]
+  ["ybuvP9uc/PpKG06GDyxe4yFY6AtrDxFgtA3aLJgDfRA=" "ofl/titilliumweb/TitilliumWeb-Light.ttf"]
+];
+tomorrow = mkFont "tomorrow" "ofl" [
+  ["UPWIoAF5e6bbAj0AwZUMszyYN4bZ6AnG4Uc2aewrFn4=" "ofl/tomorrow/Tomorrow-Black.ttf"]
+  ["7YIUf0/e+kqJzv2+/w1tD8avWj+sBziEkYv7qEbluIs=" "ofl/tomorrow/Tomorrow-Medium.ttf"]
+  ["R0PMmmIU/IqS+Ely80iuejdSGANCjjGdo4xBiHaYY7w=" "ofl/tomorrow/Tomorrow-ExtraLight.ttf"]
+  ["ZwL2XCi9P8g1rr5x7cHoYs1UoL14uBhoq6mLibHGJ9w=" "ofl/tomorrow/Tomorrow-Italic.ttf"]
+  ["8CTnVQpMYVg/GbEr+fBzCpFjTDcFSah2Z7gSN21thYo=" "ofl/tomorrow/Tomorrow-Bold.ttf"]
+  ["BCWPvdoINwHo/lr0Resvu1QJZ6oRjHbZz3jHpj0yCUs=" "ofl/tomorrow/Tomorrow-MediumItalic.ttf"]
+  ["3C3Ec3kJ1K1qe5ypN7uWBs17GlJd0bYEoIpw9e8VIEI=" "ofl/tomorrow/Tomorrow-ThinItalic.ttf"]
+  ["J/mTQtANM9paXInPU+WKCabgedB1Ee26yVlHE70jaLY=" "ofl/tomorrow/Tomorrow-SemiBold.ttf"]
+  ["5+p5ed7PG7YNg/KBds1bp5ZnqbZseCcCP8x6eH2IxDU=" "ofl/tomorrow/Tomorrow-ExtraBold.ttf"]
+  ["Ljfj/OEI3wj1Y51SmiC3+1861UJpRgXLxlcrgXMbyAM=" "ofl/tomorrow/Tomorrow-LightItalic.ttf"]
+  ["HzHhfa6l6zQLQQSYi0WEi+Vo3wp9jP9Mrz5sZo/NHfM=" "ofl/tomorrow/Tomorrow-Thin.ttf"]
+  ["W5tZvAnreYNxeuSjG+rL+tJZ8ccP3/kgPxdPUG5kXxE=" "ofl/tomorrow/Tomorrow-Light.ttf"]
+  ["RL7wOD065FWu+gboSTW4DEOfP2YbUJc2clWiEZzxxPA=" "ofl/tomorrow/Tomorrow-SemiBoldItalic.ttf"]
+  ["9/5L7RSq7B4lsRc8Tu01w8VTfoNsR9tnsGGJ7Ercexk=" "ofl/tomorrow/Tomorrow-ExtraBoldItalic.ttf"]
+  ["a7VTQXhjf0cr4JOy34dtWA58tQ31PhpLK+n5QHD/F2c=" "ofl/tomorrow/Tomorrow-Regular.ttf"]
+  ["ww9oG6URKc0tgak9WopcgmLS5TWuU+c6AB09N3BjYDg=" "ofl/tomorrow/Tomorrow-BoldItalic.ttf"]
+  ["ZinHc0RCXp3yH7rILN+UlTLswZeXXZPDHFVAKapAq+o=" "ofl/tomorrow/Tomorrow-ExtraLightItalic.ttf"]
+  ["XrmkAh2sJx5nFLIJmNXfzwsWhWvzQEQIGgcqUisrYWc=" "ofl/tomorrow/Tomorrow-BlackItalic.ttf"]
+];
+tourney = mkFont "tourney" "ofl" [
+  ["7mhqGmV8qTl9TR6bo62hwQpdm22lOuuUQRzWKxt5M3c=" "ofl/tourney/Tourney%5Bwdth,wght%5D.ttf"]
+  ["A4x4mh7Fvg6TW4p6195s7HvQ7Y5UzYLyyVR49UsHRM4=" "ofl/tourney/Tourney-Italic%5Bwdth,wght%5D.ttf"]
+];
+tradewinds = mkFont "tradewinds" "ofl" [
+  ["u8TJoXkn1sUHahlXsLFl+ubINcG/oPuMBwUyQwl+SVs=" "ofl/tradewinds/TradeWinds-Regular.ttf"]
+];
+trainone = mkFont "trainone" "ofl" [
+  ["B9Z60UIxpKQfDuUBsUvW+cepvq2l7mrykkEUhjoDRiM=" "ofl/trainone/TrainOne-Regular.ttf"]
+];
+trirong = mkFont "trirong" "ofl" [
+  ["Z8DD10oB0lhvaArqzFKKXgYg+yRIMu4y7HZ8E6AP6pk=" "ofl/trirong/Trirong-ExtraLightItalic.ttf"]
+  ["uHlcQsOIN/y5smXqRnzEmXTBE/ZJM/NMCS4+GaVqyUc=" "ofl/trirong/Trirong-ExtraLight.ttf"]
+  ["fZuu+/g3hJ6HZ/hknxndbrnvg9X2O6ygJo79xWbi/gM=" "ofl/trirong/Trirong-Medium.ttf"]
+  ["QwIFbMxUdEri2bgPNLY3fGhYy5XNU0ziUx+xOkp4B5M=" "ofl/trirong/Trirong-Light.ttf"]
+  ["X3Y/KrMC0NgfjgQ12wc7+1CkR9UtwaBgWU89w0ILqK4=" "ofl/trirong/Trirong-Bold.ttf"]
+  ["Vr6tSfK7aXVmDeWZpKSSCibNKjJyxSAE+mMUXup+khA=" "ofl/trirong/Trirong-Black.ttf"]
+  ["vmDh5pTNE7GW5gOnk+LJXj37Z0HsF2f8qpnVIiyT0jo=" "ofl/trirong/Trirong-BlackItalic.ttf"]
+  ["xFFYkWzWeNeJ8nv5VrBKqPfRhb/LDixkTT79C8G+phM=" "ofl/trirong/Trirong-Thin.ttf"]
+  ["Toy4mPt5ktt+ydW8LEbyZddt1hk47NvNzd2Tc4T1AbI=" "ofl/trirong/Trirong-SemiBold.ttf"]
+  ["X3tDBQQyDEp9P5B58fhj17wZXWC5GLpd1BhgA2w3fWo=" "ofl/trirong/Trirong-MediumItalic.ttf"]
+  ["PNGbNaJN9fzxLB+RcyTPgh1apYL36jb7DSqRul6MzQU=" "ofl/trirong/Trirong-Regular.ttf"]
+  ["9jZltV2BgjZD3iUaJC8pbDFl3oOa43fq97XRhJgI+kg=" "ofl/trirong/Trirong-ExtraBold.ttf"]
+  ["Qu6MszeIcwoC4BaPFZs3Ll8HUTgpv6VBX3mYkyyjdnY=" "ofl/trirong/Trirong-BoldItalic.ttf"]
+  ["ZBJNty3CWhU8CWsPwDgQqXaykYaBZ0+mBNybtVg8LBQ=" "ofl/trirong/Trirong-ThinItalic.ttf"]
+  ["9jgL3VqJ1i1Fyy/ui3w8ySKsv8Zzs9EqmCJTxD4g81M=" "ofl/trirong/Trirong-SemiBoldItalic.ttf"]
+  ["xwXVkXJdZQrSQcS+0DLlU8E3VoSfTGiqKlQmoAbrZ6Y=" "ofl/trirong/Trirong-Italic.ttf"]
+  ["BCxw/MLDD3+SkjkNFFECtdvli6ss3svmuy5ximbQ4q0=" "ofl/trirong/Trirong-ExtraBoldItalic.ttf"]
+  ["AB6K0Xa05WVXPWv2o1Shh17MibfdRC/jgRncpJUrkhY=" "ofl/trirong/Trirong-LightItalic.ttf"]
+];
+trispace = mkFont "trispace" "ofl" [
+  ["QCHY16vUKQfGTwvxkkRq2fhpMgVj+McaUmmTgw5AVGQ=" "ofl/trispace/Trispace%5Bwdth,wght%5D.ttf"]
+];
+trocchi = mkFont "trocchi" "ofl" [
+  ["sb32MSI5I1vvRRkk9N3jCLbBpJj+uZ8O0ltRYiJoHho=" "ofl/trocchi/Trocchi-Regular.ttf"]
+];
+trochut = mkFont "trochut" "ofl" [
+  ["WpzywlJc1W/4ZuFyovGOsmaepOm2I4yVTana3ROGxSc=" "ofl/trochut/Trochut-Bold.ttf"]
+  ["STH6DNFBjcPcnmiisaPK6D0DpqB0O84n43hBquoqRoI=" "ofl/trochut/Trochut-Italic.ttf"]
+  ["cgdZrwRqaQvrzA/uCN9oQdVkQ4IZyoZUTDdbklKhIk4=" "ofl/trochut/Trochut-Regular.ttf"]
+];
+truculenta = mkFont "truculenta" "ofl" [
+  ["CNir6FkOP+8kaAH4bvHt4w+MegAFAIVwJKWQUpxEPzw=" "ofl/truculenta/Truculenta%5Bopsz,wdth,wght%5D.ttf"]
+];
+trykker = mkFont "trykker" "ofl" [
+  ["u1YBcJz6TAsoclr9RQJa/HkxBziIbYnO2cqjYWS9IXo=" "ofl/trykker/Trykker-Regular.ttf"]
+];
+tsukimirounded = mkFont "tsukimirounded" "ofl" [
+  ["N34DG8GZCRHQVTYZ6HYbcQFO2QdPMi3NuQfQPCajuLU=" "ofl/tsukimirounded/TsukimiRounded-Bold.ttf"]
+  ["TnygxXW8jv0b0CftewdmbX1Z2iqYYRsSnWR9p17KPdI=" "ofl/tsukimirounded/TsukimiRounded-Medium.ttf"]
+  ["FfijX7qFzahRP5mzyzNPyqR2KDPH2uZVAL7SgbuNnHQ=" "ofl/tsukimirounded/TsukimiRounded-Regular.ttf"]
+  ["a6nniT2Bsp/rEGuFxWHDh9gNLGegNH/7w8enZHGeQqs=" "ofl/tsukimirounded/TsukimiRounded-Light.ttf"]
+  ["4KPAx9YYk43vU5MbFILnovk/yzGtFCGy95fi8f/a1UM=" "ofl/tsukimirounded/TsukimiRounded-SemiBold.ttf"]
+];
+tuffy = mkFont "tuffy" "ofl" [
+  ["5IGPGMRxxKan8dX4DHoO8P17lbYzZP1I8VdoxEnY+Vg=" "ofl/tuffy/Tuffy-Regular.ttf"]
+  ["A4GHNOWdGOna9miH0nXwNIGhiSkedx7gt1j6H8E5ii8=" "ofl/tuffy/Tuffy-BoldItalic.ttf"]
+  ["iy2UzgBnzjYJHCX+IiE2jyG7pALLNg/ZdzOdQ79IToc=" "ofl/tuffy/Tuffy-Italic.ttf"]
+  ["tzJ7tNmWA5+0Ln08uIW8hRzHaDUh8cCLSFCGyzmu218=" "ofl/tuffy/Tuffy-Bold.ttf"]
+];
+tulpenone = mkFont "tulpenone" "ofl" [
+  ["t3PS/TD17xdFYM4P4FsFxvqQHnECNsTp7qTD9mlYAAU=" "ofl/tulpenone/TulpenOne-Regular.ttf"]
+];
+turretroad = mkFont "turretroad" "ofl" [
+  ["o2pF0yLxj/UFCzanqC4XpcaWhbLvS3VQhpi8jgbYAJk=" "ofl/turretroad/TurretRoad-Medium.ttf"]
+  ["ny+iAbTXpxfKXK5Ibwg/4arksMNbmDEcKg61yfL6xPk=" "ofl/turretroad/TurretRoad-ExtraLight.ttf"]
+  ["zOjPs83b7ygIO8sVE+xY9KXEdk0+wgxr9J5ePsyJ3fk=" "ofl/turretroad/TurretRoad-Regular.ttf"]
+  ["4tQeh6u6obU5hN8Zk4+B/YtnFYhtgr3zryVJd1XuxNo=" "ofl/turretroad/TurretRoad-Bold.ttf"]
+  ["hhD2sLfrC+oDD2bq/Mnr7hlI8/4Y/erIYmd+1cDm7Ps=" "ofl/turretroad/TurretRoad-Light.ttf"]
+  ["VmM43pc7RzVzF6mvlv5emcD+/j1Odwd4C9eOgJDGUrg=" "ofl/turretroad/TurretRoad-ExtraBold.ttf"]
+];
+twinklestar = mkFont "twinklestar" "ofl" [
+  ["+jjP9z5k09oWGoV83Dur+4QnFJNWy2H0ChcxAmFlJgQ=" "ofl/twinklestar/TwinkleStar-Regular.ttf"]
+];
+ubuntucondensed = mkFont "ubuntucondensed" "ufl" [
+  ["bB9o0uhYMv6unqMNKmwOpx6mI+jqNCvwCkFPZJPM9yA=" "ufl/ubuntucondensed/UbuntuCondensed-Regular.ttf"]
+];
+ubuntumono = mkFont "ubuntumono" "ufl" [
+  ["vSVXhLuHtcQVE6EqhvD5zwYbzk6CVtO/5yNGEQAuj0g=" "ufl/ubuntumono/UbuntuMono-BoldItalic.ttf"]
+  ["s13Z0hMdXYOpuH/prSLGKI+j0XaI1DMCwU2imBJBfWM=" "ufl/ubuntumono/UbuntuMono-Regular.ttf"]
+  ["lgsrwobC/31JBzMDhYxl4fyQE8F6lxthEjsCw5RU73U=" "ufl/ubuntumono/UbuntuMono-Italic.ttf"]
+  ["EfFcOmu9mYqGlf3vs0dZMcN4mqA111RvLv546Ds1L2s=" "ufl/ubuntumono/UbuntuMono-Bold.ttf"]
+];
+ubuntu = mkFont "ubuntu" "ufl" [
+  ["VPZTh7Ri/vm0+0X06ENE1anPpmDigRiejV4N3PzPXow=" "ufl/ubuntu/Ubuntu-MediumItalic.ttf"]
+  ["j8UNYji+IHb2AleNhGyBpoDzwa1Yw3LMJytN7m5o/5A=" "ufl/ubuntu/Ubuntu-LightItalic.ttf"]
+  ["PNlSuLUlgeSKj6lbMciCnCuqQbY1BCppWH1X+YCSlh4=" "ufl/ubuntu/Ubuntu-Medium.ttf"]
+  ["h113bn8zxQsdG1lHkdoOuphlZI8jLwi8ugC7qd+gHZY=" "ufl/ubuntu/Ubuntu-BoldItalic.ttf"]
+  ["Z5tcHgnKsxVruO9SlzX5OCvzHKesc3OCq5WSl/jYKtQ=" "ufl/ubuntu/Ubuntu-Bold.ttf"]
+  ["pdPvifIZ6Q4fImFq3yvUqGyN3Tev9YzSI0gsROOpLu8=" "ufl/ubuntu/Ubuntu-Light.ttf"]
+  ["SrhX5y94GolnpuSprIhY+9azqfl4LbNJ1LYreO0Chgs=" "ufl/ubuntu/Ubuntu-Italic.ttf"]
+  ["MSjfhqMYBWGENtCuVlG6QoXQyd4KOQV9Al9k7jO862Q=" "ufl/ubuntu/Ubuntu-Regular.ttf"]
+];
+uchen = mkFont "uchen" "ofl" [
+  ["1Ga0HJ0RvuqEPqFrE94iDaICaDa4jzt9MGZSFfwMXS8=" "ofl/uchen/Uchen-Regular.ttf"]
+];
+ultra = mkFont "ultra" "asl20" [
+  ["nuY8/7w3nl1Otf7WoLlLdw2pGUl+XLpKInpjk9rgk54=" "apache/ultra/Ultra-Regular.ttf"]
+];
+unbounded = mkFont "unbounded" "ofl" [
+  ["HTp1Vr7Yenwk4cvEFwx5C3V/IKuIq9d/re+vjDcdInc=" "ofl/unbounded/Unbounded%5Bwght%5D.ttf"]
+];
+uncialantiqua = mkFont "uncialantiqua" "ofl" [
+  ["M6USi1nRyV1PN4gWT0qzoRlvCpgiY8ss0njEdBg2Z2Y=" "ofl/uncialantiqua/UncialAntiqua-Regular.ttf"]
+];
+underdog = mkFont "underdog" "ofl" [
+  ["M/mu5bKq64Xh9DP7IZFtDG26504juU2Xi4Exvb3cQMY=" "ofl/underdog/Underdog-Regular.ttf"]
+];
+unicaone = mkFont "unicaone" "ofl" [
+  ["XVhhrhmctpBJ53580IqP/WwU6Q2hnI243w9ABMqTvY8=" "ofl/unicaone/UnicaOne-Regular.ttf"]
+];
+unifrakturcook = mkFont "unifrakturcook" "ofl" [
+  ["6gAvqcZfGmEq8QDgDYerZfFjgfRQAg7D0CHz2/eabc0=" "ofl/unifrakturcook/UnifrakturCook-Bold.ttf"]
+];
+unifrakturmaguntia = mkFont "unifrakturmaguntia" "ofl" [
+  ["1kr8BUcFndLkp42ki9oKugqZAb5Yx/jCAaiytrRJLMg=" "ofl/unifrakturmaguntia/UnifrakturMaguntia-Book.ttf"]
+];
+unkempt = mkFont "unkempt" "asl20" [
+  ["ndNE9p61M3LbMrXXVY8q3bPRWfRyO4s5NkUU2OAypjE=" "apache/unkempt/Unkempt-Bold.ttf"]
+  ["USzo5yJuAAkwfxDUfAjumph4aQdmV5/yjFsd3foXn0w=" "apache/unkempt/Unkempt-Regular.ttf"]
+];
+unlock = mkFont "unlock" "ofl" [
+  ["QIVgs4fUnMW93nKTZTGm2jq9dKvuEX78x3YVgirLpTc=" "ofl/unlock/Unlock-Regular.ttf"]
+];
+unna = mkFont "unna" "ofl" [
+  ["PPkPuajRLrHLkJhCYzvxRogZ3q+ZPTmYginTggCneT4=" "ofl/unna/Unna-BoldItalic.ttf"]
+  ["0g3MKc0rXbGPbHgpGPJu6aaoJAo4UNeqVv2ZdwJPxbE=" "ofl/unna/Unna-Bold.ttf"]
+  ["/ZSqd8KrRXJoisitSMUWKcjWUcMrIwE7nDPNcvycd7E=" "ofl/unna/Unna-Italic.ttf"]
+  ["lCae+kSFIME1rh+ZTgpxGyFPXfTOazfy0+8Qp8zbFwA=" "ofl/unna/Unna-Regular.ttf"]
+];
+updock = mkFont "updock" "ofl" [
+  ["K5E4rBB+a1gxgoR0xfnnc8LaOnYq+3aEHetuz1/ZnvY=" "ofl/updock/Updock-Regular.ttf"]
+];
+urbanist = mkFont "urbanist" "ofl" [
+  ["dINi1R6ydoQOnwAjzS2YKZv3Calfs6WuT/y2JMY467k=" "ofl/urbanist/Urbanist%5Bwght%5D.ttf"]
+  ["Bax6Zd7NojgG0WeNRLjvI91lbWeTVVSZ3XnuJMPnd+0=" "ofl/urbanist/Urbanist-Italic%5Bwght%5D.ttf"]
+];
+vampiroone = mkFont "vampiroone" "ofl" [
+  ["bhkgpLu8ZlUveT7MaGMT7wlGmudbayWHi/iSP9/ssqI=" "ofl/vampiroone/VampiroOne-Regular.ttf"]
+];
+varela = mkFont "varela" "ofl" [
+  ["h88N3VDNKXzW+s+qyL9Zv40LGjuLZhmVe6COcgQ9GJY=" "ofl/varela/Varela-Regular.ttf"]
+];
+varelaround = mkFont "varelaround" "ofl" [
+  ["4eR+tm28LdwQZmEzjnEtkXbJ6DxmmoL94VUySCPQOqI=" "ofl/varelaround/VarelaRound-Regular.ttf"]
+];
+varta = mkFont "varta" "ofl" [
+  ["RZM/QEG6HflTwTvas4i/MSfHCBsuffvnHjb5IU0Fdg8=" "ofl/varta/Varta%5Bwght%5D.ttf"]
+];
+vastshadow = mkFont "vastshadow" "ofl" [
+  ["mL33+TwjMGlweOzifkjep9l7JTpUfWmb96/EvfpkGpM=" "ofl/vastshadow/VastShadow-Regular.ttf"]
+];
+vazirmatn = mkFont "vazirmatn" "ofl" [
+  ["aWJJosdLOf/e9V3k3ygJxbY50/+A1hjYFgoJXS/Unco=" "ofl/vazirmatn/Vazirmatn%5Bwght%5D.ttf"]
+];
+vesperlibre = mkFont "vesperlibre" "ofl" [
+  ["Rvtea1YA9jXLzyec3AEpmAq/wqdpcSsb3nFnJKIA9Ao=" "ofl/vesperlibre/VesperLibre-Medium.ttf"]
+  ["AH+3c+ol/ppiI4hg7TV5e2u2+TTLbhtK5KCr9bgXL/0=" "ofl/vesperlibre/VesperLibre-Heavy.ttf"]
+  ["EeWa5P09UnZXP5XOo+fiNhdWgXtQKbSfQ8ZnAfgdlvg=" "ofl/vesperlibre/VesperLibre-Bold.ttf"]
+  ["K+jyQ9kGheU7ttZDWYXPTRRdQr9w4/lkAmpix82W3hw=" "ofl/vesperlibre/VesperLibre-Regular.ttf"]
+];
+viaodalibre = mkFont "viaodalibre" "ofl" [
+  ["rbU+3iUQfF7UxF+ZP9AUoh74KsgrIyelZP6OmU4iiUI=" "ofl/viaodalibre/ViaodaLibre-Regular.ttf"]
+];
+vibes = mkFont "vibes" "ofl" [
+  ["KX2chJnnODrHZ1kydBYlqxLZuzq9HDHSZZs4XZZaerc=" "ofl/vibes/Vibes-Regular.ttf"]
+];
+vibur = mkFont "vibur" "ofl" [
+  ["PiNlPi8Kv6iK5JnRJl8bgAVbbK9S/jKxWG630pQie7E=" "ofl/vibur/Vibur-Regular.ttf"]
+];
+vidaloka = mkFont "vidaloka" "ofl" [
+  ["XpC0AW2hfyai9lO9lGi7t+ewgfQMEf9cJAiEIO3E2+I=" "ofl/vidaloka/Vidaloka-Regular.ttf"]
+];
+viga = mkFont "viga" "ofl" [
+  ["cwrSo4aRzhnuWqndnshK6HN7IISwbu8TQ1pPrK2bBjw=" "ofl/viga/Viga-Regular.ttf"]
+];
+voces = mkFont "voces" "ofl" [
+  ["goueib+PIHqjtLuSmy1PGe9W6SettV5aIhklZOiRosg=" "ofl/voces/Voces-Regular.ttf"]
+];
+volkhov = mkFont "volkhov" "ofl" [
+  ["SGPub86CatR7v2hTG7wM2GGmyDLopJBep53gqmrdBcI=" "ofl/volkhov/Volkhov-BoldItalic.ttf"]
+  ["AnNgpL+rz89J+VyfmUSyFHzZXDpy3LKmbqx+fvbnFPE=" "ofl/volkhov/Volkhov-Italic.ttf"]
+  ["+PSeiYpOnfkawvPg003rSRLU/iQkgxtRTeKXyARtWNk=" "ofl/volkhov/Volkhov-Regular.ttf"]
+  ["rSildJgZipM2tnPOoGhYKqRD3HLJijIiVS6DkiJa9kY=" "ofl/volkhov/Volkhov-Bold.ttf"]
+];
+vollkorn = mkFont "vollkorn" "ofl" [
+  ["zZR65JtdRugS2NCUNPvo7EUihs1VV+9qdio1YuLI0wA=" "ofl/vollkorn/Vollkorn-Italic%5Bwght%5D.ttf"]
+  ["Tr70NPdvgChiBIQDVKhNt5oNw8h97ut5HgFbcLKt5J0=" "ofl/vollkorn/Vollkorn%5Bwght%5D.ttf"]
+];
+vollkornsc = mkFont "vollkornsc" "ofl" [
+  ["tNuPdG7RoqI7c7fbrWtyOk2uUH2U4ZHFoJZJtuGo99Y=" "ofl/vollkornsc/VollkornSC-Black.ttf"]
+  ["prTbq7XPFY8jWcFfOaDu/V75lDS51EOoTmASwvy9ga4=" "ofl/vollkornsc/VollkornSC-Regular.ttf"]
+  ["yqMIwsWXC8dzKgGI60SGf8LyEk6Ky6un4aqHQDpw6AQ=" "ofl/vollkornsc/VollkornSC-SemiBold.ttf"]
+  ["5pn1g0fTEyGQLHT/O6/eDyggJAyJwyGs/x2mngFaX1Y=" "ofl/vollkornsc/VollkornSC-Bold.ttf"]
+];
+voltaire = mkFont "voltaire" "ofl" [
+  ["BtHE07lmGJwc16tgbCyq8SAxsodwCjeS2WWaWlHzkVY=" "ofl/voltaire/Voltaire-Regular.ttf"]
+];
+vt323 = mkFont "vt323" "ofl" [
+  ["z03nUa2njOrAM9vhamh3QpOZlbd7wqBSrheklXlYWU0=" "ofl/vt323/VT323-Regular.ttf"]
+];
+vujahdayscript = mkFont "vujahdayscript" "ofl" [
+  ["8QJCjaiJMfIMXtlH2fiuqF7j8dShi1GnS09Zo0TOXao=" "ofl/vujahdayscript/VujahdayScript-Regular.ttf"]
+];
+waitingforthesunrise = mkFont "waitingforthesunrise" "ofl" [
+  ["rHTnA5D1sb5pJ8Hgeb1hQ4IaNiVQsmTF637d408ImfQ=" "ofl/waitingforthesunrise/WaitingfortheSunrise.ttf"]
+];
+wallpoet = mkFont "wallpoet" "ofl" [
+  ["DY3Dar4ZX6RVpan2CinwqinHQEv4gKZ+xx8EfavvsCs=" "ofl/wallpoet/Wallpoet-Regular.ttf"]
+];
+walterturncoat = mkFont "walterturncoat" "asl20" [
+  ["q36coxcQczIRxak40shRyEwNIfavRIbzK8bTdCgbLaA=" "apache/walterturncoat/WalterTurncoat-Regular.ttf"]
+];
+warnes = mkFont "warnes" "ofl" [
+  ["LcmCvsV/htpiwhS/snn/6iaQq5e+jAtOg/MufFCOR5g=" "ofl/warnes/Warnes-Regular.ttf"]
+];
+waterbrush = mkFont "waterbrush" "ofl" [
+  ["LL3MvKXUvgBf5O3YiVuRYYp/lmOerutJh62D6Br8cac=" "ofl/waterbrush/WaterBrush-Regular.ttf"]
+];
+waterfall = mkFont "waterfall" "ofl" [
+  ["g92WTMyuEAhOPzsxaCR9R6Bjdfnv6JPO4LVIjLqD7/M=" "ofl/waterfall/Waterfall-Regular.ttf"]
+];
+wellfleet = mkFont "wellfleet" "ofl" [
+  ["NH85GHYse2HDuY1XBxsDKVSFvJe2v7bHYnvPNlzDyec=" "ofl/wellfleet/Wellfleet-Regular.ttf"]
+];
+wendyone = mkFont "wendyone" "ofl" [
+  ["Li2g6LsKWTZW04/I4mXFsJssRbKUvSPznxNcLjbIna8=" "ofl/wendyone/WendyOne-Regular.ttf"]
+];
+whisper = mkFont "whisper" "ofl" [
+  ["8fQVoN6IiJerY4/moFR0BuzEaZAdJq/QavYZ3bTGI+w=" "ofl/whisper/Whisper-Regular.ttf"]
+];
+windsong = mkFont "windsong" "ofl" [
+  ["3zUlCXywJz9hC4faUjmYefh9zODL3e4Iw+UjlRCAeao=" "ofl/windsong/WindSong-Medium.ttf"]
+  ["RL6k+M24GOnfbu9TNMY5Fay38Yd7I53rs3MnfRawqsI=" "ofl/windsong/WindSong-Regular.ttf"]
+];
+wireone = mkFont "wireone" "ofl" [
+  ["1QUFnDwJS5ITWNs+Qb6Jl4nt9MSuwex3e+FkPvzZ/AU=" "ofl/wireone/WireOne-Regular.ttf"]
+];
+wixmadefordisplay = mkFont "wixmadefordisplay" "ofl" [
+  ["A81kgMy4sKW5nMF4HutL9v+KvB0bkfcM2ZlOgbb2ZCA=" "ofl/wixmadefordisplay/WixMadeforDisplay%5Bwght%5D.ttf"]
+];
+wixmadefortext = mkFont "wixmadefortext" "ofl" [
+  ["uWhW3PufVmE7wNRSc7dnTadKBLU306riBdZqfFHnA8k=" "ofl/wixmadefortext/WixMadeforText-ExtraBold.ttf"]
+  ["6fwnX/RMRELInnU4dGHMVASPTPoQFcLrdc26O+0UbwE=" "ofl/wixmadefortext/WixMadeforText-SemiBold.ttf"]
+  ["T27MVz5v5bQrpDAtTHbJs0r/hFs+N3wpbYGUx8UzZbM=" "ofl/wixmadefortext/WixMadeforText-Medium.ttf"]
+  ["6YUKQgr0dLORgnAESbq6n0lyIK8iz4oAg/1//yQbXI0=" "ofl/wixmadefortext/WixMadeforText%5Bwght%5D.ttf"]
+  ["ukHjyDd/THh6ZCJD2ZN7rWrUIO7oorvUxK0s62ZPT6Y=" "ofl/wixmadefortext/WixMadeforText-Bold.ttf"]
+  ["51mQMsxuA+wsCpi2Xip4eaMdCVr9Z1LaJwTWTle+MvM=" "ofl/wixmadefortext/WixMadeforText-Regular.ttf"]
+];
+worksans = mkFont "worksans" "ofl" [
+  ["9Q9h8rpzjiOUQtQL8Qaa2xlcIktqWnOlgfwvPtYqn2M=" "ofl/worksans/WorkSans%5Bwght%5D.ttf"]
+  ["Cp+TXqSQ00d/yX5AJI81bCm84RoZc5OQVsQxaxIjQew=" "ofl/worksans/WorkSans-Italic%5Bwght%5D.ttf"]
+];
+xanhmono = mkFont "xanhmono" "ofl" [
+  ["507UEF78eXwF7AYxGC4Kdrtey/G2re254BcMeZZLL28=" "ofl/xanhmono/XanhMono-Italic.ttf"]
+  ["M+ZLQ/3LQL0BQYU2Aceq/9W+FevTz1Y0DSRz/4vo5pw=" "ofl/xanhmono/XanhMono-Regular.ttf"]
+];
+yaldevicolombo = mkFont "yaldevicolombo" "ofl" [
+  ["8g6evrTStnXeVXIzQf/ss5q5ePUqjhPfqB6xUnCbORk=" "ofl/yaldevicolombo/YaldeviColombo-ExtraLight.ttf"]
+  ["D59Fld2mbI2qVvYWicYviXshpIAbkNvmW5gDrvfCDu8=" "ofl/yaldevicolombo/YaldeviColombo-Medium.ttf"]
+  ["VXe6ivKJp8a/L6nWr6ZTQ1o4LEy0EyOtt/pTDbVEAhQ=" "ofl/yaldevicolombo/YaldeviColombo-Regular.ttf"]
+  ["Mqfv/hJZ17Z4susPJUnN35X6IMdfVz+MBr3CIPe057E=" "ofl/yaldevicolombo/YaldeviColombo-Light.ttf"]
+  ["cd9b2W914Xp4+4GLf8cVfPcIMcZ2QCNhGhRkgKM6cwU=" "ofl/yaldevicolombo/YaldeviColombo-Bold.ttf"]
+  ["NeOZmZ1/jYTSjSE1nXQ++K18H0apawCWsrC51oRYNBQ=" "ofl/yaldevicolombo/YaldeviColombo-SemiBold.ttf"]
+];
+yaldevi = mkFont "yaldevi" "ofl" [
+  ["IdVRbNmogxlktXUD9behGar6lgO93dAYPpGgrIyNwuQ=" "ofl/yaldevi/Yaldevi%5Bwght%5D.ttf"]
+];
+yanonekaffeesatz = mkFont "yanonekaffeesatz" "ofl" [
+  ["CRaQ+x8Q1jhIw8G0F9X85wmnpgSoLuRLRlEyki4jME8=" "ofl/yanonekaffeesatz/YanoneKaffeesatz%5Bwght%5D.ttf"]
+];
+yantramanav = mkFont "yantramanav" "ofl" [
+  ["gj27XZxzosGSNxv3M0GjApG1pBZXg2LrRge5xaW+mCE=" "ofl/yantramanav/Yantramanav-Regular.ttf"]
+  ["iGLdbboWbsEGDJ/AFZsExHDnEC85Z9F0YHK9q5ik0DE=" "ofl/yantramanav/Yantramanav-Black.ttf"]
+  ["jGKH4o8Ammh9BhatXzHg+PxRO4LfCQk+9brmXfwhYgY=" "ofl/yantramanav/Yantramanav-Medium.ttf"]
+  ["qvy78sihBHRrp/VRBQ4DtP/4oglNfqEK38o+MLzBXbg=" "ofl/yantramanav/Yantramanav-Light.ttf"]
+  ["bojjYM1yKxI+FCbk2YYCeQuAXe8fsZjs4o87/K8WhlA=" "ofl/yantramanav/Yantramanav-Thin.ttf"]
+  ["aC7068nI3eHzEsQ1reXsqcr+pqsMNgLhY4wC03WbE10=" "ofl/yantramanav/Yantramanav-Bold.ttf"]
+];
+yatraone = mkFont "yatraone" "ofl" [
+  ["xHqUpO3zD06uDKHIR3f0twvDUCIbYknea2T+/d7S080=" "ofl/yatraone/YatraOne-Regular.ttf"]
+];
+yellowtail = mkFont "yellowtail" "asl20" [
+  ["PgaEGxMACXXzzDiqhOMm5gGkN4pMUtULXp/uNZjF0jY=" "apache/yellowtail/Yellowtail-Regular.ttf"]
+];
+yeonsung = mkFont "yeonsung" "ofl" [
+  ["jl/xzBsTAq+si57lKWoEvBySrx5noq4HpZOqa14+t5I=" "ofl/yeonsung/YeonSung-Regular.ttf"]
+];
+yesevaone = mkFont "yesevaone" "ofl" [
+  ["iDYrM4IPABHhY+Z7HVcP7NRCqowF6qyJ1RYvnEDZ2sM=" "ofl/yesevaone/YesevaOne-Regular.ttf"]
+];
+yesteryear = mkFont "yesteryear" "ofl" [
+  ["F9GyxX7GSP+bE9IAC92bXBwya6FKz/RZev46cw0KLJQ=" "ofl/yesteryear/Yesteryear-Regular.ttf"]
+];
+yinmar = mkFont "yinmar" "ofl" [
+  ["oZdmOamfJSs0cYOchf5eh/wcTg0Thsn4rIxf+E01fjU=" "ofl/yinmar/Yinmar-Regular.ttf"]
+];
+yomogi = mkFont "yomogi" "ofl" [
+  ["NCTjS7lR6Jv13SVUpl2JZDNeo8BWD40eqao1ke9zy6k=" "ofl/yomogi/Yomogi-Regular.ttf"]
+];
+yrsa = mkFont "yrsa" "ofl" [
+  ["2FOh+0Dgd1N6f9XER2OKoAFiH+Vy0y3V9jPo5fWOThk=" "ofl/yrsa/Yrsa%5Bwght%5D.ttf"]
+  ["Rbo/YJTaV6MNd3gEhQ9BCPCsZTj2NmvmveOMwQWaMjA=" "ofl/yrsa/Yrsa-Italic%5Bwght%5D.ttf"]
+];
+yujiboku = mkFont "yujiboku" "ofl" [
+  ["lP2hY4TzvawkN2oADFfpmr+jFJYb2J7ye637dBAyIAM=" "ofl/yujiboku/YujiBoku-Regular.ttf"]
+];
+yujihentaiganaakari = mkFont "yujihentaiganaakari" "ofl" [
+  ["b6a/r/iFH9IPMqgH37mn3BX1R4CvVk3cjzLgdABL3ic=" "ofl/yujihentaiganaakari/YujiHentaiganaAkari-Regular.ttf"]
+];
+yujihentaiganaakebono = mkFont "yujihentaiganaakebono" "ofl" [
+  ["jjh+61wkzSlF2IBMqrj5eYW2lM7I0rIo2mPM6xbHqPM=" "ofl/yujihentaiganaakebono/YujiHentaiganaAkebono-Regular.ttf"]
+];
+yujimai = mkFont "yujimai" "ofl" [
+  ["Bdg7ZSBKXeb8NMIiBX/AgvjG4uRMBaDSj0GJs+VMVMI=" "ofl/yujimai/YujiMai-Regular.ttf"]
+];
+yujisyuku = mkFont "yujisyuku" "ofl" [
+  ["gnKOuvyMlzkeLatjNBSoBvNEuOTiIn0wcXnwe1SPymE=" "ofl/yujisyuku/YujiSyuku-Regular.ttf"]
+];
+yuseimagic = mkFont "yuseimagic" "ofl" [
+  ["ggmGFfOe2dpqjMxnS5AG5Jxw3Vt3WnoWl/a+3SLOJaI=" "ofl/yuseimagic/YuseiMagic-Regular.ttf"]
+];
+zcoolkuaile = mkFont "zcoolkuaile" "ofl" [
+  ["Y0/fiUXv7BAxmjAB9nCCPcc9aSM0gQcqdDpFyWQVlns=" "ofl/zcoolkuaile/ZCOOLKuaiLe-Regular.ttf"]
+];
+zcoolqingkehuangyou = mkFont "zcoolqingkehuangyou" "ofl" [
+  ["VPDA30MIzXTNDy/TSUrgVNvEof1vp9cfSAfrTN2LQTY=" "ofl/zcoolqingkehuangyou/ZCOOLQingKeHuangYou-Regular.ttf"]
+];
+zcoolxiaowei = mkFont "zcoolxiaowei" "ofl" [
+  ["pCtiAUD0k9tC90E1HfvzQ8CTbVhYjugAS4sqIY2Zf/E=" "ofl/zcoolxiaowei/ZCOOLXiaoWei-Regular.ttf"]
+];
+zenantique = mkFont "zenantique" "ofl" [
+  ["jFz3oTaDfucF0Gu8Ez6hisBrfdKE84qs6R9d42clwxU=" "ofl/zenantique/ZenAntique-Regular.ttf"]
+];
+zenantiquesoft = mkFont "zenantiquesoft" "ofl" [
+  ["q1ZpFyZwh/TuPulmLOCf8TBw5CxwTh6Ett5MdUV9oaU=" "ofl/zenantiquesoft/ZenAntiqueSoft-Regular.ttf"]
+];
+zendots = mkFont "zendots" "ofl" [
+  ["L4Gp9MJvMC2HpAeS4EjNcZPIhqpQ+meSpLT7YmbCVgk=" "ofl/zendots/ZenDots-Regular.ttf"]
+];
+zenkakugothicantique = mkFont "zenkakugothicantique" "ofl" [
+  ["H0/SrT+Df0sUzaFn2iKu6GrTreIKb/iqkxNg1Gdre2Y=" "ofl/zenkakugothicantique/ZenKakuGothicAntique-Light.ttf"]
+  ["55uHTvGuDP5bnXUPWZDUCIdDALF8egLLbobnOhSjMAU=" "ofl/zenkakugothicantique/ZenKakuGothicAntique-Regular.ttf"]
+  ["wMYxpqTlHUwpyMhMQPyjC4IOlm2aUhwDkCmhm05DjCk=" "ofl/zenkakugothicantique/ZenKakuGothicAntique-Bold.ttf"]
+  ["Ar3EV0T9NXsEwaj7DyOSqMMbOpJQrLmJklKpM+xm9LY=" "ofl/zenkakugothicantique/ZenKakuGothicAntique-Medium.ttf"]
+  ["pyg7LlPXjtE2jztzxUQQ0/vrnw4unak7bCxnoefCkAo=" "ofl/zenkakugothicantique/ZenKakuGothicAntique-Black.ttf"]
+];
+zenkakugothicnew = mkFont "zenkakugothicnew" "ofl" [
+  ["eVgZqXkYSYGEKZTY9OueFM5EPWh71ecx1spn3tj5ImE=" "ofl/zenkakugothicnew/ZenKakuGothicNew-Black.ttf"]
+  ["rU6XM/ljl+0MmcKV2bO1bjmg4LwCsKxWzjred5Oh7vE=" "ofl/zenkakugothicnew/ZenKakuGothicNew-Light.ttf"]
+  ["uEDNB6Z9icrMpEJJrkmqme52QOtc5iO+jYmD1qq6yAE=" "ofl/zenkakugothicnew/ZenKakuGothicNew-Regular.ttf"]
+  ["ZRo/coC382JiYB7nbYOIqNxDctzGev8CWmCJOaVitSU=" "ofl/zenkakugothicnew/ZenKakuGothicNew-Medium.ttf"]
+  ["AIHO2rxJIZgvzQYfhFoAVmSsf7ZCry3TS0AHvGPM0jU=" "ofl/zenkakugothicnew/ZenKakuGothicNew-Bold.ttf"]
+];
+zenkurenaido = mkFont "zenkurenaido" "ofl" [
+  ["WLjZMNn8EMilgQwIW643jay5jQd5Bz7m1T2Rnxnuak8=" "ofl/zenkurenaido/ZenKurenaido-Regular.ttf"]
+];
+zenloop = mkFont "zenloop" "ofl" [
+  ["euUUFzN5LYWW2b5LmrhlzL/aMLyt4CyTW1qRiHW8Rtg=" "ofl/zenloop/ZenLoop-Italic.ttf"]
+  ["BsTeNJ7ijvll+aU2HvLCiEFiitzD6GSQuYEVhKyyN4s=" "ofl/zenloop/ZenLoop-Regular.ttf"]
+];
+zenmarugothic = mkFont "zenmarugothic" "ofl" [
+  ["a9dP52zTnuDsGHdcNmHYRTQ/s/b4+gmjB2Y4QXuvdB8=" "ofl/zenmarugothic/ZenMaruGothic-Black.ttf"]
+  ["PP25ihNXHt4X/Mdp9Qk6l8OLgKe5sqt1Sia02CIJKzs=" "ofl/zenmarugothic/ZenMaruGothic-Medium.ttf"]
+  ["04ZX2Su7NDocbE+RMwJceZHvxSQZRE0W4x46l6rvLZ0=" "ofl/zenmarugothic/ZenMaruGothic-Regular.ttf"]
+  ["xOb6EP9RffN8sMEwOP4oE/PEev5ld/pKVXMgDkUIssE=" "ofl/zenmarugothic/ZenMaruGothic-Light.ttf"]
+  ["/iRCa5yLVSOgFGqCNchnTszwSTrzVKU+yJXDWW2et0U=" "ofl/zenmarugothic/ZenMaruGothic-Bold.ttf"]
+];
+zenoldmincho = mkFont "zenoldmincho" "ofl" [
+  ["2YuXg2Uggff55mKwVovd6vZGKWLdOe32h4EmjrYOo6A=" "ofl/zenoldmincho/ZenOldMincho-SemiBold.ttf"]
+  ["1rlcH/RcjawVPSiWHkw319A7ZIMwxx+ITRJNxlKhPA0=" "ofl/zenoldmincho/ZenOldMincho-Bold.ttf"]
+  ["TAUaeKIcTo6dzPHHVHdtM/NWuMxu+V2bZHYbm66BS4Q=" "ofl/zenoldmincho/ZenOldMincho-Regular.ttf"]
+  ["hKgNi8p519lHiTUEWyFu0AOtQP3qX9kRbVJOsm6HLNw=" "ofl/zenoldmincho/ZenOldMincho-Black.ttf"]
+  ["5gx5YeURDQ8I+QLeQ/5ghl8VOIRf8gksd5g3JX76w78=" "ofl/zenoldmincho/ZenOldMincho-Medium.ttf"]
+];
+zentokyozoo = mkFont "zentokyozoo" "ofl" [
+  ["ndncGl66gArKmwv0ZxvaiAt8qm0ZF0yCd2JW9nMtYEo=" "ofl/zentokyozoo/ZenTokyoZoo-Regular.ttf"]
+];
+zeyada = mkFont "zeyada" "ofl" [
+  ["CfI9DXi24WbduEgHk7tVCrTCqvZgLtpHo5T+6T0qlmc=" "ofl/zeyada/Zeyada.ttf"]
+];
+zhimangxing = mkFont "zhimangxing" "ofl" [
+  ["ZE4MrptA8LEKtymgG9MgMuOXO6wivj3MrgG/auf96Wk=" "ofl/zhimangxing/ZhiMangXing-Regular.ttf"]
+];
+zillaslabhighlight = mkFont "zillaslabhighlight" "ofl" [
+  ["5mU8fgKZwcrl5/4hFXJnreVt0wGzbNoHPEBymbglSPQ=" "ofl/zillaslabhighlight/ZillaSlabHighlight-Bold.ttf"]
+  ["LJJI26NGk8A5tuIMs0+qntOF/mduyMfzZO/7zjfjW8c=" "ofl/zillaslabhighlight/ZillaSlabHighlight-Regular.ttf"]
+];
+zillaslab = mkFont "zillaslab" "ofl" [
+  ["I4Fbc9pXGG1krccc2rTNK72b4h9x79zmDZZ2Y48HDi8=" "ofl/zillaslab/ZillaSlab-SemiBoldItalic.ttf"]
+  ["00Sw9gzV+y00xBaNKBG6aEFj5WZeIMzLz7asgi2EpQA=" "ofl/zillaslab/ZillaSlab-Medium.ttf"]
+  ["TsOgSk7vNwdLQu9ULk2HThNkZmjP5lJW4L8QBEHPhxk=" "ofl/zillaslab/ZillaSlab-Bold.ttf"]
+  ["TD381KW7ce4otsLsjov+xyD2GbwA4SoTqI8PIzr3+FE=" "ofl/zillaslab/ZillaSlab-Light.ttf"]
+  ["iZyPOB97gqeP1axFhAW2whKtJbwRRH8jWqCX8/rzS54=" "ofl/zillaslab/ZillaSlab-LightItalic.ttf"]
+  ["QaRiaETakhawMTCNRCMEXHZf5CMdmYYthdfXRQnTdwM=" "ofl/zillaslab/ZillaSlab-Regular.ttf"]
+  ["qvyylbiNUgNX2x7PmhwxZwVeh+nd9fY+Vgy9E57CgF4=" "ofl/zillaslab/ZillaSlab-SemiBold.ttf"]
+  ["/wzXovDbWdAX1RtO2QA/WL8hriGKsqllqjvB3YlMFSs=" "ofl/zillaslab/ZillaSlab-Italic.ttf"]
+  ["3mvimFMpiRA1o7OGOjJagqkYogGGUMO0P6XErhSBX1g=" "ofl/zillaslab/ZillaSlab-MediumItalic.ttf"]
+  ["eVEDbJLecePIjqAavgMdW9rd9GOQIqPhy5IyLy6I0s8=" "ofl/zillaslab/ZillaSlab-BoldItalic.ttf"]
+];
+}

--- a/pkgs/data/fonts/google-fonts/update.sh
+++ b/pkgs/data/fonts/google-fonts/update.sh
@@ -1,0 +1,171 @@
+#! /usr/bin/env bash
+
+# [RFC 0109] Nixpkgs Generated Code Policy
+# https://github.com/NixOS/rfcs/pull/109
+
+set -e
+#set -x # trace
+
+owner=google
+repo=fonts
+main_branch=main
+folder_name=google-fonts
+no_license_regex='(axisregistry|catalog|lang)'
+default_nix_file=pkgs/data/fonts/google-fonts/default.nix
+srcs_nix_file=pkgs/data/fonts/google-fonts/srcs.nix
+sha256_cache_file=pkgs/data/fonts/google-fonts/sha256.txt # cache
+
+#use_git_fetch=true # slow init, fast updates, history (font-family versions)
+use_git_fetch=false # fast init, slow updates
+
+declare -A nix_license_of_license
+nix_license_of_license[apache]=asl20 # Apache License 2.0
+nix_license_of_license[cc-by-sa]=cc-by-sa-40 # FIXME what version?
+# lib.licenses.cc-by-sa-25  lib.licenses.cc-by-sa-30  lib.licenses.cc-by-sa-40
+# only 1 family:
+# cc-by-sa/knowledge: version 4 -> cc-by-sa-40
+nix_license_of_license[ofl]=ofl # SIL Open Font License 1.1
+nix_license_of_license[ufl]=ufl # Ubuntu Font License 1.0
+
+if ! [ -f pkgs/top-level/all-packages.nix ]; then
+    echo "error: wrong workdir. please run this script in nixpkgs/"
+    exit 1
+fi
+
+# get absolute paths
+default_nix_file=$(readlink -f $default_nix_file)
+srcs_nix_file=$(readlink -f $srcs_nix_file)
+sha256_cache_file=$(readlink -f $sha256_cache_file)
+
+# https://gist.github.com/cdown/1163649?permalink_comment_id=4291617#gistcomment-4291617
+# encode special characters per RFC 3986
+urlencode() {
+    local LC_ALL=C # support unicode = loop bytes, not characters
+    local c i n=${#1}
+    for (( i=0; i<n; i++ )); do
+        c="${1:i:1}"
+        case "$c" in
+            #[-_.~A-Za-z0-9]) # also encode ;,/?:@&=+$!*'()# == encodeURIComponent in javascript
+            [-_.~A-Za-z0-9\;,/?:@\&=+\$!*\'\(\)#]) # dont encode ;,/?:@&=+$!*'()# == encodeURI in javascript
+               printf '%s' "$c" ;;
+            *) printf '%%%02X' "'$c" ;;
+        esac
+    done
+    echo
+}
+
+# TODO use only use_git_fetch
+rev=$(git ls-remote https://github.com/$owner/$repo refs/heads/$main_branch)
+rev=${rev:0:40}
+echo rev: $rev
+
+if [ -d $folder_name ]; then
+    echo using existing folder: $folder_name
+else
+    if $use_git_fetch; then
+        git clone --depth 1 https://github.com/$owner/$repo $folder_name
+        rev=$(git -C $folder_name rev-parse HEAD)
+        echo "error: use_git_fetch is not implemented"
+        exit 1
+    else
+        rev=$(git ls-remote https://github.com/$owner/$repo refs/heads/$main_branch)
+        if ! [ -e $folder_name.tar.gz ]; then
+            wget -O $folder_name.tar.gz https://github.com/$owner/$repo/archive/$rev.tar.gz
+        fi
+        mkdir $folder_name
+        tar -x --strip-components=1 -f $folder_name.tar.gz -C $folder_name
+    fi
+fi
+
+cd $folder_name
+
+licenses=$(find * -maxdepth 0 -type d | grep -v -x -E "$no_license_regex")
+#echo licenses: $licenses
+
+for license in $licenses; do
+    if [ -z "${nix_license_of_license[$license]}" ]; then
+        echo error: "no nix license mapping for license: ${license@Q}"
+        exit 1
+    fi
+done
+
+# format: ${license}/${family}
+dirs=$(find $licenses -mindepth 1 -maxdepth 1 -type d)
+
+families=$(echo "$dirs" | xargs basename -a)
+
+# assert: font family names are unique
+families_count_all=$(echo "$families" | wc -l)
+families_count_uni=$(echo "$families" | sort | uniq | wc -l)
+if ! [[ $families_count_all == $families_count_uni ]]; then
+    echo families_count_all=$families_count_all
+    echo families_count_uni=$families_count_uni
+    echo error: font family names are not unique
+    exit 1
+fi
+
+echo "families count: $families_count_all"
+
+#echo families:; echo "$families"
+
+# sort by family
+families_dirs=$(
+    while read dir; do
+        family=${dir#*/}
+        echo "$family $dir"
+    done < <(echo "$dirs") |
+    sort
+)
+
+#echo "families_dirs:"; echo "$families_dirs"; exit
+
+declare -A sha256_cache
+while read sha256 url; do
+    sha256_cache["$url"]="$sha256"
+done < $sha256_cache_file
+
+echo generating new srcs.nix file
+echo this will take about 3 minutes # 1 minute with cache
+#sha256_cache_fifo=$(mkfifo sha256_cache.fifo) # TODO append to $sha256_cache_file
+tempfile=$(mktemp)
+indent1='' # save 13380 / 395062 bytes = 3%
+indent2='  '
+echo "writing to tempfile $tempfile"
+{
+    echo '{ mkFont }:'
+    echo '{'
+    #while read -r family dir; do # error? sha256sum: '': No such file or directory
+    while read family dir; do
+        license=${dir%/*}
+        nix_license=${nix_license_of_license[$license]}
+        files=$(find $dir -name "*.ttf")
+        if [ -z "$files" ]; then
+            echo "$indent1#$family = null; # no ttf files"
+        else
+            echo "$indent1$family = mkFont \"$family\" \"$nix_license\" ["
+            while read file; do
+                file_encoded=$(urlencode "$file")
+                sha256=${sha256_cache["$file_encoded"]}
+                if [ -z "$sha256" ]; then
+                    #echo "cache miss in sha256_cache for file: $file_encoded" >&2
+                    sha256=$(sha256sum "$file")
+                    sha256=${sha256:0:64}
+                    sha256=$(echo $sha256 | xxd -r -ps | base64 -w0) # base16 to base64
+                    echo "$sha256 $file_encoded" >>$sha256_cache_file # TODO use pipe: sha256_cache_fifo
+                #else echo "cache hit in sha256_cache for file: $file_encoded" >&2
+                fi
+                echo "$indent1$indent2[\"$sha256\" \"$file_encoded\"]"
+            done <<<"$files"
+            echo "$indent1];"
+        fi
+    done <<<"$families_dirs"
+    echo '}'
+} >$tempfile
+# TODO close $sha256_cache_fifo
+
+echo "replacing srcs.nix file in 5 seconds"
+sleep 5
+mv -v $tempfile $srcs_nix_file
+
+echo "patching default.nix file"
+sed -i -E "s/rev = \"[0-9a-f]{40}\";/rev = \"$rev\";/" $default_nix_file

--- a/pkgs/data/fonts/ricty/default.nix
+++ b/pkgs/data/fonts/ricty/default.nix
@@ -17,10 +17,10 @@ stdenv.mkDerivation rec {
     sed -i 's/fonts_directories=".*"/fonts_directories="$inconsolata $migu"/' ricty_generator.sh
   '';
 
-  buildInputs = [ google-fonts migu fontforge which ];
+  buildInputs = [ google-fonts.inconsolata migu fontforge which ];
 
   buildPhase = ''
-    inconsolata=${google-fonts} migu=${migu} ./ricty_generator.sh auto
+    inconsolata=${google-fonts.inconsolata} migu=${migu} ./ricty_generator.sh auto
   '';
 
   installPhase = ''


### PR DESCRIPTION
google-fonts is a huge package (1.5 GB uncompressed)
and i would prefer one package per font family

## alternatives

override + [sparse checkout](https://github.com/NixOS/nixpkgs/pull/135881)

when a package needs some font it can do

```nix
{ google-fonts }:
let
  roboto = google-fonts.override {
    path = "apache/roboto";
    rev = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
    sha256 = "";
  };
in
...
```

## eval cost

with `recurseIntoAttrs`. without recurseIntoAttrs there is no difference

```nix
{
  #google-fonts = callPackage ../data/fonts/google-fonts { };
  google-fonts = recurseIntoAttrs (callPackage ../data/fonts/google-fonts { });
```

```
/run/current-system/sw/bin/time -v \
nix-env --extra-experimental-features no-url-literals --option system x86_64-linux --file . -qaP --json --out-path --show-trace --no-allow-import-from-derivation >all.json
Maximum resident set size (kbytes): 9504960
Maximum resident set size (kbytes): 9634772 = +130 MB = +1.37 % (recurseIntoAttrs)

du -b all.json
17957019        all.json
18436961        all.json = +480 KB = +2.67 %
```

## test

```
nix-build . -A google-fonts.roboto
```

<details>
<summary>
<code>( cd result && find * -type f )</code>
</summary>

```
share/fonts/truetype/Roboto-ThinItalic.ttf
share/fonts/truetype/RobotoCondensed-BoldItalic.ttf
share/fonts/truetype/Roboto-Thin.ttf
share/fonts/truetype/Roboto-Regular.ttf
share/fonts/truetype/RobotoCondensed-Bold.ttf
share/fonts/truetype/Roboto-Black.ttf
share/fonts/truetype/Roboto-Medium.ttf
share/fonts/truetype/RobotoCondensed-LightItalic.ttf
share/fonts/truetype/Roboto-Italic.ttf
share/fonts/truetype/Roboto-MediumItalic.ttf
share/fonts/truetype/Robotox5Bwdth,wghtx5D.ttf
share/fonts/truetype/Roboto-Bold.ttf
share/fonts/truetype/RobotoCondensed-MediumItalic.ttf
share/fonts/truetype/RobotoCondensed-Regular.ttf
share/fonts/truetype/RobotoCondensed-Medium.ttf
share/fonts/truetype/Roboto-BlackItalic.ttf
share/fonts/truetype/Roboto-Light.ttf
share/fonts/truetype/Roboto-LightItalic.ttf
share/fonts/truetype/Roboto-BoldItalic.ttf
share/fonts/truetype/Roboto-Italicx5Bwdth,wghtx5D.ttf
share/fonts/truetype/RobotoCondensed-Italic.ttf
share/fonts/truetype/RobotoCondensed-Light.ttf
```

</details>

## todo

- use [runCommandLocal](https://ryantm.github.io/nixpkgs/builders/trivial-builders/#trivial-builder-runCommandLocal) instead of `stdenvNoCC.mkDerivation`
- use recurseIntoAttrs? (note: im not using mkScope because i dont need recursion)
- fix filenames
  - `share/fonts/truetype/Roboto-Italicx5Bwdth,wghtx5D.ttf` actual
  - `share/fonts/truetype/Roboto-Italic[wdth,wght].ttf` expected
- update.sh: use only git fetch
- add version to every font-family? (non-trivial to implement + i dont see much value in this, as the fonts are "versioned" by the file checksums)
- ignore [cc-by-sa/knowledge](https://github.com/google/fonts/tree/main/cc-by-sa/knowledge) = docs

## done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## ping

@manveru

## related

https://github.com/NixOS/rfcs/pull/109