### PR TITLE
nix-prefetch-docker: fix cross-platform use

### DIFF
--- a/pkgs/build-support/docker/nix-prefetch-docker
+++ b/pkgs/build-support/docker/nix-prefetch-docker
@@ -126,21 +126,30 @@ fi
 sourceUrl="docker://$imageName@$imageDigest"
 
 tmpPath="$(mktemp -d "${TMPDIR:-/tmp}/skopeo-copy-tmp-XXXXXXXX")"
-trap "rm -rf \"$tmpPath\"" EXIT
 
-tmpFile="$tmpPath/$(get_name $finalImageName $finalImageTag)"
-
-if test -z "$QUIET"; then
-    skopeo copy "$sourceUrl" "docker-archive://$tmpFile:$finalImageName:$finalImageTag" >&2
+if [[ -z "${IS_FETCHER:-}" ]]; then
+    # prefetcher
+    trap "rm -rf \"$tmpPath\"" EXIT
+    outFile="$tmpPath/$(get_name $finalImageName $finalImageTag)"
 else
-    skopeo copy "$sourceUrl" "docker-archive://$tmpFile:$finalImageName:$finalImageTag" > /dev/null
+    # fetcher
+    outFile="$out"
 fi
 
+if test -z "$QUIET"; then
+    skopeo copy "$sourceUrl" "docker-archive://$outFile:$finalImageName:$finalImageTag" >&2
+else
+    skopeo copy "$sourceUrl" "docker-archive://$outFile:$finalImageName:$finalImageTag" > /dev/null
+fi
+
+if [[ -z "${IS_FETCHER:-}" ]]; then
+# prefetcher
+
 # Compute the hash.
-imageHash=$(nix-hash --flat --type $hashType --base32 "$tmpFile")
+imageHash=$(nix-hash --flat --type $hashType --base32 "$outFile")
 
 # Add the downloaded file to Nix store.
-finalPath=$(nix-store --add-fixed "$hashType" "$tmpFile")
+finalPath=$(nix-store --add-fixed "$hashType" "$outFile")
 
 if test -z "$QUIET"; then
     echo "-> ImageName: $imageName" >&2
@@ -174,4 +183,7 @@ cat <<EOF
 }
 EOF
 
+fi
+
+# end if prefetcher
 fi

--- a/pkgs/build-support/docker/nix-prefetch-docker
+++ b/pkgs/build-support/docker/nix-prefetch-docker
@@ -30,6 +30,10 @@ Options:
     exit 1
 }
 
+skopeo(){
+    command skopeo --insecure-policy --tmpdir "$TMPDIR" --override-os "$os" --override-arch "$arch" "$@"
+}
+
 get_image_digest(){
     local imageName=$1
     local imageTag=$2
@@ -38,7 +42,7 @@ get_image_digest(){
         imageTag="latest"
     fi
 
-    skopeo --insecure-policy --tmpdir=$TMPDIR inspect "docker://$imageName:$imageTag" | jq '.Digest' -r
+    skopeo inspect "docker://$imageName:$imageTag" | jq '.Digest' -r
 }
 
 get_name() {
@@ -127,9 +131,9 @@ trap "rm -rf \"$tmpPath\"" EXIT
 tmpFile="$tmpPath/$(get_name $finalImageName $finalImageTag)"
 
 if test -z "$QUIET"; then
-    skopeo --insecure-policy --tmpdir=$TMPDIR --override-os ${os} --override-arch ${arch} copy "$sourceUrl" "docker-archive://$tmpFile:$finalImageName:$finalImageTag" >&2
+    skopeo copy "$sourceUrl" "docker-archive://$tmpFile:$finalImageName:$finalImageTag" >&2
 else
-    skopeo --insecure-policy --tmpdir=$TMPDIR --override-os ${os} --override-arch ${arch} copy "$sourceUrl" "docker-archive://$tmpFile:$finalImageName:$finalImageTag" > /dev/null
+    skopeo copy "$sourceUrl" "docker-archive://$tmpFile:$finalImageName:$finalImageTag" > /dev/null
 fi
 
 # Compute the hash.

--- a/pkgs/build-support/docker/nix-prefetch-docker
+++ b/pkgs/build-support/docker/nix-prefetch-docker
@@ -69,6 +69,7 @@ for arg; do
             --quiet) QUIET=true;;
             --json) format=json;;
             --help) usage; exit;;
+            -*) echo >&2 echo "Unknown flag $arg"; usage; exit;;
             *)
                 : $((++argi))
                 case $argi in

--- a/pkgs/build-support/docker/nix-prefetch-docker
+++ b/pkgs/build-support/docker/nix-prefetch-docker
@@ -2,6 +2,8 @@
 
 set -e -o pipefail
 
+TMPDIR=${TMPDIR:-/tmp}
+
 os=
 arch=
 imageName=

--- a/pkgs/build-support/docker/nix-prefetch-docker.nix
+++ b/pkgs/build-support/docker/nix-prefetch-docker.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, makeWrapper, nix, skopeo, jq }:
+{ lib, callPackage, stdenv, makeWrapper, nix, skopeo, jq }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   name = "nix-prefetch-docker";
 
   nativeBuildInputs = [ makeWrapper ];
@@ -16,9 +16,19 @@ stdenv.mkDerivation {
 
   preferLocalBuild = true;
 
+  passthru = {
+    fetch = callPackage ./test/fetchDocker.nix {
+      nix-prefetch-docker = finalAttrs.finalPackage;
+    };
+    tests = callPackage ./test/fetchDocker-tests.nix {
+      nix-prefetch-docker = finalAttrs.finalPackage;
+      fetchDocker = finalAttrs.finalPackage.fetch;
+    };
+  };
+
   meta = with lib; {
     description = "Script used to obtain source hashes for dockerTools.pullImage";
     maintainers = with maintainers; [ offline ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/build-support/docker/test/busybox-1.36.0.json
+++ b/pkgs/build-support/docker/test/busybox-1.36.0.json
@@ -1,0 +1,7 @@
+{
+  "imageName": "busybox",
+  "imageDigest": "sha256:7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c",
+  "sha256": "0p1h0gq1s8fv7pjbg48vj0n68nc7r4p03z7rar1im014q9c5nsi4",
+  "finalImageName": "busybox",
+  "finalImageTag": "1.36.0"
+}

--- a/pkgs/build-support/docker/test/fetchDocker-tests.nix
+++ b/pkgs/build-support/docker/test/fetchDocker-tests.nix
@@ -1,0 +1,10 @@
+{ lib, fetchDocker, runCommand, nix-prefetch-docker, testers }:
+
+lib.recurseIntoAttrs {
+
+  busybox = testers.invalidateFetcherByDrvHash fetchDocker (lib.importJSON ./busybox-1.36.0.json // {
+    name = "busybox";
+    arch = "amd64";
+  });
+
+}

--- a/pkgs/build-support/docker/test/fetchDocker.nix
+++ b/pkgs/build-support/docker/test/fetchDocker.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  nix-prefetch-docker,
+  stdenvNoCC,
+  cacert,
+}:
+
+/*
+
+                              NOTE
+
+  This fetcher was written in order to test nix-prefetch-docker.
+  We may "rebase" the existing fetchgithub onto nix-prefetch-docker,
+  or call it fetchDocker (camelCase), and migrate users over to it.
+  Doing so has the benefit that it more closely follows the architecture of
+  some other fetchers: calling the prefetch script in the actual fetcher.
+  Until then, the purpose of this function is to test nix-prefetch-docker.
+
+*/
+args@{ name, hash ? "", sha256 ? "", os ? "linux", arch, imageName, imageTag ? finalImageTag, imageDigest, finalImageName ? imageName, finalImageTag ? imageTag }:
+
+assert args?imageTag || args?finalImageTag;
+assert args?imageName || args?finalImageName;
+
+stdenvNoCC.mkDerivation {
+  inherit name;
+  outputHashAlgo = if hash != "" then null else "sha256";
+  outputHashMode = "flat";
+  outputHash = if hash != "" then
+    hash
+  else if sha256 != "" then
+    sha256
+  else
+    lib.fakeSha256;
+  nativeBuildInputs = [ nix-prefetch-docker cacert ];
+  __structuredAttrs = true;
+  buildCommand = ''
+    export IS_FETCHER=1
+    nix-prefetch-docker ${lib.cli.toGNUCommandLineShell {} {
+      inherit os arch;
+      image-name = imageName;
+      image-tag = imageTag;
+      image-digest = imageDigest;
+      final-image-name = finalImageName;
+      final-image-tag = finalImageTag;
+    }}
+  '';
+}


### PR DESCRIPTION
###### Description of changes

nix-prefetch-docker failed to run when the target Docker image didn't exist for the host platform, regardless of the target platform specified for the image.

```console
$ nix-prefetch-docker --json pihole/pihole 2023.02.1
FATA[0001] Error parsing manifest for image: choosing image instance: no image found in manifest list for architecture amd64, variant "", OS darwin
```

The failure occurred because some calls to the skopeo CLI didn't specify the target OS and architecture. This change fixes the problem by wrapping every call to skopeo.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
