### PR TITLE
fcitx5-mozc: Build and install `mozc_emacs_helper`

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-mozc.nix
@@ -87,7 +87,8 @@ in clangStdenv.mkDerivation rec {
     python build_mozc.py build -c Release \
       server/server.gyp:mozc_server \
       gui/gui.gyp:mozc_tool \
-      unix/fcitx5/fcitx5.gyp:fcitx5-mozc
+      unix/fcitx5/fcitx5.gyp:fcitx5-mozc \
+      unix/emacs/emacs.gyp:mozc_emacs_helper
   '';
 
   installPhase = ''
@@ -101,6 +102,7 @@ in clangStdenv.mkDerivation rec {
     install -d $out/share/fcitx5/inputmethod
     install -d $out/lib/fcitx5
     ../scripts/install_fcitx5
+    install -D -m 755 out_linux/Release/mozc_emacs_helper $out/lib/mozc/mozc_emacs_helper
   '';
 
   meta = with lib; {


### PR DESCRIPTION
`mozc_emacs_helper` is needed for emacs' `mozc.el` which adds support to use `mozc` input in emacs.  `mozc` already has support to building this, it is just a matter of invoking this.

`fcitx5-mozc` (just like `fcitx-mozc` or `ibus-mozc`) build `mozc` as part of their build.  In the case of `ibus-mozc`, `mozc_emacs_helper` was enabled, however for `fcitx5-mozc` it isn't.  

As far as I can tell, one can not just install `ibus-mozc` just for the `mozc_emacs_helper` and also use `fcitx5-mozc`.  The reason is that `mozc` runs as a server globally on the system, and trying to use two different `mozc` at the same time will causes conflicts. i.e. the first program that invokes `mozc-server` wins, and the second program that tries to use it (with its differing version) gets an error.

I preferred to have this treatment uniform with `ibus-mozc`.  Over there the creation of this executable is not predicated by any boolean like `enableMozcEmacsHelper`, so it isn't here either.  If it should be behind an enabling variable, let me know.

###### Description of changes

Just like it is done for `pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix`:

1. Enabled the building of `mozc_emacs_helper`
2. Add an `install` invocation to copy the executable to `$out/lib/mozc`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
