### PR TITLE
python3Packages.jupyterthemes: init at 0.20.0

### DIFF
--- a/pkgs/development/compilers/lesscpy/default.nix
+++ b/pkgs/development/compilers/lesscpy/default.nix
@@ -2,23 +2,27 @@
 
 python3Packages.buildPythonApplication rec {
   pname   = "lesscpy";
-  version = "0.13.0";
+  version = "0.15.1";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1bbjag13kawnjdn7q4flfrkd0a21rgn9ycfqsgfdmg658jsx1ipk";
+    sha256 = "sha256-EEXRepj2iGRsp1jf8lTm6cA3RWSOBRoIGwOVw7d8gkw=";
   };
 
   checkInputs = with python3Packages; [ pytestCheckHook ];
   pythonImportsCheck = [ "lesscpy" ];
   propagatedBuildInputs = with python3Packages; [ ply six ];
 
-  doCheck = false; # Really weird test failures (`nix-build-python2.css not found`)
+  nativeCheckInputs = with python3Packages; [
+    tox
+    nose
+    flake8
+  ];
 
   meta = with lib; {
     description = "Python LESS Compiler";
     homepage    = "https://github.com/lesscpy/lesscpy";
     license     = licenses.mit;
-    maintainers = with maintainers; [ s1341 ];
+    maintainers = with maintainers; [ s1341 WhiteBlackGoose ];
   };
 }

--- a/pkgs/development/python-modules/jupyterthemes/default.nix
+++ b/pkgs/development/python-modules/jupyterthemes/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, matplotlib
+, jupyter-core
+, lesscpy
+, notebook
+}:
+
+
+buildPythonPackage rec {
+  pname = "jupyterthemes";
+  version = "0.20.0";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Ko68DISyEquZufF1f8BYKj9Tkw06dbJJLZGnyLNqtB4=";
+  };
+
+  propagatedBuildInputs = [
+    matplotlib
+    jupyter-core
+    lesscpy
+    notebook
+  ];
+
+  pythonImportsCheck = [ "jupyterthemes" ];
+
+  meta = {
+    description = "Custom Jupyter Notebook Themes";
+    homepage = "https://github.com/dunovank/jupyter-themes";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ WhiteBlackGoose ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5253,6 +5253,8 @@ self: super: with self; {
 
   jupytext = callPackage ../development/python-modules/jupytext { };
 
+  jupyterthemes = callPackage ../development/python-modules/jupyterthemes { };
+
   justbackoff = callPackage ../development/python-modules/justbackoff { };
 
   justbases = callPackage ../development/python-modules/justbases { };


### PR DESCRIPTION
###### Description of changes

Adding [jupyterthemes](https://github.com/dunovank/jupyter-themes) for themes in Jupyter Notebook. It also required a [dependency](https://github.com/lesscpy/lesscpy) to work.

Demonstration of work of this package:
![image](https://user-images.githubusercontent.com/31178401/220262152-190ff46e-78b2-4adf-9761-467c70a37c9e.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
