### PR TITLE
slop: fix build

### DIFF
--- a/pkgs/tools/misc/slop/default.nix
+++ b/pkgs/tools/misc/slop/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , pkg-config
 , glew
@@ -24,6 +25,15 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-LdBQxw8K8WWSfm4E2QpK4GYTuYvI+FX5gLOouVFSU/U=";
   };
+
+  patches = [
+    (fetchpatch {
+      # From Upstream PR#135: https://github.com/naelstrof/slop/pull/135
+      name = "Fix-linking-of-GLEW-library.patch";
+      url = "https://github.com/naelstrof/slop/commit/811b7e44648b9dd6c1da1554e70298cf4157e5fe.patch";
+      sha256 = "sha256-LNUrAeVZUJFNOt1csOaIid7gLBdtqRxp8AcC7f3cnIQ=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
slop: fix build

* FindGLEW.cmake Module silently tries to include glew-config.cmake. If it succeeds, then it stop and return to the caller. However, glew-config.cmake only sets GLEW::GLEW, resulting in missing glew shared library at link time.

References:
* https://github.com/naelstrof/slop/pull/135
* https://gitlab.exherbo.org/DanySpin97/danyspin97-exheres/-/issues/2
