### PR TITLE
upx: 3.96 -> 4.0.2

### DIFF
--- a/pkgs/tools/compression/upx/default.nix
+++ b/pkgs/tools/compression/upx/default.nix
@@ -1,39 +1,17 @@
-{ lib, stdenv, fetchurl, ucl, zlib, perl, fetchpatch }:
+{ lib, stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
   pname = "upx";
-  version = "3.96";
-  src = fetchurl {
-    url = "https://github.com/upx/upx/releases/download/v${version}/${pname}-${version}-src.tar.xz";
-    sha256 = "051pk5jk8fcfg5mpgzj43z5p4cn7jy5jbyshyn78dwjqr7slsxs7";
+  version = "4.0.2";
+  src = fetchFromGitHub {
+    owner = "upx";
+    repo = pname;
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "sha256-5jqEdMlHmsD88kT/EGieL7DktppVdfWyJWGRNRKbRc4=";
   };
 
-  buildInputs = [ ucl zlib perl ];
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/upx/upx/commit/13bc031163863cb3866aa6cdc018dff0697aa5d4.patch";
-      sha256 = "sha256-7uazgx1lOgHh2J7yn3yb1q9lTJsv4BbexdGlWRiAG/M=";
-      name = "CVE-2021-20285.patch";
-    })
-  ];
-
-  preConfigure = ''
-    export UPX_UCLDIR=${ucl}
-  '';
-
-  makeFlags = [
-    "-C" "src"
-    "CHECK_WHITESPACE=true"
-
-    # Disable blanket -Werror. Triggers failues on minor gcc-11 warnings.
-    "CXXFLAGS_WERROR="
-  ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp src/upx.out $out/bin/upx
-  '';
+  nativeBuildInputs = [ cmake ];
 
   meta = with lib; {
     homepage = "https://upx.github.io/";


### PR DESCRIPTION
###### Description of changes

https://github.com/upx/upx/blob/v4.0.2/NEWS
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>kega-fusion</li>
  </ul>
</details>
<details>
  <summary>7 packages built:</summary>
  <ul>
    <li>brogue</li>
    <li>libtcod</li>
    <li>retdec</li>
    <li>retdec-full</li>
    <li>teensyduino</li>
    <li>upx</li>
    <li>vlang</li>
  </ul>
</details>