### PR TITLE
edl: init at unstable-2022-09-07

### DIFF
--- a/pkgs/development/embedded/edl/default.nix
+++ b/pkgs/development/embedded/edl/default.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonPackage rec {
+  pname = "edl";
+  version = "unstable-2022-09-07";
+
+  src = fetchFromGitHub rec {
+    owner = "bkerler";
+    repo = "edl";
+    rev = "f6b94da5faa003b48d24a5f4a8f0b8495626fd5b";
+    fetchSubmodules = true;
+    hash = "sha256-bxnRy+inWNArE2gUA/qDPy7NKvqBm43sbxdIaTc9N28=";
+  };
+  # edl has a spurious dependency on "usb" which has nothing to do with the
+  # project and was probably added by accident trying to add pyusb
+  postPatch = ''
+    sed -i '/'usb'/d' setup.py
+  '';
+  # No tests set up
+  doCheck = false;
+  # EDL loaders are ELFs but shouldn't be touched, rest is Python anyways
+  dontStrip = true;
+  propagatedBuildInputs = with python3Packages; [
+    pyusb
+    pyserial
+    docopt
+    pylzma
+    pycryptodome
+    lxml
+    colorama
+    # usb
+    capstone
+    keystone-engine
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/bkerler/edl";
+    description = "Qualcomm EDL tool (Sahara / Firehose / Diag)";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lorenz ];
+    # Case-sensitive files in 'Loader' submodule
+    broken = stdenv.isDarwin;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6769,6 +6769,8 @@ with pkgs;
 
   edk2-uefi-shell = callPackage ../tools/misc/edk2-uefi-shell { };
 
+  edl = callPackage ../development/embedded/edl { };
+
   edlib = callPackage ../development/libraries/science/biology/edlib { };
 
   eff = callPackage ../development/interpreters/eff { };


### PR DESCRIPTION
###### Description of changes

This adds edl, a tool for interfacing with the low-level flashing and recovery interface embedded in the Boot ROM of a lot of Qualcomm SoCs.

An unreleased version is used as the last released version is very old and does not properly install itself.

I have successfully tested this for dumping and restoring an MSM8916-based device.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
