### PR TITLE
ldb: copy cross fix from tevent

### DIFF
--- a/pkgs/development/libraries/ldb/default.nix
+++ b/pkgs/development/libraries/ldb/default.nix
@@ -63,6 +63,11 @@ stdenv.mkDerivation rec {
     "--without-ldb-lmdb"
   ];
 
+  # python-config from build Python gives incorrect values when cross-compiling.
+  # If python-config is not found, the build falls back to using the sysconfig
+  # module, which works correctly in all cases.
+  PYTHON_CONFIG = "/invalid";
+
   stripDebugList = [ "bin" "lib" "modules" ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

There's an issue with building for 32 bit targets on a 64 bit host.

The following commands failed for me on an `x86_64` host:

- `nix build .#pkgsCross.raspberryPi.ldb`
- `nix build .#pkgsCross.gnu32.ldb`

I can't test at the moment but I think the same issue would be encountered on an `aarch64` host.

Saw the following on my failed builds

```
Testing pyembed configuration: Could not build a python embedded interpreter
```

I dug into the config log and this seemed to be cause of the issue:

```
['armv6l-unknown-linux-gnueabihf-gcc', '-MMD', '-D_GNU_SOURCE=1', '-D_XOPEN_SOURCE_EXTENDED=1', '-g', '-fwrapv', '-O3',
 '-I/nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9/include/python3.10', '-I/nix/store/kaiinm7cjirmv4zd3pdqa
r23rsypfqlh-libxcrypt-4.4.33/include', '-DNDEBUG', '../../test.c', '-c', '-o/build/ldb-2.6.1/bin/.conf_check_59d3a0a5b9
6e327858e281d280fec4ed/testbuild/default/test.c.1.o']
err: In file included from /nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9/include/python3.10/Python.h:8,
                 from ../../test.c:432:
/nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9/include/python3.10/pyconfig.h:1480: warning: "SIZEOF_LONG" r
edefined
 1480 | #define SIZEOF_LONG 8
      |
../../test.c:154: note: this is the location of the previous definition
  154 | #define SIZEOF_LONG 4
      |
/nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9/include/python3.10/pyconfig.h:1504: warning: "SIZEOF_SIZE_T"
 redefined
 1504 | #define SIZEOF_SIZE_T 8
      |
../../test.c:156: note: this is the location of the previous definition
  156 | #define SIZEOF_SIZE_T 4
      |
/nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9/include/python3.10/pyconfig.h:1507: warning: "SIZEOF_TIME_T" redefined
 1507 | #define SIZEOF_TIME_T 8
      |
../../test.c:170: note: this is the location of the previous definition
  170 | #define SIZEOF_TIME_T 4
      |
/nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9/include/python3.10/pyconfig.h:1513: warning: "SIZEOF_VOID_P" redefined
 1513 | #define SIZEOF_VOID_P 8
      |
../../test.c:166: note: this is the location of the previous definition
  166 | #define SIZEOF_VOID_P 4
      |
In file included from /nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9/include/python3.10/Python.h:50:
/nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9/include/python3.10/pyport.h:746:2: error: #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
  746 | #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
      |  ^~~~~
```

I'm gonna be honest I don't quite understand what setting `PYTHON_CONFIG` does so I'd appreciate if someone more knowledgeable could chime in with an explanation. I _think_ what ends up happening here is that by setting `PYTHON_CONFIG` we guarantee to use the python defined in `buildInputs` instead of the python defined in `nativeBuildInputs`. I'm out of my depth here so I could be way off in my explanation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
