### PR TITLE
zigmod: init at 90

### DIFF
--- a/pkgs/by-name/zi/zigmod/buildZigmodPackage.nix
+++ b/pkgs/by-name/zi/zigmod/buildZigmodPackage.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  stdenv,
+
+  cacert,
+  git,
+  zig,
+  zigmod,
+}:
+
+{
+  pname,
+  version,
+  src,
+  lockFile,
+  manifestFile,
+  depsOutputHash,
+  buildFlags ? "",
+  meta ? { },
+  nativeBuildInputs ? [ ],
+  postUnpack ? "",
+  preBuild ? "",
+  ...
+}@attrs:
+let
+  depsDir = ".zigmod";
+
+  deps = stdenv.mkDerivation {
+    name = "${pname}-deps.tar.gz";
+
+    inherit pname version;
+
+    srcs = [
+      lockFile
+      manifestFile
+    ];
+
+    sourceRoot = ".";
+
+    unpackPhase = ''
+      cp ${lockFile} $sourceRoot/zigmod.lock
+      cp ${manifestFile} $sourceRoot/zigmod.yml
+      chmod -R u+w $sourceRoot
+    '';
+
+    nativeBuildInputs = [
+      cacert
+      git
+      zigmod
+    ];
+
+    buildPhase = ''
+      zigmod fetch
+    '';
+
+    installPhase = ''
+      find ${depsDir} -name .git -type d -prune -exec rm -rf {} \;;
+      # Build a reproducible tar, per instructions at https://reproducible-builds.org/docs/archives/
+      tar --owner=0 --group=0 --numeric-owner --format=gnu \
+          --sort=name --mtime="@$SOURCE_DATE_EPOCH" \
+          -czf $out -C ${depsDir} .
+    '';
+
+    outputHash = depsOutputHash;
+    outputHashMode = "recursive";
+  };
+in
+stdenv.mkDerivation (
+  attrs
+  // {
+    inherit pname version src;
+
+    nativeBuildInputs = [
+      zig
+      zigmod
+    ] ++ nativeBuildInputs;
+
+    postUnpack =
+      ''
+        mkdir -p $sourceRoot/${depsDir}
+        tar -xf ${deps} -C $sourceRoot/${depsDir}
+      ''
+      + postUnpack;
+
+    buildPhase =
+      attrs.buildPhase or ''
+        runHook preBuild
+
+        zigmod fetch
+        zig build -Doptimize=ReleaseSafe -Dcpu=baseline ${buildFlags} --prefix $out
+
+        runHook postBuild
+      '';
+
+    preBuild =
+      ''
+        export XDG_CACHE_HOME="$(mktemp -d)"
+      ''
+      + preBuild;
+
+    meta = {
+      inherit (zig.meta) platforms;
+    } // meta;
+  }
+)

--- a/pkgs/by-name/zi/zigmod/package.nix
+++ b/pkgs/by-name/zi/zigmod/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  callPackage,
+
+  cacert,
+  git,
+  zig,
+}:
+
+let
+  pname = "zigmod";
+  version = "90";
+
+  src = fetchFromGitHub {
+    owner = "nektro";
+    repo = "zigmod";
+    rev = "r${version}";
+    hash = "sha256-IFcIK+dLTzogsYX5Ekw1lL9vlnUeh6I11fq9zOoW4io=";
+  };
+
+  preBuild = ''
+    export XDG_CACHE_HOME="$(mktemp -d)"
+  '';
+
+  depsDir = "zig-cache/zigmod";
+
+  deps = stdenv.mkDerivation {
+    name = "${pname}-deps.tar.gz";
+
+    inherit
+      pname
+      preBuild
+      src
+      version
+      ;
+
+    nativeBuildInputs = [
+      cacert
+      git
+      zig
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      # Dependencies will be fetched prior to building this dummy program
+      echo "pub fn main() void {}" > src/main.zig
+      zig build
+    '';
+
+    installPhase = ''
+      find ${depsDir} -name .git -type d -prune -exec rm -rf {} \;;
+      # Build a reproducible tar, per instructions at https://reproducible-builds.org/docs/archives/
+      tar --owner=0 --group=0 --numeric-owner --format=gnu \
+          --sort=name --mtime="@$SOURCE_DATE_EPOCH" \
+          -czf $out -C ${depsDir} .
+    '';
+
+    outputHash = "sha256-pwlSdzxbGpnqR4eClq2jHLTeri8b5rzs2lErNsS77Hg=";
+  };
+in
+stdenv.mkDerivation {
+  inherit
+    pname
+    version
+    src
+    preBuild
+    ;
+
+  nativeBuildInputs = [ zig ];
+
+  postUnpack = ''
+    mkdir -p $sourceRoot/${depsDir}
+    tar -xf ${deps} -C $sourceRoot/${depsDir}
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    zig build -Dmode=ReleaseSafe -Dcpu=baseline -Dtag=${version} --prefix $out
+
+    runHook postBuild
+  '';
+
+  passthru.tests = callPackage ./tests { };
+
+  meta = {
+    description = "A package manager for the Zig programming language";
+    homepage = "https://github.com/nektro/zigmod";
+    changelog = "https://github.com/nektro/zigmod/releases/tag/r${version}";
+    license = lib.licenses.mit;
+    inherit (zig.meta) platforms;
+    maintainers = with lib.maintainers; [ paveloom ];
+  };
+}

--- a/pkgs/by-name/zi/zigmod/tests/clap/.gitignore
+++ b/pkgs/by-name/zi/zigmod/tests/clap/.gitignore
@@ -1,0 +1,4 @@
+.zigmod
+deps.zig
+zig-cache
+zig-out

--- a/pkgs/by-name/zi/zigmod/tests/clap/build.zig
+++ b/pkgs/by-name/zi/zigmod/tests/clap/build.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+
+const deps = @import("deps.zig");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "test",
+        // In this case the main source file is merely a path, however, in more
+        // complicated build scripts, this could be a generated file.
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
+    b.installArtifact(exe);
+
+    deps.addAllTo(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+}
+

--- a/pkgs/by-name/zi/zigmod/tests/clap/default.nix
+++ b/pkgs/by-name/zi/zigmod/tests/clap/default.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchurl,
+  buildZigmodPackage,
+  zig_0_12,
+}:
+
+buildZigmodPackage.override { zig = zig_0_12; } {
+  pname = "zigmod-clap-test";
+  version = "1";
+
+  src = ./.;
+
+  lockFile = fetchurl {
+    url = "file:///" + ./zigmod.lock;
+    hash = "sha256-9phQeqUJ9JJmmGqE3vdGnHMFzylH8SkO1dNgTcH08VY=";
+  };
+  manifestFile = fetchurl {
+    url = "file:///" + ./zigmod.yml;
+    hash = "sha256-W6SBtM7JJdfCARx0p1VsGdqDeON/nnYhJLOGElwovk8=";
+  };
+
+  depsOutputHash = "sha256-/vwtkLpizO2itNluJlvNJE1nwfZoyEOIqPr0efO8Q+Q=";
+}

--- a/pkgs/by-name/zi/zigmod/tests/clap/src/main.zig
+++ b/pkgs/by-name/zi/zigmod/tests/clap/src/main.zig
@@ -1,0 +1,21 @@
+const std = @import("std");
+
+const clap = @import("clap");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    const params = comptime clap.parseParamsComptime(
+        \\-h, --help     Display this help and exit.
+        \\
+    );
+
+    var res = try clap.parse(clap.Help, &params, clap.parsers.default, .{
+        .allocator = gpa.allocator(),
+    });
+    defer res.deinit();
+
+    if (res.args.help != 0)
+        return clap.help(std.io.getStdErr().writer(), clap.Help, &params, .{});
+}

--- a/pkgs/by-name/zi/zigmod/tests/clap/zigmod.lock
+++ b/pkgs/by-name/zi/zigmod/tests/clap/zigmod.lock
@@ -1,0 +1,2 @@
+2
+git https://github.com/Hejsil/zig-clap commit-8c98e64

--- a/pkgs/by-name/zi/zigmod/tests/clap/zigmod.yml
+++ b/pkgs/by-name/zi/zigmod/tests/clap/zigmod.yml
@@ -1,0 +1,6 @@
+id: yncnugwm6pe1kfvgh71gkdcslsjot8eyvukp7ivm6fraumu9
+name: test
+license: MIT
+description:
+root_dependencies:
+  - src: git https://github.com/Hejsil/zig-clap commit-8c98e64

--- a/pkgs/by-name/zi/zigmod/tests/default.nix
+++ b/pkgs/by-name/zi/zigmod/tests/default.nix
@@ -1,0 +1,5 @@
+{ callPackage }:
+
+{
+  clap = callPackage ./clap { };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19885,6 +19885,11 @@ with pkgs;
 
   ytt = callPackage ../development/tools/ytt { };
 
+  zigmod = callPackage ../by-name/zi/zigmod/package.nix {
+    zig = zig_0_12;
+  };
+  buildZigmodPackage = callPackage ../by-name/zi/zigmod/buildZigmodPackage.nix { };
+
   zydis = callPackage ../development/libraries/zydis { };
 
   grabserial = callPackage ../development/tools/grabserial { };


### PR DESCRIPTION
###### Description of changes

A package manager for the Zig programming language (https://github.com/nektro/zigmod).

Note: it's gonna be broken on Darwin [until Zig 0.10.1 is fixed](https://github.com/NixOS/nixpkgs/commit/db76c9e04a75599c094d6ffccfcbf40c17004207).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
