### PR TITLE
image_optim: remove unused output binaries

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -364,6 +364,27 @@ in
     buildInputs = [ libidn ];
   };
 
+  # Clean up vendor binaries for other platforms
+  image_optim_pack = attrs:
+    let
+      vendor_path = "$out/${ruby.gemPath}/gems/image_optim_pack-${attrs.version}/vendor";
+    in if stdenv.system == "x86_64-linux" then {
+      postInstall = ''
+        rm -rf ${vendor_path}/darwin-x86_64
+        rm -rf ${vendor_path}/linux-i686
+      '';
+    } else if stdenv.system == "i686-linux" then {
+      postInstall = ''
+        rm -rf ${vendor_path}/darwin-x86_64
+        rm -rf ${vendor_path}/linux-x86_64
+      '';
+    } else if stdenv.system == "x86_64-darwin" then {
+      postInstall = ''
+        rm -rf ${vendor_path}/linux-x86_64
+        rm -rf ${vendor_path}/linux-i686
+      '';
+    } else { };
+
   # disable bundle install as it can't install anything in addition to what is
   # specified in pkgs/applications/misc/jekyll/Gemfile anyway. Also do chmod_R
   # to compensate for read-only files in site_template in nix store.


### PR DESCRIPTION
###### Description of changes

Using image_optim as a ruby gem (not standalone executable) seems to currently be broken when vendor binaries are present for other platforms. This patch does not entirely fix the issue (vendor binaries for the correct platform are still broken), but makes it possible to override the provided binaries with nixpkgs and avoid the errors. This should not break things, as the only deleted binaries wouldn't run on the current platform anyway

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`) (N/A)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
