### PR TITLE
xemu: init at 0.7.84

### DIFF
--- a/pkgs/applications/emulators/xemu/default.nix
+++ b/pkgs/applications/emulators/xemu/default.nix
@@ -1,0 +1,131 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, makeDesktopItem
+, copyDesktopItems
+, pkg-config
+, python3
+, ninja
+, meson
+, which
+, perl
+, wrapGAppsHook
+, glib
+, gtk3
+, libpcap
+, openssl
+, libepoxy
+, libsamplerate
+, SDL2
+, SDL2_image
+, mesa
+, libdrm
+, libGLU
+, gettext
+, vte
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xemu";
+  version = "0.7.84";
+
+  src = fetchFromGitHub {
+    owner = "xemu-project";
+    repo = "xemu";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-pEXjwoQKbMmVNYCnh5nqP7k0acYOAp8SqxYZwPzVwDY=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    python3
+    python3.pkgs.pyyaml
+    ninja
+    which
+    meson
+    perl
+    wrapGAppsHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    openssl
+    mesa
+    libepoxy
+    libdrm
+    libpcap
+    libsamplerate
+    SDL2
+    libGLU
+    SDL2_image
+    gettext
+    vte
+  ];
+
+  separateDebugInfo = true;
+
+  dontUseMesonConfigure = true;
+
+  setOutputFlags = false;
+
+  configureFlags = [
+    "--disable-strip"
+    "--meson=meson"
+    "--target-list=i386-softmmu"
+    "--disable-werror"
+  ];
+
+  buildFlags = [ "qemu-system-i386" ];
+
+  desktopItems = [(makeDesktopItem {
+    name = "xemu";
+    desktopName = "xemu";
+    exec = "xemu";
+    icon = "xemu";
+  })] ;
+
+  preConfigure = let
+    branch = "master";
+    commit = "d8fa50e524c22f85ecb2e43108fd6a5501744351";
+  in ''
+    patchShebangs .
+    configureFlagsArray+=("--extra-cflags=-DXBOX=1 -Wno-error=redundant-decls")
+    substituteInPlace ./scripts/xemu-version.sh \
+      --replace 'date -u' "date -d @$SOURCE_DATE_EPOCH '+%Y-%m-%d %H:%M:%S'"
+    # If the versions can't be obtained through git, the build process tries
+    # to run `XEMU_COMMIT=$(cat XEMU_COMMIT)` (and similar)
+    echo '${commit}' > XEMU_COMMIT
+    echo '${branch}' > XEMU_BRANCH
+    echo '${version}' > XEMU_VERSION
+  '';
+
+  preBuild = ''
+    cd build
+    substituteInPlace ./build.ninja --replace /usr/bin/env $(which env)
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share}
+    cp qemu-system-i386 $out/bin/xemu
+
+    for RES in 16x16 24x24 32x32 48x48 128x128 256x256 512x512
+    do
+      mkdir -p $out/share/icons/hicolor/$RES/apps/
+      cp ../ui/icons/xemu_$RES.png $out/share/icons/hicolor/$RES/apps/xemu.png
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://xemu.app/";
+    description = "Original Xbox emulator";
+    maintainers = with maintainers; [ ];
+    license = licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2263,6 +2263,8 @@ with pkgs;
 
   xcpc = callPackage ../applications/emulators/xcpc { };
 
+  xemu = callPackage ../applications/emulators/xemu { };
+
   yapesdl = callPackage ../applications/emulators/yapesdl { };
 
   zesarux = callPackage ../applications/emulators/zesarux { };


### PR DESCRIPTION
###### Description of changes

Add xemu, closes #214348 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [z] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
