### PR TITLE
discord: disableBreakingUpdates: create settings.json when missing

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/disable-breaking-updates.py
+++ b/pkgs/applications/networking/instant-messengers/discord/disable-breaking-updates.py
@@ -22,21 +22,23 @@ XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
 
 settings_path = Path(f"{XDG_CONFIG_HOME}/@configDirName@/settings.json")
 settings_path_temp = Path(f"{XDG_CONFIG_HOME}/@configDirName@/settings.json.tmp")
-try:
+
+if os.path.exists(settings_path):
     with settings_path.open(encoding="utf-8") as settings_file:
         settings = json.load(settings_file)
+else:
+    settings = {}
 
-        if settings.get("SKIP_HOST_UPDATE"):
-            print("[Nix] Disabling updates already done")
-        else:
-            skip_host_update = {"SKIP_HOST_UPDATE": True}
-            settings.update(skip_host_update)
+if settings.get("SKIP_HOST_UPDATE"):
+    print("[Nix] Disabling updates already done")
+else:
+    skip_host_update = {"SKIP_HOST_UPDATE": True}
+    settings.update(skip_host_update)
 
-            with settings_path_temp.open("w", encoding="utf-8") as settings_file_temp:
-                json.dump(settings, settings_file_temp, indent=2)
+    os.makedirs(os.path.dirname(settings_path), exist_ok=True)
 
-            settings_path_temp.rename(settings_path)
-            print("[Nix] Disabled updates")
+    with settings_path_temp.open("w", encoding="utf-8") as settings_file_temp:
+        json.dump(settings, settings_file_temp, indent=2)
 
-except IOError:
-    print("[Nix] settings.json doesn't yet exist, can't disable it yet")
+    settings_path_temp.rename(settings_path)
+    print("[Nix] Disabled updates")


### PR DESCRIPTION
###### Description of changes

Closes #211197
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
