### PR TITLE
POC: vulkan-gaming with HDR using latest gamescope and linux-hdr

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -169,6 +169,7 @@
   ./programs/fuse.nix
   ./programs/fzf.nix
   ./programs/gamemode.nix
+  ./programs/gamescope.nix
   ./programs/geary.nix
   ./programs/git.nix
   ./programs/gnome-disks.nix

--- a/nixos/modules/programs/gamescope.nix
+++ b/nixos/modules/programs/gamescope.nix
@@ -1,0 +1,84 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+with lib; let
+  cfg = config.programs.gamescope;
+
+  gamescope =
+    let
+      wrapperArgs =
+        optional (cfg.args != [ ])
+          ''--add-flags "${toString cfg.args}"''
+        ++ builtins.attrValues (mapAttrs (var: val: "--set-default ${var} ${val}") cfg.env);
+    in
+    pkgs.runCommand "gamescope" { nativeBuildInputs = [ pkgs.makeBinaryWrapper ]; } ''
+      mkdir -p $out/bin
+      makeWrapper ${cfg.package}/bin/gamescope $out/bin/gamescope --inherit-argv0 \
+        ${toString wrapperArgs}
+    '';
+in
+{
+  options.programs.gamescope = {
+    enable = mkEnableOption (mdDoc "gamescope");
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.gamescope;
+      defaultText = literalExpression "pkgs.gamescope";
+      description = mdDoc ''
+        The GameScope package to use.
+      '';
+    };
+
+    capSysNice = mkOption {
+      type = types.bool;
+      default = false;
+      description = mdDoc ''
+        Add cap_sys_nice capability to the GameScope binary.
+      '';
+    };
+
+    args = mkOption {
+      type = types.listOf types.string;
+      default = [ ];
+      example = [ "--rt" "--prefer-vk-device 8086:9bc4" ];
+      description = mdDoc ''
+        Arguments passed to GameScope on startup.
+      '';
+    };
+
+    env = mkOption {
+      type = types.attrsOf types.string;
+      default = { };
+      example = literalExpression ''
+        # for Prime render offload on Nvidia laptops.
+        # Also requires `hardware.nvidia.prime.offload.enable`.
+        {
+          __NV_PRIME_RENDER_OFFLOAD = "1";
+          __VK_LAYER_NV_optimus = "NVIDIA_only";
+          __GLX_VENDOR_LIBRARY_NAME = "nvidia";
+        }
+      '';
+      description = mdDoc ''
+        Default environment variables available to the GameScope process, overridable at runtime.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    security.wrappers = mkIf cfg.capSysNice {
+      gamescope = {
+        owner = "root";
+        group = "root";
+        source = "${gamescope}/bin/gamescope";
+        capabilities = "cap_sys_nice+pie";
+      };
+    };
+
+    environment.systemPackages = mkIf (!cfg.capSysNice) [ gamescope ];
+  };
+
+  meta.maintainers = with maintainers; [ nrdxp ];
+}

--- a/nixos/modules/programs/gamescope.nix
+++ b/nixos/modules/programs/gamescope.nix
@@ -6,6 +6,7 @@
 with lib; let
   cfg = config.programs.gamescope;
 
+  # wrapper that adds the default env, the default args.
   gamescope =
     let
       wrapperArgs =
@@ -17,6 +18,13 @@ with lib; let
       mkdir -p $out/bin
       makeWrapper ${cfg.package}/bin/gamescope $out/bin/gamescope --inherit-argv0 \
         ${toString wrapperArgs}
+    '';
+
+  # package with only the vulkan implicit layer
+  gamescope-vulkan-layers =
+    pkgs.runCommand "gamescope-vulkan-layers" { } ''
+      mkdir -p $out
+      ln -s ${cfg.package}/share $out/share
     '';
 in
 {
@@ -77,7 +85,8 @@ in
       };
     };
 
-    environment.systemPackages = mkIf (!cfg.capSysNice) [ gamescope ];
+    environment.systemPackages = [ gamescope-vulkan-layers ]
+      ++ lib.lists.optional (!cfg.capSysNice) gamescope;
   };
 
   meta.maintainers = with maintainers; [ nrdxp ];

--- a/pkgs/applications/window-managers/gamescope/default.nix
+++ b/pkgs/applications/window-managers/gamescope/default.nix
@@ -31,7 +31,7 @@
 }:
 let
   pname = "gamescope";
-  version = "3.11.52-beta6";
+  version = "3.11.52-unstable-2023-03-22";
 
   vkroots = fetchFromGitHub {
     owner = "Joshua-Ashton";
@@ -44,39 +44,14 @@ stdenv.mkDerivation {
   inherit pname version;
 
   src = fetchFromGitHub {
-    owner = "Plagman";
+    owner = "ValveSoftware";
     repo = "gamescope";
-    rev = "refs/tags/${version}";
-    hash = "sha256-2gn6VQfmwwl86mmnRh+J1uxSIpA5x/Papq578seJ3n8=";
+    rev = "5d9ecd462e6d5939fc2697509f53bcb6aba7eb92";
+    hash = "sha256-1Ya59k60YmrJ1AWQ3eoWYBFjiz+RENBNc4FxK3GcgIQ=";
   };
 
   patches = [
     ./use-pkgconfig.patch
-
-    # https://github.com/Plagman/gamescope/pull/811
-    (fetchpatch {
-      name = "fix-openvr-dependency-name.patch";
-      url = "https://github.com/Plagman/gamescope/commit/557e56badec7d4c56263d3463ca9cdb195e368d7.patch";
-      sha256 = "sha256-9Y1tJ24EsdtZEOCEA30+FJBrdzXX+Nj3nTb5kgcPfBE=";
-    })
-    # https://github.com/Plagman/gamescope/pull/813
-    (fetchpatch {
-      name = "fix-openvr-include.patch";
-      url = "https://github.com/Plagman/gamescope/commit/1331b9f81ea4b3ae692a832ed85a464c3fd4c5e9.patch";
-      sha256 = "sha256-wDtFpM/nMcqSbIpR7K5Tyf0845r3l4kQHfwll1VL4Mc=";
-    })
-    # https://github.com/Plagman/gamescope/pull/812
-    (fetchpatch {
-      name = "bump-libdisplay-info-maximum-version.patch";
-      url = "https://github.com/Plagman/gamescope/commit/b430c5b9a05951755051fd4e41ce20496705fbbc.patch";
-      sha256 = "sha256-YHtwudMUHiE8i3ZbiC9gkSjrlS0/7ydjmJsY1a8ZI2E=";
-    })
-    # https://github.com/Plagman/gamescope/pull/824
-    (fetchpatch {
-      name = "update-libdisplay-info-pkgconfig-filename.patch";
-      url = "https://github.com/Plagman/gamescope/commit/5a672f09aa07c7c5d674789f3c685c8173e7a2cf.patch";
-      sha256 = "sha256-7NX54WIsJDvZT3C58N2FQasV9PJyKkJrLGYS1r4f+kc=";
-    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/kernel/linux-testing-hdr.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-hdr.nix
@@ -1,0 +1,31 @@
+{ lib, fetchFromGitLab, buildLinux, ... } @ args:
+
+# NOTE: This patched kernel is based upon amd-staging-drm-next
+buildLinux (args // rec {
+  version = "6.0-unstable-2023-01-17";
+  extraMeta.branch = lib.versions.majorMinor version;
+
+  # modDirVersion needs to be x.y.z, will always add .0
+  modDirVersion = "6.0.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "JoshuaAshton";
+    repo = "linux-hdr";
+    rev = "ff57328e57842bb2e0475449fc598ff84e88d55c";
+    hash = "sha256-RS2AMybUw2tqxY3wDs1bWrNsaGeEsiXYLKEoqmgPMu0=";
+  };
+
+  # Never build it on Hydra
+  extraMeta.hydraPlatforms = [];
+
+  # Some unavailable options
+  structuredExtraConfig = with lib.kernel; {
+    ANDROID = lib.mkOverride 60 (option no);
+    DRM_AMD_DC_DCN = lib.mkOverride 60 (option no);
+    DRM_AMD_DC_HDCP = lib.mkOverride 60 (option no);
+    LRU_GEN = lib.mkOverride 60 (option no);
+    LRU_GEN_ENABLED = lib.mkOverride 60 (option no);
+  };
+
+} // (args.argsOverride or {}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26492,6 +26492,9 @@ with pkgs;
   linuxPackages_testing_bcachefs = linuxKernel.packages.linux_testing_bcachefs;
   linux_testing_bcachefs = linuxKernel.kernels.linux_testing_bcachefs;
 
+  linuxPackages_testing_hdr = linuxKernel.packages.linux_testing_hdr;
+  linux_testing_hdr = linuxKernel.kernels.linux_testing_hdr;
+
   # Realtime kernel
   linuxPackages-rt = linuxKernel.packageAliases.linux_rt_default;
   linuxPackages-rt_latest = linuxKernel.packageAliases.linux_rt_latest;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -215,6 +215,13 @@ in {
       kernelPatches = linux_6_1.kernelPatches;
    };
 
+    linux_testing_hdr = callPackage ../os-specific/linux/kernel/linux-testing-hdr.nix {
+      kernelPatches = [
+        kernelPatches.bridge_stp_helper
+        kernelPatches.request_key_helper
+      ];
+    };
+
     linux_hardkernel_4_14 = callPackage ../os-specific/linux/kernel/linux-hardkernel-4.14.nix {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
@@ -592,6 +599,7 @@ in {
     # Intentionally lacks recurseIntoAttrs, as -rc kernels will quite likely break out-of-tree modules and cause failed Hydra builds.
     linux_testing = packagesFor kernels.linux_testing;
     linux_testing_bcachefs = recurseIntoAttrs (packagesFor kernels.linux_testing_bcachefs);
+    linux_testing_hdr = recurseIntoAttrs (packagesFor kernels.linux_testing_hdr);
 
     linux_hardened = recurseIntoAttrs (hardenedPackagesFor packageAliases.linux_default.kernel { });
 


### PR DESCRIPTION
I won't merge this PR while all the packages here modified haven't released a new stable version.

But, we can use it as a milestone, or an always up-to-date guide for HDR.

I'm aware ofborg will tag some maintainers, sorry. Please don't hesitate to remove yourself from review and unsubscribe.

This depends on https://github.com/NixOS/nixpkgs/pull/187507 (included here)

### How to use it?

1. Merge this to your nixpkgs or use my branch as nixpkgs source.
2. Add this to your setup:
```nix
{ lib, ... }:
{
  # GameScope session
  programs.gamescope.enable = true;
  programs.steam.gamescopeSession.enable = true;

  specialisation.hdr.configuration = {
    system.nixos.tags = [ "hdr" ];
    boot.kernelPackages = lib.mkForce pkgs.linuxPackages_testing_hdr;
    environment.variables =
      {
        DXVK_HDR = "1";
        ENABLE_GAMESCOPE_WSI = "1";
      };
    programs.gamescope.args = lib.mkForce [ "--rt" "--hdr-enabled" ];
  };
}
```
3. Reboot, picking the new HDR entry in your bootloader.
4. Select the new “Steam Gamescope” session, or, login in tty3 and launch `steam-gamescope`.
5. Your display should change to HDR mode automatically, Steam colors should be fine.
6. Search in your steam library for the "Steam Linux Runtime - Soldier" (should be under "Tools") and change in "Properties" > "Beta" for opt into "client_beta".
7. Go game something, use recent Proton versions (experimental or GE)!
