### PR TITLE
kubeshark: init at 38.5

### DIFF
--- a/pkgs/applications/networking/cluster/kubeshark/default.nix
+++ b/pkgs/applications/networking/cluster/kubeshark/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, lib, buildGoModule, fetchFromGitHub, installShellFiles, testers, kubeshark, nix-update-script }:
+
+buildGoModule rec {
+  pname = "kubeshark";
+  version = "38.5";
+
+  src = fetchFromGitHub {
+    owner = "kubeshark";
+    repo = "kubeshark";
+    rev = version;
+    sha256 = "sha256-xu+IcmYNsFBYhb0Grnqyi31LCG/3XhSh1LH8XakQ3Yk=";
+  };
+
+  vendorHash = "sha256-o04XIUsHNqOBkvcejASHNz1HDnV6F9t+Q2Hg8eL/Uoc=";
+
+  ldflags = let t = "github.com/kubeshark/kubeshark"; in [
+   "-s" "-w"
+   "-X ${t}/misc.GitCommitHash=${src.rev}"
+   "-X ${t}/misc.Branch=master"
+   "-X ${t}/misc.BuildTimestamp=0"
+   "-X ${t}/misc.Platform=unknown"
+   "-X ${t}/misc.Ver=${version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  checkPhase = ''
+    go test ./...
+  '';
+  doCheck = true;
+
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+    installShellCompletion --cmd kubeshark \
+      --bash <($out/bin/kubeshark completion bash) \
+      --fish <($out/bin/kubeshark completion fish) \
+      --zsh <($out/bin/kubeshark completion zsh)
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = kubeshark;
+      command = "kubeshark version";
+      inherit version;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = with lib; {
+    changelog = "https://github.com/kubeshark/kubeshark/releases/tag/${version}";
+    description = "The API Traffic Viewer for Kubernetes";
+    homepage = "https://kubeshark.co/";
+    license = licenses.asl20;
+    longDescription = ''
+      The API traffic viewer for Kubernetes providing real-time, protocol-aware visibility into Kubernetes’ internal network,
+      Think TCPDump and Wireshark re-invented for Kubernetes
+      capturing, dissecting and monitoring all traffic and payloads going in, out and across containers, pods, nodes and clusters.
+    '';
+    maintainers = with maintainers; [ bryanasdev000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8843,6 +8843,8 @@ with pkgs;
 
   kubepug = callPackage ../development/tools/kubepug { };
 
+  kubeshark = callPackage ../applications/networking/cluster/kubeshark { };
+
   kubergrunt = callPackage ../applications/networking/cluster/kubergrunt { };
 
   kubo = callPackage ../applications/networking/kubo { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add kubeshark at 38.5, the API traffic viewer for Kubernetes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
