### PR TITLE
languagetool: allow adding custom wordlists

### DIFF
--- a/pkgs/tools/text/languagetool/default.nix
+++ b/pkgs/tools/text/languagetool/default.nix
@@ -1,5 +1,22 @@
-{ lib, stdenv, fetchzip, jre, makeWrapper, nixosTests }:
-
+{ lib
+, stdenv
+, fetchzip
+, jre
+, makeWrapper
+, nixosTests
+, writeTextFile
+, extraSpelling ? { } # Custom spelling { en = ["multithreading" "quadtree"]; global=["Nixos"];}
+}:
+let
+  mkSpellFile = lang: data: writeTextFile {
+    name = "spelling_custom_" + lang + ".txt";
+    text = builtins.concatStringsSep "\n" data;
+  };
+  mkCustomSpellPath = lang: "$out/share/org/languagetool/resource/" +
+    (if lang == "global" then "spelling_global.txt"
+    else "${lang}/hunspell/spelling_custom.txt");
+  attrValuesAsLines = set: builtins.concatStringsSep "\n" (builtins.attrValues set);
+in
 stdenv.mkDerivation rec {
   pname = "LanguageTool";
   version = "6.3";
@@ -24,6 +41,12 @@ stdenv.mkDerivation rec {
 
     makeWrapper ${jre}/bin/java $out/bin/languagetool-http-server \
       --add-flags "-cp $out/share/languagetool-server.jar org.languagetool.server.HTTPServer"
+
+
+    ${ attrValuesAsLines (builtins.mapAttrs (lang: data: ''
+      mkdir -p $(dirname ${mkCustomSpellPath lang}) # Ensure dir for custom spell exist
+      ln -f -s ${mkSpellFile lang data} ${mkCustomSpellPath lang} # symlink to spellfile
+    '') extraSpelling) }
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Description of changes

Bump languagetool and add option to add custom words

```nix
  pkgs.languagetool.override {
    extraSpelling = {
      global = ["Nix" "NixOS" "CUDA" "GPGPU" "InfluxDB" "Nginx" "SystemD"];
      en = ["multithreading" "quadtree"];
      nl = ["telprobleem" "modulorekenen"];
    };
  }
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
