### PR TITLE
[release-22.11] less: Apply patch for CVE-2022-46663

### DIFF
--- a/pkgs/tools/misc/less/default.nix
+++ b/pkgs/tools/misc/less/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ncurses, lessSecure ? false }:
+{ lib, stdenv, fetchurl, fetchpatch, ncurses, lessSecure ? false }:
 
 stdenv.mkDerivation rec {
   pname = "less";
@@ -8,6 +8,15 @@ stdenv.mkDerivation rec {
     url = "https://www.greenwoodsoftware.com/less/less-${version}.tar.gz";
     sha256 = "02f2d9d6hyf03va28ip620gjc6rf4aikmdyk47h7frqj18pbx6m6";
   };
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/advisories/GHSA-5xw7-xf7p-gm82
+      name = "CVE-2022-46663.patch";
+      url = "https://github.com/gwsw/less/commit/a78e1351113cef564d790a730d657a321624d79c.patch";
+      hash = "sha256-gWgCzoMt1WyVJVKYzkMq8HfaTlU1XUtC8fvNFUQT0sI=";
+    })
+  ];
 
   configureFlags = [ "--sysconfdir=/etc" ] # Look for ‘sysless’ in /etc.
     ++ lib.optionals lessSecure [ "--with-secure" ];


### PR DESCRIPTION
https://www.openwall.com/lists/oss-security/2023/02/07/7

(cherry picked from commit 5277b187cc6bfa4c30ca4d7ea261002a88675ab9)

cc #215216

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
