### PR TITLE
rustc: 1.67.0 -> 1.67.1

### DIFF
--- a/pkgs/development/compilers/rust/1_67.nix
+++ b/pkgs/development/compilers/rust/1_67.nix
@@ -21,8 +21,8 @@
 } @ args:
 
 import ./default.nix {
-  rustcVersion = "1.67.0";
-  rustcSha256 = "sha256-0CnxT85Foux6mmBdKgpAquRznLL9rinun3pukCWn/eQ=";
+  rustcVersion = "1.67.1";
+  rustcSha256 = "sha256-Rkg9Pl3oWjvUb456OuGDdJY5EGfb5xOiXTzwUbPZ/24=";
 
   llvmSharedForBuild = pkgsBuildBuild.llvmPackages_15.libllvm.override { enableSharedLibraries = true; };
   llvmSharedForHost = pkgsBuildHost.llvmPackages_15.libllvm.override { enableSharedLibraries = true; };
@@ -59,14 +59,6 @@ import ./default.nix {
   selectRustPackage = pkgs: pkgs.rust_1_67;
 
   rustcPatches = [
-    # fix thin archive reading
-    # https://github.com/rust-lang/rust/pull/107360
-    (fetchpatch {
-      name = "revert-back-to-llvmarchivebuilder-on-all-platforms.patch";
-      url = "https://github.com/rust-lang/rust/commit/de363d54c40a378717881240e719f5f7223ba376.patch";
-      hash = "sha256-3Xb803LZUZ1dldxGJ65Iw6gg1V1K827OB/0b32GqilU=";
-    })
-
     # Fixes ICE.
     # https://github.com/rust-lang/rust/pull/107688
     (fetchpatch {


### PR DESCRIPTION
###### Description of changes

built fd and dump_syms on master on {aarch64,x86_64}-{darwin,linux}

Diff: https://github.com/rust-lang/rust/compare/1.67.0...1.67.1

Changelog: https://blog.rust-lang.org/2023/02/09/Rust-1.67.1.html

To test on master, cherry-pick all the commits [here](https://github.com/figsoda/nixpkgs/commits/rustc/pkgs/development/compilers/rust/1_67.nix)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
