### PR TITLE
python310: 3.10.9 -> 3.10.10; python311: 3.11.1 -> 3.11.2

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -30,7 +30,7 @@
 , pkgsHostHost
 , pkgsTargetTarget
 , sourceVersion
-, sha256
+, hash
 , passthruFun
 , bash
 , stripConfig ? false
@@ -215,7 +215,7 @@ in with passthru; stdenv.mkDerivation {
 
   src = fetchurl {
     url = with sourceVersion; "https://www.python.org/ftp/python/${major}.${minor}.${patch}/Python-${version}.tar.xz";
-    inherit sha256;
+    inherit hash;
   };
 
   prePatch = optionalString stdenv.isDarwin ''
@@ -235,7 +235,7 @@ in with passthru; stdenv.mkDerivation {
       url = "https://github.com/python/cpython/commit/3fae04b10e2655a20a3aadb5e0d63e87206d0c67.diff";
       revert = true;
       excludes = [ "Misc/NEWS.d/*" ];
-      sha256 = "sha256-PmkXf2D9trtW1gXZilRIWgdg2Y47JfELq1z4DuG3wJY=";
+      hash = "sha256-PmkXf2D9trtW1gXZilRIWgdg2Y47JfELq1z4DuG3wJY=";
     })
   ] ++ [
     # Disable the use of ldconfig in ctypes.util.find_library (since

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -121,10 +121,10 @@
       sourceVersion = {
         major = "3";
         minor = "10";
-        patch = "9";
+        patch = "10";
         suffix = "";
       };
-      sha256 = "sha256-WuA+MIJgFkuro5kh/bTb+ObQPYI1qTnUWCsz8LXkaoM=";
+      sha256 = "sha256-BBnpCFv1G3pnIAmz9Q2/GFms3xi6cl0OwZqlyFA/DqM=";
     };
   };
 

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -124,7 +124,7 @@
         patch = "10";
         suffix = "";
       };
-      sha256 = "sha256-BBnpCFv1G3pnIAmz9Q2/GFms3xi6cl0OwZqlyFA/DqM=";
+      hash = "sha256-BBnpCFv1G3pnIAmz9Q2/GFms3xi6cl0OwZqlyFA/DqM=";
     };
 
     python311 = {
@@ -134,7 +134,7 @@
         patch = "2";
         suffix = "";
       };
-      sha256 = "sha256-KeS49fFlhUKowT4t0nc1jJxI8rL3MYZS7xZ15AK50q8=";
+      hash = "sha256-KeS49fFlhUKowT4t0nc1jJxI8rL3MYZS7xZ15AK50q8=";
     };
   };
 
@@ -148,7 +148,7 @@ in {
       patch = "18";
       suffix = ".6"; # ActiveState's Python 2 extended support
     };
-    sha256 = "sha256-+I0QOBkuTHMIQz71lgNn1X1vjPsjJMtFbgC0xcGTwWY=";
+    hash = "sha256-+I0QOBkuTHMIQz71lgNn1X1vjPsjJMtFbgC0xcGTwWY=";
     inherit (darwin) configd;
     inherit passthruFun;
   };
@@ -161,7 +161,7 @@ in {
       patch = "16";
       suffix = "";
     };
-    sha256 = "sha256-2F27N3QTJHPYCB3LFY80oQzK16kLlsflDqS7YfXORWI=";
+    hash = "sha256-2F27N3QTJHPYCB3LFY80oQzK16kLlsflDqS7YfXORWI=";
     inherit (darwin) configd;
     inherit passthruFun;
   };
@@ -174,7 +174,7 @@ in {
       patch = "16";
       suffix = "";
     };
-    sha256 = "sha256-It3cCZJG3SdgZlVh6K23OU6gzEOnJoTGSA+TgPd4ZDk=";
+    hash = "sha256-It3cCZJG3SdgZlVh6K23OU6gzEOnJoTGSA+TgPd4ZDk=";
     inherit (darwin) configd;
     inherit passthruFun;
   };
@@ -199,7 +199,7 @@ in {
       patch = "0";
       suffix = "a5";
     };
-    sha256 = "sha256-1m73o0L+OjVvnO47uXrcHl+0hA9rbP994P991JX4Mjs=";
+    hash = "sha256-1m73o0L+OjVvnO47uXrcHl+0hA9rbP994P991JX4Mjs=";
     inherit (darwin) configd;
     inherit passthruFun;
   };
@@ -242,7 +242,7 @@ in {
       patch = "11";
     };
 
-    sha256 = "sha256-ERevtmgx2k6m852NIIR4enRon9AineC+MB+e2bJVCTw=";
+    hash = "sha256-ERevtmgx2k6m852NIIR4enRon9AineC+MB+e2bJVCTw=";
     pythonVersion = "2.7";
     db = db.override { dbmSupport = !stdenv.isDarwin; };
     python = __splicedPackages.pythonInterpreters.pypy27_prebuilt;
@@ -259,7 +259,7 @@ in {
       patch = "11";
     };
 
-    sha256 = "sha256-sPMWb7Klqt/VzrnbXN1feSmg7MygK0omwNrgSS98qOo=";
+    hash = "sha256-sPMWb7Klqt/VzrnbXN1feSmg7MygK0omwNrgSS98qOo=";
     pythonVersion = "3.9";
     db = db.override { dbmSupport = !stdenv.isDarwin; };
     python = __splicedPackages.pypy27;
@@ -271,7 +271,7 @@ in {
   pypy38 = __splicedPackages.pypy39.override {
     self = __splicedPackages.pythonInterpreters.pypy38;
     pythonVersion = "3.8";
-    sha256 = "sha256-TWdpv8pzc06GZv1wUDt86wam4lkRDmFzMbs4mcpOYFg=";
+    hash = "sha256-TWdpv8pzc06GZv1wUDt86wam4lkRDmFzMbs4mcpOYFg=";
   };
 
   pypy37 = throw "pypy37 has been removed from nixpkgs since it is no longer supported upstream"; # Added 2023-01-04
@@ -285,7 +285,7 @@ in {
       patch = "11";
     };
 
-    sha256 = {
+    hash = {
       aarch64-linux = "sha256-6pJNod7+kyXvdg4oiwT5hGFOQFWA9TIetqXI9Tm9QVo=";
       x86_64-linux = "sha256-uo7ZWKkFwHNaTP/yh1wlCJlU3AIOCH2YKw/6W52jFs0=";
       aarch64-darwin = "sha256-zFaWq0+TzTSBweSZC13t17pgrAYC+hiQ02iImmxb93E=";
@@ -303,7 +303,7 @@ in {
       minor = "3";
       patch = "11";
     };
-    sha256 = {
+    hash = {
       aarch64-linux = "sha256-CRddxlLtiV2Y6a1j0haBK/PufjmNkAqb+espBrqDArk=";
       x86_64-linux = "sha256-1QYXLKEQcSdBdddOnFgcMWZDLQF5sDZHDjuejSDq5YE=";
       aarch64-darwin = "sha256-ka11APGjlTHb76CzRaPc/5J/+ZcWVOjS6e98WuMR9X4=";

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -126,6 +126,16 @@
       };
       sha256 = "sha256-BBnpCFv1G3pnIAmz9Q2/GFms3xi6cl0OwZqlyFA/DqM=";
     };
+
+    python311 = {
+      sourceVersion = {
+        major = "3";
+        minor = "11";
+        patch = "2";
+        suffix = "";
+      };
+      sha256 = "sha256-KeS49fFlhUKowT4t0nc1jJxI8rL3MYZS7xZ15AK50q8=";
+    };
   };
 
 in {
@@ -175,18 +185,11 @@ in {
     inherit passthruFun;
   } // sources.python310);
 
-  python311 = callPackage ./cpython {
+  python311 = callPackage ./cpython ({
     self = __splicedPackages.python311;
-    sourceVersion = {
-      major = "3";
-      minor = "11";
-      patch = "1";
-      suffix = "";
-    };
-    sha256 = "sha256-hYeRkvLP/VbLFsCSkFlJ6/Pl45S392RyNSljeQHftY8=";
     inherit (darwin) configd;
     inherit passthruFun;
-  };
+  } // sources.python311);
 
   python312 = callPackage ./cpython {
     self = __splicedPackages.python312;

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -117,15 +117,6 @@
   };
 
   sources = {
-    python39 = {
-      sourceVersion = {
-        major = "3";
-        minor = "9";
-        patch = "16";
-        suffix = "";
-      };
-      sha256 = "sha256-It3cCZJG3SdgZlVh6K23OU6gzEOnJoTGSA+TgPd4ZDk=";
-    };
     python310 = {
       sourceVersion = {
         major = "3";
@@ -165,11 +156,18 @@ in {
     inherit passthruFun;
   };
 
-  python39 = callPackage ./cpython ({
+  python39 = callPackage ./cpython {
     self = __splicedPackages.python39;
+    sourceVersion = {
+      major = "3";
+      minor = "9";
+      patch = "16";
+      suffix = "";
+    };
+    sha256 = "sha256-It3cCZJG3SdgZlVh6K23OU6gzEOnJoTGSA+TgPd4ZDk=";
     inherit (darwin) configd;
     inherit passthruFun;
-  } // sources.python39);
+  };
 
   python310 = callPackage ./cpython ({
     self = __splicedPackages.python310;

--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -173,7 +173,7 @@ let
       }
     ) {};
     pythonWithRequests = requests.pythonModule.withPackages (ps: [ requests ]);
-    in
+    in lib.optionalAttrs stdenv.isLinux
     {
       condaExamplePackage = runCommand "import-requests" {} ''
         ${pythonWithRequests.interpreter} -c "import requests" > $out

--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -43,7 +43,8 @@ let
       # Use virtualenv from a Nix env.
       nixenv-virtualenv = rec {
         env = runCommand "${python.name}-virtualenv" {} ''
-          ${pythonVirtualEnv.interpreter} -m virtualenv $out
+          ${pythonVirtualEnv.interpreter} -m virtualenv venv
+          mv venv $out
         '';
         interpreter = "${env}/bin/${python.executable}";
         is_venv = "False";

--- a/pkgs/development/python-modules/asgiref/default.nix
+++ b/pkgs/development/python-modules/asgiref/default.nix
@@ -35,6 +35,8 @@ buildPythonPackage rec {
     "test_multiprocessing"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   pythonImportsCheck = [ "asgiref" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/ephemeral-port-reserve/default.nix
+++ b/pkgs/development/python-modules/ephemeral-port-reserve/default.nix
@@ -29,6 +29,8 @@ buildPythonPackage {
     "test_fqdn"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   pythonImportsCheck = [
     "ephemeral_port_reserve"
   ];


### PR DESCRIPTION
###### Description of changes
https://docs.python.org/release/3.11.2/whatsnew/changelog.html
https://docs.python.org/release/3.10.10/whatsnew/changelog.htm

Based on master for testing purpose, will rebase against staging once testing is complete.l

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
