### PR TITLE
nchat: init at 3.17

### DIFF
--- a/pkgs/applications/networking/instant-messengers/nchat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/nchat/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv,  fetchFromGitHub, cmake, gperf
+, file, ncurses, openssl, readline, sqlite, zlib
+, AppKit, Cocoa, Foundation
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nchat";
+  version = "3.17";
+
+  src = fetchFromGitHub {
+    owner = "d99kris";
+    repo = "nchat";
+    rev = "v${version}";
+    hash = "sha256-BtWKt8paI0gCGSzLYN8x3Yp5MUpwCb2vBGcGQG2aumY=";
+  };
+
+  postPatch = ''
+    substituteInPlace lib/tgchat/ext/td/CMakeLists.txt \
+      --replace "get_git_head_revision" "#get_git_head_revision"
+  '';
+
+  nativeBuildInputs = [ cmake gperf ];
+
+  buildInputs = [
+    file # for libmagic
+    ncurses
+    openssl
+    readline
+    sqlite
+    zlib
+  ] ++ lib.optional stdenv.isDarwin [ AppKit Cocoa Foundation ];
+
+  cmakeFlags = [
+    "-DHAS_WHATSAPP=OFF" # go module build required
+  ];
+
+  meta = with lib; {
+    description = "Terminal-based chat client with support for Telegram and WhatsApp";
+    homepage = "https://github.com/d99kris/nchat";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31970,6 +31970,10 @@ with pkgs;
 
   ngt = callPackage ../development/libraries/ngt { };
 
+  nchat = callPackage ../applications/networking/instant-messengers/nchat {
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa Foundation;
+  };
+
   nheko = libsForQt5.callPackage ../applications/networking/instant-messengers/nheko {
     # https://github.com/NixOS/nixpkgs/issues/201254
     stdenv = if stdenv.isLinux && stdenv.isAarch64 && stdenv.cc.isGNU then gcc11Stdenv else stdenv;


### PR DESCRIPTION
###### Description of changes
[**nchat**](https://github.com/d99kris/nchat) - Terminal-based Telegram client.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
