### PR TITLE
squawk: 0.20.0 -> 0.21.0

### DIFF
--- a/pkgs/development/tools/squawk/correct-Cargo.lock.patch
+++ b/pkgs/development/tools/squawk/correct-Cargo.lock.patch
@@ -6,8 +6,8 @@ index d5803a8..384224d 100644
  
  [[package]]
  name = "squawk"
--version = "0.19.0"
-+version = "0.20.0"
+-version = "0.20.0"
++version = "0.21.0"
  dependencies = [
   "atty",
   "base64 0.12.3",

--- a/pkgs/development/tools/squawk/default.nix
+++ b/pkgs/development/tools/squawk/default.nix
@@ -23,16 +23,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "squawk";
-  version = "0.20.0";
+  version = "0.21.0";
 
   src = fetchFromGitHub {
     owner = "sbdchd";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-v9F+HfscX4dIExIP1YvxOldZPPtmxh8lO3SREu6M+C0=";
+    hash = "sha256-ObaYGGTAGGLOAji86Q5R9fqbCGg6GP0A3iheNLgzezY=";
   };
 
-  cargoHash = "sha256-kSaQxqom8LSCOQBoIZ1iv+q2+Ih8l61L97xXv5c4a0k=";
+  cargoHash = "sha256-VOGgwBKcJK7x+PwvzvuVu9Zd1G8t9UoC/Me3G6bdtrk=";
 
   cargoPatches = [
     ./correct-Cargo.lock.patch
@@ -54,6 +54,8 @@ rustPlatform.buildRustPackage rec {
     CoreFoundation
     Security
   ]);
+
+  OPENSSL_NO_VENDOR = 1;
 
   LIBPG_QUERY_PATH = libpg_query13;
 


### PR DESCRIPTION

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/sbdchd/squawk/releases/tag/v0.21.0
cc: @andrewsmith
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
