### PR TITLE
python3Packages.flit-scm: Fix src hash

### DIFF
--- a/pkgs/development/python-modules/flit-scm/default.nix
+++ b/pkgs/development/python-modules/flit-scm/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     owner = "WillDaSilva";
     repo = "flit_scm";
     rev = "refs/tags/${version}";
-    hash = "sha256-K5sH+oHgX/ftvhkY+vIg6wUokAP96YxrTWds3tnEtyg=";
+    hash = "sha256-2nx9kWq/2TzauOW+c67g9a3JZ2dhBM4QzKyK/sqWOPo=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;


### PR DESCRIPTION
The fetcher params were changed in the previous commit (de08f0ba6dec), but the hash wasn't updated.

- Built on platform(s)
  - [x] x86_64-linux

cc @mweinelt