### PR TITLE
enc: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12815,6 +12815,12 @@
     githubId = 5236428;
     name = "Gaëtan André";
   };
+  rvnstn = {
+    email = "github@rvnstn.de";
+    github = "rvnstn";
+    githubId = 2364742;
+    name = "Tobias Ravenstein";
+  };
   rvolosatovs = {
     email = "rvolosatovs@riseup.net";
     github = "rvolosatovs";

--- a/pkgs/tools/security/enc/default.nix
+++ b/pkgs/tools/security/enc/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, git
+, installShellFiles
+}:
+
+buildGoModule rec {
+  pname = "enc";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "life4";
+    repo = "enc";
+    rev = "v${version}";
+    sha256 = "Tt+J/MnYJNewSl5UeewS0b47NGW2yzfcVHA5+9UQWSs=";
+  };
+  vendorSha256 = "lB6GkE6prfBG7OCOJ1gm23Ee5+nAgmJg8I9Nqe1fsRw=";
+
+  proxyVendor = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  subPackages = ".";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/life4/enc/version.GitCommit=${version}"
+  ];
+
+  nativeCheckInputs = [ git ];
+
+  postInstall = ''
+    installShellCompletion --cmd enc \
+      --bash <($out/bin/enc completion bash) \
+      --fish <($out/bin/enc completion fish) \
+      --zsh <($out/bin/enc completion zsh)
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/life4/enc";
+    changelog = "https://github.com/life4/enc/releases/tag/v${version}";
+    description = "A modern and friendly alternative to GnuPG";
+    longDescription = ''
+      Enc is a CLI tool for encryption, a modern and friendly alternative to GnuPG.
+      It is easy to use, secure by default and can encrypt and decrypt files using password or encryption keys,
+      manage and download keys, and sign data.
+      Our goal was to make encryption available to all engineers without the need to learn a lot of new words, concepts,
+      and commands. It is the most beginner-friendly CLI tool for encryption, and keeping it that way is our top priority.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ rvnstn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7039,6 +7039,8 @@ with pkgs;
     boost = boost172;
   };
 
+  enc = callPackage ../tools/security/enc { };
+
   endlessh = callPackage ../servers/endlessh { };
 
   endlessh-go = callPackage ../servers/endlessh-go { };


### PR DESCRIPTION
###### Description of changes

Added enc version 1.1.0

Enc is a CLI tool for encryption, a modern and friendly alternative to [GnuPG](https://gnupg.org/). It is easy to use, secure by default and can encrypt and decrypt files using password or encryption keys, manage and download keys, and sign data. Our goal was to make encryption available to all engineers without the need to learn a lot of new words, concepts, and commands. It is the most beginner-friendly CLI tool for encryption, and keeping it that way is our top priority.
[enc GitHub repository](https://github.com/life4/enc)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).