### PR TITLE
Revert "firejail: 0.9.70 -> 0.9.72"

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "firejail";
-  version = "0.9.72";
+  version = "0.9.70";
 
   src = fetchFromGitHub {
     owner = "netblue30";
     repo = "firejail";
     rev = version;
-    sha256 = "sha256-XAlb6SSyY2S1iWDaulIlghQ16OGvT/wBCog95/nxkog=";
+    sha256 = "sha256-x1txt0uER66bZN6BD6c/31Zu6fPPwC9kl/3bxEE6Ce8=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#211245

Unfortunately the firejail update breaks compatibility with the wrappedBinaries option of the NixOS firejail module as mentioned in this comment https://github.com/NixOS/nixpkgs/pull/211245#issuecomment-1407447976

Need to fix or investigate this in a separate PR