### PR TITLE
tl-expected: 2019-11-11 -> 2023-02-15

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.nix
@@ -56,6 +56,10 @@ stdenv.mkDerivation {
     fetchSubmodules = true;
   };
 
+  patches = [
+    ./tg_owt.patch
+  ];
+
   postPatch = lib.optionalString stdenv.isLinux ''
     substituteInPlace src/modules/desktop_capture/linux/egl_dmabuf.cc \
       --replace '"libEGL.so.1"' '"${libGL}/lib/libEGL.so.1"' \

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.patch
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/tg_owt.patch
@@ -1,0 +1,23 @@
+--- a/src/modules/include/module_common_types_public.h
++++ b/src/modules/include/module_common_types_public.h
+@@ -11,6 +11,7 @@
+ #ifndef MODULES_INCLUDE_MODULE_COMMON_TYPES_PUBLIC_H_
+ #define MODULES_INCLUDE_MODULE_COMMON_TYPES_PUBLIC_H_
+ 
++#include <cstdint>
+ #include <limits>
+ 
+ #include "absl/types/optional.h"
+diff --git a/src/common_video/h265/h265_pps_parser.h b/src/common_video/h265/h265_pps_parser.h
+index 28c95ea9..790b0b73 100644
+--- a/src/common_video/h265/h265_pps_parser.h
++++ b/src/common_video/h265/h265_pps_parser.h
+@@ -13,6 +13,8 @@
+ 
+ #include "absl/types/optional.h"
+ 
++#include <stdint.h>
++
+ namespace rtc {
+ class BitBuffer;
+ }

--- a/pkgs/development/libraries/tl-expected/default.nix
+++ b/pkgs/development/libraries/tl-expected/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "tl-expected-unstable";
-  version = "2019-11-11"; # 5 commits ahead of version 1.0.0
+  version = "2023-02-15"; # 37 commits ahead of version 1.0.0
 
   src = fetchFromGitHub {
     owner = "TartanLlama";
     repo = "expected";
-    rev = "1d9c5d8c0da84b8ddc54bd3d90d632eec95c1f13";
+    rev = "9d812f5e3b5bc68023f6e31d29489cdcaacef606";
     fetchSubmodules = true;
-    sha256 = "0rzfn9yyg70zwpxbmv22qy0015baymi2rdd65ixmcb31fgnap68i";
+    hash = "sha256-ZokcGQgHH37nmTMLmxFcun4S1RjXuXb9NfWHet8Fbc4=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Description of changes

This upgrade is necessary for [`zcash`](https://github.com/NixOS/nixpkgs/pull/216422) 5.4.1.

Related: https://github.com/TartanLlama/expected/pull/117

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).