### PR TITLE
cudatoolkit: prune broken symlinks in `postFixup`

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -229,6 +229,13 @@ stdenv.mkDerivation rec {
     addOpenGLRunpath $out/cuda_sanitizer_api/compute-sanitizer/*
     addOpenGLRunpath $out/cuda_sanitizer_api/compute-sanitizer/x86/*
     addOpenGLRunpath $out/target-linux-x64/*
+  '' +
+  # Prune broken symlinks which can cause problems with consumers of this package.
+  ''
+    while read -r -d "" file; do
+      echo "Found and removing broken symlink $file"
+      rm "$file"
+    done < <(find "$out" "$lib" "$doc" -xtype l -print0)
   '';
 
   # cuda-gdb doesn't run correctly when not using sandboxing, so


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As cudatoolkit is currently written, 11.8 introduces a broken symlink in `include` (also named `include`) and in `lib` (named `lib64`).

This trips up some consumers, (e.g., it causes the build of `tensorflow-gpu` to fail), and will be a problem when switching to 11.8 as the default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Failures

- [x] TensorRT
    - Unrelated failure. Reproducible on `master` after adding `TensorRT-8.4.0.6.Linux.x86_64-gnu.cuda-11.6.cudnn8.3.tar.gz` to my store (per the guidance in the first error message, https://gist.github.com/ConnorBaker/9459ce1c741984959e78296c15e52f1e).
    - https://gist.github.com/ConnorBaker/882f8e425b585cb61f997259888b011b
- [x] tensorflow
    - Unrelated failure. Reproducible on `master`.
    - https://gist.github.com/ConnorBaker/06ceb965a933ae0659dfce58f9a8c654