### PR TITLE
modemmanager: fix build

### DIFF
--- a/pkgs/tools/networking/modemmanager/default.nix
+++ b/pkgs/tools/networking/modemmanager/default.nix
@@ -33,6 +33,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-OWP23EQ7a8rghhV7AC9yinCxRI0xwcntB5dl9XtgK6M=";
   };
 
+  patches = [
+    # Since /etc is the domain of NixOS, not Nix, we cannot install files there.
+    # But these are just placeholders so we do not need to install them at all.
+    ./no-dummy-dirs-in-sysconfdir.patch
+  ];
+
   nativeBuildInputs = [
     meson
     ninja
@@ -64,6 +70,7 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dudevdir=${placeholder "out"}/lib/udev"
+    "-Ddbus_policy_dir=${placeholder "out"}/share/dbus-1/system.d"
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     "-Dvapi=true"

--- a/pkgs/tools/networking/modemmanager/no-dummy-dirs-in-sysconfdir.patch
+++ b/pkgs/tools/networking/modemmanager/no-dummy-dirs-in-sysconfdir.patch
@@ -1,0 +1,20 @@
+diff --git a/data/dispatcher-connection/meson.build b/data/dispatcher-connection/meson.build
+index 2e7ef8b4..e0f4aa66 100644
+--- a/data/dispatcher-connection/meson.build
++++ b/data/dispatcher-connection/meson.build
+@@ -21,5 +21,4 @@ install_data(
+ )
+ 
+ mkdir_cmd = 'mkdir -p ${DESTDIR}@0@'
+-meson.add_install_script('sh', '-c', mkdir_cmd.format(mm_prefix / mm_connectiondiruser))
+ meson.add_install_script('sh', '-c', mkdir_cmd.format(mm_prefix / mm_connectiondirpackage))
+diff --git a/data/dispatcher-fcc-unlock/meson.build b/data/dispatcher-fcc-unlock/meson.build
+index 5dc3b6a0..25a948a1 100644
+--- a/data/dispatcher-fcc-unlock/meson.build
++++ b/data/dispatcher-fcc-unlock/meson.build
+@@ -39,5 +39,4 @@ foreach output, input: vidpids
+ endforeach
+ 
+ mkdir_cmd = 'mkdir -p ${DESTDIR}@0@'
+-meson.add_install_script('sh', '-c', mkdir_cmd.format(mm_prefix / mm_fccunlockdiruser))
+ meson.add_install_script('sh', '-c', mkdir_cmd.format(mm_prefix / mm_fccunlockdirpackage))


### PR DESCRIPTION
###### Description of changes

Follow up to https://github.com/NixOS/nixpkgs/pull/214086.

We did not notice it was installing files to /etc in sandbox due to Nix 2.12 regression.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
