### PR TITLE
pixelpulse2: init at 1.0.5

### DIFF
--- a/pkgs/applications/science/electronics/pixelpulse2/default.nix
+++ b/pkgs/applications/science/electronics/pixelpulse2/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libsmu
+, libusb
+, qt5
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pixelpulse2";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "analogdevicesinc";
+    repo = "pixelpulse2";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-yzkbUi8tsxpcqnz2DynB1x4Lmhe8ZlFGg1px7F98148=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libsmu
+    libusb
+    qt5.qtbase
+    qt5.qtgraphicaleffects
+  ];
+
+  meta = with lib; {
+    description = "Pixelpulse2 is a user interface for analog systems exploration";
+    longDescription = "Add libsmu to services.udev.packages if you want to run this without root";
+    homepage = "https://wiki.analog.com/university/tools/m1k/overview";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ evils ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/libsmu/default.nix
+++ b/pkgs/development/libraries/libsmu/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libusb
+, boost
+, doxygen
+, pythonSupport ? false # currently tries to install pip packages in $HOME
+, python
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libsmu";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "analogdevicesinc";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Ko3szo7Oa0k7W/sAj3M7FAifIJR7mG40oy6QF2gzMmQ=";
+  };
+
+  patches = [ ./libsmu-pc.patch ];
+
+  cmakeFlags = [
+    "-DBUILD_CLI=ON"
+    "-DWITH_DOC=ON"
+    "-DBUILD_EXAMPLES=OFF"
+    "-DINSTALL_UDEV_RULES=ON"
+    "-DUDEV_RULES_PATH=${placeholder "out"}/etc/udev/rules.d"
+    "-DBUILD_TESTS=OFF" # tests require access to the ADALM1000 hardware
+    "-DBUILD_PYTHON=${if pythonSupport then "ON" else "OFF"}"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    doxygen
+  ]
+  ++ lib.optionals (pythonSupport) [
+    (python.withPackages ( ps: with ps; [
+      build
+      wheel
+      setuptools
+      cython
+      six
+    ]))
+  ];
+
+  buildInputs = [
+    libusb
+    boost
+  ];
+
+  meta = with lib; {
+    description = "Software abstractions for the ADALM1000 USB SMU";
+    homepage = "https://analogdevicesinc.github.io/libsmu/";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.evils ];
+  };
+}

--- a/pkgs/development/libraries/libsmu/libsmu-pc.patch
+++ b/pkgs/development/libraries/libsmu/libsmu-pc.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/libsmu.pc.cmakein b/dist/libsmu.pc.cmakein
+index f89dad9..4ad9b0a 100644
+--- a/dist/libsmu.pc.cmakein
++++ b/dist/libsmu.pc.cmakein
+@@ -1,7 +1,7 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+ 
+ Name: libsmu
+ Description: Library for interfacing with M1K devices

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37117,6 +37117,8 @@ with pkgs;
 
   pcb = callPackage ../applications/science/electronics/pcb { };
 
+  pixelpulse2 = callPackage ../applications/science/electronics/pixelpulse2 { };
+
   qucs = callPackage ../applications/science/electronics/qucs { };
 
   qucs-s = callPackage ../applications/science/electronics/qucs-s { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21707,6 +21707,10 @@ with pkgs;
 
   libslirp = callPackage ../development/libraries/libslirp { };
 
+  libsmu = callPackage ../development/libraries/libsmu {
+    python = python3;
+  };
+
   libsndfile = callPackage ../development/libraries/libsndfile {
     inherit (darwin.apple_sdk.frameworks) Carbon AudioToolbox;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9533,6 +9533,11 @@ self: super: with self; {
 
   pyinfra = callPackage ../development/python-modules/pyinfra { };
 
+  pysmu = toPythonModule (pkgs.libsmu.override {
+    pythonSupport = true;
+    inherit python;
+  });
+
   pytibber = callPackage ../development/python-modules/pytibber { };
 
   pytile = callPackage ../development/python-modules/pytile { };


### PR DESCRIPTION
###### Description of changes

pixelpulse2, GUI for using the Analog Devices ADALM1000 USB SMU
which is a piece of test equipment targeted at analog electronics education
(but makes for a uniquely priced hobbyist tool)

includes the libsmu dependency, which can be used on its own (and is also needed by AD's ALICE)
this is also intended to provide a python library, which currently does not build
as it tries to install python dependencies that are already provided in $HOME
(if this issue is resolved, i'll continue packaging ALICE as well, because as far as i recall, it's less janky than pixelpulse2)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
