### PR TITLE
forgejo: 1.18.3-1 -> 1.18.3.2

### DIFF
--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -20,13 +20,13 @@
 
 buildGoModule rec {
   pname = "forgejo";
-  version = "1.18.3-1";
+  version = "1.18.3-2";
 
   src = fetchurl {
     name = "${pname}-src-${version}.tar.gz";
     # see https://codeberg.org/forgejo/forgejo/releases
-    url = "https://codeberg.org/attachments/3fdf0967-d3f4-4488-a2bf-276c4a64d97c";
-    hash = "sha256-H69qKdmz5qHJ353UZYztUlStpj/RyE6LA8cDaRnVYAQ=";
+    url = "https://codeberg.org/attachments/c1178655-1589-4afe-90a8-9f5f9f45bf4d";
+    hash = "sha256-k/yD2fBEByjj8ZastgRXKI1I4MzVlD8pbUCXwCo7UoQ=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
###### Description of changes

https://codeberg.org/forgejo/forgejo/src/commit/833c98ffaf3fbce0b917eec1ff73175e9e2c2056/RELEASE-NOTES.md#1-18-3-2

> * FORGEJO RELEASE PROCESS BUGFIXES
>    * The tag SHA in the uploaded repository must match ([#345](https://codeberg.org/forgejo/forgejo/pulls/345)) [Read more about the consequences of this on the Forgejo blog](https://forgejo.org/2023-02-12-tags/)

forgejo packaged in nixpkgs isn't affected by that, since we aren't using git tags, but the release tarballs from https://codeberg.org/forgejo/forgejo/releases, that include stuff like the vendored go mod folder and the pre-built frontend.
So we are good.

The mentioned git CVEs have been merged into staging already (both unstable [#216373] and 22.11 [#216378])

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).