### PR TITLE
strip-nondeterminism: fix build

### DIFF
--- a/pkgs/development/perl-modules/strip-nondeterminism/default.nix
+++ b/pkgs/development/perl-modules/strip-nondeterminism/default.nix
@@ -11,7 +11,7 @@
 
 buildPerlPackage rec {
   pname = "strip-nondeterminism";
-  version = "1.13.0";
+  version = "1.13.1";
 
   outputs = [ "out" "dev" ]; # no "devdoc"
 
@@ -20,7 +20,7 @@ buildPerlPackage rec {
     repo = "strip-nondeterminism";
     domain = "salsa.debian.org";
     rev = version;
-    sha256 = "sha256-KZQeoJYBPJzUvz4wlUZbiGODbpCp7/52dsg5OemKDkI=";
+    sha256 = "czx9UhdgTsQSfDNo1mMOXCM/3/nuNe+cPZeyy2xdnKs=";
   };
 
   strictDeps = true;

--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -17,6 +17,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-N1HH+6jbyDHLjXzIr/IQNUWbjOUVXviwiAon0ChHXzs=";
   };
 
+  patches = [
+    # Backport fix to identification for pyzip files.
+    # Needed for strip-nondeterminism.
+    # https://salsa.debian.org/reproducible-builds/strip-nondeterminism/-/issues/20
+    ./pyzip.patch
+  ];
+
   strictDeps = true;
   enableParallelBuilding = true;
 

--- a/pkgs/tools/misc/file/pyzip.patch
+++ b/pkgs/tools/misc/file/pyzip.patch
@@ -1,0 +1,36 @@
+From dc71304b3b1fd2ed5f7098d59fb7f6ef10cfdc85 Mon Sep 17 00:00:00 2001
+From: Christos Zoulas <christos@zoulas.com>
+Date: Sat, 31 Dec 2022 20:24:08 +0000
+Subject: [PATCH] pyzip improvements (FC Stegerman)
+
+---
+ magic/Magdir/archive | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/magic/Magdir/archive b/magic/Magdir/archive
+index a706556d5..d58201e69 100644
+--- a/magic/Magdir/archive
++++ b/magic/Magdir/archive
+@@ -1,5 +1,5 @@
+ #------------------------------------------------------------------------------
+-# $File: archive,v 1.179 2022/12/21 15:50:59 christos Exp $
++# $File: archive,v 1.180 2022/12/31 20:24:08 christos Exp $
+ # archive:  file(1) magic for archive formats (see also "msdos" for self-
+ #           extracting compressed archives)
+ #
+@@ -1876,9 +1876,14 @@
+ # https://en.wikipedia.org/wiki/ZIP_(file_format)#End_of_central_directory_record_(EOCD)
+ # by Michal Gorny <mgorny@gentoo.org>
+ -2	uleshort	0
+->&-22	string	PK\005\006	Zip archive, with extra data prepended
++>&-22	string	PK\005\006
++# without #!
++>>0	string	!#!	Zip archive, with extra data prepended
+ !:mime	application/zip
+ !:ext zip/cbz
++# with #!
++>>0	string/w	#!\ 	a
++>>>&-1	string/T	x	%s script executable (Zip archive)
+ 
+ # ACE archive (from http://www.wotsit.org/download.asp?f=ace)
+ # by Stefan `Sec` Zehl <sec@42.org>


### PR DESCRIPTION
###### Description of changes

Both the file patch and the strip-nondeterminism update are required to fix the build.  This fixes a regression in current staging-next (https://github.com/NixOS/nixpkgs/pull/214010), but I'm targeting staging since strip-nondeterminism seems to be quite a minor package, and IIRC changing file is a full stdenv rebuild.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
