### PR TITLE
electron-fiddle: 0.31.0 → 0.32.1

### DIFF
--- a/pkgs/development/tools/electron-fiddle/default.nix
+++ b/pkgs/development/tools/electron-fiddle/default.nix
@@ -1,5 +1,5 @@
 { buildFHSUserEnv
-, electron_20
+, electron_22
 , fetchFromGitHub
 , fetchYarnDeps
 , fixup_yarn_lock
@@ -14,21 +14,21 @@
 
 let
   pname = "electron-fiddle";
-  version = "0.31.0";
-  electron = electron_20;
+  version = "0.32.1";
+  electron = electron_22;
   nodejs = nodejs-16_x;
 
   src = fetchFromGitHub {
     owner = "electron";
     repo = "fiddle";
     rev = "v${version}";
-    hash = "sha256-GueLG+RYFHi3PVVxBTtpTHhfjygcQ6ZCbrp5n5I1gBM=";
+    hash = "sha256-k+cbg03mwvobyazIUqm+TO9OMYVFQICy4CtkUZmvkr8=";
   };
 
   inherit (nodejs.pkgs) yarn;
   offlineCache = fetchYarnDeps {
     yarnLock = "${src}/yarn.lock";
-    hash = "sha256-WVH1A0wtQl5nR1hvaL6mzm/7XBvo311FPKmsxB82e4U=";
+    hash = "sha256-3vM+YPIA3zeWBaEFXU5lFl+VaGmAY0Qdg4pSA6mIKl0=";
   };
 
   electronDummyMirror = "https://electron.invalid/";
@@ -89,12 +89,14 @@ in
 buildFHSUserEnv {
   name = "electron-fiddle";
   runScript = "${electron}/bin/electron ${unwrapped}/lib/electron-fiddle/resources/app.asar";
+
   extraInstallCommands = ''
     mkdir -p "$out/share/icons/hicolor/scalable/apps"
     ln -s "${unwrapped}/share/icons/hicolor/scalable/apps/electron-fiddle.svg" "$out/share/icons/hicolor/scalable/apps/"
     mkdir -p "$out/share/applications"
     cp "${desktopItem}/share/applications"/*.desktop "$out/share/applications/"
   '';
+
   targetPkgs = pkgs:
     with pkgs;
     map lib.getLib [


### PR DESCRIPTION
###### Description of changes

Upgrade Electron Fiddle from 0.31.0 to 0.32.1. This version depends on Electron 22 rather than the now EOL’d Electron 20 (#215545).

https://github.com/electron/fiddle/releases/tag/v0.32.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
