### PR TITLE
catppuccin-kde: unstable-2022-11-26 -> 0.2.2

### DIFF
--- a/pkgs/data/themes/catppuccin-kde/default.nix
+++ b/pkgs/data/themes/catppuccin-kde/default.nix
@@ -1,24 +1,47 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
+, flavour ? [ "frappe" ]
+, accents ? [ "blue" ]
+, winDecStyles ? [ "modern" ]
 }:
+
+let
+  validFlavours = [ "mocha" "macchiato" "frappe" "latte" ];
+  validAccents = [ "rosewater" "flamingo" "pink" "mauve" "red" "maroon" "peach" "yellow" "green" "teal" "sky" "sapphire" "blue" "lavender" ];
+  validWinDecStyles = [ "modern" "classic" ];
+
+  installScript = ./install.sh;
+in
+
+  lib.checkListOfEnum "Invalid accent, valid accents are ${toString validAccents}" validAccents accents
+  lib.checkListOfEnum "Invalid flavour, valid flavours are ${toString validFlavours}" validFlavours flavour
+  lib.checkListOfEnum "Invalid window decoration style, valid styles are ${toString validWinDecStyles}" validWinDecStyles winDecStyles
 
 stdenvNoCC.mkDerivation rec {
   pname = "kde";
-  version = "unstable-2022-11-26";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "catppuccin";
     repo = pname;
-    rev = "249df3ec0cdae79af379f4a10b802c50feac89ba";
-    hash = "sha256-CH9GJnFqqdyIzW7VfGb3oB1YPULEZsfK3d1eyFALwKc=";
+    rev = "v${version}";
+    hash = "sha256-P5mLLaQzMhG6aHvAj9SizUFQFLjqNKj1T1kQ4dgiacI=";
   };
 
   installPhase = ''
-    mkdir -p $out/share/{plasma/look-and-feel,color-schemes}
-    find . -type f -name "Catppuccin*.colors" -exec cp "{}" $out/share/color-schemes \;
-    find . -type f -name "*.tar.gz" -exec tar -xzf "{}" \;
-    cp -R Catppuccin-* $out/share/plasma/look-and-feel
+    runHook preInstall
+
+    patchShebangs .
+    for WINDECSTYLE in ${toString winDecStyles}; do
+      for FLAVOUR in ${toString flavour}; do
+        for ACCENT in ${toString accents}; do
+          FLAVOUR=$FLAVOUR ACCENT=$ACCENT WINDECSTYLE=$WINDECSTYLE bash ${installScript}
+        done;
+      done;
+    done;
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/data/themes/catppuccin-kde/install.sh
+++ b/pkgs/data/themes/catppuccin-kde/install.sh
@@ -1,0 +1,263 @@
+COLORDIR=$out/share/color-schemes
+AURORAEDIR=$out/share/aurorae/themes
+LOOKANDFEELDIR=$out/share/plasma/look-and-feel
+DESKTOPTHEMEDIR=$out/share/plasma/desktoptheme
+
+FLAVOUR=${FLAVOUR^}
+ACCENT=${ACCENT^}
+WINDECSTYLE=${WINDECSTYLE^}
+
+echo "Creating theme directories.."
+mkdir -p $COLORDIR
+mkdir -p $AURORAEDIR
+mkdir -p $LOOKANDFEELDIR
+mkdir -p $DESKTOPTHEMEDIR
+mkdir ./dist
+
+# Sets accent based on the pallet selected (Best to fold this in your respective editor)
+if [[ $ACCENT == "Rosewater" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#f5e0dc
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#f4dbd6
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#f2d5cf
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#dc8a78
+    fi
+    echo "Accent Rosewater(1) was selected!"
+elif [[ $ACCENT == "Flamingo" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#f2cdcd
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#f0c6c6
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#eebebe
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#dd7878
+    fi
+    echo "Accent Flamingo(2) was selected!"
+    ACCENT="2"
+elif [[ $ACCENT == "Pink" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#f5c2e7
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#f5bde6
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#f4b8e4
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#ea76cb
+    fi
+    echo "Accent Pink(3) was selected!"
+elif [[ $ACCENT == "Mauve" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#cba6f7
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#c6a0f6
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#ca9ee6
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#8839ef
+    fi
+    echo "Accent Mauve(4) was selected!"
+elif [[ $ACCENT == "Red" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#f38ba8
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#ed8796
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#e78284
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#d20f39
+    fi
+    echo "Accent Red(5) was selected!"
+elif [[ $ACCENT == "Maroon" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#eba0ac
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#ee99a0
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#ea999c
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#e64553
+    fi
+    echo "Accent Maroon(6) was selected!"
+elif [[ $ACCENT == "Peach" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#fab387
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#f5a97f
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#ef9f76
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#fe640b
+    fi
+    echo "Accent Peach(7) was selected!"
+elif [[ $ACCENT == "Yellow" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#f9e2af
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#eed49f
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#e5c890
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#df8e1d
+    fi
+    echo "Accent Yellow(8) was selected!"
+elif [[ $ACCENT == "Green" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#a6e3a1
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#a6da95
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#a6d189
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#40a02b
+    fi
+    echo "Accent Green(9) was selected!"
+elif [[ $ACCENT == "Teal" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#94e2d5
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#8bd5ca
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#81c8be
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#179299
+    fi
+    echo "Accent Teal(10) was selected!"
+elif [[ $ACCENT == "Sky" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#89dceb
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#91d7e3
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#99d1db
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#04a5e5
+    fi
+    echo "Accent Sky(11) was selected!"
+elif [[ $ACCENT == "Sapphire" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#74c7ec
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#7dc4e4
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#85c1dc
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#209fb5
+    fi
+    echo "Accent Sapphire(12) was selected!"
+elif [[ $ACCENT == "Blue" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#89b4fa
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#8aadf4
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#8caaee
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#1e66f5
+    fi
+    echo "Accent Blue(13) was selected!"
+elif [[ $ACCENT == "Lavender" ]]; then
+    if [[ $FLAVOUR == "Mocha" ]]; then
+        ACCENTCOLOR=#b4befe
+    elif [[ $FLAVOUR == "Macchiato" ]]; then
+        ACCENTCOLOR=#b7bdf8
+    elif [[ $FLAVOUR == "Frappe" ]]; then
+        ACCENTCOLOR=#babbf1
+    elif [[ $FLAVOUR == "Latte" ]]; then
+        ACCENTCOLOR=#7287fd
+    fi
+    echo "Accent Lavender(14) was selected!"
+else echo "Not a valid accent" && exit
+fi
+
+if [[ $WINDECSTYLE == "Modern" ]]; then
+    WINDECSTYLECODE=__aurorae__svg__Catppuccin$FLAVOUR-Modern
+elif [[ $WINDECSTYLE == "Classic" ]]; then
+    WINDECSTYLECODE=__aurorae__svg__Catppuccin$FLAVOUR-Classic
+fi
+
+function ModifyLightlyPlasma {
+
+    rm -rf $DESKTOPTHEMEDIR/lightly-plasma-git/icons/*
+    rm -rf $DESKTOPTHEMEDIR/lightly-plasma-git/translucent
+    rm $DESKTOPTHEMEDIR/lightly-plasma-git/widgets/tabbar.svgz
+    rm $DESKTOPTHEMEDIR/lightly-plasma-git/dialogs/background.svgz
+
+    # Copy Patches
+    cp $DESKTOPTHEMEDIR/lightly-plasma-git/solid/* $DESKTOPTHEMEDIR/lightly-plasma-git -Rf
+    cp ./Patches/glowbar.svg $DESKTOPTHEMEDIR/lightly-plasma-git/widgets -rf
+    cp ./Patches/background.svg $DESKTOPTHEMEDIR/lightly-plasma-git/widgets -rf
+    cp ./Patches/panel-background.svgz $DESKTOPTHEMEDIR/lightly-plasma-git/widgets
+
+    # Modify description to state that it has been modified by the KDE Catppuccin Installer
+    sed -e s/A\ plasma\ style\ with\ close\ to\ the\ look\ of\ the\ newest\ Lightly./*MODIFIED\ BY\ CATPPUCCIN\ KDE\ INSTALLER*\ A\ plasma\ style\ with\ close\ to\ the\ look\ of\ the\ newest\ Lightly./g $DESKTOPTHEMEDIR/lightly-plasma-git/metadata.desktop >> $DESKTOPTHEMEDIR/lightly-plasma-git/newMetadata.desktop
+    cp -f $DESKTOPTHEMEDIR/metadata.desktop $DESKTOPTHEMEDIR/lightly-plasma-git/metadata.desktop && rm $DESKTOPTHEMEDIR/metadata.desktop
+}
+
+function AuroraeInstall {
+    if [[ $WINDECSTYLE == "Modern" ]]; then
+        cp ./Resources/aurorae/Catppuccin$FLAVOUR-Modern $AURORAEDIR -r;
+    elif [[ $WINDECSTYLE == "Classic" ]]; then
+        cp ./Resources/aurorae/Catppuccin$FLAVOUR-Classic $AURORAEDIR -r;
+    fi
+}
+
+function BuildColorscheme {
+    # Add Metadata & Replace Accent in colors file
+    sed -e s/--accentColor/$ACCENTCOLOR/g -e s/--flavour/$FLAVOUR/g -e s/--accentName/$ACCENT/g ./Resources/base.colors > ./dist/base.colors
+    # Hydrate Metadata with Pallet + Accent Info
+    sed -e s/--accentName/$ACCENT/g -e s/--flavour/$FLAVOUR/g ./Resources/metadata.desktop > ./dist/Catppuccin-$FLAVOUR-$ACCENT/metadata.desktop
+    # Modify 'defaults' to set the correct Aurorae Theme
+    sed -e s/--accentName/$ACCENT/g -e s/--flavour/$FLAVOUR/g -e s/--aurorae/$WINDECSTYLECODE/g ./Resources/defaults > ./dist/Catppuccin-$FLAVOUR-$ACCENT/contents/defaults
+    # Hydrate Dummy colors according to Pallet
+    FLAVOURNAME=$FLAVOUR ACCENTNAME=$ACCENT ./Installer/color-build.sh -o ./dist/Catppuccin$FLAVOUR$ACCENT.colors -s ./dist/base.colors
+}
+
+function BuildSplashScreen {
+    # Hydrate Dummy colors according to Pallet
+    FLAVOURNAME=$FLAVOUR ./Installer/color-build.sh -s ./Resources/splash/images/busywidget.svg -o ./dist/$GLOBALTHEMENAME/contents/splash/images/_busywidget.svg
+    # Replace Accent in colors file
+    sed ./dist/$GLOBALTHEMENAME/contents/splash/images/_busywidget.svg -e s/REPLACE--ACCENT/$ACCENTCOLOR/g > ./dist/$GLOBALTHEMENAME/contents/splash/images/busywidget.svg
+    # Cleanup temporary file
+    rm ./dist/$GLOBALTHEMENAME/contents/splash/images/_busywidget.svg
+    # Hydrate Dummy colors according to Pallet (QML file)
+    FLAVOURNAME=$FLAVOUR ./Installer/color-build.sh -s ./Resources/splash/Splash.qml -o ./dist/$GLOBALTHEMENAME/contents/splash/Splash.qml
+    # Add CTP Logo
+    # TODO: Switch between latte & mocha logo based on Pallet
+    cp ./Resources/splash/images/Logo.png ./dist/$GLOBALTHEMENAME/contents/splash/images
+}
+
+# Prepare Global Theme Folder
+GLOBALTHEMENAME="Catppuccin-$FLAVOUR-$ACCENT"
+cp -r ./Resources/Catppuccin-$FLAVOUR-Global ./dist/$GLOBALTHEMENAME
+mkdir -p ./dist/$GLOBALTHEMENAME/contents/splash/images
+
+# Build SplashScreen
+echo "Building SplashScreen.."
+BuildSplashScreen
+
+# Build Colorscheme
+echo "Building Colorscheme.."
+# Generate Color scheme
+BuildColorscheme
+
+# Install Colorscheme
+echo "Installing Colorscheme.."
+mv ./dist/Catppuccin$FLAVOUR$ACCENT.colors $COLORDIR
+
+# Install Global Theme.
+echo "Installing Global Theme.."
+cp -r ./dist/$GLOBALTHEMENAME $LOOKANDFEELDIR
+
+# echo "Modifying lightly plasma theme.."
+# ModifyLightlyPlasma
+
+echo "Installing aurorae theme.."
+AuroraeInstall
+
+# Cleanup
+echo "Cleaning up.."
+rm -rf ./dist


### PR DESCRIPTION
###### Description of changes
Updated the theme to the newest tagged revision. The main change is an installation script with accent options. Unfortunately, this script takes user input, so I had to modify it to work with a declarative install. The package allows for any combination of theme flavours and accents to be installed. 

https://github.com/catppuccin/kde/releases/tag/v0.2.2

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
