### PR TITLE
webkitgtk: 2.38.4 → 2.38.5

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -69,7 +69,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "webkitgtk";
-  version = "2.38.4";
+  version = "2.38.5";
   name = "${finalAttrs.pname}-${finalAttrs.version}+abi=${if lib.versionAtLeast gtk3.version "4.0" then "5.0" else "4.${if lib.versions.major libsoup.version == "2" then "0" else "1"}"}";
 
   outputs = [ "out" "dev" "devdoc" ];
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://webkitgtk.org/releases/webkitgtk-${finalAttrs.version}.tar.xz";
-    hash = "sha256-T0fqKaLU1fFe7z3J4tbG8Gfo3oY6P2RFXhzPlpPMHTY=";
+    hash = "sha256-QMIMQwIidN9Yk/IrEFT6iUw+6gVzibsIruCMWwuwwac=";
   };
 
   patches = lib.optionals stdenv.isLinux [


### PR DESCRIPTION
###### Description of changes

https://webkitgtk.org/2023/02/15/webkitgtk2.38.5-released.html
https://webkitgtk.org/security/WSA-2023-0002.html

CVE-2023-23529

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Viewed `cmake` changes in [diff](https://salsa.debian.org/webkit-team/webkit/-/commit/a52b55ddc16d5.diff).
- [x] [`configurePhase` runs](https://github.com/NixOS/nixpkgs/blob/a44f389aaef18a7d5435bbc6d9b0a01f17ad06dd/doc/stdenv/stdenv.chapter.md#building-a-stdenv-package-in-nix-shell-sec-building-stdenv-package-in-nix-shell).
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
