### PR TITLE
dev86: 0.16.21 -> unstable-2022-07-19

### DIFF
--- a/pkgs/development/compilers/dev86/default.nix
+++ b/pkgs/development/compilers/dev86/default.nix
@@ -1,29 +1,35 @@
-{ lib, stdenv, fetchurl }:
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (self: {
   pname = "dev86";
-  version = "0.16.21";
+  version = "unstable-2022-07-19";
 
-  src = fetchurl {
-    url = "http://v3.sk/~lkundrak/dev86/Dev86src-${version}.tar.gz";
-    sha256 = "154dyr2ph4n0kwi8yx0n78j128kw29rk9r9f7s2gddzrdl712jr3";
+  src = fetchFromGitHub {
+    owner = "jbruchon";
+    repo = "dev86";
+    rev = "f5cd3e5c17a0d3cd8298bac8e30bed6e59c4e57a";
+    hash = "sha256-CWeboFkJkpKHZ/wkuvMj5a+5qB2uzAtoYy8OdyYErMg=";
   };
 
-  hardeningDisable = [ "format" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
-  makeFlags = [ "PREFIX=$(out)" ];
-
-  # Parallel builds are not supported due to build process structure:
-  # tools are built sequentially in submakefiles and are reusing the
-  # same targets as dependencies. Building dependencies in parallel
-  # from different submakes is not synchronized and fails:
+  # Parallel builds are not supported due to build process structure: tools are
+  # built sequentially in submakefiles and are reusing the same targets as
+  # dependencies. Building dependencies in parallel from different submakes is
+  # not synchronized and fails:
   #     make[3]: Entering directory '/build/dev86-0.16.21/libc'
   #     Unable to execute as86.
   enableParallelBuilding = false;
 
   meta = {
-    description = "Linux 8086 development environment";
-    homepage = "https://github.com/lkundrak/dev86";
+    homepage = "https://github.com/jbruchon/dev86";
+    description =
+      "C compiler, assembler and linker environment for the production of 8086 executables";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.AndersonTorres ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
