### PR TITLE
nixos/networkd-dispatcher: init at 2.2.4

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -38,6 +38,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [atuin](https://github.com/ellie/atuin), a sync server for shell history. Available as [services.atuin](#opt-services.atuin.enable).
 
+- [networkd-dispatcher](https://gitlab.com/craftyguy/networkd-dispatcher), a dispatcher service for systemd-networkd connection status changes. Available as [services.networkd-dispatcher](#opt-services.networkd-dispatcher.enable).
+
 - [mmsd](https://gitlab.com/kop316/mmsd), a lower level daemon that transmits and recieves MMSes. Available as [services.mmsd](#opt-services.mmsd.enable).
 
 - [QDMR](https://dm3mat.darc.de/qdmr/), a GUI application and command line tool for programming DMR radios [programs.qdmr](#opt-programs.qdmr.enable)

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -912,6 +912,7 @@
   ./services/networking/ndppd.nix
   ./services/networking/nebula.nix
   ./services/networking/netbird.nix
+  ./services/networking/networkd-dispatcher.nix
   ./services/networking/networkmanager.nix
   ./services/networking/nextdns.nix
   ./services/networking/nftables.nix

--- a/nixos/modules/services/networking/networkd-dispatcher.nix
+++ b/nixos/modules/services/networking/networkd-dispatcher.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.networkd-dispatcher;
+in {
+  options = {
+    services.networkd-dispatcher = {
+
+      enable = mkEnableOption (mdDoc ''
+        Networkd-dispatcher service for systemd-networkd connection status
+        change. See [https://gitlab.com/craftyguy/networkd-dispatcher](upstream instructions)
+        for usage.
+      '');
+
+      scriptDir = mkOption {
+        type = types.path;
+        default = "/var/lib/networkd-dispatcher";
+        description = mdDoc ''
+          This directory is used for keeping various scripts read and run by
+          networkd-dispatcher. See [https://gitlab.com/craftyguy/networkd-dispatcher](upstream instructions)
+          for directory structure and script usage.
+        '';
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd = {
+
+      packages = [ pkgs.networkd-dispatcher ];
+      services.networkd-dispatcher = {
+        wantedBy = [ "multi-user.target" ];
+        # Override existing ExecStart definition
+        serviceConfig.ExecStart = [
+          ""
+          "${pkgs.networkd-dispatcher}/bin/networkd-dispatcher -v --script-dir ${cfg.scriptDir} $networkd_dispatcher_args"
+        ];
+      };
+
+      # Directory structure required according to upstream instructions
+      # https://gitlab.com/craftyguy/networkd-dispatcher
+      tmpfiles.rules = [
+        "d '${cfg.scriptDir}'               0750 root root - -"
+        "d '${cfg.scriptDir}/routable.d'    0750 root root - -"
+        "d '${cfg.scriptDir}/dormant.d'     0750 root root - -"
+        "d '${cfg.scriptDir}/no-carrier.d'  0750 root root - -"
+        "d '${cfg.scriptDir}/off.d'         0750 root root - -"
+        "d '${cfg.scriptDir}/carrier.d'     0750 root root - -"
+        "d '${cfg.scriptDir}/degraded.d'    0750 root root - -"
+        "d '${cfg.scriptDir}/configuring.d' 0750 root root - -"
+        "d '${cfg.scriptDir}/configured.d'  0750 root root - -"
+      ];
+
+    };
+
+
+  };
+}
+

--- a/pkgs/tools/networking/networkd-dispatcher/default.nix
+++ b/pkgs/tools/networking/networkd-dispatcher/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, python3Packages
+, asciidoc
+, makeWrapper
+, iw
+}:
+
+stdenv.mkDerivation rec {
+  pname = "networkd-dispatcher";
+  version = "2.2.4";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.com";
+    owner = "craftyguy";
+    repo = pname;
+    rev = version;
+    hash = "sha256-yO9/HlUkaQmW/n9N3vboHw//YMzBjxIHA2zAxgZNEv0=";
+  };
+
+  postPatch = ''
+    # Fix paths in systemd unit file
+    substituteInPlace networkd-dispatcher.service \
+      --replace "/usr/bin/networkd-dispatcher" "$out/bin/networkd-dispatcher" \
+      --replace "/etc/conf.d" "$out/etc/conf.d"
+    # Remove conditions on existing rules path
+    sed -i '/ConditionPathExistsGlob/g' networkd-dispatcher.service
+  '';
+
+  nativeBuildInputs = [
+    asciidoc
+    makeWrapper
+    python3Packages.wrapPython
+  ];
+
+  checkInputs = with python3Packages; [
+    dbus-python
+    iw
+    mock
+    pygobject3
+    pytestCheckHook
+  ];
+
+  pythonPath = with python3Packages; [
+    configparser
+    dbus-python
+    pygobject3
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D -m755 -t $out/bin networkd-dispatcher
+    install -Dm644 networkd-dispatcher.service $out/lib/systemd/system/networkd-dispatcher.service
+    install -Dm644 networkd-dispatcher.conf $out/etc/conf.d/networkd-dispatcher.conf
+    install -D networkd-dispatcher.8 -t $out/share/man/man8/
+    runHook postInstall
+  '';
+
+  doCheck = true;
+
+  postFixup = ''
+    wrapPythonPrograms
+    wrapProgram $out/bin/networkd-dispatcher --prefix PATH : ${lib.makeBinPath [ iw ]}
+  '';
+
+  meta = with lib; {
+    description = "Dispatcher service for systemd-networkd connection status changes";
+    homepage = "https://gitlab.com/craftyguy/networkd-dispatcher";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37777,6 +37777,8 @@ with pkgs;
 
   neo = callPackage ../applications/misc/neo { };
 
+  networkd-dispatcher = callPackage ../tools/networking/networkd-dispatcher { };
+
   nixVersions = recurseIntoAttrs (callPackage ../tools/package-management/nix {
     storeDir = config.nix.storeDir or "/nix/store";
     stateDir = config.nix.stateDir or "/nix/var";


### PR DESCRIPTION
###### Description of changes

Add networkd-dispatcher package and module. To use it, add to `configuration.nix`:

```
services.networkd-dispatcher.enable = true;
``` 

Create a example script `/var/lib/networkd-dispatcher/routable.d/00-restart-tor.sh`
```
#!/usr/bin/env bash
if [[ $IFACE == "wlan0" && $AdministrativeState == "configured" ]]; then
    systemctl restart tor
fi
exit 0
```

```
mkdir -p /var/lib/networkd-dispatcher/routable.d
chmod 755 /var/lib/networkd-dispatcher/routable.d/00-restart-tor
chown root /var/lib/networkd-dispatcher/routable.d/00-restart-tor
```

When using `systemd-networkd` the script gets exectued everytime the interface `wlan0` has a successfull reconnect.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
