### PR TITLE
python3.pkgs.shiboken6, python3.pkgs.pyside6: init at 6.4.2

### DIFF
--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, cmake
+, ninja
+, qt6
+, python
+, shiboken6
+, libxcrypt
+}:
+
+stdenv.mkDerivation rec {
+  #pname = "PySide6";
+  pname = "pyside6";
+  inherit (shiboken6) version src;
+
+  postPatch = ''
+    # dont ignore optional qt modules
+    substituteInPlace sources/pyside6/cmake/PySideHelpers.cmake \
+      --replace \
+        'string(FIND "''${_module_dir}" "''${_core_abs_dir}" found_basepath)' \
+        'set (found_basepath 0)'
+
+    cd sources/${pname}
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    python
+  ] ++ (with qt6; [
+    # required
+    qtbase
+    # optional
+    qt3d
+    qtcharts
+    qtconnectivity
+    qtdatavis3d
+    qtdeclarative
+    qthttpserver
+    qtmultimedia
+    qtnetworkauth
+    qtquick3d
+    qtremoteobjects
+    qtscxml
+    qtsensors
+    qtspeech
+    qtsvg
+    qttools
+    qtwebchannel
+    qtwebengine
+    qtwebsockets
+  ]) ++ (lib.optionals (python.pythonOlder "3.9") [
+    # see similar issue: 202262
+    # libxcrypt is required for crypt.h for building older python modules
+    libxcrypt
+  ]);
+
+  propagatedBuildInputs = [
+    shiboken6
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_TESTS=OFF"
+  ];
+
+  dontWrapQtApps = true;
+
+  meta = with lib; {
+    description = "Python bindings for Qt";
+    license = licenses.lgpl21;
+    homepage = "https://wiki.qt.io/Qt_for_Python";
+    maintainers = with maintainers; [ milahu ];
+  };
+}

--- a/pkgs/development/python-modules/shiboken6/0001-use-llvm-config-includedir.patch
+++ b/pkgs/development/python-modules/shiboken6/0001-use-llvm-config-includedir.patch
@@ -1,0 +1,25 @@
+--- a/sources/shiboken6/ApiExtractor/clangparser/compilersupport.cpp
++++ b/sources/shiboken6/ApiExtractor/clangparser/compilersupport.cpp
+@@ -290,6 +290,20 @@ static QString findClangBuiltInIncludesDir()
+         if (!candidate.isEmpty())
+             return candidate + QStringLiteral("/include");
+     }
++
++    // llvm-config --includedir
++    const QString llvmConfig =
++        QStandardPaths::findExecutable(u"llvm-config"_s);
++    if (!llvmConfig.isEmpty()) {
++        QByteArray stdOut;
++        if (runProcess(llvmConfig, QStringList{u"--includedir"_s}, &stdOut)) {
++            const QString path = QFile::decodeName(stdOut.trimmed());
++            if (QFileInfo::exists(path))
++                return path;
++            qWarning("%s: %s as returned by llvm-config does not exist.", __FUNCTION__, qPrintable(path));
++        }
++    }
++
+     return QString();
+ }
+ 
+-- 
+2.39.0

--- a/pkgs/development/python-modules/shiboken6/0002-fix-include-qt-headers.patch
+++ b/pkgs/development/python-modules/shiboken6/0002-fix-include-qt-headers.patch
@@ -1,0 +1,80 @@
+--- a/sources/shiboken6/ApiExtractor/clangparser/compilersupport.cpp
++++ b/sources/shiboken6/ApiExtractor/clangparser/compilersupport.cpp
+@@ -16,6 +16,7 @@
+ #include <QtCore/QStandardPaths>
+ #include <QtCore/QStringList>
+ #include <QtCore/QVersionNumber>
++#include <QtCore/QRegularExpression>
+ 
+ #include <clang-c/Index.h>
+ 
+@@ -341,6 +342,13 @@ QByteArrayList emulatedCompilerOptions()
+ {
+     QByteArrayList result;
+     HeaderPaths headerPaths;
++
++    bool isNixDebug = qgetenv("NIX_DEBUG").toInt() > 0;
++    // examples:
++    // /nix/store/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-qtsensors-6.4.2-dev/include
++    // /nix/store/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-qtbase-6.4.2-dev/include
++    QRegularExpression qtHeaderRegex(uR"(/[0-9a-z]{32}-qt[a-z0-9]+-)"_s);
++
+     switch (compiler()) {
+     case Compiler::Msvc:
+         result.append(QByteArrayLiteral("-fms-compatibility-version=19.26.28806"));
+@@ -352,9 +360,30 @@ QByteArrayList emulatedCompilerOptions()
+             appendClangBuiltinIncludes(&headerPaths);
+         break;
+     case Compiler::Clang:
+-        headerPaths.append(gppInternalIncludePaths(compilerFromCMake(u"clang++"_s)));
++    // fix: error: cannot jump from switch statement to this case label: case Compiler::Gpp
++    // note: jump bypasses variable initialization: const HeaderPaths clangPaths =
++    {
++        //headerPaths.append(gppInternalIncludePaths(compilerFromCMake(u"clang++"_s)));
++        // fix: qt.shiboken: x is specified in typesystem, but not defined. This could potentially lead to compilation errors.
++        // PySide requires that Qt headers are not -isystem
++        // https://bugreports.qt.io/browse/PYSIDE-787
++        const HeaderPaths clangPaths = gppInternalIncludePaths(compilerFromCMake(u"clang++"_qs));
++        for (const HeaderPath &h : clangPaths) {
++            auto match = qtHeaderRegex.match(QString::fromUtf8(h.path));
++            if (!match.hasMatch()) {
++                if (isNixDebug)
++                    qDebug() << "shiboken compilersupport.cpp: found non-qt header: " << h.path;
++                // add using -isystem
++                headerPaths.append(h);
++            } else {
++                if (isNixDebug)
++                    qDebug() << "shiboken compilersupport.cpp: found qt header: " << h.path;
++                headerPaths.append({h.path, HeaderType::Standard});
++            }
++        }
+         result.append(noStandardIncludeOption());
+         break;
++    }
+     case Compiler::Gpp:
+         if (needsClangBuiltinIncludes())
+             appendClangBuiltinIncludes(&headerPaths);
+@@ -363,8 +392,20 @@ QByteArrayList emulatedCompilerOptions()
+         // <type_traits> etc (g++ 11.3).
+         const HeaderPaths gppPaths = gppInternalIncludePaths(compilerFromCMake(u"g++"_qs));
+         for (const HeaderPath &h : gppPaths) {
+-            if (h.path.contains("c++") || h.path.contains("sysroot"))
++            // fix: qt.shiboken: x is specified in typesystem, but not defined. This could potentially lead to compilation errors.
++            // PySide requires that Qt headers are not -isystem
++            // https://bugreports.qt.io/browse/PYSIDE-787
++            auto match = qtHeaderRegex.match(QString::fromUtf8(h.path));
++            if (!match.hasMatch()) {
++                if (isNixDebug)
++                    qDebug() << "shiboken compilersupport.cpp: found non-qt header: " << h.path;
++                // add using -isystem
+                 headerPaths.append(h);
++            } else {
++                if (isNixDebug)
++                    qDebug() << "shiboken compilersupport.cpp: found qt header: " << h.path;
++                headerPaths.append({h.path, HeaderType::Standard});
++            }
+         }
+         break;
+     }
+-- 
+2.39.0

--- a/pkgs/development/python-modules/shiboken6/default.nix
+++ b/pkgs/development/python-modules/shiboken6/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, fetchurl
+, llvmPackages
+, python
+, qt6
+, cmake
+, stdenv
+, libxcrypt
+}:
+
+llvmPackages.stdenv.mkDerivation rec {
+  pname = "shiboken6";
+
+  version = "6.4.2";
+
+  src = fetchurl {
+    # https://download.qt.io/official_releases/QtForPython/shiboken6/
+    url = "https://download.qt.io/official_releases/QtForPython/shiboken6/PySide6-${version}-src/pyside-setup-opensource-src-${version}.tar.xz";
+    sha256 = "sha256-HsnQk2My79IpZQzxD+02yt3f96YToupuiX3k1QTBtQU=";
+  };
+
+  patches = [
+    ./0001-use-llvm-config-includedir.patch
+    ./0002-fix-include-qt-headers.patch
+  ];
+
+  postPatch = ''
+    cd sources/${pname}
+  '';
+
+  postBuild = ''
+    echo fixing RPATH of Shiboken.abi3.so
+    set -x
+    ldd Shiboken.abi3.so
+    patchelf Shiboken.abi3.so --print-rpath | tr : $'\n'
+    # fix: bad RPATH: Shiboken.abi3.so is linked to libshiboken6.abi3.so.6.4 in build tree
+    # not fixed by autoPatchelfHook
+    # https://bugreports.qt.io/browse/PYSIDE-2233
+    patchelf Shiboken.abi3.so --shrink-rpath --allowed-rpath-prefixes $NIX_STORE
+    patchelf Shiboken.abi3.so --add-rpath $out/lib
+    set +x
+  '';
+
+  cmakeFlags = [
+    "-DBUILD_TESTS=OFF"
+  ];
+
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    llvmPackages.llvm
+    llvmPackages.libclang
+    python
+    qt6.qtbase
+  ] ++ (lib.optionals (python.pythonOlder "3.9") [
+    # see similar issue: 202262
+    # libxcrypt is required for crypt.h for building older python modules
+    libxcrypt
+  ]);
+
+  meta = with lib; {
+    description = "Generator for the pyside6 Qt bindings";
+    license = with licenses; [ gpl2 lgpl21 ];
+    homepage = "https://wiki.qt.io/Qt_for_Python";
+    maintainers = with maintainers; [ milahu ];
+    # TODO test
+    #broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8731,6 +8731,10 @@ self: super: with self; {
     inherit (pkgs) cmake ninja qt5;
   });
 
+  pyside6 = toPythonModule (callPackage ../development/python-modules/pyside6 {
+    inherit (pkgs) cmake ninja qt6;
+  });
+
   pyside = callPackage ../development/python-modules/pyside {
     inherit (pkgs) mesa;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10428,6 +10428,10 @@ self: super: with self; {
     inherit (pkgs) cmake llvmPackages qt5;
   });
 
+  shiboken6 = toPythonModule (callPackage ../development/python-modules/shiboken6 {
+    inherit (pkgs) cmake llvmPackages qt6;
+  });
+
   shippai = callPackage ../development/python-modules/shippai { };
 
   shiv = callPackage ../development/python-modules/shiv { };


### PR DESCRIPTION
add packages

- python3.pkgs.shiboken6
- python3.pkgs.pyside6

fix #216510 

ping @gebner (maintainer of shiboken2 + pyside2)

todo: pyside6-tools? (new version of pyside2-tools)

status: build works, runtime not-yet tested

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

