### PR TITLE
dracut: reduce closure and suffix DRACUT_PATH

### DIFF
--- a/pkgs/os-specific/linux/dracut/default.nix
+++ b/pkgs/os-specific/linux/dracut/default.nix
@@ -10,24 +10,17 @@
 , bash
 , kmod
 , binutils
-, busybox
 , bzip2
 , coreutils
 , cpio
 , findutils
-, glibc
 , gnugrep
 , gnused
 , gnutar
 , gzip
-, kbd
-, lvm2
 , lz4
 , lzop
-, procps
-, rng-tools
 , squashfsTools
-, systemd
 , util-linux
 , xz
 , zstd
@@ -76,23 +69,16 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/dracut --prefix PATH : ${lib.makeBinPath [
       coreutils
       util-linux
-    ]} --prefix DRACUT_PATH : ${lib.makeBinPath [
+    ]} --suffix DRACUT_PATH : ${lib.makeBinPath [
       bash
       binutils
       coreutils
       findutils
-      glibc
       gnugrep
       gnused
       gnutar
-      kbd
-      lvm2
-      procps
-      rng-tools
-      squashfsTools
-      systemd
+      stdenv.cc.libc  # for ldd command
       util-linux
-      busybox
     ]}
     wrapProgram $out/bin/dracut-catimages --set PATH ${lib.makeBinPath [
       coreutils


### PR DESCRIPTION
###### Description of changes

Implement a few usability changes for dracut framework by suffixing rather than prefixing `DRACUT_PATH` (so that downstream consumers can more easily override it) and reduce closure size by bundling fewer default utilities in `DRACUT_PATH`

Done per comments at https://github.com/NixOS/nixpkgs/pull/210075#discussion_r1088822274

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).