### PR TITLE
python310Packages.ansible-compat: add missing dependencies

### DIFF
--- a/pkgs/development/python-modules/ansible-compat/default.nix
+++ b/pkgs/development/python-modules/ansible-compat/default.nix
@@ -3,6 +3,8 @@
 , fetchPypi
 , ansible-core
 , flaky
+, jsonschema
+, packaging
 , pytest-mock
 , pytestCheckHook
 , pyyaml
@@ -25,6 +27,9 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
+    ansible-core
+    jsonschema
+    packaging
     pyyaml
     subprocess-tee
   ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added missing runtime dependencies to `propagatedBuildInputs`. It works before this change because those dependencies pulled by ansible package. But I usually remove ansible dependency from `ansible-core` because I want a clean `ansible-core` package like upstream.

https://github.com/NixOS/nixpkgs/blob/5f4e07deb7c44f27d498f8df9c5f34750acf52d2/pkgs/development/python-modules/ansible/core.nix#L47-L48

When I do this I have a build error for ansible-compat:

```
       > ERROR: Could not find a version that satisfies the requirement jsonschema>=4.6.0 (from ansible-compat) (from v
ersions: none)
       > ERROR: No matching distribution found for jsonschema>=4.6.0
```

This PR fixes it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
