### PR TITLE
c64-debugger: init at 0.64.58.6

### DIFF
--- a/pkgs/applications/emulators/c64-debugger/default.nix
+++ b/pkgs/applications/emulators/c64-debugger/default.nix
@@ -1,0 +1,101 @@
+{ lib
+, stdenv
+, fetchgit
+, alsa-lib
+, gtk3
+, libGL
+, libGLU
+, libX11
+, pkg-config
+, upx
+, xcbutil
+}:
+
+stdenv.mkDerivation {
+  name = "c64-debugger";
+  version = "0.64.58.6";
+
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/c64-debugger/code";
+    rev = "f97772e3f5c8b4fa99e8ed212ed1c4cb1e2389f1";
+    sha256 = "sha256-3SR73AHQlYSEYpJLtQ/aJ1UITZGq7aA9tQKxBsn/yuc=";
+  };
+
+  buildInputs = [
+    alsa-lib
+    gtk3
+    libGL
+    libGLU
+    pkg-config
+    libX11
+    xcbutil
+  ];
+
+  nativeBuildInputs = [
+    upx
+  ];
+
+  postPatch = ''
+    # Disable default definition of RUN_COMMODORE64
+    sed -i 's|^#define RUN_COMMODORE64|//#define RUN_COMMODORE64|' MTEngine/Games/c64/C64D_Version.h
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Build C64 debugger
+    make -C MTEngine \
+      CFLAGS="-w -O2 -fcommon" \
+      CXXFLAGS="-w -O2 --std=c++11" \
+      DEFINES="-DRUN_COMMODORE64" \
+      -j$NIX_BUILD_CORES
+    mv MTEngine/c64debugger c64debugger
+    make -C MTEngine clean
+
+    # Build 65XE debugger
+    make -C MTEngine \
+      CFLAGS="-w -O2 -fcommon" \
+      CXXFLAGS="-w -O2 --std=c++11" \
+      DEFINES="-DRUN_ATARI" \
+      -j$NIX_BUILD_CORES
+    mv MTEngine/c64debugger 65xedebugger
+    make -C MTEngine clean
+
+    # Build NES debugger
+    make -C MTEngine \
+      CFLAGS="-w -O2 -fcommon" \
+      CXXFLAGS="-w -O2 --std=c++11" \
+      DEFINES="-DRUN_NES" \
+      -j$NIX_BUILD_CORES
+    mv MTEngine/c64debugger nesdebugger
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d "$out/bin"
+    install -d "$out/share/doc"
+    install -m 755 c64debugger 65xedebugger nesdebugger "$out/bin"
+    install -m 644 MTEngine/Assets/*.txt "$out/share/doc"
+    install -m 644 MTEngine/Assets/*.pdf "$out/share/doc"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://sourceforge.net/projects/c64-debugger";
+    description = "Commodore 64, Atari XL/XE and NES code and memory debugger that works in real time";
+    license = with licenses; [
+      gpl3Only # c64-debugger
+      mit # MTEngine
+      # emulators included in c64-debugger
+      gpl2Plus # VICE, atari800
+      gpl2 # nestopiaue
+    ];
+    mainProgram = "c64debugger";
+    maintainers = [ maintainers.detegr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -368,6 +368,8 @@ with pkgs;
 
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
+  c64-debugger = callPackage ../applications/emulators/c64-debugger { };
+
   caroline = callPackage ../development/libraries/caroline { };
 
   castget = callPackage ../applications/networking/feedreaders/castget { };


### PR DESCRIPTION
###### Description of changes

Add C64-debugger building the same versions (C64, 65XE, NES) that the project's binary release supplies.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
