### PR TITLE
pdm: 2.3.4 -> 2.4.3

### DIFF
--- a/pkgs/tools/package-management/pdm/default.nix
+++ b/pkgs/tools/package-management/pdm/default.nix
@@ -24,14 +24,18 @@ in
 with python.pkgs;
 buildPythonApplication rec {
   pname = "pdm";
-  version = "2.3.4";
+  version = "2.4.3";
   format = "pyproject";
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-zaSNM5Ey4oI2MtUPYBHG0PCMgJdasVatwkjaRBrT1RQ=";
+    hash = "sha256-Gp8ju26XX0A2+LX+7b9OuEBJx4qUwR2tNUq+Chj56q4=";
   };
+
+  nativeBuildInputs = [
+    pdm-pep517
+  ];
 
   propagatedBuildInputs = [
     blinker
@@ -40,9 +44,6 @@ buildPythonApplication rec {
     findpython
     installer
     packaging
-    pdm-pep517
-    pep517
-    pip
     platformdirs
     pyproject-hooks
     python-dotenv
@@ -50,20 +51,22 @@ buildPythonApplication rec {
     resolvelib
     rich
     shellingham
-    tomli
     tomlkit
     unearth
     virtualenv
   ]
   ++ cachecontrol.optional-dependencies.filecache
-  ++ lib.optionals (pythonOlder "3.8") [
+  ++ lib.optionals (pythonOlder "3.11") [
+    tomli
+  ]
+  ++ lib.optionals (pythonOlder "3.10") [
     importlib-metadata
-    typing-extensions
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
     pytest-mock
+    pytest-rerunfailures
     pytest-xdist
   ];
 
@@ -85,6 +88,7 @@ buildPythonApplication rec {
 
   meta = with lib; {
     homepage = "https://pdm.fming.dev";
+    changelog = "https://github.com/pdm-project/pdm/releases/tag/${version}";
     description = "A modern Python package manager with PEP 582 support";
     license = licenses.mit;
     maintainers = with maintainers; [ cpcloud ];


### PR DESCRIPTION
https://github.com/pdm-project/pdm/releases/tag/2.4.3
https://github.com/pdm-project/pdm/releases/tag/2.4.2
https://github.com/pdm-project/pdm/releases/tag/2.4.1
https://github.com/pdm-project/pdm/releases/tag/2.4.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
