### PR TITLE
build-support/vm/deb/deb-closure: quote generated urls

### DIFF
--- a/pkgs/build-support/vm/deb/deb-closure.pl
+++ b/pkgs/build-support/vm/deb/deb-closure.pl
@@ -156,7 +156,7 @@ foreach my $pkgName (@order) {
     $cleanedName =~ s/~//g;
 
     print "    (fetchurl {\n";
-    print "      url = $urlPrefix/$cdata->{Filename};\n";
+    print "      url = \"$urlPrefix/$cdata->{Filename}\";\n";
     print "      sha256 = \"$cdata->{SHA256}\";\n";
     print "      name = \"$cleanedName\";\n" if $cleanedName ne $origName;
     print "    })\n";


### PR DESCRIPTION
###### Description of changes
otherwise, eval fails when the experimental no-url-literals feature is activated

unquoted urls are discouraged after https://github.com/NixOS/rfcs/pull/45

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).