### PR TITLE
[staging-22.11] c-ares: Patch CVE-2022-4904

### DIFF
--- a/pkgs/development/libraries/c-ares/CVE-2022-4904.patch
+++ b/pkgs/development/libraries/c-ares/CVE-2022-4904.patch
@@ -1,0 +1,60 @@
+From ac596026e77244481fd68736ae7f15855803a08a Mon Sep 17 00:00:00 2001
+From: hopper-vul <hopper.vul@gmail.com>
+Date: Tue, 13 Dec 2022 19:54:21 +0800
+Subject: [PATCH] Add str len check in config_sortlist to avoid stack overflow
+
+In ares_set_sortlist, it calls config_sortlist(..., sortstr) to parse
+the input str and initialize a sortlist configuration.
+
+However, ares_set_sortlist has not any checks about the validity of the input str.
+It is very easy to create an arbitrary length stack overflow with the unchecked
+`memcpy(ipbuf, str, q-str);` and `memcpy(ipbufpfx, str, q-str);`
+statements in the config_sortlist call, which could potentially cause severe
+security impact in practical programs.
+
+This commit add necessary check for `ipbuf` and `ipbufpfx` which avoid the
+potential stack overflows.
+
+fixes #496
+
+Signed-off-by: hopper-vul <hopper.vul@gmail.com>
+---
+ src/lib/ares_init.c    | 4 ++++
+ test/ares-test-init.cc | 2 ++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/src/lib/ares_init.c b/src/lib/ares_init.c
+index 7f92ef67..cc2885ee 100644
+--- a/src/lib/ares_init.c
++++ b/src/lib/ares_init.c
+@@ -1913,6 +1913,8 @@ static int config_sortlist(struct apattern **sortlist, int *nsort,
+       q = str;
+       while (*q && *q != '/' && *q != ';' && !ISSPACE(*q))
+         q++;
++      if (q-str >= 16)
++        return ARES_EBADSTR;
+       memcpy(ipbuf, str, q-str);
+       ipbuf[q-str] = '\0';
+       /* Find the prefix */
+@@ -1921,6 +1923,8 @@ static int config_sortlist(struct apattern **sortlist, int *nsort,
+           const char *str2 = q+1;
+           while (*q && *q != ';' && !ISSPACE(*q))
+             q++;
++          if (q-str >= 32)
++            return ARES_EBADSTR;
+           memcpy(ipbufpfx, str, q-str);
+           ipbufpfx[q-str] = '\0';
+           str = str2;
+diff --git a/test/ares-test-init.cc b/test/ares-test-init.cc
+index 63c6a228..ee845181 100644
+--- a/test/ares-test-init.cc
++++ b/test/ares-test-init.cc
+@@ -275,6 +275,8 @@ TEST_F(DefaultChannelTest, SetAddresses) {
+ 
+ TEST_F(DefaultChannelTest, SetSortlistFailures) {
+   EXPECT_EQ(ARES_ENODATA, ares_set_sortlist(nullptr, "1.2.3.4"));
++  EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "111.111.111.111*/16"));
++  EXPECT_EQ(ARES_EBADSTR, ares_set_sortlist(channel_, "111.111.111.111/255.255.255.240*"));
+   EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel_, "xyzzy ; lwk"));
+   EXPECT_EQ(ARES_SUCCESS, ares_set_sortlist(channel_, "xyzzy ; 0x123"));
+ }

--- a/pkgs/development/libraries/c-ares/default.nix
+++ b/pkgs/development/libraries/c-ares/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
       url = "https://github.com/jonringer/c-ares/commit/9806a8a2f999a8a3efa3c893f2854dce6919d5bb.patch";
       sha256 = "sha256-nh/ZKdan2/FTrouApRQA7O8KGZrLEUuWhxGOktiiGwU=";
     })
+    ./CVE-2022-4904.patch
   ];
 
   nativeBuildInputs = lib.optionals withCMake [ cmake ];


### PR DESCRIPTION
Fix ported from c-ares 1.19.0.

https://bugzilla.redhat.com/show_bug.cgi?id=2168631

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
