### PR TITLE
ruff-lsp: init at 0.0.18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12800,6 +12800,11 @@
     githubId = 61306;
     name = "Rene Treffer";
   };
+  ruby0b = {
+    github = "ruby0b";
+    githubId = 106119328;
+    name = "ruby0b";
+  };
   rumpelsepp = {
     name = "Stefan Tatschner";
     email = "stefan@rumpelsepp.org";

--- a/pkgs/development/python-modules/ruff-lsp/default.nix
+++ b/pkgs/development/python-modules/ruff-lsp/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, fetchPypi
+, ruff
+, pythonOlder
+, buildPythonPackage
+, hatchling
+, pygls
+, typing-extensions
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "ruff-lsp";
+  version = "0.0.18";
+
+  disabled = pythonOlder "3.7";
+
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "ruff_lsp";
+    sha256 = "sha256-GNOrEQcErJnFb7vESOB0eXmQYp1PCRPJF75YKRawLIc=";
+  };
+
+  propagatedBuildInputs = [ hatchling pygls ruff typing-extensions ];
+
+  meta = with lib; {
+    description = "A Language Server Protocol implementation for Ruff";
+    homepage = "https://github.com/charliermarsh/ruff-lsp";
+    changelog = "https://github.com/charliermarsh/ruff-lsp/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ruby0b ];
+  };
+}

--- a/pkgs/development/python-modules/ruff/default.nix
+++ b/pkgs/development/python-modules/ruff/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, rustPlatform
+, stdenv
+, darwin
+, fetchFromGitHub
+, installShellFiles
+}:
+
+buildPythonPackage rec {
+  pname = "ruff";
+  version = "0.0.244";
+
+  disabled = pythonOlder "3.7";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "charliermarsh";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-oQBNVs7hoiXNqz5lYq5YNKHfpQ/c8LZAvNvtFqpTM2E=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-61kypAXWfUZLfTbSp+b0gCKwuWtxAYVtKIwfVOcJ2o8=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+    rust.cargo
+    rust.rustc
+  ]);
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.CoreServices
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd ruff \
+      --bash <($out/bin/ruff generate-shell-completion bash) \
+      --fish <($out/bin/ruff generate-shell-completion fish) \
+      --zsh <($out/bin/ruff generate-shell-completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "Python library wrapping ruff, an extremely fast Python linter";
+    homepage = "https://github.com/charliermarsh/ruff";
+    changelog = "https://github.com/charliermarsh/ruff/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ruby0b ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38049,6 +38049,8 @@ with pkgs;
 
   ruff = callPackage ../development/tools/ruff { };
 
+  ruff-lsp = with python3Packages; toPythonApplication ruff-lsp;
+
   sam-ba = callPackage ../tools/misc/sam-ba { };
 
   sndio = callPackage ../misc/sndio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10237,6 +10237,8 @@ self: super: with self; {
 
   ruff = callPackage ../development/python-modules/ruff { };
 
+  ruff-lsp = callPackage ../development/python-modules/ruff-lsp { };
+
   ruffus = callPackage ../development/python-modules/ruffus { };
 
   runway-python = callPackage ../development/python-modules/runway-python { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10235,6 +10235,8 @@ self: super: with self; {
 
   rubymarshal = callPackage ../development/python-modules/rubymarshal { };
 
+  ruff = callPackage ../development/python-modules/ruff { };
+
   ruffus = callPackage ../development/python-modules/ruffus { };
 
   runway-python = callPackage ../development/python-modules/runway-python { };


### PR DESCRIPTION
###### Description of changes
A Language Server Protocol implementation for Ruff: https://github.com/charliermarsh/ruff-lsp

I had to package the ruff python "library" (useless python package building the actual rust program using maturin) as well even though ruff itself is [already in nixpkgs](https://github.com/NixOS/nixpkgs/blob/2abea38e0824edd57a3dcfe02f84e09a3a3734c5/pkgs/development/tools/ruff/default.nix).
This is because ruff-lsp [depends on the python package of ruff](https://github.com/charliermarsh/ruff-lsp/blob/7ae1a6ebde33453214481e8af2554afbd087bba6/pyproject.toml#L38) to ensure that the rust binary is installed when using pip.

This means that the ruff repo/cargo package is now referenced in 2 separate packages, [ruff](https://github.com/NixOS/nixpkgs/blob/2abea38e0824edd57a3dcfe02f84e09a3a3734c5/pkgs/development/tools/ruff/default.nix#L10-L20) and [pythonPackages.ruff](https://github.com/ruby0b/nixpkgs/blob/000babf8839c07aecd191ddaed2edf8755481538/pkgs/development/python-modules/ruff/default.nix#L26-L30).
I am unsure if this is a problem.
If it is then it would of course be possible to define ruff as `ruff = with python3Packages; toPythonApplication ruff;` since the binary should be the same anyway (except that the pythonPackages one is [stripped](https://github.com/charliermarsh/ruff/blob/5c987874c48e6ed5d0ef7f9a09c4cb1940bd4018/pyproject.toml#L48)).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
