### PR TITLE
xscreensaver: 6.04 -> 6.06

### DIFF
--- a/pkgs/misc/screensavers/xscreensaver/default.nix
+++ b/pkgs/misc/screensavers/xscreensaver/default.nix
@@ -2,19 +2,19 @@
 , pkg-config, intltool
 , perl, perlPackages, gettext, libX11, libXext, libXi, libXt
 , libXft, libXinerama, libXrandr, libXxf86vm, libGL, libGLU, gle
-, gtk2, gdk-pixbuf, gdk-pixbuf-xlib, libxml2, pam
+, gtk3, gdk-pixbuf, gdk-pixbuf-xlib, libxml2, pam
 , systemd, coreutils
 , forceInstallAllHacks ? false
 , withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
 }:
 
 stdenv.mkDerivation rec {
-  version = "6.04";
+  version = "6.06";
   pname = "xscreensaver";
 
   src = fetchurl {
     url = "https://www.jwz.org/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-eHAUsp8MV5Pswtk+EQmgSf9IqwwpuFHas09oPO72sVI=";
+    hash = "sha256-9TT6uFqDbeW4vo6R/CG4DKfWpO2ThuviB9S+ek50mac=";
   };
 
   nativeBuildInputs = [
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     perl gettext libX11 libXext libXi libXt
     libXft libXinerama libXrandr libXxf86vm libGL libGLU gle
-    gtk2 gdk-pixbuf gdk-pixbuf-xlib libxml2 pam
+    gtk3 gdk-pixbuf gdk-pixbuf-xlib libxml2 pam
     perlPackages.LWPProtocolHttps perlPackages.MozillaCA
   ] ++ lib.optional withSystemd systemd;
 


### PR DESCRIPTION
###### Description of changes
https://www.jwz.org/blog/2022/09/xscreensaver-6-05-out-now/
https://www.jwz.org/blog/2022/12/xscreensaver-6-06-out-now/

draft because I'm actually on wayland on my main machine. will test on something with x11 later, if nobody else does.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).