### PR TITLE
python310Packages.pyorthanc: init at 1.11.4

### DIFF
--- a/pkgs/development/python-modules/pyorthanc/default.nix
+++ b/pkgs/development/python-modules/pyorthanc/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, poetry-core
+, httpx
+, pydicom
+}:
+
+buildPythonPackage rec {
+  pname = "pyorthanc";
+  version = "1.11.4";
+  disabled = pythonOlder "3.8";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "gacou54";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-HbNeI6KpdIoLwRx09qQGJ/iJGKnRj0Z4/mkgoXhofGA=";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [ httpx pydicom ];
+
+  doCheck = false;  # requires orthanc server (not in Nixpkgs)
+
+  pythonImportsCheck = [
+    "pyorthanc"
+  ];
+
+  meta = with lib; {
+    description = "Python library that wraps the Orthanc REST API";
+    homepage = "https://github.com/gacou54/pyorthanc";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7248,6 +7248,8 @@ self: super: with self; {
 
   pynx584 = callPackage ../development/python-modules/pynx584 { };
 
+  pyorthanc = callPackage ../development/python-modules/pyorthanc { };
+
   pyoverkiz = callPackage ../development/python-modules/pyoverkiz { };
 
   pyownet = callPackage ../development/python-modules/pyownet { };


### PR DESCRIPTION
###### Description of changes

Add a package.

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
