### PR TITLE
deepin.dde-api: init at 5.5.32

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -43,6 +43,7 @@ let
     go-lib = callPackage ./go-package/go-lib { inherit replaceAll; };
     go-gir-generator = callPackage ./go-package/go-gir-generator { };
     go-dbus-factory = callPackage ./go-package/go-dbus-factory { };
+    dde-api = callPackage ./go-package/dde-api { inherit replaceAll; };
     deepin-pw-check = callPackage ./go-package/deepin-pw-check { };
 
     #### TOOLS

--- a/pkgs/desktops/deepin/go-package/dde-api/0001-fix-PATH-for-NixOS.patch
+++ b/pkgs/desktops/deepin/go-package/dde-api/0001-fix-PATH-for-NixOS.patch
@@ -1,0 +1,39 @@
+From c8f597bd7286a76e7ce371e4f7982d9d2700868a Mon Sep 17 00:00:00 2001
+From: rewine <luhongxu@deepin.org>
+Date: Wed, 28 Dec 2022 23:06:53 +0800
+Subject: [PATCH] fix PATH for NixOS
+
+---
+ device/main.go        | 2 +-
+ locale-helper/main.go | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/device/main.go b/device/main.go
+index 6c5404c..f79bcfc 100644
+--- a/device/main.go
++++ b/device/main.go
+@@ -15,7 +15,7 @@ import (
+ var logger = log.NewLogger(dbusServiceName)
+ 
+ func main() {
+-	os.Setenv("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
++	os.Setenv("PATH", "/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+ 	service, err := dbusutil.NewSystemService()
+ 	if err != nil {
+ 		logger.Fatal("failed to new system service:", err)
+diff --git a/locale-helper/main.go b/locale-helper/main.go
+index 0866e48..ef000b5 100644
+--- a/locale-helper/main.go
++++ b/locale-helper/main.go
+@@ -45,7 +45,7 @@ var (
+ )
+ 
+ func main() {
+-	os.Setenv("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
++	os.Setenv("PATH", "/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+ 	logger.BeginTracing()
+ 	defer logger.EndTracing()
+ 
+-- 
+2.38.1
+

--- a/pkgs/desktops/deepin/go-package/dde-api/default.nix
+++ b/pkgs/desktops/deepin/go-package/dde-api/default.nix
@@ -1,0 +1,109 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, buildGoPackage
+, replaceAll
+, wrapQtAppsHook
+, wrapGAppsHook
+, gtk3
+, pkg-config
+, deepin-gettext-tools
+, alsa-lib
+, go-dbus-factory
+, go-gir-generator
+, go-lib
+, libcanberra
+, libgudev
+, librsvg
+, poppler
+, pulseaudio
+, gdk-pixbuf-xlib
+, dbus
+, coreutils
+, deepin-desktop-base
+}:
+
+buildGoPackage rec {
+  pname = "dde-api";
+  version = "5.5.32";
+
+  goPackagePath = "github.com/linuxdeepin/dde-api";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-F+vEOSpysqVtjs8de5mCmeANuCbYUQ860ZHl5rwNYac=";
+  };
+
+  patches = [ ./0001-fix-PATH-for-NixOS.patch ];
+
+  postPatch = replaceAll "/usr/lib/deepin-api" "/run/current-system/sw/lib/deepin-api"
+    + replaceAll "/usr/share/i18n/language_info.json" "${deepin-desktop-base}/share/i18n/language_info.json"
+    + replaceAll "/usr/bin/dbus-send" "${dbus}/bin/dbus-send"
+    + replaceAll "/usr/bin/true" "${coreutils}/bin/true"
+    + replaceAll "/usr/sbin/alsactl" "alsactl"
+    + ''
+    substituteInPlace lunar-calendar/huangli.go adjust-grub-theme/main.go \
+      --replace "/usr/share/dde-api" "$out/share/dde-api"
+    substituteInPlace themes/{theme.go,settings.go} \
+      --replace "/usr/share" "/run/current-system/sw/share"
+  '';
+
+  goDeps = ./deps.nix;
+
+  nativeBuildInputs = [
+    pkg-config
+    deepin-gettext-tools
+    wrapQtAppsHook
+    wrapGAppsHook
+  ];
+  dontWrapGApps = true;
+
+  buildInputs = [
+    go-dbus-factory
+    go-gir-generator
+    go-lib
+    gtk3
+    alsa-lib
+    libcanberra
+    libgudev
+    librsvg
+    poppler
+    pulseaudio
+    gdk-pixbuf-xlib
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    GOPATH="$GOPATH:${go-dbus-factory}/share/gocode"
+    GOPATH="$GOPATH:${go-gir-generator}/share/gocode"
+    GOPATH="$GOPATH:${go-lib}/share/gocode"
+    make -C go/src/${goPackagePath}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    make install DESTDIR="$out" PREFIX="/" -C go/src/${goPackagePath}
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  postFixup = ''
+    for binary in $out/lib/deepin-api/*; do
+      wrapProgram $binary "''${qtWrapperArgs[@]}"
+    done
+  '';
+
+  meta = with lib; {
+    description = "Dbus interfaces used for screen zone detecting, thumbnail generating, sound playing, etc";
+    homepage = "https://github.com/linuxdeepin/dde-api";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/go-package/dde-api/deps.nix
+++ b/pkgs/desktops/deepin/go-package/dde-api/deps.nix
@@ -1,0 +1,210 @@
+[
+  {
+    goPackagePath = "gopkg.in/alecthomas/kingpin.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/alecthomas/kingpin.v2";
+      rev = "v2.2.6";
+      sha256 = "sha256-uViE2kPj7tMrGYVjjdLOl2jFDmmu+3P7GvnZBse2zVY=";
+    };
+  }
+  {
+    goPackagePath = "github.com/disintegration/imaging";
+    fetch = {
+      type = "git";
+      url = "https://github.com/disintegration/imaging";
+      rev = "v1.6.2";
+      sha256 = "sha256-pSeMTPvSkxlthh65LjNYYhPLvCZDkBgVgAGYWW0Aguo=";
+    };
+  }
+  {
+    goPackagePath = "github.com/linuxdeepin/go-x11-client";
+    fetch = {
+      type = "git";
+      url = "https://github.com/linuxdeepin/go-x11-client";
+      rev = "0.6.9";
+      sha256 = "sha256-xXNaXpFFHJN1fCFLoVrQFCXQ4ya+Kga55QWcJL/InkA=";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-sqlites";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-sqlite3";
+      rev = "v1.14.12";
+      sha256 = "sha256-SLW1FyyfJGPUid1epgmJHZGJebI77Wg5WMAPiz1GcYs=";
+    };
+  }
+  {
+    goPackagePath = "github.com/godbus/dbus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/godbus/dbus";
+      rev = "v5.1.0";
+      sha256 = "sha256-JSPtmkGEStBEVrKGszeLCb7P38SzQKgMiDC3eDppXs0=";
+    };
+  }
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "v1.5.1";
+      sha256 = "sha256-B8kZ8yiWgallT7R2j1kSRJcJkSGFVf9ise+TpXa+7XY=";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/sys";
+      rev = "289d7a0edf712062d9f1484b07bdf2383f48802f";
+      sha256 = "sha256-AzS/J3OocI7mA0xsIfQzyskNKVija7F2yvuts+EFJBs=";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.7.1";
+      sha256 = "sha256-disUVIHiIDSj/go3APtJH8awSl8QwKRRFLKI7LRnl0w=";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "sha256-nhzSUrE1fCkN0+RL04N4h8jWmRFPPPWbCuDc7Ss0akI=";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "5d4384ee4fb2527b0a1256a821ebfc92f91efefc";
+      sha256 = "sha256-XA4Oj1gdmdV/F/+8kMI+DBxKPthZ768hbKsO3d9Gx90=";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.3.0";
+      sha256 = "sha256-T753/EiD5Cpk6H2JFhd+s1gFvpNptG2XlEHxZF6dQaw=";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev = "496545a6307b2a7d7a710fd516e5e16e8ab62dbc";
+      sha256 = "sha256-j8yDji+vqsitpRZirpb4w/Em8nstgf28wpwkcrOlxBk=";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/image";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/image";
+      rev = "a8550c1d254a56cf1762a2993881d2b23c0c83dd";
+      sha256 = "sha256-gtRGCsCe8tKLsZWhKLL8c5whz9rCMoCHfH13rcSW/OM=";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/units";
+      rev = "b94a6e3cc13755c0a75fffecbb089eb346fc4289";
+      sha256 = "sha256-uriYmwxT69xbmWKO/5OAyeMa2lFBOJDrU2KtQh/+ZjY=";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/template";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/template";
+      rev = "fb15b899a75114aa79cc930e33c46b577cc664b1";
+      sha256 = "sha256-RsS4qxdRQ3q+GejA8D9Iu31A/mZNms4LbJ7518jWiu4=";
+    };
+  }
+  {
+    goPackagePath = "github.com/cryptix/wav";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cryptix/wav";
+      rev = "8bdace674401f0bd3b63c65479b6a6ff1f9d5e44";
+      sha256 = "sha256-psUCHRFGEOpN3obFbCvSfW0AGEFSI29d0q4MFsHG3qI=";
+    };
+  }
+  {
+    goPackagePath = "github.com/fogleman/gg";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fogleman/gg";
+      rev = "v1.3.0";
+      sha256 = "sha256-Fs2JI0FmF4N5EzXJzGAPZMxZxo6wKyebkN/iBZ9sdNo=";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/freetype";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/freetype";
+      rev = "e2365dfdc4a05e4b8299a783240d4a7d5a65d4e4";
+      sha256 = "sha256-rOOsv1sNLbYEKnwXZtUlB2CXVkFANyzZy2E7w2QbnKQ=";
+    };
+  }
+  {
+    goPackagePath = "github.com/gosexy/gettext";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gosexy/gettext";
+      rev = "74466a0a0c4a62fea38f44aa161d4bbfbe79dd6b";
+      sha256 = "sha256-8U2oSi446U13c3uqcbg/14okypxKmckRuvWfZlGHVys=";
+    };
+  }
+  {
+    goPackagePath = "github.com/nfnt/resize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nfnt/resize";
+      rev = "83c6a9932646f83e3267f353373d47347b6036b2";
+      sha256 = "sha256-yvPV+HlDOyJsiwAcVHQkmtw8DHSXyw+cXHkigXm8rAA=";
+    };
+  }
+  {
+    goPackagePath = "github.com/youpy/go-wav";
+    fetch = {
+      type = "git";
+      url = "https://github.com/youpy/go-wav";
+      rev = "v0.3.2";
+      sha256 = "sha256-jNqXW3F3fcgjT47+d2MVXauWkA7+1KfYVu3ZZpRCTkM=";
+    };
+  }
+  {
+    goPackagePath = "github.com/zaf/g711";
+    fetch = {
+      type = "git";
+      url = "https://github.com/zaf/g711";
+      rev = "v1.2";
+      sha256 = "sha256-G+0cgGw/fcOUFVn32AeqUE0YjyOS82Z5MTcn6IANhCY=";
+    };
+  }
+  {
+    goPackagePath = "github.com/youpy/go-riff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/youpy/go-riff";
+      rev = "v0.1.0";
+      sha256 = "sha256-d/3rkxDeRTPveZblArKc61gB4LJVV08n7g0THieuhx8=";
+    };
+  }
+]
+


### PR DESCRIPTION
###### Description of changes
https://github.com/linuxdeepin/dde-nixos/issues/9

related：
previous packaging: https://github.com/NixOS/nixpkgs/pull/48262
https://archlinux.org/packages/community/x86_64/deepin-api/
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
