### PR TITLE
clucene_core_2: fix build with musl and gcc>=11

### DIFF
--- a/pkgs/development/libraries/clucene-core/2.x.nix
+++ b/pkgs/development/libraries/clucene-core/2.x.nix
@@ -37,6 +37,10 @@ stdenv.mkDerivation rec {
     ./Install-contribs-lib.patch
     # From arch
     ./fix-missing-include-time.patch
+
+    # required for darwin and linux-musl
+    ./pthread-include.patch
+
   ] ++ lib.optionals stdenv.isDarwin [ ./fix-darwin.patch ];
 
   # fails with "Unable to find executable:

--- a/pkgs/development/libraries/clucene-core/fix-darwin.patch
+++ b/pkgs/development/libraries/clucene-core/fix-darwin.patch
@@ -1,16 +1,3 @@
---- a/src/shared/CLucene/LuceneThreads.h
-+++ b/src/shared/CLucene/LuceneThreads.h
-@@ -7,6 +7,9 @@
- #ifndef _LuceneThreads_h
- #define  _LuceneThreads_h
-
-+#if defined(_CL_HAVE_PTHREAD)
-+	#include <pthread.h>
-+#endif
-
- CL_NS_DEF(util)
- class CLuceneThreadIdCompare;
-
 --- a/src/shared/CLucene/config/repl_tchar.h
 +++ b/src/shared/CLucene/config/repl_tchar.h
 @@ -28,26 +28,26 @@

--- a/pkgs/development/libraries/clucene-core/pthread-include.patch
+++ b/pkgs/development/libraries/clucene-core/pthread-include.patch
@@ -1,0 +1,14 @@
+--- a/src/shared/CLucene/LuceneThreads.h
++++ b/src/shared/CLucene/LuceneThreads.h
+@@ -7,6 +7,9 @@
+ #ifndef _LuceneThreads_h
+ #define  _LuceneThreads_h
+
++#if defined(_CL_HAVE_PTHREAD)
++	#include <pthread.h>
++#endif
+
+ CL_NS_DEF(util)
+ class CLuceneThreadIdCompare;
+
+


### PR DESCRIPTION
###### Description of changes

Just moves a fix that was already done for darwin to be done unconditionally.

This software has not seen an upstream release in over a decade, so it is very unlikely that there will be an upstream fix for this

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
