### PR TITLE
txt2tags: unstable-2022-10-17 -> 3.8

### DIFF
--- a/pkgs/tools/text/txt2tags/default.nix
+++ b/pkgs/tools/text/txt2tags/default.nix
@@ -6,15 +6,15 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "txt2tags";
-  version = "unstable-2022-10-17";
+  version = "3.8";
 
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "txt2tags";
     repo = "txt2tags";
-    rev = "114ab24ea9111060df136bfc1c8b1a35a59fe0f2";
-    hash = "sha256-h2OtlUMzEHKyJ9AIO1Uo9Lx7jMYZNMtC6U+usBu7gNU=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-urLsA2oeQM0WcKNDgaxKJOgBPGohJT6Zq6y6bEYMTxk=";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes
Diff: https://github.com/txt2tags/txt2tags/compare/114ab24...3.8

Changelog: https://github.com/txt2tags/txt2tags/blob/refs/tags/3.8/CHANGELOG.md


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
