### PR TITLE
alembic: Fix install destinations

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -95,6 +95,9 @@ stdenv.mkDerivation rec {
   cmakeFlags =
     [
       "-DWITH_ALEMBIC=ON"
+      # Blender supplies its own FindAlembic.cmake (incompatible with the Alembic-supplied config file)
+      "-DALEMBIC_INCLUDE_DIR=${lib.getDev alembic}/include"
+      "-DALEMBIC_LIBRARY=${lib.getLib alembic}/lib/libAlembic.so"
       "-DWITH_MOD_OCEANSIM=ON"
       "-DWITH_CODEC_FFMPEG=ON"
       "-DWITH_CODEC_SNDFILE=ON"

--- a/pkgs/development/libraries/alembic/default.nix
+++ b/pkgs/development/libraries/alembic/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, unzip, cmake, openexr, hdf5-threadsafe }:
+{ lib, stdenv, fetchFromGitHub, cmake, openexr, hdf5-threadsafe, ilmbase }:
 
 stdenv.mkDerivation rec
 {
@@ -12,26 +12,50 @@ stdenv.mkDerivation rec
     sha256 = "sha256-8dQhOQN0t2Y2kC2wOpQUqbu6Woy4DUmiLqXjf1D+mxE=";
   };
 
+  # note: out is unused (but required for outputDoc anyway)
   outputs = [ "bin" "dev" "out" "lib" ];
 
-  nativeBuildInputs = [ unzip cmake ];
-  buildInputs = [ openexr hdf5-threadsafe ];
+  # Prevent cycle between bin and dev (only occurs on Darwin for some reason)
+  propagatedBuildOutputs = [ "lib" ];
 
-  buildPhase = ''
-    cmake -DUSE_HDF5=ON -DCMAKE_INSTALL_PREFIX=$out/ -DUSE_TESTS=OFF .
+  nativeBuildInputs = [ cmake ];
 
-    mkdir $out
-    mkdir -p $bin/bin
-    mkdir -p $dev/include
-    mkdir -p $lib/lib
+  # NOTE: Alembic also support imath instead of ilmbase, but some users of Alembic (e.g. Blender)
+  # are incompatible with the imath version of Alembic
+  buildInputs = [ openexr hdf5-threadsafe ilmbase ];
+
+  # Downstream packages trying to use Alembic via CMake need ilmbase as well
+  # For some reason this won't be picked up correctly otherwise
+  propagatedBuildInputs = [ ilmbase ];
+
+  # These flags along with the postPatch step ensure that all artifacts end up
+  # in the correct output without needing to move anything
+  #
+  # - bin: Uses CMAKE_INSTALL_BINDIR (set via CMake setup hooK)
+  # - lib (contains shared libraries): Uses ALEMBIC_LIB_INSTALL_DIR
+  # - dev (headers): Uses CMAKE_INSTALL_PREFIX
+  #   (this works because every other install rule uses an absolute DESTINATION)
+  # - dev (CMake files): Uses ConfigPackageLocation
+
+  cmakeFlags = [
+    "-DUSE_HDF5=ON"
+    "-DUSE_TESTS=ON"
+    "-DALEMBIC_LIB_INSTALL_DIR=${placeholder "lib"}/lib"
+    "-DConfigPackageLocation=${placeholder "dev"}/lib/cmake/Alembic"
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "dev"}"
+    "-DQUIET=ON"
+  ];
+
+  postPatch = ''
+    find bin/ -type f -name CMakeLists.txt -print -exec \
+      sed -i 's/INSTALL(TARGETS \([a-zA-Z ]*\) DESTINATION bin)/INSTALL(TARGETS \1)/' {} \;
   '';
 
-  installPhase = ''
-    make install
-
-    mv $out/bin $bin/
-    mv $out/lib $lib/
-    mv $out/include $dev/
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    ctest -j 1
+    runHook postCheck
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/alembic/default.nix
+++ b/pkgs/development/libraries/alembic/default.nix
@@ -63,6 +63,6 @@ stdenv.mkDerivation rec
     homepage = "http://alembic.io/";
     license = licenses.bsd3;
     platforms = platforms.all;
-    maintainers = [ maintainers.guibou ];
+    maintainers = with maintainers; [ guibou tmarkus ];
   };
 }


### PR DESCRIPTION
~~Note: I've written a tester (`testImportedCMakePackage`) in order to prevent issues like the one described below in the future. It's written in a generic fashion and should be applicable to other CMake projects as well. It currently resides below alembic's directory, in `pkgs/development/libraries/alembic/cmakePackageTests`, as I'm not sure about the interest in such a tester. If there's interest in using it as a generic tester I could also move it to `pkgs/build-support/testers/`. It is somewhat comparable to the `hasPkgConfigModule` tester that is already located there.~~
Edit: I've moved the tester to a separate commit for now in order to streamline this PR a bit.

###### Description of changes
The generated CMake targets file was referring to an incorrect destination as the derivation manually moved the libraries during installPhase, while CMake uses the path it thinks is going to be used (the `DESTINATION` in the install rule) in the `IMPORTED_LOCATION` property.

By setting the install destinations via CMake flags (and patching the `DESTINATION` for the binary install rules), CMake will pick up the correct locations in the generated `AlembicTargets-release.cmake` file.

Along with fixing that issue, this commit also includes the following changes:
* Remove unused unzip nativeBuildInput
* Add missing direct dependency imath: Previously it was only picked up indirectly, resulting in CMake configuration warnings
* Add ~~imath~~ ilmbase as propagatedBuildInput: Downstream users of Alembic (via CMake) need to add ~~imath~~ ilmbase as a dependency as well. For some reason this is not discovered correctly otherwise
* Use CMake setup hooks instead of setting buildPhase/installPhase
* Add maintainer tmarkus

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
