### PR TITLE
rawtherapee: upgrade from version 5.8 to 5.9

### DIFF
--- a/pkgs/applications/graphics/rawtherapee/default.nix
+++ b/pkgs/applications/graphics/rawtherapee/default.nix
@@ -4,20 +4,19 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "5.8";
+  version = "5.9";
   pname = "rawtherapee";
 
   src = fetchFromGitHub {
     owner = "Beep6581";
     repo = "RawTherapee";
     rev = version;
-    sha256 = "0d644s4grfia6f3k6y0byd5pwajr12kai2kc280yxi8v3w1b12ik";
+    sha256 = "kdctfjss/DHEcaSDPXcmT20wXTwkI8moRX/i/5wT5Hg=";
   };
 
   nativeBuildInputs = [ cmake pkg-config wrapGAppsHook ];
 
-  # This patch is upstream; remove it in 5.9.
-  patches = [ ./fix-6324.patch ]
+  patches = []
   # Disable upstream-enforced bundling on macOS.
   ++ lib.optionals stdenv.isDarwin [ ./do-not-bundle.patch ];
 

--- a/pkgs/applications/graphics/rawtherapee/default.nix
+++ b/pkgs/applications/graphics/rawtherapee/default.nix
@@ -20,8 +20,6 @@ stdenv.mkDerivation rec {
   patches = lib.optionals stdenv.isDarwin [
     ./do-not-bundle.patch
   ];
-  # Disable upstream-enforced bundling on macOS.
-  ++ lib.optionals stdenv.isDarwin [ ./do-not-bundle.patch ];
 
   buildInputs = [
     pixman libpthreadstubs gtkmm3 libXau libXdmcp

--- a/pkgs/applications/graphics/rawtherapee/default.nix
+++ b/pkgs/applications/graphics/rawtherapee/default.nix
@@ -16,7 +16,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config wrapGAppsHook ];
 
-  patches = []
+  # Disable upstream-enforced bundling on macOS.
+  patches = lib.optionals stdenv.isDarwin [
+    ./do-not-bundle.patch
+  ];
   # Disable upstream-enforced bundling on macOS.
   ++ lib.optionals stdenv.isDarwin [ ./do-not-bundle.patch ];
 


### PR DESCRIPTION
###### Description of changes
See https://github.com/Beep6581/RawTherapee/blob/9b85839884f920de0c7cd3a150f865f3c5e47732/RELEASE_NOTES.txt
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
