### PR TITLE
python310Packages.pandas-stubs: 1.5.0.221003 -> 1.5.3.230214

### DIFF
--- a/pkgs/development/python-modules/pandas-stubs/default.nix
+++ b/pkgs/development/python-modules/pandas-stubs/default.nix
@@ -4,25 +4,27 @@
 , fetchFromGitHub
 , jinja2
 , matplotlib
+, odfpy
 , openpyxl
 , pandas
 , poetry-core
-, scipy
-, sqlalchemy
-, tabulate
 , pyarrow
 , pyreadstat
-, tables
 , pytestCheckHook
 , pythonOlder
+, scipy
+, sqlalchemy
+, tables
+, tabulate
 , types-pytz
 , typing-extensions
 , xarray
+, XlsxWriter
 }:
 
 buildPythonPackage rec {
   pname = "pandas-stubs";
-  version = "1.5.0.221003";
+  version = "1.5.3.230214";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -30,8 +32,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pandas-dev";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-RV0pOTPtlwBmYs3nu8+lNwVpl/VC/VzcXKOQMg9C3qk=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-hLQXGnWtjYNzzyHO+p7CCFEHc2lrSwh35Om94K5Ozhk=";
   };
 
   nativeBuildInputs = [
@@ -46,62 +48,65 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     jinja2
     matplotlib
+    odfpy
     openpyxl
-    scipy
-    sqlalchemy
-    tabulate
     pyarrow
-    tables
     pyreadstat
     pytestCheckHook
+    scipy
+    sqlalchemy
+    tables
+    tabulate
     typing-extensions
     xarray
+    XlsxWriter
   ];
 
   disabledTests = [
     # AttributeErrors, missing dependencies, error and warning checks
-    "test_data_error"
-    "test_specification_error"
-    "test_setting_with_copy_error"
-    "test_setting_with_copy_warning"
-    "test_numexpr_clobbering_error"
-    "test_undefined_variable_error"
-    "test_indexing_error"
-    "test_pyperclip_exception"
-    "test_css_warning"
-    "test_possible_data_loss_error"
-    "test_closed_file_error"
-    "test_incompatibility_warning"
-    "test_attribute_conflict_warning"
-    "test_database_error"
-    "test_possible_precision_loss"
-    "test_value_label_type_mismatch"
-    "test_invalid_column_name"
-    "test_categorical_conversion_warning"
-    "test_join"
-    "test_isetframe"
-    "test_reset_index_150_changes"
-    "test_compare_150_changes"
-    "test_quantile_150_changes"
-    "test_resample_150_changes"
-    "test_index_astype"
-    "test_orc"
-    "test_orc_path"
-    "test_orc_buffer"
-    "test_orc_columns"
-    "test_orc_bytes"
-    "test_clipboard"
-    "test_clipboard_iterator"
-    "test_arrow_dtype"
-    "test_aggregate_series_combinations"
     "test_aggregate_frame_combinations"
-    "test_types_rank"
-    "test_reset_index"
-    "test_types_assert_series_equal"
-    "test_show_version"
+    "test_aggregate_series_combinations"
+    "test_arrow_dtype"
+    "test_attribute_conflict_warning"
+    "test_categorical_conversion_warning"
+    "test_clipboard_iterator"
+    "test_clipboard"
+    "test_closed_file_error"
+    "test_compare_150_changes"
+    "test_crosstab_args"
+    "test_css_warning"
+    "test_data_error"
+    "test_database_error"
     "test_dummies"
     "test_from_dummies_args"
+    "test_incompatibility_warning"
+    "test_index_astype"
+    "test_indexing_error"
+    "test_invalid_column_name"
+    "test_isetframe"
+    "test_join"
+    "test_numexpr_clobbering_error"
+    "test_orc_buffer"
+    "test_orc_bytes"
+    "test_orc_columns"
+    "test_orc_path"
+    "test_orc"
+    "test_possible_data_loss_error"
+    "test_possible_precision_loss"
+    "test_pyperclip_exception"
+    "test_quantile_150_changes"
+    "test_resample_150_changes"
+    "test_reset_index_150_changes"
+    "test_reset_index"
     "test_rolling_step_method"
+    "test_setting_with_copy_error"
+    "test_setting_with_copy_warning"
+    "test_show_version"
+    "test_specification_error"
+    "test_types_assert_series_equal"
+    "test_types_rank"
+    "test_undefined_variable_error"
+    "test_value_label_type_mismatch"
   ] ++ lib.optionals stdenv.isDarwin [
     "test_plotting" # Fatal Python error: Illegal instruction
   ];
@@ -112,7 +117,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Type annotations for Pandas";
-    homepage = "https://github.com/VirtusLab/pandas-stubs";
+    homepage = "https://github.com/pandas-dev/pandas-stubs";
     license = licenses.mit;
     maintainers = with maintainers; [ malo ];
   };


### PR DESCRIPTION
Diff: https://github.com/pandas-dev/pandas-stubs/compare/refs/tags/v1.5.0.221003...v1.5.3.230214

###### Description of changes
Fix build (https://hydra.nixos.org/build/209195925)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
