### PR TITLE
nixos/unbound: make stateDir writable

### DIFF
--- a/nixos/modules/services/networking/unbound.nix
+++ b/nixos/modules/services/networking/unbound.nix
@@ -286,6 +286,8 @@ in {
         LockPersonality = true;
         RestrictSUIDSGID = true;
 
+        ReadWritePaths = [ cfg.stateDir ];
+
         Restart = "on-failure";
         RestartSec = "5s";
       };


### PR DESCRIPTION
It was dropped from ReadWritePaths in https://github.com/NixOS/nixpkgs/commit/aadc07618aff8106f888c67383fb32e471dd817e under the assumption that systemd takes care of it, but that's only true if the default `/var/lib/unbound` path is used. cc @andir

Fixes https://github.com/NixOS/nixpkgs/issues/216500