### PR TITLE
init: Chromium headless-shell at stable (110.0.5481.77)

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -93,6 +93,7 @@
   libpulseaudio ? null,
   ungoogled ? false,
   ungoogled-chromium,
+  useSystemLibffi ? true,
   # Optional dependencies:
   libgcrypt ? null, # cupsSupport
   systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
@@ -720,9 +721,14 @@ let
         chrome_pgo_phase = 0;
         clang_base_path = "${llvmCcAndBintools}";
         use_qt = false;
+      }
+      // lib.optionalAttrs useSystemLibffi {
+
         # To fix the build as we don't provide libffi_pic.a
         # (ld.lld: error: unable to find library -l:libffi_pic.a):
         use_system_libffi = true;
+      }
+      // {
         # Use nixpkgs Rust compiler instead of the one shipped by Chromium.
         rust_sysroot_absolute = "${buildPackages.rustc}";
         rust_bindgen_root = "${buildPackages.rust-bindgen}";

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -33,6 +33,7 @@
   ungoogled ? false, # Whether to build chromium or ungoogled-chromium
   cupsSupport ? true,
   pulseSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
+  useSystemLibffi ? true,
   commandLineArgs ? "",
   pkgsBuildBuild,
   pkgs,
@@ -76,6 +77,7 @@ let
         cupsSupport
         pulseSupport
         ungoogled
+        useSystemLibffi
         ;
       gnChromium = buildPackages.gn.overrideAttrs (
         oldAttrs:

--- a/pkgs/applications/networking/browsers/chromium/headless-shell.nix
+++ b/pkgs/applications/networking/browsers/chromium/headless-shell.nix
@@ -1,0 +1,132 @@
+{
+  lib,
+  callPackage,
+  fontconfig,
+  makeWrapper,
+}:
+
+let
+  mkChromiumDerivation =
+    (callPackage ./. {
+      ungoogled = false;
+      enableWideVine = false;
+      pulseSupport = false;
+      cupsSupport = false;
+      proprietaryCodecs = false;
+      useSystemLibffi = false;
+    }).passthru.mkDerivation;
+
+in
+
+mkChromiumDerivation (base: rec {
+  name = "headless_shell";
+  packageName = "chromium-headless-shell";
+  buildTargets = [
+    "chrome_sandbox"
+    "headless_shell"
+  ];
+
+  outputs = [ "out" ];
+
+  nativeBuildInputs = [ makeWrapper ] ++ base.nativeBuildInputs;
+
+  gnFlags = {
+    ### Copy the contents of build/args/headless.gn, as docker-headless-shell does ###
+    ### Doesn't seem possible to just emit an import for that file ###
+    use_ozone = true;
+    ozone_auto_platforms = false;
+    ozone_platform = "headless";
+    ozone_platform_headless = true;
+    angle_enable_vulkan = true;
+    angle_enable_swiftshader = true;
+
+    # Embed resource.pak into binary to simplify deployment.
+    headless_use_embedded_resources = true;
+    headless_enable_commands = false;
+
+    # Don't use Prefs component, disabling access to Local State prefs.
+    headless_use_prefs = false;
+
+    # Don't use Policy component, disabling all policies.
+    headless_use_policy = false;
+
+    # Remove a dependency on a system fontconfig library.
+    use_bundled_fontconfig = true;
+
+    # In order to simplify deployment we build ICU data file
+    # into binary.
+    icu_use_data_file = false;
+
+    # Use embedded data instead external files for headless in order
+    # to simplify deployment.
+    v8_use_external_startup_data = false;
+
+    enable_nacl = false;
+    enable_print_preview = false;
+    enable_remoting = false;
+    use_alsa = false;
+    use_bluez = false;
+    use_cups = false;
+    use_dbus = false;
+    use_gio = false;
+    use_kerberos = false;
+    use_libpci = false;
+    use_pulseaudio = false;
+    use_udev = false;
+    rtc_use_pipewire = false;
+    v8_enable_lazy_source_positions = false;
+    use_glib = false;
+    use_gtk = false;
+    use_pangocairo = false;
+
+    # Extra stuff inspired by docker-headless-shell
+    is_debug = false;
+    symbol_level = 0;
+    blink_symbol_level = 0;
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cd "$buildPath"
+
+    cp -a ./{headless_shell,chrome_sandbox} $out/bin
+    cp -a *.so $out/bin
+
+    rm $out/bin/libEGL.so
+    rm $out/bin/libGLESv2.so
+
+    cd $out/bin
+    mv chrome_sandbox chrome-sandbox
+    mv headless_shell headless-shell
+
+    wrapProgram $out/bin/headless-shell \
+      --set CHROME_DEVEL_SANDBOX $out/bin/chrome-sandbox \
+      --set FONTCONFIG_PATH "${fontconfig.out}/etc/fonts/"
+
+    chmod -x *.so
+  '';
+
+  dontFixup = true;
+  postFixup = null;
+
+  sandboxExecutableName = "chrome-sandbox";
+
+  passthru = { inherit sandboxExecutableName; };
+
+  requiredSystemFeatures = [ "big-parallel" ];
+
+  meta = with lib; {
+    description = "An open source web browser from Google";
+    longDescription = ''
+      Chromium is an open source web browser from Google that aims to build a
+      safer, faster, and more stable way for all Internet users to experience
+      the web. It has a minimalist user interface and provides the vast majority
+      of source code for Google Chrome (which has some additional features).
+    '';
+    homepage = "https://www.chromium.org/";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    mainProgram = "chromium";
+  };
+})

--- a/pkgs/by-name/ch/chromium-headless-shell/package.nix
+++ b/pkgs/by-name/ch/chromium-headless-shell/package.nix
@@ -1,0 +1,131 @@
+{
+  lib,
+  chromium,
+  fontconfig,
+  makeWrapper,
+}:
+
+let
+  mkChromiumDerivation = chromium.passthru.mkDerivation.override {
+    ungoogled = false;
+    pulseSupport = false;
+    cupsSupport = false;
+    proprietaryCodecs = false;
+    useSystemLibffi = false;
+  };
+
+in
+
+mkChromiumDerivation (base: rec {
+  name = "headless_shell";
+  packageName = "chromium-headless-shell";
+  buildTargets = [
+    "chrome_sandbox"
+    "headless_shell"
+  ];
+
+  outputs = [ "out" ];
+
+  nativeBuildInputs = [ makeWrapper ] ++ base.nativeBuildInputs;
+
+  gnFlags = {
+    ### Copy the contents of build/args/headless.gn, as docker-headless-shell does ###
+    ### Doesn't seem possible to just emit an import for that file ###
+    use_ozone = true;
+    ozone_auto_platforms = false;
+    ozone_platform = "headless";
+    ozone_platform_headless = true;
+    angle_enable_vulkan = true;
+    angle_enable_swiftshader = true;
+
+    # Embed resource.pak into binary to simplify deployment.
+    headless_use_embedded_resources = true;
+    headless_enable_commands = false;
+
+    # Don't use Prefs component, disabling access to Local State prefs.
+    headless_use_prefs = false;
+
+    # Don't use Policy component, disabling all policies.
+    headless_use_policy = false;
+
+    # Remove a dependency on a system fontconfig library.
+    use_bundled_fontconfig = true;
+
+    # In order to simplify deployment we build ICU data file
+    # into binary.
+    icu_use_data_file = false;
+
+    # Use embedded data instead external files for headless in order
+    # to simplify deployment.
+    v8_use_external_startup_data = false;
+
+    enable_nacl = false;
+    enable_print_preview = false;
+    enable_remoting = false;
+    use_alsa = false;
+    use_bluez = false;
+    use_cups = false;
+    use_dbus = false;
+    use_gio = false;
+    use_kerberos = false;
+    use_libpci = false;
+    use_pulseaudio = false;
+    use_udev = false;
+    rtc_use_pipewire = false;
+    v8_enable_lazy_source_positions = false;
+    use_glib = false;
+    use_gtk = false;
+    use_pangocairo = false;
+
+    # Extra stuff inspired by docker-headless-shell
+    is_debug = false;
+    symbol_level = 0;
+    blink_symbol_level = 0;
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cd "$buildPath"
+
+    cp -a ./{headless_shell,chrome_sandbox} $out/bin
+    cp -a *.so $out/bin
+
+    rm $out/bin/libEGL.so
+    rm $out/bin/libGLESv2.so
+
+    cd $out/bin
+    mv chrome_sandbox chrome-sandbox
+    mv headless_shell headless-shell
+
+    wrapProgram $out/bin/headless-shell \
+      --set CHROME_DEVEL_SANDBOX $out/bin/chrome-sandbox \
+      --set FONTCONFIG_PATH "${fontconfig.out}/etc/fonts/"
+
+    chmod -x *.so
+  '';
+
+  dontFixup = true;
+  postFixup = null;
+
+  sandboxExecutableName = "chrome-sandbox";
+
+  passthru = { inherit sandboxExecutableName; };
+
+  requiredSystemFeatures = [ "big-parallel" ];
+
+  meta = with lib; {
+    description = "An open source web browser from Google";
+    longDescription = ''
+      Chromium is an open source web browser from Google that aims to build a
+      safer, faster, and more stable way for all Internet users to experience
+      the web. It has a minimalist user interface and provides the vast majority
+      of source code for Google Chrome (which has some additional features).
+    '';
+    homepage = "https://www.chromium.org/";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ thomasjm ];
+    mainProgram = "chromium";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13081,8 +13081,6 @@ with pkgs;
 
   chromium = callPackage ../applications/networking/browsers/chromium (config.chromium or {});
 
-  chromiumHeadlessShell = callPackage ../applications/networking/browsers/chromium/headless-shell.nix {};
-
   chuck = callPackage ../applications/audio/chuck {
     inherit (darwin) DarwinTools;
     inherit (darwin.apple_sdk.frameworks) AppKit Carbon CoreAudio CoreMIDI CoreServices Kernel MultitouchSupport;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13081,6 +13081,8 @@ with pkgs;
 
   chromium = callPackage ../applications/networking/browsers/chromium (config.chromium or {});
 
+  chromiumHeadlessShell = callPackage ../applications/networking/browsers/chromium/headless-shell.nix {};
+
   chuck = callPackage ../applications/audio/chuck {
     inherit (darwin) DarwinTools;
     inherit (darwin.apple_sdk.frameworks) AppKit Carbon CoreAudio CoreMIDI CoreServices Kernel MultitouchSupport;


### PR DESCRIPTION
###### Description of changes

Chrome's `headless-shell` is a special stripped-down version of the browser designed to be used in headless environments like servers, for purposes like testing, profiling, and taking screenshots. It's nice to use because the main `chromium` derivation is quite bulky. It can be used in place of normal Chrome with browser automation tools like [Puppeteer](https://pptr.dev/) or [chromedp](https://github.com/chromedp/chromedp).

The bulk of the work is getting the `gnFlags` correct in `headless-shell.nix`. For this I took a lot of inspiration from the [docker-headless-shell](https://github.com/chromedp/docker-headless-shell) project. The PR also has some minor refactoring in order to

* reuse the `meta` attrset by moving it to `meta.nix`
* avoid passing certain flags like `use_system_libffi` which the `headless_shell` build target doesn't recognize.

Here's the closure size difference:

```bash
> nix path-info -Sh .#chromiumHeadlessShell
/nix/store/aw777181vziiild0f84cv3pd0z718d60-chromium-headless-shell-unwrapped-110.0.5481.77      340.1M

> nix path-info -Sh .#chromium 
/nix/store/389w77yx3q31ai2y009y99bjrr7icn4k-chromium-110.0.5481.77         1.2G
```


###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`) (NB I tested with a version cherry-picked onto `release-22.11`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
