### PR TITLE
libdisplay-info: update patch phase

### DIFF
--- a/pkgs/development/libraries/libdisplay-info/default.nix
+++ b/pkgs/development/libraries/libdisplay-info/default.nix
@@ -25,10 +25,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ hwdata ];
 
-  prePatch = ''
-    substituteInPlace meson.build \
-        --replace "find_program('tool/gen-search-table.py')" "find_program('python3')" \
-        --replace "gen_search_table," "gen_search_table, '$src/tool/gen-search-table.py',"
+  postPatch = ''
+    patchShebangs tool/gen-search-table.py
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

- Replace `prePatch` with `postPatch` (suggested at https://github.com/NixOS/nixpkgs/pull/216315#discussion_r1110075815);
- Don't touch `meson.build` and only the python script shebang instead (smaller area of patching).

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
