### PR TITLE
catppuccin-kvantum: init at unstable-2022-07-04

### DIFF
--- a/pkgs/data/themes/catppuccin-kvantum/default.nix
+++ b/pkgs/data/themes/catppuccin-kvantum/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  accent ? "Blue",
+  variant ? "Frappe",
+}: let
+  pname = "catppuccin-kvantum";
+in
+  lib.checkListOfEnum "${pname}: theme accent" ["Blue" "Flamingo" "Green" "Lavender" "Maroon" "Mauve" "Peach" "Pink" "Red" "Rosewater" "Sapphire" "Sky" "Teal" "Yellow"] [accent]
+  lib.checkListOfEnum "${pname}: color variant" ["Latte" "Frappe" "Macchiato" "Mocha"] [variant]
+
+  stdenvNoCC.mkDerivation {
+    inherit pname;
+    version = "unstable-2022-07-04";
+
+    src = fetchFromGitHub {
+      owner = "catppuccin";
+      repo = "Kvantum";
+      rev = "d1e174c85311de9715aefc1eba4b8efd6b2730fc";
+      sha256 = "sha256-IrHo8pnR3u90bq12m7FEXucUF79+iub3I9vgH5h86Lk=";
+    };
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/share/Kvantum
+      cp -a src/Catppuccin-${variant}-${accent} $out/share/Kvantum
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "Soothing pastel theme for Kvantum";
+      homepage = "https://github.com/catppuccin/Kvantum";
+      license = licenses.mit;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ggwpaiushtha];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -386,6 +386,8 @@ with pkgs;
 
   catppuccin-kde = callPackage ../data/themes/catppuccin-kde { };
 
+  catppuccin-kvantum = callPackage ../data/themes/catppuccin-kvantum { };
+
   catppuccin-papirus-folders = callPackage ../data/icons/catppuccin-papirus-folders { };
 
   btdu = callPackage ../tools/misc/btdu { };


### PR DESCRIPTION
###### Description of changes

Init [Catppuccin Kvantum](https://github.com/catppuccin/Kvantum) theme

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
