### PR TITLE
plasma-mobile/qmlkonsole: init at 23.01.0

### DIFF
--- a/pkgs/applications/plasma-mobile/default.nix
+++ b/pkgs/applications/plasma-mobile/default.nix
@@ -78,6 +78,7 @@ let
       plasma-phonebook = callPackage ./plasma-phonebook.nix {};
       plasma-settings = callPackage ./plasma-settings.nix {};
       plasmatube = callPackage ./plasmatube {};
+      qmlkonsole = callPackage ./qmlkonsole.nix {};
       spacebar = callPackage ./spacebar.nix { inherit srcs; };
       tokodon = callPackage ./tokodon.nix {};
     };

--- a/pkgs/applications/plasma-mobile/qmlkonsole.nix
+++ b/pkgs/applications/plasma-mobile/qmlkonsole.nix
@@ -1,0 +1,42 @@
+{ lib
+, mkDerivation
+
+, cmake
+, extra-cmake-modules
+
+, kconfig
+, ki18n
+, kirigami-addons
+, kirigami2
+, kcoreaddons
+, qtquickcontrols2
+, kwindowsystem
+, qmltermwidget
+}:
+
+mkDerivation {
+  pname = "qmlkonsole";
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kconfig
+    ki18n
+    kirigami-addons
+    kirigami2
+    qtquickcontrols2
+    kcoreaddons
+    kwindowsystem
+    qmltermwidget
+  ];
+
+  meta = with lib; {
+    description = "Terminal app for Plasma Mobile";
+    homepage = "https://invent.kde.org/plasma-mobile/qmlkonsole";
+    license = with licenses; [ gpl2Plus gpl3Plus cc0 ];
+    maintainers = with maintainers; [ balsoft ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Add [qmlkonsole](https://invent.kde.org/plasma-mobile/qmlkonsole),

> A terminal application built for touch, based on qmltermwidget.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

