### PR TITLE
cctag: init at 1.0.3

### DIFF
--- a/pkgs/development/libraries/cctag/cmake-install-include-dir.patch
+++ b/pkgs/development/libraries/cctag/cmake-install-include-dir.patch
@@ -1,0 +1,11 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -209,7 +209,7 @@
+   target_include_directories(CCTag
+                            PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>"
+                                   "$<BUILD_INTERFACE:${generated_dir}>"
+-                                  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>"
++                                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+                            PUBLIC ${Boost_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
+ 
+   # just for testing

--- a/pkgs/development/libraries/cctag/default.nix
+++ b/pkgs/development/libraries/cctag/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+
+, cmake
+, boost
+, eigen
+, opencv
+, tbb
+
+, avx2Support ? stdenv.hostPlatform.avx2Support
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cctag";
+  version = "1.0.3";
+
+  outputs = [ "lib" "dev" "out" ];
+
+  src = fetchFromGitHub {
+    owner = "alicevision";
+    repo = "CCTag";
+    rev = "v${version}";
+    hash = "sha256-foB+e7BCuUucyhN8FsI6BIT3/fsNLTjY6QmjkMWZu6A=";
+  };
+
+  cmakeFlags = [
+    # Feel free to create a PR to add CUDA support
+    "-DCCTAG_WITH_CUDA=OFF"
+
+    "-DCCTAG_ENABLE_SIMD_AVX2=${if avx2Support then "ON" else "OFF"}"
+
+    "-DCCTAG_BUILD_TESTS=${if doCheck then "ON" else "OFF"}"
+    "-DCCTAG_BUILD_APPS=OFF"
+  ];
+
+  patches = [
+    ./cmake-install-include-dir.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  propagatedBuildInputs = [
+    tbb
+  ];
+
+  buildInputs = [
+    boost
+    eigen
+    opencv
+  ];
+
+  # Tests are broken on Darwin (linking issue)
+  doCheck = !stdenv.isDarwin;
+
+  meta = with lib; {
+    description = "Detection of CCTag markers made up of concentric circles";
+    homepage = "https://cctag.readthedocs.io";
+    downloadPage = "https://github.com/alicevision/CCTag";
+    license = licenses.mpl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ tmarkus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19447,6 +19447,10 @@ with pkgs;
 
   ccrtp = callPackage ../development/libraries/ccrtp { };
 
+  cctag = callPackage ../development/libraries/cctag {
+    tbb = tbb_2021_8;
+  };
+
   cctz = callPackage ../development/libraries/cctz {
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };


### PR DESCRIPTION
###### Description of changes
Add package for the CCTag library.

Links: 
* https://cctag.readthedocs.io/en/latest/
* https://github.com/alicevision/CCTag

Depends on PR #215689

Part of an ongoing effort to package [Meshroom](https://github.com/alicevision/Meshroom) (https://github.com/NixOS/nixpkgs/issues/94127). See also #215528 #215728 #216401 #216399 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
