### PR TITLE
reportlab: Move Pillow into propagatedBuildInputs

### DIFF
--- a/pkgs/development/python-modules/reportlab/default.nix
+++ b/pkgs/development/python-modules/reportlab/default.nix
@@ -26,7 +26,6 @@ in buildPythonPackage rec {
   nativeCheckInputs = [ glibcLocales ];
 
   buildInputs = [ ft ];
-  
   propagatedBuildInputs = [ pillow ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/reportlab/default.nix
+++ b/pkgs/development/python-modules/reportlab/default.nix
@@ -25,7 +25,9 @@ in buildPythonPackage rec {
 
   nativeCheckInputs = [ glibcLocales ];
 
-  buildInputs = [ ft pillow ];
+  buildInputs = [ ft ];
+  
+  propagatedBuildInputs = [ pillow ];
 
   postPatch = ''
     substituteInPlace setup.py \


### PR DESCRIPTION
###### Description of changes

Pillow needs to be available at runtime in the reportlab derivation, as it is a Python package.
This PR moves it into `propagatedBuildInputs`.

This fixes things that depend on reportlab like the Kyocera print filter, which otherwise causes a "filter error" in CUPS when the Python script crashes.

@FRidh

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
