### PR TITLE
fishPlugins.plugin-git: init at 0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15294,6 +15294,11 @@
     github = "unrooted";
     githubId = 30440603;
   };
+  unsolvedcypher = {
+    name = "Matthew M";
+    github = "UnsolvedCypher";
+    githubId = 3170853;
+  };
   uralbash = {
     email = "root@uralbash.ru";
     github = "uralbash";

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -32,6 +32,8 @@ lib.makeScope newScope (self: with self; {
 
   pisces = callPackage ./pisces.nix { };
 
+  plugin-git = callPackage ./plugin-git.nix { };
+
   puffer = callPackage ./puffer.nix { };
 
   pure = callPackage ./pure.nix { };

--- a/pkgs/shells/fish/plugins/plugin-git.nix
+++ b/pkgs/shells/fish/plugins/plugin-git.nix
@@ -1,0 +1,20 @@
+{ lib, buildFishPlugin, fetchFromGitHub }:
+
+buildFishPlugin rec {
+  pname = "plugin-git";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "jhillyerd";
+    repo = "plugin-git";
+    rev = "v0.1";
+    sha256 = "sha256-MfrRQdcj7UtIUgtqKjt4lqFLpA6YZgKjE03VaaypNzE";
+  };
+
+  meta = with lib; {
+    description = "Git plugin for fish (similar to oh-my-zsh git)";
+    homepage = "https://github.com/jhillyerd/plugin-git";
+    license = licenses.mit;
+    maintainers = with maintainers; [ unsolvedcypher ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

This is `plugin-git`: https://github.com/jhillyerd/plugin-git . It is a plugin for the Fish shell with git aliases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable: (*None applicable*)
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (*No dependent packages*)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
