### PR TITLE
mullvad-vpn: add binaries to PATH for GUI launcher script

### DIFF
--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -1,11 +1,36 @@
-{ stdenv, lib, fetchurl, dpkg
-, alsa-lib, atk, cairo, cups, dbus, expat, fontconfig, freetype
-, gdk-pixbuf, glib, pango, nspr, nss, gtk3, mesa
-, libGL, wayland, xorg, autoPatchelfHook, systemd, libnotify, libappindicator
-, makeWrapper, coreutils, gnugrep
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, alsa-lib
+, atk
+, cairo
+, cups
+, dbus
+, expat
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, pango
+, nspr
+, nss
+, gtk3
+, mesa
+, libGL
+, wayland
+, xorg
+, autoPatchelfHook
+, systemd
+, libnotify
+, libappindicator
+, makeWrapper
+, coreutils
+, gnugrep
 }:
 
-let deps = [
+let
+  deps = [
     alsa-lib
     atk
     cairo

--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -2,7 +2,7 @@
 , alsa-lib, atk, cairo, cups, dbus, expat, fontconfig, freetype
 , gdk-pixbuf, glib, pango, nspr, nss, gtk3, mesa
 , libGL, wayland, xorg, autoPatchelfHook, systemd, libnotify, libappindicator
-, makeWrapper
+, makeWrapper, coreutils, gnugrep
 }:
 
 let deps = [
@@ -77,7 +77,9 @@ stdenv.mkDerivation rec {
     ln -s $out/share/mullvad/mullvad-{gui,vpn} $out/bin/
     ln -sf $out/share/mullvad/resources/mullvad-problem-report $out/bin/mullvad-problem-report
 
-    wrapProgram $out/bin/mullvad-vpn --set MULLVAD_DISABLE_UPDATE_NOTIFICATION 1
+    wrapProgram $out/bin/mullvad-vpn \
+      --set MULLVAD_DISABLE_UPDATE_NOTIFICATION 1 \
+      --prefix PATH : ${lib.makeBinPath [ coreutils gnugrep ]}
 
     wrapProgram $out/bin/mullvad-daemon \
         --set-default MULLVAD_RESOURCE_DIR "$out/share/mullvad/resources"


### PR DESCRIPTION
###### Description of changes

~~Uses `substituteInPlace` to substitute `grep`, `echo`, `dirname` and `pwd` in the [GUI launcher script](https://github.com/mullvad/mullvadvpn-app/blob/5d87248c1c052f6f6f338b60ff3ff284dd617bfd/dist-assets/linux/mullvad-gui-launcher.sh).~~
Uses existing `wrapProgram` to add `coreutils` and `gnugrep`to the `PATH` of the [GUI launcher script](https://github.com/mullvad/mullvadvpn-app/blob/5d87248c1c052f6f6f338b60ff3ff284dd617bfd/dist-assets/linux/mullvad-gui-launcher.sh), which uses `grep`, `echo`, `dirname` and `pwd`.
Otherwise, the script may not work properly depending on whether those programs are available in `$PATH`.

Also formats with `nixpkgs-fmt`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
