### PR TITLE
gcc: Add enableFramePointer option

### DIFF
--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -19,6 +19,7 @@
 , gnatboot ? null
 , enableMultilib ? false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
+, eanbleFramePointer ? false
 , name ? "gcc"
 , libcCross ? null
 , threadsCross ? null # for MinGW
@@ -102,6 +103,7 @@ let majorVersion = "10";
         buildPackages
         cloog
         crossStageStatic
+        eanbleFramePointer
         enableLTO
         enableMultilib
         enablePlugin

--- a/pkgs/development/compilers/gcc/11/default.nix
+++ b/pkgs/development/compilers/gcc/11/default.nix
@@ -19,6 +19,7 @@
 , gnatboot ? null
 , enableMultilib ? false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
+, enableFramePointer ? false
 , name ? "gcc"
 , libcCross ? null
 , threadsCross ? null # for MinGW
@@ -111,6 +112,7 @@ let majorVersion = "11";
         buildPackages
         cloog
         crossStageStatic
+        enableFramePointer
         enableLTO
         enableMultilib
         enablePlugin

--- a/pkgs/development/compilers/gcc/12/default.nix
+++ b/pkgs/development/compilers/gcc/12/default.nix
@@ -20,6 +20,7 @@
 , gnatboot ? null
 , enableMultilib ? false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
+, enableFramePointer ? false
 , name ? "gcc"
 , libcCross ? null
 , threadsCross ? null # for MinGW
@@ -142,6 +143,7 @@ let majorVersion = "12";
         buildPackages
         cloog
         crossStageStatic
+        enableFramePointer
         enableLTO
         enableMultilib
         enablePlugin

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -23,6 +23,7 @@
 , x11Support ? langJava
 , enableMultilib ? false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
+, enableFramePointer ? false
 , name ? "gcc"
 , libcCross ? null
 , threadsCross ? null # for MinGW
@@ -135,6 +136,7 @@ let majorVersion = "4";
         buildPackages
         cloog
         crossStageStatic
+        enableFramePointer
         enableLTO
         enableMultilib
         enablePlugin

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -23,6 +23,7 @@
 , x11Support ? langJava
 , enableMultilib ? false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
+, enableFramePointer ? false
 , name ? "gcc"
 , libcCross ? null
 , threadsCross ? null # for MinGW
@@ -151,6 +152,7 @@ let majorVersion = "4";
         buildPackages
         cloog
         crossStageStatic
+        enableFramePointer
         enableLTO
         enableMultilib
         enablePlugin

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -26,6 +26,7 @@
 , x11Support ? langJava
 , enableMultilib ? false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
+, enableFramePointer ? false
 , name ? "gcc"
 , libcCross ? null
 , threadsCross ? null # for MinGW
@@ -139,6 +140,7 @@ let majorVersion = "6";
         buildPackages
         cloog
         crossStageStatic
+        enableFramePointer
         enableLTO
         enableMultilib
         enablePlugin

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -16,6 +16,7 @@
 , zlib ? null
 , enableMultilib ? false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
+, enableFramePointer ? false
 , name ? "gcc"
 , libcCross ? null
 , threadsCross ? null # for MinGW
@@ -110,6 +111,7 @@ let majorVersion = "7";
         buildPackages
         cloog
         crossStageStatic
+        enableFramePointer
         enableLTO
         enableMultilib
         enablePlugin

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -16,6 +16,7 @@
 , zlib ? null
 , enableMultilib ? false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
+, enableFramePointer ? false
 , name ? "gcc"
 , libcCross ? null
 , threadsCross ? null # for MinGW
@@ -92,6 +93,7 @@ let majorVersion = "8";
         buildPackages
         cloog
         crossStageStatic
+        enableFramePointer
         enableLTO
         enableMultilib
         enablePlugin

--- a/pkgs/development/compilers/gcc/9/default.nix
+++ b/pkgs/development/compilers/gcc/9/default.nix
@@ -19,6 +19,7 @@
 , gnatboot ? null
 , enableMultilib ? false
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
+, enableFramePointer ? false
 , name ? "gcc"
 , libcCross ? null
 , threadsCross ? null # for MinGW
@@ -103,6 +104,7 @@ let majorVersion = "9";
         buildPackages
         cloog
         crossStageStatic
+        enableFramePointer
         enableLTO
         enableMultilib
         enablePlugin

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -13,6 +13,11 @@
 , enablePlugin
 , enableShared
 
+# GCC 4.6 started to default to -fno-omit-frame-pointer on -O1 and higher
+# Set enableFramePointer to true in order to disable passing
+# -fomit-frame-pointer by default
+, enableFramePointer ? false
+
 , langC
 , langCC
 , langD ? false
@@ -166,6 +171,8 @@ let
           )
       }"
     ]
+
+    ++ lib.optional enableFramePointer "--enable-frame-pointer"
 
     ++ (if (enableMultilib || targetPlatform.isAvr)
       then ["--enable-multilib" "--disable-libquadmath"]


### PR DESCRIPTION
###### Background
GCC started enabling -fomit-frame-pointer by default in 4.6 for -O1 and higher.
See https://gcc.gnu.org/onlinedocs/gcc-4.9.2/gcc/Optimize-Options.html

Compiling with -fomit-frame-pointer can make certain debugging and profiling tasks more complicated and inaccurate. Therefore it might be desirable to compile certain programs with -fno-omit-frame-pointer.
The recently released Fedora 38 adds frame pointer to all binaries (see https://lwn.net/Articles/919940/).

Using the configure flag --enable-frame-pointer, the default of GCC prior to 4.6 is reverted and it will not omit the frame pointer by default. This allows compilation of frame pointer-enabled packages without intrusive fiddling with compile flags.

Based on this, I'd say it makes sense to offer the option to enable frame pointers by default in GCC.

###### Description of changes
This PR add `enableFramePointer`as a GCC-level option that is *disabled by default* (therefore it should not affect anything by default).
Whether to it might make sense to enable frame pointers in GCC by default is a separate discussion.

Additional discussion:
* https://lwn.net/Articles/919940/
* https://rwmj.wordpress.com/2023/02/14/frame-pointers-vs-dwarf-my-verdict/
* https://news.ycombinator.com/item?id=34632677

I tested this change by compiling `nix` with a modified stdenv (using `overrideCC`) and subsequently comparing the flame graphs after running `perf record`. The recorded call graphs on frame pointer-enabled nix where noticeably more accurate than the DWARF call graphs, likely because of the deep stack frames during evaluation.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
