### PR TITLE
invoice2data: 0.3.6 -> 0.4.2

### DIFF
--- a/pkgs/tools/text/invoice2data/default.nix
+++ b/pkgs/tools/text/invoice2data/default.nix
@@ -1,26 +1,25 @@
 { lib
 , fetchFromGitHub
+, ghostscript
 , imagemagick
+, poppler_utils
 , python3
-, tesseract
-, xpdf
+, tesseract5
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "invoice2data";
-  version = "0.3.6";
+  version = "0.4.2";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "invoice-x";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-t1jgLyKtQsLINlnkCdSbVfTM6B/EiD1yGtx9UHjyZVE=";
+    sha256 = "sha256-ss2h8cg0sga+lzJyQHckrZB/Eb63Oj3FkqmGqWCzCQ8=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
-    setuptools-git
-  ];
+  buildInputs = with python3.pkgs; [ setuptools-git ];
 
   propagatedBuildInputs = with python3.pkgs; [
     chardet
@@ -28,6 +27,7 @@ python3.pkgs.buildPythonApplication rec {
     pdfminer-six
     pillow
     pyyaml
+    setuptools
     unidecode
   ];
 
@@ -37,9 +37,10 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   makeWrapperArgs = ["--prefix" "PATH" ":" (lib.makeBinPath [
+    ghostscript
     imagemagick
-    tesseract
-    xpdf
+    tesseract5
+    poppler_utils
   ])];
 
   # Tests fails even when ran manually on my ubuntu machine !!


### PR DESCRIPTION
###### Description of changes

Update invoice2data to version v0.4.2 [released on 2023-02-11](https://github.com/invoice-x/invoice2data/releases/tag/v0.4.2).

This change also
* Installs `ghostscript`, which is used to convert pdfs to images used as input for tesseract
* Uses tesseract 5 instead of tesseract 3
* Switches from `xpdf` (which is also marked as insecure) to `poppler_utils`, which is the recommended provider of `pdftotext` according to the `invoice2data` repo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
