### PR TITLE
Revert "python3Packages.bokeh: 2.4.3 -> 3.0.3"; python310Packages.panels: 0.14.2 -> 0.14.3

### DIFF
--- a/pkgs/development/python-modules/bokeh/default.nix
+++ b/pkgs/development/python-modules/bokeh/default.nix
@@ -28,19 +28,16 @@
 , icalendar
 , pandas
 , pythonImportsCheckHook
-, contourpy
-, xyzservices
 }:
 
 buildPythonPackage rec {
   pname = "bokeh";
   # update together with panel which is not straightforward
-  version = "3.0.3";
-  format = "setuptools";
+  version = "2.4.3";
 
   src = fetchPypi {
     inherit pname version;
-    hash= "sha256-HChHHvXmEQulvtUTE3/SYFTrxEVLx2hlDq7vxTuJioo=";
+    sha256 = "sha256-7zOAEWGvN5Zlq3o0aE8iCYYeOu/VyAOiH7u5nZSHSwM=";
   };
 
   patches = [
@@ -73,10 +70,10 @@ buildPythonPackage rec {
     requests
     nbconvert
     icalendar
+    pandas
   ];
 
   propagatedBuildInputs = [
-    contourpy
     pillow
     jinja2
     python-dateutil
@@ -84,10 +81,8 @@ buildPythonPackage rec {
     pyyaml
     tornado
     numpy
-    pandas
     packaging
     typing-extensions
-    xyzservices
   ]
   ++ lib.optionals ( isPy27 ) [
     futures

--- a/pkgs/development/python-modules/bokeh/hardcode-nodejs-npmjs-paths.patch
+++ b/pkgs/development/python-modules/bokeh/hardcode-nodejs-npmjs-paths.patch
@@ -1,9 +1,9 @@
-diff --git a/src/bokeh/util/compiler.py b/src/bokeh/util/compiler.py
-index 9af8691..4b93543 100644
---- a/src/bokeh/util/compiler.py
-+++ b/src/bokeh/util/compiler.py
-@@ -415,8 +415,8 @@ def _detect_nodejs() -> str:
-     raise RuntimeError(f'node.js v{version_repr} or higher is needed to allow compilation of custom models ' +
+diff --git a/bokeh/util/compiler.py b/bokeh/util/compiler.py
+index a752aad7d..8af05ff63 100644
+--- a/bokeh/util/compiler.py
++++ b/bokeh/util/compiler.py
+@@ -442,8 +442,8 @@ def _detect_nodejs():
+     raise RuntimeError('node.js v%s or higher is needed to allow compilation of custom models ' % version +
                         '("conda install nodejs" or follow https://nodejs.org/en/download/)')
  
 -_nodejs = None
@@ -11,5 +11,5 @@ index 9af8691..4b93543 100644
 +_nodejs = "@node_bin@"
 +_npmjs = "@npm_bin@"
  
- def _nodejs_path() -> str:
+ def _nodejs_path():
      global _nodejs

--- a/pkgs/development/python-modules/panel/default.nix
+++ b/pkgs/development/python-modules/panel/default.nix
@@ -1,20 +1,22 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonRelaxDepsHook
 , bleach
 , bokeh
 , param
 , pyviz-comms
 , markdown
 , pyct
-, testpath
+, requests
+, setuptools
 , tqdm
-, nodejs
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "panel";
-  version = "0.14.2";
+  version = "0.14.3";
 
   format = "wheel";
 
@@ -23,31 +25,42 @@ buildPythonPackage rec {
   # tries to fetch even more artifacts
   src = fetchPypi {
     inherit pname version format;
-    hash = "sha256-cDjrim7esGduL8IHxPpoqHB43uA78R9UMIrhNktqUdU=";
+    hash = "sha256-XOu17oydXwfyowYUmCKF7/RC0RQ0Uf1Ixmn+VTa85Lo=";
   };
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "bokeh"
+  ];
 
   propagatedBuildInputs = [
     bleach
     bokeh
-    param
-    pyviz-comms
     markdown
+    param
     pyct
-    testpath
+    pyviz-comms
+    requests
+    setuptools
     tqdm
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "panel"
   ];
 
   # infinite recursion in test dependencies (hvplot)
   doCheck = false;
 
-  passthru = {
-    inherit nodejs; # For convenience
-  };
-
   meta = with lib; {
     description = "A high level dashboarding library for python visualization libraries";
-    homepage = "https://pyviz.org";
+    homepage = "https://github.com/holoviz/panel";
+    changelog = "https://github.com/holoviz/panel/releases/tag/v${version}";
     license = licenses.bsd3;
-    maintainers = [ maintainers.costrouc ];
+    maintainers = with maintainers; [ costrouc ];
   };
 }


### PR DESCRIPTION
This reverts commit 1ac65c0.

Reverse dependencies are not ready yet, breaks panel and multiple other
packages.

And updatets panel to 0.14.3

https://github.com/holoviz/panel/releases/tag/v0.14.3

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
