### PR TITLE
grafana-dash-n-grab: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15983,6 +15983,12 @@
     github = "wr0belj";
     githubId = 40501814;
   };
+  wraithm = {
+    name = "Matthew Wraith";
+    email = "wraithm@gmail.com";
+    github = "wraithm";
+    githubId = 1512913;
+  };
   wrmilling = {
     name = "Winston R. Milling";
     email = "Winston@Milli.ng";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -81,6 +81,7 @@ with lib.maintainers; {
     # Verify additions to this team with at least one already existing member of the team.
     members = [
       cdepillabout
+      wraithm
     ];
     scope = "Group registration for packages maintained by Bitnomial.";
     shortName = "Bitnomial employees";

--- a/pkgs/servers/monitoring/grafana-dash-n-grab/default.nix
+++ b/pkgs/servers/monitoring/grafana-dash-n-grab/default.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
     description = "Grafana Dash-n-Grab (gdg) -- backup and restore Grafana dashboards, datasources, and other entities";
     license = licenses.bsd3;
     homepage = "https://github.com/esnet/gdg";
-    maintainers = with maintainers; [ wraithm ] ++ teams.bitnomial.members;
+    maintainers = with maintainers; teams.bitnomial.members;
     platforms = platforms.unix;
     mainProgram = "gdg";
     changelog =

--- a/pkgs/servers/monitoring/grafana-dash-n-grab/default.nix
+++ b/pkgs/servers/monitoring/grafana-dash-n-grab/default.nix
@@ -1,0 +1,37 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "grafana-dash-n-grab";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "esnet";
+    repo = "gdg";
+    sha256 = "sha256-M4V4ybOizXCLxTTuS17M0y2tRmjQmTIBdXVbumzOoeA=";
+  };
+
+  vendorSha256 = "sha256-pXo80Tean5OkQ0Sv2+/RlRnAtaClwGP7tuDC2irsh+E=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${version}"
+    "-X github.com/esnet/gdg/version.GitCommit=${src.rev}"
+  ];
+
+  # The test suite tries to communicate with a running version of grafana locally. This fails if
+  # you don't have grafana running.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Grafana Dash-n-Grab (gdg) -- backup and restore Grafana dashboards, datasources, and other entities";
+    license = licenses.bsd3;
+    homepage = "https://github.com/esnet/gdg";
+    maintainers = with maintainers; [ wraithm ] ++ teams.bitnomial.members;
+    platforms = platforms.unix;
+    mainProgram = "gdg";
+    changelog =
+      "https://github.com/esnet/gdg/releases/tag/v${version}";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24485,6 +24485,8 @@ with pkgs;
 
   grafana-image-renderer = callPackage ../servers/monitoring/grafana-image-renderer { };
 
+  grafana-dash-n-grab = callPackage ../servers/monitoring/grafana-dash-n-grab { };
+
   gerbera = callPackage ../servers/gerbera {};
 
   gobetween = callPackage ../servers/gobetween { };


### PR DESCRIPTION
###### Description of changes

New package grafana-dash-n-grab (bin: gdg) 0.3.1

Homepage: https://github.com/esnet/gdg

Grafana Dash-n-Grab (GDG) -- Dashboard/DataSource Manager. The purpose of this project is to provide an easy to use CLI to interact with the grafana API allowing you to backup and restore dashboard, datasources, and other entities.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
