### PR TITLE
opencryptoki: 3.8.2 -> 3.19.0

### DIFF
--- a/pkgs/tools/security/opencryptoki/default.nix
+++ b/pkgs/tools/security/opencryptoki/default.nix
@@ -1,18 +1,36 @@
-{ lib, stdenv, fetchFromGitHub, openssl, trousers, autoreconfHook, libtool, bison, flex }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, bison
+, flex
+, openldap
+, openssl
+, trousers
+}:
 
 stdenv.mkDerivation rec {
   pname = "opencryptoki";
-  version = "3.8.2";
+  version = "3.19.0";
 
   src = fetchFromGitHub {
     owner = "opencryptoki";
     repo = "opencryptoki";
     rev = "v${version}";
-    sha256 = "1rf7cmibmx636vzv7p54g212478a8wim2lfjf2861hfd0m96nv4l";
+    hash = "sha256-ym13I34H3d1JuVBnItkceUbqpjYFhD+mPgWYHPetF7Y=";
   };
 
-  nativeBuildInputs = [ autoreconfHook libtool bison flex ];
-  buildInputs = [ openssl trousers ];
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
+    flex
+  ];
+
+  buildInputs = [
+    openldap
+    openssl
+    trousers
+  ];
 
   postPatch = ''
     substituteInPlace configure.ac \
@@ -20,18 +38,22 @@ stdenv.mkDerivation rec {
       --replace "groupadd" "true" \
       --replace "chmod" "true" \
       --replace "chgrp" "true"
-    substituteInPlace usr/lib/Makefile.am --replace "DESTDIR" "out"
   '';
 
   configureFlags = [
-    "--prefix=$(out)"
+    "--prefix="
     "--disable-ccatok"
     "--disable-icatok"
   ];
 
   enableParallelBuilding = true;
 
+  installFlags = [
+    "DESTDIR=${placeholder "out"}"
+  ];
+
   meta = with lib; {
+    changelog   = "https://github.com/opencryptoki/opencryptoki/blob/${src.rev}/ChangeLog";
     description = "PKCS#11 implementation for Linux";
     homepage    = "https://github.com/opencryptoki/opencryptoki";
     license     = licenses.cpl10;


### PR DESCRIPTION
###### Description of changes
fixes CVE-2021-3798

Diff: https://github.com/opencryptoki/opencryptoki/compare/v3.8.2...v3.19.0

Changelog: https://github.com/opencryptoki/opencryptoki/blob/v3.19.0/ChangeLog


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @ts468