### PR TITLE
input-leap: init at unstable-2023-05-24

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14557,6 +14557,11 @@
     githubId = 6224096;
     name = "Soner Sayakci";
   };
+  shymega = {
+    name = "Dom Rodriguez";
+    github = "shymega";
+    githubId = 1334592;
+  };
   siddharthist = {
     email = "langston.barrett@gmail.com";
     github = "langston-barrett";

--- a/pkgs/applications/misc/input-leap/default.nix
+++ b/pkgs/applications/misc/input-leap/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, cmake
+
+, withLibei ? true
+
+, avahi
+, curl
+, libICE
+, libSM
+, libX11
+, libXdmcp
+, libXext
+, libXinerama
+, libXrandr
+, libXtst
+, libei
+, libportal
+, openssl
+, pkg-config
+, qtbase
+, qttools
+, wrapGAppsHook
+}:
+
+mkDerivation rec {
+  pname = "input-leap";
+  version = "unstable-2023-05-24";
+
+  src = fetchFromGitHub {
+    owner = "input-leap";
+    repo = "input-leap";
+    rev = "5e2f37bf9ec17627ae33558d99f90b7608ace422";
+    hash = "sha256-55RqdRu/Hi2OTiLjAFJ6Gdgg9iO5NIIJCsOkUQjR9hk=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkg-config cmake wrapGAppsHook qttools ];
+  buildInputs = [
+    curl qtbase avahi
+    libX11 libXext libXtst libXinerama libXrandr libXdmcp libICE libSM
+  ] ++ lib.optionals withLibei [ libei libportal ];
+
+  cmakeFlags = [
+    "-DINPUTLEAP_REVISION=${builtins.substring 0 8 src.rev}"
+  ] ++ lib.optional withLibei "-DINPUTLEAP_BUILD_LIBEI=ON";
+
+  dontWrapGApps = true;
+  preFixup = ''
+    qtWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+        --prefix PATH : "${lib.makeBinPath [ openssl ]}"
+    )
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/share/applications/input-leap.desktop \
+      --replace "Exec=input-leap" "Exec=$out/bin/input-leap"
+  '';
+
+  meta = {
+    description = "Open-source KVM software";
+    longDescription = ''
+      Input Leap is software that mimics the functionality of a KVM switch, which historically
+      would allow you to use a single keyboard and mouse to control multiple computers by
+      physically turning a dial on the box to switch the machine you're controlling at any
+      given moment. Input Leap does this in software, allowing you to tell it which machine
+      to control by moving your mouse to the edge of the screen, or by using a keypress
+      to switch focus to a different system.
+    '';
+    homepage = "https://github.com/input-leap/input-leap";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ kovirobi phryneas twey shymega ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30365,6 +30365,10 @@ with pkgs;
 
   icesl = callPackage ../applications/misc/icesl { };
 
+  input-leap = libsForQt5.callPackage ../applications/misc/input-leap {
+    avahi = avahi.override { withLibdnssdCompat = true; };
+  };
+
   karlender = callPackage ../applications/office/karlender { };
 
   keepassxc = libsForQt5.callPackage ../applications/misc/keepassxc {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [Input Leap](https://github.com/input-leap/input-leap), a [maintained](https://github.com/input-leap/input-leap/issues/1414) fork of [Barrier](https://github.com/debauchee/barrier/) which we already have in the repository.

Amongst other things, Input Leap correctly generates SSL certificates and fingerprints out of the box, which Barrier does not.

This derivation is based off [that derivation](https://github.com/NixOS/nixpkgs/blob/00952e4e96d4edf5b72110df4b33781461b4dd2f/pkgs/applications/misc/barrier/default.nix) with a few tweaks to support dependency changes; as such I've left [phryneas](https://github.com/phryneas) as maintainer for now (alongside myself).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
