### PR TITLE
solo5: fix tests

### DIFF
--- a/pkgs/os-specific/solo5/0001-Fix-test.patch
+++ b/pkgs/os-specific/solo5/0001-Fix-test.patch
@@ -1,0 +1,25 @@
+From bf1f143455d1c8283d90964e0121b50c14a67bda Mon Sep 17 00:00:00 2001
+From: Lana Black <lana@illuminati.industries>
+Date: Sat, 11 Feb 2023 11:53:21 +0000
+Subject: [PATCH] Fix test.
+
+---
+ tests/tests.bats | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/tests.bats b/tests/tests.bats
+index c542b7a..98520ee 100644
+--- a/tests/tests.bats
++++ b/tests/tests.bats
+@@ -196,7 +196,7 @@ xen_expect_abort() {
+   run test_hello/test_hello.hvt
+   case "${CONFIG_HOST}" in
+   Linux)
+-    [ "$status" -eq 127 ] && [[ "$output" == *"No such file or directory"* ]]
++    [ "$status" -eq 127 ] && ([[ "$output" == *"No such file or directory"* ]] || [[ "$output" == *"required file not found"* ]])
+     ;;
+   FreeBSD)
+     # XXX: imgact_elf.c:load_interp() outputs the "ELF interpreter ... not
+-- 
+2.39.0
+

--- a/pkgs/os-specific/solo5/default.nix
+++ b/pkgs/os-specific/solo5/default.nix
@@ -24,6 +24,8 @@ in stdenv.mkDerivation {
     sha256 = "sha256-viwrS9lnaU8sTGuzK/+L/PlMM/xRRtgVuK5pixVeDEw=";
   };
 
+  patches = [ ./0001-Fix-test.patch ];
+
   hardeningEnable = [ "pie" ];
 
   configurePhase = ''


### PR DESCRIPTION
###### Description of changes

As of recently, solo5 tests fail on NixOS due to a changed error message.

See here for a bit more details: https://github.com/Solo5/solo5/pull/547
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Fix one test.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
