### PR TITLE
nixos/mediatomb: fix transcoding option

### DIFF
--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -39,7 +39,7 @@ let
         <transcode mimetype="video/x-flv" using="vlcmpeg" />
         <transcode mimetype="application/ogg" using="vlcmpeg" />
         <transcode mimetype="audio/ogg" using="ogg2mp3" />
-        <transcode mimetype="audio/x-flac" using="oggflac2raw"/>
+        <transcode mimetype="audio/x-flac" using="ogg2mp3"/>
       </mimetype-profile-mappings>
       <profiles>
         <profile name="ogg2mp3" enabled="no" type="external">
@@ -55,7 +55,7 @@ let
           <accept-url>yes</accept-url>
           <first-resource>yes</first-resource>
           <accept-ogg-theora>yes</accept-ogg-theora>
-          <agent command="${libsForQt5.vlc}/bin/vlc"
+          <agent command="${vlc}/bin/vlc"
             arguments="-I dummy %in --sout #transcode{venc=ffmpeg,vcodec=mp2v,vb=4096,fps=25,aenc=ffmpeg,acodec=mpga,ab=192,samplerate=44100,channels=2}:standard{access=file,mux=ps,dst=%out} vlc:quit" />
           <buffer size="14400000" chunk-size="512000" fill-size="120000" />
         </profile>


### PR DESCRIPTION
###### Description of changes

fixes issues introduced by 1db9813dd3c when `services.mediatomb.transcoding = true`:

- attribute 'vlc' missing, at nixos/modules/services/misc/mediatomb.nix:58:29
- error: Error in configuration: you specified a mimetype to transcoding profile mapping, but the profile "oggflac2raw" for mimetype "audio/x-flac" does not exists

The option probably should just be removed though, it's been broken for a long time and even after these fixes it does nothing of value afaict - the transcoding profiles themselves [are all disabled anyway](https://github.com/NixOS/nixpkgs/blob/dcf4487fc79fcdc1b3adba6e9b3d70eeec27f527/nixos/modules/services/misc/mediatomb.nix#L45)?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
