### PR TITLE
fetchTorrent: init

### DIFF
--- a/pkgs/build-support/fetchtorrent/ariacommand.sh
+++ b/pkgs/build-support/fetchtorrent/ariacommand.sh
@@ -1,0 +1,156 @@
+ariaCommand() {
+    # filter status messages of aria to make it less verbose
+    # use the output-filter only with a known version of aria
+    if $debug || [ "$(aria2c --version | head -n1 )" != "aria2 version 1.36.0" ]; then
+        aria2c "$@"
+        return $?
+    fi
+
+    # create DHT cache file
+    # hide false error: Exception caught while loading DHT routing table
+    # https://github.com/aria2/aria2/issues/1253
+    # based on aria2/src/DHTRoutingTableDeserializer.cc
+    if ! [ -e $HOME/.cache/aria2/dht.dat ]; then
+        hex=""
+        hex+="a1 a2" # 0+2: magic
+        hex+="02" # 2+1: format
+        hex+="00 00 00" # 3+3
+        hex+="00 03" # 6+2: version
+        hex+=$(printf "%016x\n" $(date --utc +%s)) # 8+8: time
+        hex+="00 00 00 00 00 00 00 00" # 16+8: localnode
+        hex+=$(dd if=/dev/random bs=1 count=40 status=none | sha1sum - | cut -c1-40) # 24+20: localnode ID
+        hex+="00 00 00 00" # 44+4: reserved
+        hex+="00 00 00 00" # 48+4: num_nodes uint32_t
+        hex+="00 00 00 00" # 52+4: reserved
+        mkdir -p $HOME/.cache/aria2
+        echo $hex | xxd -r -p >$HOME/.cache/aria2/dht.dat
+    fi
+
+    # need coproc to capture return code of aria
+    coproc aria_process { LANG=C LC_ALL=C aria2c "$@"; }
+    # aria_process[0] = stdout
+    # aria_process[1] = stdin
+    # { echo asdf; } >&${aria_process[1]} # write to stdin
+    #exec {aria_process[1]}>&- # close stdin
+
+    local line
+    local L
+    local state=0
+    local linebuf=()
+    local summary_time=
+    local seen_summary=false
+    local line_time=
+    local line_rest=
+    local green_notice=$'\e[1;32mNOTICE\e[0m'
+    local red_error=$'\e[1;31mERROR\e[0m'
+
+    # read stdout of aria
+    while read -ru ${aria_process[0]} line; do
+        #echo "state $state: line: ${line@Q}"
+
+        if [ $state = 0 ]; then
+            if [ -z "$line" ]; then
+                # ignore empty line
+                continue
+            fi
+            if [[ "$line" = "[#"* ]]; then
+                # "[#" line = start of summary?
+                #echo "state: $state -> 1"
+                state=1
+                linebuf+=("$line")
+                continue
+            elif [[ "$line" = "*** Download Progress Summary"* ]]; then
+                # start of summary without previous "[#" lines
+                summary_time=$(echo "$line" | cut -d' ' -f7-11)
+                summary_time=$(date -d"$summary_time" +"%F %T")
+                #echo "state: $state -> 2"
+                state=2
+                continue
+            fi
+            if echo "$line" | grep -q -E '^[0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} '; then
+                # fix time format: 02/19 11:02:00
+                line_time=$(date -d"${line:0:14}" +"%F %T")
+                line_rest="${line:15}"
+                line="$line_time $line_rest"
+            fi
+            if ! $seen_summary && [[ "$line" = *"[$red_error] Checksum error detected"* ]]; then
+                # ignore false checksum error on empty output
+                # https://github.com/aria2/aria2/issues/2033
+                continue
+            fi
+            # ignore some status messages
+            if [[ "$line" = *"[$green_notice] Download of selected files was complete." ]]; then
+                continue
+            fi
+            if [[ "$line" = *"[$green_notice] Seeding is over." ]]; then
+                continue
+            fi
+            if [[ "$line" = *"[$green_notice] Download complete: "* ]]; then
+                continue
+            fi
+            echo "$line"
+            continue
+        fi
+
+        # bug in aria: when output to pipe, "[#" lines can appear before summary
+        # bug in aria: no empty line before the first summary
+
+        if [ $state = 1 ]; then
+            linebuf+=("$line")
+            if [[ "$line" = "[#"* ]]; then
+                # another "[#" line = start of summary?
+                continue
+            elif [[ "$line" = "*** Download Progress Summary"* ]]; then
+                # start of summary after previous "[#" lines
+                summary_time=$(echo "$line" | cut -d' ' -f7-11)
+                summary_time=$(date -d"$summary_time" +"%F %T")
+                #echo "state: $state -> 2"
+                state=2
+                continue
+            fi
+            # no start of summary
+            for L in "${linebuf[@]}"; do
+                if [ -z "$line" ]; then
+                    continue
+                fi
+                if [[ "$line" = "[#"* ]]; then
+                    L="${L:1: -1}" # remove square brackets
+                fi
+                L="$(date +"%F %T") $L" # # add time prefix
+                echo "$L"
+            done
+            # reset
+            #echo "state: $state -> 0"
+            state=0
+            linebuf=()
+            continue
+        fi
+
+        if [ $state = 2 ]; then
+            linebuf+=("$line")
+            if [ -n "$line" ] && [[ "$line" != "-"* ]]; then
+                continue
+            fi
+            # dash line or empty line
+            # end of summary
+            #printf "summary line: %s\n" "${linebuf[@]}"
+            last_progress=$(printf "%s\n" "${linebuf[@]}" | grep '^\[' | tail -n1)
+            last_progress="${last_progress:1: -1}" # remove square brackets
+            last_progress="${last_progress:8}" # remove collection hash
+            echo "$summary_time $last_progress"
+            # reset
+            #echo "state: $state -> 0"
+            state=0
+            linebuf=()
+            continue
+        fi
+    done
+
+    if (( ${#linebuf[@]} > 0 )); then
+        # print unprocessed lines
+        printf "%s\n" "${linebuf[@]}"
+    fi
+
+    # get return code of aria
+    wait $aria_process_PID
+}

--- a/pkgs/build-support/fetchtorrent/builder.sh
+++ b/pkgs/build-support/fetchtorrent/builder.sh
@@ -1,0 +1,212 @@
+source $stdenv/setup
+
+aria_home=$TMP
+mkdir -p $aria_home/.aria2
+
+# declare -a requestedFiles=(...)
+source $requestedFilesArrayPath
+
+if [ -n "$ariaCommandFile" ]; then
+    source $ariaCommandFile
+fi
+
+if ! type ariaCommand >/dev/null 2>&1; then
+    ariaCommand() {
+        aria2c "$@"
+    }
+fi
+
+echo
+echo tracker list:
+cat $trackerslistFile | grep .
+echo
+
+if [ -n "$extraTrackerslistFile" ]; then
+    echo
+    echo extra tracker list:
+    cat $extraTrackerslistFile | grep .
+fi
+
+debug=false
+#debug=true
+if (( NIX_DEBUG >= 1 )); then debug=true; fi
+
+
+
+# create config
+
+cat >$aria_home/.aria2/aria2.conf <<EOF
+bt-tracker=$(cat $trackerslistFile $extraTrackerslistFile | xargs printf "%s,")
+seed-time=0
+ca-certificate=$caCertificate
+listen-port=$listenPort
+dht-listen-port=$dhtListenPort
+enable-dht=$(
+    # TODO better
+    if [ "$enableDHT" = 1 ]; then echo true; else echo false; fi
+)
+check-integrity=true
+file-allocation=$fileAllocation
+summary-interval=$summaryInterval
+download-result=hide
+$(if ! $doUpload; then
+    # FIXME disable seeding completely
+    # this will limit upload to 1 byte/sec
+    # https://askubuntu.com/questions/989780/prevent-aria2c-from-uploading-torrent-files
+    echo max-upload-limit=1
+fi)
+EOF
+
+
+
+# fetch metadata
+
+echo fetching metadata
+HOME=$aria_home ariaCommand "magnet:?xt=urn:btih:$btih" --bt-save-metadata --bt-metadata-only
+
+torrentfile=$PWD/$btih.torrent
+
+echo
+echo torrent metadata:
+for key in name comment source created-by creation-date size piece-size piece-count http-seeds web-seeds private protocol; do
+    value="$(torrenttools show $key $torrentfile)"
+    echo "$key: ${value@Q}"
+done
+# too verbose: files, trackers
+#torrenttools info $torrentfile
+echo
+
+
+
+# fetch files
+
+ariaOptions=()
+
+declare -a allFiles="($(torrenttools info --raw $torrentfile | jq -r '.info.files | (.[].path | join("/")) | @sh'))"
+
+echo all files in torrent:
+n=1
+for file in "${allFiles[@]}"; do
+    echo "file $n: ${file@Q}"
+    n=$((n + 1))
+done
+echo
+
+if (( ${#requestedFiles[@]} > ${#allFiles[@]} )); then
+    echo error: requested more files than files in torrent. requested ${#requestedFiles[@]} vs torrent ${#allFiles[@]}
+    exit 1
+fi
+
+fileNumbers=()
+if [[ ${#allFiles[@]} != 1 ]] && [[ ${#requestedFiles[@]} != 0 ]]; then
+    echo selected files for download:
+    for file in "${requestedFiles[@]}"; do
+        found=false
+        n=1
+        for f in "${allFiles[@]}"; do
+            if [[ "$file" != "$f" ]]; then
+                n=$((n + 1))
+                continue
+            fi
+            echo "file $n: ${file@Q}"
+            fileNumbers+=($n)
+            found=true
+            break
+        done
+        if ! $found; then
+            echo
+            echo error: file not found in torrent: ${file@Q}
+            exit 1
+        fi
+    done
+    echo
+    if [[ ${#fileNumbers[@]} == 0 ]]; then
+        echo error: not found requested files
+        exit 1
+    fi
+    ariaOptions+=(--select-file=$(printf "%s," ${fileNumbers[@]}))
+fi
+
+if [[ ${#allFiles[@]} == 1 ]] || [[ ${#requestedFiles[@]} == 1 ]]; then
+    echo fetching a single file to $out
+    if [[ ${#allFiles[@]} == 1 ]]; then
+        n=1
+    else
+        n=${fileNumbers[0]}
+    fi
+    ariaOptions+=("--dir=$NIX_STORE")
+    ariaOptions+=("--index-out=$n=$(basename $out)")
+else
+    echo fetching multiple files to $out
+    # TODO wording. better than "multiple". all files? N files?
+    # workaround: strip first component of all paths
+    # aria has no option to strip the root folder
+    # we would need something like: tar --strip-components=1
+    if true; then
+        # download to symlinked root folder
+        mkdir $out
+        ln -s $out "$(torrenttools show name $torrentfile)"
+    else
+        # rename all files
+        ariaOptions+=("--dir=$out")
+        n=1
+        for file in "${allFiles[@]}"; do
+            ariaOptions+=("--index-out=$n=$file")
+            n=$((n + 1))
+        done
+    fi
+fi
+echo
+
+if $debug; then
+    echo ariaOptions:
+    for option in "${ariaOptions[@]}"; do
+        echo option: $option
+    done
+    echo
+fi
+
+HOME=$aria_home ariaCommand $torrentfile "${ariaOptions[@]}"
+
+
+
+if [ "$fileAllocation" != "none" ]; then
+    # workaround for bug in file-allocation != none
+    # aria will create too many files
+    # because one torrent chunk can span across multiple files
+    # https://github.com/aria2/aria2/issues/2032
+    if (( 1 < ${#requestedFiles[@]} )) && (( ${#requestedFiles[@]} < ${#allFiles[@]} )); then
+        # partial download of 2 or more files
+        cd $out
+        downloadedFiles=()
+        while read file; do
+            downloadedFiles+=("$file")
+        done < <(find . -not -type d -printf "%P\n")
+        if (( ${#requestedFiles[@]} < ${#downloadedFiles[@]} )); then
+            if $debug; then
+                echo "removing unwanted files (workaround for bug: aria2 creates empty files)"
+            fi
+            for file in "${downloadedFiles[@]}"; do
+                requested=false
+                for f in "${requestedFiles[@]}"; do
+                    if [[ "$f" == "$file" ]]; then
+                        requested=true
+                        break
+                    fi
+                done
+                if ! $requested; then
+                    if $debug; then
+                        rm -v "$file"
+                    else
+                        rm "$file"
+                    fi
+                fi
+            done
+        fi
+    fi
+fi
+
+if $debug; then
+    echo result:
+    (cd $out && find . -printf "%P\n")
+fi

--- a/pkgs/build-support/fetchtorrent/default.nix
+++ b/pkgs/build-support/fetchtorrent/default.nix
@@ -1,0 +1,94 @@
+# FIXME aria2c has no manpage in nixpkgs
+# https://aria2.github.io/manual/en/html/aria2c.html
+
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, aria2
+, cacert
+, torrenttools
+, jq
+, unixtools
+}:
+
+{
+  btih,
+  #torrentFile ? "", # TODO implement
+  sha256 ? "",
+  hash ? "",
+  name ? "",
+  file ? "", # single file -> flat hash
+  files ? [], # one or more files -> recursive hash (default)
+  singleFile ? false, # single file without file name # TODO implement
+  trackers ? [],
+  extraTrackers ? [],
+  doUpload ? false,
+  fileAllocation ? "falloc", # https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-file-allocation
+  # TODO is prealloc better for hard disks?
+  # at least prealloc makes sure we have enough disk space
+  # but there is a bug in aria where too many files are created
+  # so prealloc will use more space than needed ...
+  # https://github.com/aria2/aria2/issues/2032
+} @ attrs:
+
+stdenvNoCC.mkDerivation rec {
+
+  builder = ./builder.sh;
+  ariaCommandFile = ./ariacommand.sh;
+
+  nativeBuildInputs = [
+    aria2
+    torrenttools
+    jq
+    unixtools.xxd
+  ];
+
+  files = attrs.files or (if (file != "") then [file] else []);
+  name = attrs.name or (if (file != "") then (builtins.baseNameOf file) else "btih-${btih}");
+
+  # TODO allow passing trackerslist as string
+  trackerslistFile =
+    if (trackers != [])
+    then
+    (builtins.writeFile "trackerslist.txt" (builtins.concatStringsSep "\n" trackers))
+    else
+    (fetchFromGitHub {
+      # https://github.com/ngosang/trackerslist
+      # using trackers by IP address to avoid DNS blocking
+      owner = "ngosang";
+      repo = "trackerslist";
+      rev = "8ba874e69da0532166644922ea207da3084dff66"; # 2023-02-18
+      sha256 = "sha256-QCE7gDtDBLLpFgGWa3r/1YOz16dTXKx6rYy8m0DCH8k=";
+    }) + "/trackers_best_ip.txt"; # 16 trackers
+    #}) + "/trackers_all_ip.txt"; # 97 trackers
+
+  extraTrackerslistFile =
+    if (extraTrackers != [])
+    then
+    (builtins.writeFile "trackerslist.txt" (builtins.concatStringsSep "\n" extraTrackers))
+    else
+    "";
+
+  outputHashMode = if (singleFile == true || file != "") then "flat" else "recursive";
+  outputHashAlgo = if (builtins.hasAttr "sha256" attrs) then "sha256" else builtins.head (builtins.split "[:-]" hash);
+  outputHash = attrs.sha256 or (
+    let hash2 = attrs.hash or (throw "sha256 or hash is required"); in
+    if hash2 != "" then hash2 else (
+        builtins.trace "warning: found empty hash, assuming '${lib.fakeHash}'"
+      lib.fakeHash));
+
+  inherit btih fileAllocation singleFile;
+
+  caCertificate = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  requestedFile = file;
+  requestedFilesArray = lib.toShellVar "requestedFiles" files;
+  passAsFile = [
+    "requestedFilesArray"
+  ];
+
+  # todo: use impure envs for ports?
+  listenPort = 6881;
+  dhtListenPort = 6881;
+  summaryInterval = 4; # show progress every N seconds
+  enableDHT = true;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -939,6 +939,8 @@ with pkgs;
 
   fetchPypi = callPackage ../build-support/fetchpypi { };
 
+  fetchTorrent = callPackage ../build-support/fetchtorrent { };
+
   resolveMirrorURLs = {url}: fetchurl {
     showURLs = true;
     inherit url;


### PR DESCRIPTION
add fetcher for torrent / bittorrent / magnet links

this got a little complex, to work around all the bugs in aria2

draft because single file mode via `requestedFile` is not implemented

fix #16953

todo: expose [dht-entry-point](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-dht-entry-point) option, see also https://github.com/aria2/aria2/issues/362

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
