### PR TITLE
liburing: backport portability fixes 

### DIFF
--- a/pkgs/development/libraries/liburing/0001-Add-custom-error-function-for-tests.patch
+++ b/pkgs/development/libraries/liburing/0001-Add-custom-error-function-for-tests.patch
@@ -1,0 +1,66 @@
+From d4714fd7aac9c5f499c406703bc437dc6cf72ef3 Mon Sep 17 00:00:00 2001
+From: Steffen <steffen.winter@proton.me>
+Date: Mon, 13 Feb 2023 17:32:16 +0100
+Subject: [PATCH 1/3] Add custom error function for tests.
+
+On musl systems, liburing cannot build examples and tests due to
+it's usage of error.h. t_error calls fprintf(stderr, ...) and
+exits.
+
+Closes: #786
+
+Signed-off-by: Steffen Winter <steffen.winter@proton.me>
+---
+ test/helpers.c | 18 ++++++++++++++++++
+ test/helpers.h |  2 ++
+ 2 files changed, 20 insertions(+)
+
+diff --git a/test/helpers.c b/test/helpers.c
+index 8fb32b8..caa887e 100644
+--- a/test/helpers.c
++++ b/test/helpers.c
+@@ -8,6 +8,7 @@
+ #include <stdio.h>
+ #include <fcntl.h>
+ #include <unistd.h>
++#include <stdarg.h>
+ #include <sys/types.h>
+ 
+ #include <arpa/inet.h>
+@@ -266,3 +267,20 @@ bool t_probe_defer_taskrun(void)
+ 	io_uring_queue_exit(&ring);
+ 	return true;
+ }
++
++/*
++ * Implementation of error(3), prints an error message and exits.
++ */
++void t_error(int status, int errnum, const char *format, ...)
++{
++	va_list args;
++    	va_start(args, format);
++
++	vfprintf(stderr, format, args);
++    	if (errnum)
++        	fprintf(stderr, ": %s", strerror(errnum));
++
++	fprintf(stderr, "\n");
++	va_end(args);
++    	exit(status);
++}
+diff --git a/test/helpers.h b/test/helpers.h
+index 4375a9e..33b82cf 100644
+--- a/test/helpers.h
++++ b/test/helpers.h
+@@ -87,6 +87,8 @@ bool t_probe_defer_taskrun(void);
+ 
+ #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+ 
++void t_error(int status, int errnum, const char *format, ...);
++
+ #ifdef __cplusplus
+ }
+ #endif
+-- 
+2.39.1
+

--- a/pkgs/development/libraries/liburing/0002-test-Use-t_error-instead-of-glibc-s-error.patch
+++ b/pkgs/development/libraries/liburing/0002-test-Use-t_error-instead-of-glibc-s-error.patch
@@ -1,0 +1,109 @@
+From e84f40ca872f0bce72b5686c95a11739d9c89494 Mon Sep 17 00:00:00 2001
+From: Steffen <steffen.winter@proton.me>
+Date: Mon, 13 Feb 2023 17:56:03 +0100
+Subject: [PATCH 2/3] test: Use t_error instead of glibc's error.
+
+On musl systems, liburing cannot build examples and tests due to
+it's usage of error.h. Replacing calls to error() with t_error().
+
+Closes: #786
+
+Signed-off-by: Steffen Winter <steffen.winter@proton.me>
+---
+ test/defer-taskrun.c |  1 -
+ test/send-zerocopy.c |  1 -
+ test/single-issuer.c | 15 +++++++--------
+ 3 files changed, 7 insertions(+), 10 deletions(-)
+
+diff --git a/test/defer-taskrun.c b/test/defer-taskrun.c
+index 9283f28..87cd256 100644
+--- a/test/defer-taskrun.c
++++ b/test/defer-taskrun.c
+@@ -4,7 +4,6 @@
+ #include <unistd.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <error.h>
+ #include <sys/eventfd.h>
+ #include <signal.h>
+ #include <poll.h>
+diff --git a/test/send-zerocopy.c b/test/send-zerocopy.c
+index 4db102b..be33094 100644
+--- a/test/send-zerocopy.c
++++ b/test/send-zerocopy.c
+@@ -4,7 +4,6 @@
+ #include <stdint.h>
+ #include <assert.h>
+ #include <errno.h>
+-#include <error.h>
+ #include <limits.h>
+ #include <fcntl.h>
+ #include <unistd.h>
+diff --git a/test/single-issuer.c b/test/single-issuer.c
+index 1d13f47..d71cd74 100644
+--- a/test/single-issuer.c
++++ b/test/single-issuer.c
+@@ -5,7 +5,6 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <fcntl.h>
+-#include <error.h>
+ #include <sys/types.h>
+ #include <sys/wait.h>
+ 
+@@ -56,13 +55,13 @@ static int try_submit(struct io_uring *ring)
+ 		return ret;
+ 
+ 	if (ret != 1)
+-		error(1, ret, "submit %i", ret);
++		t_error(1, ret, "submit %i", ret);
+ 	ret = io_uring_wait_cqe(ring, &cqe);
+ 	if (ret)
+-		error(1, ret, "wait fail %i", ret);
++		t_error(1, ret, "wait fail %i", ret);
+ 
+ 	if (cqe->res || cqe->user_data != 42)
+-		error(1, ret, "invalid cqe");
++		t_error(1, ret, "invalid cqe");
+ 
+ 	io_uring_cqe_seen(ring, cqe);
+ 	return 0;
+@@ -106,7 +105,7 @@ int main(int argc, char *argv[])
+ 	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER |
+ 					    IORING_SETUP_R_DISABLED);
+ 	if (ret)
+-		error(1, ret, "ring init (2) %i", ret);
++		t_error(1, ret, "ring init (2) %i", ret);
+ 
+ 	if (!fork_t()) {
+ 		io_uring_enable_rings(&ring);
+@@ -122,7 +121,7 @@ int main(int argc, char *argv[])
+ 	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER |
+ 					    IORING_SETUP_R_DISABLED);
+ 	if (ret)
+-		error(1, ret, "ring init (3) %i", ret);
++		t_error(1, ret, "ring init (3) %i", ret);
+ 
+ 	io_uring_enable_rings(&ring);
+ 	if (!fork_t()) {
+@@ -137,7 +136,7 @@ int main(int argc, char *argv[])
+ 	/* test that anyone can submit to a SQPOLL|SINGLE_ISSUER ring */
+ 	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER|IORING_SETUP_SQPOLL);
+ 	if (ret)
+-		error(1, ret, "ring init (4) %i", ret);
++		t_error(1, ret, "ring init (4) %i", ret);
+ 
+ 	ret = try_submit(&ring);
+ 	if (ret) {
+@@ -157,7 +156,7 @@ int main(int argc, char *argv[])
+ 	/* test that IORING_ENTER_REGISTERED_RING doesn't break anything */
+ 	ret = io_uring_queue_init(8, &ring, IORING_SETUP_SINGLE_ISSUER);
+ 	if (ret)
+-		error(1, ret, "ring init (5) %i", ret);
++		t_error(1, ret, "ring init (5) %i", ret);
+ 
+ 	if (!fork_t()) {
+ 		ret = try_submit(&ring);
+-- 
+2.39.1
+

--- a/pkgs/development/libraries/liburing/0003-examples-Use-t_error-instead-of-glibc-s-error.patch
+++ b/pkgs/development/libraries/liburing/0003-examples-Use-t_error-instead-of-glibc-s-error.patch
@@ -1,0 +1,226 @@
+From 23704bbd1416ed1a051b32d5d44e46dd654b8ffe Mon Sep 17 00:00:00 2001
+From: Steffen <steffen.winter@proton.me>
+Date: Mon, 13 Feb 2023 18:23:44 +0100
+Subject: [PATCH 3/3] examples: Use t_error instead of glibc's error.
+
+On musl systems, liburing cannot build examples and tests due to
+it's usage of error.h. t_error copied from test/helpers.c.
+Replacing calls to error() with t_error().
+
+Closes: #786
+
+Signed-off-by: Steffen Winter <steffen.winter@proton.me>
+---
+ examples/send-zerocopy.c | 61 +++++++++++++++++++++++++---------------
+ 1 file changed, 39 insertions(+), 22 deletions(-)
+
+diff --git a/examples/send-zerocopy.c b/examples/send-zerocopy.c
+index 7f5f2b1..6092af9 100644
+--- a/examples/send-zerocopy.c
++++ b/examples/send-zerocopy.c
+@@ -5,11 +5,11 @@
+ #include <stdint.h>
+ #include <assert.h>
+ #include <errno.h>
+-#include <error.h>
+ #include <limits.h>
+ #include <fcntl.h>
+ #include <unistd.h>
+ #include <stdbool.h>
++#include <stdarg.h>
+ #include <string.h>
+ 
+ #include <arpa/inet.h>
+@@ -57,6 +57,23 @@ static struct sockaddr_storage cfg_dst_addr;
+ 
+ static char payload[IP_MAXPACKET] __attribute__((aligned(4096)));
+ 
++/*
++ * Implementation of error(3), prints an error message and exits.
++ */
++static void t_error(int status, int errnum, const char *format, ...)
++{
++	va_list args;
++	va_start(args, format);
++
++	vfprintf(stderr, format, args);
++	if (errnum)
++		fprintf(stderr, ": %s", strerror(errnum));
++
++	fprintf(stderr, "\n");
++	va_end(args);
++	exit(status);
++}
++
+ static unsigned long gettimeofday_ms(void)
+ {
+ 	struct timeval tv;
+@@ -68,7 +85,7 @@ static unsigned long gettimeofday_ms(void)
+ static void do_setsockopt(int fd, int level, int optname, int val)
+ {
+ 	if (setsockopt(fd, level, optname, &val, sizeof(val)))
+-		error(1, errno, "setsockopt %d.%d: %d", level, optname, val);
++		t_error(1, errno, "setsockopt %d.%d: %d", level, optname, val);
+ }
+ 
+ static void setup_sockaddr(int domain, const char *str_addr,
+@@ -84,7 +101,7 @@ static void setup_sockaddr(int domain, const char *str_addr,
+ 		addr4->sin_port = htons(cfg_port);
+ 		if (str_addr &&
+ 		    inet_pton(AF_INET, str_addr, &(addr4->sin_addr)) != 1)
+-			error(1, 0, "ipv4 parse error: %s", str_addr);
++			t_error(1, 0, "ipv4 parse error: %s", str_addr);
+ 		break;
+ 	case PF_INET6:
+ 		memset(addr6, 0, sizeof(*addr6));
+@@ -92,10 +109,10 @@ static void setup_sockaddr(int domain, const char *str_addr,
+ 		addr6->sin6_port = htons(cfg_port);
+ 		if (str_addr &&
+ 		    inet_pton(AF_INET6, str_addr, &(addr6->sin6_addr)) != 1)
+-			error(1, 0, "ipv6 parse error: %s", str_addr);
++			t_error(1, 0, "ipv6 parse error: %s", str_addr);
+ 		break;
+ 	default:
+-		error(1, 0, "illegal domain");
++		t_error(1, 0, "illegal domain");
+ 	}
+ }
+ 
+@@ -105,12 +122,12 @@ static int do_setup_tx(int domain, int type, int protocol)
+ 
+ 	fd = socket(domain, type, protocol);
+ 	if (fd == -1)
+-		error(1, errno, "socket t");
++		t_error(1, errno, "socket t");
+ 
+ 	do_setsockopt(fd, SOL_SOCKET, SO_SNDBUF, 1 << 21);
+ 
+ 	if (connect(fd, (void *) &cfg_dst_addr, cfg_alen))
+-		error(1, errno, "connect");
++		t_error(1, errno, "connect");
+ 	return fd;
+ }
+ 
+@@ -125,7 +142,7 @@ static inline struct io_uring_cqe *wait_cqe_fast(struct io_uring *ring)
+ 
+ 	ret = io_uring_wait_cqe(ring, &cqe);
+ 	if (ret)
+-		error(1, ret, "wait cqe");
++		t_error(1, ret, "wait cqe");
+ 	return cqe;
+ }
+ 
+@@ -143,17 +160,17 @@ static void do_tx(int domain, int type, int protocol)
+ 
+ 	ret = io_uring_queue_init(512, &ring, IORING_SETUP_COOP_TASKRUN);
+ 	if (ret)
+-		error(1, ret, "io_uring: queue init");
++		t_error(1, ret, "io_uring: queue init");
+ 
+ 	if (cfg_fixed_files) {
+ 		ret = io_uring_register_files(&ring, &fd, 1);
+ 		if (ret < 0)
+-			error(1, ret, "io_uring: files registration");
++			t_error(1, ret, "io_uring: files registration");
+ 	}
+ 	if (cfg_reg_ringfd) {
+ 		ret = io_uring_register_ring_fd(&ring);
+ 		if (ret < 0)
+-			error(1, ret, "io_uring: io_uring_register_ring_fd");
++			t_error(1, ret, "io_uring: io_uring_register_ring_fd");
+ 	}
+ 
+ 	iov.iov_base = payload;
+@@ -161,7 +178,7 @@ static void do_tx(int domain, int type, int protocol)
+ 
+ 	ret = io_uring_register_buffers(&ring, &iov, 1);
+ 	if (ret)
+-		error(1, ret, "io_uring: buffer registration");
++		t_error(1, ret, "io_uring: buffer registration");
+ 
+ 	tstop = gettimeofday_ms() + cfg_runtime_ms;
+ 	do {
+@@ -193,14 +210,14 @@ static void do_tx(int domain, int type, int protocol)
+ 
+ 		ret = io_uring_submit(&ring);
+ 		if (ret != cfg_nr_reqs)
+-			error(1, ret, "submit");
++			t_error(1, ret, "submit");
+ 
+ 		for (i = 0; i < cfg_nr_reqs; i++) {
+ 			cqe = wait_cqe_fast(&ring);
+ 
+ 			if (cqe->flags & IORING_CQE_F_NOTIF) {
+ 				if (cqe->flags & IORING_CQE_F_MORE)
+-					error(1, -EINVAL, "F_MORE notif");
++					t_error(1, -EINVAL, "F_MORE notif");
+ 				compl_cqes--;
+ 				i--;
+ 				io_uring_cqe_seen(&ring, cqe);
+@@ -217,7 +234,7 @@ static void do_tx(int domain, int type, int protocol)
+ 				fprintf(stderr, "Connection failure");
+ 				goto out_fail;
+ 			} else if (cqe->res != -EAGAIN) {
+-				error(1, cqe->res, "send failed");
++				t_error(1, cqe->res, "send failed");
+ 			}
+ 			io_uring_cqe_seen(&ring, cqe);
+ 		}
+@@ -226,7 +243,7 @@ static void do_tx(int domain, int type, int protocol)
+ out_fail:
+ 	shutdown(fd, SHUT_RDWR);
+ 	if (close(fd))
+-		error(1, errno, "close");
++		t_error(1, errno, "close");
+ 
+ 	fprintf(stderr, "tx=%lu (MB=%lu), tx/s=%lu (MB/s=%lu)\n",
+ 			packets, bytes >> 20,
+@@ -254,7 +271,7 @@ static void do_test(int domain, int type, int protocol)
+ 
+ static void usage(const char *filepath)
+ {
+-	error(1, 0, "Usage: %s [-n<N>] [-z<val>] [-s<payload size>] "
++	t_error(1, 0, "Usage: %s [-n<N>] [-z<val>] [-s<payload size>] "
+ 		    "(-4|-6) [-t<time s>] -D<dst_ip> udp", filepath);
+ }
+ 
+@@ -276,13 +293,13 @@ static void parse_opts(int argc, char **argv)
+ 		switch (c) {
+ 		case '4':
+ 			if (cfg_family != PF_UNSPEC)
+-				error(1, 0, "Pass one of -4 or -6");
++				t_error(1, 0, "Pass one of -4 or -6");
+ 			cfg_family = PF_INET;
+ 			cfg_alen = sizeof(struct sockaddr_in);
+ 			break;
+ 		case '6':
+ 			if (cfg_family != PF_UNSPEC)
+-				error(1, 0, "Pass one of -4 or -6");
++				t_error(1, 0, "Pass one of -4 or -6");
+ 			cfg_family = PF_INET6;
+ 			cfg_alen = sizeof(struct sockaddr_in6);
+ 			break;
+@@ -311,9 +328,9 @@ static void parse_opts(int argc, char **argv)
+ 	}
+ 
+ 	if (cfg_nr_reqs > MAX_SUBMIT_NR)
+-		error(1, 0, "-n: submit batch nr exceeds max (%d)", MAX_SUBMIT_NR);
++		t_error(1, 0, "-n: submit batch nr exceeds max (%d)", MAX_SUBMIT_NR);
+ 	if (cfg_payload_len > max_payload_len)
+-		error(1, 0, "-s: payload exceeds max (%d)", max_payload_len);
++		t_error(1, 0, "-s: payload exceeds max (%d)", max_payload_len);
+ 
+ 	setup_sockaddr(cfg_family, daddr, &cfg_dst_addr);
+ 
+@@ -333,7 +350,7 @@ int main(int argc, char **argv)
+ 	else if (!strcmp(cfg_test, "udp"))
+ 		do_test(cfg_family, SOCK_DGRAM, 0);
+ 	else
+-		error(1, 0, "unknown cfg_test %s", cfg_test);
++		t_error(1, 0, "unknown cfg_test %s", cfg_test);
+ 
+ 	return 0;
+ }
+-- 
+2.39.1
+

--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -12,6 +12,19 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-vN6lLb5kpgHTKDxwibJPS61sdelILETVtJE2BYgp79k=";
   };
 
+  patches = [
+    # Backported portability fixes from liburing master, needed for pkgsMusl.liburing
+    ./0001-Add-custom-error-function-for-tests.patch
+    ./0002-test-Use-t_error-instead-of-glibc-s-error.patch
+    ./0003-examples-Use-t_error-instead-of-glibc-s-error.patch
+
+    # More portability fixes, in the process of being upstreamed
+    (fetchpatch {
+      url = "https://github.com/axboe/liburing/pull/798/commits/0fbcc44fe1fb2dc6807660b2cff1c2995add095b.patch";
+      hash = "sha256-xOMsw0VpYGst/+Isd2Tmq8CmBDK+uyLw3KNKPnsCSoA=";
+    })
+  ];
+
   separateDebugInfo = true;
   enableParallelBuilding = true;
   # Upstream's configure script is not autoconf generated, but a hand written one.


### PR DESCRIPTION
###### Description of changes

In #216201 liburing was updated to 2.3, which broke the pkgsMusl.liburing build. Specifically tests/example code is requiring glibc specific GNU extensions, which has since been fixed upstream.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
