### PR TITLE
posteid-seed-extractor: init at unstable-23-02-2022

### DIFF
--- a/pkgs/tools/security/posteid-seed-extractor/default.nix
+++ b/pkgs/tools/security/posteid-seed-extractor/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "posteid-seed-extractor";
+  version = "unstable-2022-02-23";
+
+  src = fetchFromGitHub {
+    owner = "simone36050";
+    repo = "PosteID-seed-extractor";
+    rev = "667e2997a98aa3273a6bf6b4b34ca77715120e7f";
+    hash = "sha256-smNwp67HYbZuMrl0uf2X2yox2JqeEV6WzIBp4dALwgw=";
+  };
+
+  format = "other";
+
+  pythonPath = with python3Packages; [
+   certifi
+   cffi
+   charset-normalizer
+   cryptography
+   idna
+   jwcrypto
+   pycparser
+   pycryptodome
+   pyotp
+   qrcode
+   requests
+   urllib3
+   wrapt
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 extractor.py $out/bin/posteid-seed-extractor
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/simone36050/PosteID-seed-extractor";
+    description = "Extract OTP seed instead of using PosteID app";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aciceri ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11038,6 +11038,8 @@ with pkgs;
     libjpeg8 = libjpeg.override { enableJpeg8 = true; };
   };
 
+  posteid-seed-extractor = callPackage ../tools/security/posteid-seed-extractor {};
+
   postscript-lexmark = callPackage ../misc/drivers/postscript-lexmark { };
 
   povray = callPackage ../tools/graphics/povray {


### PR DESCRIPTION
###### Description of changes
Adding "PosteID seed extractor", which consists of a script to extract the OTP seed for one italian "digital identity" provider. Check https://github.com/simone36050/PosteID-seed-extractor

I've just tried it and it works :)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).