### PR TITLE
GNOME updates

### DIFF
--- a/pkgs/applications/networking/mailreaders/evolution/evolution-ews/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution-ews/default.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-ews";
-  version = "3.46.3";
+  version = "3.46.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "BFnqQFY2OKWllPQt3BzHGRotOCLCEcz/+82LNtMmQCU=";
+    sha256 = "bLYE99MKkh7MgxA9ZPKOj1+1VcFT9mHSQvayB/9Hy58=";
   };
 
   patches = [

--- a/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
@@ -44,11 +44,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution";
-  version = "3.46.3";
+  version = "3.46.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "riIQdCXTDRejo0w1bNpfQKrXhG12vbYINEUYtdQpwfM=";
+    sha256 = "eghCMc7SRaNLcT141Dp3Zgyso79S5qT1AwpqCAxpez0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome/core/evolution-data-server/default.nix
@@ -50,13 +50,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
-  version = "3.46.3";
+  version = "3.46.4";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "CTjiJ55c+8IgR2bKnT/qVwkRaZsHwQy+AaymKn6LK+4=";
+    sha256 = "pZslQUXFn6zXx7U4LbeNxfDtH2pum4/n1edZWfk8DMg=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/core/evolution-data-server/hardcode-gsettings.patch
+++ b/pkgs/desktops/gnome/core/evolution-data-server/hardcode-gsettings.patch
@@ -298,7 +298,7 @@ index e61160c..b6553a4 100644
  		G_CALLBACK (mi_user_headers_settings_changed_cb), NULL);
  	G_UNLOCK (mi_user_headers);
 diff --git a/src/camel/providers/imapx/camel-imapx-server.c b/src/camel/providers/imapx/camel-imapx-server.c
-index 611d5c8..4790fca 100644
+index 28755e2..da8c40c 100644
 --- a/src/camel/providers/imapx/camel-imapx-server.c
 +++ b/src/camel/providers/imapx/camel-imapx-server.c
 @@ -5593,7 +5593,18 @@ camel_imapx_server_skip_old_flags_update (CamelStore *store)

--- a/pkgs/desktops/gnome/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-software/default.nix
@@ -45,11 +45,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "gnome-software";
-  version = "43.3";
+  version = "43.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-software/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "k+6AdHl4rSzALlrnPQo9Psgu6hNPx3niqpFpAbu1gJA=";
+    sha256 = "6d8GDrq1n0lpfV7yYw7DbeYEVBadwZGvYNNINyCq2z4=";
   };
 
   patches = [


### PR DESCRIPTION
###### Description of changes

This PR updates projects maintained by mcrha.

https://gitlab.gnome.org/GNOME/evolution/-/commits/gnome-43
https://gitlab.gnome.org/GNOME/evolution-data-server/-/commits/gnome-43
https://gitlab.gnome.org/GNOME/evolution-ews/-/commits/gnome-43
https://gitlab.gnome.org/GNOME/gnome-software/-/commits/gnome-43

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review pr 216101` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages marked as broken and skipped:</summary>
  <ul>
    <li>elementary-planner</li>
    <li>gnome.gnome-todo</li>
    <li>pantheon.elementary-tasks</li>
    <li>xmonad_log_applet</li>
  </ul>
</details>
<details>
  <summary>46 packages built:</summary>
  <ul>
    <li>adapta-gtk-theme</li>
    <li>almanah</li>
    <li>bubblemail</li>
    <li>calls</li>
    <li>chatty</li>
    <li>cinnamon.cinnamon-common</li>
    <li>cinnamon.cinnamon-gsettings-overrides</li>
    <li>cinnamon.cinnamon-screensaver</li>
    <li>endeavour</li>
    <li>evolution</li>
    <li>evolution-data-server (gnome.evolution-data-server)</li>
    <li>evolution-data-server-gtk4</li>
    <li>evolution-ews</li>
    <li>evolutionWithPlugins</li>
    <li>folks</li>
    <li>gnome-browser-connector</li>
    <li>gnome.geary</li>
    <li>gnome.gnome-applets</li>
    <li>gnome.gnome-calendar</li>
    <li>gnome.gnome-contacts</li>
    <li>gnome.gnome-flashback</li>
    <li>gnome.gnome-notes</li>
    <li>gnome.gnome-panel</li>
    <li>gnome.gnome-session</li>
    <li>gnome.gnome-shell</li>
    <li>gnome.gnome-software</li>
    <li>gnome.gnome-terminal</li>
    <li>gnome.gnome-tweaks</li>
    <li>gnome.nixos-gsettings-overrides</li>
    <li>gnomeExtensions.easyScreenCast</li>
    <li>gnomeExtensions.gsconnect</li>
    <li>gnomeExtensions.system-monitor</li>
    <li>mojave-gtk-theme</li>
    <li>pantheon.elementary-calendar</li>
    <li>pantheon.elementary-greeter</li>
    <li>pantheon.elementary-mail</li>
    <li>pantheon.elementary-session-settings</li>
    <li>pantheon.switchboard-plug-onlineaccounts</li>
    <li>pantheon.switchboard-with-plugs</li>
    <li>pantheon.wingpanel-applications-menu</li>
    <li>pantheon.wingpanel-indicator-datetime</li>
    <li>pantheon.wingpanel-with-indicators</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>vimix-gtk-themes</li>
    <li>whitesur-gtk-theme</li>
  </ul>
</details>
