### PR TITLE
starsector: fix the icon symlink

### DIFF
--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchzip
-, libXxf86vm
 , libGL
 , makeWrapper
 , openal
@@ -48,7 +47,8 @@ stdenv.mkDerivation rec {
     cp -r ./* $out/share/starsector
 
     mkdir -p $out/share/icons/hicolor/64x64/apps
-    ln -s $out/graphics/ui/s_icon64.png $out/share/icons/hicolor/64x64/apps/starsector.png
+    ln -s $out/share/starsector/graphics/ui/s_icon64.png \
+      $out/share/icons/hicolor/64x64/apps/starsector.png
 
     wrapProgram $out/share/starsector/starsector.sh \
       --prefix PATH : ${lib.makeBinPath [ openjdk xorg.xrandr ]} \
@@ -71,14 +71,6 @@ stdenv.mkDerivation rec {
       --replace "-XX:+CompilerThreadHintNoPreempt" "-XX:+UnlockDiagnosticVMOptions -XX:-BytecodeVerificationRemote -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSConcurrentMTEnabled -XX:+DisableExplicitGC"
   '';
 
-  meta = with lib; {
-    description = "Open-world single-player space-combat, roleplaying, exploration, and economic game";
-    homepage = "https://fractalsoftworks.com";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.unfree;
-    maintainers = with maintainers; [ bbigras rafaelrc ];
-  };
-
   passthru.updateScript = writeScript "starsector-update-script" ''
     #!/usr/bin/env nix-shell
     #!nix-shell -i bash -p curl gnugrep common-updater-scripts
@@ -86,4 +78,12 @@ stdenv.mkDerivation rec {
     version=$(curl -s https://fractalsoftworks.com/preorder/ | grep -oP "https://f005.backblazeb2.com/file/fractalsoftworks/release/starsector_linux-\K.*?(?=\.zip)" | head -1)
     update-source-version ${pname} "$version" --file=./pkgs/games/starsector/default.nix
   '';
+
+  meta = with lib; {
+    description = "Open-world single-player space-combat, roleplaying, exploration, and economic game";
+    homepage = "https://fractalsoftworks.com";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ bbigras rafaelrc ];
+  };
 }


### PR DESCRIPTION
###### Description of changes
#202808 forgot to update the icon symlink so it's broken and the icon is absent from menus and whatnot

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
