### PR TITLE
kicad: 6.0.11 -> 7.0.0

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -22,6 +22,7 @@
 , libXdmcp
 , lndir
 , unixODBC
+, fetchpatch
 
 , util-linux
 , libselinux
@@ -71,6 +72,19 @@ stdenv.mkDerivation rec {
   patches = [
     # upstream issue 12941 (attempted to upstream, but appreciably unacceptable)
     ./writable.patch
+  ]
+  ++ optionals (stable) # the 2 wxGTK ones should in the next stable point release
+  [
+    (fetchpatch { # for wxGTK 3.2.2.1's .1 field
+      name = "support wxWidgets subrelease field";
+      url = "https://gitlab.com/kicad/code/kicad/-/commit/b536580119c59fde78e38d8d6388f2540ecb6cf9.diff";
+      hash = "sha256-F+J5oZO0BsT1VWKpx0KGA7ecn5/PBgCw8uiScihM+54=";
+    })
+    (fetchpatch { # for wxGTK 3.2.2.1's .1 field, but for wxPython
+      name = "relax wxPython check to just major.minor";
+      url = "https://gitlab.com/kicad/code/kicad/-/commit/1e8cc6855d6a8fc1f9dfc933224c3a10fb759f9c.diff";
+      hash = "sha256-CGNgxZ7QiVLkaauNl7Pmcl152lwyDZqA/HSyFdOswwU=";
+    })
   ];
 
   # tagged releases don't have "unknown"

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -34,6 +34,7 @@
 , at-spi2-core
 , libXtst
 , pcre2
+, libdeflate
 
 , swig4
 , python
@@ -50,7 +51,6 @@
 , withNgspice
 , withScripting
 , withI18n
-, withPCM
 , debug
 , sanitizeAddress
 , sanitizeThreads
@@ -88,6 +88,7 @@ stdenv.mkDerivation rec {
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
     "-DCMAKE_SKIP_BUILD_RPATH=ON"
     "-DKICAD_USE_EGL=ON"
+    "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;qa_eeschema'"  # upstream issue 12491
   ]
   ++ optionals (withScripting) [
     "-DKICAD_SCRIPTING_WXPYTHON=ON"
@@ -117,12 +118,6 @@ stdenv.mkDerivation rec {
   ]
   ++ optionals (withI18n) [
     "-DKICAD_BUILD_I18N=ON"
-  ]
-  ++ optionals (!withPCM && stable) [
-    "-DKICAD_PCM=OFF"
-  ]
-  ++ optionals (!stable) [ # upstream issue 12491
-    "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;qa_eeschema'"
   ];
 
   nativeBuildInputs = [
@@ -167,8 +162,9 @@ stdenv.mkDerivation rec {
     boost
     swig4
     python
+    unixODBC
+    libdeflate
   ]
-  ++ optional (!stable) unixODBC
   ++ optional (withScripting) wxPython
   ++ optional (withNgspice) libngspice
   ++ optional (withOCC) opencascade-occt

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -24,7 +24,6 @@
 , sanitizeThreads ? false
 , with3d ? true
 , withI18n ? true
-, withPCM ? true # Plugin and Content Manager
 , srcs ? { }
 }:
 
@@ -118,7 +117,7 @@ stdenv.mkDerivation rec {
     inherit stable baseName;
     inherit kicadSrc kicadVersion;
     inherit wxGTK python wxPython;
-    inherit withOCC withNgspice withScripting withI18n withPCM;
+    inherit withOCC withNgspice withScripting withI18n;
     inherit debug sanitizeAddress sanitizeThreads;
   };
 
@@ -150,15 +149,15 @@ stdenv.mkDerivation rec {
     "--prefix GIO_EXTRA_MODULES : ${dconf}/lib/gio/modules"
     # required to open a bug report link in firefox-wayland
     "--set-default MOZ_DBUS_REMOTE 1"
-    "--set-default KICAD6_FOOTPRINT_DIR ${footprints}/share/kicad/footprints"
-    "--set-default KICAD6_SYMBOL_DIR ${symbols}/share/kicad/symbols"
-    "--set-default KICAD6_TEMPLATE_DIR ${templates}/share/kicad/template"
-    "--prefix KICAD6_TEMPLATE_DIR : ${symbols}/share/kicad/template"
-    "--prefix KICAD6_TEMPLATE_DIR : ${footprints}/share/kicad/template"
+    "--set-default KICAD7_FOOTPRINT_DIR ${footprints}/share/kicad/footprints"
+    "--set-default KICAD7_SYMBOL_DIR ${symbols}/share/kicad/symbols"
+    "--set-default KICAD7_TEMPLATE_DIR ${templates}/share/kicad/template"
+    "--prefix KICAD7_TEMPLATE_DIR : ${symbols}/share/kicad/template"
+    "--prefix KICAD7_TEMPLATE_DIR : ${footprints}/share/kicad/template"
   ]
   ++ optionals (with3d)
   [
-    "--set-default KICAD6_3DMODEL_DIR ${packages3d}/share/kicad/3dmodels"
+    "--set-default KICAD7_3DMODEL_DIR ${packages3d}/share/kicad/3dmodels"
   ]
   ++ optionals (withNgspice) [ "--prefix LD_LIBRARY_PATH : ${libngspice}/lib" ]
 
@@ -172,7 +171,7 @@ stdenv.mkDerivation rec {
     let
       bin = if stdenv.isDarwin then "*.app/Contents/MacOS" else "bin";
       tools = [ "kicad" "pcbnew" "eeschema" "gerbview" "pcb_calculator" "pl_editor" "bitmap2component" ];
-      utils = [ "dxf2idf" "idf2vrml" "idfcyl" "idfrect" "kicad2step" ];
+      utils = [ "dxf2idf" "idf2vrml" "idfcyl" "idfrect" "kicad-cli" ];
     in
     (concatStringsSep "\n"
       (flatten [

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -25,23 +25,23 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2022-12-19";
+      version =			"2023-02-14";
       src = {
-        rev =			"a3a2e2e5b1981ebfbb60f1e8e40bd02625d33692";
-        sha256 =		"1584n2gn68vdyzlm9805ln1bdgzf831j5l4v29z08dkbi2sl3rg0";
+        rev =			"29c4482bc898f627cebcd5f64e063e8a813a5445";
+        sha256 =		"1hs1p79skmrn2k7qrpnkynzkk2g8ry20lqivzfqg87c56rd1522y";
       };
     };
     libVersion = {
-      version =			"2022-12-19";
+      version =			"2023-02-14";
       libSources = {
-        symbols.rev =		"2fa69d6d1dce065f8d0998733f66d2cd7db31b9e";
-        symbols.sha256 =	"1kp8v0q1pirpi4v485j5bg72jpnxglbpgxjxda6kvq8d2124pwlb";
-        templates.rev =		"ae2b46f8756d79379b90fec01d4fdde1ccfd73c1";
-        templates.sha256 =	"08zxh83fbygh1x2jhca8nrp3f9kihf7kmg65qmyp95wvps4p5h8v";
-        footprints.rev =	"24671f7754c74dfa528e6b62ebef33b161aa4ab6";
-        footprints.sha256 =	"1rs05n1wjb2w3x7xqkkijbdxyw3fj0fph8znvnsxp9bgwaaipd4h";
-        packages3d.rev =	"7aeaa02a2e7438fbbe94a00ca321366a39dc1267";
-        packages3d.sha256 =	"13wfcm7fgsgl3a0g00ra3v35c8wqw9yzgdiai54f1m77r2cr7bhp";
+        symbols.rev =		"3ad8b98287ddf528ce8ff07bbe70aed85cb4410a";
+        symbols.sha256 =	"1p0wa3bhw2qgdvb5vzwvrbhkb6sqpc93d754rbcs2xh79d75l9nn";
+        templates.rev =		"867eef383a0f61015cb69677d5c632d78a2ea01a";
+        templates.sha256 =	"1qi20mrsfn4fxmr1fyphmil2i9p2nzmwk5rlfchc5aq2194nj3lq";
+        footprints.rev =	"a168dd18ea63c2df948c2de3026dc19730cb70cf";
+        footprints.sha256 =	"0y3cl9fcyi8z4yrn0kfgfy28gn9ngrdvnpgbpwykbbp8fpx401nk";
+        packages3d.rev =	"a0919e5e805157bccd65af313806de3833c1673e";
+        packages3d.sha256 =	"1yizw9g3skz7i9x9iwbnn3gk3lnh10krf6xg32plb2plxfynz3cw";
       };
     };
   };

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,23 +3,23 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"6.0.11";
+      version =			"7.0.0";
       src = {
-        rev =			"2627ca5db025d40933329af642df28c4a2193dbf";
-        sha256 =		"1bhzmgs921wv1pc0mpyigmpp630086kmpifc3a91cbkv4xf0akkq";
+        rev =			"da2b9df05c3ccd5ec104cf8cd8ded34f5dd25216";
+        sha256 =		"1zgpj1rvf97qv36hg4dja46pbzyixlh2g04wlh7cizcrs16b9mzw";
       };
     };
     libVersion = {
-      version =			"6.0.11";
+      version =			"7.0.0";
       libSources = {
-        symbols.rev =		"c2277d1e39c5e9ba5e04ca5ef3eb252a74291375";
-        symbols.sha256 =	"1fwnr8x345jbifk71rhyd4b88c4ijp2rcw3pmivnwfb444hbr1lp";
-        templates.rev =		"049baf307d2fdf5e6138ebab40a8be720b4ae62e";
-        templates.sha256 =	"08zxh83fbygh1x2jhca8nrp3f9kihf7kmg65qmyp95wvps4p5h8v";
-        footprints.rev =	"72fb90dda096bd59295ccc2c8c0881ee02a1221c";
-        footprints.sha256 =	"1rs05n1wjb2w3x7xqkkijbdxyw3fj0fph8znvnsxp9bgwaaipd4h";
-        packages3d.rev =	"3fc9daed3ca80a1b6f3bbb1ef505f0dc79972d44";
-        packages3d.sha256 =	"0nmvfchp25i4bkx6yf7fz1rwy7w6whj2w7mlp02ag3w5v4f137vz";
+        symbols.rev =		"08a25991d07924b263cbf87c6e513feac2b2169f";
+        symbols.sha256 =	"1r87xr1453dpfglkg1m4p5d7kcv9gxls1anwk3vp2yppnwz24ydm";
+        templates.rev =		"66d76556d9e81f8a5be74457686d211c666ed200";
+        templates.sha256 =	"02i279269mhq7wjhb1yqk90820ncssxl9n7b20qr2r4fmm7jpvxv";
+        footprints.rev =	"a0388d07e4a37e8db13a716efb3ad4750c839f9c";
+        footprints.sha256 =	"1akhifnjm8jvqsvscn2rr1wpzrls73bpdc6sk40355r1in2djmry";
+        packages3d.rev =	"bbee2295519bcf469d97f5e06bcf7175cddd2037";
+        packages3d.sha256 =	"1qw5xm0wbhv6gqvd8mn0jp4abjbizrkx79r6y8f6911mkzi47r6n";
       };
     };
   };


### PR DESCRIPTION
###### Description of changes

https://www.kicad.org/blog/2023/02/Version-7.0.0-Released/

this change depends on #215971
(at least on my sway setup, without it KiCad crashes when trying to open the file picker)

it also includes a kicad-unstable update, as this avoids some feature flagging in the package

the `withPCM` option was removed, i'd be surprised if anyone ever touched that, so i didn't bother with a warning

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).