### PR TITLE
dde-polkit-agent: init at 5.5.22; dpa-ext-gnomekeyring: init at 5.0.11

### DIFF
--- a/pkgs/desktops/deepin/core/dde-polkit-agent/default.nix
+++ b/pkgs/desktops/deepin/core/dde-polkit-agent/default.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, dtkwidget
+, qt5integration
+, qt5platform-plugins
+, dde-qt-dbus-factory
+, pkg-config
+, cmake
+, qttools
+, wrapQtAppsHook
+, polkit-qt
+, qtbase
+}:
+stdenv.mkDerivation rec {
+  pname = "dde-polkit-agent";
+  version = "5.5.22";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-4wAqMymLPxKXbfAx2PtkEGfwenphPxBZn+qCdcyqNc0=";
+  };
+
+  postPatch = ''
+    substituteInPlace AuthDialog.cpp \
+      --replace "/usr/share/dde-session-shell/dde-session-shell.conf" "/etc/dde-session-shell/dde-session-shell.conf"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qttools
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    dtkwidget
+    qt5platform-plugins
+    dde-qt-dbus-factory
+    polkit-qt
+  ];
+
+  # qt5integration must be placed before qtsvg in QT_PLUGIN_PATH
+  qtWrapperArgs = [
+    "--prefix QT_PLUGIN_PATH : ${qt5integration}/${qtbase.qtPluginPrefix}"
+  ];
+
+  postFixup = ''
+    wrapQtApp $out/lib/polkit-1-dde/dde-polkit-agent
+  '';
+
+  meta = with lib; {
+    description = "PolicyKit agent for Deepin Desktop Environment";
+    homepage = "https://github.com/linuxdeepin/dde-polkit-agent";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/core/dpa-ext-gnomekeyring/default.nix
+++ b/pkgs/desktops/deepin/core/dpa-ext-gnomekeyring/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, qttools
+, wrapQtAppsHook
+, dtkwidget
+, dde-polkit-agent
+, libsecret
+, libgnome-keyring
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dpa-ext-gnomekeyring";
+  version = "5.0.11";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-mXaGwbtEwaqfOT0izK64zX4s3VFmsRpUGOVm6oSEhn8=";
+  };
+
+  postPatch = ''
+    substituteInPlace gnomekeyringextention.cpp \
+      --replace "/usr/share/dpa-ext-gnomekeyring" "$out/share/dpa-ext-gnomekeyring"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qttools
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    dtkwidget
+    dde-polkit-agent
+    libgnome-keyring
+    libsecret
+  ];
+
+  meta = with lib; {
+    description = "GNOME keyring extension for dde-polkit-agent";
+    homepage = "https://github.com/linuxdeepin/dpa-ext-gnomekeyring";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = teams.deepin.members;
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -29,6 +29,9 @@ let
     image-editor = callPackage ./library/image-editor { };
     udisks2-qt5 = callPackage ./library/udisks2-qt5 { };
 
+    #### CORE
+    dde-polkit-agent = callPackage ./core/dde-polkit-agent { };
+
     #### Dtk Application
     deepin-album = callPackage ./apps/deepin-album { };
     deepin-calculator = callPackage ./apps/deepin-calculator { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -31,6 +31,7 @@ let
 
     #### CORE
     dde-polkit-agent = callPackage ./core/dde-polkit-agent { };
+    dpa-ext-gnomekeyring = callPackage ./core/dpa-ext-gnomekeyring { };
 
     #### Dtk Application
     deepin-album = callPackage ./apps/deepin-album { };


### PR DESCRIPTION
###### Description of changes

Part of https://github.com/linuxdeepin/dde-nixos/issues/9 , 

Refer to the previous packaging： https://github.com/NixOS/nixpkgs/pull/48576
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
