### PR TITLE
Systemd optional deps

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -85,6 +85,7 @@
 , withAcl ? true
 , withAnalyze ? true
 , withApparmor ? true
+, withAudit ? true
 , withCompression ? true  # adds bzip2, lz4, xz and zstd
 , withCoredump ? true
 , withCryptsetup ? true
@@ -378,7 +379,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs =
     [
-      audit
       kmod
       libxcrypt
       libcap
@@ -392,6 +392,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withTests glib
     ++ lib.optional withAcl acl
     ++ lib.optional withApparmor libapparmor
+    ++ lib.optional withAudit audit
     ++ lib.optional wantCurl (lib.getDev curl)
     ++ lib.optionals withCompression [ bzip2 lz4 xz zstd ]
     ++ lib.optional withCoredump elfutils
@@ -439,6 +440,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dtests=false"
     "-Dacl=${lib.boolToString withAcl}"
     "-Danalyze=${lib.boolToString withAnalyze}"
+    "-Daudit=${lib.boolToString withAudit}"
     "-Dgcrypt=${lib.boolToString wantGcrypt}"
     "-Dimportd=${lib.boolToString withImportd}"
     "-Dlz4=${lib.boolToString withCompression}"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -106,6 +106,7 @@
 , withNetworkd ? true
 , withNss ? !stdenv.hostPlatform.isMusl
 , withOomd ? true
+, withPam ? true
 , withPCRE2 ? true
 , withPolkit ? true
 , withPortabled ? !stdenv.hostPlatform.isMusl
@@ -132,6 +133,7 @@
 assert withImportd -> withCompression;
 assert withCoredump -> withCompression;
 assert withHomed -> withCryptsetup;
+assert withHomed -> withPam;
 
 let
   wantCurl = withRemote || withImportd;
@@ -384,7 +386,6 @@ stdenv.mkDerivation (finalAttrs: {
       libcap
       libuuid
       linuxHeaders
-      pam
       bashInteractive # for patch shebangs
     ]
 
@@ -402,6 +403,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withLibidn2 libidn2
     ++ lib.optional withLibseccomp libseccomp
     ++ lib.optional withNetworkd iptables
+    ++ lib.optional withPam pam
     ++ lib.optional withPCRE2 pcre2
     ++ lib.optional withSelinux libselinux
     ++ lib.optional withRemote libmicrohttpd
@@ -427,6 +429,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Ddbuspolicydir=${placeholder "out"}/share/dbus-1/system.d"
     "-Ddbussessionservicedir=${placeholder "out"}/share/dbus-1/services"
     "-Ddbussystemservicedir=${placeholder "out"}/share/dbus-1/system-services"
+    "-Dpam=${lib.boolToString withPam}"
     "-Dpamconfdir=${placeholder "out"}/etc/pam.d"
     "-Drootprefix=${placeholder "out"}"
     "-Dpkgconfiglibdir=${placeholder "dev"}/lib/pkgconfig"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -97,6 +97,7 @@
 , withLibBPF ? lib.versionAtLeast buildPackages.llvmPackages.clang.version "10.0"
     && stdenv.hostPlatform.isAarch -> lib.versionAtLeast stdenv.hostPlatform.parsed.cpu.version "6" # assumes hard floats
     && !stdenv.hostPlatform.isMips64   # see https://github.com/NixOS/nixpkgs/pull/194149#issuecomment-1266642211
+, withLibidn2 ? true
 , withLocaled ? true
 , withLogind ? true
 , withMachined ? true
@@ -278,7 +279,7 @@ stdenv.mkDerivation (finalAttrs: {
           # Systemd does this decision during configure time and uses ifdef's to
           # enable specific branches. We can safely ignore (nuke) the libidn "v1"
           # libraries.
-          { name = "libidn2.so.0"; pkg = libidn2; }
+          { name = "libidn2.so.0"; pkg = opt withLibidn2 libidn2; }
           { name = "libidn.so.12"; pkg = null; }
           { name = "libidn.so.11"; pkg = null; }
 
@@ -381,7 +382,6 @@ stdenv.mkDerivation (finalAttrs: {
       kmod
       libxcrypt
       libcap
-      libidn2
       libuuid
       linuxHeaders
       pam
@@ -397,6 +397,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withCryptsetup (lib.getDev cryptsetup.dev)
     ++ lib.optional withEfi gnu-efi
     ++ lib.optional withKexectools kexec-tools
+    ++ lib.optional withLibidn2 libidn2
     ++ lib.optional withLibseccomp libseccomp
     ++ lib.optional withNetworkd iptables
     ++ lib.optional withPCRE2 pcre2
@@ -461,7 +462,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dsplit-usr=false"
     "-Dlibcurl=${lib.boolToString wantCurl}"
     "-Dlibidn=false"
-    "-Dlibidn2=true"
+    "-Dlibidn2=${lib.boolToString withLibidn2}"
     "-Dquotacheck=false"
     "-Dldconfig=false"
     "-Dsmack=true"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -82,6 +82,7 @@
 , bpftools
 , libbpf
 
+, withAcl ? true
 , withAnalyze ? true
 , withApparmor ? true
 , withCompression ? true  # adds bzip2, lz4, xz and zstd
@@ -377,7 +378,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs =
     [
-      acl
       audit
       kmod
       libxcrypt
@@ -390,6 +390,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     ++ lib.optionals wantGcrypt [ libgcrypt libgpg-error ]
     ++ lib.optional withTests glib
+    ++ lib.optional withAcl acl
     ++ lib.optional withApparmor libapparmor
     ++ lib.optional wantCurl (lib.getDev curl)
     ++ lib.optionals withCompression [ bzip2 lz4 xz zstd ]
@@ -436,6 +437,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dglib=${lib.boolToString withTests}"
     # while we do not run tests we should also not build them. Removes about 600 targets
     "-Dtests=false"
+    "-Dacl=${lib.boolToString withAcl}"
     "-Danalyze=${lib.boolToString withAnalyze}"
     "-Dgcrypt=${lib.boolToString wantGcrypt}"
     "-Dimportd=${lib.boolToString withImportd}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26921,7 +26921,6 @@ with pkgs;
     withCryptsetup = true;
     withFido2 = true;
     withKmod = true;
-    withPam = true;
     withTpm2Tss = true;
   };
   systemdStage1Network = systemdStage1.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26880,8 +26880,10 @@ with pkgs;
   };
   systemdMinimal = systemd.override {
     pname = "systemd-minimal";
+    withAcl = false;
     withAnalyze = false;
     withApparmor = false;
+    withAudit = false;
     withCompression = false;
     withCoredump = false;
     withCryptsetup = false;
@@ -26892,7 +26894,9 @@ with pkgs;
     withHomed = false;
     withHwdb = false;
     withImportd = false;
+    withKmod = false;
     withLibBPF = false;
+    withLibidn2 = false;
     withLocaled = false;
     withLogind = false;
     withMachined = false;
@@ -26900,6 +26904,7 @@ with pkgs;
     withNss = false;
     withOomd = false;
     withPCRE2 = false;
+    withPam = false;
     withPolkit = false;
     withPortabled = false;
     withRemote = false;
@@ -26912,13 +26917,17 @@ with pkgs;
   };
   systemdStage1 = systemdMinimal.override {
     pname = "systemd-stage-1";
+    withAcl = true;
     withCryptsetup = true;
     withFido2 = true;
+    withKmod = true;
+    withPam = true;
     withTpm2Tss = true;
   };
   systemdStage1Network = systemdStage1.override {
     pname = "systemd-stage-1-network";
     withNetworkd = true;
+    withLibidn2 = true;
   };
 
 


### PR DESCRIPTION
###### Description of changes
Allow to slim down the systemd build by:

- Making ACL (access control list) support via `libacl` optional;
- Making Linux Audit Framework integration optional;
- Making kmod/modprobe integration optional;
- Making IDN (Internationalized Domain Names) support via `libidn2` optional;
- Making PAM (Pluggable Authentication Module) stack integration optional;
- Fix the `systemd-initrd-simple` test

Fixes #216461 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] ~For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~ Testing on NixOS.
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


###### Test suites
Tests were executed from the current `master` branch with my commits cherry-picked on top in order to avoid some broken state in the current `staging`.

Test logs are uploaded to pastebin due to their massive size and GH limits
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.hibernate-systemd-stage-1](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/hibernate-systemd-stage-1.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.initrdNetwork](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/initrdNetwork.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.installer.bcache](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/installer.bcache.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.installer.bcachefsEncrypted](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/installer.bcachefsEncrypted.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.installer.bcachefsMulti](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/installer.bcachefsMulti.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.installer.bcachefsSimple](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/installer.bcachefsSimple.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.installer.btrfsSimple](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/installer.btrfsSimple.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.installer.btrfsSubvolDefault](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/installer.btrfsSubvolDefault.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.installer.btrfsSubvolEscape](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/installer.btrfsSubvolEscape.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.installer.btrfsSubvols](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/installer.btrfsSubvols.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.installer.encryptedFSWithKeyfile](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/installer.encryptedFSWithKeyfile.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.installer.fullDiskEncryption](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/installer.fullDiskEncryption.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.systemd](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/systemd.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.systemd-initrd-btrfs-raid](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/systemd-initrd-btrfs-raid.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.systemd-initrd-luks-fido2](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/systemd-initrd-luks-fido2.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.systemd-initrd-luks-keyfile](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/systemd-initrd-luks-keyfile.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.systemd-initrd-luks-password](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/systemd-initrd-luks-password.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.systemd-initrd-luks-tpm2](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/systemd-initrd-luks-tpm2.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.systemd-initrd-modprobe](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/systemd-initrd-modprobe.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.systemd-initrd-shutdown](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/systemd-initrd-shutdown.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.systemd-initrd-simple](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/systemd-initrd-simple.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.systemd-initrd-swraid](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/systemd-initrd-swraid.log)
- [[root@nixos:~/nixpkgs]# nix-build -A nixosTests.systemd-initrd-vconsole](https://github.com/filakhtov/test-proof-artifacts/blob/bd2dd505ee2301148289c8d4383e1c661b152a19/gh/nixos/nixpkgs/217249/systemd-initrd-vconsole.log)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
