### PR TITLE
flatcam: mark broken

### DIFF
--- a/pkgs/applications/science/electronics/flatcam/default.nix
+++ b/pkgs/applications/science/electronics/flatcam/default.nix
@@ -53,5 +53,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://bitbucket.org/jpcgt/flatcam";
     license = licenses.mit;
     maintainers = with maintainers; [ trepetti ];
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Description of changes

Tests have been failing since Shapely was updated to 2.0.0, e.g.:

	Traceback (most recent call last):
	  File "/build/source/tests/test_paint.py", line 89, in test_jump
	    result = Geometry.paint_connect(mkstorage(deepcopy(paths)), self.boundary, tooldia)
	  File "/build/source/camlib.py", line 792, in paint_connect
	    candidate.coords = list(candidate.coords)[::-1]
	AttributeError: can't set attribute 'coords'

The AttributeError comes from non-test code, so I assume the program is actually broken.

Upstream is dead.  There appears to be a maintained fork[1], but it fails to build with Python 3.9 so I didn't get very far with it[2]. Not dropping the package though, in case it gets fixed.

[1]: https://bitbucket.org/marius_stanciu/flatcam_beta/
[2]: https://bitbucket.org/jpcgt/flatcam/issues/625/makefile-on-beta-branch-thinks-python-311

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
