### PR TITLE
ocamlPackages.mirage-xen: 7.2.0 → 8.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-bootvar-xen/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-bootvar-xen/default.nix
@@ -10,13 +10,13 @@ buildDunePackage rec {
   pname = "mirage-bootvar-xen";
   version = "0.8.0";
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-bootvar-xen/releases/download/v${version}/mirage-bootvar-xen-v${version}.tbz";
-    sha256 = "0nk80giq9ng3svbnm68fjby2f1dnarddm3lk7mw7w59av71q0rcv";
+    hash = "sha256:0nk80giq9ng3svbnm68fjby2f1dnarddm3lk7mw7w59av71q0rcv";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/mirage-xen/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-xen/default.nix
@@ -17,14 +17,15 @@
 
 buildDunePackage rec {
   pname = "mirage-xen";
-  version = "7.2.0";
+  version = "8.0.1";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-xen/releases/download/v${version}/mirage-xen-${version}.tbz";
-    sha256 = "sha256-5ZdzourQshHGtYPPdJtJLpH8P6ZLNbjQWy7TDxcY3OA=";
+    hash = "sha256-x8i2Kbz0EcifZK/lbDIFa9Kwtl1/xzbYV9h9E+EtGP4=";
   };
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     cstruct


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/mirage-xen/blob/v8.0.1/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
