### PR TITLE
forgejo: 1.18.3-0 -> 1.18.3-1

### DIFF
--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -20,13 +20,13 @@
 
 buildGoModule rec {
   pname = "forgejo";
-  version = "1.18.3-0";
+  version = "1.18.3-1";
 
   src = fetchurl {
     name = "${pname}-src-${version}.tar.gz";
     # see https://codeberg.org/forgejo/forgejo/releases
-    url = "https://codeberg.org/attachments/384fd9ab-7c64-4c29-9b1b-cdb803c48103";
-    hash = "sha256-zBGd+wPJDw7bwRvAlscqbQHDG6po3dlbpYccfanbtyU=";
+    url = "https://codeberg.org/attachments/3fdf0967-d3f4-4488-a2bf-276c4a64d97c";
+    hash = "sha256-H69qKdmz5qHJ353UZYztUlStpj/RyE6LA8cDaRnVYAQ=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
I originally intended to let @r-ryantm raise this PR instead of me, which is why I waited a few days.

But looks like none of the other package repositories listed on repology[^1] updated forgejo yet, so @r-ryantm just isn't aware that `1.18.3-1` is out already :woman_shrugging: 

[^1]: https://repology.org/project/forgejo/versions

Unrelated, but successful run of the `passthru.updateScript` added in #214298 :partying_face: 
https://r.ryantm.com/log/forgejo/2023-02-08.log

###### Description of changes

changelog: https://codeberg.org/forgejo/forgejo/src/commit/fbf5449d87d63443376c6af3f0a8b30aa063f967/RELEASE-NOTES.md#1-18-3-1

nothing too interesting, just a few accessibility improvements (yay!) and bugfixes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
