### PR TITLE
agda: fix passthru

### DIFF
--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -20,7 +20,11 @@ let
     nativeBuildInputs = [ makeWrapper ];
     passthru = {
       unwrapped = Agda;
-      tests = { inherit (nixosTests) agda; };
+      inherit withPackages;
+      tests = {
+        inherit (nixosTests) agda;
+        allPackages = withPackages (lib.filter self.lib.isUnbrokenAgdaPackage (lib.attrValues self));
+      };
     };
     inherit (Agda) meta;
   } ''

--- a/pkgs/top-level/agda-packages.nix
+++ b/pkgs/top-level/agda-packages.nix
@@ -1,9 +1,9 @@
-{ pkgs, lib, callPackage, newScope, Agda }:
+{ pkgs, lib, newScope, Agda }:
 
 let
   mkAgdaPackages = Agda: lib.makeScope newScope (mkAgdaPackages' Agda);
   mkAgdaPackages' = Agda: self: let
-    callPackage = self.callPackage;
+    inherit (self) callPackage;
     inherit (callPackage ../build-support/agda {
       inherit Agda self;
       inherit (pkgs.haskellPackages) ghcWithPackages;
@@ -13,10 +13,7 @@ let
 
     lib = lib.extend (final: prev: import ../build-support/agda/lib.nix { lib = prev; });
 
-    agda = withPackages [] // {
-      inherit withPackages;
-      passthru.tests.allPackages = withPackages (lib.filter (pkg: self.lib.isUnbrokenAgdaPackage pkg) (lib.attrValues self));
-    };
+    agda = withPackages [];
 
     standard-library = callPackage ../development/libraries/agda/standard-library {
       inherit (pkgs.haskellPackages) ghcWithPackages;


### PR DESCRIPTION
The current `//` override to `agda.passthru.tests` is non-recursive so it destroys everything else under `passthru`, and furthermore does not go through `mkDerivation` so that we end up with different values for `agda.tests` and `agda.passthru.tests`.

Fix it by moving the `allPackages` test to the definition of `withPackages`.