### PR TITLE
pythonPackages.lektor: 3.4.0b2 -> 3.4.0b4

### DIFF
--- a/pkgs/development/python-modules/lektor/default.nix
+++ b/pkgs/development/python-modules/lektor/default.nix
@@ -10,6 +10,7 @@
 , importlib-metadata
 , inifile
 , jinja2
+, markupsafe
 , marshmallow
 , marshmallow-dataclass
 , mistune
@@ -19,8 +20,10 @@
 , pytest-mock
 , pytest-pylint
 , pytestCheckHook
+, python
 , pythonOlder
 , python-slugify
+, pytz
 , requests
 , setuptools
 , typing-inspect
@@ -30,7 +33,7 @@
 
 buildPythonPackage rec {
   pname = "lektor";
-  version = "3.4.0b2";
+  version = "3.4.0b4";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -39,7 +42,7 @@ buildPythonPackage rec {
     owner = "lektor";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-5w3tT0celHgjmLlsM3sdBdYlXx57z3kMePVGSQkOP7M=";
+    hash = "sha256-O0bTmJqRymrQuHW19Y7/Kp+2XlbmDzcjl/jDACDlCSk=";
   };
 
   propagatedBuildInputs = [
@@ -51,12 +54,14 @@ buildPythonPackage rec {
     flask
     inifile
     jinja2
+    markupsafe
     marshmallow
     marshmallow-dataclass
     mistune
     pip
     pyopenssl
     python-slugify
+    pytz
     requests
     setuptools
     typing-inspect
@@ -72,9 +77,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "typing.inspect < 0.8.0" "typing.inspect"
+  postInstall = ''
+    cp -r lektor/translations "$out/${python.sitePackages}/lektor/"
   '';
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/lektor/default.nix
+++ b/pkgs/development/python-modules/lektor/default.nix
@@ -93,6 +93,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A static content management system";
     homepage = "https://www.getlektor.com/";
+    changelog = "https://github.com/lektor/lektor/blob/v${version}/CHANGES.md";
     license = licenses.bsd0;
     maintainers = with maintainers; [ costrouc ];
   };


### PR DESCRIPTION
###### Description of changes

Package is currently broken:

```console
❯ lektor --help
Traceback (most recent call last):
  File "/nix/store/wcv8s6zsnk3zn0hknpxhbnga4bp0xa1c-python3.9-lektor-3.4.0b2/bin/.lektor-wrapped", line 6, in <module>
    from lektor.cli import main
  File "/nix/store/wcv8s6zsnk3zn0hknpxhbnga4bp0xa1c-python3.9-lektor-3.4.0b2/lib/python3.9/site-packages/lektor/cli.py", line 11, in <module>
    from lektor.cli_utils import AliasedGroup
  File "/nix/store/wcv8s6zsnk3zn0hknpxhbnga4bp0xa1c-python3.9-lektor-3.4.0b2/lib/python3.9/site-packages/lektor/cli_utils.py", line 8, in <module>
    from lektor.i18n import get_default_lang
  File "/nix/store/wcv8s6zsnk3zn0hknpxhbnga4bp0xa1c-python3.9-lektor-3.4.0b2/lib/python3.9/site-packages/lektor/i18n.py", line 9, in <module>
    x[:-5] for x in os.listdir(translations_path) if x.endswith(".json")
FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/wcv8s6zsnk3zn0hknpxhbnga4bp0xa1c-python3.9-lektor-3.4.0b2/lib/python3.9/site-packages/lektor/translations'
```

This fixes that and updates to latest.

https://github.com/lektor/lektor/blob/v3.4.0b4/CHANGES.md#340b4-2022-11-05

###### Things don

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).