### PR TITLE
serd: 0.30.10 -> 0.30.16

### DIFF
--- a/pkgs/development/libraries/serd/default.nix
+++ b/pkgs/development/libraries/serd/default.nix
@@ -1,21 +1,59 @@
-{ lib, stdenv, fetchurl, pkg-config, python3, wafHook }:
+{ lib
+, stdenv
+, fetchurl
+, doxygen
+, mandoc
+, meson
+, ninja
+, pkg-config
+, python3
+, sphinx
+, writeScript
+}:
 
 stdenv.mkDerivation rec {
   pname = "serd";
-  version = "0.30.10";
+  version = "0.30.16";
+
+  outputs = [ "out" "dev" "doc" "man" ];
 
   src = fetchurl {
-    url = "https://download.drobilla.net/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-r/qA3ux4kh+GM15vw/GLgK7+z0JPaldV6fL6DrBxDt8=";
+    url = "https://download.drobilla.net/${pname}-${version}.tar.xz";
+    hash = "sha256-9Q9IbaUZzdjQOyDJ5CQU5FkTP1okRBHY5jyu+NmskUY=";
   };
 
-  dontAddWafCrossFlags = true;
+  nativeBuildInputs = [
+    doxygen
+    mandoc
+    meson
+    ninja
+    pkg-config
+    python3
+    sphinx
+  ];
 
-  nativeBuildInputs = [ pkg-config python3 wafHook ];
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  passthru = {
+    updateScript = writeScript "update-poke" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl pcre common-updater-scripts
+
+      set -eu -o pipefail
+
+      # Expect the text in format of 'download.drobilla.net/serd-0.30.16.tar.xz">'
+      new_version="$(curl -s https://drobilla.net/category/serd/ |
+          pcregrep -o1 'download.drobilla.net/serd-([0-9.]+).tar.xz' |
+          head -n1)"
+      update-source-version ${pname} "$new_version"
+    '';
+  };
 
   meta = with lib; {
     description = "A lightweight C library for RDF syntax which supports reading and writing Turtle and NTriples";
-    homepage = "http://drobilla.net/software/serd";
+    homepage = "https://drobilla.net/software/serd";
     license = licenses.mit;
     maintainers = [ maintainers.goibhniu ];
     mainProgram = "serdi";


### PR DESCRIPTION
On top of upstream changes `nixpkgs` changes are:
- switch from waf to meson
- aded trivial auto-updater
- added multiple outputs to accomodate for added html docs

Changes: https://drobilla.net/category/serd/

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
