### PR TITLE
python310Packages.check-manifest: 0.48 -> 0.49 

### DIFF
--- a/pkgs/development/python-modules/check-manifest/default.nix
+++ b/pkgs/development/python-modules/check-manifest/default.nix
@@ -3,12 +3,10 @@
 , build
 , buildPythonPackage
 , fetchPypi
-, fetchpatch
 , git
-, mock
 , pep517
 , pytestCheckHook
-, toml
+, tomli
 , pythonOlder
 }:
 
@@ -17,32 +15,27 @@ buildPythonPackage rec {
   version = "0.49";
   format = "setuptools";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-ZKZARFVCzyJpGWV8e3jQLZwcpbHCXX5m4OH/MlBg9BY=";
   };
 
-  patches = [
-    # Fix git submodule tests using file: protocol
-    (fetchpatch {
-      url = "https://github.com/mgedmin/check-manifest/pull/159.patch";
-      hash = "sha256-CDtuIoHgP4THLt+xF32C/OrjakwPOEVTKUh5JuQB5wM=";
-    })
-  ];
-
   propagatedBuildInputs = [
     build
     pep517
-    toml
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    tomli
   ];
 
   nativeCheckInputs = [
-    breezy
     git
-    mock
     pytestCheckHook
+  ];
+
+  checkInputs = [
+    breezy
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/check-manifest/default.nix
+++ b/pkgs/development/python-modules/check-manifest/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "check-manifest";
-  version = "0.48";
+  version = "0.49";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-O1dfHa3nvrMHjvS/M6lFGYNEV8coHbxyaxXFRmtVxlc=";
+    hash = "sha256-ZKZARFVCzyJpGWV8e3jQLZwcpbHCXX5m4OH/MlBg9BY=";
   };
 
   patches = [
@@ -57,6 +57,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Check MANIFEST.in in a Python source package for completeness";
     homepage = "https://github.com/mgedmin/check-manifest";
+    changelog = "https://github.com/mgedmin/check-manifest/blob/${version}/CHANGES.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ lewo ];
   };


### PR DESCRIPTION
###### Description of changes
Depends on #216235
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
