### PR TITLE
blink: init at 0.9.2

### DIFF
--- a/pkgs/development/tools/blink/default.nix
+++ b/pkgs/development/tools/blink/default.nix
@@ -1,0 +1,60 @@
+{ lib, stdenv, fetchFromGitHub
+}:
+
+
+stdenv.mkDerivation (rec {
+  pname = "blink";
+  version = "7d3fa0d1525dd0863dd57cfc4a6e60000795fab6";
+
+  src = fetchFromGitHub {
+    owner = "jart";
+    repo = "blink";
+    rev = "${version}";
+    hash = "sha256-LbvMh3FyV8dHIIQhYAY8U1na79ksmrf5vFmWdfk5cC8=";
+  };
+
+  doCheck = false;
+  enableParallelBuilding = true;
+
+  preCheck = ''
+    rm third_party/cosmo/cosmo.mk
+    # Removing that file because of the following problems:
+    #  > make: *** [third_party/cosmo/cosmo.mk:6: third_party/cosmo/2/intrin_test.com.dbg.gz] Error 127
+    #  > make: *** [third_party/cosmo/cosmo.mk:6: third_party/cosmo/2/lockscale_test.com.gz] Error 127
+    #  > make: *** [third_party/cosmo/cosmo.mk:6: third_party/cosmo/2/lockscale_test.com.dbg.gz] Error 127
+    #  > make: *** [third_party/cosmo/cosmo.mk:6: third_party/cosmo/2/palignr_test.com.gz] Error 127
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install o/blink/blink $out/bin/blink
+    install o/blink/blinkenlights $out/bin/blinkenlights
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "tiniest x86-64-linux emulator";
+
+    longDescription = ''
+    blink is a virtual machine that runs x86-64-linux programs on different operating systems and hardware architectures. It's designed to do the same thing as the qemu-x86_64 command, except that
+
+    blink is 190kb in size, whereas the qemu-x86_64 executable is 4mb
+
+    blink will run your Linux binaries on any POSIX platform, whereas qemu-x86_64 only supports Linux
+
+    blink goes 2x faster than qemu-x86_64 on some benchmarks, such as SSE integer / floating point math. Blink is also faster at running ephemeral programs such as compilers
+    '';
+
+    license = lib.licenses.isc;
+
+    homepage = "https://github.com/jart/blink";
+
+    maintainers = [ ];
+  };
+} // lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
+  # This may be moved above during a stdenv rebuild.
+  preConfigure = ''
+    configureFlagsArray+=("CC=$CC")
+  '';
+})

--- a/pkgs/development/tools/blink/default.nix
+++ b/pkgs/development/tools/blink/default.nix
@@ -4,25 +4,24 @@
 
 stdenv.mkDerivation (rec {
   pname = "blink";
-  version = "7d3fa0d1525dd0863dd57cfc4a6e60000795fab6";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "jart";
     repo = "blink";
     rev = "${version}";
-    hash = "sha256-LbvMh3FyV8dHIIQhYAY8U1na79ksmrf5vFmWdfk5cC8=";
+    hash = "sha256-GQ1uOZr75CXLQ6aUX4oohJhwsYy41StaZiQRNrD/FXQ=";
   };
 
-  doCheck = false;
+  doCheck = true;
   enableParallelBuilding = true;
 
-  preCheck = ''
-    rm third_party/cosmo/cosmo.mk
-    # Removing that file because of the following problems:
-    #  > make: *** [third_party/cosmo/cosmo.mk:6: third_party/cosmo/2/intrin_test.com.dbg.gz] Error 127
-    #  > make: *** [third_party/cosmo/cosmo.mk:6: third_party/cosmo/2/lockscale_test.com.gz] Error 127
-    #  > make: *** [third_party/cosmo/cosmo.mk:6: third_party/cosmo/2/lockscale_test.com.dbg.gz] Error 127
-    #  > make: *** [third_party/cosmo/cosmo.mk:6: third_party/cosmo/2/palignr_test.com.gz] Error 127
+  checkPhase = ''
+          runHook preCheck
+          # The library author suggested this test as a fast one but very thorough.
+          # Right now they depend on downloading binaries and that is why it is commented out.
+          #make o//third_party/cosmo/2/intrin_test.com.ok
+          runHook postCheck
   '';
 
   installPhase = ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -166,7 +166,6 @@ mapAliases ({
   bitwarden_rs-vault = vaultwarden-vault;
 
 
-  blink = throw "blink has been removed from nixpkgs, it was unmaintained and required python2 at the time of removal"; # Added 2022-01-12
   bs1770gain = throw "bs1770gain has been removed from nixpkgs, as it had no maintainer or reverse dependencies"; # Added 2021-01-02
   bsod = throw "bsod has been removed: deleted by upstream"; # Added 2022-01-07
   btc1 = throw "btc1 has been removed, it was abandoned by upstream"; # Added 2020-11-03

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3823,6 +3823,8 @@ with pkgs;
 
   bless = callPackage ../applications/editors/bless { };
 
+  blink = callPackage ../development/tools/blink { };
+
   blink1-tool = callPackage ../tools/misc/blink1-tool { };
 
   blis = callPackage ../development/libraries/science/math/blis { };


### PR DESCRIPTION
###### Description of changes

blink is a virtual machine that runs x86-64-linux programs on different operating systems and hardware architectures. It's designed to do the same thing as the qemu-x86_64 command, except that

blink is 190kb in size, whereas the qemu-x86_64 executable is 4mb

blink will run your Linux binaries on any POSIX platform, whereas qemu-x86_64 only supports Linux

blink goes 2x faster than qemu-x86_64 on some benchmarks, such as SSE integer / floating point math. Blink is also faster at running ephemeral programs such as compilers

https://github.com/jart/blink

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
