### PR TITLE
zsh: set environment variables in zshenv instead of zprofile

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -187,6 +187,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   The `{aclUse,superUser,disableActions}` attributes have been renamed, `pluginsConfig` now also accepts an attribute set of booleans, passing plain PHP is deprecated.
   Same applies to `acl` which now also accepts structured settings.
 
+- The `zsh` package changes the way to set environment variables on NixOS systems where `programs.zsh.enable` equals `false`.  It now sources `/etc/set-environment` when reading the system-level `zshenv` file.  Before, it sourced `/etc/profile` when reading the system-level `zprofile` file.
+
 - The `wordpress` service now takes configuration via the `services.wordpress.sites.<name>.settings` attribute set, `extraConfig` is still available to append  additional text to `wp-config.php`.
 
 - To reduce closure size in `nixos/modules/profiles/minimal.nix` profile disabled installation documentations and manuals. Also disabled `logrotate` and `udisks2` services.

--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
     "--enable-multibyte"
     "--with-tcsetpgrp"
     "--enable-pcre"
-    "--enable-zprofile=${placeholder "out"}/etc/zprofile"
+    "--enable-zshenv=${placeholder "out"}/etc/zshenv"
     "--disable-site-fndir"
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform && !stdenv.hostPlatform.isStatic) [
     # Also see: https://github.com/buildroot/buildroot/commit/2f32e668aa880c2d4a2cce6c789b7ca7ed6221ba
@@ -64,34 +64,36 @@ stdenv.mkDerivation {
   postInstall = ''
     make install.info install.html
     mkdir -p $out/etc/
-    cat > $out/etc/zprofile <<EOF
+    cat > $out/etc/zshenv <<EOF
 if test -e /etc/NIXOS; then
-  if test -r /etc/zprofile; then
-    . /etc/zprofile
+  if test -r /etc/zshenv; then
+    . /etc/zshenv
   else
     emulate bash
     alias shopt=false
-    . /etc/profile
+    if [ -z "$__NIXOS_SET_ENVIRONMENT_DONE" ]; then
+      . /etc/set-environment
+    fi
     unalias shopt
     emulate zsh
   fi
-  if test -r /etc/zprofile.local; then
-    . /etc/zprofile.local
+  if test -r /etc/zshenv.local; then
+    . /etc/zshenv.local
   fi
 else
-  # on non-nixos we just source the global /etc/zprofile as if we did
+  # on non-nixos we just source the global /etc/zshenv as if we did
   # not use the configure flag
-  if test -r /etc/zprofile; then
-    . /etc/zprofile
+  if test -r /etc/zshenv; then
+    . /etc/zshenv
   fi
 fi
 EOF
     ${if stdenv.hostPlatform == stdenv.buildPlatform then ''
-      $out/bin/zsh -c "zcompile $out/etc/zprofile"
+      $out/bin/zsh -c "zcompile $out/etc/zshenv"
     '' else ''
-      ${lib.getBin buildPackages.zsh}/bin/zsh -c "zcompile $out/etc/zprofile"
+      ${lib.getBin buildPackages.zsh}/bin/zsh -c "zcompile $out/etc/zshenv"
     ''}
-    mv $out/etc/zprofile $out/etc/zprofile_zwc_is_used
+    mv $out/etc/zshenv $out/etc/zshenv_zwc_is_used
 
     rm $out/bin/zsh-${version}
     mkdir -p $out/share/doc/


### PR DESCRIPTION
This patch fixes two issues:

1. The file in which environment variables are set is inconsistent.
  - This file sets them in zprofile since 2011[1].  This is the case when programs.zsh.enable is not set.
  - Zsh module sets them in zshenv since the very beginning in 2012[2].  This is the case when programs.zsh.enable is set.

2. Setting environment variables in zprofile overrides what users set in .zshenv.  See these[3] home-manager[4] issues[5].

[1]: 0009c1f650ba619de97df36322fbd0346db0c099
[2]: ffa4b28dcec622c98c1491a09c9b254dc13b0741
[3]: https://github.com/nix-community/home-manager/issues/2751#issuecomment-1048682643
[4]: https://github.com/nix-community/home-manager/issues/2991
[5]: https://github.com/nix-community/home-manager/issues/3681#issuecomment-1436054233

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
