### PR TITLE
 python310Packages.finvizfinance: init at 0.14.5 

### DIFF
--- a/pkgs/development/python-modules/finvizfinance/default.nix
+++ b/pkgs/development/python-modules/finvizfinance/default.nix
@@ -1,0 +1,71 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, beautifulsoup4
+, datetime
+, lxml
+, pandas
+, pytest-mock
+, pytestCheckHook
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "finvizfinance";
+  version = "0.14.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "lit26";
+    repo = "finvizfinance";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-yhOa/CS+9UdI+TVMObBsOqIp9XggMJvNjteSMa5DJcM=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "bs4" "beautifulsoup4"
+  '';
+
+  nativeCheckInputs = [
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    datetime
+    lxml
+    pandas
+    requests
+  ];
+
+  pythonImportsCheck = [
+    "finvizfinance"
+  ];
+
+  disabledTests = [
+    # Tests require network access
+    "test_finvizfinance_calendar"
+    "test_finvizfinance_crypto"
+    "test_forex_performance_percentage"
+    "test_group_overview"
+    "test_finvizfinance_insider"
+    "test_finvizfinance_news"
+    "test_finvizfinance_finvizfinance"
+    "test_statements"
+    "test_screener_overview"
+  ];
+
+  meta = with lib; {
+    description = "Finviz Finance information downloader";
+    homepage = "https://github.com/lit26/finvizfinance";
+    changelog = "https://github.com/lit26/finvizfinance/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ icyrockcom ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3499,6 +3499,8 @@ self: super: with self; {
 
   fints = callPackage ../development/python-modules/fints { };
 
+  finvizfinance = callPackage ../development/python-modules/finvizfinance { };
+
   fiona = callPackage ../development/python-modules/fiona { };
 
   fipy = callPackage ../development/python-modules/fipy { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

New package https://github.com/lit26/finvizfinance

finvizfinance is a package which collects financial information from FinViz website

PR for required datetime package: https://github.com/NixOS/nixpkgs/pull/215393.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
