### PR TITLE
python3Packages.mocket: Resolve test failures

### DIFF
--- a/pkgs/development/python-modules/geoip2/default.nix
+++ b/pkgs/development/python-modules/geoip2/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, lib, fetchPypi, pythonOlder
+{ buildPythonPackage, lib, fetchPypi, pythonOlder, pythonAtLeast
 , aiohttp
 , maxminddb
 , mocket
@@ -29,6 +29,8 @@ buildPythonPackage rec {
     requests-mock
     pytestCheckHook
   ];
+
+  disabledTests = lib.optional (pythonAtLeast "3.11") "TestAsyncClient";
 
   pythonImportsCheck = [ "geoip2" ];
 

--- a/pkgs/development/python-modules/mocket/default.nix
+++ b/pkgs/development/python-modules/mocket/default.nix
@@ -2,12 +2,14 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
+, pythonAtLeast
 , isPy3k
 , decorator
 , http-parser
 , python-magic
 , urllib3
 , pytestCheckHook
+, pytest-asyncio
 , pytest-mock
 , aiohttp
 , fastapi
@@ -38,6 +40,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-asyncio
     pytest-mock
     aiohttp
     fastapi
@@ -54,6 +57,10 @@ buildPythonPackage rec {
   pytestFlagsArray = [
     # Requires a live Redis instance
     "--ignore=tests/main/test_redis.py"
+  ] ++ lib.optionals (pythonAtLeast "3.11") [
+    # Do not work with newer versions of pytest-asyncio
+    "--ignore=tests/main/test_http_aiohttp.py"
+    "--ignore=tests/tests38/test_http_aiohttp.py"
   ] ++ lib.optionals (pythonOlder "3.8") [
     # Uses IsolatedAsyncioTestCase which is only available >= 3.8
     "--ignore=tests/tests38/test_http_aiohttp.py"


### PR DESCRIPTION
###### Description of changes

Add pytest-asyncio in order to allow async tests to run. They were previously silently skipped with a warning.

Disable three more tests (test_http*_session) that depend on Internet connectivity and thus fail in sandboxed builds.

This should some Hydra failures, e.g. this one: https://hydra.nixos.org/build/208832590
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
