### PR TITLE
damask: init at 0.1.3

### DIFF
--- a/pkgs/applications/graphics/damask/default.nix
+++ b/pkgs/applications/graphics/damask/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, nix-update-script
+, blueprint-compiler
+, desktop-file-utils
+, gettext
+, gtk4
+, json-glib
+, libadwaita
+, libgee
+, libportal
+, libportal-gtk4
+, libsoup_3
+, meson
+, ninja
+, pkg-config
+, vala
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "damask";
+  version = "0.1.3";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "subpop";
+    repo = "damask";
+    rev = "v${version}";
+    sha256 = "sha256-CKt4CBwOjryXzvKdak/yWnT1OUZtDr8DugU6I1gXGzA";
+  };
+
+  nativeBuildInputs = [
+    blueprint-compiler
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gettext
+    gtk4
+    json-glib
+    libadwaita
+    libgee
+    libportal
+    libportal-gtk4
+    libsoup_3
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = with lib; {
+    description = "Automatically set wallpaper images from Internet sources";
+    homepage = "https://gitlab.gnome.org/subpop/damask";
+    maintainers = with maintainers; [ samdroid-apps ];
+    platforms = platforms.linux;
+    license = licenses.gpl3Plus;
+    mainProgram = "damask";
+  };
+}


### PR DESCRIPTION
###### Description of changes

Adds [Damask](https://gitlab.gnome.org/subpop/damask), a GNOME app to change your wallpaper to the wallpaper of the day from Bing or various other online sources.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).