### PR TITLE
linux_{5_15,6_1}: revert patch to fix Equinix Metal bonded networking with `ice` driver

### DIFF
--- a/pkgs/os-specific/linux/kernel/fix-em-ice-bonding.patch
+++ b/pkgs/os-specific/linux/kernel/fix-em-ice-bonding.patch
@@ -1,0 +1,87 @@
+From 1640688018f329559c61352646f283f98938af31 Mon Sep 17 00:00:00 2001
+From: Cole Helbling <cole.helbling@determinate.systems>
+Date: Thu, 16 Feb 2023 09:30:21 -0800
+Subject: [PATCH] Revert "RDMA/irdma: Report the correct link speed"
+
+This reverts commit 425c9bd06b7a70796d880828d15c11321bdfb76d.
+
+Some Equinix Metal instances, such as a3.large.x86, m3.large.x86
+(specific hardware revisions), and n3.large.x86, use the `ice` kernel
+driver for their network cards, in conjunction with bonded devices.
+However, this commit caused a regression where these bonded devices
+would deadlock. This was initially reported by Jaroslav Pulchart on
+the netdev mailing list[1], and there were follow-up patches from Dave
+Ertman[2][3] that attempted to fix this but were not up to snuff for
+various reasons[4].
+
+Specifically, v2 of the patch ([3]) appears to fix the issue on some
+devices (tested with 8086:159B network cards), while it is still broken
+on others (such as an 8086:1593 network card).
+
+We revert the patch exposing the issue until upstream has a working
+solution in order to make Equinix Metal instances work reliably again.
+
+[1]: https://lore.kernel.org/netdev/CAK8fFZ6A_Gphw_3-QMGKEFQk=sfCw1Qmq0TVZK3rtAi7vb621A@mail.gmail.com/
+[2]: https://patchwork.ozlabs.org/project/intel-wired-lan/patch/20230111183145.1497367-1-david.m.ertman@intel.com/
+[3]: https://patchwork.ozlabs.org/project/intel-wired-lan/patch/20230215191757.1826508-1-david.m.ertman@intel.com/
+[4]: https://lore.kernel.org/netdev/cb31a911-ba80-e2dc-231f-851757cfd0b8@intel.com/T/#m6e53f8c43093693c10268140126abe99e082dc1c
+---
+ drivers/infiniband/hw/irdma/verbs.c | 35 ++++++++++++++++++++++++++---
+ 1 file changed, 32 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/infiniband/hw/irdma/verbs.c b/drivers/infiniband/hw/irdma/verbs.c
+index c5971a840b87..911902d2b93e 100644
+--- a/drivers/infiniband/hw/irdma/verbs.c
++++ b/drivers/infiniband/hw/irdma/verbs.c
+@@ -60,6 +60,36 @@ static int irdma_query_device(struct ib_device *ibdev,
+ 	return 0;
+ }
+ 
++/**
++ * irdma_get_eth_speed_and_width - Get IB port speed and width from netdev speed
++ * @link_speed: netdev phy link speed
++ * @active_speed: IB port speed
++ * @active_width: IB port width
++ */
++static void irdma_get_eth_speed_and_width(u32 link_speed, u16 *active_speed,
++					  u8 *active_width)
++{
++	if (link_speed <= SPEED_1000) {
++		*active_width = IB_WIDTH_1X;
++		*active_speed = IB_SPEED_SDR;
++	} else if (link_speed <= SPEED_10000) {
++		*active_width = IB_WIDTH_1X;
++		*active_speed = IB_SPEED_FDR10;
++	} else if (link_speed <= SPEED_20000) {
++		*active_width = IB_WIDTH_4X;
++		*active_speed = IB_SPEED_DDR;
++	} else if (link_speed <= SPEED_25000) {
++		*active_width = IB_WIDTH_1X;
++		*active_speed = IB_SPEED_EDR;
++	} else if (link_speed <= SPEED_40000) {
++		*active_width = IB_WIDTH_4X;
++		*active_speed = IB_SPEED_FDR10;
++	} else {
++		*active_width = IB_WIDTH_4X;
++		*active_speed = IB_SPEED_EDR;
++	}
++}
++
+ /**
+  * irdma_query_port - get port attributes
+  * @ibdev: device pointer from stack
+@@ -87,9 +117,8 @@ static int irdma_query_port(struct ib_device *ibdev, u32 port,
+ 		props->state = IB_PORT_DOWN;
+ 		props->phys_state = IB_PORT_PHYS_STATE_DISABLED;
+ 	}
+-
+-	ib_get_eth_speed(ibdev, port, &props->active_speed,
+-			 &props->active_width);
++	irdma_get_eth_speed_and_width(SPEED_100000, &props->active_speed,
++				      &props->active_width);
+ 
+ 	if (rdma_protocol_roce(ibdev, 1)) {
+ 		props->gid_tbl_len = 32;
+-- 
+2.39.0
+

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -57,4 +57,9 @@
     name = "export-rt-sched-migrate";
     patch = ./export-rt-sched-migrate.patch;
   };
+
+  fix-em-ice-bonding = {
+    name = "fix-em-ice-bonding";
+    patch = ./fix-em-ice-bonding.patch;
+  };
 }

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -148,6 +148,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.fix-em-ice-bonding
       ];
     };
 
@@ -169,6 +170,7 @@ in {
       kernelPatches = [
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
+        kernelPatches.fix-em-ice-bonding
       ];
     };
 


### PR DESCRIPTION
Some Equinix Metal instances, such as a3.large.x86, m3.large.x86 (specific hardware revisions), and n3.large.x86, use the `ice` kernel driver for their network cards, in conjunction with bonded devices. However, this commit caused a regression where these bonded devices would deadlock. This was initially reported by Jaroslav Pulchart on the netdev mailing list[1], and there were follow-up patches from Dave Ertman[2][3] that attempted to fix this but were not up to snuff for various reasons[4].

Specifically, v2 of the patch ([3]) appears to fix the issue on some devices (tested with 8086:159B network cards), while it is still broken on others (such as an 8086:1593 network card).

We revert the patch exposing the issue until upstream has a working solution in order to make Equinix Metal instances work reliably again.

[1]; https://lore.kernel.org/netdev/CAK8fFZ6A_Gphw_3-QMGKEFQk=sfCw1Qmq0TVZK3rtAi7vb621A@mail.gmail.com/
[2]; https://patchwork.ozlabs.org/project/intel-wired-lan/patch/20230111183145.1497367-1-david.m.ertman@intel.com/
[3]; https://patchwork.ozlabs.org/project/intel-wired-lan/patch/20230215191757.1826508-1-david.m.ertman@intel.com/
[4]; https://lore.kernel.org/netdev/cb31a911-ba80-e2dc-231f-851757cfd0b8@intel.com/T/#m6e53f8c43093693c10268140126abe99e082dc1c

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
    * Tested on an instance booting 5.15.86
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
