### PR TITLE
outline: fix broken links to public assets

### DIFF
--- a/pkgs/servers/web-apps/outline/default.nix
+++ b/pkgs/servers/web-apps/outline/default.nix
@@ -56,15 +56,16 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out/bin $out/share/outline
-    mv node_modules build $out/share/outline/
+    mv public node_modules build $out/share/outline/
+
+    node_modules=$out/share/outline/node_modules
+    build=$out/share/outline/build
+
     # On NixOS the WorkingDirectory is set to the build directory, as
     # this contains files needed in the onboarding process. This folder
     # must also contain the `public` folder for mail notifications to
     # work, as it contains the mail templates.
-    mv public $out/share/outline/build
-
-    node_modules=$out/share/outline/node_modules
-    build=$out/share/outline/build
+    ln -s $out/share/outline/public $build/public
 
     makeWrapper ${nodejs}/bin/node $out/bin/outline-server \
       --add-flags $build/server/index.js \


### PR DESCRIPTION
Static images in Outline are no longer accessible after commit 06a70ad. Links to all favicons and static images are broken and redirected to an HTML page.

The public assets has been moved to `$out/share/outline/build` (in order to fix [email notification issue](https://github.com/NixOS/nixpkgs/commit/06a70adfa9c6f303306a595bb675465e40080311)), but those are no longer at the [expected path](https://github.com/outline/outline/blob/v0.67.2/server/routes/index.ts#L32) in Outline. This patch lets Outline find the correct path to its public assets again.
With this patch, the links to these static images are working (at least in my local tests). 


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
