### PR TITLE
gokrazy-rsync: init at unstable-2022-10-17

### DIFF
--- a/pkgs/applications/networking/sync/gokrazy-rsync/default.nix
+++ b/pkgs/applications/networking/sync/gokrazy-rsync/default.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, lib
+, buildGoModule
+, fetchFromGitHub
+, rsync
+, openssh
+, writeShellScript
+, unstableGitUpdater
+, _experimental-update-script-combinators
+}:
+
+buildGoModule rec {
+  pname = "gokrazy-rsync";
+  version = "unstable-2022-10-17";
+
+  src = fetchFromGitHub {
+    owner = "gokrazy";
+    repo = "rsync";
+    rev = "197246cdaa697ce55d511dd99491a2cc1465ef18";
+    sha256 = "sha256-u7Z9eXpq1pvi46nkfbaZzXXkKvR8DCOeqdop0p3HYgw=";
+  };
+
+  vendorHash = "sha256-NIiTVJfAU8L9wZB7TeiVzDjkI6d7SGFiLr36kWdHtlw=";
+
+  nativeCheckInputs = [
+    rsync
+    openssh
+  ];
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isMinGW ''
+    # Depends on Unix functions
+    rm -r internal/rsynctest
+  '';
+
+  passthru = {
+    updateScript =
+      let
+        updateSource = unstableGitUpdater { };
+        updateVendor = writeShellScript "update-gokrazy-rsync-vendor-hash" ''
+          set -euo pipefail
+          FILE="$(nix-instantiate --eval -E 'with import ./. {}; (builtins.unsafeGetAttrPos "version" gokrazy-rsync).file' | tr -d '"')"
+          replaceHash() {
+            old="''${1?old hash missing}"
+            new="''${2?new hash missing}"
+            awk -v OLD="$old" -v NEW="$new" '{
+              if (i=index($0, OLD)) {
+                $0 = substr($0, 1, i-1) NEW substr($0, i+length(OLD));
+              }
+              print $0;
+            }' "$FILE" | sponge "$FILE"
+          }
+          extractVendorHash() {
+            original="''${1?original hash missing}"
+            result="$(nix-build -A gokrazy-rsync.go-modules 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
+            [ -z "$result" ] && { echo "$original"; } || { echo "$result"; }
+          }
+
+          goHash="$(nix-instantiate --eval -A gokrazy-rsync.vendorHash | tr -d '"')"
+            emptyHash="$(nix-instantiate --eval -A lib.fakeHash | tr -d '"')"
+            replaceHash "$goHash" "$emptyHash"
+            replaceHash "$emptyHash" "$(extractVendorHash "$goHash")"
+        '';
+      in
+        _experimental-update-script-combinators.sequence [
+          updateSource
+          updateVendor
+        ];
+  };
+
+  meta = {
+    description = "Back-end for Vikunja to-do list app";
+    homepage = "https://github.com/gokrazy/rsync";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jtojnar ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7685,6 +7685,8 @@ with pkgs;
 
   gokart = callPackage ../development/tools/gokart { };
 
+  gokrazy-rsync = callPackage ../applications/networking/sync/gokrazy-rsync { };
+
   gl2ps = callPackage ../development/libraries/gl2ps { };
 
   glusterfs = callPackage ../tools/filesystems/glusterfs { };


### PR DESCRIPTION
###### Description of changes

https://github.com/gokrazy/rsync

Script for updating vendorHash taken from grafana

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] `pkgsCross.mingwW64.gokrazy-rsync`
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
