### PR TITLE
ghostscript: wrap binaries to add correct PATH

### DIFF
--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -40,7 +40,6 @@
 , gnused
 , which
 , gawk
-, texlive
 }:
 
 let
@@ -64,7 +63,6 @@ let
       mv -v * "$out/"
     '';
   };
-  dvips = texlive.combine { inherit (texlive) scheme-infraonly dvips; };
 
 in
 stdenv.mkDerivation rec {
@@ -162,8 +160,6 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/bin/unix-lpr.sh \
       --replace "PATH=/bin:/usr/bin:/usr/ucb:/usr/etc" ""
     wrapProgram $out/bin/unix-lpr.sh --prefix PATH : ${lib.makeBinPath [ coreutils gnused ]}:$out/bin
-
-    wrapProgram $out/bin/dvipdf --prefix PATH : ${lib.makeBinPath [ coreutils dvips ]}:$out/bin
 
   '' + lib.optionalString stdenv.isDarwin ''
     install_name_tool -change libgs.dylib.$dylib_version $out/lib/libgs.dylib.$dylib_version $out/bin/gs


### PR DESCRIPTION
###### Description of changes

For scripts in `${ghostscript}/bin`, they are not properly wrapped to put the binaries in PATH. When running them without packages in PATH, the scripts complain command not found. For example,

```
env -i nix shell p#ghostscript_headless -c ps2pdf
/nix/store/qg3n3ncn0hsi94ljr20m7f5w4kpxhqxg-ghostscript-9.56.1/bin/ps2pdf: line 8: dirname: command not found
/nix/store/qg3n3ncn0hsi94ljr20m7f5w4kpxhqxg-ghostscript-9.56.1/bin/ps2pdf14: line 3: dirname: command not found
/nix/store/qg3n3ncn0hsi94ljr20m7f5w4kpxhqxg-ghostscript-9.56.1/bin/ps2pdfwr: line 7: dirname: command not found
/nix/store/qg3n3ncn0hsi94ljr20m7f5w4kpxhqxg-ghostscript-9.56.1/bin/ps2pdfwr: line 24: basename: command not found
```

We wrapped these binaries to prefix the necessary packages to PATH.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
