### PR TITLE
magma: init 2.7.1; migrate to cudaPackages

### DIFF
--- a/pkgs/development/libraries/science/math/magma/default.nix
+++ b/pkgs/development/libraries/science/math/magma/default.nix
@@ -1,83 +1,53 @@
-{ lib
-, stdenv
-, fetchurl
-, cmake
-, ninja
-, gfortran
-, libpthreadstubs
-, lapack
-, blas
-, cudaPackages
-, hip
-, hipblas
-, hipsparse
-, openmp
-, useCUDA ? true
-, useROCM ? false
-, gpuTargets ? [ ]
+args@{ callPackage
+, lib
+, ...
 }:
 
+# Type aliases
+# Release = {
+#  version: String
+#  hash: String
+#  supportedGpuTargets: List String
+# }
+
 let
-  inherit (cudaPackages) cudatoolkit cudaFlags;
-in stdenv.mkDerivation (finalAttrs: {
-  pname = "magma";
-  version = "2.6.2";
+  inherit (lib) lists strings trivial;
 
-  src = fetchurl {
-    name = "magma-${finalAttrs.version}.tar.gz";
-    url = "https://icl.cs.utk.edu/projectsfiles/magma/downloads/magma-${finalAttrs.version}.tar.gz";
-    hash = "sha256-dbVU2rAJA+LRC5cskT5Q5/iMvGLzrkMrWghsfk7aCnE=";
+  computeName = version: "magma_${strings.replaceStrings [ "." ] [ "_" ] version}";
+
+  # buildMagmaPackage :: Release -> Derivation
+  buildMagmaPackage = magmaRelease: callPackage ./generic.nix (
+    (builtins.removeAttrs args [ "callPackage" ]) // {
+      inherit magmaRelease;
+    }
+  );
+
+  # Reverse the list to have the latest release first
+  # magmaReleases :: List Release
+  magmaReleases = lists.reverseList (builtins.import ./releases.nix);
+
+  # The latest release is the first element of the list and will be our default choice
+  # latestReleaseName :: String
+  latestReleaseName = computeName (builtins.head magmaReleases).version;
+
+  # Function to transform our releases into build attributes
+  # toBuildAttrs :: Release -> { name: String, value: Derivation }
+  toBuildAttrs = release: {
+    name = computeName release.version;
+    value = buildMagmaPackage release;
   };
 
-  nativeBuildInputs = [
-    cmake
-    ninja
-    gfortran
-  ];
+  # Add all supported builds as attributes
+  # allBuilds :: AttrSet String Derivation
+  allBuilds = builtins.listToAttrs (lists.map toBuildAttrs magmaReleases);
 
-  buildInputs = [
-    libpthreadstubs
-    lapack
-    blas
-  ] ++ lib.optionals useCUDA [
-    cudatoolkit
-  ] ++ lib.optionals useROCM [
-    hip
-    hipblas
-    hipsparse
-    openmp
-  ];
+  # The latest release will be our default build
+  # defaultBuild :: AttrSet String Derivation
+  defaultBuild.magma = allBuilds.${latestReleaseName};
 
-  cmakeFlags = lib.optionals useCUDA [
-    "-DCMAKE_C_COMPILER=${cudatoolkit.cc}/bin/gcc"
-    "-DCMAKE_CXX_COMPILER=${cudatoolkit.cc}/bin/g++"
-    "-DMAGMA_ENABLE_CUDA=ON"
-    "-DGPU_TARGET=${builtins.concatStringsSep "," cudaFlags.cudaRealArches}"
-  ] ++ lib.optionals useROCM [
-    "-DCMAKE_C_COMPILER=${hip}/bin/hipcc"
-    "-DCMAKE_CXX_COMPILER=${hip}/bin/hipcc"
-    "-DMAGMA_ENABLE_HIP=ON"
-    "-DGPU_TARGET=${builtins.concatStringsSep "," (if gpuTargets == [ ] then hip.gpuTargets else gpuTargets)}"
-  ];
+  # builds :: AttrSet String Derivation
+  builds = allBuilds // defaultBuild;
+in
 
-  buildFlags = [
-    "magma"
-    "magma_sparse"
-  ];
+builds
 
-  doCheck = false;
-
-  passthru = {
-    inherit cudatoolkit;
-  };
-
-  meta = with lib; {
-    description = "Matrix Algebra on GPU and Multicore Architectures";
-    license = licenses.bsd3;
-    homepage = "http://icl.cs.utk.edu/magma/index.html";
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ tbenst ];
-    # CUDA and ROCm are mutually exclusive
-    broken = useCUDA && useROCM || useCUDA && versionOlder cudatoolkit.version "9";
-  };
-})

--- a/pkgs/development/libraries/science/math/magma/generic.nix
+++ b/pkgs/development/libraries/science/math/magma/generic.nix
@@ -1,0 +1,160 @@
+# Type aliases
+# Release = {
+#  version: String
+#  hash: String
+#  supportedGpuTargets: List String
+# }
+
+{ blas
+, cmake
+, cudaPackages
+, cudaSupport ? true
+, fetchurl
+, gfortran
+, gpuTargets ? [ ]
+, hip
+, hipblas
+, hipsparse
+, lapack
+, lib
+, libpthreadstubs
+, magmaRelease
+, ninja
+, openmp
+, rocmSupport ? false
+, stdenv
+, symlinkJoin
+}:
+
+
+let
+  inherit (lib) lists strings trivial;
+  inherit (cudaPackages) cudatoolkit cudaFlags cudaVersion;
+  inherit (magmaRelease) version hash supportedGpuTargets;
+
+  # NOTE: The lists.subtractLists function is perhaps a bit unintuitive. It subtracts the elements
+  #   of the first list *from* the second list. That means:
+  #   lists.subtractLists a b = b - a
+
+  # For CUDA
+  supportedCudaSmArches = lists.intersectLists cudaFlags.cudaRealArches supportedGpuTargets;
+  # Subtract the supported SM architectures from the real SM architectures to get the unsupported
+  # SM architectures.
+  unsupportedCudaSmArches = lists.subtractLists supportedCudaSmArches cudaFlags.cudaRealArches;
+
+  # For ROCm
+  # NOTE: The hip.gpuTargets are prefixed with "gfx" instead of "sm" like cudaFlags.cudaRealArches.
+  #   For some reason, Magma's CMakeLists.txt file does not handle the "gfx" prefix, so we must
+  #   remove it.
+  rocmArches = lists.map (x: strings.removePrefix "gfx" x) hip.gpuTargets;
+  supportedRocmArches = lists.intersectLists rocmArches supportedGpuTargets;
+  unsupportedRocmArches = lists.subtractLists supportedRocmArches rocmArches;
+
+  supportedCustomGpuTargets = lists.intersectLists gpuTargets supportedGpuTargets;
+  unsupportedCustomGpuTargets = lists.subtractLists supportedCustomGpuTargets gpuTargets;
+
+  # Use trivial.warnIf to print a warning if any unsupported GPU targets are specified.
+  gpuArchWarner = supported: unsupported:
+    trivial.throwIf (supported == [ ])
+      (
+        "No supported GPU targets specified. Requested GPU targets: "
+        + strings.concatStringsSep ", " unsupported
+      )
+      supported;
+
+  # Create the gpuTargetString.
+  gpuTargetString = strings.concatStringsSep "," (
+    if gpuTargets != [ ] then
+    # If gpuTargets is specified, it always takes priority.
+      gpuArchWarner supportedCustomGpuTargets unsupportedCustomGpuTargets
+    else if cudaSupport then
+      gpuArchWarner supportedCudaSmArches unsupportedCudaSmArches
+    else if rocmSupport then
+      gpuArchWarner supportedRocmArches unsupportedRocmArches
+    else
+      throw "No GPU targets specified"
+  );
+
+  cuda_joined = symlinkJoin {
+    name = "cuda-redist-${cudaVersion}";
+    paths = with cudaPackages; [
+      cuda_nvcc
+      cuda_cudart # cuda_runtime.h
+      libcublas
+      libcusparse
+      cuda_nvprof # <cuda_profiler_api.h>
+    ];
+  };
+in
+
+stdenv.mkDerivation {
+  pname = "magma";
+  inherit version;
+
+  src = fetchurl {
+    name = "magma-${version}.tar.gz";
+    url = "https://icl.cs.utk.edu/projectsfiles/magma/downloads/magma-${version}.tar.gz";
+    inherit hash;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    gfortran
+  ];
+
+  buildInputs = [
+    libpthreadstubs
+    lapack
+    blas
+  ] ++ lists.optionals cudaSupport [
+    cuda_joined
+  ] ++ lists.optionals rocmSupport [
+    hip
+    hipblas
+    hipsparse
+    openmp
+  ];
+
+  cmakeFlags = lists.optionals cudaSupport [
+    "-DCMAKE_C_COMPILER=${cudatoolkit.cc}/bin/cc"
+    "-DCMAKE_CXX_COMPILER=${cudatoolkit.cc}/bin/c++"
+    "-DMAGMA_ENABLE_CUDA=ON"
+  ] ++ lists.optionals rocmSupport [
+    "-DCMAKE_C_COMPILER=${hip}/bin/hipcc"
+    "-DCMAKE_CXX_COMPILER=${hip}/bin/hipcc"
+    "-DMAGMA_ENABLE_HIP=ON"
+  ];
+
+  # NOTE: We must set GPU_TARGET in preConfigure in this way because it may contain spaces.
+  preConfigure = ''
+    cmakeFlagsArray+=("-DGPU_TARGET=${gpuTargetString}")
+  ''
+  # NOTE: The stdenv's CXX is used when compiling the CMake test to determine the version of
+  #   CUDA available. This isn't necessarily the same as cudatoolkit.cc, so we must set
+  #   CUDAHOSTCXX.
+  + strings.optionalString cudaSupport ''
+    export CUDAHOSTCXX=${cudatoolkit.cc}/bin/c++
+  '';
+
+  buildFlags = [
+    "magma"
+    "magma_sparse"
+  ];
+
+  doCheck = false;
+
+  passthru = {
+    inherit cudaPackages cudaSupport;
+  };
+
+  meta = with lib; {
+    description = "Matrix Algebra on GPU and Multicore Architectures";
+    license = licenses.bsd3;
+    homepage = "http://icl.cs.utk.edu/magma/index.html";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ tbenst ];
+    # CUDA and ROCm are mutually exclusive
+    broken = cudaSupport && rocmSupport || cudaSupport && strings.versionOlder cudaVersion "9";
+  };
+}

--- a/pkgs/development/libraries/science/math/magma/releases.nix
+++ b/pkgs/development/libraries/science/math/magma/releases.nix
@@ -1,0 +1,98 @@
+# NOTE: Order matters! Put the oldest version first, and the newest version last.
+# NOTE: Make sure the supportedGpuTargets are in order of oldest to newest.
+#   You can update the supportedGpuTargets by looking at the CMakeLists.txt file.
+#   CUDA starts here: https://bitbucket.org/icl/magma/src/f4ec79e2c13a2347eff8a77a3be6f83bc2daec20/CMakeLists.txt#lines-175
+#   HIP is here: https://bitbucket.org/icl/magma/src/f4ec79e2c13a2347eff8a77a3be6f83bc2daec20/CMakeLists.txt#lines-386
+[
+  {
+    version = "2.6.2";
+    hash = "sha256-dbVU2rAJA+LRC5cskT5Q5/iMvGLzrkMrWghsfk7aCnE=";
+    supportedGpuTargets = [
+      "sm_20"
+      "sm_30"
+      "sm_35"
+      "sm_37"
+      "sm_50"
+      "sm_52"
+      "sm_53"
+      "sm_60"
+      "sm_61"
+      "sm_62"
+      "sm_70"
+      "sm_71"
+      "sm_75"
+      "sm_80"
+      "700"
+      "701"
+      "702"
+      "703"
+      "704"
+      "705"
+      "801"
+      "802"
+      "803"
+      "805"
+      "810"
+      "900"
+      "902"
+      "904"
+      "906"
+      "908"
+      "909"
+      "90c"
+      "1010"
+      "1011"
+      "1012"
+      "1030"
+      "1031"
+      "1032"
+      "1033"
+    ];
+  }
+  {
+    version = "2.7.1";
+    hash = "sha256-2chxHAR6OMrhbv3nS+4uszMyF/0nEeHpuGBsu7SuGlA=";
+    supportedGpuTargets = [
+      "sm_20"
+      "sm_30"
+      "sm_35"
+      "sm_37"
+      "sm_50"
+      "sm_52"
+      "sm_53"
+      "sm_60"
+      "sm_61"
+      "sm_62"
+      "sm_70"
+      "sm_71"
+      "sm_75"
+      "sm_80"
+      "sm_90"
+      "700"
+      "701"
+      "702"
+      "703"
+      "704"
+      "705"
+      "801"
+      "802"
+      "803"
+      "805"
+      "810"
+      "900"
+      "902"
+      "904"
+      "906"
+      "908"
+      "909"
+      "90c"
+      "1010"
+      "1011"
+      "1012"
+      "1030"
+      "1031"
+      "1032"
+      "1033"
+    ];
+  }
+]

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -51,7 +51,7 @@ assert !cudaSupport || (let majorIs = lib.versions.major cudatoolkit.version;
 
 # confirm that cudatoolkits are sync'd across dependencies
 assert !(MPISupport && cudaSupport) || mpi.cudatoolkit == cudatoolkit;
-assert !cudaSupport || magma.cudatoolkit == cudatoolkit;
+assert !cudaSupport || magma.cudaPackages.cudatoolkit == cudatoolkit;
 
 let
   setBool = v: if v then "1" else "0";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36661,18 +36661,19 @@ with pkgs;
 
   lie = callPackage ../applications/science/math/LiE { };
 
-  magma = callPackage ../development/libraries/science/math/magma {
+  inherit (callPackage ../development/libraries/science/math/magma {
     inherit (llvmPackages_rocm) openmp;
-  };
+  }) magma magma_2_7_1 magma_2_6_2;
 
   magma-cuda = magma.override {
-    useCUDA = true;
-    useROCM = false;
+    cudaSupport = true;
+    rocmSupport = false;
   };
 
-  magma-hip = magma.override {
-    useCUDA = false;
-    useROCM = true;
+  # TODO:AMD won't compile with anything newer than 2.6.2 -- it fails at the linking stage.
+  magma-hip = magma_2_6_2.override {
+    cudaSupport = false;
+    rocmSupport = true;
   };
 
   clmagma = callPackage ../development/libraries/science/math/clmagma { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds magma 2.7.1 and makes it the default.

AMD's HIP doesn't work on anything newer than 2.6.2 -- something causes a failure when trying to link `libmagma.so` -- so 2.6.2 remains the default for `magma-hip`.

Note that this PR includes a move to using a `releases.json`. This is done mostly to remove boilerplate from the Nix derivation and avoid clutter from `supportedGpuTargets`.

I've run into this problem elsewhere, but it's important that packages which target specific GPU architectures are aware of the architectures they support. The architectures available to this package via `hip.gpuTargets`, `cudaFlags.cudaRealArchs`, and the `gpuTargets` argument can cause frustrating build failures if they are not sanitized. Unfortunately, in this case that meant looking at Magma's CMakeLists.txt to find out which architectures are supported. For both CUDA and ROCm, I decided to use the SM and GFX names respectively, because Magma allows more granular support than when building for entire generations.

Following in the footsteps of @SomeoneSerge's work (https://github.com/NixOS/nixpkgs/pull/168745), migrate to `cudaPackages`.

Updated torch to reference the new `passthru` attribute `cudaPackages` instead of `cudatoolkit`.

Closure before:

`/nix/store/mcl5f361f3zix9bymp7rx9xcml0b2g4y-magma-2.6.2 518.6M 5.4G`

<details>

```bash
$ nix path-info -rsSh /nix/store/mcl5f361f3zix9bymp7rx9xcml0b2g4y-magma-2.6.2
/nix/store/jdjpni8kq3i95dj1d49nlf9m10wl0kqq-libunistring-1.0              	   1.7M	   1.7M
/nix/store/na1irnycfp8z5mab0g5jvrnhnscsaqsb-libidn2-2.3.2                 	 254.1K	   2.0M
/nix/store/lqz6hmd86viw83f9qll2ip87jhb7p1ah-glibc-2.35-224                	  28.9M	  30.8M
/nix/store/2sbvvb4a86953sxn05gnrfkmali7wvp0-libXdmcp-1.1.3                	  31.6K	  30.9M
/nix/store/y68a044xy6mrysszvpf50hadls4ijj61-libXau-1.0.9                  	  23.4K	  30.9M
/nix/store/g9wiz0czjlhippnyd3p6v10wvj9if4yy-libxcb-1.14                   	   1.3M	  32.2M
/nix/store/b6dyy0mxd4xhkkimlm0v8g0pbq0qpay5-libX11-1.8.3                  	   2.6M	  34.8M
/nix/store/2240471gsys943kbdwpqnffzg6sav0li-libXrender-0.9.10             	  53.6K	  34.9M
/nix/store/2a6yagz3pa8kiawg5mk2js70f8kwqzqd-bzip2-1.0.8                   	  79.5K	  30.9M
/nix/store/9dz5lmff9ywas225g6cpn34s0wbldnxa-zlib-1.2.13                   	 125.6K	  31.0M
/nix/store/9pdbnv128m77c9g3sr840vk0gfg94zy0-brotli-1.0.9-lib              	   1.7M	  32.5M
/nix/store/d1b4yv4wgydcazgz4d76z1srpnf29n5v-libpng-apng-1.6.39            	 249.3K	  31.2M
/nix/store/970v1z9hdxby0s2dcj06ri1mxiyajj12-freetype-2.12.1               	   2.0M	  35.0M
/nix/store/22wig7q4bj2clxz1ysl7gmh4667i00m4-expat-2.5.0                   	 253.2K	  31.1M
/nix/store/kxyymi9ywi3ajhap2irq8zqjk8msa7yg-dejavu-fonts-minimal-2.37     	 742.6K	 742.6K
/nix/store/mf23q09biqpw6vz0zp0fc41xzsfk066y-fontconfig-2.14.0             	   1.6M	   2.3M
/nix/store/s6slp93zplkd70zsahrvsp615vlcy2i8-fontconfig-2.14.0-lib         	 360.8K	  37.9M
/nix/store/6znwhg9i0b8q3mfpjx5qbw9fhym46zlj-libXft-2.3.6                  	 148.2K	  42.0M
/nix/store/i7iqa6jry20sli8h5ja30afa95hsghl6-fribidi-1.0.12                	 237.5K	  31.1M
/nix/store/2vx26jr5gib9ppjc6bxw03xrc9z3mf8c-util-linux-minimal-2.38.1-lib 	   1.6M	  32.5M
/nix/store/3lbgw28yzqxf96wvr8frbpsb8khz19yl-pcre2-10.42                   	   1.8M	  32.6M
/nix/store/rxm8zji9mijl6hghi9gyazfmi24xcxjj-pcre-8.45                     	 514.4K	  31.3M
/nix/store/5dyx08pwri1982dqcwfxf8530b9ffs91-libselinux-3.3                	   1.1M	  32.5M
/nix/store/bmnh7b67zx6l5wi6vgjvsfwrzw7ivfph-libffi-3.4.4                  	  55.2K	  30.9M
/nix/store/jzh15bi6zablx3d9s928w3lgqy6and91-glib-2.74.3                   	  13.1M	  49.2M
/nix/store/k88zxp7cvd5gpharprhg9ah0vhz2asq7-gcc-12.2.0-lib                	   7.8M	  38.6M
/nix/store/pyyq1zqx0afs8fyjpii937ifwcsmhwcr-graphite2-1.3.14              	 264.9K	  38.9M
/nix/store/ilc97wkhfsspbhag79l2gsmvpas435ik-harfbuzz-6.0.0                	   2.5M	  63.7M
/nix/store/r7d1qf7l4767ksh8awx44jaxpnmm33fs-libXext-1.3.4                 	  94.2K	  34.9M
/nix/store/2nmbapxhrl1yv752f9aiy67kmgnclbmk-libglvnd-1.6.0                	   2.5M	  37.4M
/nix/store/yma1kl8g80yl6m485b1p8hphxv28288j-pixman-0.42.2                 	 787.2K	  31.6M
/nix/store/vvzy4pkshya199mdgv053f14n0ji332n-cairo-1.16.0                  	   1.8M	  65.3M
/nix/store/0mpma5p8jrf8giv43fi5zlw3aby563kk-libdatrie-2019-12-20-lib      	  42.2K	  30.9M
/nix/store/ychcr25gy9akhpzkskw992nb8d4h7m42-libthai-0.1.29                	 627.1K	  31.5M
/nix/store/06kjhnjp3b9k2r2wfbsgj6vjf6r6sbqa-pango-1.50.12                 	 843.4K	  77.7M
/nix/store/w3qi8zxj01mn4i92r8asmyljm42ps401-gmp-with-cxx-6.2.1            	 729.2K	  39.3M
/nix/store/09j8gdvywyyszay6y5aczij45njqq7v6-nettle-3.8.1                  	 666.7K	  40.0M
/nix/store/2zxqsy84y680khkgn24hd0dafab322jp-gdbm-1.23                     	 805.4K	  31.6M
/nix/store/35s126gfkfrwbiv49kv9kxqdpd9zvcvm-ncurses-6.4                   	   3.5M	  34.4M
/nix/store/502zrfyc2agh928111zhwy6959bqd8m0-xz-5.4.1                      	 781.1K	  31.6M
/nix/store/561wgc73s0x1250hrgp7jm22hhv7yfln-bash-5.2-p15                  	   1.6M	  32.4M
/nix/store/66fr4mlfnwym5dw4bx61xs7nb81q58cb-tzdata-2022g                  	   2.0M	   2.0M
/nix/store/ih35ndii8g86q4hlr2f1ma0z14ga4d0r-mailcap-2.1.53                	 109.4K	 109.4K
/nix/store/kaiinm7cjirmv4zd3pdqar23rsypfqlh-libxcrypt-4.4.33              	 230.5K	  31.1M
/nix/store/kqzlfxnfx7p9f5wb7fz708514mxjlf9j-openssl-3.0.8                 	   6.2M	  37.0M
/nix/store/pwhg9383i9j7vxhl2sb5mxsbdy70mrzj-readline-8.2p1                	 459.3K	  34.8M
/nix/store/zqf9r5d9yv4ccv64ja8xjn8kasgqg3cy-sqlite-3.40.1                 	   1.4M	  32.4M
/nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9                	  82.9M	 131.3M
/nix/store/16ygcrdykbf84s3b1i8l9x34k1ihayp2-libtasn1-4.19.0               	  91.7K	  30.9M
/nix/store/105ndg4hy5ap6iyddy3yw3xp8pcf8hcg-p11-kit-0.24.1                	   3.5M	  36.1M
/nix/store/12wczkzi5db1ajbjp4hdyif3v9y5rbi5-xz-5.4.1-bin                  	 174.6K	  31.8M
/nix/store/17pkxcz3js3549kn9dc3hhvp4adbwvs1-bzip2-1.0.8-bin               	  68.5K	  31.0M
/nix/store/zdrprrspysn9839f4idaszacp1dlzxmj-libICE-1.0.10                 	 114.8K	  30.9M
/nix/store/ik5y5fvmq1c832avds355assilpxnfiq-libSM-1.2.3                   	  45.1K	  32.6M
/nix/store/1jw1sj2pc1nr8fdldqvz06gqzdha0119-libXt-1.2.1                   	 470.9K	  37.1M
/nix/store/25s737gk43a986fg8wq0j2n3z8751nbi-libXrandr-1.5.2               	  62.9K	  35.0M
/nix/store/2h3xshmdgd4a7am0lif3gr6lkchlzi8f-ncurses-abi5-compat-6.4       	   3.5M	  34.3M
/nix/store/478fqhkz8mhva1wz8d3jlnm3xrdvsda2-db-4.8.30                     	   3.4M	  42.0M
/nix/store/bx079w1lv8wds8jz7bsjw4ahnpajx5xz-audit-2.8.5                   	 714.1K	  33.1M
/nix/store/mfrwmnawf8pb913m0zl5a9m5jw3rw46n-linux-pam-1.5.2               	   1.8M	  46.4M
/nix/store/p2x737hw7fkflrqb836vlfyi581brhg6-glibc-2.35-224-bin            	   3.0M	  33.8M
/nix/store/s01hk39lcrzqc6bf67b38vxdk69vfjvh-tcb-1.2                       	  88.8K	  46.4M
/nix/store/9w1s6lv21m9s218drvjw6qfik7m5jhf2-shadow-4.13                   	   4.3M	  53.8M
/nix/store/wy751a62ji2x0k4bsn404pwriizls4v9-libcap-ng-0.8.3               	 151.1K	  31.0M
/nix/store/2zfiyhsx1f0b1s07an288mxh6i7fxhh7-util-linux-minimal-2.38.1-bin 	   6.6M	  62.2M
/nix/store/46w4wzwj12740rj5i9ra1xkx7qv29y7f-cudatoolkit-11.7.0-lib        	   1.8M	   1.8M
/nix/store/vlry6bc6b8hiyg12cc4nr0726cz9gv3y-libXi-1.8                     	  84.4K	  35.0M
/nix/store/4fzcn2b446pisijnam149fqdqvn4ingx-libXtst-1.2.3                 	 121.8K	  35.1M
/nix/store/s38k7bkfbrrggcwirnq1j7pshaw975jx-linux-headers-6.1             	   6.0M	   6.0M
/nix/store/4grm35slwd5il8v9sfkibl164ays38hp-glibc-2.35-224-dev            	   2.2M	  42.0M
/nix/store/4v8icfa150a2j4p3v9agyl0lmnmrwmjd-libXfixes-6.0.0               	  38.2K	  34.8M
/nix/store/6dpc2s3bbrfyszwdqd8hamv26cd1xvyd-alsa-ucm-conf-1.2.8           	 374.6K	 374.6K
/nix/store/83q5sbysda8285svx8mjlpc17bd3n630-attr-2.5.1                    	  78.8K	  30.9M
/nix/store/aqd9cz92qz1pfnvw09bsidi6vrcfhl9r-gmp-with-cxx-stage4-6.2.1     	 730.4K	  39.3M
/nix/store/jwlr603mdcq2lkaqpxmg9kkp2acszb1n-acl-2.3.1                     	 108.9K	  31.0M
/nix/store/7w1s50i8yplw2gkpf9hpha6n9vci8g98-coreutils-9.1                 	   1.4M	  40.9M
/nix/store/g5rki6d2wnz5av7x9kwnfzmfppj5sr72-kexec-tools-2.0.25            	 237.0K	  31.2M
/nix/store/h4mynp9fg0h5g0njs41437dv0gwl2q0z-bash-interactive-5.2-p15      	   6.9M	  41.8M
/nix/store/i4cg4jyfwav2843b141iq0nswqd6nagm-libcap-2.66-lib               	  78.0K	  30.9M
/nix/store/rp105if73inzqr3pm7817aqhfnndzbd6-zstd-1.5.2                    	   1.1M	  39.7M
/nix/store/khsxb6d5qbs60jq56lmncy7i0slwq9h1-kmod-30-lib                   	 120.4K	  40.6M
/nix/store/krbmv9vj3vwhgqcj4mw5kqg2figqa2bp-kmod-30                       	 206.2K	  40.6M
/nix/store/rkx76ks9fqis40bdidb7bb7bcc9pzg3d-libseccomp-2.5.4-lib          	 138.9K	  31.0M
/nix/store/rma0wk4ryapmms9f7lp11lnm4i02vyk3-getent-glibc-2.35-224         	 528.0 	  33.8M
/nix/store/kj1hi99d4w5489y7nbikadadsvvkr87b-gnugrep-3.7                   	 773.2K	  32.1M
/nix/store/7pn4xhvb9sa8x7ff727ipwq5723zgr9s-zstd-1.5.2-bin                	 307.9K	  42.8M
/nix/store/yqnrjbiwxa7gdfr2xlmyklw2acydny2g-gzip-1.12                     	 153.1K	  32.6M
/nix/store/s2v9fg0jla4952p807d8la3xbmnzskam-kbd-2.5.1                     	   2.6M	  55.1M
/nix/store/gl5j6zi4r0h0nivgv5lpk790hr3nf4gh-systemd-minimal-252.5         	  12.3M	  95.0M
/nix/store/6ghah4xaclnr82dwzgmr550sv6jydfwx-dbus-1.14.4-lib               	 449.5K	  99.4M
/nix/store/p0fc2j9kxd3pnb90pkmn2ybm4lachh5n-libevent-2.1.12               	 850.2K	  31.7M
/nix/store/pyvvzb5jfrywrx2gwhzg617jb34iyy11-libdaemon-0.14                	  68.5K	  30.9M
/nix/store/958k3v7v16np56xjywql0mkx7xnyqmq2-avahi-0.8                     	   1.7M	 118.3M
/nix/store/ch4qfri30sdrdiir0n7f8rg962w109qb-unbound-1.17.1-lib            	   1.0M	  41.9M
/nix/store/lg9xbfryrgbajk5jplq5x26f72py0yw3-dns-root-data-2019-01-11      	   4.4K	   4.4K
/nix/store/rcc1kds0l48xghc1mvsaywggrw8hjhwp-gnutls-3.7.8                  	   3.0M	  50.2M
/nix/store/7asbbz7hvpf99kz4bf4pxsiddsdl97lz-cups-2.4.2-lib                	   4.6M	 131.9M
/nix/store/7hv98dabrkwm0y3ccnp73afszra7w780-libXinerama-1.1.4             	  21.9K	  34.9M
/nix/store/9liigzjwhg5yckahhjkgsa03k2l9rz5w-expand-response-params        	  16.4K	  30.9M
/nix/store/9n47hl48jg9f33xd838ay043dpp2c26f-libXcomposite-0.4.5           	  25.1K	  34.8M
/nix/store/j5qck88fjfc32aghfxhsz41drkxswfi1-libXcursor-1.2.0              	  68.4K	  35.0M
/nix/store/kkd5d0v5a682yirk12gzxmsbz9nw1xnp-libjpeg-turbo-2.1.4           	   1.6M	  32.4M
/nix/store/h30ch0y194751svawkf9hm66533dmg4r-libdeflate-1.8                	 279.7K	  31.1M
/nix/store/pl4bpbmvhz0m01a09lq5wlbs2fqyy4ds-libtiff-4.5.0                 	 597.5K	  41.9M
/nix/store/mihzapwslgszs2amsvkywb7qnhnxb5zm-gdk-pixbuf-2.42.10            	   2.8M	  63.1M
/nix/store/i0j80sadwj1hlbplqd4ygkfrlr3q1kzx-dconf-0.40.0-lib              	 304.1K	  49.4M
/nix/store/sbplbg2bl41a8q7j1p3s4rzi647vnbkh-gsettings-desktop-schemas-43.0	   4.9M	   4.9M
/nix/store/mwnbxksb7w5mngl2av421q5jw5rpnf20-at-spi2-core-2.46.0           	   2.1M	 123.1M
/nix/store/f4a5b3zjicfmmq277vqhaigirdbx4wwb-gtk+-2.24.33                  	  27.0M	 188.3M
/nix/store/g93a9k7gg8cgzkgzlgdz203g801mp02c-mpfr-4.2.0                    	 774.0K	  40.1M
/nix/store/ps7an26cirhh0xy1wrlc2icvfhrd39cj-gcc-11.3.0-lib                	   7.5M	  38.3M
/nix/store/qglpm9v1f80qc4cy7wfdwqgvmmdb25bj-binutils-2.40-lib             	   2.7M	  33.7M
/nix/store/qmmd097h4rwh2pwgz9l9i0byxb0x8q8l-binutils-2.40                 	  28.2M	  69.6M
/nix/store/vg3cf88380rfm0sh98a9nv4h066mcq1f-binutils-wrapper-2.40         	  48.5K	  84.8M
/nix/store/mq3v15nrjmrn8zb9yjl8ipvwfifsybbm-libmpc-1.3.1                  	 273.4K	  40.4M
/nix/store/v8qym9bgmvriwngw00dm3g1r4mgwzvxc-isl-0.20                      	   2.5M	  41.8M
/nix/store/z12xhkzals98aw0466dm7z6g2z84gaff-gcc-11.3.0                    	 180.6M	 242.2M
/nix/store/rx9jkyz6a2g8kkcyahjyjrk3kfb8r5f6-gcc-wrapper-11.3.0            	  55.2K	 278.4M
/nix/store/zw64s9wij31wvb1mdwj05rjd9mrppp4a-alsa-topology-conf-1.2.5.1    	 336.1K	 336.1K
/nix/store/sk1hjc1njyv86w9y1chzxchhpdwa6z8g-alsa-lib-1.2.8                	   1.6M	  33.1M
/nix/store/zii9iaq88vhsjnqkb8mij3cj2nc1zn65-unixODBC-2.3.11               	   1.1M	  31.9M
/nix/store/icbiixrrd6i8xc8zxynqhx4gvs741mvw-cudatoolkit-11.7.0            	   4.3G	   4.8G
/nix/store/rvcwh7255pja22bsiks4ia06afgdkp2z-gfortran-12.2.0-lib           	  10.7M	  41.6M
/nix/store/j3y0iashqysxm5blljcvmqidzygja02c-openblas-0.3.21               	  26.1M	  67.7M
/nix/store/m39wyb50jz4mqj22459nz397ascvmgiv-blas-3                        	  53.3M	 121.0M
/nix/store/mcl5f361f3zix9bymp7rx9xcml0b2g4y-magma-2.6.2                   	 518.6M	   5.4G
```

</details>

Closure after (for a previous version of this PR targeting 2.7.0; the size different is still as large):

`/nix/store/jb024nl0mvvrrsxw06ha1s96wsx69993-magma-2.7.0 389.5M 2.3G`

<details>

```bash
$ nix path-info -rsSh /nix/store/jb024nl0mvvrrsxw06ha1s96wsx69993-magma-2.7.0
/nix/store/jdjpni8kq3i95dj1d49nlf9m10wl0kqq-libunistring-1.0     	   1.7M	   1.7M
/nix/store/na1irnycfp8z5mab0g5jvrnhnscsaqsb-libidn2-2.3.2        	 254.1K	   2.0M
/nix/store/lqz6hmd86viw83f9qll2ip87jhb7p1ah-glibc-2.35-224       	  28.9M	  30.8M
/nix/store/561wgc73s0x1250hrgp7jm22hhv7yfln-bash-5.2-p15         	   1.6M	  32.4M
/nix/store/k88zxp7cvd5gpharprhg9ah0vhz2asq7-gcc-12.2.0-lib       	   7.8M	  38.6M
/nix/store/a1699yplj3ipj0crn4sy7452gpd9xvfd-cuda_nvcc-11.7.64    	 114.8M	 155.0M
/nix/store/f36ra9mgxl5fc7m2fw6mcp6976q2b4g5-cuda_cudart-11.7.60  	   6.2M	   6.2M
/nix/store/k5796bjdij8x796x03qvzz93m28q5ksq-libcublas-11.10.1.25 	   1.1G	   1.2G
/nix/store/ma02xli1c0hrbg9q2qx7bn6n71p18x5x-libcusparse-11.7.3.50	 488.1M	 488.1M
/nix/store/rr7vi3d9nn5ilbqfkqpwg4xi4wcm22cb-cuda_cupti-11.7.50   	  88.4M	  88.4M
/nix/store/ycgglv3x1z8517j2aq208m2kk1hw66a5-cuda_nvprof-11.7.50  	   9.9M	 129.1M
/nix/store/fhxhahas5l72hr9w45vm4zlspybr0amr-cuda-redist-11.7     	  62.5K	   1.8G
/nix/store/rvcwh7255pja22bsiks4ia06afgdkp2z-gfortran-12.2.0-lib  	  10.7M	  41.6M
/nix/store/j3y0iashqysxm5blljcvmqidzygja02c-openblas-0.3.21      	  26.1M	  67.7M
/nix/store/m39wyb50jz4mqj22459nz397ascvmgiv-blas-3               	  53.3M	 121.0M
/nix/store/ps7an26cirhh0xy1wrlc2icvfhrd39cj-gcc-11.3.0-lib       	   7.5M	  38.3M
/nix/store/jb024nl0mvvrrsxw06ha1s96wsx69993-magma-2.7.0          	 389.5M	   2.3G
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Failures


The below is kept for posterity; it was my attempt at troubleshooting AMD support prior to deciding to keep a copy of 2.6.2.

<details>

- [ ] magma-hip
  - Fails at `Linking CXX shared library lib/libmagma.so`.
  - This is a problem with 2.7.0, not the derivation. Leaving the derivation the same but overriding the source with 2.6.2 works fine.
  - https://gist.github.com/ConnorBaker/0d29214a241afdbd5e0bff251f22aef4
- [ ] python310Packages.torchWithRocm (depends on magma-hip)

And so we do a rough binary search through the commit history of Magma to find out when it broke :(

EDIT: What a headache. I'll split the package so CUDA gets 2.7.0 and HIP can stay on 2.6.2.

- ❌ `2023-02-10` revert api changes for the batch gemv routines that accept pointer arrays: https://bitbucket.org/icl/magma/commits/1814c2518a76b81d75e5987d35797305ef2c9f4d.
- ❌ `2022-10-28` update release note: https://bitbucket.org/icl/magma/commits/e96d4c97be78a8b19b273dbaa99955d6529e539a.
- ⁉️ `2022-10-17` bug fix: https://bitbucket.org/icl/magma/src/001df2f69f8c25f4e722a6ff997a2aa69da0d4e0.
  - Same as unrelated error below.
- ⁉️ `2022-10-11` unnecessary includes: https://bitbucket.org/icl/magma/commits/e8a673d27c7e927ec8eda0c2059b7a213baa6e4e.
  - Unrelated error: https://gist.github.com/ConnorBaker/2196817754d3caed907056a2bf28dc55.
- ⁉️ `2022-06-26` update notes for next release: https://bitbucket.org/icl/magma/src/24410113e61fc72c2cbc039c2cef9aa7dc815a92.
  - Same unrelated error as above.
- ⁉️ `2022-06-24` allow launch bounds for CUDA: https://bitbucket.org/icl/magma/src/849bf8e00e929da7699a02424466e127a883668f.
  - Same unrelated error as above.
- ⁉️ `2022-06-23` Merged in master (pull request `#21`): https://bitbucket.org/icl/magma/src/9e0b130afaf3fe635441cba351555505c9d68e28.
  - Unrelated error: `Makefile:357: magmablas_hip/Makefile.src: No such file or directory`.
- ✅ `2022-05-24` call the new gemm prototype with version 2: https://bitbucket.org/icl/magma/src/ec35ab142120a1a067f1a77f5392b70f5367e8a9.
- ✅ `2022-05-24` minor: https://bitbucket.org/icl/magma/src/5eec59630f963a46bff59cbab6f39610fc9c610b.
- ✅ `2022-04-20` potential fix for failures at very large matrix sizes: https://bitbucket.org/icl/magma/commits/d998fcbb94d9046ec98ae93757010a1472902d54.

</details>