### PR TITLE
LibreSSL: 3.5.3 → 3.5.4, 3.6.1 → 3.6.2

### DIFF
--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -12,7 +12,13 @@ let
     then "DYLD_LIBRARY_PATH"
     else "LD_LIBRARY_PATH";
 
-  generic = { version, hash, patches ? [] }: stdenv.mkDerivation rec {
+  generic =
+    { version
+    , hash
+    , patches ? []
+    , knownVulnerabilities ? []
+    }: stdenv.mkDerivation rec
+  {
     pname = "libressl";
     inherit version;
 
@@ -80,6 +86,7 @@ let
       license = with licenses; [ publicDomain bsdOriginal bsd0 bsd3 gpl3 isc openssl ];
       platforms   = platforms.all;
       maintainers = with maintainers; [ thoughtpolice fpletz ];
+      knownVulnerabilities = knownVulnerabilities;
     };
   };
 
@@ -87,6 +94,10 @@ in {
   libressl_3_4 = generic {
     version = "3.4.3";
     hash = "sha256-/4i//jVIGLPM9UXjyv5FTFAxx6dyFwdPUzJx1jw38I0=";
+    knownVulnerabilities = [
+      "Support ended 2022-10-14."
+      "https://marc.info/?l=libressl&m=167582148932407&w=2"
+    ];
   };
 
   libressl_3_5 = generic {

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -90,8 +90,8 @@ in {
   };
 
   libressl_3_5 = generic {
-    version = "3.5.3";
-    hash = "sha256-OrXl6u9pziDGsXDuZNeFtCI19I8uYrCV/KXXtmcriyg=";
+    version = "3.5.4";
+    hash = "sha256-A3naE0Si9xrUpOO+MO+dgu7N3Of43CrmZjGh3+FDQ6w=";
 
     patches = [
       # Fix endianness detection on aarch64-darwin, issue #181187

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -86,7 +86,7 @@ let
       license = with licenses; [ publicDomain bsdOriginal bsd0 bsd3 gpl3 isc openssl ];
       platforms   = platforms.all;
       maintainers = with maintainers; [ thoughtpolice fpletz ];
-      knownVulnerabilities = knownVulnerabilities;
+      inherit knownVulnerabilities;
     };
   };
 
@@ -94,9 +94,16 @@ in {
   libressl_3_4 = generic {
     version = "3.4.3";
     hash = "sha256-/4i//jVIGLPM9UXjyv5FTFAxx6dyFwdPUzJx1jw38I0=";
-    knownVulnerabilities = [
-      "Support ended 2022-10-14."
-      "https://marc.info/?l=libressl&m=167582148932407&w=2"
+    knownVulnerabilities = [ "Support ended 2022-10-14." ];
+    patches = [
+      (fetchpatch {
+        # https://marc.info/?l=libressl&m=167582148932407&w=2
+        name = "backport-type-confusion-fix.patch";
+        url = "https://raw.githubusercontent.com/libressl/portable/30dc760ed1d7c70766b135500950d8ca9d17b13a/patches/x509_genn.c.diff";
+        sha256 = "sha256-N9jsOueqposDWZwaR+n/v/cHgNiZbZ644d8/wKjN2/M=";
+        stripLen = 2;
+        extraPrefix = "crypto/";
+      })
     ];
   };
 

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -104,7 +104,7 @@ in {
   };
 
   libressl_3_6 = generic {
-    version = "3.6.1";
-    hash = "sha256-rPrGExbpO5GcKNYtUwN8pzTehcRrTXA/Gf2Dlc8AZ3Q=";
+    version = "3.6.2";
+    hash = "sha256-S+gP/wc3Rs9QtKjlur4nlayumMaxMqngJRm0Rd+/0DM=";
   };
 }


### PR DESCRIPTION
###### Description of changes

Update both supported versions of LibreSSL to the latest patch release. Both were released February 7th and include an important security fix:

> A malicious certificate revocation list or timestamp response token would allow an attacker to read arbitrary memory.

* [3.6.2 release notes](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.6.2-relnotes.txt)
* [3.5.4 release notes](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.5.4-relnotes.txt)

I suspect that 3.4, which is still packaged, is also affected, but 3.4 was introduced in [OpenBSD 7.0](https://www.openbsd.org/70.html), which was released October 14th 2021, and LibreSSL branches are only maintained for one year after the corresponding OpenBSD release, so 3.4 is no longer supported.

<del>I will make a separate pull request to try and remove 3.4.</del><ins>There are two blockers for removing 3.4, I opened #216207 to track those.</ins>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
