### PR TITLE
nixos/i2pd: add options, harden service

### DIFF
--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -18,7 +18,7 @@ let
   optionalEmptyList = o: l: optional ([] != l) (lstOpt o l);
 
   mkEnableTrueOption = name: mkEnableOption (lib.mdDoc name) // { default = true; };
-  
+
   typeMaps = {
     signatureType = {
       "ECDSA-P256" = 1;
@@ -117,7 +117,7 @@ let
     };
     explicitPeers = mkOption {
       type = with types; nullOr str;
-      description = lib.mdDoc "List of b64 addresses of peers to use.";
+      description = lib.mdDoc "List of comma-separated b64 addresses of peers to use.";
       default = null;
     };
     signatureType = mkOption {
@@ -150,12 +150,12 @@ let
     };
     i2cp.leaseSetClient.dh.nnn = mkOption {
       type = with types; nullOr str;
-      description = lib.mdDoc "Client name:client's public DH in base64.";
+      description = lib.mdDoc "Client name:client's public DH in base64, for authentication type DH.";
       default = null;
     };
     i2cp.leaseSetClient.psk.nnn = mkOption {
       type = with types; nullOr str;
-      description = lib.mdDoc "Client name:client's PSK in base64.";
+      description = lib.mdDoc "Client name:client's PSK in base64, for authentication type PSK.";
       default = null;
     };
     destination = mkOption {

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -751,6 +751,10 @@ in
         If true, i2pd will be wait for closing transit connections.
         Enabling this option may delay system shutdown/reboot up to 10 minutes!
       '');
+
+      autoRestart = mkEnableOption (lib.mdDoc ''
+        If true, i2pd will be restarted on failure (does not affect clean exit).
+      '');
     };
   };
 
@@ -777,8 +781,9 @@ in
       {
         User = "i2pd";
         WorkingDirectory = homeDir;
-        Restart = "on-abort";
         ExecStart = "${cfg.package}/bin/i2pd ${i2pdFlags}";
+        ## Auto restart
+        Restart = if cfg.autoRestart then "on-failure" else "no";
         ## Graceful shutdown
         KillSignal = if cfg.gracefulShutdown then "SIGINT" else "SIGTERM";
         TimeoutStopSec = if cfg.gracefulShutdown then "10m" else "30s";

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -746,6 +746,11 @@ in
           Serve something on I2P network at port and delegate requests to address inPort.
         '';
       };
+
+      gracefulShutdown = mkEnableOption (lib.mdDoc ''
+        If true, i2pd will be wait for closing transit connections.
+        Enabling this option may delay system shutdown/reboot up to 10 minutes!
+      '');
     };
   };
 
@@ -774,6 +779,10 @@ in
         WorkingDirectory = homeDir;
         Restart = "on-abort";
         ExecStart = "${cfg.package}/bin/i2pd ${i2pdFlags}";
+        ## Graceful shutdown
+        KillSignal = if cfg.gracefulShutdown then "SIGINT" else "SIGTERM";
+        TimeoutStopSec = if cfg.gracefulShutdown then "10m" else "30s";
+        SendSIGKILL = true;
       };
     };
   };

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -788,6 +788,32 @@ in
         KillSignal = if cfg.gracefulShutdown then "SIGINT" else "SIGTERM";
         TimeoutStopSec = if cfg.gracefulShutdown then "10m" else "30s";
         SendSIGKILL = true;
+        ## Hardening
+        # Taken from https://github.com/archlinux/svntogit-community/blob/packages/i2pd/trunk/030-i2pd-systemd-service-hardening.patch
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        NoNewPrivileges = true;
+        MemoryDenyWriteExecute = true;
+        LockPersonality = true;
+        SystemCallFilter = "@system-service";
+        RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6 AF_NETLINK";
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        PrivateMounts = true;
+        PrivateUsers = true;
+        ReadWritePaths = homeDir;
+        RemoveIPC = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
       };
     };
   };


### PR DESCRIPTION
###### Description of changes:
* Add input/output tunnels options ([manual](https://i2pd.readthedocs.io/en/latest/user-guide/tunnels/), related [issue](https://github.com/NixOS/nixpkgs/issues/161367#issuecomment-1049688476))
* Add gracefull shutdown option ([manual](https://i2pd.readthedocs.io/en/latest/user-guide/run/#starting-stopping-and-reloading-configuration))
* Add auto restart option
* Harden systemd service
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
