### PR TITLE
build-support/rust/lib: Add `toTargetVendor`

### DIFF
--- a/pkgs/build-support/rust/lib/default.nix
+++ b/pkgs/build-support/rust/lib/default.nix
@@ -30,10 +30,17 @@ rec {
     else lib.optional platform.isUnix "unix"
       ++ lib.optional platform.isWindows "windows";
 
+  # https://doc.rust-lang.org/reference/conditional-compilation.html#target_vendor
+  toTargetVendor = platform: let
+    inherit (platform.parsed) vendor;
+  in platform.rustc.platform.vendor or {
+    "w64" = "pc";
+  }.${vendor.name} or vendor.name;
+
   # Returns the name of the rust target, even if it is custom. Adjustments are
   # because rust has slightly different naming conventions than we do.
   toRustTarget = platform: let
-    inherit (platform.parsed) cpu vendor kernel abi;
+    inherit (platform.parsed) cpu kernel abi;
     cpu_ = platform.rustc.platform.arch or {
       "armv7a" = "armv7";
       "armv7l" = "armv7";
@@ -41,9 +48,7 @@ rec {
       "armv5tel" = "armv5te";
       "riscv64" = "riscv64gc";
     }.${cpu.name} or cpu.name;
-    vendor_ = platform.rustc.platform.vendor or {
-      "w64" = "pc";
-    }.${vendor.name} or vendor.name;
+    vendor_ = toTargetVendor platform;
   in platform.rustc.config
     or "${cpu_}-${vendor_}-${kernel.name}${lib.optionalString (abi.name != "unknown") "-${abi.name}"}";
 


### PR DESCRIPTION
###### Description of changes

Add `toTargetVendor` function. @Ericson2314 

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
