### PR TITLE
python311Packages.aiocache: 0.11.1 -> 0.12.0

### DIFF
--- a/pkgs/development/python-modules/aiocache/default.nix
+++ b/pkgs/development/python-modules/aiocache/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   passthru.optional-dependencies = {
     redis = [
-      redis
+      aioredis
     ];
     msgpack = [
       msgpack

--- a/pkgs/development/python-modules/aiocache/default.nix
+++ b/pkgs/development/python-modules/aiocache/default.nix
@@ -3,17 +3,21 @@
 , buildPythonPackage
 , fetchFromGitHub
 , msgpack
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aiocache";
   version = "0.12.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-jNfU5jT2xLgwVeVp8jXrQ6QQuUDwMOxf+hZ7VFsMFpM=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-jNfU5jT2xLgwVeVp8jXrQ6QQuUDwMOxf+hZ7VFsMFpM=";
   };
 
   propagatedBuildInputs = [
@@ -23,11 +27,15 @@ buildPythonPackage rec {
 
   # aiomcache would be required but last release was in 2017
   doCheck = false;
-  pythonImportsCheck = [ "aiocache" ];
+
+  pythonImportsCheck = [
+    "aiocache"
+  ];
 
   meta = with lib; {
     description = "Python API Rate Limit Decorator";
-    homepage = "https://github.com/tomasbasham/ratelimit";
+    homepage = "https://github.com/aio-libs/aiocache";
+    changelog = "https://github.com/aio-libs/aiocache/releases/tag/v${version}";
     license = with licenses; [ bsd3 ];
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/aiocache/default.nix
+++ b/pkgs/development/python-modules/aiocache/default.nix
@@ -20,10 +20,14 @@ buildPythonPackage rec {
     hash = "sha256-jNfU5jT2xLgwVeVp8jXrQ6QQuUDwMOxf+hZ7VFsMFpM=";
   };
 
-  propagatedBuildInputs = [
-    aioredis
-    msgpack
-  ];
+  passthru.optional-dependencies = {
+    redis = [
+      redis
+    ];
+    msgpack = [
+      msgpack
+    ];
+  };
 
   # aiomcache would be required but last release was in 2017
   doCheck = false;

--- a/pkgs/development/python-modules/aiocache/default.nix
+++ b/pkgs/development/python-modules/aiocache/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "aiocache";
-  version = "0.11.1";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = pname;
-    rev = version;
-    sha256 = "1czs8pvhzi92qy2dch2995rb62mxpbhd80dh2ir7zpa9qcm6wxvx";
+    rev = "v${version}";
+    sha256 = "sha256-jNfU5jT2xLgwVeVp8jXrQ6QQuUDwMOxf+hZ7VFsMFpM=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyflunearyou/default.nix
+++ b/pkgs/development/python-modules/pyflunearyou/default.nix
@@ -9,6 +9,7 @@
 , pytest-aiohttp
 , pytestCheckHook
 , pythonOlder
+, pythonRelaxDepsHook
 , msgpack
 , ujson
 }:
@@ -27,13 +28,14 @@ buildPythonPackage rec {
     sha256 = "sha256-Q65OSE4qckpvaIvZULBR434i7hwuVM97eSq1Blb1oIU=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'ujson = ">=1.35,<5.0"' 'ujson = "*"'
-  '';
+  pythonRelaxDeps = [
+    "aiocache"
+    "ujson"
+  ];
 
   nativeBuildInputs = [
     poetry-core
+    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
python311Packages.aiocache: 0.11.1 -> 0.12.0

Release: https://github.com/aio-libs/aiocache/releases/tag/v0.12.0

Diff: https://github.com/aio-libs/aiocache/compare/0.11.1...v0.12.0

Note: `aiocache` version 0.11.1 is currently broken for Python 3.11. This fixes it.

(This PR is result from downstream build errors in SDL2 PR.)