### PR TITLE
tts: 0.10.2 -> 0.11.1

### DIFF
--- a/pkgs/tools/audio/tts/default.nix
+++ b/pkgs/tools/audio/tts/default.nix
@@ -33,28 +33,15 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "tts";
-  version = "0.10.2";
+  version = "0.11.1";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "coqui-ai";
     repo = "TTS";
     rev = "refs/tags/v${version}";
-    hash = "sha256-IcuRhsURgEYIuS7ldZtxAy4Z/XNDehTGsOfYW+DhScg=";
+    hash = "sha256-EVFFETiGbrouUsrIhMFZEex3UGCCWTI3CC4yFAcERyw=";
   };
-
-  patches = [
-    # Use packaging.version for version comparisons
-    (fetchpatch {
-      url = "https://github.com/coqui-ai/TTS/commit/77a9ef8ac97ea1b0f7f8d8287dba69a74fdf22ce.patch";
-      hash = "sha256-zWJmINyxw2efhR9KIVkDPHao5703zlpCKwdzOh/1APY=";
-    })
-    # Fix espeak version detection logic
-    (fetchpatch {
-      url = "https://github.com/coqui-ai/TTS/commit/0031df0143b069d7db59ba04d1adfafcc1a92f47.patch";
-      hash = "sha256-6cL9YqWrB+0QomINpA9BxdYmEDpXF03udGEchydQmBA=";
-    })
-  ];
 
   postPatch = let
     relaxedConstraints = [
@@ -149,6 +136,7 @@ python.pkgs.buildPythonApplication rec {
     "test_models_offset_2_step_3"
     "test_run_all_models"
     "test_synthesize"
+    "test_voice_cloning"
     "test_voice_conversion"
     "test_multi_speaker_multi_lingual_model"
     "test_single_speaker_model"
@@ -166,9 +154,12 @@ python.pkgs.buildPythonApplication rec {
     "tests/tts_tests/test_align_tts_train.py"
     "tests/tts_tests/test_fast_pitch_speaker_emb_train.py"
     "tests/tts_tests/test_fast_pitch_train.py"
+    "tests/tts_tests/test_fastspeech_2_speaker_emb_train.py"
+    "tests/tts_tests/test_fastspeech_2_train.py"
     "tests/tts_tests/test_glow_tts_d-vectors_train.py"
     "tests/tts_tests/test_glow_tts_speaker_emb_train.py"
     "tests/tts_tests/test_glow_tts_train.py"
+    "tests/tts_tests/test_neuralhmm_tts_train.py"
     "tests/tts_tests/test_overflow_train.py"
     "tests/tts_tests/test_speedy_speech_train.py"
     "tests/tts_tests/test_tacotron2_d-vectors_train.py"


### PR DESCRIPTION
https://github.com/coqui-ai/TTS/releases/tag/v0.11.0
https://github.com/coqui-ai/TTS/releases/tag/v0.11.1

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
