### PR TITLE
rubyfmt: init at 0.8.1

### DIFF
--- a/pkgs/development/tools/rubyfmt/0001-cargo-lock-update-version.patch
+++ b/pkgs/development/tools/rubyfmt/0001-cargo-lock-update-version.patch
@@ -1,0 +1,25 @@
+From d9df7aaaaf9c758499f569376a041045d99e4015 Mon Sep 17 00:00:00 2001
+From: Bob van der Linden <bobvanderlinden@gmail.com>
+Date: Thu, 9 Feb 2023 16:17:46 +0100
+Subject: [PATCH 1/2] cargo: lock: update version
+
+---
+ Cargo.lock | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 79a81d1..374c10a 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -642,7 +642,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "rubyfmt-main"
+-version = "0.8.0-pre"
++version = "0.8.1"
+ dependencies = [
+  "atty",
+  "clap",
+-- 
+2.39.1
+

--- a/pkgs/development/tools/rubyfmt/0002-remove-dependency-on-git.patch
+++ b/pkgs/development/tools/rubyfmt/0002-remove-dependency-on-git.patch
@@ -1,0 +1,62 @@
+From 3bbc396c4ddc8a5e26f7776155bb366c8d47c440 Mon Sep 17 00:00:00 2001
+From: Bob van der Linden <bobvanderlinden@gmail.com>
+Date: Thu, 9 Feb 2023 16:55:00 +0100
+Subject: [PATCH 2/2] remove dependency on git
+
+---
+ librubyfmt/build.rs | 35 +++--------------------------------
+ 1 file changed, 3 insertions(+), 32 deletions(-)
+
+diff --git a/librubyfmt/build.rs b/librubyfmt/build.rs
+index ef94c09..4668785 100644
+--- a/librubyfmt/build.rs
++++ b/librubyfmt/build.rs
+@@ -26,27 +26,9 @@ fn main() -> Output {
+     let path = std::env::current_dir()?;
+     let ruby_checkout_path = path.join("ruby_checkout");
+ 
+-    let old_checkout_sha = if ruby_checkout_path.join(ripper).exists() {
+-        Some(get_ruby_checkout_sha())
+-    } else {
+-        None
+-    };
+-
+-    let _ = Command::new("git")
+-        .args(&["submodule", "update", "--init"])
+-        .status();
+-
+-    let new_checkout_sha = get_ruby_checkout_sha();
+-
+-    // Only rerun this build if the ruby_checkout has changed
+-    match old_checkout_sha {
+-        Some(old_sha) if old_sha == new_checkout_sha => {}
+-        _ => {
+-            make_configure(&ruby_checkout_path)?;
+-            run_configure(&ruby_checkout_path)?;
+-            build_ruby(&ruby_checkout_path)?;
+-        }
+-    }
++    make_configure(&ruby_checkout_path)?;
++    run_configure(&ruby_checkout_path)?;
++    build_ruby(&ruby_checkout_path)?;
+ 
+     cc::Build::new()
+         .file("src/rubyfmt.c")
+@@ -152,14 +134,3 @@ fn check_process_success(command: &str, code: ExitStatus) -> Output {
+     }
+ }
+ 
+-fn get_ruby_checkout_sha() -> String {
+-    String::from_utf8(
+-        Command::new("git")
+-            .args(&["rev-parse", "HEAD"])
+-            .current_dir("./ruby_checkout")
+-            .output()
+-            .expect("git rev-parse shouldn't fail")
+-            .stdout,
+-    )
+-    .expect("output should be valid utf8")
+-}
+-- 
+2.39.1
+

--- a/pkgs/development/tools/rubyfmt/default.nix
+++ b/pkgs/development/tools/rubyfmt/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , rustPlatform
 , fetchFromGitHub
 , autoconf
@@ -6,7 +7,13 @@
 , bison
 , ruby
 , zlib
+, readline
+, libiconv
+, libobjc
+, libunwind
 , libxcrypt
+, Foundation
+, Security
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -31,7 +38,21 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     zlib
     libxcrypt
+  ] ++ lib.optionals stdenv.isDarwin [
+    readline
+    libiconv
+    libobjc
+    libunwind
+    Foundation
+    Security
   ];
+
+  preConfigure = ''
+    pushd librubyfmt/ruby_checkout
+    autoreconf --install --force --verbose
+    ./configure
+    popd
+  '';
 
   cargoPatches = [
     # The 0.8.1 release did not have an up-to-date lock file. The rubyfmt

--- a/pkgs/development/tools/rubyfmt/default.nix
+++ b/pkgs/development/tools/rubyfmt/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, autoconf
+, automake
+, bison
+, ruby
+, zlib
+, libxcrypt
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rubyfmt";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "fables-tales";
+    repo = "rubyfmt";
+    rev = "v${version}";
+    hash = "sha256-lHq9lcLMp6HUHMonEe3T2YGwMYW1W131H1jo1cy6kyc=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    bison
+    ruby
+  ];
+
+  buildInputs = [
+    zlib
+    libxcrypt
+  ];
+
+  cargoPatches = [
+    # The 0.8.1 release did not have an up-to-date lock file. The rubyfmt
+    # version in Cargo.toml was bumped, but it wasn't updated in the lock file.
+    ./0001-cargo-lock-update-version.patch
+
+    # Avoid checking whether ruby gitsubmodule is up-to-date.
+    ./0002-remove-dependency-on-git.patch
+  ];
+
+  cargoHash = "sha256-keeIonGNgE0U0IVi8DeXAy6ygTXVXH+WDjob36epUDI=";
+
+  preFixup = ''
+    mv $out/bin/rubyfmt{-main,}
+  '';
+
+  meta = with lib; {
+    description = "A Ruby autoformatter";
+    homepage = "https://github.com/fables-tales/rubyfmt";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bobvanderlinden ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17152,6 +17152,8 @@ with pkgs;
 
   rbenv = callPackage ../development/ruby-modules/rbenv { };
 
+  rubyfmt = callPackage ../development/tools/rubyfmt { };
+
   inherit (callPackage ../development/interpreters/ruby {
     inherit (darwin) libobjc libunwind;
     inherit (darwin.apple_sdk.frameworks) Foundation;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17152,7 +17152,10 @@ with pkgs;
 
   rbenv = callPackage ../development/ruby-modules/rbenv { };
 
-  rubyfmt = callPackage ../development/tools/rubyfmt { };
+  rubyfmt = callPackage ../development/tools/rubyfmt {
+    inherit (darwin.apple_sdk.frameworks) Foundation Security;
+    inherit (darwin) libobjc;
+  };
 
   inherit (callPackage ../development/interpreters/ruby {
     inherit (darwin) libobjc libunwind;


### PR DESCRIPTION
###### Description of changes

This adds the rubyfmt tool; a formatter for Ruby files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
