### PR TITLE
libdisplay-info: init at 0.1.0

### DIFF
--- a/pkgs/development/libraries/libdisplay-info/default.nix
+++ b/pkgs/development/libraries/libdisplay-info/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, pkg-config
+, ninja
+, python3
+, hwdata
+, edid-decode
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libdisplay-info";
+  version = "0.1.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "emersion";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-jfi7RpEtyQicW0WWhrQg28Fta60YWxTbpbmPHmXxDhw=";
+  };
+
+  nativeBuildInputs = [ meson pkg-config ninja edid-decode python3 ];
+
+  buildInputs = [ hwdata ];
+
+  prePatch = ''
+    substituteInPlace meson.build \
+        --replace "find_program('tool/gen-search-table.py')" "find_program('python3')" \
+        --replace "gen_search_table," "gen_search_table, '$src/tool/gen-search-table.py',"
+  '';
+
+  meta = with lib; {
+    description = "EDID and DisplayID library";
+    homepage = "https://gitlab.freedesktop.org/emersion/libdisplay-info";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ pedrohlc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20913,6 +20913,8 @@ with pkgs;
 
   libdiscid = callPackage ../development/libraries/libdiscid { };
 
+  libdisplay-info = callPackage ../development/libraries/libdisplay-info { };
+
   libdivecomputer = callPackage ../development/libraries/libdivecomputer { };
 
   libdivsufsort = callPackage ../development/libraries/libdivsufsort { };


### PR DESCRIPTION
###### Description of changes

The first guy to get out from https://github.com/NixOS/nixpkgs/pull/215343 to the world.

###### Things done

Built and tested with the PR mentioned above.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).