### PR TITLE
touchosc: make updateScript more readable and robust, 1.1.6.150 → 1.1.9.163

### DIFF
--- a/pkgs/applications/audio/touchosc/default.nix
+++ b/pkgs/applications/audio/touchosc/default.nix
@@ -45,7 +45,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "touchosc";
-  version = "1.1.6.150";
+  version = "1.1.9.163";
 
   suffix = {
     aarch64-linux = "linux-arm64";
@@ -56,9 +56,9 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "https://hexler.net/pub/${pname}/${pname}-${version}-${suffix}.deb";
     hash = {
-      aarch64-linux = "sha256-sYkAFyXnmzgSzo68OF0oiv8tUvY+g1WCcY783OZO+RM=";
-      armv7l-linux  = "sha256-GWpYW1262plxIzPVzBEh4Z3fQIhSmy0N9xAgwnjXrQE=";
-      x86_64-linux  = "sha256-LUWlLEsTUqVoWAkjXC/zOziPqO85H8iIlwJU7eqLRcY=";
+      aarch64-linux = "sha256-LhF0pgMRbEXeLt5g56VBNuCssaTjsczx/+C76ckmGZo=";
+      armv7l-linux  = "sha256-T4AzXIbhO6fNN8xDFwz6M2lSH6hLgNjVyDsSt8m+Mr4=";
+      x86_64-linux  = "sha256-LJ36kHx8PPzfLpJMx1ANSmifS84saCQ8pF0quhgzdt0=";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
 

--- a/pkgs/applications/audio/touchosc/update.sh
+++ b/pkgs/applications/audio/touchosc/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p nix curl libxml2 jq common-updater-scripts
+#!nix-shell -i bash -p nix curl libxml2 jq
 
 set -euo pipefail
 
@@ -7,6 +7,20 @@ nixpkgs="$(git rev-parse --show-toplevel || (printf 'Could not find root of nixp
 
 attr="${UPDATE_NIX_ATTR_PATH:-touchosc}"
 version="$(curl -sSL https://hexler.net/touchosc/appcast/linux | xmllint --xpath '/rss/channel/item/enclosure/@*[local-name()="version"]' - | cut -d= -f2- | tr -d '"' | head -n1)"
+
+narhash() {
+    nix --extra-experimental-features nix-command store prefetch-file --json "$url" | jq -r .hash
+}
+
+nixeval() {
+    if [ "$#" -ge 2 ]; then
+        systemargs=(--argstr system "$2")
+    else
+        systemargs=()
+    fi
+
+    nix --extra-experimental-features nix-command eval --json --impure "${systemargs[@]}" -f "$nixpkgs" "$1" | jq -r .
+}
 
 findpath() {
     path="$(nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1.meta.position" | jq -r . | cut -d: -f1)"
@@ -19,15 +33,22 @@ findpath() {
     echo "$path"
 }
 
+oldversion="${UPDATE_NIX_OLD_VERSION:-$(nixeval "$attr".version)}"
+
 pkgpath="$(findpath "$attr")"
 
-sed -i -e "/version\s*=/ s|\"$UPDATE_NIX_OLD_VERSION\"|\"$version\"|" "$pkgpath"
+if [ "$version" = "$oldversion" ]; then
+    echo 'update.sh: New version same as old version, nothing to do.'
+    exit 0
+fi
+
+sed -i -e "/version\s*=/ s|\"$oldversion\"|\"$version\"|" "$pkgpath"
 
 for system in aarch64-linux armv7l-linux x86_64-linux; do
-    url="$(nix --extra-experimental-features nix-command eval --json --impure --argstr system "$system" -f "$nixpkgs" "$attr".src.url | jq -r .)"
+    url="$(nixeval "$attr".src.url "$system")"
 
-    curhash="$(nix --extra-experimental-features nix-command eval --json --impure --argstr system "$system" -f "$nixpkgs" "$attr".src.outputHash | jq -r .)"
-    newhash="$(nix --extra-experimental-features nix-command store prefetch-file --json "$url" | jq -r .hash)"
+    curhash="$(nixeval "$attr".src.outputHash "$system")"
+    newhash="$(narhash "$url")"
 
     sed -i -e "s|\"$curhash\"|\"$newhash\"|" "$pkgpath"
 done


### PR DESCRIPTION
###### Description of changes

Performed misc cleaning on an `updateScript` for one of my packages

Changes:
* factor out different system attrs for `nixeval` function
* factor out `narhash` function
* avoid doing work if version has not actually changed
* better support running script directly instead of via `maintainers/scripts/update.nix`

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).