### PR TITLE
clippy: fix on darwin

### DIFF
--- a/pkgs/development/compilers/rust/clippy.nix
+++ b/pkgs/development/compilers/rust/clippy.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage {
   # changes hash of vendor directory otherwise
   dontUpdateAutotoolsGnuConfigScripts = true;
 
-  buildInputs = [ rustc rustc.llvm ] ++ lib.optionals stdenv.isDarwin [ Security ];
+  buildInputs = [ rustc.llvm ] ++ lib.optionals stdenv.isDarwin [ Security ];
 
   # fixes: error: the option `Z` is only accepted on the nightly compiler
   RUSTC_BOOTSTRAP = 1;

--- a/pkgs/development/compilers/rust/clippy.nix
+++ b/pkgs/development/compilers/rust/clippy.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage {
   meta = with lib; {
     homepage = "https://rust-lang.github.io/rust-clippy/";
     description = "A bunch of lints to catch common mistakes and improve your Rust code";
-    maintainers = with maintainers; [ basvandijk ];
+    maintainers = with maintainers; [ basvandijk ] ++ teams.rust.members;
     license = with licenses; [ mit asl20 ];
     platforms = platforms.unix;
   };

--- a/pkgs/development/compilers/rust/clippy.nix
+++ b/pkgs/development/compilers/rust/clippy.nix
@@ -20,8 +20,15 @@ rustPlatform.buildRustPackage {
   #   (/private/tmp/nix-build-clippy-1.36.0.drv-0/rustc-1.36.0-src/src/librustc_llvm)
   doCheck = false;
 
+  # Clippy uses the rustc_driver and std private libraries, and Rust's build process forces them to have
+  # an install name of `@rpath/...` [0] [1] instead of the standard on macOS, which is an absolute path
+  # to itself.
+  #
+  # [0]: https://github.com/rust-lang/rust/blob/f77f4d55bdf9d8955d3292f709bd9830c2fdeca5/src/bootstrap/builder.rs#L1543
+  # [1]: https://github.com/rust-lang/rust/blob/f77f4d55bdf9d8955d3292f709bd9830c2fdeca5/compiler/rustc_codegen_ssa/src/back/linker.rs#L323-L331
   preFixup = lib.optionalString stdenv.isDarwin ''
-    install_name_tool -add_rpath "${rustc}/lib" $out/bin/clippy-driver
+    install_name_tool -add_rpath "${rustc}/lib" "$out/bin/clippy-driver"
+    install_name_tool -add_rpath "${rustc}/lib" "$out/bin/cargo-clippy"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

For whatever reason, on Darwin, `clippy-driver` has always pointed to
RPATH for `rustc_driver`, requiring us to add `${rustc}/lib` to RPATH
during fixup with `install_name_tool`. I wish I knew why (the linker
arguments rustc passes are sane), and I wish I knew why this didn't
occur on Linux. Either way, this is now required for `cargo-clippy` to
run, so let's do the same thing for it until we get a better sense of
what's going on here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
