### PR TITLE
cudaFlags: rewrite to capture all architectures and fix NixOS#215436

### DIFF
--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
       "-DUSE_OLDCMAKECUDA=ON"  # see https://github.com/apache/incubator-mxnet/issues/10743
       "-DCUDA_ARCH_NAME=All"
       "-DCUDA_HOST_COMPILER=${cudatoolkit.cc}/bin/cc"
-      "-DMXNET_CUDA_ARCH=${cudaFlags.cudaCapabilitiesSemiColonString}"
+      "-DMXNET_CUDA_ARCH=${builtins.concatStringsSep ";" cudaFlags.cudaRealArches}"
     ] else [ "-DUSE_CUDA=OFF" ])
     ++ lib.optional (!cudnnSupport) "-DUSE_CUDNN=OFF";
 

--- a/pkgs/development/compilers/cudatoolkit/flags.nix
+++ b/pkgs/development/compilers/cudatoolkit/flags.nix
@@ -2,7 +2,18 @@
 , lib
 , cudatoolkit
 }:
+
+# Type aliases
+# Gpu = {
+#   archName: String, # e.g., "Hopper"
+#   computeCapability: String, # e.g., "9.0"
+#   minCudaVersion: String, # e.g., "11.8"
+#   maxCudaVersion: String, # e.g., "12.0"
+# }
+
 let
+  inherit (lib) attrsets lists strings trivial versions;
+  cudaVersion = cudatoolkit.version;
 
   # Flags are determined based on your CUDA toolkit by default.  You may benefit
   # from improved performance, reduced file size, or greater hardware suppport by
@@ -13,66 +24,116 @@ let
   #
   # Please see the accompanying documentation or https://github.com/NixOS/nixpkgs/pull/205351
 
-  defaultCudaCapabilities = rec {
-    cuda9 = [
-      "3.0"
-      "3.5"
-      "5.0"
-      "5.2"
-      "6.0"
-      "6.1"
-      "7.0"
-    ];
+  # gpus :: List Gpu
+  gpus = builtins.import ./gpus.nix;
 
-    cuda10 = cuda9 ++ [
-      "7.5"
-    ];
+  # isVersionIn :: Gpu -> Bool
+  isSupported = gpu:
+    let
+      inherit (gpu) minCudaVersion maxCudaVersion;
+      lowerBoundSatisfied = strings.versionAtLeast cudaVersion minCudaVersion;
+      upperBoundSatisfied = !(strings.versionOlder maxCudaVersion cudaVersion);
+    in
+    lowerBoundSatisfied && upperBoundSatisfied;
 
-    cuda11 = [
-      "3.5"
-      "5.0"
-      "5.2"
-      "6.0"
-      "6.1"
-      "7.0"
-      "7.5"
-      "8.0"
-      "8.6"
-    ];
+  # supportedGpus :: List Gpu
+  # GPUs which are supported by the provided CUDA version.
+  supportedGpus = builtins.filter isSupported gpus;
 
-  };
+  # cudaArchNameToVersions :: AttrSet String (List String)
+  # Maps the name of a GPU architecture to different versions of that architecture.
+  # For example, "Ampere" maps to [ "8.0" "8.6" "8.7" ].
+  cudaArchNameToVersions =
+    lists.groupBy'
+      (versions: gpu: versions ++ [ gpu.computeCapability ])
+      [ ]
+      (gpu: gpu.archName)
+      supportedGpus;
 
-  cudaMicroarchitectureNames = {
-    "3" = "Kepler";
-    "5" = "Maxwell";
-    "6" = "Pascal";
-    "7" = "Volta";
-    "8" = "Ampere";
-    "9" = "Hopper";
-  };
+  # cudaArchNames :: List String
+  # NOTE: It's important that we don't rely on builtins.attrNames cudaArchNameToVersions here;
+  #   otherwise, we'll get the names sorted in alphabetical order. The JSON array we read them
+  #   from is already sorted, so we'll preserve that order here.
+  cudaArchNames = lists.unique (lists.map (gpu: gpu.archName) supportedGpus);
 
-  defaultCudaArchList = defaultCudaCapabilities."cuda${lib.versions.major cudatoolkit.version}";
-  cudaRealCapabilities = config.cudaCapabilities or defaultCudaArchList;
-  capabilitiesForward = "${lib.last cudaRealCapabilities}+PTX";
+  # cudaComputeCapabilityToName :: AttrSet String String
+  # Maps the version of a GPU architecture to the name of that architecture.
+  # For example, "8.0" maps to "Ampere".
+  cudaComputeCapabilityToName = builtins.listToAttrs (
+    lists.map
+      (gpu: {
+        name = gpu.computeCapability;
+        value = gpu.archName;
+      })
+      supportedGpus
+  );
 
-  dropDot = ver: builtins.replaceStrings ["."] [""] ver;
+  # cudaComputeCapabilities :: List String
+  # NOTE: It's important that we don't rely on builtins.attrNames cudaComputeCapabilityToName here;
+  #   otherwise, we'll get the versions sorted in alphabetical order. The JSON array we read them
+  #   from is already sorted, so we'll preserve that order here.
+  # Use the user-provided list of CUDA capabilities if it's provided.
+  cudaComputeCapabilities = config.cudaCapabilities
+    or (lists.map (gpu: gpu.computeCapability) supportedGpus);
 
-  archMapper = feat: map (ver: "${feat}_${dropDot ver}");
-  gencodeMapper = feat: map (ver: "-gencode=arch=compute_${dropDot ver},code=${feat}_${dropDot ver}");
-  cudaRealArchs = archMapper "sm" cudaRealCapabilities;
-  cudaPTXArchs = archMapper "compute" cudaRealCapabilities;
-  cudaArchs = cudaRealArchs ++ [ (lib.last cudaPTXArchs) ];
+  # cudaForwardComputeCapability :: String
+  cudaForwardComputeCapability = (lists.last cudaComputeCapabilities) + "+PTX";
 
-  cudaArchNames = lib.unique (map (v: cudaMicroarchitectureNames.${lib.versions.major v}) cudaRealCapabilities);
-  cudaCapabilities = cudaRealCapabilities ++ lib.optional (config.cudaForwardCompat or true) capabilitiesForward;
-  cudaGencode = gencodeMapper "sm" cudaRealCapabilities ++ lib.optionals (config.cudaForwardCompat or true) (gencodeMapper "compute" [ (lib.last cudaPTXArchs) ]);
+  # cudaComputeCapabilitiesAndForward :: List String
+  # The list of supported CUDA architectures, including the forward compatibility architecture.
+  # If forward compatibility is disabled, this will be the same as cudaComputeCapabilities.
+  cudaComputeCapabilitiesAndForward = cudaComputeCapabilities
+    ++ lists.optional (config.cudaForwardCompat or true) cudaForwardComputeCapability;
 
-  cudaCapabilitiesCommaString = lib.strings.concatStringsSep "," cudaCapabilities;
-  cudaCapabilitiesSemiColonString = lib.strings.concatStringsSep ";" cudaCapabilities;
-  cudaRealCapabilitiesCommaString = lib.strings.concatStringsSep "," cudaRealCapabilities;
+  # dropDot :: String -> String
+  dropDot = ver: builtins.replaceStrings [ "." ] [ "" ] ver;
+
+  # archMapper :: String -> List String -> List String
+  # Maps a feature across a list of architecture versions to produce a list of architectures.
+  # For example, "sm" and [ "8.0" "8.6" "8.7" ] produces [ "sm_80" "sm_86" "sm_87" ].
+  archMapper = feat: lists.map (computeCapability: "${feat}_${dropDot computeCapability}");
+
+  # gencodeMapper :: String -> List String -> List String
+  # Maps a feature across a list of architecture versions to produce a list of gencode arguments.
+  # For example, "sm" and [ "8.0" "8.6" "8.7" ] produces [ "-gencode=arch=compute_80,code=sm_80"
+  # "-gencode=arch=compute_86,code=sm_86" "-gencode=arch=compute_87,code=sm_87" ].
+  gencodeMapper = feat: lists.map (
+    computeCapability:
+    "-gencode=arch=compute_${dropDot computeCapability},code=${feat}_${dropDot computeCapability}"
+  );
+
+  # cudaRealArches :: List String
+  # The real architectures are physical architectures supported by the CUDA version.
+  # For example, "sm_80".
+  cudaRealArches = archMapper "sm" cudaComputeCapabilities;
+
+  # cudaVirtualArches :: List String
+  # The virtual architectures are typically used for forward compatibility, when trying to support
+  # an architecture newer than the CUDA version allows.
+  # For example, "compute_80".
+  cudaVirtualArches = archMapper "compute" cudaComputeCapabilities;
+
+  # cudaArches :: List String
+  # By default, build for all supported architectures and forward compatibility via a virtual
+  # architecture for the newest supported architecture.
+  cudaArches = cudaRealArches ++
+    lists.optional (config.cudaForwardCompat or true) (lists.last cudaVirtualArches);
+
+  # cudaGencode :: List String
+  # A list of CUDA gencode arguments to pass to NVCC.
+  cudaGencode =
+    let
+      base = gencodeMapper "sm" cudaComputeCapabilities;
+      forwardCompat = gencodeMapper "compute" [ (lists.last cudaComputeCapabilities) ];
+    in
+    base ++ lists.optionals (config.cudaForwardCompat or true) forwardCompat;
 
 in
 {
-   inherit cudaArchs cudaArchNames cudaCapabilities cudaCapabilitiesCommaString cudaCapabilitiesSemiColonString
-     cudaRealCapabilities cudaRealCapabilitiesCommaString cudaGencode cudaRealArchs cudaPTXArchs;
+  inherit
+    cudaArchNames
+    cudaArchNameToVersions cudaComputeCapabilityToName
+    cudaRealArches cudaVirtualArches cudaArches
+    cudaGencode;
+  cudaCapabilities = cudaComputeCapabilitiesAndForward;
 }

--- a/pkgs/development/compilers/cudatoolkit/gpus.nix
+++ b/pkgs/development/compilers/cudatoolkit/gpus.nix
@@ -1,0 +1,110 @@
+[
+  {
+    archName = "Kepler";
+    computeCapability = "3.0";
+    minCudaVersion = "10.0";
+    maxCudaVersion = "10.2";
+  }
+  {
+    archName = "Kepler";
+    computeCapability = "3.2";
+    minCudaVersion = "10.0";
+    maxCudaVersion = "10.2";
+  }
+  {
+    archName = "Kepler";
+    computeCapability = "3.5";
+    minCudaVersion = "10.0";
+    maxCudaVersion = "11.8";
+  }
+  {
+    archName = "Kepler";
+    computeCapability = "3.7";
+    minCudaVersion = "10.0";
+    maxCudaVersion = "11.8";
+  }
+  {
+    archName = "Maxwell";
+    computeCapability = "5.0";
+    minCudaVersion = "10.0";
+    maxCudaVersion = "12.0";
+  }
+  {
+    archName = "Maxwell";
+    computeCapability = "5.2";
+    minCudaVersion = "10.0";
+    maxCudaVersion = "12.0";
+  }
+  {
+    archName = "Maxwell";
+    computeCapability = "5.3";
+    minCudaVersion = "10.0";
+    maxCudaVersion = "12.0";
+  }
+  {
+    archName = "Pascal";
+    computeCapability = "6.0";
+    minCudaVersion = "10.0";
+    maxCudaVersion = "12.0";
+  }
+  {
+    archName = "Pascal";
+    computeCapability = "6.1";
+    minCudaVersion = "10.0";
+    maxCudaVersion = "12.0";
+  }
+  {
+    archName = "Pascal";
+    computeCapability = "6.2";
+    minCudaVersion = "10.0";
+    maxCudaVersion = "12.0";
+  }
+  {
+    archName = "Volta";
+    computeCapability = "7.0";
+    minCudaVersion = "10.0";
+    maxCudaVersion = "12.0";
+  }
+  {
+    archName = "Volta";
+    computeCapability = "7.2";
+    minCudaVersion = "10.0";
+    maxCudaVersion = "12.0";
+  }
+  {
+    archName = "Turing";
+    computeCapability = "7.5";
+    minCudaVersion = "10.0";
+    maxCudaVersion = "12.0";
+  }
+  {
+    archName = "Ampere";
+    computeCapability = "8.0";
+    minCudaVersion = "11.2";
+    maxCudaVersion = "12.0";
+  }
+  {
+    archName = "Ampere";
+    computeCapability = "8.6";
+    minCudaVersion = "11.2";
+    maxCudaVersion = "12.0";
+  }
+  {
+    archName = "Ampere";
+    computeCapability = "8.7";
+    minCudaVersion = "11.5";
+    maxCudaVersion = "12.0";
+  }
+  {
+    archName = "Ada";
+    computeCapability = "8.9";
+    minCudaVersion = "11.8";
+    maxCudaVersion = "12.0";
+  }
+  {
+    archName = "Hopper";
+    computeCapability = "9.0";
+    minCudaVersion = "11.8";
+    maxCudaVersion = "12.0";
+  }
+]

--- a/pkgs/development/libraries/science/math/magma/default.nix
+++ b/pkgs/development/libraries/science/math/magma/default.nix
@@ -52,7 +52,7 @@ in stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_C_COMPILER=${cudatoolkit.cc}/bin/gcc"
     "-DCMAKE_CXX_COMPILER=${cudatoolkit.cc}/bin/g++"
     "-DMAGMA_ENABLE_CUDA=ON"
-    "-DGPU_TARGET=${builtins.concatStringsSep "," cudaFlags.cudaRealArchs}"
+    "-DGPU_TARGET=${builtins.concatStringsSep "," cudaFlags.cudaRealArches}"
   ] ++ lib.optionals useROCM [
     "-DCMAKE_C_COMPILER=${hip}/bin/hipcc"
     "-DCMAKE_CXX_COMPILER=${hip}/bin/hipcc"

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -164,7 +164,7 @@ let
       build --action_env TF_CUDA_PATHS="${cudatoolkit_joined},${cudnn},${nccl}"
       build --action_env TF_CUDA_VERSION="${lib.versions.majorMinor cudatoolkit.version}"
       build --action_env TF_CUDNN_VERSION="${lib.versions.major cudnn.version}"
-      build:cuda --action_env TF_CUDA_COMPUTE_CAPABILITIES="${cudaFlags.cudaRealCapabilitiesCommaString}"
+      build:cuda --action_env TF_CUDA_COMPUTE_CAPABILITIES="${builtins.concatStringsSep "," cudaFlags.cudaRealArches}"
     '' + ''
       CFG
     '';

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -301,7 +301,7 @@ let
     TF_CUDA_PATHS = lib.optionalString cudaSupport "${cudatoolkit_joined},${cudnn},${nccl}";
     GCC_HOST_COMPILER_PREFIX = lib.optionalString cudaSupport "${cudatoolkit_cc_joined}/bin";
     GCC_HOST_COMPILER_PATH = lib.optionalString cudaSupport "${cudatoolkit_cc_joined}/bin/gcc";
-    TF_CUDA_COMPUTE_CAPABILITIES = builtins.concatStringsSep "," cudaFlags.cudaRealArchs;
+    TF_CUDA_COMPUTE_CAPABILITIES = builtins.concatStringsSep "," cudaFlags.cudaRealArches;
 
     postPatch = ''
       # bazel 3.3 should work just as well as bazel 3.1

--- a/pkgs/development/python-modules/torchvision/default.nix
+++ b/pkgs/development/python-modules/torchvision/default.nix
@@ -15,13 +15,13 @@
 }:
 
 let
-  inherit (torch.cudaPackages) cudatoolkit cudaFlags cudnn;
+  inherit (torch) gpuTargetString;
+  inherit (torch.cudaPackages) cudatoolkit cudnn;
 
   cudatoolkit_joined = symlinkJoin {
     name = "${cudatoolkit.name}-unsplit";
     paths = [ cudatoolkit.out cudatoolkit.lib ];
   };
-  cudaArchStr = lib.optionalString cudaSupport lib.strings.concatStringsSep ";" torch.cudaArchList;
 in buildPythonPackage rec {
   pname = "torchvision";
   version = "0.14.1";
@@ -45,7 +45,7 @@ in buildPythonPackage rec {
   propagatedBuildInputs = [ numpy pillow torch scipy ];
 
   preBuild = lib.optionalString cudaSupport ''
-    export TORCH_CUDA_ARCH_LIST="${cudaFlags.cudaCapabilitiesSemiColonString}"
+    export TORCH_CUDA_ARCH_LIST="${gpuTargetString}"
     export FORCE_CUDA=1
   '';
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- `cudaFlags` is rewritten to capture all of NVIDIA's supported architectures.
  - A new `gpus.json` is added containing support GPUs, their architecture name, and their compute capability (as well as the range of CUDA versions which support them).
  - Packages dependent on `cudaFlags` have been updated to match.
- Fixes #215436.
- `torch` exposes (via `passthru`) `gpuTargetString` and `cudaCapabilities` for `torchvision` and other consumers so they can avoid re-creating it.
  - Re-using the string/filtered compute capabilities has the added benefit of `torchvision` being built with support for only the GPUs defined in `torch`'s `cpp_extension.py`: https://github.com/pytorch/pytorch/blob/49444c3e546bf240bed24a101e747422d1f8a0ee/torch/utils/cpp_extension.py#L1751.
- `torchvision` re-uses the `gpuTargetString` computed by `torch`

On changing `torch` and `torchvision`:

- Some packages hard-code supported architectures -- `torch` and `torchvision` are two such packages.
  - `torch`'s list can be found here: https://github.com/pytorch/pytorch/blob/49444c3e546bf240bed24a101e747422d1f8a0ee/torch/utils/cpp_extension.py#L1751.
- I think packages which can be built with CUDA or ROCm support but only support certain architectures *should* include some way to ensure the flags provided to the package won't cause a build error.
- This way, the CUDA portion of Nixpkgs can add new architectures without causing breakages in packages like `torch`, which are aware of the architectures they support.
- Another package with hard-coded support is `magma`. I have a PR open which implements this design here: https://github.com/NixOS/nixpkgs/pull/217410.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Failures

- [x] python310Packages.persim
  - Unrelated. https://gist.github.com/ConnorBaker/4ff64c7f955d240f448c81ca6965006b.
- [x] python310Packages.kmapper
  - Unrelated. https://gist.github.com/ConnorBaker/81108ee28d2e59c160525e9783bf0486.
- [x] python310Packages.apache-beam
  - Unrelated. https://gist.github.com/ConnorBaker/08c8963e5da8263f3278f9a9638411ca.
  - Seems other python packages have also encountered this failure: https://github.com/NixOS/nixpkgs/pull/216494.
- [x] python310Packages.dalle-mini
  - Unrelated. https://gist.github.com/ConnorBaker/07157847a38ce26e51fc58370f84d1e1.
- [x] python310Packages.treex
  - Unrelated. https://gist.github.com/ConnorBaker/46a4486c4b781789d0a2276b07b0a92a.
- [x] python310Packages.tensorflowWithCuda
  - Unrelated. https://gist.github.com/ConnorBaker/79160741b25a51f46b36d12166c4df0d.
- [x] python310Packages.tensorflow-datasets
  - Due to python310Packages.tensorflowWithCuda failure.