### PR TITLE
curl: add patch for the HTTP/2 issue

### DIFF
--- a/pkgs/tools/networking/curl/7.88.0-http2-breakage.patch
+++ b/pkgs/tools/networking/curl/7.88.0-http2-breakage.patch
@@ -1,0 +1,62 @@
+From 3103de2053ca8cacf9cdbe78764ba6814481709f Mon Sep 17 00:00:00 2001
+Date: Wed, 15 Feb 2023 22:11:13 +0100
+Subject: [PATCH] http2: buffer/pausedata and output flush fix.
+
+ * do not process pending input data when copying pausedata to the
+   caller
+ * return CURLE_AGAIN if the output buffer could not be completely
+   written out.
+
+Ref: #10525
+Closes #10529
+---
+ lib/http2.c | 15 +++------------
+ 1 file changed, 3 insertions(+), 12 deletions(-)
+
+diff --git a/lib/http2.c b/lib/http2.c
+index 46fc746457726..1ef5d3949218f 100644
+--- a/lib/http2.c
++++ b/lib/http2.c
+@@ -467,6 +467,7 @@ static CURLcode flush_output(struct Curl_cfilter *cf,
+   }
+   if((size_t)written < buflen) {
+     Curl_dyn_tail(&ctx->outbuf, buflen - (size_t)written);
++    return CURLE_AGAIN;
+   }
+   else {
+     Curl_dyn_reset(&ctx->outbuf);
+@@ -1790,6 +1791,7 @@ static ssize_t cf_h2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
+ 
+     stream->pausedata += nread;
+     stream->pauselen -= nread;
++    drain_this(cf, data);
+ 
+     if(stream->pauselen == 0) {
+       DEBUGF(LOG_CF(data, cf, "[h2sid=%u] Unpaused", stream->stream_id));
+@@ -1798,18 +1800,6 @@ static ssize_t cf_h2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
+ 
+       stream->pausedata = NULL;
+       stream->pauselen = 0;
+-
+-      /* When NGHTTP2_ERR_PAUSE is returned from
+-         data_source_read_callback, we might not process DATA frame
+-         fully.  Calling nghttp2_session_mem_recv() again will
+-         continue to process DATA frame, but if there is no incoming
+-         frames, then we have to call it again with 0-length data.
+-         Without this, on_stream_close callback will not be called,
+-         and stream could be hanged. */
+-      if(h2_process_pending_input(cf, data, err) != 0) {
+-        nread = -1;
+-        goto out;
+-      }
+     }
+     DEBUGF(LOG_CF(data, cf, "[h2sid=%u] recv: returns unpaused %zd bytes",
+                   stream->stream_id, nread));
+@@ -1933,6 +1923,7 @@ static ssize_t cf_h2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
+       drained_transfer(cf, data);
+     }
+ 
++    *err = CURLE_OK;
+     nread = retlen;
+     DEBUGF(LOG_CF(data, cf, "[h2sid=%u] cf_h2_recv -> %zd",
+                   stream->stream_id, nread));

--- a/pkgs/tools/networking/curl/7.88.0-http2-breakage.patch
+++ b/pkgs/tools/networking/curl/7.88.0-http2-breakage.patch
@@ -60,3 +60,42 @@ index 46fc746457726..1ef5d3949218f 100644
      nread = retlen;
      DEBUGF(LOG_CF(data, cf, "[h2sid=%u] cf_h2_recv -> %zd",
                    stream->stream_id, nread));
+
+
+From 87ed650d04dc1a6f7944a5d952f7d5b0934a19ac Mon Sep 17 00:00:00 2001
+From: Harry Sintonen <sintonen@iki.fi>
+Date: Thu, 16 Feb 2023 06:26:26 +0200
+Subject: [PATCH] http2: set drain on stream end
+
+Ensure that on_frame_recv() stream end will trigger a read if there is
+pending data. Without this it could happen that the pending data is
+never consumed.
+
+This combined with https://github.com/curl/curl/pull/10529 should fix
+https://github.com/curl/curl/issues/10525
+
+Ref: https://github.com/curl/curl/issues/10525
+Closes #10530
+---
+ lib/http2.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/lib/http2.c b/lib/http2.c
+index 1ef5d3949218f..bdb5e7378e9cb 100644
+--- a/lib/http2.c
++++ b/lib/http2.c
+@@ -868,6 +868,14 @@ static int on_frame_recv(nghttp2_session *session, const nghttp2_frame *frame,
+         return NGHTTP2_ERR_CALLBACK_FAILURE;
+       }
+     }
++    if(frame->hd.flags & NGHTTP2_FLAG_END_STREAM) {
++      /* Stream has ended. If there is pending data, ensure that read
++         will occur to consume it. */
++      if(!data->state.drain && stream->memlen) {
++        drain_this(cf, data_s);
++        Curl_expire(data, 0, EXPIRE_RUN_NOW);
++      }
++    }
+     break;
+   case NGHTTP2_HEADERS:
+     DEBUGF(LOG_CF(data_s, cf, "[h2sid=%u] recv frame HEADERS", stream_id));

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./7.79.1-darwin-no-systemconfiguration.patch
+    ./7.88.0-http2-breakage.patch
   ];
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];


### PR DESCRIPTION
###### Description of changes

See upstream issue https://github.com/curl/curl/issues/10525
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
