### PR TITLE
texlive: use looping in tl2nix

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/tl2nix.sed
+++ b/pkgs/tools/typesetting/tex/texlive/tl2nix.sed
@@ -2,37 +2,47 @@
 1itl: { # no indentation
 $a}
 
-# trash packages we don't want
-/^name .*\./,/^$/d
-
-# quote package names, as some start with a number :-/
-s/^name (.*)/name "\1"/
-
-# extract revision
-s/^revision ([0-9]*)$/  revision = \1;/p
-
 # form an attrmap per package
-/^name /s/^name (.*)/\1 = {/p
-/^$/,1i};
+# ignore packages whose name contains "." (such as binaries)
+/^name ([^.]+)$/,/^$/{
+  # quote package names, as some start with a number :-/
+  s/^name (.*)$/"\1" = {/p
+  /^$/,1i};
 
-# extract hashes of *.tar.xz
-s/^containerchecksum (.*)/  sha512.run = "\1";/p
-s/^doccontainerchecksum (.*)/  sha512.doc = "\1";/p
-s/^srccontainerchecksum (.*)/  sha512.source = "\1";/p
-/^runfiles /i\  hasRunfiles = true;
+  # extract revision
+  s/^revision ([0-9]*)$/  revision = \1;/p
 
-# number of path components to strip, defaulting to 1 ("texmf-dist/")
-/^relocated 1/i\  stripPrefix = 0;
+  # extract hashes of *.tar.xz
+  s/^containerchecksum (.*)/  sha512.run = "\1";/p
+  s/^doccontainerchecksum (.*)/  sha512.doc = "\1";/p
+  s/^srccontainerchecksum (.*)/  sha512.source = "\1";/p
+  /^runfiles /i\  hasRunfiles = true;
 
-# extract version and clean unwanted chars from it
-/^catalogue-version/y/ \/~/_--/
-/^catalogue-version/s/[\#,:\(\)]//g
-s/^catalogue-version_(.*)/  version = "\1";/p
+  # number of path components to strip, defaulting to 1 ("texmf-dist/")
+  /^relocated 1/i\  stripPrefix = 0;
 
-# extract deps
-s/^depend ([^.]*)$/  deps."\1" = tl."\1";/p
+  # extract version and clean unwanted chars from it
+  /^catalogue-version/y/ \/~/_--/
+  /^catalogue-version/s/[\#,:\(\)]//g
+  s/^catalogue-version_(.*)/  version = "\1";/p
 
-# extract hyphenation patterns and formats
-# (this may create duplicate lines, use uniq to remove them)
-/^execute\sAddHyphen/i\  hasHyphens = true;
-/^execute\sAddFormat/i\  hasFormats = true;
+  # extract deps
+  /^depend [^.]+$/{
+    s/^depend (.+)$/  deps."\1" = tl."\1";/
+
+    # loop through following depend lines
+    :next
+      h ; N     # save & read next line
+      s/\ndepend (.+)\.(.+)$//
+      s/\ndepend (.+)$/\n  deps."\1" = tl."\1";/
+      t next    # loop if the previous lines matched
+
+    x; p; x     # print saved deps
+    s/^.*\n//   # remove deps, resume processing
+  }
+
+  # extract hyphenation patterns and formats
+  # (this may create duplicate lines, use uniq to remove them)
+  /^execute\sAddHyphen/i\  hasHyphens = true;
+  /^execute\sAddFormat/i\  hasFormats = true;
+}


### PR DESCRIPTION
###### Description of changes
Make tl2nix a tad more sophisticated, by using a loop to process package dependencies.

For now, this creates the exact same `pkgs.nix` as before, to make the review easier (please verify yourself that the output is identical). But it sets up the stage for future improvements, in this case switching from the old
```nix
  deps."package1" = tl."package1";
  deps."package2" = tl."package2";
```
to the simpler
```nix
  deps = [ "package1" "package2" ];
```
which will be helpful when fixing the dependency resolution issues (cycles, speed, memory usage).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
