### PR TITLE
libdeltachat: 1.108.0 -> 1.109.0

### DIFF
--- a/pkgs/development/libraries/libdeltachat/default.nix
+++ b/pkgs/development/libraries/libdeltachat/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libdeltachat";
-  version = "1.108.0";
+  version = "1.109.0";
 
   src = fetchFromGitHub {
     owner = "deltachat";
     repo = "deltachat-core-rust";
     rev = version;
-    hash = "sha256-6nEjSo0EuYJd9/0NyvTzfUON1OMJt5FBLx7Y8sjnb3I=";
+    hash = "sha256-6zlXa9N7gaF1ta6mjszsA25+QRrHF8m1brKoSiL5OHo=";
   };
 
   patches = [
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-/tCEiPvoIPScpKcDmJ0t21AN+bOBH5/XzOBajQg+7ck=";
+    hash = "sha256-Z7CLKhKWqAaLhsXi81OOKWmwQddHCebCJibbKiNNptk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/deltachat/default.nix
+++ b/pkgs/development/python-modules/deltachat/default.nix
@@ -1,9 +1,10 @@
 { lib
 , buildPythonPackage
-, isPy27
+, pythonOlder
 , pkg-config
 , pkgconfig
 , setuptools-scm
+, wheel
 , libdeltachat
 , cffi
 , imap-tools
@@ -18,12 +19,16 @@ buildPythonPackage rec {
   inherit (libdeltachat) version src;
   sourceRoot = "${src.name}/python";
 
-  disabled = isPy27;
+  disabled = pythonOlder "3.7";
+  format = "pyproject";
 
   nativeBuildInputs = [
+    cffi
     pkg-config
     pkgconfig
+    setuptools
     setuptools-scm
+    wheel
   ];
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -37,7 +42,7 @@ buildPythonPackage rec {
     imap-tools
     pluggy
     requests
-    setuptools
+    setuptools # for pkg_resources
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
###### Description of changes
Diff: https://github.com/deltachat/deltachat-core-rust/compare/1.108.0...1.109.0

Changelog: https://github.com/deltachat/deltachat-core-rust/blob/1.109.0/CHANGELOG.md
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
