### PR TITLE
Revert "cimg: 3.2.0 -> 3.2.1"

### DIFF
--- a/pkgs/development/libraries/cimg/default.nix
+++ b/pkgs/development/libraries/cimg/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cimg";
-  version = "3.2.1";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "dtschump";
     repo = "CImg";
     rev = "v.${version}";
-    hash = "sha256-MPkZGKewusCw5TsW5NOtnrjqEK2dxRSCal1fn7Yiaio=";
+    hash = "sha256-laLi3ks5r0C61LDoCEgVqmqZ7/C18qQKxPm4zmQrw78=";
   };
 
   outputs = [ "out" "doc" ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#217015

There are some hard-to-understand bugs happening, as reported and verified in https://github.com/NixOS/nixpkgs/issues/217082