### PR TITLE
mongoc: 1.23.1 -> 1.23.2

### DIFF
--- a/pkgs/development/libraries/mongoc/default.nix
+++ b/pkgs/development/libraries/mongoc/default.nix
@@ -10,7 +10,11 @@
   cyrus_sasl,
   libbson,
   snappy,
+  darwin,
 }:
+let
+  inherit (darwin.apple_sdk.frameworks) Security;
+in  
 stdenv.mkDerivation rec {
   pname = "mongoc";
   version = "1.23.2";
@@ -30,7 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [cmake pkg-config perl];
-  buildInputs = [openssl zlib cyrus_sasl];
+  buildInputs = [openssl zlib cyrus_sasl] ++ lib.optionals stdenv.isDarwin [Security];
   propagatedBuildInputs = [libbson snappy];
 
   # -DMONGOC_TEST_USE_CRYPT_SHARED=OFF

--- a/pkgs/development/libraries/mongoc/default.nix
+++ b/pkgs/development/libraries/mongoc/default.nix
@@ -13,15 +13,21 @@
 }:
 stdenv.mkDerivation rec {
   pname = "mongoc";
-  version = "1.23.1";
+  version = "1.23.2";
 
   src = fetchzip {
     url = "https://github.com/mongodb/mongo-c-driver/releases/download/${version}/mongo-c-driver-${version}.tar.gz";
-    sha256 = "1vnnk3pwbcmwva1010bl111kdcdx3yb2w7j7a78hhvrm1k9r1wp8";
+    sha256 = "08v7xc5m86apd338swd8g83ccvd6ni75xbdhqqwkrjbznljf8fjf";
   };
 
   # https://github.com/NixOS/nixpkgs/issues/25585
   preFixup = ''rm -rf "$(pwd)" '';
+  postPatch = ''
+    substituteInPlace src/libmongoc/CMakeLists.txt \
+      --replace "\\\''${prefix}/" ""
+    substituteInPlace src/libbson/CMakeLists.txt \
+      --replace "\\\''${prefix}/" ""
+  '';
 
   nativeBuildInputs = [cmake pkg-config perl];
   buildInputs = [openssl zlib cyrus_sasl];

--- a/pkgs/development/libraries/mongoc/default.nix
+++ b/pkgs/development/libraries/mongoc/default.nix
@@ -14,7 +14,7 @@
 }:
 let
   inherit (darwin.apple_sdk.frameworks) Security;
-in  
+in
 stdenv.mkDerivation rec {
   pname = "mongoc";
   version = "1.23.2";

--- a/pkgs/development/libraries/mongoc/default.nix
+++ b/pkgs/development/libraries/mongoc/default.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
+    broken = stdenv.isDarwin && stdenv.isx86_64;
     description = "The official C client library for MongoDB";
     homepage = "http://mongoc.org";
     license = licenses.asl20;

--- a/pkgs/development/libraries/mongoc/default.nix
+++ b/pkgs/development/libraries/mongoc/default.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
 
   # https://github.com/NixOS/nixpkgs/issues/25585
   preFixup = ''rm -rf "$(pwd)" '';
+  # https://github.com/mongodb/mongo-c-driver/pull/1157
+  # related:
+  # https://github.com/NixOS/nixpkgs/issues/144170
+  # mongoc's cmake incorrectly injects a prefix to library paths, breaking Nix. This removes the prefix from paths.
   postPatch = ''
     substituteInPlace src/libmongoc/CMakeLists.txt \
       --replace "\\\''${prefix}/" ""


### PR DESCRIPTION
###### Description of changes

http://mongoc.org/libmongoc/1.23.2/index.html
fix: sha256 didn't match 1.23.1 version (matched 1.8.0) - now matches 1.23.2.
fix: 1.23.x failed at install [phase](https://github.com/NixOS/nixpkgs/issues/144170).
fix: add frameworks.Security as dependency for darwin.
broken: darwin x86_64 marked as broken (compile error).
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).




I'm Running Nix package manager on an ArchLinux Install (SteamOS 3.4, actually. but it's arch based).

Tested basic library functionality using:
[hello_mongo.c](http://mongoc.org/libmongoc/1.23.2/tutorial.html#making-a-connection)