### PR TITLE
pairdrop: init at 1.1.0

### DIFF
--- a/pkgs/applications/misc/pairdrop/default.nix
+++ b/pkgs/applications/misc/pairdrop/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, nodejs
+}:
+
+buildNpmPackage rec {
+  pname = "pairdrop";
+  version = "1.7.6";
+
+  src = fetchFromGitHub {
+    owner = "schlagmichdoch";
+    repo = "PairDrop";
+    rev = "v${version}";
+    hash = "sha256-AOFATOCLf2KigeqoUzIfNngyeDesNrThRzxFvqtsXBs=";
+  };
+
+  npmDepsHash = "sha256-3nKjmC5eizoV/mrKDBhsSlVQxEHyIsWR6KHFwZhBugI=";
+
+  dontNpmBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib
+    cp -r * $out/lib
+
+    makeWrapper ${nodejs}/bin/node "$out/bin/pairdrop" --add-flags "index.js public --rate-limit --auto-restart"
+    wrapProgram $out/bin/pairdrop --chdir "$out/lib"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Local file sharing in your browser";
+    longDescription = ''
+      PairDrop is a sublime alternative to AirDrop that works on all platforms.
+      Send images, documents or text via peer to peer connection to devices in the same local network/Wi-Fi or to paired devices.
+    '';
+    homepage = "https://github.com/schlagmichdoch/PairDrop";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3370,6 +3370,8 @@ with pkgs;
 
   pacparser = callPackage ../tools/networking/pacparser { };
 
+  pairdrop = callPackage ../applications/misc/pairdrop { };
+
   opencbm = callPackage ../tools/misc/opencbm { };
 
   parquet-tools = callPackage ../tools/misc/parquet-tools { };


### PR DESCRIPTION
###### Description of changes

https://github.com/schlagmichdoch/PairDrop
PairDrop: Local file sharing in your browser. Inspired by Apple's AirDrop. Fork of Snapdrop. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
