### PR TITLE
haskellPackages: fixes

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2223,6 +2223,7 @@ self: super: {
             # but it compiles cleanly using deps in LTS-18 as well.  This jailbreak can
             # likely be removed when purescript-0.14.6 is released.
             doJailbreak
+            (appendPatch ./patches/purescript-jailbreak-build-tool-depends.patch)
             # Generate shell completions
             (self.generateOptparseApplicativeCompletions [ "purs" ])
           ]);

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -321,4 +321,7 @@ self: super: ({
   # same
   # https://hydra.nixos.org/build/174540882/nixlog/9
   jacinda = dontCheck super.jacinda;
+
+  # "resource exhausted (Too many open files)' (after 100 tests)"
+  tz = dontCheck super.tz;
 })

--- a/pkgs/development/haskell-modules/patches/purescript-jailbreak-build-tool-depends.patch
+++ b/pkgs/development/haskell-modules/patches/purescript-jailbreak-build-tool-depends.patch
@@ -1,0 +1,32 @@
+diff --git a/purescript.cabal b/purescript.cabal
+index ac78a66075f..96cefbb9abf 100644
+--- a/purescript.cabal
++++ b/purescript.cabal
+@@ -233,7 +233,7 @@ library
+         Language.PureScript.Types
+         System.IO.UTF8
+ 
+-    build-tool-depends: happy:happy ==1.20.0
++    build-tool-depends: happy:happy
+     hs-source-dirs:     src
+     other-modules:
+         Data.Text.PureScript
+@@ -322,7 +322,7 @@ library
+ 
+ executable purs
+     main-is:            Main.hs
+-    build-tool-depends: happy:happy ==1.20.0
++    build-tool-depends: happy:happy
+     hs-source-dirs:     app
+     other-modules:
+         Command.Bundle
+@@ -435,8 +435,7 @@ test-suite tests
+     type:               exitcode-stdio-1.0
+     main-is:            Main.hs
+     build-tool-depends:
+-        happy:happy ==1.20.0, hspec-discover:hspec-discover,
+-        purescript:purs
++        happy:happy, hspec-discover:hspec-discover, purescript:purs
+ 
+     hs-source-dirs:     tests
+     other-modules:


### PR DESCRIPTION
Opened a PR for the `build-tool-depends` thing: https://github.com/NixOS/jailbreak-cabal/pull/20