### PR TITLE
shuriken: init at 0.5.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -920,6 +920,12 @@
     githubId = 1079173;
     name = "Andrew Dunham";
   };
+  andrewb = {
+    email = "me@andrewbruce.net";
+    github = "camelpunch";
+    githubId = 141733;
+    name = "Andrew Bruce";
+  };
   andrewchambers = {
     email = "ac@acha.ninja";
     github = "andrewchambers";

--- a/pkgs/applications/audio/shuriken/default.nix
+++ b/pkgs/applications/audio/shuriken/default.nix
@@ -59,7 +59,15 @@ mkDerivation rec {
 
   meta = with lib;
     {
-      description = "Shuriken is an open source beat slicer which harnesses the power of aubio's onset detection algorithms and Rubber Band's time stretching capabilities. A simple Qt interface makes it easy to slice up drum loops, assign individual drum hits to MIDI keys, and change the tempo of loops in real-time. The JUCE library takes care of handling audio and MIDI behind the scenes.";
+      description = "Shuriken Beat Slicer";
+      longDescription = ''
+        Shuriken is an open source beat slicer which harnesses the power of
+        aubio's onset detection algorithms and Rubber Band's time stretching
+        capabilities. A simple Qt interface makes it easy to slice up drum
+        loops, assign individual drum hits to MIDI keys, and change the tempo
+        of loops in real-time. The JUCE library takes care of handling audio
+        and MIDI behind the scenes.
+      '';
       homepage = "https://github.com/rock-hopper/shuriken";
       license = licenses.gpl2;
       platforms = platforms.linux;

--- a/pkgs/applications/audio/shuriken/default.nix
+++ b/pkgs/applications/audio/shuriken/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenv
+, pkgs
+, fetchFromGitHub
+, pkg-config
+, alsa-lib
+, aubio
+, libjack2
+, liblo
+, libsamplerate
+, libsndfile
+, qmake
+, qtbase
+, qttools
+, rtaudio
+, rubberband
+, wrapQtAppsHook
+, mkDerivation
+}:
+
+mkDerivation rec {
+  pname = "shuriken";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "rock-hopper";
+    repo = "shuriken";
+    rev = "v${version}";
+    hash = "sha256-WpQ1XV/HLYuNj6Fgxmav8fg9i3oOjz1NipE7cL+Bedc=";
+  };
+
+  nativeBuildInputs = [
+    aubio
+    libjack2
+    liblo
+    libsamplerate
+    libsndfile
+    pkg-config
+    qmake
+    qttools
+    rubberband
+  ];
+
+  buildInputs = [
+    alsa-lib
+    qtbase
+  ];
+
+  builder = pkgs.writeShellScript "builder.sh" ''
+    source ${stdenv}/setup
+    cp -a ${src} "$out"
+    (
+    cd "$out"
+    chmod --recursive u+w .
+    echo yes | bash build
+    INSTALL_ROOT=$out make install
+    )
+  '';
+
+  meta = with lib;
+    {
+      description = "Shuriken is an open source beat slicer which harnesses the power of aubio's onset detection algorithms and Rubber Band's time stretching capabilities. A simple Qt interface makes it easy to slice up drum loops, assign individual drum hits to MIDI keys, and change the tempo of loops in real-time. The JUCE library takes care of handling audio and MIDI behind the scenes.";
+      homepage = "https://github.com/rock-hopper/shuriken";
+      license = licenses.gpl2;
+      platforms = platforms.linux;
+      maintainers = with lib.maintainers; [ andrewb ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29583,7 +29583,7 @@ with pkgs;
 
   sherlock = callPackage ../tools/security/sherlock { };
 
-  shuriken = callPackage ../applications/audio/shuriken { };
+  shuriken = libsForQt5.callPackage ../applications/audio/shuriken { };
 
   rhythmbox = callPackage ../applications/audio/rhythmbox { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29583,6 +29583,8 @@ with pkgs;
 
   sherlock = callPackage ../tools/security/sherlock { };
 
+  shuriken = callPackage ../applications/audio/shuriken { };
+
   rhythmbox = callPackage ../applications/audio/rhythmbox { };
 
   puddletag = libsForQt5.callPackage ../applications/audio/puddletag { };


### PR DESCRIPTION
###### Description of changes

A new derivation for [shuriken](https://github.com/rock-hopper/shuriken), an audio beat-slicer.

This is my first nix contribution, and I'm new to nix. It's a Qt app, and I'm having great difficulty getting the plugin paths in order. I run into the `qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""` error when running the app, unless I explicitly set the `QT_QPA_PLATFORM_PLUGIN_PATH`, with something like:

```
QT_QPA_PLATFORM_PLUGIN_PATH="/nix/store/k306l2gzs92hwmjbmm0qwhg37w6nv0fk-qtbase-5.15.7-bin/lib/qt-5.15.7/plugins" shuriken
```

I've tried:

- using the bare `mkDerivation` [as recommended in this part of the manual](https://hydra.nixos.org/build/96804884/download/1/nixpkgs/manual.html#sec-language-qt)
- using `stdenv.mkDerivation` setting `qtWrapperArgs` to  `--set QT_QPA_PLATFORM_PLUGIN_PATH /nix/store/*qtbase*bin*/lib/qt-*/plugins/platforms` (even if  this worked, I realise I should be using a variable from another package, but don't know which - `qtbase` doesn't show up in the repl as a package?)
- using `dontWrapQtApps` and various hooks

All of the above attempts have failed to change the executable, and it continues to be  an apparently unwrapped binary file.

Any help appreciated!

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).