### PR TITLE
xborders: init at 3.4

### DIFF
--- a/pkgs/tools/X11/xborders/default.nix
+++ b/pkgs/tools/X11/xborders/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+, libwnck
+, gtk3
+, libnotify
+, wrapGAppsHook
+, gobject-introspection
+, substituteAll
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "xborders";
+  version = "3.4"; # in version.txt
+
+  src = fetchFromGitHub {
+    owner = "deter0";
+    repo = "xborder";
+    rev = "e74ae532b9555c59d195537934fa355b3fea73c5";
+    hash = "sha256-UKsseNkXest6npPqJKvKL0iBWeK+S7zynrDlyXIOmF4=";
+  };
+
+  buildInputs = [
+    libwnck
+    gtk3
+    libnotify
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    gobject-introspection
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pycairo
+    requests
+    pygobject3
+  ];
+
+  postPatch = let
+    setup = substituteAll {
+      src = ./setup.py;
+      desc = meta.description; # "description" is reserved
+      inherit pname version;
+    };
+  in ''
+    ln -s ${setup} setup.py
+  '';
+
+  meta = with lib; {
+    description = "Active window border replacement for window managers";
+    homepage = "https://github.com/deter0/xborder";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ elnudev ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/X11/xborders/setup.py
+++ b/pkgs/tools/X11/xborders/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    name='@pname@',
+    version='@version@',
+    author='deter0',
+    description='@desc@',
+    install_requires=['pycairo', 'requests', 'PyGObject'],
+    scripts=[
+        'xborders',
+    ],
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33956,6 +33956,8 @@ with pkgs;
     gtk = gtk2;
   };
 
+  xborders = callPackage ../tools/X11/xborders { };
+
   xxh = callPackage ../tools/networking/xxh { };
 
   kodiPackages = recurseIntoAttrs (kodi.packages);


### PR DESCRIPTION
###### Description of changes

Init xborders at 3.4. xborders (https://github.com/deter0/xborder) is a program that provides an active window border replacement for window managers. Despite the repository being called xborder not xborders and inconsistent naming, the owner has confirmed that the name is https://github.com/deter0/xborder/issues/36#issuecomment-1244355598. In `preBuild`, I'm replacing the contents of the `get_version` function with the version number, because otherwise xborders requires a version.txt file to be next to the executable to fetch the version number from.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
