### PR TITLE
lens: Change lens' listed license from MIT to their own proprietary license

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -618,6 +618,12 @@ in mkLicense lset) ({
     fullName = "Licence Art Libre 1.3";
   };
 
+  lens = {
+    fullName = "Lens Terms of Service Agreement";
+    url = "https://k8slens.dev/licenses/tos";
+    free = false;
+  };
+
   lgpl2Only = {
     spdxId = "LGPL-2.0-only";
     fullName = "GNU Library General Public License v2 only";

--- a/pkgs/applications/networking/cluster/lens/darwin.nix
+++ b/pkgs/applications/networking/cluster/lens/darwin.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "The Kubernetes IDE";
     homepage = "https://k8slens.dev/";
-    license = licenses.mit;
+    license = licenses.lens;
     maintainers = with maintainers; [ dbirks ];
     platforms = [ "aarch64-darwin" ];
   };

--- a/pkgs/applications/networking/cluster/lens/linux.nix
+++ b/pkgs/applications/networking/cluster/lens/linux.nix
@@ -37,7 +37,7 @@ appimageTools.wrapType2 {
   meta = with lib; {
     description = "The Kubernetes IDE";
     homepage = "https://k8slens.dev/";
-    license = licenses.mit;
+    license = licenses.lens;
     maintainers = with maintainers; [ dbirks RossComputerGuy ];
     platforms = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
Although Lens is based on a free core component ("OpenLens"), the tarballs provided by Mirantis include a proprietary version of Lens that requires a subscription.

As the proprietary option offers additional features, it would not be wise to simply rewrite the derivation and base it on the FOSS source code. Instead, implementing a new derivation for OpenLens is likely the better approach.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
 The license listed for the lens derivation has been changed from MIT to Mirantis' own proprietary one in order to reflect the license of the tarball being used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
CC maintainers: @dbirks @RossComputerGuy 
