### PR TITLE
adi1090x-plymouth-themes: init at 2020-12-28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13567,6 +13567,15 @@
     githubId = 12828415;
     name = "Michel Weitbrecht";
   };
+  slwst = {
+    email = "email@slw.st";
+    github = "slwst";
+    githubId = 11047377;
+    name = "slwst";
+    keys = [{
+      fingerprint = "6CEB 4A2F E6DC C345 1B2B  4733 AD52 C5FB 3EFE CC7A";
+    }];
+  };
   smakarov = {
     email = "setser200018@gmail.com";
     github = "SeTSeR";

--- a/pkgs/data/themes/adi1090x-plymouth-themes/default.nix
+++ b/pkgs/data/themes/adi1090x-plymouth-themes/default.nix
@@ -1,0 +1,63 @@
+{
+  stdenv,
+  fetchurl,
+  lib,
+  unzip,
+  # To select only certain themes, pass `selected_themes` as a list of strings.
+  # reference ./shas.nix for available themes
+  selected_themes ? [],
+}: let
+  version = "2020-12-28";
+  # this file is generated via ./update.sh
+  # borrowed from pkgs/data/fonts/nerdfonts
+  themeShas = import ./shas.nix;
+  knownThemes = builtins.attrNames themeShas;
+  selectedThemes =
+    if (selected_themes == [])
+    then knownThemes
+    else let
+      unknown = lib.subtractLists knownThemes selected_themes;
+    in
+      if (unknown != [])
+      then throw "Unknown theme(s): ${lib.concatStringsSep " " unknown}"
+      else selected_themes;
+  srcs = lib.lists.forEach selectedThemes (
+    name: (fetchurl {
+      url = themeShas.${name}.url;
+      sha256 = themeShas.${name}.sha;
+    })
+  );
+in
+  stdenv.mkDerivation {
+    pname = "adi1090x-plymouth-themes";
+    inherit version srcs;
+
+    nativeBuildInputs = [
+      unzip
+    ];
+
+    sourceRoot = ".";
+    unpackCmd = "tar xzf $curSrc";
+
+    installPhase = ''
+      mkdir -p $out/share/plymouth/themes
+      for theme in ${toString selectedThemes}; do
+        mv $theme $out/share/plymouth/themes/$theme
+      done
+      find $out/share/plymouth/themes/ -name \*.plymouth -exec sed -i "s@\/usr\/@$out\/@" {} \;
+    '';
+
+    meta = with lib; {
+      description = "Plymouth boot themes from adi1090x";
+      longDescription = ''
+        A variety of plymouth boot screens by adi1090x.  Using the default value
+        of `selected_themes` will install all themes (~524M).  Consider overriding
+        this with a list of the string names of each theme to install.  Check
+        ./shas.nix for available themes.
+      '';
+      homepage = "https://github.com/adi1090x/plymouth-themes";
+      license = licenses.gpl3;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [slwst];
+    };
+  }

--- a/pkgs/data/themes/adi1090x-plymouth-themes/shas.nix
+++ b/pkgs/data/themes/adi1090x-plymouth-themes/shas.nix
@@ -1,0 +1,322 @@
+{
+  "abstract_ring" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/abstract_ring.tar.gz";
+    sha = "133gifr4571b14ci44jmm49j91yhq785yx4b3h6yvx0188liibr2";
+  };
+  "abstract_ring_alt" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/abstract_ring_alt.tar.gz";
+    sha = "157yg2y4vfwjfly2paq2xn1p6h2wrbvvzwy4lbpbhlmhyhrymjvj";
+  };
+  "alienware" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/alienware.tar.gz";
+    sha = "1i3i0gj927drbgivcx3fqj6fqdwm2gqy0wrwfkdqdjyqzq1286a5";
+  };
+  "angular" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/angular.tar.gz";
+    sha = "06n3ix7k8zpraqc75wy4fnk1bzcyhfajjxjq9kyy470wgsjrw6p4";
+  };
+  "angular_alt" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/angular_alt.tar.gz";
+    sha = "1l1iy9p0k4a8mcdps30avscjp6wfv20m9zy376r18y7xwcz19qbj";
+  };
+  "black_hud" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/black_hud.tar.gz";
+    sha = "13y32zxcshnfyjxs0r7f1sz010sr6brsaap90im2cb4rlvp0ajsz";
+  };
+  "blockchain" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/blockchain.tar.gz";
+    sha = "1f60nvrk506bqw47g90wzbvn3bp5h1gbi0ll5f3bd6wj77qfk05i";
+  };
+  "circle" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/circle.tar.gz";
+    sha = "04085lkh4i5diszpr1w5xnhnngp8ba1ckalcjj5s8hm8lk6wd4nc";
+  };
+  "circle_alt" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/circle_alt.tar.gz";
+    sha = "0awbjrd31fv2cb0q7n58h5iji29di8n550bmpz5qdg6xn55baqqx";
+  };
+  "circle_flow" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/circle_flow.tar.gz";
+    sha = "0ffxgjmx5la55dn3nyqgxi8fyd1ci4wckmvfaa6s1kyd7xsk8785";
+  };
+  "circle_hud" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/circle_hud.tar.gz";
+    sha = "0sd28d0ac7wvkwmbrnvg42bccz6y4iyl2wp1pg7awwjxvag0azlf";
+  };
+  "circuit" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/circuit.tar.gz";
+    sha = "1jzlr6c47n3zs0f1cafgjy92sks5060d1gs0774kxc0c96bysypg";
+  };
+  "colorful" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/colorful.tar.gz";
+    sha = "18lbyffvhdav5cjh0xnidf09amryf5dcj5rizl9z7ghxpz2z57pr";
+  };
+  "colorful_loop" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/colorful_loop.tar.gz";
+    sha = "0qcn19gxl9w2q0w7lihi8wnlwlh8h3k0ddbp3ww9wcw1q0wsy1vi";
+  };
+  "colorful_sliced" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/colorful_sliced.tar.gz";
+    sha = "0d9lafg76w2y77ywj1f1p5n1ci2q9jnfqfd16akf6f28h0iz1f9r";
+  };
+  "connect" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/connect.tar.gz";
+    sha = "1a0z59l391xv795d8mhcwa816wlmzyl75pwiizvvra2a0i8g6wz0";
+  };
+  "cross_hud" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/cross_hud.tar.gz";
+    sha = "188wj6hkvryawmw4r3bwcsvqxx52h10jb4ddq3jx7sh2rz1kpvwa";
+  };
+  "cubes" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/cubes.tar.gz";
+    sha = "0bydagjwfkvbhgr7sv903a7pjkrmrdz6vh22i4qjx5rhzw2wvvsk";
+  };
+  "cuts" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/cuts.tar.gz";
+    sha = "0znz82zzgyqkfprvzhkzv974amcnxqdg38ajsm4d7wlagc52zs0d";
+  };
+  "cuts_alt" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_1/cuts_alt.tar.gz";
+    sha = "1bgs4v5kkh96m1xh29wjmdxinfsxh4g7lg9fk1nqj87igdg7wwss";
+  };
+  "cyanide" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/cyanide.tar.gz";
+    sha = "04aklg9il310iv7zjpan6z4ha7gvh1b0yzgwi91679vm38cg0593";
+  };
+  "cybernetic" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/cybernetic.tar.gz";
+    sha = "0ad75fcra24bjzs4pqn89l19wb4rcjph63j71lv60m0rz75vgjfb";
+  };
+  "dark_planet" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/dark_planet.tar.gz";
+    sha = "03i2knrfi56f8lbc8hs8rqa4jg432nsmjn74wibb04ppmvm8f47j";
+  };
+  "darth_vader" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/darth_vader.tar.gz";
+    sha = "0mlxy17l1hjf3nq390wc26n4x3c45n5hmks75zkzjz3l5ac1fah6";
+  };
+  "deus_ex" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/deus_ex.tar.gz";
+    sha = "1mllj0xj9g1nn01vcq0xsfcwd0qnmk1s3vj5d03f9qp513k8qzdl";
+  };
+  "dna" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/dna.tar.gz";
+    sha = "0xcf4vxd99w3d44bhrdk1yqsfcakix6cd7hdpjsgccgs1jd02hi1";
+  };
+  "double" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/double.tar.gz";
+    sha = "07gxkzqrp0cfisdkq0wqfiai37m2yr2fhcpdpazmzkkxnm4qf25y";
+  };
+  "dragon" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/dragon.tar.gz";
+    sha = "0ypr1vyl6zilfzncymlh2s1ivxr7n88kfaygmz2y83l332asjs66";
+  };
+  "flame" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/flame.tar.gz";
+    sha = "0kvly5rgp47a4lby3blb1dird9xwy9y9c8a0wg17qfvz3zr69r0g";
+  };
+  "glitch" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/glitch.tar.gz";
+    sha = "0s0kmrw01wj9i7qd7zbwvmfbbh7r3jfkc4522jv44m4rl6r4h84c";
+  };
+  "glowing" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/glowing.tar.gz";
+    sha = "19nkbk2cw6j763idz5z7l71lx529xcgyx1dcd9qd356x9ifdw206";
+  };
+  "green_blocks" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/green_blocks.tar.gz";
+    sha = "0x8pgsyfbchy7z6d4rijsk2nml6fl1xwba0f0h3lw9i6359k7j3j";
+  };
+  "green_loader" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/green_loader.tar.gz";
+    sha = "00rdpy1gbc4ikxx487w3k27z622z2rjcsi0d18i23s5p3xqd1l3a";
+  };
+  "hexagon" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/hexagon.tar.gz";
+    sha = "0yk47hs5qfv09q5df4x6j82ivrxfxh1bxsw8p8x7hcmlb08dh6g6";
+  };
+  "hexagon_2" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/hexagon_2.tar.gz";
+    sha = "175im23q769s2if3xi8j669r0b5y0dagz8rsbvq7kghznzw4abc2";
+  };
+  "hexagon_alt" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/hexagon_alt.tar.gz";
+    sha = "1ayhw1gzrb98hf7f77b6ka5wi19ymp3mljhhgm5lx8w8pwawsxnb";
+  };
+  "hexagon_dots" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/hexagon_dots.tar.gz";
+    sha = "0pdw9ih9fsxvv394yc5vfj7nlq7mca9w05y0s631gnsdzgqxsyd6";
+  };
+  "hexagon_dots_alt" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/hexagon_dots_alt.tar.gz";
+    sha = "0aff3bgpva41b4jk4mp0fxdvli286x4pk3q9ysvps7z7srw4fvvn";
+  };
+  "hexagon_hud" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/hexagon_hud.tar.gz";
+    sha = "0wpmsffdp59dy2g5ggprgr7l50rf131c7v8pbgpir230lpn10xzi";
+  };
+  "hexagon_red" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_2/hexagon_red.tar.gz";
+    sha = "0fgmma5j6fnjykpwplji4rm57d07l9shfpay079gz1nhbhnq3rkl";
+  };
+  "hexa_retro" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/hexa_retro.tar.gz";
+    sha = "1cbyhqhv2ysx9w8cpbfidrm0w70wssp4fld0q1g01fgcbg93b7mf";
+  };
+  "hud" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/hud.tar.gz";
+    sha = "0s01p1n75ckwa69iy5v2z2cg85ipzgx356n4yvdyi1jh9pnl22k9";
+  };
+  "hud_2" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/hud_2.tar.gz";
+    sha = "1bvkl5f0fwi7xzy23pj3p7c98fbz2zk8abz7frxr0pp0xj3ql87i";
+  };
+  "hud_3" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/hud_3.tar.gz";
+    sha = "1n5qqkp0qb4mlpp7g20hpvazgwxw4gjb2p0ys0q2bglb3amzc2xr";
+  };
+  "hud_space" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/hud_space.tar.gz";
+    sha = "0dhajnica048smn5wpwc13ij0n9g6c10a0qxgi4rwiczr7p9vajj";
+  };
+  "ibm" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/ibm.tar.gz";
+    sha = "0xri6x716ma3y7d59yn9vm7skw5y53kn6s2ivfrvlfsac9n1zj4m";
+  };
+  "infinite_seal" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/infinite_seal.tar.gz";
+    sha = "0r9plydfdc35s2is1zi3pbx3s0bs5hqkim3laiav8fv3rzq0f3lq";
+  };
+  "ironman" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/ironman.tar.gz";
+    sha = "0af6qfdqj0n5qgsxg6nnrs2k8xas6cd18jw96mrwfcckpfz091cm";
+  };
+  "liquid" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/liquid.tar.gz";
+    sha = "0ghavh6nj68kwcgvrnwbabkzn44zq0m2ic1b2cl278d2vffzqv87";
+  };
+  "loader" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/loader.tar.gz";
+    sha = "1zlba3mra45ii0gahlw8v1vq1j7nbfjq62pcjn43vb40zcc1j873";
+  };
+  "loader_2" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/loader_2.tar.gz";
+    sha = "1yw4n9bw483pl7m3ks2ajgfldslgyc4gb1kw61fszfp5x4l3k4rg";
+  };
+  "loader_alt" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/loader_alt.tar.gz";
+    sha = "1pi97pfhg13wq5s8hai4fd31s6bcfq09r969fl216yxksj8h69wj";
+  };
+  "lone" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/lone.tar.gz";
+    sha = "0413mxr8lqlznbps5c4qgbhm0zpz8dlkbdj67r9gvzi9v020qjgl";
+  };
+  "metal_ball" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/metal_ball.tar.gz";
+    sha = "129q23q992fxfi976px5r68sf8wqbac3zby4yjh97s48zm83rzb5";
+  };
+  "motion" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/motion.tar.gz";
+    sha = "0g84ac8ps69ihic2z7gr4nlwib9ra86il2fdl7rl7w5nc8xzhx1y";
+  };
+  "optimus" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/optimus.tar.gz";
+    sha = "1l4bmbiqqypwqvyhcd561nnxhrq5zif8pmkyk2hdwscbq6rlbc7r";
+  };
+  "owl" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/owl.tar.gz";
+    sha = "03gqqcvp4320qy1d3az1k2a8rj97alk8qzgkz6xg4akz9ccd731y";
+  };
+  "pie" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/pie.tar.gz";
+    sha = "1j479l428gq1b2g0g2ybkf81jzad69n59kphm0ns5gfv6khx10ga";
+  };
+  "pixels" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/pixels.tar.gz";
+    sha = "13rfdd9v7h0k2wbwr428h2w8dv5vhhbw03wvirlmafsbhmgjz5xs";
+  };
+  "polaroid" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_3/polaroid.tar.gz";
+    sha = "096iz34hpmicixrdrqaxmx8m83vggm90xqz4zyy5vkpcy3vl60mf";
+  };
+  "red_loader" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/red_loader.tar.gz";
+    sha = "0n2jmfy558rma6knraskb7rgccvnayxh7csl0jaarx2xl9zxzzay";
+  };
+  "rings" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/rings.tar.gz";
+    sha = "1g9p2cdn1w7dmy2z017xdkv6rm50gdb5qqd8a0y0662fzph5adg0";
+  };
+  "rings_2" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/rings_2.tar.gz";
+    sha = "07v4mq1lpw9vfzg0rfxmkyfhyhz3nv5zab5kf10bjjgpjq8c9fi3";
+  };
+  "rog" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/rog.tar.gz";
+    sha = "13lcrsdk1v1xn7fxn54xbk1jkh55kmsf813q1v7x8a2l8p9pl0hp";
+  };
+  "rog_2" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/rog_2.tar.gz";
+    sha = "0cgc1y1jrb689h9wd7jf3wvf9r996k4ik965v4wclmp9wra5gflk";
+  };
+  "seal" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/seal.tar.gz";
+    sha = "0ip23x69ljdj1bwxlhvz3fbg3ia47m2aw6d122v2rqhwqasmy40n";
+  };
+  "seal_2" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/seal_2.tar.gz";
+    sha = "1fc91n6ys2fl8xbzdj0ywck87xnyn1gp4jvjk307w49jmkpdzs15";
+  };
+  "seal_3" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/seal_3.tar.gz";
+    sha = "1l2jlxhhaf5whbvbdf31ypcasalx4fsd4yn90xybmjq7b27bz5b2";
+  };
+  "sliced" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/sliced.tar.gz";
+    sha = "0363lwq3rwdcz3fg47f6kch150vxspvpjdqzg87aahli30kkjfdi";
+  };
+  "sphere" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/sphere.tar.gz";
+    sha = "1zjlwign7f2zd70qkg25adbbmq8ndm9b44gc4pa0ls64i6yfd6fz";
+  };
+  "spin" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/spin.tar.gz";
+    sha = "0hwjc4i69zmzw7cpmsrhmx00w5k5y46m317m1imw2ycmhm0jicm5";
+  };
+  "spinner_alt" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/spinner_alt.tar.gz";
+    sha = "1ifs9xxd1cxvgjcnqjfw2zxkcapssv10hvchjrlf9nl60ayyp4m4";
+  };
+  "splash" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/splash.tar.gz";
+    sha = "12l8hwzmi68mjqgl384wf1fscvnzwp4a3vmlsb2zcbfwhrs5q717";
+  };
+  "square" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/square.tar.gz";
+    sha = "1mpyrivchsj2gr8flwj0g45vb792fvjjb5jmkn9xz1glrxxs7zww";
+  };
+  "square_hud" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/square_hud.tar.gz";
+    sha = "1lvv00r5rg8yjwibfqncka1s0p59fnpklhz3v6ifbs7ynlyp0kag";
+  };
+  "target" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/target.tar.gz";
+    sha = "1ipsd3rjclmwzg2l4bxpj0mgfl5bwxs1ihf498660zhm0bqqpgpr";
+  };
+  "target_2" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/target_2.tar.gz";
+    sha = "16lipy5c0pyyb1idwj1zchfr8g0cy6qr46c87b8g1kv2g96n5cn6";
+  };
+  "tech_a" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/tech_a.tar.gz";
+    sha = "0fn8aib05kmjxnp7j2bmgrs3avaj6bn06kxz55bw8fdg8ihxnxg0";
+  };
+  "tech_b" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/tech_b.tar.gz";
+    sha = "03i8jcvql76mhcq0dqaj2wygfza72fc7c22vfcyp38cx1lm6ilbv";
+  };
+  "unrap" = {
+    url = "https://github.com/adi1090x/files/raw/1f8b8d834eb0978d8b0260ffd161e9997b3ee0a2/plymouth-themes/themes/pack_4/unrap.tar.gz";
+    sha = "08gqwb11539kz5178ga6f96jv82xmyyzv44q6d05ajcw3pxk5j4c";
+  };
+}

--- a/pkgs/data/themes/adi1090x-plymouth-themes/update.sh
+++ b/pkgs/data/themes/adi1090x-plymouth-themes/update.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash --keep GITHUB_TOKEN -p nix-prefetch jq
+
+set -eo pipefail
+
+curl_args=( '--silent' )
+
+# optionally takes a GITHUB_TOKEN to overcome api rate limiting.
+if [ -n "$GITHUB_TOKEN" ]; then curl_args+=( --header "authorization: Bearer ${GITHUB_TOKEN}" ); fi
+
+# get last master ref
+curl_args+=( --url https://api.github.com/repos/adi1090x/files/commits/master )
+last_ref=$(curl "${curl_args[@]}" | jq -r '.sha' )
+
+unset curl_args[-1]
+curl_args+=( https://api.github.com/repos/adi1090x/files/git/trees/$last_ref\?recursive=1 )
+
+theme_archives=$(curl "${curl_args[@]}" \
+  | jq '.tree | map(select(.path| test("^plymouth-themes/themes/pack_.*tar.gz$"))| .path)')
+
+dirname="$(dirname "$0")"
+
+printf '{\n' > "$dirname/shas.nix"
+
+repo_url="https://github.com/adi1090x/files/raw/$last_ref"
+
+while
+  read -r file_path
+do
+    name=$(basename $file_path)
+    printf '  "%s" = {\n    url = "%s";\n    sha = "%s";\n  };\n' "${name%%.*}" "$repo_url/$file_path" "$(nix-prefetch-url "$repo_url/$file_path")" >>"$dirname/shas.nix"
+done < <(jq -r '.[]' <<<"$theme_archives")
+
+printf '}\n' >> "$dirname/shas.nix"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26827,6 +26827,8 @@ with pkgs;
 
   adementary-theme = callPackage ../data/themes/adementary { };
 
+  adi1090x-plymouth-themes = callPackage ../data/themes/adi1090x-plymouth-themes { };
+
   adwaita-qt = libsForQt5.callPackage ../data/themes/adwaita-qt { };
 
   adwaita-qt6 = qt6Packages.callPackage ../data/themes/adwaita-qt {


### PR DESCRIPTION
###### Description of changes
* adi1090x-plymouth-themes: init at 2023-02-09

Provides Plymouth boot themes ported from android by adi1090x.  More info and theme previews available at [project upstream](https://github.com/adi1090x/plymouth-themes)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

