### PR TITLE
python310Packages.boltons: 21.0.0 -> 23.0.0

### DIFF
--- a/pkgs/development/python-modules/boltons/default.nix
+++ b/pkgs/development/python-modules/boltons/default.nix
@@ -1,15 +1,13 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , pytestCheckHook
-, pythonAtLeast
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "boltons";
-  version = "21.0.0";
+  version = "23.0.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -18,20 +16,11 @@ buildPythonPackage rec {
     owner = "mahmoud";
     repo = "boltons";
     rev = "refs/tags/${version}";
-    hash = "sha256-8HO7X2PQEbQIQsCa2cMHQI3rlofVT22GYrWNXY34MLk=";
+    hash = "sha256-NqlCu0W/BQkLiaLYs9DB1RrEya6KGPfNtpAzKXxoRD0=";
   };
 
   nativeCheckInputs = [
     pytestCheckHook
-  ];
-
-  patches = lib.optionals (pythonAtLeast "3.10") [
-    # pprint has no attribute _safe_repr, https://github.com/mahmoud/boltons/issues/294
-    (fetchpatch {
-      name = "fix-pprint-attribute.patch";
-      url = "https://github.com/mahmoud/boltons/commit/270e974975984f662f998c8f6eb0ebebd964de82.patch";
-      sha256 = "sha256-pZLfr6SRCw2aLwZeYaX7bzfJeZC4cFUILEmnVsKR6zc=";
-    })
   ];
 
   # Tests bind to localhost
@@ -39,11 +28,6 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "boltons"
-  ];
-
-  disabledTests = lib.optionals (pythonAtLeast "3.11") [
-    # https://github.com/mahmoud/boltons/issues/326
-    "test_frozendict_api"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Diff: https://github.com/mahmoud/boltons/compare/refs/tags/21.0.0...23.0.0

Changelog: https://github.com/mahmoud/boltons/blob/23.0.0/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
