### PR TITLE
s3backer: 1.6.3 -> 2.0.2

### DIFF
--- a/pkgs/tools/filesystems/s3backer/default.nix
+++ b/pkgs/tools/filesystems/s3backer/default.nix
@@ -4,14 +4,20 @@
 
 stdenv.mkDerivation rec {
   pname = "s3backer";
-  version = "1.6.3";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
-    sha256 = "sha256-DOf+kpflDd2U1nXDLKYts/yf121CrBFIBI47OQa5XBs=";
+    sha256 = "sha256-xmOtL4v3UxdjrL09sSfXyF5FoMrNerSqG9nvEuwMvNM=";
     rev = version;
     repo = "s3backer";
     owner = "archiecobbs";
   };
+
+  patches = [
+    # from upstream, after latest release
+    # https://github.com/archiecobbs/s3backer/commit/303a669356fa7cd6bc95ac7076ce51b1cab3970a
+    ./fix-darwin-builds.patch
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ fuse curl expat ];
@@ -20,11 +26,6 @@ stdenv.mkDerivation rec {
   postPatch = lib.optionalString stdenv.cc.isClang ''
     substituteInPlace configure.ac --replace \
       'AC_CHECK_DECLS(fdatasync)' ""
-  '';
-
-  autoreconfPhase = ''
-    patchShebangs ./autogen.sh
-    ./autogen.sh
   '';
 
   meta = with lib; {

--- a/pkgs/tools/filesystems/s3backer/fix-darwin-builds.patch
+++ b/pkgs/tools/filesystems/s3backer/fix-darwin-builds.patch
@@ -1,0 +1,25 @@
+From 303a669356fa7cd6bc95ac7076ce51b1cab3970a Mon Sep 17 00:00:00 2001
+From: Adrian Ho <the.gromgit@gmail.com>
+Date: Tue, 6 Sep 2022 10:49:10 +0800
+Subject: [PATCH] Enable macOS builds
+
+macOS requires explicit `environ` declaration.
+---
+ s3backer.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/s3backer.h b/s3backer.h
+index ccc9053..383e246 100644
+--- a/s3backer.h
++++ b/s3backer.h
+@@ -90,6 +90,10 @@
+ #include <zlib.h>
+ #include <fuse.h>
+ 
++#ifdef __APPLE__
++extern char **environ;
++#endif
++
+ #ifndef FUSE_OPT_KEY_DISCARD
+ #define FUSE_OPT_KEY_DISCARD -4
+ #endif


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
