### PR TITLE
vmTools: update debian versions

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1032,22 +1032,22 @@ rec {
     };
 
     debian11i386 = {
-      name = "debian-11.5-bullseye-i386";
-      fullName = "Debian 11.5 Bullseye (i386)";
+      name = "debian-11.6-bullseye-i386";
+      fullName = "Debian 11.6 Bullseye (i386)";
       packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20221126T084953Z/dists/bullseye/main/binary-i386/Packages.xz";
-        hash = "sha256-tHrWSd4K5TCwIaLTPqK/Rcon0O0r+Jsxb7OcchOo8Vo=";
+        url = "https://snapshot.debian.org/archive/debian/20230131T034648Z/dists/bullseye/main/binary-i386/Packages.xz";
+        hash = "sha256-z9eG7RlvelEnZAaeCfIO+XxTZVL3d+zTA7ShU43l/pw=";
       };
       urlPrefix = "mirror://debian";
       packages = commonDebianPackages;
     };
 
     debian11x86_64 = {
-      name = "debian-11.5-bullseye-amd64";
-      fullName = "Debian 11.5 Bullseye (amd64)";
+      name = "debian-11.6-bullseye-amd64";
+      fullName = "Debian 11.6 Bullseye (amd64)";
       packagesList = fetchurl {
-        url = "https://snapshot.debian.org/archive/debian/20221126T084953Z/dists/bullseye/main/binary-amd64/Packages.xz";
-        hash = "sha256-whpBERKOPyhrWguVQ2QchrwRHU4tCkGwu42x6khF/2g=";
+        url = "https://snapshot.debian.org/archive/debian/20230131T034648Z/dists/bullseye/main/binary-amd64/Packages.xz";
+        hash = "sha256-mz0eCWdn6uWt40OxsSPheHzEnMeLE52yR/vpb48/VF0=";
       };
       urlPrefix = "mirror://debian";
       packages = commonDebianPackages;


### PR DESCRIPTION
###### Description of changes
Fixes error:
```sh
base-files_11.1+deb11u5_amd64.deb> trying https://httpredir.debian.org/debian/pool/main/b/base-files/base-files_11.1+deb11u5_amd64.deb
base-files_11.1+deb11u5_amd64.deb>   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
base-files_11.1+deb11u5_amd64.deb>                                  Dload  Upload   Total   Spent    Left  Speed
base-files_11.1+deb11u5_amd64.deb>   0   260    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
base-files_11.1+deb11u5_amd64.deb> curl: (22) The requested URL returned error: 404
```

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
