### PR TITLE
skopeo: 1.11.0 -> 1.11.1

### DIFF
--- a/pkgs/development/tools/skopeo/default.nix
+++ b/pkgs/development/tools/skopeo/default.nix
@@ -12,17 +12,19 @@
 , fuse-overlayfs
 , dockerTools
 , runCommand
+, testers
+, skopeo
 }:
 
 buildGoModule rec {
   pname = "skopeo";
-  version = "1.11.0";
+  version = "1.11.1";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "containers";
     repo = "skopeo";
-    hash = "sha256-P556Is03BeC0Tf+kNv+Luy0KASgTXsyZ/MrPaPFUHE8=";
+    hash = "sha256-wTOcluPSguF6ZnKHlLelM5R2dIF9nd66qu7u/48uNyU=";
   };
 
   outputs = [ "out" "man" ];
@@ -45,8 +47,7 @@ buildGoModule rec {
 
   installPhase = ''
     runHook preInstall
-    PREFIX=$out make install-binary install-completions
-    PREFIX=$man make install-docs
+    PREFIX=${placeholder "out"} make install-binary install-completions install-docs
     install ${passthru.policy}/default-policy.json -Dt $out/etc/containers
   '' + lib.optionalString stdenv.isLinux ''
     wrapProgram $out/bin/skopeo \
@@ -60,11 +61,15 @@ buildGoModule rec {
       install ${src}/default-policy.json -Dt $out
     '';
     tests = {
+      version = testers.testVersion {
+        package = skopeo;
+      };
       inherit (dockerTools.examples) testNixFromDockerHub;
     };
   };
 
   meta = with lib; {
+    changelog = "https://github.com/containers/skopeo/releases/tag/${src.rev}";
     description = "A command line utility for various operations on container images and image repositories";
     homepage = "https://github.com/containers/skopeo";
     maintainers = with maintainers; [ lewo ] ++ teams.podman.members;


### PR DESCRIPTION
Diff: https://github.com/containers/skopeo/compare/v1.11.0...v1.11.1

Changelog: https://github.com/containers/skopeo/releases/tag/v1.11.1

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
