### PR TITLE
linuxHeaders: Remove the Python 2 dependency

### DIFF
--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -1,10 +1,10 @@
 { stdenvNoCC, lib, buildPackages, fetchurl, perl, elf-header
-, bison ? null, flex ? null, python ? null, rsync ? null
+, bison ? null, flex ? null, rsync ? null
 , writeTextFile
 }:
 
 assert stdenvNoCC.hostPlatform.isAndroid ->
-  (flex != null && bison != null && python != null && rsync != null);
+  (flex != null && bison != null && rsync != null);
 
 let
 
@@ -50,7 +50,7 @@ let
     nativeBuildInputs = [
       perl elf-header
     ] ++ lib.optionals stdenvNoCC.hostPlatform.isAndroid [
-      flex bison python rsync
+      flex bison rsync
     ] ++ lib.optionals (stdenvNoCC.buildPlatform.isDarwin &&
                         stdenvNoCC.hostPlatform.isMips) [
       darwin-endian-h


### PR DESCRIPTION
Fixes #215409 
###### Description of changes

Remove the Python dependency from the Android build of the linuxHeaders package.  The Python 2 dependency breaks the build since Python 2 is unsupported.  Also, the build succeeds fine with no Python supplied at all.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
