### PR TITLE
solo5: mark broken

### DIFF
--- a/pkgs/os-specific/solo5/default.nix
+++ b/pkgs/os-specific/solo5/default.nix
@@ -54,7 +54,10 @@ in stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  doCheck = stdenv.hostPlatform.isLinux;
+  # Tests are failing
+  # https://gist.github.com/superherointj/e3b3929d16fbb39b7ff1740443e59675
+  doCheck = false;
+
   nativeCheckInputs = [ util-linux qemu ];
   checkPhase = ''
     runHook preCheck


### PR DESCRIPTION
solo5: disable tests
* Error logs: https://gist.github.com/superherointj/e3b3929d16fbb39b7ff1740443e59675

`solo5` shows up as downstream breakage in several PRs.

I have no context of `solo5`. I was unsure whether to mark broken (because I can't verify it's fine) or just skip tests.
Tried to build `ocaml-freestanding` (to validate package is fine) but errored too. Also errors mirage-crypto, checkseum, tcpip with flag withFreestanding enabled.

> nix build --impure --expr '(import ./. {}).ocaml-ng.ocamlPackages.tcpip.override({ withFreestanding = true; })'

I wish there was a way to somehow mark `ocaml-freestanding` as not buildable. Because it is, it just fails. More noise for downstream builds. :-(

Related: #153204