### PR TITLE
ethtool: apply upstream diff to fix build on musl

### DIFF
--- a/pkgs/tools/misc/ethtool/default.nix
+++ b/pkgs/tools/misc/ethtool/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , libmnl
 , pkg-config
 , writeScript
@@ -14,6 +15,16 @@ stdenv.mkDerivation rec {
     url = "mirror://kernel/software/network/${pname}/${pname}-${version}.tar.xz";
     sha256 = "sha256-xB/Igf+lpAQy0t2CnrRMZKSd7kgucWuqz5Jixk2qj5A=";
   };
+
+  patches = [
+    # Patch that fixes build with musl libc
+    # NOTE remove on next release, since it is applied in upstream
+    (fetchpatch {
+      name = "Fix-build-with-musl-libc.patch";
+      url = "https://git.kernel.org/pub/scm/network/ethtool/ethtool.git/patch/marvell.c?id=41be533331fc3c6b711dbe532405782d3b8be5d1";
+      sha256 = "sha256-CItvt/eeNJkr1sOzaaHZhAnaybDutL9cT2O6XwQll+M=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
###### Description of changes

Fixes pkgsMusl.ethtool

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
