### PR TITLE
suitesparse: 5.13.0 -> 7.0.1

### DIFF
--- a/pkgs/development/libraries/ceres-solver/default.nix
+++ b/pkgs/development/libraries/ceres-solver/default.nix
@@ -1,6 +1,5 @@
 { lib
 , stdenv
-, fetchpatch
 , fetchurl
 , blas
 , cmake
@@ -34,6 +33,13 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=${if enableStatic then "OFF" else "ON"}"
+  ];
+
+  patches = [
+    (fetchurl {
+      url = "https://github.com/ceres-solver/ceres-solver/commit/352b320ab1b5438a0838aea09cbbf07fa4ff5d71.patch";
+      hash = "sha256-jUXzsv20xj/mGIJ1X2QaBzGSG3FCzsK8iZYgWiodxVw=";
+    })
   ];
 
   # The Basel BUILD file conflicts with the cmake build directory on

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchFromGitHub
+, cmake
 , gfortran
 , blas, lapack
 , metis
@@ -12,7 +13,7 @@
 
 stdenv.mkDerivation rec {
   pname = "suitesparse";
-  version = "5.13.0";
+  version = "7.0.1";
 
   outputs = [ "out" "dev" "doc" ];
 
@@ -20,10 +21,11 @@ stdenv.mkDerivation rec {
     owner = "DrTimothyAldenDavis";
     repo = "SuiteSparse";
     rev = "v${version}";
-    sha256 = "sha256-Anen1YtXsSPhk8DpA4JtADIz9m8oXFl9umlkb4iImf8=";
+    hash = "sha256-EIreweeOx44YDxlnxnJ7l31Ie1jSx6y87VAyEX+4NsQ=";
   };
 
   nativeBuildInputs = [
+    cmake
   ] ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   # Use compatible indexing for lapack and blas used
@@ -35,18 +37,36 @@ stdenv.mkDerivation rec {
     mpfr
   ] ++ lib.optional enableCuda cudatoolkit;
 
+  propagatedBuildInputs = [
+    gmp
+    mpfr
+  ];
+
   preConfigure = ''
     # Mongoose and GraphBLAS are packaged separately
     sed -i "Makefile" -e '/GraphBLAS\|Mongoose/d'
   '';
 
-  makeFlags = [
-    "INSTALL=${placeholder "out"}"
-    "INSTALL_INCLUDE=${placeholder "dev"}/include"
-    "JOBS=$(NIX_BUILD_CORES)"
-    "MY_METIS_LIB=-lmetis"
+  FC = "${gfortran}/bin/gfortran";
+
+  dontUseCmakeConfigure = true;
+
+  cmakeFlags = [
+    "-DBLA_VENDOR=Generic"
+    # Definitions from CMake's setup hook
+    # Unfortunately, it is not possible to extract the additional cmakeFlags generated there
+    "-DCMAKE_INSTALL_BINDIR=${placeholder "out"}/bin"
+    "-DCMAKE_INSTALL_INCLUDEDIR=${placeholder "dev"}/include"
+    "-DCMAKE_INSTALL_LIBDIR=${placeholder "out"}/lib"
   ] ++ lib.optionals blas.isILP64 [
-    "CFLAGS=-DBLAS64"
+    "-DALLOW_64BIT_BLAS=ON"
+  ];
+
+  # CMAKE_OPTIONS will be picked up via the Makefile
+  CMAKE_OPTIONS = lib.concatStringsSep " "cmakeFlags;
+
+  makeFlags = [
+    "JOBS=$(NIX_BUILD_CORES)"
   ] ++ lib.optionals enableCuda [
     "CUDA_PATH=${cudatoolkit}"
     "CUDART_LIB=${cudatoolkit.lib}/lib/libcudart.so"
@@ -54,15 +74,31 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals stdenv.isDarwin [
     # Unless these are set, the build will attempt to use `Accelerate` on darwin, see:
     # https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/v5.13.0/SuiteSparse_config/SuiteSparse_config.mk#L368
-    "BLAS=-lblas"
-    "LAPACK=-llapack"
-  ]
-  ;
+    #"BLAS=-lblas"
+    #"LAPACK=-llapack"
+  ];
 
   buildFlags = [
     # Build individual shared libraries, not demos
     "library"
+    "docs"
   ];
+
+  postInstall = ''
+    mkdir -p $doc
+    for docdir in */Doc; do
+      local name="$(dirname "$docdir")"
+      local dest_dir="$doc/share/doc/$name"
+
+      if [[ $name = Mongoose || $name = GraphBLAS ]]; then
+        # Mongoose and GraphBLAS are packaged separately
+        continue
+      fi
+
+      echo "installing docs from $docdir to $dest_dir"
+      install -Dt "$dest_dir" "$docdir/"*.{txt,pdf}
+    done
+    '';
 
   meta = with lib; {
     homepage = "http://faculty.cse.tamu.edu/davis/suitesparse.html";


### PR DESCRIPTION
###### Description of changes

Release notes: https://github.com/DrTimothyAldenDavis/SuiteSparse/releases/tag/v7.0.1

Comes with a new funky *hybrid* CMake/Make build system! No, I'm not talking about CMake generating Makefiles. The Makefile invokes CMake to generate some configuration files, and the uses the result files in the build.

This update might break some packages. Currently I'm just updating the default package, but it might be necessary to retain SuiteSparse version 5 just like for 4.2 and 4.4. Let's see.
Companion SuiteSparse PR: #216399

Part of an ongoing effort to package [Meshroom](https://github.com/alicevision/Meshroom) (https://github.com/NixOS/nixpkgs/issues/94127). See also #215528 #215728 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
