### PR TITLE
thrift: 0.17.0 -> 0.18.0

### DIFF
--- a/pkgs/development/libraries/thrift/default.nix
+++ b/pkgs/development/libraries/thrift/default.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation rec {
   pname = "thrift";
-  version = "0.17.0";
+  version = "0.18.0";
 
   src = fetchurl {
     url = "https://archive.apache.org/dist/thrift/${version}/${pname}-${version}.tar.gz";
-    hash = "sha256-snLBeIuxZdmVIaJZmzG5f6aeWTHQmQFdka4QegsMxY8=";
+    hash = "sha256-fBk4nLeRCiDli45GkDyMGjY1MAj5/MGwP3SKzPm18+E=";
   };
 
   # Workaround to make the Python wrapper not drop this package:
@@ -74,6 +74,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/apache/thrift/commit/2ab850824f75d448f2ba14a468fb77d2594998df.diff";
       hash = "sha256-ejMKFG/cJgoPlAFzVDPI4vIIL7URqaG06/IWdQ2NkhY=";
     })
+    (fetchpatch {
+      name = "thrift-fix-tests-OpenSSL3.patch"; # https://github.com/apache/thrift/pull/2760
+      url = "https://github.com/apache/thrift/commit/eae3ac418f36c73833746bcd53e69ed8a12f0e1a.diff";
+      hash = "sha256-0jlN4fo94cfGFUKcLFQgVMI/x7uxn5OiLiFk6txVPzs=";
+    })
   ];
 
   cmakeFlags = [
@@ -90,6 +95,7 @@ stdenv.mkDerivation rec {
 
   disabledTests = [
     "PythonTestSSLSocket"
+    "PythonThriftTNonblockingServer"
   ] ++ lib.optionals stdenv.isDarwin [
     # Tests that hang up in the Darwin sandbox
     "SecurityTest"
@@ -106,7 +112,6 @@ stdenv.mkDerivation rec {
     "StressTest"
     "StressTestConcurrent"
     "StressTestNonBlocking"
-    "PythonThriftTNonblockingServer"
   ];
 
   doCheck = !static;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23517,9 +23517,7 @@ with pkgs;
 
   theft = callPackage ../development/libraries/theft { };
 
-  thrift = callPackage ../development/libraries/thrift {
-    openssl = openssl_1_1;
-  };
+  thrift = callPackage ../development/libraries/thrift { };
 
   thrift-0_10 = callPackage ../development/libraries/thrift/0.10.nix { };
 


### PR DESCRIPTION
###### Description of changes

https://github.com/apache/thrift/blob/0.18.0/CHANGES.md#0180

###### Things done

* Unpinned OpenSSLv1.1. I'd argue this was not a good idea, as many downstream libraries link against OpenSSLv3 now, which introduces a potential conflict at runtime.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
