### PR TITLE
beam/fetch-mix-deps: replace mixEnv with MIX_ENV

### DIFF
--- a/pkgs/development/beam-modules/fetch-mix-deps.nix
+++ b/pkgs/development/beam-modules/fetch-mix-deps.nix
@@ -45,7 +45,7 @@ stdenvNoCC.mkDerivation (attrs // {
 
   installPhase = attrs.installPhase or ''
     runHook preInstall
-    mix deps.get ''${mixEnv:+--only $mixEnv}
+    mix deps.get ''${MIX_ENV:+--only $MIX_ENV}
     find "$TEMPDIR/deps" -path '*/.git/*' -a ! -name HEAD -exec rm -rf {} +
     cp -r --no-preserve=mode,ownership,timestamps $TEMPDIR/deps $out
     runHook postInstall


### PR DESCRIPTION
beam/fetch-mix-deps: replace mixEnv with MIX_ENV

* Currently, when fetchMixDeps is executed without mixEnv argument. "mixEnv" envvar is empty at installPhase, instead of having value "prod". This happens because optional attrs values are not included in @attrs variable. Thrus being necessary to replace mixEnv for MIX_ENV, which holds value "prod".

* Reference: https://github.com/NixOS/nixpkgs/pull/216214#issuecomment-1434737238
