### PR TITLE
python3Packagess Replace checkInputs with nativeCheckInputs

### DIFF
--- a/pkgs/development/python-modules/aio-geojson-usgs-earthquakes/default.nix
+++ b/pkgs/development/python-modules/aio-geojson-usgs-earthquakes/default.nix
@@ -31,12 +31,9 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
-  checkInputs = [
     aresponses
     pytest-asyncio
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/aio-pika/default.nix
+++ b/pkgs/development/python-modules/aio-pika/default.nix
@@ -28,10 +28,8 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-  ];
-  checkInputs = [
     aiomisc
+    pytestCheckHook
     shortuuid
   ];
   # Tests attempt to connect to a RabbitMQ server

--- a/pkgs/development/python-modules/aiormq/default.nix
+++ b/pkgs/development/python-modules/aiormq/default.nix
@@ -35,11 +35,10 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    aiomisc
     pytestCheckHook
   ];
-  checkInputs = [
-    aiomisc
-  ];
+
   # Tests attempt to connect to a RabbitMQ server
   disabledTestPaths = [
     "tests/test_channel.py"

--- a/pkgs/development/python-modules/ansiwrap/default.nix
+++ b/pkgs/development/python-modules/ansiwrap/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
       --replace "set(range(120, 400)).difference(LINE_LENGTHS)" "sorted(set(range(120, 400)).difference(LINE_LENGTHS))"
   '';
 
-  checkInputs = [
+  nativeCheckInputs = [
     ansicolors
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/apache-beam/default.nix
+++ b/pkgs/development/python-modules/apache-beam/default.nix
@@ -123,7 +123,7 @@ buildPythonPackage rec {
     "apache_beam"
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     freezegun
     hypothesis
     mock

--- a/pkgs/development/python-modules/asf-search/default.nix
+++ b/pkgs/development/python-modules/asf-search/default.nix
@@ -43,12 +43,9 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
-  checkInputs = [
-    requests-mock
     defusedxml
+    pytestCheckHook
+    requests-mock
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/bravado-core/default.nix
+++ b/pkgs/development/python-modules/bravado-core/default.nix
@@ -47,11 +47,8 @@ buildPythonPackage rec {
   ] ++ jsonschema.optional-dependencies.format;
 
   nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
-  checkInputs = [
     mock
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/cached-property/default.nix
+++ b/pkgs/development/python-modules/cached-property/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     })
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
     freezegun
   ];

--- a/pkgs/development/python-modules/configobj/default.nix
+++ b/pkgs/development/python-modules/configobj/default.nix
@@ -26,11 +26,8 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
-  checkInputs = [
     mock
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/dataproperty/default.nix
+++ b/pkgs/development/python-modules/dataproperty/default.nix
@@ -20,8 +20,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ mbstrdecoder typepy ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-  checkInputs = [ termcolor ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    termcolor
+   ];
 
   # Tests fail, even on non-nixos
   pytestFlagsArray = [

--- a/pkgs/development/python-modules/dicom-numpy/default.nix
+++ b/pkgs/development/python-modules/dicom-numpy/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     pydicom
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/django-login-required-middleware/default.nix
+++ b/pkgs/development/python-modules/django-login-required-middleware/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     django
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     djangorestframework
   ];
 

--- a/pkgs/development/python-modules/effect/default.nix
+++ b/pkgs/development/python-modules/effect/default.nix
@@ -32,9 +32,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ];
-
-  checkInputs = [
     testtools
   ];
 

--- a/pkgs/development/python-modules/elastic-apm/default.nix
+++ b/pkgs/development/python-modules/elastic-apm/default.nix
@@ -54,10 +54,6 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
-  checkInputs = [
     asynctest
     ecs-logging
     jinja2
@@ -70,6 +66,7 @@ buildPythonPackage rec {
     pytest-mock
     pytest-localserver
     pytest-random-order
+    pytestCheckHook
     sanic-testing
     structlog
     webob

--- a/pkgs/development/python-modules/flask-babel/default.nix
+++ b/pkgs/development/python-modules/flask-babel/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     "flask_babel"
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytest-mock
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/gassist-text/default.nix
+++ b/pkgs/development/python-modules/gassist-text/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/graphite-web/default.nix
+++ b/pkgs/development/python-modules/graphite-web/default.nix
@@ -75,7 +75,7 @@ buildPythonPackage rec {
       --replace "join(WEBAPP_DIR, 'content')" "join('$out', 'webapp', 'content')"
   '';
 
-  checkInputs = [ mock ];
+  nativeCheckInputs = [ mock ];
   checkPhase = ''
     runHook preCheck
 

--- a/pkgs/development/python-modules/hist/default.nix
+++ b/pkgs/development/python-modules/hist/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     numpy
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
     pytest-mpl
   ];

--- a/pkgs/development/python-modules/histoprint/default.nix
+++ b/pkgs/development/python-modules/histoprint/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/hledger-utils/default.nix
+++ b/pkgs/development/python-modules/hledger-utils/default.nix
@@ -45,13 +45,10 @@ buildPythonPackage rec {
     asteval
   ];
 
-  checkInputs = [
-    unittestCheckHook
-  ];
-
   nativeCheckInputs = [
     hledger
     perl
+    unittestCheckHook
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/incomfort-client/default.nix
+++ b/pkgs/development/python-modules/incomfort-client/default.nix
@@ -27,12 +27,9 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
-  checkInputs = [
     aioresponses
     pytest-asyncio
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/leidenalg/default.nix
+++ b/pkgs/development/python-modules/leidenalg/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     igraph-c
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     ddt
     unittestCheckHook
   ];

--- a/pkgs/development/python-modules/lsprotocol/default.nix
+++ b/pkgs/development/python-modules/lsprotocol/default.nix
@@ -5,9 +5,8 @@
 , fetchFromGitHub
 , flit-core
 , jsonschema
-, nox
 , pyhamcrest
-, pytest
+, pytestCheckHook
 , pythonOlder
 }:
 
@@ -27,7 +26,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     flit-core
-    nox
   ];
 
   propagatedBuildInputs = [
@@ -36,22 +34,10 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytest
-  ];
-
-  checkInputs = [
     jsonschema
     pyhamcrest
+    pytestCheckHook
   ];
-
-  checkPhase = ''
-    runHook preCheck
-
-    sed -i "/^    _install_requirements/d" noxfile.py
-    nox --session tests
-
-    runHook postCheck
-  '';
 
   pythonImportsCheck = [
     "lsprotocol"

--- a/pkgs/development/python-modules/maison/default.nix
+++ b/pkgs/development/python-modules/maison/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     toml
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/mautrix/default.nix
+++ b/pkgs/development/python-modules/mautrix/default.nix
@@ -51,11 +51,8 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
-  checkInputs = [
     pytest-asyncio
+    pytestCheckHook
     aiosqlite
     sqlalchemy
     asyncpg

--- a/pkgs/development/python-modules/mbstrdecoder/default.nix
+++ b/pkgs/development/python-modules/mbstrdecoder/default.nix
@@ -19,8 +19,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ chardet ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-  checkInputs = [ faker ];
+  nativeCheckInputs = [
+    faker
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/thombashi/mbstrdecoder";

--- a/pkgs/development/python-modules/merkletools/default.nix
+++ b/pkgs/development/python-modules/merkletools/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
       --replace "install_requires=install_requires" "install_requires=[],"
   '';
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/nox/default.nix
+++ b/pkgs/development/python-modules/nox/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
   ];
 
 
-  checkInputs = [
+  nativeCheckInputs = [
     jinja2
     tox
     pytestCheckHook

--- a/pkgs/development/python-modules/ormar/default.nix
+++ b/pkgs/development/python-modules/ormar/default.nix
@@ -96,14 +96,11 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
-  checkInputs = [
     fastapi
     httpx
     nest-asyncio
     pytest-asyncio
+    pytestCheckHook
   ] ++ passthru.optional-dependencies.all;
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -76,7 +76,7 @@ buildPythonPackage rec {
       --replace "--cov=papis" ""
   '';
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/parameterized/default.nix
+++ b/pkgs/development/python-modules/parameterized/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     hash = "sha256-Qbv/N9YYZDD3f5ANd35btqJJKKHEb7HeaS+LUriDO1w=";
   };
 
-  checkInputs = [
+  nativeCheckInputs = [
     mock
     nose
     pytestCheckHook

--- a/pkgs/development/python-modules/paver/default.nix
+++ b/pkgs/development/python-modules/paver/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     six
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     cogapp
     mock
     nose

--- a/pkgs/development/python-modules/pyTelegramBotAPI/default.nix
+++ b/pkgs/development/python-modules/pyTelegramBotAPI/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     ];
   };
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
     requests
   ] ++ passthru.optional-dependencies.watchdog

--- a/pkgs/development/python-modules/pyquery/default.nix
+++ b/pkgs/development/python-modules/pyquery/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pyquery" ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
     requests
     webob

--- a/pkgs/development/python-modules/pyquil/default.nix
+++ b/pkgs/development/python-modules/pyquil/default.nix
@@ -62,14 +62,11 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
-  checkInputs = [
     pytest-asyncio
     pytest-freezegun
     pytest-httpx
     pytest-mock
+    pytestCheckHook
     respx
     ipython
   ];

--- a/pkgs/development/python-modules/pytablewriter/default.nix
+++ b/pkgs/development/python-modules/pytablewriter/default.nix
@@ -35,8 +35,14 @@ buildPythonPackage rec {
     typepy
   ];
 
-  checkInputs = [ pyyaml toml elasticsearch dominate ];
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pyyaml
+    toml
+    elasticsearch
+    dominate
+   ];
+
   # Circular dependency
   disabledTests = [
     "test_normal_from_file"

--- a/pkgs/development/python-modules/pytautulli/default.nix
+++ b/pkgs/development/python-modules/pytautulli/default.nix
@@ -34,12 +34,9 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
-  checkInputs = [
     aresponses
     pytest-asyncio
+    pytestCheckHook
   ];
 
   pytestFlagsArray = [

--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     jax
     jaxlib
     numba

--- a/pkgs/development/python-modules/remotezip/default.nix
+++ b/pkgs/development/python-modules/remotezip/default.nix
@@ -28,9 +28,6 @@ buildPythonPackage {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ];
-
-  checkInputs = [
     requests-mock
   ];
 

--- a/pkgs/development/python-modules/siuba/default.nix
+++ b/pkgs/development/python-modules/siuba/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     sqlalchemy
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     hypothesis
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/tld/default.nix
+++ b/pkgs/development/python-modules/tld/default.nix
@@ -20,12 +20,9 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
-  checkInputs = [
     factory_boy
     faker
+    pytestCheckHook
   ];
 
   # These tests require network access, but disabledTestPaths doesn't work.

--- a/pkgs/development/python-modules/ttach/default.nix
+++ b/pkgs/development/python-modules/ttach/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ torch ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
   pythonImportsCheck = [ "ttach" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/typed-settings/default.nix
+++ b/pkgs/development/python-modules/typed-settings/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     ];
   };
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
     typing-extensions
   ] ++ passthru.optional-dependencies.click;

--- a/pkgs/development/python-modules/typepy/default.nix
+++ b/pkgs/development/python-modules/typepy/default.nix
@@ -22,8 +22,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ mbstrdecoder python-dateutil pytz packaging ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-  checkInputs = [ tcolorpy ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    tcolorpy
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/thombashi/typepy";

--- a/pkgs/development/python-modules/uhi/default.nix
+++ b/pkgs/development/python-modules/uhi/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     numpy
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/vector/default.nix
+++ b/pkgs/development/python-modules/vector/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     packaging
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     awkward
     notebook
     numba

--- a/pkgs/development/python-modules/volvooncall/default.nix
+++ b/pkgs/development/python-modules/volvooncall/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     ];
   };
 
-  checkInputs = [
+  nativeCheckInputs = [
     mock
     pytest-asyncio
     pytestCheckHook


### PR DESCRIPTION
These crept in since the introduction of nativeCheckInputs and are hereby squashed.

For python `checkInputs` makes little sense, given that we usually don't exactly link libraries into executables.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
