### PR TITLE
beam/fetchMixDeps: disable --only flag when mixEnv is empty

### DIFF
--- a/doc/languages-frameworks/beam.section.md
+++ b/doc/languages-frameworks/beam.section.md
@@ -171,6 +171,7 @@ let
     inherit src version;
     # nix will complain and tell you the right value to replace this with
     hash = lib.fakeHash;
+    mixEnv = ""; # default is "prod", when empty includes all dependencies, such as "dev", "test".
     # if you have build time environment variables add them here
     MY_ENV_VAR="my_value";
   };

--- a/pkgs/development/beam-modules/fetch-mix-deps.nix
+++ b/pkgs/development/beam-modules/fetch-mix-deps.nix
@@ -45,7 +45,7 @@ stdenvNoCC.mkDerivation (attrs // {
 
   installPhase = attrs.installPhase or ''
     runHook preInstall
-    mix deps.get --only ${mixEnv}
+    mix deps.get ''${mixEnv:+--only $mixEnv}
     find "$TEMPDIR/deps" -path '*/.git/*' -a ! -name HEAD -exec rm -rf {} +
     cp -r --no-preserve=mode,ownership,timestamps $TEMPDIR/deps $out
     runHook postInstall


### PR DESCRIPTION
beam/fetchMixDeps: disable --only flag when mixEnv is empty

* mixEnv being empty will include all dependencies.

* Brief documenting because it's useful for loading tests dependencies.
  * I'm a bit unsure about how to document this... Still thinking.
  * (Actually, tests should be documented in Elixir.)