### PR TITLE
libdeflate: 1.8 -> 1.17

### DIFF
--- a/pkgs/development/libraries/libdeflate/default.nix
+++ b/pkgs/development/libraries/libdeflate/default.nix
@@ -1,38 +1,28 @@
-{ stdenv, lib, fetchpatch, fetchFromGitHub, fixDarwinDylibNames, pkgsStatic }:
-
+{ lib
+, stdenv
+, fetchFromGitHub
+, fixDarwinDylibNames
+, pkgsStatic
+, cmake
+}:
 stdenv.mkDerivation rec {
   pname = "libdeflate";
-  version = "1.8";
+  version = "1.17";
 
   src = fetchFromGitHub {
     owner = "ebiggers";
     repo = "libdeflate";
     rev = "v${version}";
-    sha256 = "sha256-P7YbuhP2/zJCpE9dxZev1yy5oda8WKAHY84ZLTL8gVs=";
+    sha256 = "sha256-tKs8feGbeodOID8FPIUc/1LfBz1p0oN1Jfkv2OnA2qc=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/ebiggers/libdeflate/commit/ee4d18872bfe09a32cfd031c716b9069a04a50a0.diff";
-      sha256 = "0d2lllg60zbbbch0w0qrcqijrgski8xlsy5llg3i684d66ci538a";
-    })
-  ];
+  cmakeFlags = lib.optionals stdenv.hostPlatform.isStatic [ "-DLIBDEFLATE_BUILD_SHARED_LIB=OFF" ];
 
-  postPatch = ''
-    substituteInPlace Makefile --replace /usr/local $out
-  '';
-
-  makeFlags = lib.optionals stdenv.hostPlatform.isStatic [ "DISABLE_SHARED=1"];
-
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
-
-  configurePhase = ''
-    make programs/config.h
-  '';
-
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ cmake ]
+    ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 
   passthru.tests.static = pkgsStatic.libdeflate;
+
   meta = with lib; {
     description = "Fast DEFLATE/zlib/gzip compressor and decompressor";
     license = licenses.mit;


### PR DESCRIPTION
###### Description of changes

https://github.com/ebiggers/libdeflate/blob/bd925ae68e99f65d69f20181cb845aaba5c8f098/NEWS.md

package update and cleanup to resolve a minor warning in the KiCad build
(not finding libdeflate.pc, which was introduced in 1.9)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - 18260 packages affected
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
