### PR TITLE
ocamlPackages.cfstream: 1.3.1 → 1.3.2

### DIFF
--- a/pkgs/development/ocaml-modules/biocaml/default.nix
+++ b/pkgs/development/ocaml-modules/biocaml/default.nix
@@ -8,6 +8,7 @@ buildDunePackage rec {
   version = "0.11.2";
 
   minimalOCamlVersion = "4.11";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "biocaml";

--- a/pkgs/development/ocaml-modules/cfstream/default.nix
+++ b/pkgs/development/ocaml-modules/cfstream/default.nix
@@ -1,18 +1,18 @@
-{ lib, buildDunePackage, fetchFromGitHub, m4, core_kernel, ounit }:
+{ lib, buildDunePackage, fetchFromGitHub, m4, camlp-streams, core_kernel, ounit }:
 
 buildDunePackage rec {
   pname = "cfstream";
-  version = "1.3.1";
+  version = "1.3.2";
 
-  useDune2 = true;
+  duneVersion = "3";
 
-  minimumOCamlVersion = "4.04.1";
+  minimalOCamlVersion = "4.04.1";
 
   src = fetchFromGitHub {
     owner = "biocaml";
     repo   = pname;
     rev    = version;
-    sha256 = "0qnxfp6y294gjsccx7ksvwn9x5q20hi8sg24rjypzsdkmlphgdnd";
+    hash = "sha256-iSg0QsTcU0MT/Cletl+hW6bKyH0jkp7Jixqu8H59UmQ=";
   };
 
   patches = [ ./git_commit.patch ];
@@ -21,7 +21,7 @@ buildDunePackage rec {
 
   nativeBuildInputs = [ m4 ];
   checkInputs = [ ounit ];
-  propagatedBuildInputs = [ core_kernel ];
+  propagatedBuildInputs = [ camlp-streams core_kernel ];
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/phylogenetics/default.nix
+++ b/pkgs/development/ocaml-modules/phylogenetics/default.nix
@@ -26,6 +26,7 @@ buildDunePackage rec {
   };
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   nativeCheckInputs = [ bppsuite ];
   checkInputs = [ alcotest ];


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5.0: https://github.com/biocaml/cfstream/blob/1.3.2/Changes.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
