### PR TITLE
apptainer: always specify either --with-suid or --without-suid build flag

### DIFF
--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -52,6 +52,9 @@ in
   # SingularityCE 3.10.0 and above requires explicit --without-seccomp when libseccomp is not available.
 , enableSeccomp ? true
   # Whether the configure script treat SUID support as default
+  # When equal to enableSuid, it supress the --with-suid / --without-suid build flag
+  # It can be set to `null` to always pass either --with-suid or --without-suided
+  # Type: null or boolean
 , defaultToSuid ? true
   # Whether to compile with SUID support
 , enableSuid ? false
@@ -131,8 +134,7 @@ buildGoModule {
     "--runstatedir=/var/run"
   ]
   ++ lib.optional (!enableSeccomp) "--without-seccomp"
-  ++ lib.optional (defaultToSuid && !enableSuid) "--without-suid"
-  ++ lib.optional (!defaultToSuid && enableSuid) "--with-suid"
+  ++ lib.optional (enableSuid != defaultToSuid) (if enableSuid then "--with-suid" else "--without-suid")
   ++ extraConfigureFlags
   ;
 

--- a/pkgs/applications/virtualization/singularity/packages.nix
+++ b/pkgs/applications/virtualization/singularity/packages.nix
@@ -29,10 +29,10 @@ let
       # Apptainer doesn't depend on conmon
       conmon = null;
 
-      # defaultToSuid becomes false since Apptainer 1.1.0
-      # https://github.com/apptainer/apptainer/pull/495
-      # https://github.com/apptainer/apptainer/releases/tag/v1.1.0
-      defaultToSuid = false;
+      # Apptainer builders require explicit --with-suid / --without-suid flag
+      # when building on a system with disabled unprivileged namespace.
+      # See https://github.com/NixOS/nixpkgs/pull/215690#issuecomment-1426954601
+      defaultToSuid = null;
     };
 
   singularity = callPackage


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This change fixes `singularity/generic.nix` to allow `defaultToSuid` to be specified as `null`, which means that either `--with-suid` or `--without-suid` will be passed to `mconfig`.

Previously, `defaultToSuid` only accepts boolean values and will pass the `--with[out]-suid` flag only when `enableSuid != defaultToSuid`.

The build on NixOnDroid is still bothered by https://github.com/apptainer/apptainer/issues/372, which seems to be a Go compiler problem. The build-with-unprivileged-ns-disabled issue (mentioned below) got fixed anyway.

Fixes: https://github.com/NixOS/nixpkgs/pull/215690#issuecomment-1426954601

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
