### PR TITLE
python310Packages.weconnect: 0.52.0 -> 0.54.0, python310Packages.weconnect-mqtt: 0.42.0 -> 0.42.1 

### DIFF
--- a/pkgs/development/python-modules/ascii-magic/default.nix
+++ b/pkgs/development/python-modules/ascii-magic/default.nix
@@ -3,16 +3,20 @@
 , colorama
 , fetchPypi
 , pillow
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "ascii-magic";
-  version = "1.6";
+  version = "2.1.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "ascii_magic";
     inherit version;
-    sha256 = "sha256-faVRj3No5z8R4hUaDAYIBKoUniZ7Npt+52U/vXsEalE=";
+    hash = "sha256-YfGa+3nuqAAo69TydxO6uKNMcqZAkOEi/PMP8Frasfw=";
   };
 
   propagatedBuildInputs = [
@@ -21,6 +25,7 @@ buildPythonPackage rec {
   ];
 
   # Project is not tagging releases and tests are not shipped with PyPI source
+  # https://github.com/LeandroBarone/python-ascii_magic/issues/10
   doCheck = false;
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/ascii-magic/default.nix
+++ b/pkgs/development/python-modules/ascii-magic/default.nix
@@ -30,6 +30,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python module to converts pictures into ASCII art";
     homepage = "https://github.com/LeandroBarone/python-ascii_magic";
+    changelog = "https://github.com/LeandroBarone/python-ascii_magic#changelog";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/weconnect-mqtt/default.nix
+++ b/pkgs/development/python-modules/weconnect-mqtt/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "weconnect-mqtt";
-  version = "0.42.0";
+  version = "0.42.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "tillsteinbach";
     repo = "WeConnect-mqtt";
     rev = "refs/tags/v${version}";
-    hash = "sha256-jxfV2RDyGLugnPae+uNtg/GBsWbKCSbKxuHll10guhU=";
+    hash = "sha256-/YCrnDOJdKc687pRKj1gVTOTj7dEpplN49VuFJOlQIE=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/weconnect/default.nix
+++ b/pkgs/development/python-modules/weconnect/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "weconnect";
-  version = "0.52.0";
+  version = "0.54.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "tillsteinbach";
     repo = "WeConnect-python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-SfdN/em4NrzNeItcaVuyOcUxmE50n5/jjmY4I5hfpQI=";
+    hash = "sha256-mCUaaWR8jRqm8V8ZQBMgycExkN2zjoJxWIEohVH2K/o=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
