### PR TITLE
nflz: init at 1.0.2

### DIFF
--- a/pkgs/misc/nflz/default.nix
+++ b/pkgs/misc/nflz/default.nix
@@ -1,0 +1,34 @@
+{ fetchCrate
+, lib
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nflz";
+  version = "1.0.2";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-c9+79zrIU/M1Rh+DiaLJzbrNSa4IKrYk1gP0dsabUiw=";
+  };
+
+  cargoHash = "sha256-+SOoZFVJ6mASRKufQE4JmHGKR5rbBgg1PmCrI6dvvko=";
+
+  # Tests do not work in the package published on crates.io, since the folder
+  # with test resources is not packaged.
+  doCheck = false;
+
+  meta = {
+    description = "Numbered Files Leading Zeros helps you to manage ascending numbered file names";
+    longDescription = ''
+      CLI to add leading zeros to ascending numbered file names.
+      NFLZ stands for Numbered Files Leading Zeros.
+
+      This library helps you to manage files inside your file system that
+      belong to a set of ordered files. An example are photos from a camera.
+    '';
+    homepage = "https://github.com/phip1611/nflz";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ phip1611 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10110,6 +10110,8 @@ with pkgs;
 
   nfs-ganesha = callPackage ../servers/nfs-ganesha { };
 
+  nflz = callPackage ../misc/nflz { };
+
   ngrep = callPackage ../tools/networking/ngrep { };
 
   ngrok = callPackage ../tools/networking/ngrok { };


### PR DESCRIPTION
###### Description of changes

This adds <https://crates.io/crates/nflz> to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
