### PR TITLE
vscode-extensions.rust-lang.rust-analyzer: 0.3.1059 -> 0.3.1426

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/rust-analyzer/build-deps/package.json
+++ b/pkgs/applications/editors/vscode/extensions/rust-analyzer/build-deps/package.json
@@ -1,20 +1,23 @@
 {
   "name": "rust-analyzer",
-  "version": "0.3.1059",
+  "version": "0.3.1426",
   "dependencies": {
-    "d3": "^7.3.0",
-    "d3-graphviz": "^4.1.0",
-    "vscode-languageclient": "8.0.0-next.14",
-    "@types/node": "~14.17.5",
+    "anser": "^2.1.1",
+    "d3": "^7.6.1",
+    "d3-graphviz": "^5.0.2",
+    "vscode-languageclient": "^8.0.2",
+    "@types/node": "~16.11.7",
     "@types/vscode": "~1.66.0",
-    "@typescript-eslint/eslint-plugin": "^5.16.0",
-    "@typescript-eslint/parser": "^5.16.0",
-    "@vscode/test-electron": "^2.1.3",
+    "@typescript-eslint/eslint-plugin": "^5.30.5",
+    "@typescript-eslint/parser": "^5.30.5",
+    "@vscode/test-electron": "^2.1.5",
     "cross-env": "^7.0.3",
-    "eslint": "^8.11.0",
-    "tslib": "^2.3.0",
-    "typescript": "^4.6.3",
-    "typescript-formatter": "^7.2.2",
-    "vsce": "^2.7.0"
+    "eslint": "^8.19.0",
+    "eslint-config-prettier": "^8.5.0",
+    "ovsx": "^0.5.2",
+    "prettier": "^2.7.1",
+    "tslib": "^2.4.0",
+    "typescript": "^4.7.4",
+    "vsce": "^2.9.2"
   }
 }

--- a/pkgs/applications/editors/vscode/extensions/rust-analyzer/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rust-analyzer/default.nix
@@ -20,13 +20,13 @@ let
   # Use the plugin version as in vscode marketplace, updated by update script.
   inherit (vsix) version;
 
-  releaseTag = "2022-05-17";
+  releaseTag = "2023-03-06";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "rust-analyzer";
     rev = releaseTag;
-    sha256 = "sha256-vrVpgQYUuJPgK1NMb1nxlCdxjoYo40YkUbZpH2Z2mwM=";
+    sha256 = "sha256-Njlus+vY3N++qWE0JXrGjwcXY2QDFuOV/7NruBBMETY=";
   };
 
   build-deps = nodePackages."rust-analyzer-build-deps-../../applications/editors/vscode/extensions/rust-analyzer/build-deps";

--- a/pkgs/applications/editors/vscode/extensions/rust-analyzer/update.sh
+++ b/pkgs/applications/editors/vscode/extensions/rust-analyzer/update.sh
@@ -48,4 +48,4 @@ else
     ./"$node_packages"/generate.sh
 fi
 
-echo "Remember to also update the revisionTag and hash in default.nix!"
+echo "Remember to also update the releaseTag and hash in default.nix!"


### PR DESCRIPTION
###### Description of changes

Changelog: [Changelog #130](https://rust-analyzer.github.io/thisweek/2022/05/23/changelog-130.html) to [Changelog #168](https://rust-analyzer.github.io/thisweek/2023/02/13/changelog-168.html)

Supersedes #213850. Only after doing all the updating did I realize somebody else had already opened a PR, but the RA release cycle marches on relentlessly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
