### PR TITLE
services.openssh: remove authorizedKeysCommand*

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -527,6 +527,26 @@
         <itemizedlist spacing="compact">
           <listitem>
             <para>
+              <literal>services.openssh.authorizedKeysFile</literal> to
+              <literal>services.openssh.settings.AuthorizedKeysFile</literal>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>services.openssh.authorizedKeysCommand</literal>
+              to
+              <literal>services.openssh.settings.AuthorizedKeysCommand</literal>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>services.openssh.authorizedKeysCommandUser</literal>
+              to
+              <literal>services.openssh.settings.AuthorizedKeysCommandUser</literal>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
               <literal>services.openssh.forwardX11</literal> to
               <literal>services.openssh.settings.X11Forwarding</literal>
             </para>

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -129,6 +129,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The module `usbmuxd` now has the ability to change the package used by the daemon. In case you're experiencing issues with `usbmuxd` you can try an alternative program like `usbmuxd2`. Available as [services.usbmuxd.package](#opt-services.usbmuxd.package)
 
 - A few openssh options have been moved from extraConfig to the new freeform option `settings` and renamed as follows:
+  - `services.openssh.authorizedKeysFile` to `services.openssh.settings.AuthorizedKeysFile`
+  - `services.openssh.authorizedKeysCommand` to `services.openssh.settings.AuthorizedKeysCommand`
+  - `services.openssh.authorizedKeysCommandUser` to `services.openssh.settings.AuthorizedKeysCommandUser`
   - `services.openssh.forwardX11` to `services.openssh.settings.X11Forwarding`
   - `services.openssh.kbdInteractiveAuthentication` -> `services.openssh.settings.KbdInteractiveAuthentication`
   - `services.openssh.passwordAuthentication` to `services.openssh.settings.PasswordAuthentication`

--- a/nixos/modules/security/google_oslogin.nix
+++ b/nixos/modules/security/google_oslogin.nix
@@ -64,8 +64,8 @@ in
         exec ${package}/bin/google_authorized_keys "$@"
       '';
     };
-    services.openssh.authorizedKeysCommand = "/etc/ssh/authorized_keys_command_google_oslogin %u";
-    services.openssh.authorizedKeysCommandUser = "nobody";
+    services.openssh.settings.AuthorizedKeysCommand = "/etc/ssh/authorized_keys_command_google_oslogin %u";
+    services.openssh.settings.AuthorizedKeysCommandUser = "nobody";
   };
 
 }

--- a/nixos/modules/services/misc/sourcehut/default.nix
+++ b/nixos/modules/services/misc/sourcehut/default.nix
@@ -770,7 +770,7 @@ in
       services.nginx.recommendedProxySettings = mkDefault true;
     })
     (mkIf (cfg.builds.enable || cfg.git.enable || cfg.hg.enable) {
-      services.openssh = {
+      services.openssh.settings = {
         # Note that sshd will continue to honor AuthorizedKeysFile.
         # Note that you may want automatically rotate
         # or link to /dev/null the following log files:
@@ -778,12 +778,10 @@ in
         # - /var/log/{build,git,hg}srht-keys
         # - /var/log/{git,hg}srht-shell
         # - /var/log/gitsrht-update-hook
-        authorizedKeysCommand = ''/etc/ssh/sourcehut/subdir/srht-dispatch "%u" "%h" "%t" "%k"'';
+        AuthorizedKeysCommand = ''/etc/ssh/sourcehut/subdir/srht-dispatch "%u" "%h" "%t" "%k"'';
         # srht-dispatch will setuid/setgid according to [git.sr.ht::dispatch]
-        authorizedKeysCommandUser = "root";
-        extraConfig = ''
-          PermitUserEnvironment SRHT_*
-        '';
+        AuthorizedKeysCommandUser = "root";
+        PermitUserEnvironment = "SRHT_*";
       };
       environment.etc."ssh/sourcehut/config.ini".source =
         settingsFormat.generate "sourcehut-dispatch-config.ini"

--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -153,8 +153,8 @@ in {
         exec ${pkgs.sssd}/bin/sss_ssh_authorizedkeys "$@"
       '';
     };
-    services.openssh.authorizedKeysCommand = "/etc/ssh/authorized_keys_command";
-    services.openssh.authorizedKeysCommandUser = "nobody";
+    services.openssh.settings.AuthorizedKeysCommand = "/etc/ssh/authorized_keys_command";
+    services.openssh.settings.AuthorizedKeysCommandUser = "nobody";
   })];
 
   meta.maintainers = with maintainers; [ bbigras ];

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -100,6 +100,8 @@ in
     (mkAliasOptionModuleMD [ "services" "openssh" "knownHosts" ] [ "programs" "ssh" "knownHosts" ])
     (mkRenamedOptionModule [ "services" "openssh" "challengeResponseAuthentication" ] [ "services" "openssh" "kbdInteractiveAuthentication" ])
 
+    (mkRenamedOptionModule [ "services" "openssh" "authorizedKeysCommand" ] [  "services" "openssh" "settings" "AuthorizedKeysCommand" ])
+    (mkRenamedOptionModule [ "services" "openssh" "authorizedKeysCommandUser" ] [  "services" "openssh" "settings" "AuthorizedKeysCommandUser" ])
     (mkRenamedOptionModule [ "services" "openssh" "kbdInteractiveAuthentication" ] [  "services" "openssh" "settings" "KbdInteractiveAuthentication" ])
     (mkRenamedOptionModule [ "services" "openssh" "passwordAuthentication" ] [  "services" "openssh" "settings" "PasswordAuthentication" ])
     (mkRenamedOptionModule [ "services" "openssh" "useDns" ] [  "services" "openssh" "settings" "UseDns" ])
@@ -253,28 +255,6 @@ in
           See AuthorizedKeysFile in man sshd_config for details.
         '';
       };
-
-      authorizedKeysCommand = mkOption {
-        type = types.str;
-        default = "none";
-        description = lib.mdDoc ''
-          Specifies a program to be used to look up the user's public
-          keys. The program must be owned by root, not writable by group
-          or others and specified by an absolute path.
-        '';
-      };
-
-      authorizedKeysCommandUser = mkOption {
-        type = types.str;
-        default = "nobody";
-        description = lib.mdDoc ''
-          Specifies the user under whose account the AuthorizedKeysCommand
-          is run. It is recommended to use a dedicated user that has no
-          other role on the host than running authorized keys commands.
-        '';
-      };
-
-
 
       settings = mkOption {
         description = lib.mdDoc "Configuration for `sshd_config(5)`.";
@@ -561,10 +541,6 @@ in
         ''}
         PrintMotd no # handled by pam_motd
         AuthorizedKeysFile ${toString cfg.authorizedKeysFiles}
-        ${optionalString (cfg.authorizedKeysCommand != "none") ''
-          AuthorizedKeysCommand ${cfg.authorizedKeysCommand}
-          AuthorizedKeysCommandUser ${cfg.authorizedKeysCommandUser}
-        ''}
 
         ${flip concatMapStrings cfg.hostKeys (k: ''
           HostKey ${k.path}


### PR DESCRIPTION
WIP PR to deal with openssh settings.


not needed now that they can be set via services.openssh.settings. If you only set services.openssh.AuthorizedKeysCommand without its AuthorizedKeysCommandUser counterpart (the user under which to run services.openssh.settings.AuthorizedKeysCommand), the sshd config validation will fail. The previous default was "nobody" so if you haven't deviated from it the migration path would be

services.openssh.settings.AuthorizedKeysCommandUser = "nobody" if not set else or services.openssh.settings.authorizedKeysCommandUser.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
