### PR TITLE
monocraft: 1.4 -> 2.4

### DIFF
--- a/pkgs/data/fonts/monocraft/default.nix
+++ b/pkgs/data/fonts/monocraft/default.nix
@@ -1,15 +1,25 @@
-{ stdenv, lib, fetchFromGitHub }:
+{ stdenv, lib, fetchurl }:
 
-stdenv.mkDerivation rec {
-  pname = "monocraft";
-  version = "1.4";
-
-  src = fetchFromGitHub {
-    owner = "IdreesInc";
-    repo = "Monocraft";
-    rev = "v${version}";
-    sha256 = "sha256-YF0uPCc+dajJtG6mh/JpoSr6GirAhif5L5sp6hFmKLE=";
+let
+  version = "2.4";
+  relArtifact = name: hash: fetchurl {
+    inherit name hash;
+    url = "https://github.com/IdreesInc/Monocraft/releases/download/v${version}/${name}";
   };
+in
+stdenv.mkDerivation {
+  pname = "monocraft";
+  inherit version;
+
+  srcs = [
+    (relArtifact "Monocraft.otf" "sha256-PA1W+gOUStGw7cDmtEbG+B6M+sAYr8cft+Ckxj5LciU=")
+    (relArtifact "Monocraft.ttf" "sha256-S4j5v2bTJbhujT3Bt8daNN1YGYYP8zVPf9XXjuR64+o=")
+    (relArtifact "Monocraft-no-ligatures.ttf" "sha256-MuHfoP+dsXe+ODN4vWFIj50jwOxYyIiS0dd1tzVxHts=")
+    (relArtifact "Monocraft-nerd-fonts-patched.ttf" "sha256-QxMp8UwcRjWySNHWoNeX2sX9teZ4+tCFj+DG41azsXw=")
+  ];
+
+  sourceRoot = ".";
+  unpackCmd = ''cp "$curSrc" $(basename $curSrc)'';
 
   dontConfigure = true;
   dontBuild = true;
@@ -17,6 +27,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
     install -Dm644 -t $out/share/fonts/opentype *.otf
+    install -Dm644 -t $out/share/fonts/truetype *.ttf
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Description of changes

https://github.com/IdreesInc/Monocraft/compare/v1.4...v2.4

The biggest change seems to be that Monocraft can be built from source now(?), and there is also TrueType version now. But I tried to not change things too much, so this still uses the release artifacts. It might be worth looking into in the future though, because having a bunch of separate `srcs` is a pain to deal with.

I was also unsure about including the no ligatures/nerd fonts versions (because, more `srcs` to deal with), but I figured it was probably best to include them for now. If there's a way to make updating/overriding packages with lots of `srcs` easier, please let me know!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
