### PR TITLE
cargo-binstall: init at 0.19.3

### DIFF
--- a/pkgs/development/tools/rust/cargo-binstall/default.nix
+++ b/pkgs/development/tools/rust/cargo-binstall/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, bzip2
+, xz
+, zstd
+, stdenv
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-binstall";
+  version = "0.19.3";
+
+  src = fetchFromGitHub {
+    owner = "cargo-bins";
+    repo = "cargo-binstall";
+    rev = "v${version}";
+    hash = "sha256-MxbZlUlan58TVgcr2n5ZA+L01u90bYYqf88GU+sLmKk=";
+  };
+
+  cargoHash = "sha256-HG43UCjPCB5bEH0GYPoHsOlaJQNPRrD175SuUJ6QbEI=";
+
+  patches = [
+    # make it possible to disable the static feature
+    # https://github.com/cargo-bins/cargo-binstall/pull/782
+    ./fix-features.patch
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    bzip2
+    xz
+    zstd
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "fancy-no-backtrace"
+    "pkg-config"
+    "rustls"
+    "trust-dns"
+    "zstd-thin"
+  ];
+
+  # remove cargo config so it can find the linker on aarch64-unknown-linux-gnu
+  postPatch = ''
+    rm .cargo/config
+  '';
+
+  meta = with lib; {
+    description = "A tool for installing rust binaries as an alternative to building from source";
+    homepage = "https://github.com/cargo-bins/cargo-binstall";
+    changelog = "https://github.com/cargo-bins/cargo-binstall/releases/tag/v${version}";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/development/tools/rust/cargo-binstall/fix-features.patch
+++ b/pkgs/development/tools/rust/cargo-binstall/fix-features.patch
@@ -1,0 +1,22 @@
+--- a/crates/bin/Cargo.toml
++++ b/crates/bin/Cargo.toml
+@@ -22,7 +22,7 @@ pkg-fmt = "zip"
+ pkg-fmt = "zip"
+ 
+ [dependencies]
+-binstalk = { path = "../binstalk", version = "0.7.1" }
++binstalk = { path = "../binstalk", version = "0.7.1", default-features = false }
+ binstalk-manifests = { path = "../binstalk-manifests", version = "0.2.0" }
+ clap = { version = "4.1.1", features = ["derive"] }
+ crates_io_api = { version = "0.8.1", default-features = false }
+--- a/crates/binstalk/Cargo.toml
++++ b/crates/binstalk/Cargo.toml
+@@ -11,7 +11,7 @@ license = "GPL-3.0"
+ 
+ [dependencies]
+ async-trait = "0.1.61"
+-binstalk-downloader = { version = "0.3.2", path = "../binstalk-downloader" }
++binstalk-downloader = { version = "0.3.2", path = "../binstalk-downloader", default-features = false }
+ binstalk-types = { version = "0.2.0", path = "../binstalk-types" }
+ cargo_toml = "0.14.0"
+ command-group = { version = "2.0.1", features = ["with-tokio"] }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15695,6 +15695,7 @@ with pkgs;
   cargo-audit = callPackage ../development/tools/rust/cargo-audit {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  cargo-binstall = callPackage ../development/tools/rust/cargo-binstall { };
   cargo-bisect-rustc = callPackage ../development/tools/rust/cargo-bisect-rustc {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

cargo-binstall is s tool for installing rust binaries as an alternative to building from source

https://github.com/cargo-bins/cargo-binstall

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
