### PR TITLE
ocaml-top: 1.2.0-rc → 1.2.0

### DIFF
--- a/pkgs/development/tools/ocaml/ocaml-top/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-top/default.nix
@@ -2,13 +2,13 @@
 
 with ocamlPackages; buildDunePackage rec {
   pname = "ocaml-top";
-  version = "1.2.0-rc";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "OCamlPro";
     repo = "ocaml-top";
     rev = version;
-    sha256 = "sha256-ZXnPnPvJmHshkTwYWeBojrgJYAF/R6vUo0XkvVMFSeQ=";
+    hash = "sha256-xmPGGB/zUpfeAxUIhR1PhfoESAJq7sTpqHuf++EH3Lw=";
   };
 
   nativeBuildInputs = [ ocp-build ];
@@ -17,11 +17,6 @@ with ocamlPackages; buildDunePackage rec {
   configurePhase = ''
     export TERM=xterm
     ocp-build -init
-  '';
-
-  postPatch = ''
-    substituteInPlace src/completion.ml \
-      --replace 'LibIndex.load ' 'LibIndex.load ~qualify:false '
   '';
 
   meta = {


### PR DESCRIPTION
###### Description of changes

https://github.com/OCamlPro/ocaml-top/blob/1.2.0/CHANGELOG

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
