### PR TITLE
cmake: 3.24.3 -> 3.25.2

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/002-application-services.diff
+++ b/pkgs/development/tools/build-managers/cmake/002-application-services.diff
@@ -1,20 +1,20 @@
 diff --git a/Source/CMakeLists.txt b/Source/CMakeLists.txt
-index 9a18184fd3..278d146dd1 100644
+index c268a92111..2e736af7a7 100644
 --- a/Source/CMakeLists.txt
 +++ b/Source/CMakeLists.txt
-@@ -933,7 +933,6 @@ endif()
+@@ -916,7 +916,6 @@ endif()
  # On Apple we need CoreFoundation and CoreServices
  if(APPLE)
-   target_link_libraries(CMakeLib "-framework CoreFoundation")
--  target_link_libraries(CMakeLib "-framework CoreServices")
+   target_link_libraries(CMakeLib PUBLIC "-framework CoreFoundation")
+-  target_link_libraries(CMakeLib PUBLIC "-framework CoreServices")
  endif()
  
  if(WIN32 AND NOT UNIX)
 diff --git a/Source/cmGlobalXCodeGenerator.cxx b/Source/cmGlobalXCodeGenerator.cxx
-index 77403b076a..d5aac95e1e 100644
+index 116e510c6f..69ce510ff7 100644
 --- a/Source/cmGlobalXCodeGenerator.cxx
 +++ b/Source/cmGlobalXCodeGenerator.cxx
-@@ -49,10 +49,6 @@ struct cmLinkImplementation;
+@@ -56,10 +56,6 @@
  
  #if !defined(CMAKE_BOOTSTRAP) && defined(__APPLE__)
  #  include <CoreFoundation/CoreFoundation.h>
@@ -26,12 +26,12 @@ index 77403b076a..d5aac95e1e 100644
  
  #if !defined(CMAKE_BOOTSTRAP)
 diff --git a/Utilities/cmlibarchive/CMakeLists.txt b/Utilities/cmlibarchive/CMakeLists.txt
-index 79452ffff6..a848731b7e 100644
+index b38e6530a3..8aa71d95cd 100644
 --- a/Utilities/cmlibarchive/CMakeLists.txt
 +++ b/Utilities/cmlibarchive/CMakeLists.txt
-@@ -2013,11 +2013,6 @@ IF(ENABLE_TEST)
+@@ -2041,11 +2041,6 @@ IF(ENABLE_TEST)
+   ADD_CUSTOM_TARGET(run_all_tests)
  ENDIF(ENABLE_TEST)
- ENDIF()
  
 -# We need CoreServices on Mac OS.
 -IF(APPLE)

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -40,11 +40,11 @@ stdenv.mkDerivation rec {
     + lib.optionalString isBootstrap "-boot"
     + lib.optionalString cursesUI "-cursesUI"
     + lib.optionalString qt5UI "-qt5UI";
-  version = "3.24.3";
+  version = "3.25.2";
 
   src = fetchurl {
     url = "https://cmake.org/files/v${lib.versions.majorMinor version}/cmake-${version}.tar.gz";
-    sha256 = "sha256-tTqhD6gr/4TM21kGWSe3LTvuSfTYYmEkn8CYSzs2cpE=";
+    sha256 = "sha256-wCbyLLkx3VMvZI8IfVh/B6GEPG5mo9/KT7DqIZRO0zw=";
   };
 
   patches = [


### PR DESCRIPTION
###### Description of changes

Bump `cmake` and regenerate `002-application-services.diff` because it could no longer be applied cleanly.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
