### PR TITLE
nix-your-shell: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -169,6 +169,12 @@
     githubId = 12578560;
     name = "Quinn Bohner";
   };
+  _9999years = {
+    email = "rbt@fastmail.com";
+    github = "9999years";
+    githubId = 15312184;
+    name = "Rebecca Turner";
+  };
   a1russell = {
     email = "adamlr6+pub@gmail.com";
     github = "a1russell";

--- a/pkgs/shells/nix-your-shell/default.nix
+++ b/pkgs/shells/nix-your-shell/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, nix-update-script
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "nix-your-shell";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "MercuryTechnologies";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-kdZFwMHatnhdXGSIItuE3g27qqUKqT/Hkbz13Ba5eq4=";
+  };
+
+  cargoSha256 = "sha256-U4nN/N345XFRj0L9cLJAjRuND0W3OE6XEB/z3zXaUiQ=";
+
+  meta = with lib; {
+    description = "A `nix` and `nix-shell` wrapper for shells other than `bash`";
+    homepage = "https://github.com/MercuryTechnologies/nix-your-shell";
+    license = [ licenses.mit ];
+    maintainers = [ maintainers._9999years ];
+  };
+
+  passthru.updateScript = nix-update-script { };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13840,6 +13840,8 @@ with pkgs;
 
   any-nix-shell = callPackage ../shells/any-nix-shell { };
 
+  nix-your-shell = callPackage ../shells/nix-your-shell { };
+
   bash = lowPrio (callPackage ../shells/bash/5.nix {
     binutils = stdenv.cc.bintools;
   });


### PR DESCRIPTION
###### Description of changes

An `any-nix-shell` alternative with support for `nix develop` / flakes.

https://github.com/MercuryTechnologies/nix-your-shell

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).