### PR TITLE
maintainers: Fix github account names/ids

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -76,7 +76,7 @@
   _0xB10C = {
     email = "nixpkgs@b10c.me";
     name = "0xB10C";
-    github = "0xb10c";
+    github = "0xB10C";
     githubId = 19157360;
   };
   _0xbe7a = {
@@ -817,7 +817,7 @@
   notbandali = {
     name = "Amin Bandali";
     email = "bandali@gnu.org";
-    github = "notbandali";
+    github = "bandali0";
     githubId = 1254858;
     keys = [{
       fingerprint = "BE62 7373 8E61 6D6D 1B3A  08E8 A21A 0202 4881 6103";
@@ -1760,7 +1760,7 @@
   benesim = {
     name = "Benjamin Isbarn";
     email = "benjamin.isbarn@gmail.com";
-    github = "benesim";
+    github = "BeneSim";
     githubId = 29384538;
     keys = [{
       fingerprint = "D35E C9CE E631 638F F1D8  B401 6F0E 410D C3EE D02";
@@ -3130,7 +3130,7 @@
   cust0dian = {
     email = "serg@effectful.software";
     github = "cust0dian";
-    githubId = 389387;
+    githubId = 119854490;
     name = "Serg Nesterov";
     keys = [{
       fingerprint = "6E7D BA30 DB5D BA60 693C  3BE3 1512 F6EB 84AE CC8C";
@@ -3409,7 +3409,7 @@
   };
   davsanchez = {
     email = "davidslt+nixpkgs@pm.me";
-    github = "davsanchez";
+    github = "DavSanchez";
     githubId = 11422515;
     name = "David Sánchez";
   };
@@ -3902,6 +3902,7 @@
     name = "Davide Peressoni";
     email = "davide.peressoni@tuta.io";
     matrix = "@dpd-:matrix.org";
+    github = "DPDmancul";
     githubId = 3186857;
   };
   dpercy = {
@@ -4332,7 +4333,7 @@
   };
   elnudev = {
     email = "elnu@elnu.com";
-    github = "elnudev";
+    github = "ElnuDev";
     githubId = 9874955;
     name = "Elnu";
   };
@@ -4620,7 +4621,7 @@
   };
   ewok = {
     email = "ewok@ewok.ru";
-    github = "ewok";
+    github = "ewok-old";
     githubId = 454695;
     name = "Artur Taranchiev";
   };
@@ -5751,7 +5752,7 @@
   };
   harrisonthorne = {
     email = "harrisonthorne@proton.me";
-    github = "harrisonthorne";
+    github = "muni-corn";
     githubId = 33523827;
     name = "Harrison Thorne";
   };
@@ -6986,7 +6987,7 @@
   };
   jkarlson = {
     email = "jekarlson@gmail.com";
-    github = "jkarlson";
+    github = "ethorsoe";
     githubId = 1204734;
     name = "Emil Karlson";
   };
@@ -7764,7 +7765,7 @@
     name = "Kid";
   };
   kidsan = {
-    github = "kidsan";
+    github = "Kidsan";
     githubId = 8798449;
     name = "kidsan";
   };
@@ -8661,6 +8662,8 @@
   loveisgrief = {
     name = "LoveIsGrief";
     email = "loveisgrief@tuta.io";
+    github = "LoveIsGrief";
+    githubId = 2829538;
     keys = [{
       fingerprint = "9847 4F48 18C6 4E0A F0C5  3529 E96D 1EDF A053 45EB";
     }];
@@ -8812,7 +8815,7 @@
   };
   lux = {
     email = "lux@lux.name";
-    github = "luxferresum";
+    github = "luxzeitlos";
     githubId = 1208273;
     matrix = "@lux:ontheblueplanet.com";
     name = "Lux";
@@ -9285,7 +9288,7 @@
   };
   maxwell-lt = {
     email = "maxwell.lt@live.com";
-    github = "maxwell-lt";
+    github = "Maxwell-lt";
     githubId = 17859747;
     name = "Maxwell L-T";
   };
@@ -9924,7 +9927,7 @@
     name = "Mon Aaraj";
     email = "owo69uwu69@gmail.com";
     matrix = "@mon:tchncs.de";
-    github = "MonAaraj";
+    github = "ribosomerocker";
     githubId = 46468162;
   };
   monsieurp = {
@@ -10173,7 +10176,7 @@
   munksgaard = {
     name = "Philip Munksgaard";
     email = "philip@munksgaard.me";
-    github = "munksgaard";
+    github = "Munksgaard";
     githubId = 230613;
     matrix = "@philip:matrix.munksgaard.me";
     keys = [{
@@ -10790,7 +10793,7 @@
   };
   nrhelmi = {
     email = "helmiinour@gmail.com";
-    github = "nrhelmi";
+    github = "NRHelmi";
     githubId = 15707703;
     name = "Helmi Nour";
   };
@@ -11167,7 +11170,7 @@
   };
   paddygord = {
     email = "pgpatrickgordon@gmail.com";
-    github = "paddygord";
+    github = "avaunit02";
     githubId = 10776658;
     name = "Patrick Gordon";
   };
@@ -12217,7 +12220,7 @@
   };
   ratsclub = {
     email = "victor@freire.dev.br";
-    github = "vtrf";
+    github = "ratsclub";
     githubId = 25647735;
     name = "Victor Freire";
   };
@@ -12481,7 +12484,7 @@
   };
   rika = {
     email = "rika@paymentswit.ch";
-    github = "NekomimiScience";
+    github = "ScarletHg";
     githubId = 1810487;
     name = "Rika";
   };
@@ -13476,7 +13479,7 @@
   shreerammodi = {
     name = "Shreeram Modi";
     email = "shreerammodi10@gmail.com";
-    github = "Shrimpram";
+    github = "shrimpram";
     githubId = 67710369;
     keys = [{
       fingerprint = "EA88 EA07 26E9 6CBF 6365  3966 163B 16EE 76ED 24CE";
@@ -13714,7 +13717,7 @@
   sno2wman = {
     name = "SnO2WMaN";
     email = "me@sno2wman.net";
-    github = "sno2wman";
+    github = "SnO2WMaN";
     githubId = 15155608;
   };
   snpschaaf = {
@@ -14468,7 +14471,7 @@
   };
   teozkr = {
     email = "teo@nullable.se";
-    github = "teozkr";
+    github = "nightkr";
     githubId = 649832;
     name = "Teo Klestrup Röijezon";
   };
@@ -14955,7 +14958,7 @@
   };
   tonyshkurenko = {
     email = "support@twingate.com";
-    github = "tonyshkurenko";
+    github = "antonshkurenko";
     githubId = 8597964;
     name = "Anton Shkurenko";
   };
@@ -15294,7 +15297,7 @@
   };
   uthar = {
     email = "galkowskikasper@gmail.com";
-    github = "uthar";
+    github = "Uthar";
     githubId = 15697697;
     name = "Kasper Gałkowski";
   };
@@ -16424,7 +16427,7 @@
   zebreus = {
     matrix = "@lennart:cicen.net";
     email = "lennarteichhorn+nixpkgs@gmail.com";
-    github = "Zebreus";
+    github = "zebreus";
     githubId = 1557253;
     name = "Lennart Eichhorn";
   };


### PR DESCRIPTION
- cust0dian is now known on github as @cust0dian-old @cust0dian.
- davsanchez is now known on github as @DavSanchez.
- luxferresum is now known on github as @luxzeitlos.
- benesim is now known on github as @BeneSim.
- DPDmancul has no github handle @DPDmancul 
- maxwell-lt is now known on github as @Maxwell-lt.
- paddygord is now known on github as @avaunit02.
- ewok is now known on github as @ewok-old @ewok.
- nrhelmi is now known on github as @NRHelmi.
- elnudev is now known on github as @ElnuDev.
- jkarlson is now known on github as @ethorsoe.
- Zebreus is now known on github as @zebreus.
- vtrf is now known on github as @ratsclub.
- loveisgrief has no github handle @LoveIsGrief 
- sno2wman is now known on github as @SnO2WMaN.
- kidsan is now known on github as @Kidsan.
- harrisonthorne is now known on github as @muni-corn.
- teozkr is now known on github as @nightkr.
- 0xb10c is now known on github as @0xB10C.
- NekomimiScience is now known on github as @ScarletHg.
- tonyshkurenko is now known on github as @antonshkurenko.
- notbandali is now known on github as @bandali0.
- Shrimpram is now known on github as @shrimpram.
- munksgaard is now known on github as @Munksgaard.
- MonAaraj is now known on github as @ribosomerocker.
- uthar is now known on github as @Uthar.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
