### PR TITLE
Lattice Diamond packaging improvements

### DIFF
--- a/pkgs/development/embedded/fpga/lattice-diamond/default.nix
+++ b/pkgs/development/embedded/fpga/lattice-diamond/default.nix
@@ -79,7 +79,8 @@ stdenv.mkDerivation {
             # dependencies from nix.
             patchelf \
                 --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-                --set-rpath "$libPath" --force-rpath \
+                --set-rpath "$libPath:$out/$prefix/bin/lin64:$out/$prefix/ispfpga/bin/lin64" \
+                --force-rpath \
                 $f
         done
     done

--- a/pkgs/development/embedded/fpga/lattice-diamond/default.nix
+++ b/pkgs/development/embedded/fpga/lattice-diamond/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation {
     done
 
     # Patch executable ELFs.
-    for path in bin/lin64 ispfpga/bin/lin64; do
+    for path in bin/lin64 ispfpga/bin/lin64 synpbase/linux_a_64 synpbase/linux_a_64/mbin; do
         cd $out/$prefix/$path
         for f in *; do
             if ! file $f | grep -q "ELF 64-bit LSB executable" ; then

--- a/pkgs/development/embedded/fpga/lattice-diamond/default.nix
+++ b/pkgs/development/embedded/fpga/lattice-diamond/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, rpmextract, patchelf, makeWrapper, file, requireFile, glib, zlib,
-    freetype, fontconfig, xorg, libusb-compat-0_1 }:
+    freetype, fontconfig, xorg, libusb-compat-0_1, coreutils }:
 
 stdenv.mkDerivation {
   pname = "diamond";
@@ -84,6 +84,9 @@ stdenv.mkDerivation {
                 $f
         done
     done
+
+    # Patch absolute /usr/bin/id path in script
+    sed -i -e "s#/usr/bin/id#${coreutils}/bin/id#" $out/$prefix/synpbase/bin/config/platform_set
 
     # Remove 32-bit libz.
     rm $out/$prefix/bin/lin64/libz.{so,so.1}

--- a/pkgs/development/embedded/fpga/lattice-diamond/default.nix
+++ b/pkgs/development/embedded/fpga/lattice-diamond/default.nix
@@ -87,11 +87,10 @@ stdenv.mkDerivation {
     # Remove 32-bit libz.
     rm $out/$prefix/bin/lin64/libz.{so,so.1}
 
-    # Make wrappers (should these target more than the 'diamond' tool?).
-    # The purpose of these is just to call the target program using its
-    # absolute path - otherwise, it will crash.
+    # Make wrappers. The purpose of these is just to call the target program
+    # using its absolute path - otherwise, it will crash.
     mkdir -p bin
-    for tool in diamond ; do
+    for tool in diamond pnmainc ddtcmd ; do
         makeWrapper $out/$prefix/bin/lin64/$tool $out/bin/$tool
     done
   '';


### PR DESCRIPTION
###### Description of changes

This set of patches makes it possible to run [Amaranth](https://github.com/amaranth-lang/amaranth)-generated builds for Lattice MachXO2 and MachXO3L FPGAs with Lattice Diamond installed via nixpkgs.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux — not applicable
  - [ ] x86_64-darwin — not applicable
  - [ ] aarch64-darwin — not applicable
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
