### PR TITLE
cvc4: Fix build failure from new bash 5.2 feature

### DIFF
--- a/pkgs/applications/science/logic/cvc4/cvc4-bash-patsub-replacement.patch
+++ b/pkgs/applications/science/logic/cvc4/cvc4-bash-patsub-replacement.patch
@@ -1,0 +1,39 @@
+Per https://bodhi.fedoraproject.org/updates/FEDORA-2022-dc47174c36:
+
+This update fixes a failure to build with source with bash 5.2. Bash's
+`patsub_replacement` feature makes ampersand a special character when doing
+variable substitution, which was not previously the case. This update instructs
+bash to turn off the new behavior.
+
+The patch itself is adapted from
+https://src.fedoraproject.org/rpms/cvc4/blob/f7c24c6ad72a8812d244313f13032fa23d393315/f/cvc4-bash-patsub-replacement.patch.
+--- a/src/expr/mkexpr	2020-06-19 10:59:27.000000000 -0600
++++ b/src/expr/mkexpr	2022-10-11 14:28:31.120453409 -0600
+@@ -16,6 +16,7 @@
+ #
+ 
+ copyright=2010-2014
++shopt -u patsub_replacement
+ 
+ filename=`basename "$1" | sed 's,_template,,'`
+ 
+--- a/src/expr/mkkind	2020-06-19 10:59:27.000000000 -0600
++++ b/src/expr/mkkind	2022-10-11 14:34:17.008996126 -0600
+@@ -15,6 +15,7 @@
+ #
+ 
+ copyright=2010-2014
++shopt -u patsub_replacement
+ 
+ filename=`basename "$1" | sed 's,_template,,'`
+ 
+--- a/src/expr/mkmetakind	2020-06-19 10:59:27.000000000 -0600
++++ b/src/expr/mkmetakind	2022-10-11 14:34:32.248020036 -0600
+@@ -18,6 +18,7 @@
+ #
+ 
+ copyright=2010-2014
++shopt -u patsub_replacement
+ 
+ cat <<EOF
+ /*********************                                                        */

--- a/pkgs/applications/science/logic/cvc4/default.nix
+++ b/pkgs/applications/science/logic/cvc4/default.nix
@@ -28,6 +28,10 @@ stdenv.mkDerivation rec {
     patch -p1 -i ${./minisat-fenv.patch} -d src/prop/bvminisat
   '';
 
+  patches = [
+    ./cvc4-bash-patsub-replacement.patch
+  ];
+
   preConfigure = ''
     patchShebangs ./src/
   '';


### PR DESCRIPTION
Per https://bodhi.fedoraproject.org/updates/FEDORA-2022-dc47174c36:

>   This update fixes a failure to build with source with bash 5.2.
>   Bash's `patsub_replacement` feature makes ampersand a special
>   character when doing variable substitution, which was not previously
>   the case. This update instructs bash to turn off the new behavior.

We exclude the unrelated change in that Fedora update (i.e. using Python 3.11's `tomllib` instead of the PyPI `toml` package) since:

- we package cvc4 with Python versions earlier than 3.11; and
- since cvc4 is no longer being updated, sticking with the PyPI `toml` package causes no extra work in the future.

###### Description of changes

See above.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
