### PR TITLE
python310Packages.pytest-forked: 1.4.0 -> 1.6.0

### DIFF
--- a/pkgs/development/python-modules/pytest-forked/default.nix
+++ b/pkgs/development/python-modules/pytest-forked/default.nix
@@ -1,9 +1,10 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, fetchPypi
-, fetchpatch
+, fetchFromGitHub
+, setuptools
 , setuptools-scm
+, wheel
 , py
 , pytest
 , pytestCheckHook
@@ -11,28 +12,26 @@
 
 buildPythonPackage rec {
   pname = "pytest-forked";
-  version = "1.4.0";
+  version = "1.6.0";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-i2dYfI+Yy7rf3YBFOe1UVbbtA4AiA0hd0vU8FCLXRA4=";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "pytest-dev";
+    repo = "pytest-forked";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-owkGwF5WQ17/CXwTsIYJ2AgktekRB4qhtsDxR0LCI/k=";
   };
 
-  patches = [
-    # pytest 7.2.0 compat, remove after 1.4.0
-    (fetchpatch {
-      url = "https://github.com/pytest-dev/pytest-forked/commit/c3c753e96916a4bc5a8a37699e75c6cbbd653fa2.patch";
-      hash = "sha256-QPgxBeMQ0eKJyHXYZyBicVbE+JyKPV/Kbjsb8gNJBGA=";
-    })
-    (fetchpatch {
-      url = "https://github.com/pytest-dev/pytest-forked/commit/de584eda15df6db7912ab6197cfb9ff23024ef23.patch";
-      hash = "sha256-VLE32xZRwFK0nEgCWuSoMW/yyFHEURtNFU9Aa9haLhk=";
-    })
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+    wheel
   ];
 
-  nativeBuildInputs = [ setuptools-scm ];
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   buildInputs = [
     pytest
@@ -50,6 +49,7 @@ buildPythonPackage rec {
   setupHook = ./setup-hook.sh;
 
   meta = {
+    changelog = "https://github.com/pytest-dev/pytest-forked/blob/${src.rev}/CHANGELOG.rst";
     description = "Run tests in isolated forked subprocesses";
     homepage = "https://github.com/pytest-dev/pytest-forked";
     license = lib.licenses.mit;


### PR DESCRIPTION
###### Description of changes
Diff: https://github.com/pytest-dev/pytest-forked/compare/refs/tags/v1.4.0...v1.6.0

Changelog: https://github.com/pytest-dev/pytest-forked/blob/refs/tags/v1.6.0/CHANGELOG.rst


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
