### PR TITLE
mediawiki2latex: init at 7.45

### DIFF
--- a/pkgs/tools/misc/mediawiki2latex/default.nix
+++ b/pkgs/tools/misc/mediawiki2latex/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, haskellPackages
+, fetchurl
+, makeWrapper
+, librsvg
+, imagemagick
+}:
+
+haskellPackages.mkDerivation  rec {
+  pname = "mediawiki2latex";
+  version = "7.45";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/wb2pdf/${version}/${pname}-${version}.tar.gz";
+    sha256 = "sha256-Z0ZiEofPdNA/S5ssMS/HZYXJTAaDZvzvZ1+wA/tuHgU=";
+  };
+
+  executableHaskellDepends = with haskellPackages; [
+    HTTP
+    cereal
+    directory-tree
+    file-embed
+    happstack-server
+    http-client
+    http-conduit
+    http-types
+    hxt
+    hxt-http
+    network
+    network-uri
+    strict
+    tagsoup
+    temporary
+    url
+    utf8-string
+    utility-ht
+    word8
+    zip-archive
+  ];
+  isExecutable = true;
+  buildTools = [ makeWrapper ];
+  postInstall = ''
+    wrapProgram $out/bin/mediawiki2latex \
+      --prefix PATH : ${librsvg}/bin \
+      --prefix PATH : ${imagemagick}/bin
+  '';
+
+  homepage = "https://mediawiki2latex.wmflabs.org/";
+  description = "converts MediaWiki markup to LaTeX and generates a PDF.";
+  license = lib.licenses.gpl2Plus;
+  maintainers = with lib.maintainers; [ doronbehar ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9711,6 +9711,8 @@ with pkgs;
 
   mediawiki = callPackage ../servers/web-apps/mediawiki { };
 
+  mediawiki2latex = callPackage ../tools/misc/mediawiki2latex { };
+
   memtier-benchmark = callPackage ../tools/networking/memtier-benchmark { };
 
   memtest86-efi = callPackage ../tools/misc/memtest86-efi { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
