### PR TITLE
libsecret: fix non-deterministic fail of test-collection

### DIFF
--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
 
     dbus-run-session \
       --config-file=${dbus}/share/dbus-1/session.conf \
-      meson test --print-errorlogs
+      meson test --print-errorlogs --timeout-multiplier 0
 
     runHook postCheck
   '';


### PR DESCRIPTION
libsecret: fix non-deterministic fail of test-collection
* Problem usually happens when all CPUs are busy.

Error logs: https://gist.github.com/superherointj/08d68a9674f695e73bbabcf8c9a1e535

Upstream issue: https://gitlab.gnome.org/GNOME/libsecret/-/issues/80

Update: It is unclear if this actually solves the problem. Likely doesn't. Because at logs, timeout is 0! (Should list some timeout.)