### PR TITLE
python310Packages.pytapo: init at 2.9.2

### DIFF
--- a/pkgs/development/python-modules/pytapo/default.nix
+++ b/pkgs/development/python-modules/pytapo/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+
+# propagates
+, pycryptodome
+, requests
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "pytapo";
+  version = "2.9.2";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-LW14uDQBqIVsigOzO0bNTpjY7Fk0IWAeDMPEuWM/nOo=";
+  };
+
+  propagatedBuildInputs = [
+    pycryptodome
+    requests
+    urllib3
+  ];
+
+  pythonImportsCheck = [
+    "pytapo"
+  ];
+
+  # Tests require actual hardware
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python library for communication with Tapo Cameras ";
+    homepage = "https://github.com/JurajNyiri/pytapo";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fleaz ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8772,6 +8772,8 @@ self: super: with self; {
 
   pytap2 = callPackage ../development/python-modules/pytap2 { };
 
+  pytapo = callPackage ../development/python-modules/pytapo { };
+
   pytautulli = callPackage ../development/python-modules/pytautulli { };
 
   pyte = callPackage ../development/python-modules/pyte { };


### PR DESCRIPTION
###### Description of changes

Python library for communication with Tapo cameras from TP-Link. This is e.g. required when using the custom "tapo" integration from HACS in Home Assistant. 

Tests require access to an actual camera, therefore I disabled them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
