### PR TITLE
theforceengine: init at 1.09.100

### DIFF
--- a/pkgs/games/theforceengine/default.nix
+++ b/pkgs/games/theforceengine/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, SDL2
+, libdevil
+, rtaudio
+, rtmidi
+, glew
+, alsa-lib
+, cmake
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "theforceengine";
+  version = "1.09.100";
+
+  src = fetchFromGitHub {
+    owner = "luciusDXL";
+    repo = "TheForceEngine";
+    rev = "v${version}";
+    sha256 = "sha256-nw9yp/StaSi5thafVT1V5YA2ZCYGWNoHUvQTpK90Foc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    SDL2
+    libdevil
+    rtaudio
+    rtmidi
+    glew
+    alsa-lib
+  ];
+
+  prePatch = ''
+    # use nix store path instead of hardcoded /usr/share for support data
+    substituteInPlace TheForceEngine/TFE_FileSystem/paths-posix.cpp \
+      --replace "/usr/share" "$out/share"
+  '';
+
+  meta = with lib; {
+    description = "Modern \"Jedi Engine\" replacement supporting Dark Forces, mods, and in the future Outlaws.";
+    homepage = "https://theforceengine.github.io";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ devusb ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35656,6 +35656,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
+  theforceengine = callPackage ../games/theforceengine { };
+
   tbe = libsForQt5.callPackage ../games/the-butterfly-effect { };
 
   tbls = callPackage ../tools/misc/tbls { };


### PR DESCRIPTION
###### Description of changes

Adds [TheForceEngine](https://github.com/luciusDXL/TheForceEngine), a modern "Jedi Engine" replacement supporting Dark Forces, mods, and in the future Outlaws.

Fixes https://github.com/NixOS/nixpkgs/issues/209233

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
