### PR TITLE
nixos-rebuild: use sudo when whoami != root

### DIFF
--- a/nixos/doc/manual/manpages/nixos-rebuild.8
+++ b/nixos/doc/manual/manpages/nixos-rebuild.8
@@ -56,7 +56,9 @@ must run
 .Nm
 to make the changes take effect. It builds the new system in
 .Pa /nix/store Ns
-, runs its activation script, and stop and (re)starts any system services if
+, runs its activation script (invoking
+.Ic sudo Ns
+\& if required), and stop and (re)starts any system services if
 needed. Please note that user services need to be started manually as they
 aren't detected by the activation script at the moment.
 .
@@ -354,6 +356,11 @@ or
 .Fl -build-host
 is also set. This is useful when the target-host connection to cache.nixos.org
 is faster than the connection between hosts.
+.
+.It Fl -no-auto-sudo
+When set, disables automatic use of
+.Ic sudo Ns
+\& when deploying to localhost as a non-root user.
 .
 .It Fl -use-remote-sudo
 When set, nixos-rebuild prefixes remote commands that run on the

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -205,6 +205,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - A new `virtualisation.rosetta` module was added to allow running `x86_64` binaries through [Rosetta](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment) inside virtualised NixOS guests on Apple silicon. This feature works by default with the [UTM](https://docs.getutm.app/) virtualisation [package](https://search.nixos.org/packages?channel=unstable&show=utm&from=0&size=1&sort=relevance&type=packages&query=utm).
 
+- `nixos-rebuild` now uses `sudo` when deploying to localhost as a non-root user. This behaviour can be disabled with `--no-auto-sudo`.
+
 - The new option `users.motdFile` allows configuring a Message Of The Day that can be updated dynamically.
 
 - The `root` package is now built with the `"-Dgnuinstall=ON"` CMake flag, making the output conform the `bin` `lib` `share` layout. In this layout, `tutorials` is under `share/doc/ROOT/`; `cmake`, `font`, `icons`, `js` and `macro` under `share/root`; `Makefile.comp` and `Makefile.config` under `etc/root`.


### PR DESCRIPTION
###### Description of changes

Currently, executing `nixos-rebuild switch` as a non-root user will
result in a somewhat confusing error about being unable to link a
profile to a nix store path. This is not ideal, especially as we already
have most of the code to handle this properly and use `sudo` to elevate
permissions to install.

This is preferrable for flakes (better eval caching), and also more
intuitive for new users.

FIXME

- [x] Add this to the release notes
- [x] Mention it in the documentation
- [ ] Consider printing some message about using sudo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
