### PR TITLE
debian-devscripts: Add missing Perl dependencies for uscan

### DIFF
--- a/pkgs/tools/misc/debian-devscripts/default.nix
+++ b/pkgs/tools/misc/debian-devscripts/default.nix
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper pkg-config ];
   buildInputs = [ xz dpkg libxslt python setuptools curl gnupg diffutils bash-completion help2man ] ++
-    (with perlPackages; [ perl CryptSSLeay LWP TimeDate DBFile FileDesktopEntry ParseDebControl LWPProtocolHttps ]);
+    (with perlPackages; [ perl CryptSSLeay LWP TimeDate DBFile FileDesktopEntry ParseDebControl LWPProtocolHttps Moo FileHomeDir IPCRun FileDirList FileTouch ]);
 
   preConfigure = ''
     export PERL5LIB="$PERL5LIB''${PERL5LIB:+:}${dpkg}";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9139,6 +9139,22 @@ let
     };
   };
 
+  FileDirList = buildPerlPackage {
+    version = "0.05";
+    pname = "File-DirList";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/T/TP/TPABA/File-DirList/File-DirList-0.05.tar.gz";
+      sha256 = "sha256-mTt9dmLlV5hEih7azLmr0oHSvSO+fquZ9Wm44pYtO8M=";
+    };
+    preCheck = ''
+      export HOME="$TMPDIR"
+    '';
+    meta = {
+      description = "Provide a sorted list of directory content";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   FileFindIterator = buildPerlPackage {
     pname = "File-Find-Iterator";
     version = "0.4";


### PR DESCRIPTION
###### Description of changes

Add the missing Perl dependencies for `uscan`. Before:

```console
$ uscan --download-current-version
Can't locate Moo.pm in @INC (you may need to install the Moo module) (@INC contains: /nix/store/dw5037j09zl640ln4yzj2kzbmmv75az5-debian-devscripts-2.22.2/share/devscripts /nix/store/19sspvcdv37j2rhnvsdw1q59c809rbsk-dpkg-1.21.1ubuntu2.1/lib/perl5/site_perl /nix/store/lh5bndikd7jhvniph23vknchcv9g72ld-perl-5.36.0/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/lh5bndikd7jhvniph23vknchcv9g72ld-perl-5.36.0/lib/perl5/site_perl/5.36.0 /nix/store/lh5bndikd7jhvniph23vknchcv9g72ld-perl-5.36.0/lib/perl5/site_perl /nix/store/n5asmfrr5ni6r8cwvyxsg0650x804c70-perl5.36.0-Crypt-SSLeay-0.73_06/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/n5asmfrr5ni6r8cwvyxsg0650x804c70-perl5.36.0-Crypt-SSLeay-0.73_06/lib/perl5/site_perl/5.36.0 /nix/store/n5asmfrr5ni6r8cwvyxsg0650x804c70-perl5.36.0-Crypt-SSLeay-0.73_06/lib/perl5/site_perl /nix/store/r5qbvlghk24aq6bz4lkrzd0sqg8n5jh0-perl5.36.0-Bytes-Random-Secure-0.29/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/r5qbvlghk24aq6bz4lkrzd0sqg8n5jh0-perl5.36.0-Bytes-Random-Secure-0.29/lib/perl5/site_perl/5.36.0 /nix/store/r5qbvlghk24aq6bz4lkrzd0sqg8n5jh0-perl5.36.0-Bytes-Random-Secure-0.29/lib/perl5/site_perl /nix/store/4cii029zp0x4k88qfpwm1ri3y8cqzxpz-perl5.36.0-Crypt-Random-Seed-0.03/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/4cii029zp0x4k88qfpwm1ri3y8cqzxpz-perl5.36.0-Crypt-Random-Seed-0.03/lib/perl5/site_perl/5.36.0 /nix/store/4cii029zp0x4k88qfpwm1ri3y8cqzxpz-perl5.36.0-Crypt-Random-Seed-0.03/lib/perl5/site_perl /nix/store/6mhbi5gsqjkppnr0l7ralqqa6mkvw94m-perl5.36.0-Crypt-Random-TESHA2-0.01/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/6mhbi5gsqjkppnr0l7ralqqa6mkvw94m-perl5.36.0-Crypt-Random-TESHA2-0.01/lib/perl5/site_perl/5.36.0 /nix/store/6mhbi5gsqjkppnr0l7ralqqa6mkvw94m-perl5.36.0-Crypt-Random-TESHA2-0.01/lib/perl5/site_perl /nix/store/qwx6zgap7mgamzgxgmh6i9jcr929h1jy-perl5.36.0-Math-Random-ISAAC-1.004/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/qwx6zgap7mgamzgxgmh6i9jcr929h1jy-perl5.36.0-Math-Random-ISAAC-1.004/lib/perl5/site_perl/5.36.0 /nix/store/qwx6zgap7mgamzgxgmh6i9jcr929h1jy-perl5.36.0-Math-Random-ISAAC-1.004/lib/perl5/site_perl /nix/store/xp4jdx40v0w4s261cqc7j35ki8yi6v9a-perl5.36.0-LWP-Protocol-https-6.09/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/xp4jdx40v0w4s261cqc7j35ki8yi6v9a-perl5.36.0-LWP-Protocol-https-6.09/lib/perl5/site_perl/5.36.0 /nix/store/xp4jdx40v0w4s261cqc7j35ki8yi6v9a-perl5.36.0-LWP-Protocol-https-6.09/lib/perl5/site_perl /nix/store/vdfr260m3j70a8yb6s3n3wpf8522fn5w-perl5.36.0-IO-Socket-SSL-2.068/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/vdfr260m3j70a8yb6s3n3wpf8522fn5w-perl5.36.0-IO-Socket-SSL-2.068/lib/perl5/site_perl/5.36.0 /nix/store/vdfr260m3j70a8yb6s3n3wpf8522fn5w-perl5.36.0-IO-Socket-SSL-2.068/lib/perl5/site_perl /nix/store/hqvbfk5wjn3jb20h2pc84wca7v1xmnyy-perl5.36.0-Mozilla-CA-20200520/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/hqvbfk5wjn3jb20h2pc84wca7v1xmnyy-perl5.36.0-Mozilla-CA-20200520/lib/perl5/site_perl/5.36.0 /nix/store/hqvbfk5wjn3jb20h2pc84wca7v1xmnyy-perl5.36.0-Mozilla-CA-20200520/lib/perl5/site_perl /nix/store/9c26h76acwlxfrf8n0x47j3zimlnazd6-perl5.36.0-Net-SSLeay-1.92/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/9c26h76acwlxfrf8n0x47j3zimlnazd6-perl5.36.0-Net-SSLeay-1.92/lib/perl5/site_perl/5.36.0 /nix/store/9c26h76acwlxfrf8n0x47j3zimlnazd6-perl5.36.0-Net-SSLeay-1.92/lib/perl5/site_perl /nix/store/55g4rmc1p0qf67qnakfnh92rvcjhryjf-perl5.36.0-libwww-perl-6.67/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/55g4rmc1p0qf67qnakfnh92rvcjhryjf-perl5.36.0-libwww-perl-6.67/lib/perl5/site_perl/5.36.0 /nix/store/55g4rmc1p0qf67qnakfnh92rvcjhryjf-perl5.36.0-libwww-perl-6.67/lib/perl5/site_perl /nix/store/ig07v5903s83gaga1b9v586fz1x4y5zz-perl5.36.0-File-Listing-6.14/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/ig07v5903s83gaga1b9v586fz1x4y5zz-perl5.36.0-File-Listing-6.14/lib/perl5/site_perl/5.36.0 /nix/store/ig07v5903s83gaga1b9v586fz1x4y5zz-perl5.36.0-File-Listing-6.14/lib/perl5/site_perl /nix/store/bnm3klsq1dpblx8kpi5ywx3ngya8jyn7-perl5.36.0-HTTP-Date-6.05/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/bnm3klsq1dpblx8kpi5ywx3ngya8jyn7-perl5.36.0-HTTP-Date-6.05/lib/perl5/site_perl/5.36.0 /nix/store/bnm3klsq1dpblx8kpi5ywx3ngya8jyn7-perl5.36.0-HTTP-Date-6.05/lib/perl5/site_perl /nix/store/9ywr5sfnb9fpi32nvvg5gzlyrvk3lkpm-perl5.36.0-TimeDate-2.33/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/9ywr5sfnb9fpi32nvvg5gzlyrvk3lkpm-perl5.36.0-TimeDate-2.33/lib/perl5/site_perl/5.36.0 /nix/store/9ywr5sfnb9fpi32nvvg5gzlyrvk3lkpm-perl5.36.0-TimeDate-2.33/lib/perl5/site_perl /nix/store/1cnvcq4iwpw8qk5wa1mswkpady8bf7qc-perl5.36.0-HTML-Parser-3.75/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/1cnvcq4iwpw8qk5wa1mswkpady8bf7qc-perl5.36.0-HTML-Parser-3.75/lib/perl5/site_perl/5.36.0 /nix/store/1cnvcq4iwpw8qk5wa1mswkpady8bf7qc-perl5.36.0-HTML-Parser-3.75/lib/perl5/site_perl /nix/store/c0rbpi4jzddr77vskjnixcp5r895kj0h-perl5.36.0-HTML-Tagset-3.20/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/c0rbpi4jzddr77vskjnixcp5r895kj0h-perl5.36.0-HTML-Tagset-3.20/lib/perl5/site_perl/5.36.0 /nix/store/c0rbpi4jzddr77vskjnixcp5r895kj0h-perl5.36.0-HTML-Tagset-3.20/lib/perl5/site_perl /nix/store/sxx9dqnccyy1c97kxdmq8dwa4fvqwh1q-perl5.36.0-HTTP-Message-6.26/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/sxx9dqnccyy1c97kxdmq8dwa4fvqwh1q-perl5.36.0-HTTP-Message-6.26/lib/perl5/site_perl/5.36.0 /nix/store/sxx9dqnccyy1c97kxdmq8dwa4fvqwh1q-perl5.36.0-HTTP-Message-6.26/lib/perl5/site_perl /nix/store/m86jlv2hrysai853d2548jhq6h16i5wh-perl5.36.0-Encode-Locale-1.05/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/m86jlv2hrysai853d2548jhq6h16i5wh-perl5.36.0-Encode-Locale-1.05/lib/perl5/site_perl/5.36.0 /nix/store/m86jlv2hrysai853d2548jhq6h16i5wh-perl5.36.0-Encode-Locale-1.05/lib/perl5/site_perl /nix/store/c5mm25l3qy4v31yb6w76pdzrnxnybqpv-perl5.36.0-IO-HTML-1.004/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/c5mm25l3qy4v31yb6w76pdzrnxnybqpv-perl5.36.0-IO-HTML-1.004/lib/perl5/site_perl/5.36.0 /nix/store/c5mm25l3qy4v31yb6w76pdzrnxnybqpv-perl5.36.0-IO-HTML-1.004/lib/perl5/site_perl /nix/store/92bqdvnp2vayv76rfjabrs9j6n7wpxsp-perl5.36.0-LWP-MediaTypes-6.04/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/92bqdvnp2vayv76rfjabrs9j6n7wpxsp-perl5.36.0-LWP-MediaTypes-6.04/lib/perl5/site_perl/5.36.0 /nix/store/92bqdvnp2vayv76rfjabrs9j6n7wpxsp-perl5.36.0-LWP-MediaTypes-6.04/lib/perl5/site_perl /nix/store/0ng99r29axlhdp6xn88lsw7khp8175i1-perl5.36.0-URI-5.05/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/0ng99r29axlhdp6xn88lsw7khp8175i1-perl5.36.0-URI-5.05/lib/perl5/site_perl/5.36.0 /nix/store/0ng99r29axlhdp6xn88lsw7khp8175i1-perl5.36.0-URI-5.05/lib/perl5/site_perl /nix/store/5sgmmlbn2amh8rly36242d13s8ksw47y-perl5.36.0-HTTP-Cookies-6.09/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/5sgmmlbn2amh8rly36242d13s8ksw47y-perl5.36.0-HTTP-Cookies-6.09/lib/perl5/site_perl/5.36.0 /nix/store/5sgmmlbn2amh8rly36242d13s8ksw47y-perl5.36.0-HTTP-Cookies-6.09/lib/perl5/site_perl /nix/store/sw3ix4mb99akynkaniidbncr7madqk7h-perl5.36.0-HTTP-Negotiate-6.01/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/sw3ix4mb99akynkaniidbncr7madqk7h-perl5.36.0-HTTP-Negotiate-6.01/lib/perl5/site_perl/5.36.0 /nix/store/sw3ix4mb99akynkaniidbncr7madqk7h-perl5.36.0-HTTP-Negotiate-6.01/lib/perl5/site_perl /nix/store/pif1aw3qv9k0z2dwkfw2rs2kqhf9h25q-perl5.36.0-Net-HTTP-6.19/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/pif1aw3qv9k0z2dwkfw2rs2kqhf9h25q-perl5.36.0-Net-HTTP-6.19/lib/perl5/site_perl/5.36.0 /nix/store/pif1aw3qv9k0z2dwkfw2rs2kqhf9h25q-perl5.36.0-Net-HTTP-6.19/lib/perl5/site_perl /nix/store/ygazfnlkfcxpiwpa5wdhlac6fb3p92ic-perl5.36.0-Try-Tiny-0.30/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/ygazfnlkfcxpiwpa5wdhlac6fb3p92ic-perl5.36.0-Try-Tiny-0.30/lib/perl5/site_perl/5.36.0 /nix/store/ygazfnlkfcxpiwpa5wdhlac6fb3p92ic-perl5.36.0-Try-Tiny-0.30/lib/perl5/site_perl /nix/store/qa6jzms5zg2y506x16nqwa7iyslqnwd1-perl5.36.0-WWW-RobotRules-6.02/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/qa6jzms5zg2y506x16nqwa7iyslqnwd1-perl5.36.0-WWW-RobotRules-6.02/lib/perl5/site_perl/5.36.0 /nix/store/qa6jzms5zg2y506x16nqwa7iyslqnwd1-perl5.36.0-WWW-RobotRules-6.02/lib/perl5/site_perl /nix/store/b6dafxi35vkz2mhwl94sbq6l07ji9v63-perl5.36.0-DB_File-1.855/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/b6dafxi35vkz2mhwl94sbq6l07ji9v63-perl5.36.0-DB_File-1.855/lib/perl5/site_perl/5.36.0 /nix/store/b6dafxi35vkz2mhwl94sbq6l07ji9v63-perl5.36.0-DB_File-1.855/lib/perl5/site_perl /nix/store/6ii2ibn4yz3x4kxsb8kppmr7p9vxamha-perl5.36.0-File-DesktopEntry-0.22/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/6ii2ibn4yz3x4kxsb8kppmr7p9vxamha-perl5.36.0-File-DesktopEntry-0.22/lib/perl5/site_perl/5.36.0 /nix/store/6ii2ibn4yz3x4kxsb8kppmr7p9vxamha-perl5.36.0-File-DesktopEntry-0.22/lib/perl5/site_perl /nix/store/ia53k89kipif3xcgiz81xvad64v6wbiy-perl5.36.0-File-BaseDir-0.08/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/ia53k89kipif3xcgiz81xvad64v6wbiy-perl5.36.0-File-BaseDir-0.08/lib/perl5/site_perl/5.36.0 /nix/store/ia53k89kipif3xcgiz81xvad64v6wbiy-perl5.36.0-File-BaseDir-0.08/lib/perl5/site_perl /nix/store/z1i2p6y4psfvzn2a4wxypfgfl30m1i6y-perl5.36.0-IPC-System-Simple-1.30/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/z1i2p6y4psfvzn2a4wxypfgfl30m1i6y-perl5.36.0-IPC-System-Simple-1.30/lib/perl5/site_perl/5.36.0 /nix/store/z1i2p6y4psfvzn2a4wxypfgfl30m1i6y-perl5.36.0-IPC-System-Simple-1.30/lib/perl5/site_perl /nix/store/s2slbdcx4q3kj5wjyxlqbqn7kp5ykbd0-perl5.36.0-Parse-DebControl-2.005/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/s2slbdcx4q3kj5wjyxlqbqn7kp5ykbd0-perl5.36.0-Parse-DebControl-2.005/lib/perl5/site_perl/5.36.0 /nix/store/s2slbdcx4q3kj5wjyxlqbqn7kp5ykbd0-perl5.36.0-Parse-DebControl-2.005/lib/perl5/site_perl /nix/store/fvydid5rqlflb1jvw2f7wnsxdmnlkwzq-perl5.36.0-IO-Stringy-2.113/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/fvydid5rqlflb1jvw2f7wnsxdmnlkwzq-perl5.36.0-IO-Stringy-2.113/lib/perl5/site_perl/5.36.0 /nix/store/fvydid5rqlflb1jvw2f7wnsxdmnlkwzq-perl5.36.0-IO-Stringy-2.113/lib/perl5/site_perl /nix/store/19sspvcdv37j2rhnvsdw1q59c809rbsk-dpkg-1.21.1ubuntu2.1 /nix/store/lh5bndikd7jhvniph23vknchcv9g72ld-perl-5.36.0/lib/perl5/site_perl/5.36.0/x86_64-linux-thread-multi /nix/store/lh5bndikd7jhvniph23vknchcv9g72ld-perl-5.36.0/lib/perl5/site_perl/5.36.0 /nix/store/lh5bndikd7jhvniph23vknchcv9g72ld-perl-5.36.0/lib/perl5/5.36.0/x86_64-linux-thread-multi /nix/store/lh5bndikd7jhvniph23vknchcv9g72ld-perl-5.36.0/lib/perl5/5.36.0) at /nix/store/dw5037j09zl640ln4yzj2kzbmmv75az5-debian-devscripts-2.22.2/share/devscripts/Devscripts/Uscan/Config.pm line 24.
BEGIN failed--compilation aborted at /nix/store/dw5037j09zl640ln4yzj2kzbmmv75az5-debian-devscripts-2.22.2/share/devscripts/Devscripts/Uscan/Config.pm line 24.
Compilation failed in require at /nix/store/dw5037j09zl640ln4yzj2kzbmmv75az5-debian-devscripts-2.22.2/bin/.uscan-wrapped line 2137.
BEGIN failed--compilation aborted at /nix/store/dw5037j09zl640ln4yzj2kzbmmv75az5-debian-devscripts-2.22.2/bin/.uscan-wrapped line 2137.
```

After:

```console
$ uscan --download-current-version
.uscan-wrapped: Newest version of git on remote site is 2.39.2, specified download version is 2.39.2
Successfully symlinked ../git-2.39.2.tar.xz to ../git_2.39.2.orig.tar.xz.
.uscan-wrapped warn: more than one main upstream tarballs listed.
.uscan-wrapped warn: In debian/watch no matching hrefs for version 2.39.2 in watch line
  https://www.kernel.org/pub/software/scm/git/testing/git-([\d.]+rc\d+)\.tar\.xz
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
