### PR TITLE
Revert "podman: remove wrapper"

### DIFF
--- a/pkgs/applications/virtualization/podman/wrapper.nix
+++ b/pkgs/applications/virtualization/podman/wrapper.nix
@@ -1,0 +1,78 @@
+{ podman-unwrapped
+, runCommand
+, makeWrapper
+, symlinkJoin
+, lib
+, stdenv
+, extraPackages ? []
+, runc # Default container runtime
+, crun # Container runtime (default with cgroups v2 for podman/buildah)
+, conmon # Container runtime monitor
+, slirp4netns # User-mode networking for unprivileged namespaces
+, fuse-overlayfs # CoW for images, much faster than default vfs
+, util-linux # nsenter
+, iptables
+, iproute2
+, catatonit
+, gvproxy
+, aardvark-dns
+, netavark
+}:
+
+# do not add qemu to this wrapper, store paths get written to the podman vm config and break when GCed
+
+let
+  binPath = lib.makeBinPath ([
+  ] ++ lib.optionals stdenv.isLinux [
+    runc
+    crun
+    conmon
+    slirp4netns
+    fuse-overlayfs
+    util-linux
+    iptables
+    iproute2
+  ] ++ extraPackages);
+
+  helpersBin = symlinkJoin {
+    name = "${podman-unwrapped.pname}-helper-binary-wrapper-${podman-unwrapped.version}";
+
+    # this only works for some binaries, others may need to be be added to `binPath` or in the modules
+    paths = [
+      gvproxy
+    ] ++ lib.optionals stdenv.isLinux [
+      aardvark-dns
+      catatonit # added here for the pause image and also set in `containersConf` for `init_path`
+      netavark
+      podman-unwrapped.rootlessport
+    ];
+  };
+
+in runCommand podman-unwrapped.name {
+  name = "${podman-unwrapped.pname}-wrapper-${podman-unwrapped.version}";
+  inherit (podman-unwrapped) pname version passthru;
+
+  preferLocalBuild = true;
+
+  meta = builtins.removeAttrs podman-unwrapped.meta [ "outputsToInstall" ];
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+} ''
+  ln -s ${podman-unwrapped.man} $man
+
+  mkdir -p $out/bin
+  ln -s ${podman-unwrapped}/etc $out/etc
+  ln -s ${podman-unwrapped}/lib $out/lib
+  ln -s ${podman-unwrapped}/share $out/share
+  makeWrapper ${podman-unwrapped}/bin/podman $out/bin/podman \
+    --set CONTAINERS_HELPER_BINARY_DIR ${helpersBin}/bin \
+    --prefix PATH : ${lib.escapeShellArg binPath}
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11006,7 +11006,8 @@ with pkgs;
 
   pocketbase = callPackage ../servers/pocketbase { };
 
-  podman = callPackage ../applications/virtualization/podman { };
+  podman = callPackage ../applications/virtualization/podman/wrapper.nix { };
+  podman-unwrapped = callPackage ../applications/virtualization/podman { };
 
   podman-compose = python3Packages.callPackage ../applications/virtualization/podman-compose {};
 


### PR DESCRIPTION
This reverts commit 02f92550441de39d0e42b39b538ac5529714ed41.

broke rootlessport port forwarding

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
