### PR TITLE
mfoc-hardnested: init at unstable-2021-08-14

### DIFF
--- a/pkgs/tools/security/mfoc-hardnested/default.nix
+++ b/pkgs/tools/security/mfoc-hardnested/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, libnfc, xz }:
+
+stdenv.mkDerivation rec {
+  pname = "mfoc-hardnested";
+  version = "unstable-2021-08-14";
+
+  src = fetchFromGitHub {
+    owner = "nfc-tools";
+    repo = pname;
+    rev = "2c25bf05a0b13827b9d06382c5d384b2e5c88238";
+    hash = "sha256-fhfevQCw0E5TorHx61Vltpmv7DAjgH73i27O7aBKxz4=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ libnfc xz ];
+
+  meta = with lib; {
+    description = "A fork of mfoc integrating hardnested code from the proxmark";
+    license = licenses.gpl2;
+    homepage = "https://github.com/nfc-tools/mfoc-hardnested";
+    maintainers = with maintainers; [ azuwis ];
+    platforms = platforms.unix;
+    broken = (stdenv.isDarwin && stdenv.isAarch64); # Undefined symbols "_memalign" referenced
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9762,6 +9762,8 @@ with pkgs;
 
   mfoc = callPackage ../tools/security/mfoc { };
 
+  mfoc-hardnested = callPackage ../tools/security/mfoc-hardnested { };
+
   microbin = callPackage ../servers/microbin { };
 
   microdnf = callPackage ../tools/package-management/microdnf { };


### PR DESCRIPTION
###### Description of changes

A fork of mfoc integrating hardnested code from the proxmark https://github.com/nfc-tools/mfoc-hardnested

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
