### PR TITLE
rofi-bluetooth: unstable-2021-03-05 -> unstable-2023-02-03

### DIFF
--- a/pkgs/applications/misc/rofi-bluetooth/default.nix
+++ b/pkgs/applications/misc/rofi-bluetooth/default.nix
@@ -2,20 +2,19 @@
 , stdenv
 , fetchFromGitHub
 , makeWrapper
-, rofi-unwrapped
 , bluez
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rofi-bluetooth";
-  version = "unstable-2021-03-05";
+  version = "unstable-2023-02-03";
 
   src = fetchFromGitHub {
     owner = "nickclyde";
-    repo = "rofi-bluetooth";
+    repo = finalAttrs.pname;
     # https://github.com/nickclyde/rofi-bluetooth/issues/19
-    rev = "893db1f2b549e7bc0e9c62e7670314349a29cdf2";
-    sha256 = "sha256-3oROJKEQCuSnLfbJ+JSSc9hcmJTPrLHRQJsrUcaOMss=";
+    rev = "9d91c048ff129819f4c6e9e48a17bd54343bbffb";
+    sha256 = "sha256-1Xe3QFThIvJDCUznDP5ZBzwZEMuqmxpDIV+BcVvQDG8=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -26,7 +25,7 @@ stdenv.mkDerivation rec {
     install -D --target-directory=$out/bin/ ./rofi-bluetooth
 
     wrapProgram $out/bin/rofi-bluetooth \
-      --prefix PATH ":" ${lib.makeBinPath [ rofi-unwrapped bluez ] }
+      --prefix PATH ":" ${lib.makeBinPath [ bluez ] }
 
     runHook postInstall
   '';
@@ -38,4 +37,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ MoritzBoehme ];
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

Update rofi-bluetooth to newest version and give users the option to use wayland supported rofi fork (disabled by default).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
