### PR TITLE
[Backport release-22.11] ploticus: Fix PREFAB settings, add test

### DIFF
--- a/pkgs/tools/graphics/ploticus/default.nix
+++ b/pkgs/tools/graphics/ploticus/default.nix
@@ -7,14 +7,15 @@
 , libjpeg
 , gd
 , freetype
+, runCommand
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ploticus";
   version = "2.42";
 
   src = fetchurl {
-    url = "mirror://sourceforge/ploticus/ploticus/${version}/ploticus${lib.replaceStrings [ "." ] [ "" ] version}_src.tar.gz";
+    url = "mirror://sourceforge/ploticus/ploticus/${finalAttrs.version}/ploticus${lib.replaceStrings [ "." ] [ "" ] finalAttrs.version}_src.tar.gz";
     sha256 = "PynkufQFIDqT7+yQDlgW2eG0OBghiB4kHAjKt91m4LA=";
   };
 
@@ -42,6 +43,10 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
+  postPatch = ''
+    substituteInPlace src/pl.h --subst-var out
+  '';
+
   preBuild = ''
     cd src
   '';
@@ -62,6 +67,16 @@ stdenv.mkDerivation rec {
     ln -s "pl" "$out/bin/ploticus"
   '';
 
+  passthru.tests = {
+    prefab = runCommand "ploticus-prefab-test" {
+      buildInputs = [ finalAttrs.finalPackage ];
+    } ''
+      # trivial test to see if the prefab path munging works
+      mkdir $out/
+      pl -prefab scat inlinedata="A 1 2" x=2 y=3 -png -o $out/out.png
+    '';
+  };
+
   meta = with lib; {
     description = "A non-interactive software package for producing plots and charts";
     longDescription = ''
@@ -77,4 +92,4 @@ stdenv.mkDerivation rec {
     homepage = "http://ploticus.sourceforge.net/";
     platforms = with platforms; linux ++ darwin;
   };
-}
+})


### PR DESCRIPTION
Previously, I would get

    pl: error 22: Cannot open specified scriptfile (@out@/share/ploticus/prefabs/chron.pl)

and it seems the PREFAB setting last changed in
https://github.com/NixOS/nixpkgs/commit/fbc4b41e692f04511f063d1ec2b438c4d47775eb
didn't quite work.

So this adds a test to demonstrate the issue, and fixes it by substituting the placeholder.

(cherry picked from commit ea4d2f7e6110b7016e9f2ef41cfd7df945877078, backport of https://github.com/NixOS/nixpkgs/pull/216926)