### PR TITLE
rbdoom-3-bfg: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16352,6 +16352,12 @@
     githubId = 908716;
     name = "Zach Coyle";
   };
+  Zaechus = {
+    email = "zaechus@proton.me";
+    github = "Zaechus";
+    githubId = 19353212;
+    name = "Maxwell Anderson";
+  };
   zagy = {
     email = "cz@flyingcircus.io";
     github = "zagy";

--- a/pkgs/games/rbdoom-3-bfg/default.nix
+++ b/pkgs/games/rbdoom-3-bfg/default.nix
@@ -1,0 +1,82 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, directx-shader-compiler
+, libGLU
+, libpng
+, libjpeg_turbo
+, openal
+, rapidjson
+, SDL2
+, vulkan-headers
+, vulkan-loader
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rbdoom-3-bfg";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "RobertBeckebans";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-r/dvTirgFXdBJ+Gjl6zpHoGCTPoo0tRmOCV9oCdnltI=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "remove-jpeg_internals-define.patch";
+      url = "https://github.com/RobertBeckebans/RBDOOM-3-BFG/commit/de6ab9d31ffcd6eba26df69f8c77da38a0ab4722.diff";
+      hash = "sha256-3XbWmQtY/8a90IqDtN5TNT5EOa+i5mFOH+H9tuZqTmU=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    directx-shader-compiler
+  ];
+
+  buildInputs = [
+    libGLU
+    libpng
+    libjpeg_turbo
+    openal
+    rapidjson
+    SDL2
+    vulkan-headers
+    vulkan-loader
+    zlib
+  ];
+
+  cmakeDir = "../neo";
+  cmakeFlags = [
+    "-DFFMPEG=OFF"
+    "-DBINKDEC=ON"
+    "-DUSE_SYSTEM_LIBGLEW=ON"
+    "-DUSE_SYSTEM_LIBPNG=ON"
+    "-DUSE_SYSTEM_LIBJPEG=ON"
+    "-DUSE_SYSTEM_RAPIDJSON=ON"
+    "-DUSE_SYSTEM_ZLIB=ON"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install RBDoom3BFG $out/bin/RBDoom3BFG
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/RobertBeckebans/RBDOOM-3-BFG";
+    description = "Doom 3 BFG Edition with modern engine features";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ Zaechus ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34791,6 +34791,8 @@ with pkgs;
 
   keeperrl = callPackage ../games/keeperrl { };
 
+  rbdoom-3-bfg = callPackage ../games/rbdoom-3-bfg { };
+
   ### GAMES/LGAMES
 
   barrage = callPackage ../games/lgames/barrage { };


### PR DESCRIPTION
###### Description of changes

Add [RBDOOM-3-BFG](https://github.com/RobertBeckebans/RBDOOM-3-BFG), a Doom 3 BFG Edition fork with modern engine features

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).