### PR TITLE
k3s: test all versions

### DIFF
--- a/nixos/tests/k3s/default.nix
+++ b/nixos/tests/k3s/default.nix
@@ -1,9 +1,21 @@
 { system ? builtins.currentSystem
 , pkgs ? import ../../.. { inherit system; }
+, lib ? pkgs.lib
 }:
+let
+  allK3s = {
+    inherit (pkgs)
+      k3s
+      k3s_1_23
+      k3s_1_24
+      k3s_1_25
+      k3s_1_26
+      ;
+  };
+in
 {
   # Run a single node k3s cluster and verify a pod can run
-  single-node = import ./single-node.nix { inherit system pkgs; };
+  single-node = lib.mapAttrs (_: k3s: import ./single-node.nix { inherit system pkgs k3s; }) allK3s;
   # Run a multi-node k3s cluster and verify pod networking works across nodes
-  multi-node = import ./multi-node.nix { inherit system pkgs; };
+  multi-node = lib.mapAttrs (_: k3s: import ./multi-node.nix { inherit system pkgs k3s; }) allK3s;
 }

--- a/nixos/tests/k3s/default.nix
+++ b/nixos/tests/k3s/default.nix
@@ -3,15 +3,7 @@
 , lib ? pkgs.lib
 }:
 let
-  allK3s = {
-    inherit (pkgs)
-      k3s
-      k3s_1_23
-      k3s_1_24
-      k3s_1_25
-      k3s_1_26
-      ;
-  };
+  allK3s = lib.filterAttrs (n: _: lib.strings.hasPrefix "k3s_" n) pkgs;
 in
 {
   # Run a single node k3s cluster and verify a pod can run

--- a/nixos/tests/k3s/multi-node.nix
+++ b/nixos/tests/k3s/multi-node.nix
@@ -1,4 +1,4 @@
-import ../make-test-python.nix ({ pkgs, lib, ... }:
+import ../make-test-python.nix ({ pkgs, lib, k3s, ... }:
   let
     imageEnv = pkgs.buildEnv {
       name = "k3s-pause-image-env";
@@ -39,7 +39,7 @@ import ../make-test-python.nix ({ pkgs, lib, ... }:
     tokenFile = pkgs.writeText "token" "p@s$w0rd";
   in
   {
-    name = "k3s-multi-node";
+    name = "${k3s.name}-multi-node";
 
     nodes = {
       server = { pkgs, ... }: {
@@ -52,7 +52,7 @@ import ../make-test-python.nix ({ pkgs, lib, ... }:
           inherit tokenFile;
           enable = true;
           role = "server";
-          package = pkgs.k3s;
+          package = k3s;
           clusterInit = true;
           extraFlags = builtins.toString [
             "--disable" "coredns"

--- a/nixos/tests/k3s/single-node.nix
+++ b/nixos/tests/k3s/single-node.nix
@@ -1,4 +1,4 @@
-import ../make-test-python.nix ({ pkgs, lib, ... }:
+import ../make-test-python.nix ({ pkgs, lib, k3s, ... }:
   let
     imageEnv = pkgs.buildEnv {
       name = "k3s-pause-image-env";
@@ -24,7 +24,7 @@ import ../make-test-python.nix ({ pkgs, lib, ... }:
     '';
   in
   {
-    name = "k3s";
+    name = "${k3s.name}-single-node";
     meta = with pkgs.lib.maintainers; {
       maintainers = [ euank ];
     };
@@ -38,7 +38,7 @@ import ../make-test-python.nix ({ pkgs, lib, ... }:
 
       services.k3s.enable = true;
       services.k3s.role = "server";
-      services.k3s.package = pkgs.k3s;
+      services.k3s.package = k3s;
       # Slightly reduce resource usage
       services.k3s.extraFlags = builtins.toString [
         "--disable" "coredns"

--- a/pkgs/applications/networking/cluster/k3s/1_23/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_23/default.nix
@@ -324,8 +324,7 @@ buildGoModule rec {
   # Fix-Me: Needs to be adapted specifically for 1.23
   # passthru.updateScript = ./update.sh;
 
-  # Fix-Me: Needs to be adapted specifically for 1.23
-  # passthru.tests = { inherit (nixosTests) k3s-single-node k3s-single-node-docker; };
+  passthru.tests = k3s.passthru.mkTests k3sVersion;
 
   meta = baseMeta;
 }

--- a/pkgs/applications/networking/cluster/k3s/1_24/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_24/default.nix
@@ -322,8 +322,7 @@ buildGoModule rec {
   # Fix-Me: Needs to be adapted specifically for 1.24
   # passthru.updateScript = ./update.sh;
 
-  # Fix-Me: Needs to be adapted specifically for 1.24
-  # passthru.tests = nixosTests.k3s;
+  passthru.tests = k3s.passthru.mkTests k3sVersion;
 
   meta = baseMeta;
 }

--- a/pkgs/applications/networking/cluster/k3s/1_25/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_25/default.nix
@@ -322,8 +322,7 @@ buildGoModule rec {
   # Fix-Me: Needs to be adapted specifically for 1.25
   # passthru.updateScript = ./update.sh;
 
-  # Fix-Me: Needs to be adapted specifically for 1.25
-  # passthru.tests = nixosTests.k3s;
+  passthru.tests = k3s.passthru.mkTests k3sVersion;
 
   meta = baseMeta;
 }

--- a/pkgs/applications/networking/cluster/k3s/1_26/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_26/default.nix
@@ -319,7 +319,14 @@ buildGoModule rec {
 
   passthru.updateScript = ./update.sh;
 
-  passthru.tests = nixosTests.k3s;
+  passthru.mkTests = version:
+    let k3s_version = "k3s_" + lib.replaceStrings ["."] ["_"] (lib.versions.majorMinor version);
+    in {
+      single-node = nixosTests.k3s.single-node.${k3s_version};
+      multi-node = nixosTests.k3s.multi-node.${k3s_version};
+    };
+  passthru.tests = passthru.mkTests k3sVersion;
+
 
   meta = baseMeta;
 }


### PR DESCRIPTION


###### Description of changes
Since https://github.com/NixOS/nixpkgs/issues/213943 got fixed, only the main k3s derivation is tested.

Here I changed the tests a bit to make them test all provided k3s derivations

@moduon MT-1718
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
@eunak