### PR TITLE
ocaml-ng.ocamlPackages_4_09.ocaml: fix with GCC 12

### DIFF
--- a/pkgs/development/compilers/ocaml/4.09.1-Werror.patch
+++ b/pkgs/development/compilers/ocaml/4.09.1-Werror.patch
@@ -1,0 +1,16 @@
+The 4.09.1 tarball appears to have been acidentally generated as a
+development tarball, which causes configure to enable -Werror.  This
+means newer compilers will make the build fail.
+
+diff a/configure b/configure
+--- a/configure
++++ b/configure
+@@ -12360,7 +12360,7 @@ case $ocaml_cv_cc_vendor in #(
+   msvc-*) :
+     outputobj=-Fo; CPP="cl -nologo -EP"; gcc_warnings="" ;; #(
+   *) :
+-    outputobj='-o $(EMPTY)'; case 4.09.1+dev1-2020-03-13 in #(
++    outputobj='-o $(EMPTY)'; case 4.09.1 in #(
+   *+dev*) :
+     gcc_warnings="-Wall -Werror" ;; #(
+   *) :

--- a/pkgs/development/compilers/ocaml/4.09.nix
+++ b/pkgs/development/compilers/ocaml/4.09.nix
@@ -8,6 +8,7 @@ import ./generic.nix {
   hardeningDisable = [ "strictoverflow" ];
 
   patches = [
+    ./4.09.1-Werror.patch
     # Compatibility with Glibc 2.34
     { url = "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch";
       sha256 = "sha256:1b3jc6sj2k23yvfwrv6nc1f4x2n2biqbhbbp74aqb6iyqyjsq35n"; }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
