### PR TITLE
caddy: 2.6.3 -> 2.6.4

### DIFF
--- a/pkgs/servers/caddy/default.nix
+++ b/pkgs/servers/caddy/default.nix
@@ -7,12 +7,12 @@
 , installShellFiles
 }:
 let
-  version = "2.6.3";
+  version = "2.6.4";
   dist = fetchFromGitHub {
     owner = "caddyserver";
     repo = "dist";
     rev = "v${version}";
-    sha256 = "sha256-SJO1q4g9uyyky9ZYSiqXJgNIvyxT5RjrpYd20YDx8ec=";
+    hash = "sha256-SJO1q4g9uyyky9ZYSiqXJgNIvyxT5RjrpYd20YDx8ec=";
   };
 in
 buildGoModule {
@@ -23,10 +23,10 @@ buildGoModule {
     owner = "caddyserver";
     repo = "caddy";
     rev = "v${version}";
-    sha256 = "sha256-YH+lo6gKqmhu1/3HZdWXnxTXaUwC8To+OCmGpji6i3k=";
+    hash = "sha256-3a3+nFHmGONvL/TyQRqgJtrSDIn0zdGy9YwhZP17mU0=";
   };
 
-  vendorSha256 = "sha256-sqjN+NgwdP2qw7/CBxKvSwwA3teg/trXg/oa1Ff0N8s=";
+  vendorHash = "sha256-toi6efYZobjDV3YPT9seE/WZAzNaxgb1ioVG4txcuXM=";
 
   subPackages = [ "cmd/caddy" ];
 


### PR DESCRIPTION
###### Description of changes

changelog: https://github.com/caddyserver/caddy/releases/tag/v2.6.4

> [...] contains a hotfix for a regression in v2.6.3 related to proxying chunked requests [...]

v2.6.3 has been backported in #215437, meaning 22.11 is affected by that (somewhat specific performance) regression as well.

BUT, also from the release notes:

> Note that, in an effort to make error-prone configs less likely, we have deprecated the reverse proxy options:
> 
> - `buffer_requests`
> - `buffer_responses
> - `max_buffer_size`
> 
> and have introduced 2 new ones which take a size argument to enable 
> - `request_buffers <size>`
> - `response_buffers <size>`
> 
> The deprecated options will be removed in a later version of Caddy, so please start using the new parameters instead.

Which isn't really compatible with the acceptable backport criterias.

But with me being somewhat involved in Caddy, I can vouch that those options are barely used by users, and that those will work just fine for a while - like the release notes state at the end.

Caddy keeps deprecated options for a few versions, just printing a deprecation notice, before actually removing them.

So I would say, this bump is safe to backport, and I will keep an eye on future versions, until 23.05 is out.
Should I add this, in one way or another, to the 23.05 release notes? 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

