### PR TITLE
python310Packages: Improve unsupported throws

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -66,7 +66,7 @@ buildPythonPackage rec {
       "x86_64-darwin"  = "-std=c++11 -lc -D_REENTRANT -dynamiclib -o attach_x86_64.dylib";
       "i686-darwin"    = "-std=c++11 -lc -D_REENTRANT -dynamiclib -o attach_x86.dylib";
       "aarch64-darwin" = "-std=c++11 -lc -D_REENTRANT -dynamiclib -o attach_arm64.dylib";
-    }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}")}
+    }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system} for package ${pname}")}
   )'';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/home-assistant-chip-core/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-core/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
         name = "x86_64";
         hash = "sha256-zXxbDGfyFUXuEnaH4a8R4LXH0gfbMCkKPBJJGp77xHM=";
       };
-    }.${stdenv.system} or (throw "Unsupported system");
+    }.${stdenv.system} or (throw "Unsupported system ${stdenv.system} for package ${pname}");
   in fetchPypi {
     pname = "home_assistant_chip_core";
     inherit version format;

--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -21,8 +21,10 @@
 }:
 
 let
+  pname = "playwright";
+
   inherit (stdenv.hostPlatform) system;
-  throwSystem = throw "Unsupported system: ${system}";
+  throwSystem = throw "Unsupported system ${system} for package ${pname}";
 
   driverVersion = "1.27.1";
 
@@ -135,7 +137,7 @@ let
   '');
 in
 buildPythonPackage rec {
-  pname = "playwright";
+  inherit pname;
   version = "1.27.1";
   format = "setuptools";
   disabled = pythonOlder "3.7";

--- a/pkgs/development/python-modules/torch/bin.nix
+++ b/pkgs/development/python-modules/torch/bin.nix
@@ -17,16 +17,14 @@
 }:
 
 let
+  pname = "torch";
+  version = "1.13.1"; # Don't forget to update torch to the same version.
+
   pyVerNoDot = builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
   srcs = import ./binary-hashes.nix version;
-  unsupported = throw "Unsupported system";
-  version = "1.13.1";
+  unsupported = throw "Unsupported system ${stdenv.system} for package ${pname}-bin";
 in buildPythonPackage {
-  inherit version;
-
-  pname = "torch";
-  # Don't forget to update torch to the same version.
-
+  inherit pname version;
   format = "wheel";
 
   disabled = !(isPy37 || isPy38 || isPy39 || isPy310);

--- a/pkgs/development/python-modules/torchaudio/bin.nix
+++ b/pkgs/development/python-modules/torchaudio/bin.nix
@@ -18,9 +18,10 @@ buildPythonPackage rec {
   format = "wheel";
 
   src =
-    let pyVerNoDot = lib.replaceStrings [ "." ] [ "" ] python.pythonVersion;
-        unsupported = throw "Unsupported system";
-        srcs = (import ./binary-hashes.nix version)."${stdenv.system}-${pyVerNoDot}" or unsupported;
+    let
+     pyVerNoDot = lib.replaceStrings [ "." ] [ "" ] python.pythonVersion;
+     unsupported = throw "Unsupported system ${stdenv.system} for package ${pname}-bin";
+     srcs = (import ./binary-hashes.nix version)."${stdenv.system}-${pyVerNoDot}" or unsupported;
     in fetchurl srcs;
 
   disabled = !(isPy37 || isPy38 || isPy39 || isPy310);

--- a/pkgs/development/python-modules/torchvision/bin.nix
+++ b/pkgs/development/python-modules/torchvision/bin.nix
@@ -13,14 +13,13 @@
 }:
 
 let
+  pname = "torchvision";
   pyVerNoDot = builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
   srcs = import ./binary-hashes.nix version;
-  unsupported = throw "Unsupported system";
+  unsupported = throw "Unsupported system ${stdenv.system} for package ${pname}-bin";
   version = "0.14.1";
 in buildPythonPackage {
-  inherit version;
-
-  pname = "torchvision";
+  inherit pname version;
 
   format = "wheel";
 


### PR DESCRIPTION
by consistently printing the system and package name.

```diff
❯ nix-build -A tts --system aarch64-linux
-error: Unsupported system
+error: Unsupported system aarch64-linux for package torch-bin
```


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
