### PR TITLE
sane-backends: 1.1.1 -> 1.2.1

### DIFF
--- a/pkgs/applications/graphics/sane/backends/default.nix
+++ b/pkgs/applications/graphics/sane/backends/default.nix
@@ -16,7 +16,7 @@
 
 stdenv.mkDerivation {
   pname = "sane-backends";
-  version = "1.1.1";
+  version = "1.2.1";
 
   src = fetchurl {
     # raw checkouts of the repo do not work because, the configure script is
@@ -25,8 +25,8 @@ stdenv.mkDerivation {
     # unfortunately this make the url unpredictable on update, to find the link
     # go to https://gitlab.com/sane-project/backends/-/releases and choose
     # the link under the heading "Other".
-    url = "https://gitlab.com/sane-project/backends/uploads/7d30fab4e115029d91027b6a58d64b43/sane-backends-1.1.1.tar.gz";
-    sha256 = "sha256-3UsEw3pC8UxGGejupqlX9MfGF/5Z4yrihys3OUCotgM=";
+    url = "https://gitlab.com/sane-project/backends/uploads/110fc43336d0fb5e514f1fdc7360dd87/sane-backends-1.2.1.tar.gz";
+    sha256 = "f832395efcb90bb5ea8acd367a820c393dda7e0dd578b16f48928b8f5bdd0524";
   };
 
   patches = [


### PR DESCRIPTION
changelog: https://gitlab.com/sane-project/backends/-/tags/1.2.1

Tested by scanning in nixos-rebuild build-vm, which can be done by passing your USB printer to the vm as follows:
QEMU_OPTS="-device usb-ehci,id=ehci -device usb-host,vendorid=0x1234,productid=0xabcd" result/bin/run-nixos-vm where lsusb reports
Bus 003 Device 008: ID 1234:abcd The Printer

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
