### PR TITLE
supercronic: init at 0.2.27

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10310,6 +10310,11 @@
     githubId = 6709831;
     name = "Jake Hill";
   };
+  nasageek = {
+    github = "NasaGeek";
+    githubId = 474937;
+    name = "Chris Roberts";
+  };
   nasirhm = {
     email = "nasirhussainm14@gmail.com";
     github = "nasirhm";

--- a/pkgs/tools/system/supercronic/default.nix
+++ b/pkgs/tools/system/supercronic/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, python3
+, bash
+, coreutils
+}:
+
+buildGoModule rec {
+  pname = "supercronic";
+  version = "0.2.27";
+
+  src = fetchFromGitHub {
+    owner = "aptible";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-sgKvE8Ze2qKPgdaAwN1sB0wX7k5VRx8+llkT54xXvrM=";
+  };
+
+  vendorHash = "sha256-j1iduvu+dKmhvPN8pe50fGQU5cC9N3gfoMh9gSQDbf8=";
+
+  excludedPackages = [ "cronexpr/cronexpr" ];
+
+  nativeCheckInputs = [ python3 bash coreutils ];
+
+  postConfigure = ''
+    # There are tests that set the shell to various paths
+    substituteInPlace cron/cron_test.go --replace /bin/sh ${bash}/bin/sh
+    substituteInPlace cron/cron_test.go --replace /bin/false ${coreutils}/bin/false
+  '';
+
+  meta = with lib; {
+    description = "Cron tool designed for use in containers";
+    homepage = "https://github.com/aptible/supercronic";
+    license = licenses.mit;
+    maintainers = with maintainers; [ nasageek ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1566,6 +1566,8 @@ with pkgs;
 
   steamtinkerlaunch = callPackage ../tools/games/steamtinkerlaunch {};
 
+  supercronic = callPackage ../tools/system/supercronic { };
+
   supermin = callPackage ../tools/virtualization/supermin { };
 
   sx-go = callPackage ../tools/security/sx-go { };


### PR DESCRIPTION
###### Description of changes

Supercronic is a handy cron-alike that is well-suited for running in a container for the following reasons:
* Does not daemonize by default
* Preserves container environment for crontab
* Runs as non-root
* Logs crontab output to stdout

https://github.com/aptible/supercronic

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
