### PR TITLE
localsend: init at 1.8.0

### DIFF
--- a/pkgs/applications/networking/localsend/default.nix
+++ b/pkgs/applications/networking/localsend/default.nix
@@ -1,0 +1,64 @@
+{ lib, stdenv, appimageTools, fetchurl, undmg }:
+
+let
+  pname = "localsend";
+  version = "1.8.0";
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/localsend/localsend/releases/download/v${version}/LocalSend-${version}.AppImage";
+      hash = "sha256-Setxw0urfJCiHI+Ms+Igroi1CLCgB0H5BsV6RkxyBME=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://github.com/localsend/localsend/releases/download/v${version}/LocalSend-${version}.dmg";
+      hash = "sha256-uVZ/ULhr8CiV/wL9Yaw6q2IYAHNqld606ADKab/EVlU=";
+    };
+  };
+  src = srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+
+  linux = appimageTools.wrapType2 rec {
+    inherit pname version src meta;
+
+    extraPkgs = p: [ p.libepoxy ];
+
+    extraInstallCommands = ''
+      mv $out/bin/${pname}-${version} $out/bin/${pname}
+
+      install -m 444 -D ${appimageContents}/org.localsend.localsend_app.desktop \
+        $out/share/applications/${pname}.desktop
+      substituteInPlace $out/share/applications/${pname}.desktop \
+        --replace 'Icon=application-vnd.appimage' 'Icon=${pname}' \
+        --replace 'Exec=localsend_app' 'Exec=$out/bin/localsend'
+
+      install -m 444 -D ${appimageContents}/application-vnd.appimage.svg \
+        $out/share/icons/hicolor/scalable/apps/${pname}.svg
+    '';
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit pname version src meta;
+
+    nativeBuildInputs = [ undmg ];
+
+    sourceRoot = ".";
+
+    installPhase = ''
+      mkdir -p $out/Applications
+      cp -r *.app $out/Applications
+    '';
+  };
+
+  meta = with lib; {
+    description = "An open source cross-platform alternative to AirDrop";
+    homepage = "https://localsend.org/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = builtins.attrNames srcs;
+  };
+in
+if stdenv.isDarwin
+then darwin
+else linux

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31093,6 +31093,8 @@ with pkgs;
 
   lls = callPackage ../applications/networking/lls { };
 
+  localsend = callPackage ../applications/networking/localsend { };
+
   lmms = libsForQt5.callPackage ../applications/audio/lmms {
     lame = null;
     libsoundio = null;


### PR DESCRIPTION
###### Description of changes
[**localsend**](https://github.com/localsend/localsend) - an open source cross-platform alternative to AirDrop .

It should be possible to build localsend from sources with `flutter.mkFlutterApp`, but I didn't manage, too many issues.

[![Packaging status](https://repology.org/badge/tiny-repos/localsend.svg)](https://repology.org/project/localsend/versions)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
