### PR TITLE
adguardhome: add source for armv6l and armv7l

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -20,4 +20,12 @@ aarch64-linux = fetchurl {
   sha256 = "sha256-qC7BrBhI9berbuIVIQ6yOo74eHRsoneVRJMx1K/Ljds=";
   url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.23/AdGuardHome_linux_arm64.tar.gz";
 };
+armv6l-linux = fetchurl {
+  sha256 = "sha256-cWoEpOScFzcz3tsG7IIBV2xpBT+uvSYMEfrmE3pohWA=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.23/AdGuardHome_linux_armv6.tar.gz";
+};
+armv7l-linux = fetchurl {
+  sha256 = "sha256-DTGyyNCncbGrrpHzcIxpZqukAYsHarqSJhlbYvjN6dA=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.23/AdGuardHome_linux_armv7.tar.gz";
+};
 }

--- a/pkgs/servers/adguardhome/update.sh
+++ b/pkgs/servers/adguardhome/update.sh
@@ -22,6 +22,8 @@ declare -A systems
 systems[linux_386]=i686-linux
 systems[linux_amd64]=x86_64-linux
 systems[linux_arm64]=aarch64-linux
+systems[linux_armv6]=armv6l-linux
+systems[linux_armv7]=armv7l-linux
 systems[darwin_amd64]=x86_64-darwin
 systems[darwin_arm64]=aarch64-darwin
 
@@ -30,7 +32,7 @@ echo '{' >> "$bins"
 
 for asset in $(curl --silent https://api.github.com/repos/AdguardTeam/AdGuardHome/releases/latest | jq -c '.assets[]') ; do
     url="$(jq -r '.browser_download_url' <<< "$asset")"
-    adg_system="$(grep -Eo '(darwin|linux)_(386|amd64|arm64)' <<< "$url" || true)"
+    adg_system="$(grep -Eo '(darwin|linux)_(386|amd64|arm64|armv6|armv7)' <<< "$url" || true)"
     if [ -n "$adg_system" ]; then
         fetch="$(grep '\.zip$' <<< "$url" > /dev/null && echo fetchzip || echo fetchurl)"
         nix_system=${systems[$adg_system]}


### PR DESCRIPTION
###### Description of changes

Adds support for armv6l-linux and armv7l-linux. These are officially supported by the AdGuard team (they provide binaries for these architectures -- see release assets [here](https://github.com/AdguardTeam/AdGuardHome/releases)).

I cross compiled these two binaries on an x86_64 host. I'll be honest though, I only tested the armv6l binary (armv7l should also work -- it's supported by the project maintainers).

This is my first PR to nixpkgs so I apologize in advance if I overlooked something.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
     *NOTE*: I tried running `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD --system armv6l-linux"` and it failed (some issue evaluating `configureFlags` of the derivation `grub-2.06`), but the [nixpkgs-review](https://github.com/Mic92/nixpkgs-review#review-changes-for-other-operating-systemsarchitectures) docs do mention not all hooks may execute correctly so I think this failure is fine (not sure).
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
    *NOTE*: I've only actually tested the armv6l binary. armv7l is supported by the AdGuard team though (see release assets [here](https://github.com/AdguardTeam/AdGuardHome/releases))
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
