### PR TITLE
flutter: 3.3.8 -> 3.7.3

### DIFF
--- a/pkgs/applications/misc/yubioath-flutter/default.nix
+++ b/pkgs/applications/misc/yubioath-flutter/default.nix
@@ -10,8 +10,8 @@
 }:
 let
   vendorHashes = {
-    x86_64-linux = "sha256-Upe0cEDG02RJD50Ht9VNMwkelsJHX8zOuJZssAhMuMY=";
-    aarch64-linux = "sha256-lKER4+gcyFqnCvgBl/qdVBCbUpocWUnXGLXsX82MSy4=";
+    x86_64-linux = "sha256-eTpbccqcCliejc0SHzj7YS8D2+WZmcmSJVPhV46IX+U=";
+    aarch64-linux = "sha256-76NiHYAUu25dMsyCgj8hIq6Kd+uHT3PHZLiCraHpMSE=";
   };
 in
 flutter.mkFlutterApp rec {

--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -31,12 +31,12 @@ in
   inherit mkFlutter flutterDrv flutter2Patches flutter3Patches;
   stable = flutterDrv {
     pname = "flutter";
-    version = "3.3.8";
-    dartVersion = "2.18.4";
-    hash = "sha256-QH+10F6a0XYEvBetiAi45Sfy7WTdVZ1i8VOO4JuSI24=";
+    version = "3.7.3";
+    dartVersion = "2.19.2";
+    hash = "sha256-ez0pAM4ONn1z2FWR1dQ6EflKIjJ43TIgd2sDqD4jSGU=";
     dartHash = {
-      x86_64-linux = "sha256-lFw+KaxzhuAMnu6ypczINqywzpiD+8Kd+C/UHJDrO9Y=";
-      aarch64-linux = "sha256-snlFTY4oJ4ALGLc210USbI2Z///cx1IVYUWm7Vo5z2I=";
+      x86_64-linux = "sha256-Mm9gharzpnM/PPLvrOGFE6+9B8cOQGjE2pxogBYd2ys=";
+      aarch64-linux = "sha256-TG9ROb3nn1V6+SeQ0hnmTxouBDpleEjlYY77y4L5t34=";
     };
     patches = flutter3Patches;
   };

--- a/pkgs/development/compilers/flutter/patches/flutter3/move-cache.patch
+++ b/pkgs/development/compilers/flutter/patches/flutter3/move-cache.patch
@@ -1,73 +1,5 @@
 diff --git a/packages/flutter_tools/lib/src/artifacts.dart b/packages/flutter_tools/lib/src/artifacts.dart
-diff --git a/packages/flutter_tools/lib/src/asset.dart b/packages/flutter_tools/lib/src/asset.dart
-index 9dd7272fbe..642c8e48e4 100644
---- a/packages/flutter_tools/lib/src/asset.dart
-+++ b/packages/flutter_tools/lib/src/asset.dart
-@@ -16,6 +16,7 @@ import 'convert.dart';
- import 'dart/package_map.dart';
- import 'devfs.dart';
- import 'flutter_manifest.dart';
-+import 'globals.dart' as globals;
- import 'license_collector.dart';
- import 'project.dart';
- 
-@@ -530,8 +531,7 @@ class ManifestAssetBundle implements AssetBundle {
-         final Uri entryUri = _fileSystem.path.toUri(asset);
-         result.add(_Asset(
-           baseDir: _fileSystem.path.join(
--            Cache.flutterRoot!,
--            'bin', 'cache', 'artifacts', 'material_fonts',
-+            globals.fsUtils.homeDirPath!, '.cache', 'flutter', 'artifacts', 'material_fonts',
-           ),
-           relativeUri: Uri(path: entryUri.pathSegments.last),
-           entryUri: entryUri,
-diff --git a/packages/flutter_tools/lib/src/cache.dart b/packages/flutter_tools/lib/src/cache.dart
-index dd80b1e46e..8e54517765 100644
---- a/packages/flutter_tools/lib/src/cache.dart
-+++ b/packages/flutter_tools/lib/src/cache.dart
-@@ -22,6 +22,7 @@ import 'base/user_messages.dart';
- import 'build_info.dart';
- import 'convert.dart';
- import 'features.dart';
-+import 'globals.dart' as globals;
- 
- const String kFlutterRootEnvironmentVariableName = 'FLUTTER_ROOT'; // should point to //flutter/ (root of flutter/flutter repo)
- const String kFlutterEngineEnvironmentVariableName = 'FLUTTER_ENGINE'; // should point to //engine/src/ (root of flutter/engine repo)
-@@ -318,8 +319,13 @@ class Cache {
-       return;
-     }
-     assert(_lock == null);
-+    final Directory dir = _fileSystem.directory(_fileSystem.path.join(globals.fsUtils.homeDirPath!, '.cache', 'flutter'));
-+    if (!dir.existsSync()) {
-+      dir.createSync(recursive: true);
-+      globals.os.chmod(dir, '755');
-+    }
-     final File lockFile =
--      _fileSystem.file(_fileSystem.path.join(flutterRoot!, 'bin', 'cache', 'lockfile'));
-+      _fileSystem.file(_fileSystem.path.join(globals.fsUtils.homeDirPath!, '.cache', 'flutter', 'lockfile'));
-     try {
-       _lock = lockFile.openSync(mode: FileMode.write);
-     } on FileSystemException catch (e) {
-@@ -378,8 +384,7 @@ class Cache {
- 
-   String get devToolsVersion {
-     if (_devToolsVersion == null) {
--      const String devToolsDirPath = 'dart-sdk/bin/resources/devtools';
--      final Directory devToolsDir = getCacheDir(devToolsDirPath, shouldCreate: false);
-+      final Directory devToolsDir = _fileSystem.directory(_fileSystem.path.join(flutterRoot!, 'bin/cache/dart-sdk/bin/resources/devtools'));
-       if (!devToolsDir.existsSync()) {
-         throw Exception('Could not find directory at ${devToolsDir.path}');
-       }
-@@ -532,7 +537,7 @@ class Cache {
-     if (_rootOverride != null) {
-       return _fileSystem.directory(_fileSystem.path.join(_rootOverride!.path, 'bin', 'cache'));
-     } else {
--      return _fileSystem.directory(_fileSystem.path.join(flutterRoot!, 'bin', 'cache'));
-+      return _fileSystem.directory(_fileSystem.path.join(globals.fsUtils.homeDirPath!, '.cache', 'flutter'));
-     }
-   }
- 
-index c539d67156..4e0a64f7a9 100644
+index 5ac870497b..de430b1fcd 100644
 --- a/packages/flutter_tools/lib/src/artifacts.dart
 +++ b/packages/flutter_tools/lib/src/artifacts.dart
 @@ -346,10 +346,10 @@ class CachedArtifacts implements Artifacts {
@@ -138,27 +70,27 @@ index c539d67156..4e0a64f7a9 100644
        case Artifact.icuData:
          final String engineArtifactsPath = _cache.getArtifactDirectory('engine').path;
          final String platformDirName = _enginePlatformDirectoryName(platform);
-@@ -776,7 +774,7 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
-         final String path = _fileSystem.path.join(_hostEngineOutPath, 'dart-sdk', 'bin', 'snapshots', _hostArtifactToFileName(artifact, _platform));
+@@ -781,7 +779,7 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
+         final String path = _fileSystem.path.join(_getDartSdkPath(), 'bin', 'snapshots', _hostArtifactToFileName(artifact, _platform));
          return _fileSystem.file(path);
        case HostArtifact.dartdevcSnapshot:
--        final String path = _fileSystem.path.join(_dartSdkPath(_cache), 'bin', 'snapshots', _hostArtifactToFileName(artifact, _platform));
+-        final String path = _fileSystem.path.join(_getDartSdkPath(), 'bin', 'snapshots', _hostArtifactToFileName(artifact, _platform));
 +        final String path = _fileSystem.path.join(_dartSdkPath(_fileSystem), 'bin', 'snapshots', _hostArtifactToFileName(artifact, _platform));
          return _fileSystem.file(path);
        case HostArtifact.kernelWorkerSnapshot:
-         final String path = _fileSystem.path.join(_hostEngineOutPath, 'dart-sdk', 'bin', 'snapshots', _hostArtifactToFileName(artifact, _platform));
-@@ -901,9 +899,7 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
+         final String path = _fileSystem.path.join(_getDartSdkPath(), 'bin', 'snapshots', _hostArtifactToFileName(artifact, _platform));
+@@ -910,9 +908,7 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
        case Artifact.windowsCppClientWrapper:
          return _fileSystem.path.join(_hostEngineOutPath, artifactFileName);
        case Artifact.frontendServerSnapshotForEngineDartSdk:
 -        return _fileSystem.path.join(
--          _hostEngineOutPath, 'dart-sdk', 'bin', 'snapshots', artifactFileName,
+-          _getDartSdkPath(), 'bin', 'snapshots', artifactFileName,
 -        );
 +        return _fileSystem.path.join(_hostEngineOutPath, 'gen', artifactFileName);
      }
    }
  
-@@ -1011,8 +1007,8 @@ class OverrideArtifacts implements Artifacts {
+@@ -1065,8 +1061,8 @@ class OverrideArtifacts implements Artifacts {
  }
  
  /// Locate the Dart SDK.
@@ -169,8 +101,77 @@ index c539d67156..4e0a64f7a9 100644
  }
  
  class _TestArtifacts implements Artifacts {
+diff --git a/packages/flutter_tools/lib/src/asset.dart b/packages/flutter_tools/lib/src/asset.dart
+index b109d98eb8..2aeb178323 100644
+--- a/packages/flutter_tools/lib/src/asset.dart
++++ b/packages/flutter_tools/lib/src/asset.dart
+@@ -16,6 +16,7 @@ import 'convert.dart';
+ import 'dart/package_map.dart';
+ import 'devfs.dart';
+ import 'flutter_manifest.dart';
++import 'globals.dart' as globals;
+ import 'license_collector.dart';
+ import 'project.dart';
+ 
+@@ -518,8 +519,8 @@ class ManifestAssetBundle implements AssetBundle {
+         final Uri entryUri = _fileSystem.path.toUri(asset);
+         result.add(_Asset(
+           baseDir: _fileSystem.path.join(
+-            Cache.flutterRoot!,
+-            'bin', 'cache', 'artifacts', 'material_fonts',
++            globals.fsUtils.homeDirPath!,
++            '.cache', 'flutter', 'artifacts', 'material_fonts',
+           ),
+           relativeUri: Uri(path: entryUri.pathSegments.last),
+           entryUri: entryUri,
+diff --git a/packages/flutter_tools/lib/src/cache.dart b/packages/flutter_tools/lib/src/cache.dart
+index a8ab2613a8..b6da642628 100644
+--- a/packages/flutter_tools/lib/src/cache.dart
++++ b/packages/flutter_tools/lib/src/cache.dart
+@@ -22,6 +22,7 @@ import 'base/user_messages.dart';
+ import 'build_info.dart';
+ import 'convert.dart';
+ import 'features.dart';
++import 'globals.dart' as globals;
+ 
+ const String kFlutterRootEnvironmentVariableName = 'FLUTTER_ROOT'; // should point to //flutter/ (root of flutter/flutter repo)
+ const String kFlutterEngineEnvironmentVariableName = 'FLUTTER_ENGINE'; // should point to //engine/src/ (root of flutter/engine repo)
+@@ -318,8 +319,13 @@ class Cache {
+       return;
+     }
+     assert(_lock == null);
++    final Directory dir = _fileSystem.directory(_fileSystem.path.join(globals.fsUtils.homeDirPath!, '.cache', 'flutter'));
++    if (!dir.existsSync()) {
++      dir.createSync(recursive: true);
++      globals.os.chmod(dir, '755');
++    }
+     final File lockFile =
+-      _fileSystem.file(_fileSystem.path.join(flutterRoot!, 'bin', 'cache', 'lockfile'));
++      _fileSystem.file(_fileSystem.path.join(globals.fsUtils.homeDirPath!, '.cache', 'flutter', 'lockfile'));
+     try {
+       _lock = lockFile.openSync(mode: FileMode.write);
+     } on FileSystemException catch (e) {
+@@ -378,8 +384,7 @@ class Cache {
+ 
+   String get devToolsVersion {
+     if (_devToolsVersion == null) {
+-      const String devToolsDirPath = 'dart-sdk/bin/resources/devtools';
+-      final Directory devToolsDir = getCacheDir(devToolsDirPath, shouldCreate: false);
++      final Directory devToolsDir = _fileSystem.directory(_fileSystem.path.join(flutterRoot!, 'bin/cache/dart-sdk/bin/resources/devtools'));
+       if (!devToolsDir.existsSync()) {
+         throw Exception('Could not find directory at ${devToolsDir.path}');
+       }
+@@ -532,7 +537,7 @@ class Cache {
+     if (_rootOverride != null) {
+       return _fileSystem.directory(_fileSystem.path.join(_rootOverride!.path, 'bin', 'cache'));
+     } else {
+-      return _fileSystem.directory(_fileSystem.path.join(flutterRoot!, 'bin', 'cache'));
++      return _fileSystem.directory(_fileSystem.path.join(globals.fsUtils.homeDirPath!, '.cache', 'flutter'));
+     }
+   }
+ 
 diff --git a/packages/flutter_tools/test/general.shard/artifacts_test.dart b/packages/flutter_tools/test/general.shard/artifacts_test.dart
-index aed3eb9285..81b8362648 100644
+index 2fdb19ea6e..97e71d75fe 100644
 --- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
 +++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
 @@ -141,10 +141,6 @@ void main() {
@@ -184,7 +185,7 @@ index aed3eb9285..81b8362648 100644
      });
  
      testWithoutContext('precompiled web artifact paths are correct', () {
-@@ -310,11 +306,6 @@ void main() {
+@@ -317,11 +313,6 @@ void main() {
          artifacts.getHostArtifact(HostArtifact.engineDartSdkPath).path,
          fileSystem.path.join('/out', 'host_debug_unopt', 'dart-sdk'),
        );
@@ -193,6 +194,6 @@ index aed3eb9285..81b8362648 100644
 -        fileSystem.path.join('/out', 'host_debug_unopt', 'dart-sdk', 'bin',
 -          'snapshots', 'frontend_server.dart.snapshot')
 -      );
-       expect(
-         artifacts.getHostArtifact(HostArtifact.impellerc).path,
-         fileSystem.path.join('/out', 'host_debug_unopt', 'impellerc'),
+ 
+ 
+       fileSystem.file(fileSystem.path.join('/out', 'host_debug_unopt', 'impellerc'))


### PR DESCRIPTION
###### Description of changes

Update flutter version. Also we need update yubioath vendorHashes. For some reason this changes breaks yubioath build on aarch64 systems. Can someone help me figure that out? 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
