### PR TITLE
supercollider,supercolliderPlugins.sc3-plugins: add updateScript and enable strictDeps

### DIFF
--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -2,8 +2,8 @@
 , pkg-config, alsa-lib, libjack2, libsndfile, fftw
 , curl, gcc, libXt, qtbase, qttools, qtwebengine
 , readline, qtwebsockets, useSCEL ? false, emacs
-, supercollider-with-plugins, supercolliderPlugins
-, writeText, runCommand
+, gitUpdater, supercollider-with-plugins
+, supercolliderPlugins, writeText, runCommand
 }:
 
 mkDerivation rec {
@@ -26,6 +26,8 @@ mkDerivation rec {
     })
   ];
 
+  strictDeps = true;
+
   nativeBuildInputs = [ cmake pkg-config qttools ];
 
   buildInputs = [ gcc libjack2 libsndfile fftw curl libXt qtbase qtwebengine qtwebsockets readline ]
@@ -39,24 +41,32 @@ mkDerivation rec {
     "-DSC_EL=${if useSCEL then "ON" else "OFF"}"
   ];
 
-  passthru.tests = {
-    # test to make sure sclang runs and included plugins are successfully found
-    sclang-sc3-plugins = let
-      supercollider-with-test-plugins = supercollider-with-plugins.override {
-        plugins = with supercolliderPlugins; [ sc3-plugins ];
-      };
-      testsc = writeText "test.sc" ''
-        var err = 0;
-        try {
-        MdaPiano.name.postln;
-        } {
-        err = 1;
+  passthru = {
+    updateScript = gitUpdater {
+      url = "https://github.com/supercollider/supercollider.git";
+      rev-prefix = "Version-";
+      ignoredVersions = "rc|beta";
+    };
+
+    tests = {
+      # test to make sure sclang runs and included plugins are successfully found
+      sclang-sc3-plugins = let
+        supercollider-with-test-plugins = supercollider-with-plugins.override {
+          plugins = with supercolliderPlugins; [ sc3-plugins ];
         };
-        err.exit;
+        testsc = writeText "test.sc" ''
+          var err = 0;
+          try {
+          MdaPiano.name.postln;
+          } {
+          err = 1;
+          };
+          err.exit;
+        '';
+      in runCommand "sclang-sc3-plugins-test" { } ''
+        timeout 60s env XDG_CONFIG_HOME="$(mktemp -d)" QT_QPA_PLATFORM=minimal ${supercollider-with-test-plugins}/bin/sclang ${testsc} >$out
       '';
-    in runCommand "sclang-sc3-plugins-test" {} ''
-      timeout 60s env XDG_CONFIG_HOME="$(mktemp -d)" QT_QPA_PLATFORM=minimal ${supercollider-with-test-plugins}/bin/sclang ${testsc} >$out
-    '';
+    };
   };
 
   meta = with lib; {

--- a/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
+++ b/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, cmake, supercollider, fftw }:
+{ stdenv, lib, fetchurl, cmake, supercollider, fftw, gitUpdater }:
 
 stdenv.mkDerivation rec {
   pname = "sc3-plugins";
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     url = "https://github.com/supercollider/sc3-plugins/releases/download/Version-${version}/sc3-plugins-${version}-Source.tar.bz2";
     sha256 = "sha256-JjUmu7PJ+x3yRibr+Av2gTREng51fPo7Rk+B4y2JvkQ=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [ cmake ];
 
@@ -22,6 +24,12 @@ stdenv.mkDerivation rec {
   ];
 
   stripDebugList = [ "lib" "share" ];
+
+  passthru.updateScript = gitUpdater {
+    url = "https://github.com/supercollider/sc3-plugins.git";
+    rev-prefix = "Version-";
+    ignoredVersions = "rc|beta";
+  };
 
   meta = with lib; {
     description = "Community plugins for SuperCollider";


### PR DESCRIPTION
###### Description of changes

Performed misc cleaning of my SuperCollider packages, to ensure they build with strictDeps and to have an automatic git update script

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>8 packages built:</summary>
  <ul>
    <li>foxdot (python310Packages.foxdot)</li>
    <li>python311Packages.foxdot</li>
    <li>sonic-pi</li>
    <li>supercollider</li>
    <li>supercollider-with-plugins</li>
    <li>supercollider-with-sc3-plugins</li>
    <li>supercolliderPlugins.sc3-plugins</li>
    <li>supercollider_scel</li>
  </ul>
</details>