### PR TITLE
kodelife: add updateScript

### DIFF
--- a/pkgs/applications/graphics/kodelife/default.nix
+++ b/pkgs/applications/graphics/kodelife/default.nix
@@ -95,6 +95,8 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     homepage = "https://hexler.net/kodelife";
     description = "Real-time GPU shader editor";

--- a/pkgs/applications/graphics/kodelife/update.sh
+++ b/pkgs/applications/graphics/kodelife/update.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix curl libxml2 jq
+
+set -euo pipefail
+
+nixpkgs="$(git rev-parse --show-toplevel || (printf 'Could not find root of nixpkgs repo\nAre we running from within the nixpkgs git repo?\n' >&2; exit 1))"
+
+attr="${UPDATE_NIX_ATTR_PATH:-kodelife}"
+version="$(curl -sSL https://hexler.net/kodelife/appcast/linux | xmllint --xpath '/rss/channel/item/enclosure/@*[local-name()="version"]' - | cut -d= -f2- | tr -d '"' | head -n1)"
+
+narhash() {
+    nix --extra-experimental-features nix-command store prefetch-file --json "$url" | jq -r .hash
+}
+
+nixeval() {
+    if [ "$#" -ge 2 ]; then
+        systemargs=(--argstr system "$2")
+    else
+        systemargs=()
+    fi
+
+    nix --extra-experimental-features nix-command eval --json --impure "${systemargs[@]}" -f "$nixpkgs" "$1" | jq -r .
+}
+
+findpath() {
+    path="$(nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1.meta.position" | jq -r . | cut -d: -f1)"
+    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "builtins.fetchGit \"$nixpkgs\"")"
+
+    if [ -n "$outpath" ]; then
+        path="${path/$(echo "$outpath" | jq -r .)/$nixpkgs}"
+    fi
+
+    echo "$path"
+}
+
+oldversion="${UPDATE_NIX_OLD_VERSION:-$(nixeval "$attr".version)}"
+
+pkgpath="$(findpath "$attr")"
+
+if [ "$version" = "$oldversion" ]; then
+    echo 'update.sh: New version same as old version, nothing to do.'
+    exit 0
+fi
+
+sed -i -e "/version\s*=/ s|\"$oldversion\"|\"$version\"|" "$pkgpath"
+
+for system in aarch64-linux armv7l-linux x86_64-linux; do
+    url="$(nixeval "$attr".src.url "$system")"
+
+    curhash="$(nixeval "$attr".src.outputHash "$system")"
+    newhash="$(narhash "$url")"
+
+    sed -i -e "s|\"$curhash\"|\"$newhash\"|" "$pkgpath"
+done


### PR DESCRIPTION
###### Description of changes

Added a custom `updateScript` to one of my packages. This mostly matches the updated script for touchosc (in PR #216850) since they are packaged similary and come from the same website

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).