### PR TITLE
gitea-actions-runner: init at unstable

### DIFF
--- a/pkgs/development/tools/continuous-integration/gitea-actions-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitea-actions-runner/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitea, buildGoModule }:
+
+buildGoModule rec {
+  pname = "gitea-actions-runner";
+  version = "unstable-2023-02-08";
+
+  src = fetchFromGitea {
+    domain = "gitea.com";
+    owner = "gitea";
+    repo = "act_runner";
+    rev = "990cf93c7136669408eb1832cd05df3ad4dd81b3";
+    sha256 = "1ysp7g199dzh1zpxxhki88pn96qghln7a5g8zfjip9173q1rgiyb";
+  };
+
+  vendorSha256 = "0a3q7rsk37dc6v3vnqaywkimaqvyjmkrwljhcjcnswsdfcgng62b";
+
+  meta = with lib; {
+    mainProgram = "act_runner";
+    maintainers = with maintainers; [ techknowlogick ];
+    license = licenses.mit;
+    homepage = "https://gitea.com/gitea/act_runner";
+    description = "A runner for Gitea based on act";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7661,6 +7661,8 @@ with pkgs;
 
   gitea = callPackage ../applications/version-management/gitea { };
 
+  gitea-actions-runner = callPackage ../development/tools/continuous-integration/gitea-actions-runner { };
+
   forgejo = callPackage ../applications/version-management/forgejo {};
 
   gokart = callPackage ../development/tools/gokart { };


### PR DESCRIPTION
###### Description of changes

more details found here: https://gitea.com/gitea/act_runner.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
