### PR TITLE
python3Packages.stravalib: 1.1.0 → 1.2.0

### DIFF
--- a/pkgs/development/python-modules/stravalib/default.nix
+++ b/pkgs/development/python-modules/stravalib/default.nix
@@ -2,20 +2,24 @@
 , buildPythonPackage
 , fetchPypi
 , nose
+, setuptools
 , arrow
 , requests
 , units
+, pint
+, pydantic
 , pytz
 , six
 }:
 
 buildPythonPackage rec {
   pname = "stravalib";
-  version = "1.1.0";
+  version = "1.2.0";
+  format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-qn46u1Kq2fkEL/JnjDNKbJZMTz/pitveNFPaf2xkbYs=";
+    sha256 = "sha256-P00oxUz0oVQB969c/N2wpKLe09wtvQWPH4DH4EZUaxc=";
   };
 
   nativeCheckInputs = [
@@ -26,7 +30,10 @@ buildPythonPackage rec {
     arrow
     requests
     units
+    pint
+    pydantic
     pytz
+    setuptools
     six
   ];
 
@@ -36,7 +43,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python library for interacting with Strava v3 REST API";
-    homepage = "https://github.com/hozn/stravalib";
+    homepage = "https://github.com/stravalib/stravalib";
     license = licenses.asl20;
     maintainers = [ maintainers.costrouc ];
   };


### PR DESCRIPTION
###### Description of changes
* Fix build https://hydra.nixos.org/build/209306067
* [Changelog](https://github.com/stravalib/stravalib/releases/tag/v1.2.0)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
