### PR TITLE
nixos/prowlarr: add package and datadir options

### DIFF
--- a/nixos/modules/services/misc/prowlarr.nix
+++ b/nixos/modules/services/misc/prowlarr.nix
@@ -4,7 +4,6 @@ with lib;
 
 let
   cfg = config.services.prowlarr;
-
 in
 {
   options = {
@@ -13,7 +12,7 @@ in
 
       dataDir = mkOption {
         type = types.str;
-        default = "/var/lib/prowlarr/.config/Prowlarr";
+        default = "/var/lib/private/prowlarr";
         description = lib.mdDoc "The directory where Prowlarr stores its data files.";
       };
 
@@ -44,7 +43,8 @@ in
         Type = "simple";
         DynamicUser = true;
         StateDirectory = "prowlarr";
-        ExecStart = "${cfg.package}/bin/Prowlarr -nobrowser -data=${cfg.dataDir}";
+        BindPaths = [ cfg.dataDir ];
+        ExecStart = "${cfg.package}/bin/Prowlarr -nobrowser -data=/var/lib/prowlarr";
         Restart = "on-failure";
       };
     };

--- a/nixos/modules/services/misc/prowlarr.nix
+++ b/nixos/modules/services/misc/prowlarr.nix
@@ -11,10 +11,25 @@ in
     services.prowlarr = {
       enable = mkEnableOption (lib.mdDoc "Prowlarr");
 
+      dataDir = mkOption {
+        type = types.str;
+        default = "/var/lib/prowlarr/.config/Prowlarr";
+        description = lib.mdDoc "The directory where Prowlarr stores its data files.";
+      };
+
       openFirewall = mkOption {
         type = types.bool;
         default = false;
         description = lib.mdDoc "Open ports in the firewall for the Prowlarr web interface.";
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.prowlarr;
+        defaultText = literalExpression "pkgs.prowlarr";
+        description = lib.mdDoc ''
+          Prowlarr package to use.
+        '';
       };
     };
   };
@@ -29,7 +44,7 @@ in
         Type = "simple";
         DynamicUser = true;
         StateDirectory = "prowlarr";
-        ExecStart = "${pkgs.prowlarr}/bin/Prowlarr -nobrowser -data=/var/lib/prowlarr";
+        ExecStart = "${cfg.package}/bin/Prowlarr -nobrowser -data=${cfg.dataDir}";
         Restart = "on-failure";
       };
     };


### PR DESCRIPTION
###### Description of changes

This should bring Prowlarr a little closer to sonarr and radarr in terms of alignment. Mainly, allows choosing a different source for the package than the stable branch.

**The default value for `dataDir` destination changes.**

Users might want to set their old destination path in the config, or manually move the files:

```
mkdir /tmp/Prowlarr
mv -r /var/lib/prowlarr/* /tmp/Prowlarr
mkdir -p /var/lib/prowlarr/.config
mv -r /tmp/Prowlarr /var/lib/prowlarr/.config
```

###### Things done

Didn't get to testing. Based of a different package.

Resolves #195273