### PR TITLE
qtwirediff: init at unstable-2022-01-15

### DIFF
--- a/pkgs/applications/networking/sniffers/qtwirediff/default.nix
+++ b/pkgs/applications/networking/sniffers/qtwirediff/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qtbase
+, qmake
+, wrapQtAppsHook
+, wireshark-cli
+}:
+
+
+stdenv.mkDerivation {
+  pname = "qtwirediff";
+  version = "unstable-2023-03-07";
+
+  src = fetchFromGitHub {
+    owner = "aaptel";
+    repo = "qtwirediff";
+    rev = "e0a38180cdf9d94b7535c441487dcefb3a8ec72e";
+    hash = "sha256-QS4PslSHe2qhxayF7IHvtFASgd4A7vVtSY8tFQ6dqXM=";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 -T qtwirediff $out/bin/qtwirediff
+    wrapProgram $out/bin/qtwirediff \
+      --prefix PATH : "${lib.makeBinPath [ wireshark-cli ]}"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Debugging tool to diff network traffic leveraging Wireshark";
+    homepage = "https://github.com/aaptel/qtwirediff";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ janik ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29506,6 +29506,8 @@ with pkgs;
   };
   wireshark-qt = wireshark;
 
+  qtwirediff = qt6.callPackage ../applications/networking/sniffers/qtwirediff {};
+
   tshark = wireshark-cli;
   wireshark-cli = wireshark.override {
     withQt = false;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
