### PR TITLE
paperjam: init at 1.2

### DIFF
--- a/pkgs/applications/misc/paperjam/default.nix
+++ b/pkgs/applications/misc/paperjam/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  qpdf,
+  libpaper,
+  asciidoc,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "paperjam";
+  version = "1.2";
+
+  src = fetchgit {
+    url = "git://git.ucw.cz/paperjam.git";
+    #rev = "v${finalAttrs.version}";
+    # this is v1.2 + build fix
+    rev = "65444824e308470f49b5e4f98fd1763b7da3bd24";
+    hash = "sha256-AMoSiHDKbnVtmNR07sniXruVKH7p/Pl5aey4SF8aMWA=";
+  };
+
+  buildInputs = [
+    qpdf
+    libpaper
+    asciidoc
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    # prevent real build date which is impure
+    "BUILD_DATE=\\<unknown\\>"
+    "BUILD_COMMIT=${finalAttrs.src.rev}"
+  ];
+
+  meta = {
+    homepage = "https://mj.ucw.cz/sw/paperjam/";
+    description = "A program for transforming PDF files";
+    longDescription = ''
+      PaperJam is a program for transforming PDF files. It can re-arrange
+      pages, scale and rotate them, put multiple pages on a single sheet, draw
+      cropmarks, and many other tricks.
+    '';
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ vojta001 ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11582,6 +11582,8 @@ with pkgs;
 
   pamtester = callPackage ../tools/security/pamtester { };
 
+  paperjam = callPackage ../applications/misc/paperjam { };
+
   paperless-ngx = callPackage ../applications/office/paperless-ngx { };
 
   paperoni = callPackage ../tools/text/paperoni { };


### PR DESCRIPTION
###### Description of changes

[Paperjam](https://mj.ucw.cz/sw/paperjam/) is a simple command line tool for manipulating PDF files (rotate pages, reorder them, put multiple pages on one for cheaper printing…). It is similar to `pspdftool`, but maintained (can correctly handle compressed PDFs for example).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
