### PR TITLE
c-ares: 1.18.1 -> 1.19.0

### DIFF
--- a/pkgs/development/libraries/c-ares/default.nix
+++ b/pkgs/development/libraries/c-ares/default.nix
@@ -1,5 +1,4 @@
 { lib, stdenv, fetchurl, writeTextDir
-, fetchpatch
 , withCMake ? true, cmake
 
 # sensitive downstream packages
@@ -14,22 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "c-ares";
-  version = "1.18.1";
+  version = "1.19.0";
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "https://c-ares.haxx.se/download/${pname}-${version}.tar.gz";
-    sha256 = "sha256-Gn1SqKhKn7/7G+kTPA9uFyF9kepab6Yfa0cpzaeOu88=";
+    sha256 = "sha256-v866N+I/1TEpOCkALKwEAe9JptxVkj9/kiNlhbetHdM=";
   };
-
-  # c-ares is used for fetchpatch, so avoid using it for c-aresMinimal
-  patches = lib.optionals withCMake [
-    # fix .pc paths created by cmake build
-    (fetchpatch {
-      url = "https://github.com/jonringer/c-ares/commit/9806a8a2f999a8a3efa3c893f2854dce6919d5bb.patch";
-      sha256 = "sha256-nh/ZKdan2/FTrouApRQA7O8KGZrLEUuWhxGOktiiGwU=";
-    })
-  ];
 
   nativeBuildInputs = lib.optionals withCMake [ cmake ];
 
@@ -47,6 +37,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A C library for asynchronous DNS requests";
     homepage = "https://c-ares.haxx.se";
+    changelog = "https://c-ares.org/changelog.html#${lib.replaceStrings [ "." ] [ "_" ] version}";
     license = licenses.mit;
     platforms = platforms.all;
   };


### PR DESCRIPTION
https://c-ares.org/changelog.html#1_19_0

Fixes: CVE-2022-4904

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
