### PR TITLE
androidenv: fix autopatching toolchains

### DIFF
--- a/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
+++ b/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
@@ -7,13 +7,34 @@ let
     coreutils file findutils gawk gnugrep gnused jdk python3 which
   ]) + ":${platform-tools}/platform-tools";
 in
-deployAndroidPackage {
+deployAndroidPackage rec {
   inherit package os;
   nativeBuildInputs = [ makeWrapper ]
     ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
   autoPatchelfIgnoreMissingDeps = true;
   buildInputs = lib.optionals (os == "linux") [ pkgs.zlib ];
-  patchInstructions = ''
+
+  patchElfBnaries = ''
+    # Patch the executables of the toolchains, but not the libraries -- they are needed for crosscompiling
+    if [ -d $out/libexec/android-sdk/ndk-bundle/toolchains/renderscript/prebuilt/linux-x86_64/lib64 ]; then
+      addAutoPatchelfSearchPath $out/libexec/android-sdk/ndk-bundle/toolchains/renderscript/prebuilt/linux-x86_64/lib64
+    fi
+
+    if [ -d $out/libexec/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/lib64 ]; then
+      addAutoPatchelfSearchPath $out/libexec/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/lib64
+    fi
+
+    find toolchains -type d -name bin -or -name lib64 | while read dir; do
+      autoPatchelf "$dir"
+    done
+
+    # Patch executables
+    if [ -d prebuilt/linux-x86_64 ]; then
+      autoPatchelf prebuilt/linux-x86_64
+    fi
+  '';
+
+  patchOsAgnostic = ''
     patchShebangs .
 
     # TODO: allow this stuff
@@ -22,47 +43,31 @@ deployAndroidPackage {
     # Ndk now has a prebuilt toolchains inside, the file layout has changed, we do a symlink
     # to still support the old standalone toolchains builds.
     if [ -d $out/libexec/android-sdk/ndk ] && [ ! -d $out/libexec/android-sdk/ndk-bundle ]; then
-        ln -sf $out/libexec/android-sdk/ndk/${package.revision} $out/libexec/android-sdk/ndk-bundle
+      ln -sf $out/libexec/android-sdk/ndk/${package.revision} $out/libexec/android-sdk/ndk-bundle
     elif [ ! -d $out/libexec/android-sdk/ndk-bundle ]; then
-        echo "The ndk-bundle layout has changed. The nix expressions have to be updated!"
-        exit 1
-    fi
-
-    # Patch the executables of the toolchains, but not the libraries -- they are needed for crosscompiling
-    if [ -d $out/libexec/android-sdk/ndk-bundle/toolchains/renderscript/prebuilt/linux-x86_64/lib64 ]; then
-        addAutoPatchelfSearchPath $out/libexec/android-sdk/ndk-bundle/toolchains/renderscript/prebuilt/linux-x86_64/lib64
-    fi
-
-    if [ -d $out/libexec/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/lib64 ]; then
-        addAutoPatchelfSearchPath $out/libexec/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/lib64
-    fi
-
-    if [ -d toolchains/llvm/prebuilt/linux-x86_64 ]; then
-        find toolchains/llvm/prebuilt/linux-x86_64 -type d -name bin -or -name lib64 | while read dir; do
-            autoPatchelf "$dir"
-        done
+      echo "The ndk-bundle layout has changed. The nix expressions have to be updated!"
+      exit 1
     fi
 
     # fix ineffective PROGDIR / MYNDKDIR determination
     for progname in ndk-build; do
-        sed -i -e 's|^PROGDIR=`dirname $0`|PROGDIR=`dirname $(readlink -f $(which $0))`|' $progname
+      sed -i -e 's|^PROGDIR=`dirname $0`|PROGDIR=`dirname $(readlink -f $(which $0))`|' $progname
     done
-
-    # Patch executables
-    if [ -d prebuilt/linux-x86_64 ]; then
-        autoPatchelf prebuilt/linux-x86_64
-    fi
 
     # wrap
     for progname in ndk-build; do
-        wrapProgram "$(pwd)/$progname" --prefix PATH : "${runtime_paths}"
+      wrapProgram "$(pwd)/$progname" --prefix PATH : "${runtime_paths}"
     done
 
     # make some executables available in PATH
     mkdir -p $out/bin
     for progname in ndk-build; do
-        ln -sf ../libexec/android-sdk/ndk-bundle/$progname $out/bin/$progname
+      ln -sf ../libexec/android-sdk/ndk-bundle/$progname $out/bin/$progname
     done
   '';
+
+  patchInstructions = patchOsAgnostic
+    + lib.optionalString stdenv.isLinux patchElfBnaries;
+
   noAuditTmpdir = true; # Audit script gets invoked by the build/ component in the path for the make standalone script
 }


### PR DESCRIPTION
###### Description of changes
Use of binaries from NDK `toolchains` has been broken by following PR:

* https://github.com/NixOS/nixpkgs/pull/195752

I'm splitting the `patchInstructions` to run the ELF patching only on Linux.

```
[nix-shell:~/work/status-mobile]$ $ANDROID_HOME/ndk/22.1.7171670/toolchains/x86_64-4.9/prebuilt/linux-x86_64/bin/x86_64-linux-android-strip --help
bash: /nix/store/084pp923k5k24gnb44h9d6azk84grnh8-androidsdk-mod-sdk/ndk/22.1.7171670/toolchains/x86_64-4.9/prebuilt/linux-x86_64/bin/x86_64-linux-android-strip: No such file or directory
```
Related to another fix of bug introduced by #195752:

* https://github.com/NixOS/nixpkgs/pull/215492

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).