### PR TITLE
ouroboros: init at 0.19.3

### DIFF
--- a/pkgs/applications/networking/ouroboros/default.nix
+++ b/pkgs/applications/networking/ouroboros/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+
+, cmake
+, dnsutils
+, fetchgit
+, fuse
+, libgcrypt
+, pkgconfig
+, protobuf
+, protobufc
+, systemd
+}:
+stdenv.mkDerivation rec {
+  pname = "ouroboros";
+  version = "0.19.3";
+  src = fetchgit {
+    url = "git://ouroboros.rocks/${pname}";
+    rev = version;
+    hash = "sha256-DYkQHmfAOxoCA6AqIunHgx7SbeRxpwlPT7ztRzLgv10=";
+  };
+  buildInputs = [
+    cmake
+    dnsutils
+    fuse
+    libgcrypt
+    pkgconfig
+    protobuf
+    protobufc
+    systemd
+  ];
+  cmakeFlags = [ "-DSYSTEMD_UNITDIR=${placeholder "out"}/etc/systemd/system" ];
+  meta = {
+    description = "A future network prototype descended from RINA";
+    homepage = https://ouroboros.rocks/;
+    license = with lib.licenses; [
+      lgpl21 # library
+      gpl2 # daemons
+      bsd3 # tools
+    ];
+    maintainers = with lib.maintainers; [ twey ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/applications/networking/ouroboros/default.nix
+++ b/pkgs/applications/networking/ouroboros/default.nix
@@ -1,6 +1,5 @@
 { stdenv
 , lib
-
 , cmake
 , dnsutils
 , fetchgit
@@ -32,7 +31,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DSYSTEMD_UNITDIR=${placeholder "out"}/etc/systemd/system" ];
   meta = {
     description = "A future network prototype descended from RINA";
-    homepage = https://ouroboros.rocks/;
+    homepage = "https://ouroboros.rocks/";
     license = with lib.licenses; [
       lgpl21 # library
       gpl2 # daemons

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5344,6 +5344,8 @@ with pkgs;
 
   osv-scanner = callPackage ../tools/security/osv-scanner {};
 
+  ouroboros = callPackage ../applications/networking/ouroboros { };
+
   pastel = callPackage ../applications/misc/pastel {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Ouroboros](https://ouroboros.rocks/) ([GitHub mirror](https://github.com/dstaesse/ouroboros)) is a future networking architecture [descended from](https://ouroboros.rocks/blog/2021/03/20/how-does-ouroboros-relate-to-rina-the-recursive-internetwork-architecture/) the [Recursive Internetwork Architecture (RINA)](https://en.wikipedia.org/wiki/Recursive_Internetwork_Architecture).  This package provides a prototype userspace implementation of the architecture for Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
