### PR TITLE
etesync-dav: fix broken dependancies 

### DIFF
--- a/pkgs/applications/misc/etesync-dav/default.nix
+++ b/pkgs/applications/misc/etesync-dav/default.nix
@@ -7,6 +7,13 @@
 let
   python = python3.override {
     packageOverrides = self: super: {
+      flask = super.flask.overridePythonAttrs (old: rec {
+        version = "2.0.3";
+        src = old.src.override {
+          inherit version;
+          sha256 = "sha256-4RIMIoyi9VO0cN9KX6knq2YlhGdSYGmYGz6wqRkCaH0=";
+        };
+      });
       flask-wtf = super.flask-wtf.overridePythonAttrs (old: rec {
         version = "0.15.1";
         src = old.src.override {
@@ -16,6 +23,11 @@ let
         disabledTests = [
           "test_outside_request"
         ];
+        disabledTestPaths = [
+          "tests/test_form.py"
+          "tests/test_html5.py"
+        ];
+        patches = [ ];
       });
       werkzeug = super.werkzeug.overridePythonAttrs (old: rec {
         version = "2.0.3";
@@ -23,16 +35,6 @@ let
           inherit version;
           sha256 = "b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c";
         };
-      });
-      wtforms = super.wtforms.overridePythonAttrs (old: rec {
-        version = "2.3.3";
-        src = old.src.override {
-          inherit version;
-          sha256 = "81195de0ac94fbc8368abbaf9197b88c4f3ffd6c2719b5bf5fc9da744f3d829c";
-        };
-        checkPhase = ''
-          ${self.python.interpreter} tests/runtests.py
-        '';
       });
     };
   };
@@ -52,6 +54,7 @@ in python.pkgs.buildPythonApplication rec {
     flask
     flask-wtf
     msgpack
+    setuptools
     (python.pkgs.toPythonModule (radicale3.override { python3 = python; }))
     requests
   ] ++ requests.optional-dependencies.socks;


### PR DESCRIPTION
###### Description of changes

Related https://github.com/NixOS/nixpkgs/issues/206852

This was failing due to newer versions of Flask requiring newer versions of werkzeug. I referenced https://github.com/etesync/etesync-dav/blob/master/requirements.txt to downgrade flake and use the current wtforms. The issue with using flask-wtf==0.15.1 and wtforms==3.0.1 is there are tests in flask-wtf that reference import paths that are removed in wtforms 3.0.0:

https://github.com/wtforms/flask-wtf/blob/v0.15.1/tests/test_form.py#L5

So I've just skipped the tests that failed. Once everything compiled I tried running the binary which complained:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

So I added setuptools to the propagatedBuildInputs. After I was able to render the page at http://localhost:37358/.web/add/


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
