### PR TITLE
node2nix: pull in patch to fix bin scripts with crlf line-endings

### DIFF
--- a/pkgs/development/node-packages/node-env.nix
+++ b/pkgs/development/node-packages/node-env.nix
@@ -530,12 +530,15 @@ let
         then
             ln -s $out/lib/node_modules/.bin $out/bin
 
-            # Patch the shebang lines of all the executables
+            # Fixup all executables
             ls $out/bin/* | while read i
             do
                 file="$(readlink -f "$i")"
                 chmod u+rwx "$file"
-                patchShebangs "$file"
+                if isScript "$file"
+                then
+                    sed -i 's/\r$//' "$file"  # convert crlf to lf
+                fi
             done
         fi
 

--- a/pkgs/development/node-packages/overrides.nix
+++ b/pkgs/development/node-packages/overrides.nix
@@ -342,14 +342,22 @@ final: prev: {
     };
     nativeBuildInputs = [ pkgs.buildPackages.makeWrapper ];
     postInstall = let
-      # Needed to fix Node.js 16+ - PR svanderburg/node2nix#302
-      npmPatch = fetchpatch {
-        name = "emit-lockfile-v2-and-fix-bin-links-with-npmv7.patch";
-        url = "https://github.com/svanderburg/node2nix/commit/375a055041b5ee49ca5fb3f74a58ca197c90c7d5.patch";
-        hash = "sha256-uVYrXptJILojeur9s2O+J/f2vyPNCaZMn1GM/NoC5n8=";
-      };
+      patches = [
+        # Needed to fix Node.js 16+ - PR svanderburg/node2nix#302
+        (fetchpatch {
+          name = "emit-lockfile-v2-and-fix-bin-links-with-npmv7.patch";
+          url = "https://github.com/svanderburg/node2nix/commit/375a055041b5ee49ca5fb3f74a58ca197c90c7d5.patch";
+          hash = "sha256-uVYrXptJILojeur9s2O+J/f2vyPNCaZMn1GM/NoC5n8=";
+        })
+        # Needed to fix packages with DOS line-endings after above patch - PR svanderburg/node2nix#314
+        (fetchpatch {
+          name = "convert-crlf-for-script-bin-files.patch";
+          url = "https://github.com/svanderburg/node2nix/commit/91aa511fe7107938b0409a02ab8c457a6de2d8ca.patch";
+          hash = "sha256-ISiKYkur/o8enKDzJ8mQndkkSC4yrTNlheqyH+LiXlU=";
+        })
+      ];
     in ''
-      patch -d $out/lib/node_modules/node2nix -p1 < ${npmPatch}
+      ${lib.concatStringsSep "\n" (map (patch: "patch -d $out/lib/node_modules/node2nix -p1 < ${patch}") patches)}
       wrapProgram "$out/bin/node2nix" --prefix PATH : ${lib.makeBinPath [ pkgs.nix ]}
     '';
   };


### PR DESCRIPTION
###### Description of changes

Pull in fix from svanderburg/node2nix#314

This is minor fallout from #193337 which made node2nix handle installing script bins itself (since npm stopped doing that correctly)

It seems npm was doing line-ending normalization when installing these files itself, so in addition to making all bins executable we now also do a crlf to lf conversionon on them if they are a script with a shebang

This is rather hacky, but hopefully we'll be able to support most Node.js packages with more modern tooling soon and can use node2nix less in the future

Fixes #216306

cc: @winterqt

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review pr 216728` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>7 packages marked as broken and skipped:</summary>
  <ul>
    <li>breitbandmessung</li>
    <li>odoo</li>
    <li>oni2</li>
    <li>teleprompter</li>
    <li>vimPlugins.coc-imselect</li>
    <li>whalebird</li>
    <li>zerobin</li>
  </ul>
</details>
<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>tests.writers</li>
  </ul>
</details>
<details>
  <summary>5 packages failed to build: (<i>note</i>: failures exist on </code>master</code> too)</summary>
  <ul>
    <li>openmoji-black</li>
    <li>openmoji-color</li>
    <li>sage</li>
    <li>sageWithDoc</li>
    <li>spacegun</li>
  </ul>
</details>
<details>
  <summary>207 packages built:</summary>
  <ul>
    <li>airfield</li>
    <li>akkoma-frontends.akkoma-fe</li>
    <li>antennas</li>
    <li>antora</li>
    <li>balanceofsatoshis</li>
    <li>base16-builder</li>
    <li>bat-extras.prettybat</li>
    <li>bibtex-tidy</li>
    <li>bitwarden-cli</li>
    <li>castnow</li>
    <li>cinnamon.xreader</li>
    <li>code-server</li>
    <li>commitlint</li>
    <li>concurrently</li>
    <li>create-cycle-app</li>
    <li>discourse</li>
    <li>discourseAllPlugins</li>
    <li>electron-fiddle</li>
    <li>elmPackages.create-elm-app</li>
    <li>elmPackages.elm-analyse</li>
    <li>elmPackages.elm-coverage</li>
    <li>elmPackages.elm-doc-preview</li>
    <li>elmPackages.elm-git-install</li>
    <li>elmPackages.elm-language-server</li>
    <li>elmPackages.elm-live</li>
    <li>elmPackages.elm-optimize-level-2</li>
    <li>elmPackages.elm-pages</li>
    <li>elmPackages.elm-review</li>
    <li>elmPackages.elm-test</li>
    <li>elmPackages.elm-upgrade</li>
    <li>elmPackages.elm-verify-examples</li>
    <li>elmPackages.elm-xref</li>
    <li>emanote</li>
    <li>emojione</li>
    <li>epgstation</li>
    <li>ethercalc</li>
    <li>fast-cli</li>
    <li>flexoptix-app</li>
    <li>flood</li>
    <li>gnomeExtensions.pop-shell</li>
    <li>google-clasp</li>
    <li>grafana-image-renderer</li>
    <li>gtop</li>
    <li>haskellPackages.aeson-typescript</li>
    <li>haskellPackages.emanote</li>
    <li>haskellPackages.servant-typescript</li>
    <li>haskellPackages.tailwind</li>
    <li>hueadm</li>
    <li>image_optim</li>
    <li>imapnotify</li>
    <li>imgbrd-grabber</li>
    <li>joplin</li>
    <li>lessc</li>
    <li>lighthouse</li>
    <li>mastodon-bot</li>
    <li>mongosh</li>
    <li>morgen</li>
    <li>mx-puppet-discord</li>
    <li>n8n</li>
    <li>node2nix</li>
    <li>onlykey</li>
    <li>pm2</li>
    <li>postcss-cli</li>
    <li>pscid</li>
    <li>psitransfer</li>
    <li>pulp</li>
    <li>purescript-psa</li>
    <li>pyright</li>
    <li>python310Packages.batchspawner</li>
    <li>python310Packages.dockerspawner</li>
    <li>python310Packages.jupyterhub</li>
    <li>python310Packages.jupyterhub-ldapauthenticator</li>
    <li>python310Packages.jupyterhub-systemdspawner</li>
    <li>python310Packages.jupyterhub-tmpauthenticator</li>
    <li>python310Packages.oauthenticator</li>
    <li>python311Packages.batchspawner</li>
    <li>python311Packages.dockerspawner</li>
    <li>python311Packages.jupyterhub</li>
    <li>python311Packages.jupyterhub-ldapauthenticator</li>
    <li>python311Packages.jupyterhub-systemdspawner</li>
    <li>python311Packages.jupyterhub-tmpauthenticator</li>
    <li>python311Packages.oauthenticator</li>
    <li>quarto</li>
    <li>redoc-cli</li>
    <li>reveal-md</li>
    <li>shepherd</li>
    <li>shout</li>
    <li>slack</li>
    <li>sloc</li>
    <li>styx</li>
    <li>tandoor-recipes</li>
    <li>teams</li>
    <li>teck-programmer</li>
    <li>theLoungePlugins.plugins.closepms</li>
    <li>theLoungePlugins.plugins.giphy</li>
    <li>theLoungePlugins.plugins.shortcuts</li>
    <li>theLoungePlugins.themes.abyss</li>
    <li>theLoungePlugins.themes.amoled</li>
    <li>theLoungePlugins.themes.amoled-sourcecodepro</li>
    <li>theLoungePlugins.themes.bdefault</li>
    <li>theLoungePlugins.themes.bmorning</li>
    <li>theLoungePlugins.themes.chord</li>
    <li>theLoungePlugins.themes.classic</li>
    <li>theLoungePlugins.themes.common</li>
    <li>theLoungePlugins.themes.crypto</li>
    <li>theLoungePlugins.themes.discordapp</li>
    <li>theLoungePlugins.themes.dracula</li>
    <li>theLoungePlugins.themes.dracula-official</li>
    <li>theLoungePlugins.themes.flat-blue</li>
    <li>theLoungePlugins.themes.flat-dark</li>
    <li>theLoungePlugins.themes.gruvbox</li>
    <li>theLoungePlugins.themes.hexified</li>
    <li>theLoungePlugins.themes.ion</li>
    <li>theLoungePlugins.themes.light</li>
    <li>theLoungePlugins.themes.midnight</li>
    <li>theLoungePlugins.themes.mininapse</li>
    <li>theLoungePlugins.themes.monokai-console</li>
    <li>theLoungePlugins.themes.mortified</li>
    <li>theLoungePlugins.themes.neuron-fork</li>
    <li>theLoungePlugins.themes.new-morning</li>
    <li>theLoungePlugins.themes.new-morning-compact</li>
    <li>theLoungePlugins.themes.nologo</li>
    <li>theLoungePlugins.themes.nord</li>
    <li>theLoungePlugins.themes.onedark</li>
    <li>theLoungePlugins.themes.purplenight</li>
    <li>theLoungePlugins.themes.scoutlink</li>
    <li>theLoungePlugins.themes.seraphimrp</li>
    <li>theLoungePlugins.themes.solarized</li>
    <li>theLoungePlugins.themes.solarized-fork-monospace</li>
    <li>theLoungePlugins.themes.zenburn</li>
    <li>theLoungePlugins.themes.zenburn-monospace</li>
    <li>theLoungePlugins.themes.zenburn-sourcecodepro</li>
    <li>thelounge</li>
    <li>triton</li>
    <li>typescript</li>
    <li>uppy-companion</li>
    <li>vimPlugins.YouCompleteMe</li>
    <li>vimPlugins.coc-clangd</li>
    <li>vimPlugins.coc-cmake</li>
    <li>vimPlugins.coc-css</li>
    <li>vimPlugins.coc-diagnostic</li>
    <li>vimPlugins.coc-docker</li>
    <li>vimPlugins.coc-emmet</li>
    <li>vimPlugins.coc-eslint</li>
    <li>vimPlugins.coc-explorer</li>
    <li>vimPlugins.coc-flutter</li>
    <li>vimPlugins.coc-git</li>
    <li>vimPlugins.coc-go</li>
    <li>vimPlugins.coc-haxe</li>
    <li>vimPlugins.coc-highlight</li>
    <li>vimPlugins.coc-html</li>
    <li>vimPlugins.coc-java</li>
    <li>vimPlugins.coc-jest</li>
    <li>vimPlugins.coc-json</li>
    <li>vimPlugins.coc-lists</li>
    <li>vimPlugins.coc-ltex</li>
    <li>vimPlugins.coc-markdownlint</li>
    <li>vimPlugins.coc-metals</li>
    <li>vimPlugins.coc-nginx</li>
    <li>vimPlugins.coc-pairs</li>
    <li>vimPlugins.coc-prettier</li>
    <li>vimPlugins.coc-pyright</li>
    <li>vimPlugins.coc-python</li>
    <li>vimPlugins.coc-r-lsp</li>
    <li>vimPlugins.coc-rls</li>
    <li>vimPlugins.coc-rust-analyzer</li>
    <li>vimPlugins.coc-sh</li>
    <li>vimPlugins.coc-smartf</li>
    <li>vimPlugins.coc-snippets</li>
    <li>vimPlugins.coc-solargraph</li>
    <li>vimPlugins.coc-spell-checker</li>
    <li>vimPlugins.coc-sqlfluff</li>
    <li>vimPlugins.coc-stylelint</li>
    <li>vimPlugins.coc-sumneko-lua</li>
    <li>vimPlugins.coc-tabnine</li>
    <li>vimPlugins.coc-texlab</li>
    <li>vimPlugins.coc-toml</li>
    <li>vimPlugins.coc-tslint</li>
    <li>vimPlugins.coc-tslint-plugin</li>
    <li>vimPlugins.coc-tsserver</li>
    <li>vimPlugins.coc-ultisnips</li>
    <li>vimPlugins.coc-vetur</li>
    <li>vimPlugins.coc-vimlsp</li>
    <li>vimPlugins.coc-vimtex</li>
    <li>vimPlugins.coc-wxml</li>
    <li>vimPlugins.coc-yaml</li>
    <li>vimPlugins.coc-yank</li>
    <li>vimPlugins.markdown-preview-nvim</li>
    <li>vscode</li>
    <li>vscode-extensions.matklad.rust-analyzer (vscode-extensions.rust-lang.rust-analyzer)</li>
    <li>vscode-extensions.ms-python.vscode-pylance</li>
    <li>vscode-fhs</li>
    <li>vscode-with-extensions</li>
    <li>vscodium</li>
    <li>vscodium-fhs</li>
    <li>wasm-strip</li>
    <li>wasm-text-gen</li>
    <li>wast-refmt</li>
    <li>webassemblyjs-cli</li>
    <li>webassemblyjs-repl</li>
    <li>weylus</li>
    <li>whitebophir</li>
    <li>wrangler</li>
    <li>wring</li>
    <li>yaml-language-server</li>
    <li>ycmd</li>
    <li>zx</li>
  </ul>
</details>