### PR TITLE
cargo-leptos: init at 0.1.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1845,6 +1845,12 @@
     githubId = 75972;
     name = "Ben Booth";
   };
+  benwis = {
+    name = "Ben Wishovich";
+    email = "ben@benw.is";
+    github = "benwis";
+    githubId = 6953353;
+  };
   berberman = {
     email = "berberman@yandex.com";
     matrix = "@berberman:mozilla.org";

--- a/pkgs/development/tools/rust/cargo-leptos/default.nix
+++ b/pkgs/development/tools/rust/cargo-leptos/default.nix
@@ -1,0 +1,47 @@
+{ darwin
+, fetchFromGitHub
+, lib
+, openssl
+, pkg-config
+, rustPlatform
+, stdenv
+}:
+let
+  inherit (darwin.apple_sdk.frameworks)
+    CoreServices
+    Security;
+  inherit (lib) optionals;
+  inherit (stdenv) isDarwin isLinux;
+in
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-leptos";
+  version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "leptos-rs";
+    repo = pname;
+    rev = version;
+    hash = "sha256-z4AqxvKu9E8GGMj6jNUAAWeqoE/j+6NoAEZWeNZ+1BA=";
+  };
+
+  cargoHash = "sha256-w/9W4DXbh4G5DZ8IGUz4nN3LEjHhL7HgybHqODMFzHw=";
+  nativeBuildInputs = optionals (!isDarwin) [ pkg-config ];
+
+  buildInputs = optionals (!isDarwin) [
+    openssl
+  ] ++ optionals isDarwin [
+    Security
+    CoreServices
+  ];
+
+  # https://github.com/leptos-rs/cargo-leptos#dependencies
+  buildFeatures = [ "no_downloads" ]; # cargo-leptos will try to install missing dependencies on its own otherwise
+  doCheck = false; # Check phase tries to query crates.io
+
+  meta = with lib; {
+    description = "A build tool for the Leptos web framework";
+    homepage = "https://github.com/leptos-rs/cargo-leptos";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ benwis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15974,6 +15974,7 @@ with pkgs;
   cargo-edit = callPackage ../development/tools/rust/cargo-edit {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  cargo-leptos = callPackage ../development/tools/rust/cargo-leptos { };
   cargo-kcov = callPackage ../development/tools/rust/cargo-kcov { };
   cargo-graph = callPackage ../development/tools/rust/cargo-graph { };
   cargo-guppy = callPackage ../development/tools/rust/cargo-guppy { };


### PR DESCRIPTION
###### Description of changes
cargo-leptos is a build tool to allow easier generation of server side rendered sites for the Leptos web framework. While there is currently no website, they can be found on git [here](https://github.com/leptos-rs/leptos) and cargo-leptos [here](https://github.com/leptos-rs/cargo-leptos)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [?] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x]  Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Let me know if I've done something wrong, this is my first package!
