### PR TITLE
geogram: init at 1.8.3

### DIFF
--- a/pkgs/development/libraries/geogram/default.nix
+++ b/pkgs/development/libraries/geogram/default.nix
@@ -1,0 +1,128 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchFromGitHub
+
+, cmake
+, doxygen
+, zlib
+, python3Packages
+}:
+
+let
+  testdata = fetchFromGitHub {
+    owner = "BrunoLevy";
+    repo = "geogram.data";
+    rev = "8fd071a560bd6859508f1710981386d0b2ba01b1";
+    hash = "sha256-jMUGX6/uYIZMVwXxTAAGUaOXqF+NrFQqgmIPCD58cwM=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "geogram";
+  version = "1.8.3";
+
+  src = fetchurl {
+    url = "https://github.com/BrunoLevy/geogram/releases/download/v${version}/geogram_${version}.tar.gz";
+    hash = "sha256-91q0M/4kAr0UoWXOQIEYS1VbgEQ/F4EBOfJE9Vr1bnw=";
+  };
+
+  outputs = [ "bin" "lib" "dev" "doc" "out" ];
+
+  cmakeFlags = [
+    # Triangle is unfree
+    "-DGEOGRAM_WITH_TRIANGLE=OFF"
+
+    # Disable some extra features (feel free to create a PR if you need one of those)
+
+    # If GEOGRAM_WITH_LEGACY_NUMERICS is enabled GeoGram will build its own version of
+    # ARPACK, CBLAS, CLAPACK, LIBF2C and SUPERLU
+    "-DGEOGRAM_WITH_LEGACY_NUMERICS=OFF"
+
+    # Don't build Lua
+    "-DGEOGRAM_WITH_LUA=OFF"
+
+    # Disable certain features requiring GLFW
+    "-DGEOGRAM_WITH_GRAPHICS=OFF"
+
+    # NOTE: Options introduced by patch (see below)
+    "-DGEOGRAM_INSTALL_CMAKE_DIR=${placeholder "dev"}/lib/cmake"
+    "-DGEOGRAM_INSTALL_PKGCONFIG_DIR=${placeholder "dev"}/lib/pkgconfig"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+  ];
+
+  buildInputs = [
+    zlib
+  ];
+
+  patches = [
+    # See https://github.com/BrunoLevy/geogram/pull/76
+    ./fix-cmake-install-destination.patch
+
+    # This patch replaces the bundled (outdated) zlib with our zlib
+    # Should be harmless, but if there are issues this patch can also be removed
+    # Also check https://github.com/BrunoLevy/geogram/issues/49 for progress
+    ./replace-bundled-zlib.patch
+  ];
+
+  postPatch = lib.optionalString stdenv.isAarch64 ''
+    substituteInPlace cmake/platforms/*/config.cmake \
+      --replace "-m64" ""
+  '';
+
+  postBuild = ''
+    make doc-devkit-full
+  '';
+
+  nativeCheckInputs = [
+    python3Packages.robotframework
+  ];
+
+  doCheck = true;
+
+  checkPhase =
+    let
+      skippedTests = [
+        # Failing tests as of version 1.8.3
+        "FileConvert"
+        "Reconstruct"
+        "Remesh"
+
+        # Skip slow RVD test
+        "RVD"
+      ];
+    in
+    ''
+      runHook preCheck
+
+      ln -s ${testdata} ../tests/data
+
+      source tests/testenv.sh
+      robot \
+        ${lib.concatMapStringsSep " " (t: lib.escapeShellArg "--skip=${t}") skippedTests} \
+        ../tests
+
+      runHook postCheck
+    '';
+
+  meta = with lib; {
+    description = "Programming Library with Geometric Algorithms";
+    longDescription = ''
+      Geogram contains the main results in Geometry Processing from the former ALICE Inria project,
+      that is, more than 30 research articles published in ACM SIGGRAPH, ACM Transactions on Graphics,
+      Symposium on Geometry Processing and Eurographics.
+    '';
+    homepage = "https://github.com/BrunoLevy/geogram";
+    license = licenses.bsd3;
+
+    # Broken on aarch64-linux as of version 1.8.3
+    # See https://github.com/BrunoLevy/geogram/issues/74
+    broken = stdenv.isLinux && stdenv.isAarch64;
+
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    maintainers = with maintainers; [ tmarkus ];
+  };
+}

--- a/pkgs/development/libraries/geogram/fix-cmake-install-destination.patch
+++ b/pkgs/development/libraries/geogram/fix-cmake-install-destination.patch
@@ -1,0 +1,92 @@
+--- a/cmake/utilities.cmake	1970-01-01 01:00:01.000000000 +0100
++++ b/cmake/utilities.cmake	2023-03-09 19:28:16.556251981 +0100
+@@ -241,9 +241,9 @@
+     install(
+         TARGETS ${ARGN}
+         COMPONENT runtime
+-        RUNTIME DESTINATION bin
+-        LIBRARY DESTINATION lib
+-        ARCHIVE DESTINATION lib
++        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     )
+ endfunction()
+ 
+@@ -270,9 +270,9 @@
+         install(
+             TARGETS ${ARGN}
+             COMPONENT ${component}
+-            RUNTIME DESTINATION bin
+-            LIBRARY DESTINATION lib
+-            ARCHIVE DESTINATION lib
++            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         )
+     endforeach()
+ endfunction()
+--- a/src/lib/geogram/CMakeLists.txt	1970-01-01 01:00:01.000000000 +0100
++++ b/src/lib/geogram/CMakeLists.txt	2023-03-09 20:29:12.346780432 +0100
+@@ -76,7 +76,7 @@
+ # Install include files for the standard devkit
+ install(
+     DIRECTORY api
+-    DESTINATION include/${VORPALINE_INCLUDE_SUBPATH}/geogram
++    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${VORPALINE_INCLUDE_SUBPATH}/geogram
+     COMPONENT devkit
+     FILES_MATCHING PATTERN *.h
+ )
+@@ -84,7 +84,7 @@
+ # Install include files for the full devkit
+ install(
+     DIRECTORY .
+-    DESTINATION include/${VORPALINE_INCLUDE_SUBPATH}/geogram
++    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${VORPALINE_INCLUDE_SUBPATH}/geogram
+     COMPONENT devkit-full
+     FILES_MATCHING PATTERN *.h
+     # Exclude all files related to licensing
+@@ -93,7 +93,7 @@
+ 
+ install(
+         FILES "${PROJECT_BINARY_DIR}/geogram${VORPALINE_VERSION_MAJOR}.pc"
+-        DESTINATION lib${LIB_SUFFIX}/pkgconfig
++        DESTINATION ${GEOGRAM_INSTALL_PKGCONFIG_DIR}
+ )
+ 
+ 
+--- a/CMakeLists.txt	1970-01-01 01:00:01.000000000 +0100
++++ b/CMakeLists.txt	2023-03-09 20:40:20.075218356 +0100
+@@ -158,7 +158,7 @@
+ 
+ # FindGeogram.cmake
+ 
+-install(FILES cmake/FindGeogram.cmake DESTINATION lib/cmake/modules COMPONENT devkit)
++install(FILES cmake/FindGeogram.cmake DESTINATION ${GEOGRAM_INSTALL_CMAKE_DIR} COMPONENT devkit)
+ 
+ # Configure CPack
+ 
+--- a/doc/CMakeLists.txt	1970-01-01 01:00:01.000000000 +0100
++++ b/doc/CMakeLists.txt	2023-03-09 21:12:04.386327003 +0100
+@@ -25,14 +25,14 @@
+ 
+   # Install documentation
+   if(GEOGRAM_WITH_VORPALINE)
+-      install(FILES README.txt DESTINATION doc COMPONENT runtime)
+-      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/LICENSE.txt DESTINATION doc COMPONENT runtime OPTIONAL)
++      install(FILES README.txt DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT runtime)
++      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/LICENSE.txt DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT runtime OPTIONAL)
+   endif()
+ 
+-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/VERSION.txt DESTINATION doc/geogram COMPONENT runtime OPTIONAL)
+-  
+-  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/devkit/html DESTINATION doc/devkit COMPONENT doc-devkit OPTIONAL)
+-  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/devkit-full/html DESTINATION doc/devkit COMPONENT doc-devkit-full OPTIONAL)
+-  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/devkit-internal/html DESTINATION doc/devkit COMPONENT doc-devkit-internal OPTIONAL)
++  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/VERSION.txt DESTINATION ${CMAKE_INSTALL_DOCDIR}/geogram COMPONENT runtime OPTIONAL)
++
++  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/devkit/html DESTINATION ${CMAKE_INSTALL_DOCDIR}/devkit COMPONENT doc-devkit OPTIONAL)
++  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/devkit-full/html DESTINATION ${CMAKE_INSTALL_DOCDIR}/devkit COMPONENT doc-devkit-full OPTIONAL)
++  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/devkit-internal/html DESTINATION ${CMAKE_INSTALL_DOCDIR}/devkit COMPONENT doc-devkit-internal OPTIONAL)
+ 
+ endif()

--- a/pkgs/development/libraries/geogram/replace-bundled-zlib.patch
+++ b/pkgs/development/libraries/geogram/replace-bundled-zlib.patch
@@ -1,0 +1,46 @@
+--- a/src/lib/geogram/third_party/CMakeLists.txt	1970-01-01 01:00:01.000000000 +0100
++++ b/src/lib/geogram/third_party/CMakeLists.txt	2023-03-09 20:46:16.740801862 +0100
+@@ -33,7 +33,6 @@
+ aux_source_directories(SOURCES "Source Files\\LM6"          LM7)
+ aux_source_directories(SOURCES "Source Files\\rply"         rply)
+ aux_source_directories(SOURCES "Source Files\\shewchuk"     shewchuk)
+-aux_source_directories(SOURCES "Source Files\\zlib"         zlib)
+ aux_source_directories(SOURCES "Source Files\\PoissonRecon" PoissonRecon)
+ aux_source_directories(SOURCES "Source Files\\xatlas"       xatlas)
+ 
+--- a/src/lib/geogram/CMakeLists.txt	1970-01-01 01:00:01.000000000 +0100
++++ b/src/lib/geogram/CMakeLists.txt	2023-03-09 20:49:21.080059939 +0100
+@@ -70,6 +70,9 @@
+     target_link_libraries(geogram psapi)
+ endif()
+ 
++find_package(ZLIB REQUIRED)
++target_link_libraries(geogram ZLIB::ZLIB)
++
+ # Install the library
+ install_devkit_targets(geogram)
+ 
+--- a/src/lib/geogram/basic/geofile.h	1970-01-01 01:00:01.000000000 +0100
++++ b/src/lib/geogram/basic/geofile.h	2023-03-09 20:52:33.713329571 +0100
+@@ -44,7 +44,7 @@
+ #include <geogram/basic/numeric.h>
+ #include <geogram/basic/memory.h>
+ #include <geogram/basic/string.h>
+-#include <geogram/third_party/zlib/zlib.h>
++#include <zlib.h>
+ 
+ #include <stdexcept>
+ #include <fstream>
+--- a/src/lib/geogram/third_party/CMakeLists.txt	1970-01-01 01:00:01.000000000 +0100
++++ b/src/lib/geogram/third_party/CMakeLists.txt	2023-03-09 20:54:50.276520762 +0100
+@@ -60,8 +59,10 @@
+     ${ANDROID_NDK}/sources/android/native_app_glue
+   )
+   message(STATUS "building for Android")
+ endif()  
+ 
++find_package(ZLIB REQUIRED)
++target_link_libraries(geogram_third_party PUBLIC ZLIB::ZLIB)
+ 
+ set_target_properties(
+     geogram_third_party PROPERTIES

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19755,6 +19755,8 @@ with pkgs;
     geoipDatabase = geolite-legacy;
   };
 
+  geogram = callPackage ../development/libraries/geogram { };
+
   geographiclib = callPackage ../development/libraries/geographiclib { };
 
   geoip = callPackage ../development/libraries/geoip { };


### PR DESCRIPTION
###### Description of changes

Add the [Geogram](https://github.com/BrunoLevy/geogram) library.
Part of an ongoing effort to package [Meshroom](https://github.com/alicevision/Meshroom) (https://github.com/NixOS/nixpkgs/issues/94127).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
