### PR TITLE
tvnamer: fix building on all platforms

### DIFF
--- a/pkgs/development/python-modules/tvdb_api/default.nix
+++ b/pkgs/development/python-modules/tvdb_api/default.nix
@@ -1,17 +1,19 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , requests-cache
 , pytest
 }:
 
 buildPythonPackage rec {
   pname = "tvdb_api";
-  version = "3.1.0";
+  version = "3.2.0-beta";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "f63f6db99441bb202368d44aaabc956acc4202b18fc343a66bf724383ee1f563";
+  src = fetchFromGitHub {
+    owner = "dbr";
+    repo = "tvdb_api";
+    rev = "ce0382181a9e08a5113bfee0fed2c78f8b1e613f";
+    sha256 = "sha256-poUuwySr6+8U9PIHhqFaR7nXzh8kSaW7mZkuKTUJKj8=";
   };
 
   propagatedBuildInputs = [ requests-cache ];
@@ -26,7 +28,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/dbr/tvdb_api";
     license = licenses.unlicense;
     maintainers = with maintainers; [ peterhoeg ];
-    # https://github.com/dbr/tvdb_api/issues/94
-    broken = true;
   };
 }

--- a/pkgs/tools/misc/tvnamer/default.nix
+++ b/pkgs/tools/misc/tvnamer/default.nix
@@ -4,15 +4,19 @@
 
 let
   python' = python3.override {
-    packageOverrides = self: super: rec {
+    packageOverrides = final: prev: rec {
       # tvdb_api v3.1.0 has a hard requirement on requests-cache < 0.6
-      requests-cache = super.requests-cache.overridePythonAttrs (super: rec {
+      requests-cache = prev.requests-cache.overridePythonAttrs (oldAttrs: rec {
         version = "0.5.2";
-        src = self.fetchPypi {
-          inherit (super) pname;
+        src = final.fetchPypi {
+          inherit (oldAttrs) pname;
           inherit version;
           sha256 = "sha256-gTAjJpaGBF+OAeIonMHn6a5asi3dHihJqQk6s6tycOs=";
         };
+
+        nativeBuildInputs = with final; [
+          setuptools
+        ];
 
         # too many changes have been made to requests-cache based on version 0.6 so
         # simply disable tests


### PR DESCRIPTION
###### Description of changes

This change unblocks tvnamer by using the latest version of tvnamer. In addition, it fixes the build of requests-cache 0.5.2 dependency, that was missing setuptools.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
