### PR TITLE
Add option for ruby gems to not modify RUBYLIB

### DIFF
--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -46,6 +46,7 @@ lib.makeOverridable (
 # If you need to apply patches, make sure to set `dontBuild = false`;
 , dontBuild ? true
 , dontInstallManpages ? false
+, dontAddToRubylib ? false
 , propagatedBuildInputs ? []
 , propagatedUserEnvPkgs ? []
 , buildFlags ? []
@@ -87,6 +88,7 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
   inherit dontBuild;
   inherit dontStrip;
   gemType = type;
+  inherit dontAddToRubylib;
 
   nativeBuildInputs = [
     ruby makeWrapper

--- a/pkgs/development/ruby-modules/gem/gem-post-build.rb
+++ b/pkgs/development/ruby-modules/gem/gem-post-build.rb
@@ -46,8 +46,10 @@ end
 # add this gem to the GEM_PATH for dependencies
 File.open("#{out}/nix-support/setup-hook", "a") do |f|
   f.puts("addToSearchPath GEM_PATH #{gem_home}")
-  spec.require_paths.each do |dir|
-    f.puts("addToSearchPath RUBYLIB #{install_path}/#{dir}")
+  if ENV["dontAddToRubylib"] == "false"
+    spec.require_paths.each do |dir|
+      f.puts("addToSearchPath RUBYLIB #{install_path}/#{dir}")
+    end
   end
 end
 


### PR DESCRIPTION
###### Description of changes

Right now each gem is automatically put into $RUBYLIB. This caused some issues for me when I had multiple versions of a gem and different scripts that required different versions of that gem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
