### PR TITLE
python310Packages.argh: 0.26.2 -> 0.27.1

### DIFF
--- a/pkgs/development/python-modules/argh/default.nix
+++ b/pkgs/development/python-modules/argh/default.nix
@@ -9,21 +9,12 @@
 
 buildPythonPackage rec {
   pname = "argh";
-  version = "0.26.2";
+  version = "0.27.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65";
+    hash = "sha256-2wbZEIHxck40fM23iclXD+yUc351WvFZiDcpPgH8TNI=";
   };
-
-  patches = [
-    # https://github.com/neithere/argh/issues/148
-    (fetchpatch {
-      name = "argh-0.26.2-fix-py3.9-msgs.patch";
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-python/argh/files/argh-0.26.2-fix-py3.9-msgs.patch?id=6f194f12a2e30aad7da347848f7b0187e188f983";
-      sha256 = "nBmhF2PXVeS7cBNujzip6Bb601LRHrjmhlGKFr/++Oo=";
-    })
-  ];
 
   nativeCheckInputs = [
     iocapture
@@ -34,6 +25,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "argh" ];
 
   meta = with lib; {
+    changelog = "https://github.com/neithere/argh/blob/v${version}/CHANGES";
     homepage = "https://github.com/neithere/argh";
     description = "An unobtrusive argparse wrapper with natural syntax";
     license = licenses.lgpl3Plus;


### PR DESCRIPTION

###### Description of changes
Changelog: https://github.com/neithere/argh/blob/v0.27.1/CHANGES

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
