### PR TITLE
treewide: replace http by https when https is a permanent redirection

### DIFF
--- a/pkgs/applications/audio/ams/default.nix
+++ b/pkgs/applications/audio/ams/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Realtime modular synthesizer for ALSA";
-    homepage = "http://alsamodular.sourceforge.net";
+    homepage = "https://alsamodular.sourceforge.net";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ sjfloat ];

--- a/pkgs/applications/audio/bristol/default.nix
+++ b/pkgs/applications/audio/bristol/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation  rec {
 
   meta = with lib; {
     description = "A range of synthesiser, electric piano and organ emulations";
-    homepage = "http://bristol.sourceforge.net";
+    homepage = "https://bristol.sourceforge.net";
     license = licenses.gpl3;
     platforms = ["x86_64-linux" "i686-linux"];
     maintainers = [ maintainers.goibhniu ];

--- a/pkgs/applications/audio/calf/default.nix
+++ b/pkgs/applications/audio/calf/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "http://calf-studio-gear.org";
+    homepage = "https://calf-studio-gear.org";
     description = "A set of high quality open source audio plugins for musicians";
     license = licenses.lgpl2;
     maintainers = [ maintainers.goibhniu ];

--- a/pkgs/applications/audio/eflite/default.nix
+++ b/pkgs/applications/audio/eflite/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   CFLAGS = lib.optionalString debug " -DDEBUG=2";
 
   meta = {
-    homepage = "http://eflite.sourceforge.net";
+    homepage = "https://eflite.sourceforge.net";
     description = "Speech server for screen readers";
     longDescription = ''
       EFlite is a speech server for Emacspeak and other screen

--- a/pkgs/applications/audio/freewheeling/default.nix
+++ b/pkgs/applications/audio/freewheeling/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
         software, released under the GNU GPL license.
     '' ;
 
-    homepage = "http://freewheeling.sourceforge.net";
+    homepage = "https://freewheeling.sourceforge.net";
     license = lib.licenses.gpl2;
     maintainers = [ lib.maintainers.sepi ];
     platforms = lib.platforms.linux;

--- a/pkgs/applications/audio/jamin/default.nix
+++ b/pkgs/applications/audio/jamin/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://jamin.sourceforge.net";
+    homepage = "https://jamin.sourceforge.net";
     description = "JACK Audio Mastering interface";
     license = licenses.gpl2;
     maintainers = [ maintainers.nico202 ];

--- a/pkgs/applications/audio/petrifoo/default.nix
+++ b/pkgs/applications/audio/petrifoo/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation  rec {
   meta = with lib; {
     description = "MIDI controllable audio sampler";
     longDescription = "a fork of Specimen";
-    homepage = "http://petri-foo.sourceforge.net";
+    homepage = "https://petri-foo.sourceforge.net";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.goibhniu ];

--- a/pkgs/applications/audio/qmidiarp/default.nix
+++ b/pkgs/applications/audio/qmidiarp/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       parallel.
     '';
 
-    homepage = "http://qmidiarp.sourceforge.net";
+    homepage = "https://qmidiarp.sourceforge.net";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ sjfloat ];

--- a/pkgs/applications/audio/qtscrobbler/default.nix
+++ b/pkgs/applications/audio/qtscrobbler/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       It is able to gather this information from Apple iPods or DAPs running the Rockbox replacement firmware.
     '';
 
-    homepage = "http://qtscrob.sourceforge.net";
+    homepage = "https://qtscrob.sourceforge.net";
     license = licenses.gpl2;
     maintainers = [ maintainers.vanzef ];
     platforms = platforms.linux;

--- a/pkgs/applications/audio/rakarrack/default.nix
+++ b/pkgs/applications/audio/rakarrack/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation  rec {
 
   meta = with lib; {
     description = "Multi-effects processor emulating a guitar effects pedalboard";
-    homepage = "http://rakarrack.sourceforge.net";
+    homepage = "https://rakarrack.sourceforge.net";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.goibhniu ];

--- a/pkgs/applications/audio/yasr/default.nix
+++ b/pkgs/applications/audio/yasr/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   ]; # taken from the debian yasr package
 
   meta = {
-    homepage = "http://yasr.sourceforge.net";
+    homepage = "https://yasr.sourceforge.net";
     description = "A general-purpose console screen reader";
     longDescription = "Yasr is a general-purpose console screen reader for GNU/Linux and other Unix-like operating systems.";
     platforms = lib.platforms.linux;

--- a/pkgs/applications/editors/bviplus/default.nix
+++ b/pkgs/applications/editors/bviplus/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Ncurses based hex editor with a vim-like interface";
-    homepage = "http://bviplus.sourceforge.net";
+    homepage = "https://bviplus.sourceforge.net";
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ cstrahan ];

--- a/pkgs/applications/editors/ht/default.nix
+++ b/pkgs/applications/editors/ht/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "File editor/viewer/analyzer for executables";
-    homepage = "http://hte.sourceforge.net";
+    homepage = "https://hte.sourceforge.net";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ cstrahan ];

--- a/pkgs/applications/graphics/gqview/default.nix
+++ b/pkgs/applications/graphics/gqview/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A fast image viewer";
-    homepage = "http://gqview.sourceforge.net";
+    homepage = "https://gqview.sourceforge.net";
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ];

--- a/pkgs/applications/misc/artha/default.nix
+++ b/pkgs/applications/misc/artha/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An offline thesaurus based on WordNet";
-    homepage = "http://artha.sourceforge.net";
+    homepage = "https://artha.sourceforge.net";
     license = licenses.gpl2;
     maintainers = [ maintainers.goibhniu ];
     platforms = platforms.linux;

--- a/pkgs/applications/misc/audio/soxr/default.nix
+++ b/pkgs/applications/misc/audio/soxr/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An audio resampling library";
-    homepage = "http://soxr.sourceforge.net";
+    homepage = "https://soxr.sourceforge.net";
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ];

--- a/pkgs/applications/misc/djvulibre/default.nix
+++ b/pkgs/applications/misc/djvulibre/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "The big set of CLI tools to make/modify/optimize/show/export DJVU files";
-    homepage = "http://djvu.sourceforge.net";
+    homepage = "https://djvu.sourceforge.net";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ Anton-Latukha ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/eaglemode/default.nix
+++ b/pkgs/applications/misc/eaglemode/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "http://eaglemode.sourceforge.net";
+    homepage = "https://eaglemode.sourceforge.net";
     description = "Zoomable User Interface";
     changelog = "https://eaglemode.sourceforge.net/ChangeLog.html";
     license = licenses.gpl3;

--- a/pkgs/applications/misc/eureka-editor/default.nix
+++ b/pkgs/applications/misc/eureka-editor/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://eureka-editor.sourceforge.net";
+    homepage = "https://eureka-editor.sourceforge.net";
     description = "A map editor for the classic DOOM games, and a few related games such as Heretic and Hexen";
     license = licenses.gpl2Plus;
     platforms = platforms.all;

--- a/pkgs/applications/misc/menumaker/default.nix
+++ b/pkgs/applications/misc/menumaker/default.nix
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = with lib; {
     description = "Heuristics-driven menu generator for several window managers";
-    homepage = "http://menumaker.sourceforge.net";
+    homepage = "https://menumaker.sourceforge.net";
     license = licenses.bsd2;
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/applications/misc/wcalc/default.nix
+++ b/pkgs/applications/misc/wcalc/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A command line calculator";
-    homepage = "http://w-calc.sourceforge.net";
+    homepage = "https://w-calc.sourceforge.net";
     license = licenses.gpl2;
     platforms = platforms.all;
   };

--- a/pkgs/applications/radio/unixcw/default.nix
+++ b/pkgs/applications/radio/unixcw/default.nix
@@ -31,7 +31,7 @@ mkDerivation rec {
        These change the parameters used when sounding the Morse code.
        cw reports any errors in  embedded  commands
      '';
-    homepage = "http://unixcw.sourceforge.net";
+    homepage = "https://unixcw.sourceforge.net";
     maintainers = [ maintainers.mafo ];
     license = licenses.gpl2;
     platforms=platforms.linux;

--- a/pkgs/applications/science/astronomy/xplanet/default.nix
+++ b/pkgs/applications/science/astronomy/xplanet/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Renders an image of the earth or other planets into the X root window";
-    homepage = "http://xplanet.sourceforge.net";
+    homepage = "https://xplanet.sourceforge.net";
     license = licenses.gpl2;
     maintainers = with maintainers; [ lassulus sander ];
     platforms = platforms.all;

--- a/pkgs/applications/science/biology/bowtie/default.nix
+++ b/pkgs/applications/science/biology/bowtie/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "An ultrafast memory-efficient short read aligner";
     license = licenses.artistic2;
-    homepage = "http://bowtie-bio.sourceforge.net";
+    homepage = "https://bowtie-bio.sourceforge.net";
     maintainers = with maintainers; [ prusnak ];
     platforms = platforms.all;
   };

--- a/pkgs/applications/science/biology/seaview/default.nix
+++ b/pkgs/applications/science/biology/seaview/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
           Gouy M., Guindon S. & Gascuel O. (2010) SeaView version 4 : a multiplatform graphical user interface for sequence alignment and phylogenetic tree building. Molecular Biology and Evolution 27(2):221-224.
     '';
-    homepage = "http://doua.prabi.fr/software/seaview";
+    homepage = "https://doua.prabi.fr/software/seaview";
     license = licenses.gpl3;
     maintainers = [ maintainers.iimog ];
     platforms = platforms.linux;

--- a/pkgs/applications/science/electronics/gtkwave/default.nix
+++ b/pkgs/applications/science/electronics/gtkwave/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "VCD/Waveform viewer for Unix and Win32";
-    homepage = "http://gtkwave.sourceforge.net";
+    homepage = "https://gtkwave.sourceforge.net";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ thoughtpolice jiegec ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;

--- a/pkgs/applications/science/electronics/qucs/default.nix
+++ b/pkgs/applications/science/electronics/qucs/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Integrated circuit simulator";
-    homepage = "http://qucs.sourceforge.net";
+    homepage = "https://qucs.sourceforge.net";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [viric];
     platforms = with lib.platforms; linux;

--- a/pkgs/applications/science/electronics/xoscope/default.nix
+++ b/pkgs/applications/science/electronics/xoscope/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Oscilloscope through the sound card";
-    homepage = "http://xoscope.sourceforge.net";
+    homepage = "https://xoscope.sourceforge.net";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [viric];
     platforms = with lib.platforms; linux;

--- a/pkgs/applications/science/logic/yices/default.nix
+++ b/pkgs/applications/science/logic/yices/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A high-performance theorem prover and SMT solver";
-    homepage    = "http://yices.csl.sri.com";
+    homepage    = "https://yices.csl.sri.com";
     license     = licenses.gpl3;
     platforms   = with platforms; linux ++ darwin;
     maintainers = with maintainers; [ thoughtpolice ];

--- a/pkgs/applications/science/math/gretl/default.nix
+++ b/pkgs/applications/science/math/gretl/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
       gretl is a cross-platform software package for econometric analysis,
       written in the C programming language.
     '';
-    homepage = "http://gretl.sourceforge.net";
+    homepage = "https://gretl.sourceforge.net";
     license = licenses.gpl3;
     maintainers = with maintainers; [ dmrauh ];
     platforms = with platforms; all;

--- a/pkgs/applications/science/math/lp_solve/default.nix
+++ b/pkgs/applications/science/math/lp_solve/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A Mixed Integer Linear Programming (MILP) solver";
-    homepage = "http://lpsolve.sourceforge.net";
+    homepage = "https://lpsolve.sourceforge.net";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ smironov ];
     platforms = platforms.unix;

--- a/pkgs/applications/science/math/singular/default.nix
+++ b/pkgs/applications/science/math/singular/default.nix
@@ -166,7 +166,7 @@ stdenv.mkDerivation rec {
     # https://www.singular.uni-kl.de:8002/trac/ticket/837
     platforms = subtractLists platforms.i686 platforms.unix;
     license = licenses.gpl3; # Or GPLv2 at your option - but not GPLv4
-    homepage = "http://www.singular.uni-kl.de";
+    homepage = "https://www.singular.uni-kl.de";
     downloadPage = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/";
     mainProgram = "Singular";
   };

--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -70,7 +70,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://www.gromacs.org";
+    homepage = "https://www.gromacs.org";
     license = licenses.gpl2;
     description = "Molecular dynamics software package";
     longDescription = ''

--- a/pkgs/applications/video/imagination/default.nix
+++ b/pkgs/applications/video/imagination/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Lightweight and simple DVD slide show maker";
-    homepage = "http://imagination.sourceforge.net";
+    homepage = "https://imagination.sourceforge.net";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ austinbutler ];
     platforms = platforms.linux;

--- a/pkgs/applications/video/tivodecode/default.nix
+++ b/pkgs/applications/video/tivodecode/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Converts a .TiVo file (produced by TiVoToGo) to a normal MPEG file";
-    homepage = "http://tivodecode.sourceforge.net";
+    homepage = "https://tivodecode.sourceforge.net";
     platforms = platforms.unix;
     license = licenses.bsd3;
   };

--- a/pkgs/data/fonts/proggyfonts/default.nix
+++ b/pkgs/data/fonts/proggyfonts/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://www.upperbounds.net";
+    homepage = "https://www.upperbounds.net";
     description = "A set of fixed-width screen fonts that are designed for code listings";
     license = licenses.mit;
     platforms = platforms.all;

--- a/pkgs/development/interpreters/metamath/default.nix
+++ b/pkgs/development/interpreters/metamath/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       in the Metamath Proof Explorer, and it generated its web pages. The *.mm
       ASCII databases (set.mm and others) are also included in this derivation.
     '';
-    homepage = "http://us.metamath.org";
+    homepage = "https://us.metamath.org";
     downloadPage = "https://us.metamath.org/#downloads";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.taneb ];

--- a/pkgs/development/libraries/armadillo/default.nix
+++ b/pkgs/development/libraries/armadillo/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "C++ linear algebra library";
-    homepage = "http://arma.sourceforge.net";
+    homepage = "https://arma.sourceforge.net";
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [ juliendehos knedlsepp ];

--- a/pkgs/development/libraries/clucene-core/2.x.nix
+++ b/pkgs/development/libraries/clucene-core/2.x.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
 
       CLucene is a port of the very popular Java Lucene text search engine API.
     '';
-    homepage = "http://clucene.sourceforge.net";
+    homepage = "https://clucene.sourceforge.net";
     platforms = platforms.unix;
     license = with licenses; [ asl20 lgpl2 ];
   };

--- a/pkgs/development/libraries/clucene-core/default.nix
+++ b/pkgs/development/libraries/clucene-core/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
       CLucene is a port of the very popular Java Lucene text search engine API.
     '';
-    homepage = "http://clucene.sourceforge.net";
+    homepage = "https://clucene.sourceforge.net";
     platforms = platforms.unix;
     license = with licenses; [ asl20 lgpl2 ];
   };

--- a/pkgs/development/libraries/dbus-cplusplus/default.nix
+++ b/pkgs/development/libraries/dbus-cplusplus/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--disable-ecore" "--disable-tests" ];
 
   meta = with lib; {
-    homepage = "http://dbus-cplusplus.sourceforge.net";
+    homepage = "https://dbus-cplusplus.sourceforge.net";
     description = "C++ API for D-BUS";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/gtkspell/default.nix
+++ b/pkgs/development/libraries/gtkspell/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Word-processor-style highlighting and replacement of misspelled words";
-    homepage = "http://gtkspell.sourceforge.net";
+    homepage = "https://gtkspell.sourceforge.net";
     platforms = platforms.unix;
     license = licenses.gpl2;
   };

--- a/pkgs/development/libraries/hamlib/4.nix
+++ b/pkgs/development/libraries/hamlib/4.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     command line interface or in a text-oriented interactive interface.
     '';
     license = with licenses; [ gpl2Plus lgpl2Plus ];
-    homepage = "http://hamlib.sourceforge.net";
+    homepage = "https://hamlib.sourceforge.net";
     maintainers = with maintainers; [ relrod ];
     platforms = with platforms; unix;
   };

--- a/pkgs/development/libraries/hamlib/default.nix
+++ b/pkgs/development/libraries/hamlib/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
     command line interface or in a text-oriented interactive interface.
     '';
     license = with licenses; [ gpl2Plus lgpl2Plus ];
-    homepage = "http://hamlib.sourceforge.net";
+    homepage = "https://hamlib.sourceforge.net";
     maintainers = with maintainers; [ relrod ];
     platforms = with platforms; unix;
   };

--- a/pkgs/development/libraries/hunspell/default.nix
+++ b/pkgs/development/libraries/hunspell/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   meta = with lib; {
-    homepage = "http://hunspell.sourceforge.net";
+    homepage = "https://hunspell.sourceforge.net";
     description = "Spell checker";
     longDescription = ''
       Hunspell is the spell checker of LibreOffice, OpenOffice.org, Mozilla

--- a/pkgs/development/libraries/id3lib/default.nix
+++ b/pkgs/development/libraries/id3lib/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Library for reading, writing, and manipulating ID3v1 and ID3v2 tags";
-    homepage = "http://id3lib.sourceforge.net";
+    homepage = "https://id3lib.sourceforge.net";
     platforms = platforms.unix;
     license = licenses.lgpl2;
   };

--- a/pkgs/development/libraries/java/httpunit/default.nix
+++ b/pkgs/development/libraries/java/httpunit/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://httpunit.sourceforge.net";
+    homepage = "https://httpunit.sourceforge.net";
     platforms = platforms.unix;
     license = licenses.mit;
   };

--- a/pkgs/development/libraries/lesstif/default.nix
+++ b/pkgs/development/libraries/lesstif/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An open source clone of the Motif widget set";
-    homepage = "http://lesstif.sourceforge.net";
+    homepage = "https://lesstif.sourceforge.net";
     platforms = platforms.unix;
     license = with licenses; [ gpl2 lgpl2 ];
   };

--- a/pkgs/development/libraries/libcdaudio/default.nix
+++ b/pkgs/development/libraries/libcdaudio/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A portable library for controlling audio CDs";
-    homepage = "http://libcdaudio.sourceforge.net";
+    homepage = "https://libcdaudio.sourceforge.net";
     platforms = lib.platforms.linux;
     license = lib.licenses.lgpl2;
   };

--- a/pkgs/development/libraries/libiodbc/default.nix
+++ b/pkgs/development/libraries/libiodbc/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "iODBC driver manager";
-    homepage = "http://www.iodbc.org";
+    homepage = "https://www.iodbc.org";
     platforms = platforms.unix;
     license = licenses.bsd3;
   };

--- a/pkgs/development/libraries/liblastfmSF/default.nix
+++ b/pkgs/development/libraries/liblastfmSF/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    homepage = "http://liblastfm.sourceforge.net";
+    homepage = "https://liblastfm.sourceforge.net";
     description = "Unofficial C lastfm library";
     license = lib.licenses.gpl3;
   };

--- a/pkgs/development/libraries/liblouis/default.nix
+++ b/pkgs/development/libraries/liblouis/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Open-source braille translator and back-translator";
-    homepage = "http://liblouis.org/";
+    homepage = "https://liblouis.org/";
     license = with licenses; [
       lgpl21Plus # library
       gpl3Plus # tools

--- a/pkgs/development/libraries/libmcrypt/default.nix
+++ b/pkgs/development/libraries/libmcrypt/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Replacement for the old crypt() package and crypt(1) command, with extensions";
-    homepage = "http://mcrypt.sourceforge.net";
+    homepage = "https://mcrypt.sourceforge.net";
     license = "GPL";
     platforms = lib.platforms.all;
   };

--- a/pkgs/development/libraries/libmhash/default.nix
+++ b/pkgs/development/libraries/libmhash/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       following rfc2104 (HMAC). It also includes some key generation algorithms
       which are based on hash algorithms.
     '';
-    homepage = "http://mhash.sourceforge.net";
+    homepage = "https://mhash.sourceforge.net";
     license = "LGPL";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/libraries/libwpd/0.8.nix
+++ b/pkgs/development/libraries/libwpd/0.8.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Library for importing WordPerfect documents";
-    homepage = "http://libwpd.sourceforge.net";
+    homepage = "https://libwpd.sourceforge.net";
     license = with licenses; [ lgpl21 mpl20 ];
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/libwpg/default.nix
+++ b/pkgs/development/libraries/libwpg/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
 
   meta = with lib; {
-    homepage = "http://libwpg.sourceforge.net";
+    homepage = "https://libwpg.sourceforge.net";
     description = "C++ library to parse WPG";
     license = with licenses; [ lgpl21 mpl20 ];
     platforms = platforms.all;

--- a/pkgs/development/libraries/loki/default.nix
+++ b/pkgs/development/libraries/loki/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A C++ library of designs, containing flexible implementations of common design patterns and idioms";
-    homepage = "http://loki-lib.sourceforge.net";
+    homepage = "https://loki-lib.sourceforge.net";
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = with maintainers; [ peterhoeg ];

--- a/pkgs/development/libraries/podofo/default.nix
+++ b/pkgs/development/libraries/podofo/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://podofo.sourceforge.net";
+    homepage = "https://podofo.sourceforge.net";
     description = "A library to work with the PDF file format";
     platforms = platforms.all;
     license = with licenses; [ gpl2Plus lgpl2Plus ];

--- a/pkgs/development/libraries/ucx/default.nix
+++ b/pkgs/development/libraries/ucx/default.nix
@@ -55,7 +55,7 @@ in stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Unified Communication X library";
-    homepage = "http://www.openucx.org";
+    homepage = "https://www.openucx.org";
     license = licenses.bsd3;
     platforms = platforms.linux;
     maintainers = [ maintainers.markuskowa ];

--- a/pkgs/development/libraries/unixODBC/default.nix
+++ b/pkgs/development/libraries/unixODBC/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     urls = [
       "ftp://ftp.unixodbc.org/pub/unixODBC/${pname}-${version}.tar.gz"
-      "http://www.unixodbc.org/${pname}-${version}.tar.gz"
+      "https://www.unixodbc.org/${pname}-${version}.tar.gz"
     ];
     sha256 = "sha256-2eVcjnEYNH48ZshzOIVtrRUWtJD7fHVsFWKiwmfHO1w=";
   };
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "ODBC driver manager for Unix";
-    homepage = "http://www.unixodbc.org/";
+    homepage = "https://www.unixodbc.org/";
     license = licenses.lgpl2;
     platforms = platforms.unix;
   };

--- a/pkgs/development/python-modules/mdp/default.nix
+++ b/pkgs/development/python-modules/mdp/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Library for building complex data processing software by combining widely used machine learning algorithms";
-    homepage = "http://mdp-toolkit.sourceforge.net";
+    homepage = "https://mdp-toolkit.sourceforge.net";
     license = licenses.bsd3;
     maintainers = with maintainers; [ nico202 ];
   };

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -83,7 +83,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Optional static typing for Python";
-    homepage = "http://www.mypy-lang.org";
+    homepage = "https://www.mypy-lang.org";
     license = licenses.mit;
     maintainers = with maintainers; [ martingms lnl7 SuperSandro2000 ];
   };

--- a/pkgs/development/python-modules/mypy/extensions.nix
+++ b/pkgs/development/python-modules/mypy/extensions.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Experimental type system extensions for programs checked with the mypy typechecker";
-    homepage = "http://www.mypy-lang.org";
+    homepage = "https://www.mypy-lang.org";
     license = licenses.mit;
     maintainers = with maintainers; [ martingms lnl7 SuperSandro2000 ];
   };

--- a/pkgs/development/python-modules/pyopengl-accelerate/default.nix
+++ b/pkgs/development/python-modules/pyopengl-accelerate/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "This set of C (Cython) extensions provides acceleration of common operations for slow points in PyOpenGL 3.x";
-    homepage = "http://pyopengl.sourceforge.net/";
+    homepage = "https://pyopengl.sourceforge.net/";
     maintainers = with lib.maintainers; [ laikq ];
     license = lib.licenses.bsd3;
   };

--- a/pkgs/development/tools/explain/default.nix
+++ b/pkgs/development/tools/explain/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Library and utility to explain system call errors";
-    homepage = "http://libexplain.sourceforge.net";
+    homepage = "https://libexplain.sourceforge.net";
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ McSinyx ];
     platforms = platforms.unix;

--- a/pkgs/development/tools/literate-programming/nuweb/default.nix
+++ b/pkgs/development/tools/literate-programming/nuweb/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A simple literate programming tool";
-    homepage = "http://nuweb.sourceforge.net";
+    homepage = "https://nuweb.sourceforge.net";
     license = licenses.free;
     maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.unix;

--- a/pkgs/development/tools/misc/dfu-util/default.nix
+++ b/pkgs/development/tools/misc/dfu-util/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       phones. With dfu-util you are able to download firmware to your device or
       upload firmware from it.
     '';
-    homepage = "http://dfu-util.sourceforge.net";
+    homepage = "https://dfu-util.sourceforge.net";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = [ maintainers.fpletz ];

--- a/pkgs/development/tools/solarus-quest-editor/default.nix
+++ b/pkgs/development/tools/solarus-quest-editor/default.nix
@@ -33,7 +33,7 @@ mkDerivation rec {
       Many full-fledged games have been writen for the engine.
       Games can be created easily using the editor.
     '';
-    homepage = "http://www.solarus-games.org";
+    homepage = "https://www.solarus-games.org";
     license = licenses.gpl3;
     maintainers = [ ];
     platforms = platforms.linux;

--- a/pkgs/development/tools/udis86/default.nix
+++ b/pkgs/development/tools/udis86/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "out" "dev" "lib" ];
 
   meta = with lib; {
-    homepage = "http://udis86.sourceforge.net";
+    homepage = "https://udis86.sourceforge.net";
     license = licenses.bsd2;
     maintainers = with maintainers; [ timor ];
     mainProgram = "udcli";

--- a/pkgs/games/rili/default.nix
+++ b/pkgs/games/rili/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ SDL SDL_mixer ];
 
   meta = {
-    homepage = "http://ri-li.sourceforge.net";
+    homepage = "https://ri-li.sourceforge.net";
     license = lib.licenses.gpl2Plus;
     description = "A children's train game";
     longDescription = ''

--- a/pkgs/games/solarus/default.nix
+++ b/pkgs/games/solarus/default.nix
@@ -33,7 +33,7 @@ mkDerivation rec {
       Solarus is a game engine for Zelda-like ARPG games written in lua.
       Many full-fledged games have been writen for the engine.
     '';
-    homepage = "http://www.solarus-games.org";
+    homepage = "https://www.solarus-games.org";
     license = licenses.gpl3;
     maintainers = [ ];
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/guvcview/default.nix
+++ b/pkgs/os-specific/linux/guvcview/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A simple interface for devices supported by the linux UVC driver";
-    homepage = "http://guvcview.sourceforge.net";
+    homepage = "https://guvcview.sourceforge.net";
     maintainers = [ maintainers.coconnor ];
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/nmon/default.nix
+++ b/pkgs/os-specific/linux/nmon/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "AIX & Linux Performance Monitoring tool";
-    homepage = "http://nmon.sourceforge.net";
+    homepage = "https://nmon.sourceforge.net";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ sveitser ];

--- a/pkgs/os-specific/linux/uvcdynctrl/default.nix
+++ b/pkgs/os-specific/linux/uvcdynctrl/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "A simple interface for devices supported by the linux UVC driver";
-    homepage = "http://guvcview.sourceforge.net";
+    homepage = "https://guvcview.sourceforge.net";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.puffnfresh ];
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/xf86-input-wacom/default.nix
+++ b/pkgs/os-specific/linux/xf86-input-wacom/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     maintainers = with maintainers; [ goibhniu fortuneteller2k ];
     description = "Wacom digitizer driver for X11";
-    homepage = "http://linuxwacom.sourceforge.net";
+    homepage = "https://linuxwacom.sourceforge.net";
     license = licenses.gpl2Only;
     platforms = platforms.linux; # Probably, works with other unixes as well
   };

--- a/pkgs/tools/backup/partimage/default.nix
+++ b/pkgs/tools/backup/partimage/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Opensource disk backup software";
-    homepage = "http://www.partimage.org";
+    homepage = "https://www.partimage.org";
     license = lib.licenses.gpl2;
     maintainers = [lib.maintainers.marcweber];
     platforms = lib.platforms.linux;

--- a/pkgs/tools/filesystems/curlftpfs/default.nix
+++ b/pkgs/tools/filesystems/curlftpfs/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Filesystem for accessing FTP hosts based on FUSE and libcurl";
-    homepage = "http://curlftpfs.sourceforge.net";
+    homepage = "https://curlftpfs.sourceforge.net";
     license = licenses.gpl2Only;
     platforms = platforms.unix;
   };

--- a/pkgs/tools/filesystems/jfsutils/default.nix
+++ b/pkgs/tools/filesystems/jfsutils/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "IBM JFS utilities";
-    homepage = "http://jfs.sourceforge.net";
+    homepage = "https://jfs.sourceforge.net";
     license = licenses.gpl3;
     platforms = platforms.linux;
   };

--- a/pkgs/tools/graphics/structure-synth/default.nix
+++ b/pkgs/tools/graphics/structure-synth/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Application for generating 3D structures by specifying a design grammar";
-    homepage = "http://structuresynth.sourceforge.net";
+    homepage = "https://structuresynth.sourceforge.net";
     maintainers = with maintainers; [ hodapp ];
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/tools/misc/empty/default.nix
+++ b/pkgs/tools/misc/empty/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://empty.sourceforge.net";
+    homepage = "https://empty.sourceforge.net";
     description = "A simple tool to automate interactive terminal applications";
     license = licenses.bsd3;
     platforms = platforms.all;

--- a/pkgs/tools/misc/mcrypt/default.nix
+++ b/pkgs/tools/misc/mcrypt/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       for the old Unix crypt, except that they are under the GPL and support an
       ever-wider range of algorithms and modes.
     '';
-    homepage = "http://mcrypt.sourceforge.net";
+    homepage = "https://mcrypt.sourceforge.net";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.qknight ];

--- a/pkgs/tools/misc/ttylog/default.nix
+++ b/pkgs/tools/misc/ttylog/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   meta = with lib; {
-    homepage = "http://ttylog.sourceforge.net";
+    homepage = "https://ttylog.sourceforge.net";
     description = "Simple serial port logger";
     longDescription = ''
       A serial port logger which can be used to print everything to stdout

--- a/pkgs/tools/misc/wv2/default.nix
+++ b/pkgs/tools/misc/wv2/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Excellent MS Word filter lib, used in most Office suites";
     license = lib.licenses.lgpl2;
-    homepage = "http://wvware.sourceforge.net";
+    homepage = "https://wvware.sourceforge.net";
   };
 }

--- a/pkgs/tools/misc/xstow/default.nix
+++ b/pkgs/tools/misc/xstow/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     broken = stdenv.isDarwin;
     description = "A replacement of GNU Stow written in C++";
-    homepage = "http://xstow.sourceforge.net";
+    homepage = "https://xstow.sourceforge.net";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ nzbr ];
     platforms = platforms.unix;

--- a/pkgs/tools/networking/atinout/default.nix
+++ b/pkgs/tools/networking/atinout/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://atinout.sourceforge.net";
+    homepage = "https://atinout.sourceforge.net";
     description = "Tool for talking to modems";
     platforms = platforms.unix;
     license = licenses.gpl3;

--- a/pkgs/tools/networking/proxychains/default.nix
+++ b/pkgs/tools/networking/proxychains/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Proxifier for SOCKS proxies";
-    homepage = "http://proxychains.sourceforge.net";
+    homepage = "https://proxychains.sourceforge.net";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ fab ];
     platforms = platforms.linux;

--- a/pkgs/tools/networking/ssldump/default.nix
+++ b/pkgs/tools/networking/ssldump/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "An SSLv3/TLS network protocol analyzer";
-    homepage = "http://ssldump.sourceforge.net";
+    homepage = "https://ssldump.sourceforge.net";
     license = "BSD-style";
     maintainers = with maintainers; [ aycanirican ];
     platforms = platforms.unix;

--- a/pkgs/tools/security/srm/default.nix
+++ b/pkgs/tools/security/srm/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
       provide drop in security for users who wish to prevent recovery
       of deleted information, even if the machine is compromised.
     '';
-    homepage = "http://srm.sourceforge.net";
+    homepage = "https://srm.sourceforge.net";
     license = licenses.mit;
     maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.unix;

--- a/pkgs/tools/system/gdmap/default.nix
+++ b/pkgs/tools/system/gdmap/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = "-lm";
 
   meta = with lib; {
-    homepage = "http://gdmap.sourceforge.net";
+    homepage = "https://gdmap.sourceforge.net";
     description = "Recursive rectangle map of disk usage";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/tools/system/safecopy/default.nix
+++ b/pkgs/tools/system/safecopy/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
          resets and other helpful low level operations on a number of other device classes.
        '';
 
-    homepage = "http://safecopy.sourceforge.net";
+    homepage = "https://safecopy.sourceforge.net";
 
     license = lib.licenses.gpl2Plus;
 

--- a/pkgs/tools/text/tab/default.nix
+++ b/pkgs/tools/text/tab/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Programming language/shell calculator";
-    homepage    = "http://tab-lang.xyz";
+    homepage    = "https://tab-lang.xyz";
     license     = licenses.boost;
     maintainers = with maintainers; [ mstarzyk ];
     platforms   = with platforms; unix;

--- a/pkgs/tools/typesetting/tex/pgf-tikz/pgfplots.nix
+++ b/pkgs/tools/typesetting/tex/pgf-tikz/pgfplots.nix
@@ -24,7 +24,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    homepage = "http://pgfplots.sourceforge.net";
+    homepage = "https://pgfplots.sourceforge.net";
     description = "TeX package to draw plots directly in TeX in two and three dimensions";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];

--- a/pkgs/tools/video/xjadeo/default.nix
+++ b/pkgs/tools/video/xjadeo/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       soundtrack composition, video monitoring or any task that requires to
       synchronizing movie frames with external events.
     '';
-    homepage = "http://xjadeo.sourceforge.net";
+    homepage = "https://xjadeo.sourceforge.net";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ mitchmindtree ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -2001,7 +2001,7 @@ let
     propagatedBuildInputs = [ ExtUtilsDepends ExtUtilsPkgConfig ];
     meta = {
       description = "Perl interface to the cairo 2d vector graphics library";
-      homepage = "http://gtk2-perl.sourceforge.net";
+      homepage = "https://gtk2-perl.sourceforge.net";
       license = with lib.licenses; [ lgpl21Only ];
     };
   };
@@ -2017,7 +2017,7 @@ let
     propagatedBuildInputs = [ Cairo Glib ];
     meta = {
       description = "Integrate Cairo into the Glib type system";
-      homepage = "http://gtk2-perl.sourceforge.net";
+      homepage = "https://gtk2-perl.sourceforge.net";
       license = with lib.licenses; [ lgpl21Only ];
     };
   };
@@ -10224,7 +10224,7 @@ let
     propagatedBuildInputs = [ ExtUtilsDepends ExtUtilsPkgConfig ];
     meta = {
       description = "Perl wrappers for the GLib utility and Object libraries";
-      homepage = "http://gtk2-perl.sourceforge.net";
+      homepage = "https://gtk2-perl.sourceforge.net";
       license = with lib.licenses; [ lgpl21Only ];
     };
   };
@@ -10252,7 +10252,7 @@ let
     doCheck = !stdenv.isDarwin;
     meta = {
       description = "Dynamically create Perl language bindings";
-      homepage = "http://gtk2-perl.sourceforge.net";
+      homepage = "https://gtk2-perl.sourceforge.net";
       license = with lib.licenses; [ lgpl21Only ];
     };
   };
@@ -10268,7 +10268,7 @@ let
     propagatedBuildInputs = [ pkgs.gnome2.libgnomeui ];
     meta = {
       description = "(DEPRECATED) Perl interface to the 2.x series of the GNOME libraries";
-      homepage = "http://gtk2-perl.sourceforge.net";
+      homepage = "https://gtk2-perl.sourceforge.net";
       license = with lib.licenses; [ lgpl21Plus ];
       broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/perl534Packages.Gnome2Canvas.x86_64-darwin
     };
@@ -10568,7 +10568,7 @@ let
     propagatedBuildInputs = [ Pango ];
     meta = {
       description = "Perl interface to the 2.x series of the Gimp Toolkit library";
-      homepage = "http://gtk2-perl.sourceforge.net";
+      homepage = "https://gtk2-perl.sourceforge.net";
       license = with lib.licenses; [ lgpl21Plus ];
     };
   };
@@ -18732,7 +18732,7 @@ let
     propagatedBuildInputs = [ Cairo Glib ];
     meta = {
       description = "Layout and render international text";
-      homepage = "http://gtk2-perl.sourceforge.net";
+      homepage = "https://gtk2-perl.sourceforge.net";
       license = with lib.licenses; [ lgpl21Plus ];
     };
   };


### PR DESCRIPTION
###### Description of changes

I've create a little python script https://github.com/mothsART/repology-nixpkgs who update package's urls when http can be replace by https (permanent redirection).

Some correction and updates after https://github.com/NixOS/nixpkgs/pull/212002

###### Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
