### PR TITLE
mutt: assert relations between configuration options

### DIFF
--- a/pkgs/applications/networking/mailreaders/mutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/mutt/default.nix
@@ -18,6 +18,8 @@
 , gssSupport   ? true
 , writeScript
 }:
+assert smimeSupport -> sslSupport;
+assert gpgmeSupport -> sslSupport;
 
 stdenv.mkDerivation rec {
   pname = "mutt";


### PR DESCRIPTION

Existing postPatch/postInstall phases bring reference to "openssl" if gpgme or
smime are enabled, regardless of "enableSSL" configuration option.

To avoid unnecessary illusion we refuse to evaluate "+gpgme -ssl" configuration
instead of building output that does not match requested configuration.

maintainers: @rnhmjoj
