### PR TITLE
rPackages.quarto: add quarto dependency

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1019,7 +1019,7 @@ let
     quarto = old.quarto.overrideDerivation (attrs: {
       postPatch = ''
         substituteInPlace "R/quarto.R" \
-          --replace "path_env <- Sys.getenv(\"QUARTO_PATH\", unset = NA)" "path_env <- Sys.getenv(\"QUARTO_PATH\", unset = '${pkgs.quarto}/bin/quarto')"
+          --replace "path_env <- Sys.getenv(\"QUARTO_PATH\", unset = NA)" "path_env <- Sys.getenv(\"QUARTO_PATH\", unset = '${lib.getBin pkgs.quarto}/bin/quarto')"
       '';
     });
 

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1016,6 +1016,13 @@ let
       '';
     });
 
+    quarto = old.quarto.overrideDerivation (attrs: {
+      postPatch = ''
+        substituteInPlace "R/quarto.R" \
+          --replace "path_env <- Sys.getenv(\"QUARTO_PATH\", unset = NA)" "path_env <- Sys.getenv(\"QUARTO_PATH\", unset = '${pkgs.quarto}/bin/quarto')"
+      '';
+    });
+
     s2 = old.s2.overrideDerivation (attrs: {
       PKGCONFIG_CFLAGS = "-I${pkgs.openssl.dev}/include";
       PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -lssl -lcrypto";


### PR DESCRIPTION
The quarto R packages requires the quarto-cli package at runtime. This PR adds quarto to the propagatedBuildInputs of the R package, but the input is not detected automatically at runtime. The R package relies on [two methods](https://quarto-dev.github.io/quarto-r/reference/quarto_path.html) to detect the quarto application, but neither seems to work:

1. QUARTO_HOME Variable
2. Sys.which("quarto")

What's the best way to configure the input in r-modules?
@jbedo @alexvorobiev 