### PR TITLE
python3Packages.gdtoolkit: Use lark_0_8_0 (split from python3Packages.lark) and enable tests

### DIFF
--- a/pkgs/development/python-modules/gdtoolkit/default.nix
+++ b/pkgs/development/python-modules/gdtoolkit/default.nix
@@ -85,6 +85,6 @@ buildPythonPackage rec {
     description = "Independent set of tools for working with Godot's GDScript - parser, linter and formatter";
     homepage = "https://github.com/Scony/godot-gdscript-toolkit";
     license = licenses.mit;
-    maintainers = with maintainers; [ shiryel ];
+    maintainers = with maintainers; [ shiryel tmarkus ];
   };
 }

--- a/pkgs/development/tools/gdtoolkit/default.nix
+++ b/pkgs/development/tools/gdtoolkit/default.nix
@@ -1,29 +1,23 @@
 { lib
-, buildPythonPackage
+, python3Packages
 , fetchFromGitHub
-, pythonOlder
-, lark
-, docopt
-, pyyaml
-, setuptools
-, pytestCheckHook
 , godot-server
-, hypothesis
 }:
 
-let lark080 = lark.overrideAttrs (old: rec {
+let lark080 = python3Packages.lark.overrideAttrs (old: rec {
   # gdtoolkit needs exactly this lark version
   version = "0.8.0";
   src = fetchFromGitHub {
     owner = "lark-parser";
     repo = "lark";
     rev = version;
-    sha256 = "su7kToZ05OESwRCMPG6Z+XlFUvbEb3d8DgsTEcPJMg4=";
+    hash = "sha256-KN9buVlH8hJ8t0ZP5yefeYM5vH5Gg7a7TEDGKJYpozs=";
+    fetchSubmodules = true;
   };
 });
 
 in
-buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   pname = "gdtoolkit";
   version = "3.3.1";
 
@@ -35,18 +29,18 @@ buildPythonPackage rec {
     sha256 = "13nnpwy550jf5qnm9ixpxl1bwfnhhbiys8vqfd25g3aim4bm3gnn";
   };
 
-  disabled = pythonOlder "3.7";
+  disabled = python3Packages.pythonOlder "3.7";
 
-  propagatedBuildInputs = [
-    lark080
+  propagatedBuildInputs = [ lark080
+  ] ++ (with python3Packages; [
     docopt
     pyyaml
     setuptools
-  ];
+  ]);
 
   doCheck = true;
 
-  nativeCheckInputs = [
+  nativeCheckInputs = with python3Packages; [
     pytestCheckHook
     hypothesis
     godot-server

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7581,6 +7581,8 @@ with pkgs;
 
   gdmap = callPackage ../tools/system/gdmap { };
 
+  gdtoolkit = callPackage ../development/tools/gdtoolkit { };
+
   gef = callPackage ../development/tools/misc/gef { };
 
   gelasio = callPackage ../data/fonts/gelasio { };

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -91,6 +91,7 @@ mapAliases ({
   functorch = throw "functorch is now part of the torch package and has therefore been removed. See https://github.com/pytorch/functorch/releases/tag/v1.13.0 for more info."; # added 2022-12-01
   garages-amsterdam = throw "garages-amsterdam has been renamed odp-amsterdam."; # added 2023-01-04
   garminconnect-ha = garminconnect; # added 2022-02-05
+  gdtoolkit = throw "gdtoolkit has been promoted to a top-level attribute"; # added 2023-02-15
   gigalixir = throw "gigalixir has been promoted to a top-level attribute"; # Added 2022-10-02
   gitdb2 = throw "gitdb2 has been deprecated, use gitdb instead."; # added 2020-03-14
   GitPython = gitpython; # added 2022-10-28

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3722,8 +3722,6 @@ self: super: with self; {
 
   gdown = callPackage ../development/python-modules/gdown { };
 
-  gdtoolkit = callPackage ../development/python-modules/gdtoolkit { };
-
   ge25519 = callPackage ../development/python-modules/ge25519 { };
 
   geant4 = toPythonModule (pkgs.geant4.override {


### PR DESCRIPTION
###### Description of changes

Based on my findings in https://github.com/NixOS/nixpkgs/pull/216280#issuecomment-1429521866 (gdtoolkit is broken with lark 1.1.5):
* ~~Split `python3Packages.lark` into `python3Packages.lark_0_8_0` and `python3Packages.lark_1_1_5` (`python3Packages.lark` points to `python3Packages.lark_1_1_5`)~~
* ~~Use `python3Packages.lark_0_8_0` for `python3Packages.gdtoolkit`~~

Edit: I've edited the PR based on https://github.com/NixOS/nixpkgs/pull/216329#issuecomment-1430165592:
* Move `gdtoolkit` from `pkgs/development/python-modules` to `pkgs/development/tools/gdtoolkit` (also, remove gdtoolkit from `pkgs/top-level/python-packages.nix` and add it to `pkgs/top-level/all-packages.nix`)
* Run gdtoolkit tests

PR is based on #216280.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
