### PR TITLE
brother-hll6400dw: init at 3.5.1-1

### DIFF
--- a/pkgs/misc/cups/drivers/brother/hll6400dw/default.nix
+++ b/pkgs/misc/cups/drivers/brother/hll6400dw/default.nix
@@ -1,0 +1,197 @@
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, makeWrapper
+, autoPatchelfHook
+, coreutils
+, ghostscript
+, gnugrep
+, gnused
+, which
+, perl
+}:
+
+let
+  make = "brother";
+  model = "hll6400dw";
+  version = "3.5.1-1";
+
+  modelUpper = lib.strings.toUpper model;
+  modelDir = modelUpper;
+  reldir = "opt/brother/Printers/${modelDir}";
+
+  srcs = {
+    driver = rec {
+      # https://download.brother.com/welcome/dlf102432/hll6400dwlpr-3.5.1-1.i386.deb
+      inherit model version reldir;
+      suffix = "lpr";
+      dlf = "dlf102432";
+      url = "https://download.brother.com/welcome/${dlf}/${model}${suffix}-${version}.i386.deb";
+      sha256 = "sha256-dWB0fQuvLPs8FJMR8J8L2uoMfXAo/4lukJ2SXTjRx2E=";
+    };
+    wrapper = rec {
+      # https://download.brother.com/welcome/dlf102433/hll6400dwcupswrapper-3.5.1-1.i386.deb
+      inherit model version reldir;
+      suffix = "cupswrapper";
+      dlf = "dlf102433";
+      url = "https://download.brother.com/welcome/${dlf}/${model}${suffix}-${version}.i386.deb";
+      sha256 = "sha256-qLgPvS630nm6Kcefr5nTGn2fYNUfivlXTZArS5OLb4k=";
+    };
+  };
+
+  fixupPerlScripts = ''
+    fixupPerlScripts() {
+      local path=$1
+      local basedir=$2
+      local modelDir=$3
+      shift 3
+      for script in "$@"; do
+        echo "fixupPerlScripts: fixing script: $script"
+        sed -i '
+            s|^my $basedir\s*=.*;$|my $basedir = "'$basedir'";|;
+            s|^$basedir\s*=~.*;$||;
+            s|^my $PRINTER\s*=.*;$|my $PRINTER = "'$modelDir'";|;
+            s|^$PRINTER\s*=~.*;$||;
+          ' $script
+        wrapProgram $script \
+          --prefix PATH : $path \
+          --set LANG C
+      done
+    }
+  '';
+
+  platformDirMap = {
+    "x86_64-linux" = "x86_64";
+    "i686-linux" = "i686";
+    "armv7l-linux" = "armv7l";
+  };
+
+  platformDir = platformDirMap.${stdenv.hostPlatform.system};
+in
+
+stdenv.mkDerivation rec {
+  inherit version;
+  pname = "${make}-${model}-${suffix}";
+  inherit (srcs.wrapper) suffix;
+
+  src = fetchurl {
+    inherit (srcs.wrapper) url sha256;
+  };
+
+  inherit (driver) nativeBuildInputs buildInputs unpackPhase;
+
+  runtimeDeps = [
+    coreutils
+    gnugrep
+    gnused
+  ];
+
+  driver = stdenv.mkDerivation rec {
+    inherit version;
+    pname = "${make}-${model}-${suffix}";
+    inherit (srcs.driver) suffix;
+
+    src = fetchurl {
+      inherit (srcs.driver) url sha256;
+    };
+
+    nativeBuildInputs = [
+      dpkg
+      makeWrapper
+      autoPatchelfHook
+    ];
+
+    buildInputs = [
+      perl
+    ];
+
+    runtimeDeps = [
+      coreutils
+      ghostscript
+      gnugrep
+      gnused
+      which
+    ];
+
+    unpackPhase = "dpkg-deb -x $src $out";
+
+    installPhase = ''
+      dir=$out/${reldir}
+      subdir=$dir/lpd
+      basedir=$out/${reldir}
+
+      ${fixupPerlScripts}
+
+      fixupPerlScripts \
+        ${lib.makeBinPath runtimeDeps} \
+        $basedir \
+        ${modelDir} \
+        $subdir/*lpdfilter*
+
+      chmod -R +x $subdir
+      mv $subdir/${platformDir}/* $subdir
+      rm -rf $subdir/{${builtins.concatStringsSep "," (builtins.attrValues platformDirMap)}}
+    '';
+
+    meta = with lib; {
+      description = "Brother ${modelUpper} driver";
+      longDescription = ''
+        This driver works with the socket protocol,
+        for example socket://192.168.0.150,
+        but not with the IPP protocol.
+      '';
+      homepage = "http://www.brother.com/";
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+      license = licenses.unfree;
+      platforms = builtins.attrNames platformDirMap;
+      maintainers = with maintainers; [ milahu ];
+    };
+  };
+
+  installPhase = ''
+    dir=$out/${reldir}
+    subdir=$dir/${suffix}
+    basedir=${driver}/${reldir}
+
+    # this file is expected by the PPD file
+    # *cupsFilter:    "application/vnd.cups-pdf 0 brother_lpdwrapper_HLL6400DW"
+    mv $subdir/*lpdwrapper* $subdir/brother_lpdwrapper_${modelUpper}
+
+    chmod +x $subdir/*lpdwrapper*
+    chmod +x $subdir/*paperconfig* || true
+
+    ${fixupPerlScripts}
+
+    fixupPerlScripts \
+      ${lib.makeBinPath runtimeDeps} \
+      $basedir \
+      ${modelDir} \
+      $subdir/*lpdwrapper*
+
+    echo patching the PPD file: $subdir/*.ppd
+    # make the name consistent with other brother drivers
+    # example:
+    # - Brother HLL6400DW
+    # + Brother HL-L6400DW
+    sed -i -E 's/(Brother ${
+        builtins.substring 0 2 (modelUpper)
+      })(${
+        builtins.substring 2 999 (modelUpper)
+      })/\1-\2/g' $subdir/*.ppd
+
+    mkdir -p $out/lib/cups/filter
+    ln -s -v $subdir/*lpdwrapper* $out/lib/cups/filter
+
+    mkdir -p $out/share/cups/model
+    ln -s -v $subdir/*.ppd $out/share/cups/model
+  '';
+
+  meta = with lib; {
+    description = "Brother ${modelUpper} CUPS wrapper driver";
+    homepage = "http://www.brother.com/";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ milahu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37794,6 +37794,8 @@ with pkgs;
 
   cups-brother-hll2375dw = callPackage ../misc/cups/drivers/brother/hll2375dw { };
 
+  brother-hll6400dw = callPackage ../misc/cups/drivers/brother/hll6400dw { };
+
   mfcl8690cdwcupswrapper = callPackage ../misc/cups/drivers/mfcl8690cdwcupswrapper { };
   mfcl8690cdwlpr = callPackage ../misc/cups/drivers/mfcl8690cdwlpr { };
 


### PR DESCRIPTION
add printer driver for Brother HL-L6400DW

limitation: works only with `socket` protocol, does not work with `ipp` protocol
this is documented in the driver's `meta.longDescription`

i was not 100% sure how to package this
because brother distributes this as 2 packages: cupswrapper and driver

currently, the cupswrapper is the user-facing package

```nix
{
  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
    "brother-hll6400dw-lpr"
  ];

  services.printing.drivers = [
    pkgs.brother-hll6400dw
  ];
```

and the actual "driver" (mostly the filter executable `rawtobr3`)
is a dependency of the cupswrapper

anyway, works for me

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
