### PR TITLE
python310Packages.astropy-healpix: skip test_interpolate_bilinear_skycoord

### DIFF
--- a/pkgs/development/python-modules/astropy-healpix/default.nix
+++ b/pkgs/development/python-modules/astropy-healpix/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , numpy
@@ -35,6 +36,8 @@ buildPythonPackage rec {
     pytest-doctestplus
     hypothesis
   ];
+
+  disabledTests = lib.optional (!stdenv.hostPlatform.isDarwin) "test_interpolate_bilinear_skycoord";
 
   # tests must be run in the build directory
   preCheck = ''


### PR DESCRIPTION
python310Packages.astropy-healpix: skip test_interpolate_bilinear_skycoord

Py3.10 Logs: https://termbin.com/oq09
Py3.11 Logs: https://termbin.com/0f68

(Found this package broken on downstream builds at staging. I have no domain knowledge here.)