### PR TITLE
phpExtensions.opcache: remove flaky test on darwin

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -84,7 +84,6 @@ lib.makeScope pkgs.newScope (self: with self; {
     , zendExtension ? false
     , doCheck ? true
     , extName ? name
-    , allowLocalNetworking ? false
     , ...
     }@args: stdenv.mkDerivation ((builtins.removeAttrs args [ "name" ]) // {
       pname = "php-${name}";
@@ -104,7 +103,6 @@ lib.makeScope pkgs.newScope (self: with self; {
       ];
 
       inherit configureFlags internalDeps buildInputs zendExtension doCheck;
-      __darwinAllowLocalNetworking = allowLocalNetworking;
 
       preConfigurePhases = [
         "cdToExtensionRootPhase"
@@ -413,8 +411,17 @@ lib.makeScope pkgs.newScope (self: with self; {
             valgrind.dev
           ];
           zendExtension = true;
+          postPatch = lib.optionalString stdenv.isDarwin ''
+            # Tests are flaky on darwin
+            rm ext/opcache/tests/blacklist.phpt
+            rm ext/opcache/tests/bug66338.phpt
+            rm ext/opcache/tests/bug78106.phpt
+            rm ext/opcache/tests/issue0115.phpt
+            rm ext/opcache/tests/issue0149.phpt
+            rm ext/opcache/tests/revalidate_path_01.phpt
+          '';
           # Tests launch the builtin webserver.
-          allowLocalNetworking = true;
+          __darwinAllowLocalNetworking = true;
         }
         {
           name = "openssl";


### PR DESCRIPTION
###### Description of changes

Some of the tests of ext-opcache are flaky on darwin.
Issue is not obvious to me and I cannot troubleshoot this locally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Result of `nixpkgs-review pr 215539` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>76 packages built:</summary>
  <ul>
    <li>adminer</li>
    <li>php (apacheHttpdPackages.php)</li>
    <li>arcanist</li>
    <li>bookstack</li>
    <li>drush</li>
    <li>easyeffects</li>
    <li>freshrss</li>
    <li>icingaweb2</li>
    <li>libsForQt5.kcachegrind</li>
    <li>lsp-plugins</li>
    <li>matomo</li>
    <li>matomo-beta</li>
    <li>n98-magerun</li>
    <li>n98-magerun2</li>
    <li>nagios</li>
    <li>nextcloud-news-updater</li>
    <li>nominatim</li>
    <li>pdepend</li>
    <li>phoronix-test-suite</li>
    <li>php80</li>
    <li>php80Extensions.opcache</li>
    <li>php80Packages.box</li>
    <li>php80Packages.composer</li>
    <li>php80Packages.deployer</li>
    <li>php80Packages.grumphp</li>
    <li>php80Packages.phan</li>
    <li>php80Packages.phing</li>
    <li>php80Packages.phive</li>
    <li>php80Packages.php-cs-fixer</li>
    <li>php80Packages.php-parallel-lint</li>
    <li>php80Packages.phpcbf</li>
    <li>php80Packages.phpcs</li>
    <li>php80Packages.phpmd</li>
    <li>php80Packages.phpstan</li>
    <li>php80Packages.psalm</li>
    <li>php80Packages.psysh</li>
    <li>php81Extensions.opcache</li>
    <li>php81Packages.box</li>
    <li>php81Packages.composer</li>
    <li>php81Packages.deployer</li>
    <li>php81Packages.grumphp</li>
    <li>php81Packages.phan</li>
    <li>php81Packages.phing</li>
    <li>php81Packages.phive</li>
    <li>php81Packages.php-cs-fixer</li>
    <li>php81Packages.php-parallel-lint</li>
    <li>php81Packages.phpcbf</li>
    <li>php81Packages.phpcs</li>
    <li>php81Packages.phpmd</li>
    <li>php81Packages.phpstan</li>
    <li>php81Packages.psalm</li>
    <li>php81Packages.psysh</li>
    <li>php82</li>
    <li>php82Extensions.opcache</li>
    <li>php82Packages.box</li>
    <li>php82Packages.composer</li>
    <li>php82Packages.deployer</li>
    <li>php82Packages.grumphp</li>
    <li>php82Packages.phan</li>
    <li>php82Packages.phing</li>
    <li>php82Packages.phive</li>
    <li>php82Packages.php-cs-fixer</li>
    <li>php82Packages.php-parallel-lint</li>
    <li>php82Packages.phpcbf</li>
    <li>php82Packages.phpcs</li>
    <li>php82Packages.phpmd</li>
    <li>php82Packages.phpstan</li>
    <li>php82Packages.psalm</li>
    <li>php82Packages.psysh</li>
    <li>platformsh</li>
    <li>pulseeffects-legacy</li>
    <li>qcachegrind</li>
    <li>snipe-it</li>
    <li>unit</li>
    <li>wp-cli</li>
    <li>yle-dl</li>
  </ul>
</details>