### PR TITLE
torq: 0.17.3 -> 0.18.17, fix frontend build

### DIFF
--- a/pkgs/applications/blockchains/torq/default.nix
+++ b/pkgs/applications/blockchains/torq/default.nix
@@ -29,7 +29,7 @@ let
     # override npmInstallHook, we only care about the build/ directory
     installPhase = ''
       mkdir $out
-      cp -r build $out/
+      cp -r build/* $out/
     '';
   };
 in
@@ -47,7 +47,8 @@ buildGoModule rec {
   ];
 
   postInstall = ''
-    ln -s ${web} $out/web
+    mkdir -p $out/web/build
+    cp -r ${web}/* $out/web/build/
   '';
 
   meta = with lib; {

--- a/pkgs/applications/blockchains/torq/default.nix
+++ b/pkgs/applications/blockchains/torq/default.nix
@@ -6,20 +6,20 @@
 
 let
   pname = "torq";
-  version = "0.17.3";
+  version = "0.18.17";
 
   src = fetchFromGitHub {
     owner = "lncapital";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-fqHJZi1NQCrZqsa+N+FVYZ8s9o0D555Sqn5qNlJ1MmI=";
+    hash = "sha256-xiA66yGo8b1+zZ7jQ7SFOtNPmqbdna7fUCT21uibrIM=";
   };
 
   web = buildNpmPackage {
     pname = "${pname}-frontend";
     inherit version;
     src = "${src}/web";
-    npmDepsHash = "sha256-8mUfTFzPjQlQvhC3zZf+WruDBkYnmGt3yckNi0CPWs0=";
+    npmDepsHash = "sha256-/7x5RWYIB5BChYMnMuFVVaZd0pVkew4i4QrF7hSFnCM=";
 
     # copied from upstream Dockerfile
     npmInstallFlags = [ "--legacy-peer-deps" ];
@@ -36,7 +36,7 @@ in
 buildGoModule rec {
   inherit pname version src;
 
-  vendorHash = "sha256-HETN2IMnpxnTyg6bQDpoD0saJu+gKocdEf0VzEi12Gs=";
+  vendorHash = "sha256-bvisI589Gq9IdyJEqI+uzs3iDPOTUkq95P3n/KoFhF0=";
 
   subPackages = [ "cmd/torq" ];
 


### PR DESCRIPTION
###### Description of changes

New version. https://github.com/lncapital/torq/releases/tag/v0.18.17

Found out that linking to the torq-web derivation does not automatically add a dependency so after garbage collection there is a dead link. Files are now copied instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
