### PR TITLE
nnpdf: 4.0.4 -> 4.0.6, provide n3fit

### DIFF
--- a/pkgs/applications/science/physics/nnpdf/default.nix
+++ b/pkgs/applications/science/physics/nnpdf/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , pkg-config
 , apfel
@@ -16,21 +15,14 @@
 
 stdenv.mkDerivation rec {
   pname = "nnpdf";
-  version = "4.0.4";
+  version = "4.0.6";
 
   src = fetchFromGitHub {
     owner = "NNPDF";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Alx4W0TkPzJBsnRXcKBrlEU6jWTnOjrji/IPk+dNCw0=";
+    hash = "sha256-mwOMNlYFhHZq/wakO1/HGwcxvKGKh5OyFa2D9d3Y3IA=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/NNPDF/nnpdf/commit/7943b62a91d3a41fd4f6366b18881d50695f4b45.diff";
-      hash = "sha256-UXhTO7vZgJiY8h3bgjg7SQC0gMUQsYQ/V/PgtCEQ7VU=";
-    })
-  ];
 
   postPatch = ''
     for file in CMakeLists.txt buildmaster/CMakeLists.txt; do

--- a/pkgs/development/python-modules/n3fit/default.nix
+++ b/pkgs/development/python-modules/n3fit/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, hyperopt
+, keras
+, nnpdf
+, psutil
+, tensorflow
+, validphys2
+}:
+
+buildPythonPackage rec {
+  pname = "n3fit";
+  version = "4.0";
+  format = "setuptools";
+
+  inherit (nnpdf) src;
+
+  prePatch = ''
+    cd n3fit
+  '';
+
+  postPatch = ''
+    substituteInPlace src/n3fit/version.py \
+      --replace '= __give_git()' '= "'$version'"'
+  '';
+
+  propagatedBuildInputs = [
+    hyperopt
+    keras
+    psutil
+    tensorflow
+    validphys2
+  ];
+
+  postInstall = ''
+    for prog in "$out"/bin/*; do
+      wrapProgram "$prog" --set PYTHONPATH "$PYTHONPATH:$(toPythonPath "$out")"
+    done
+  '';
+
+  doCheck = false; # no tests
+  pythonImportsCheck = [ "n3fit" ];
+
+  meta = with lib; {
+    description = "NNPDF fitting framework";
+    homepage = "https://docs.nnpdf.science";
+    inherit (nnpdf.meta) license;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/python-modules/validphys2/default.nix
+++ b/pkgs/development/python-modules/validphys2/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace src/validphys/version.py \
-      --replace '= __give_git()' '= "${version}"'
+      --replace '= __give_git()' '= "'$version'"'
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6188,6 +6188,8 @@ self: super: with self; {
 
   myst-parser = callPackage ../development/python-modules/myst-parser { };
 
+  n3fit = callPackage ../development/python-modules/n3fit { };
+
   nad-receiver = callPackage ../development/python-modules/nad-receiver { };
 
   nagiosplugin = callPackage ../development/python-modules/nagiosplugin { };


### PR DESCRIPTION
###### Description of changes

"The n3fit code is designed in python and replaces the nnfit program used in the NNPDF3.X family of fits."

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
