### PR TITLE
python310Packages.axis: 46 -> 47

### DIFF
--- a/pkgs/development/python-modules/axis/default.nix
+++ b/pkgs/development/python-modules/axis/default.nix
@@ -6,19 +6,22 @@
 , httpx
 , orjson
 , packaging
+, pythonOlder
 , xmltodict
 }:
 
 buildPythonPackage rec {
   pname = "axis";
-  version = "46";
+  version = "47";
   format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "Kane610";
     repo = pname;
-    rev = "v${version}";
-    hash = "sha256-alhezwRPag+6JoC4zbusWdxFyZQ2dZl04Uj1PkiN4qo=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-a8YvFX3IcbX4Sm75GzGv7vIyMmSHxwGejyq6nE7foOE=";
   };
 
   propagatedBuildInputs = [
@@ -32,7 +35,10 @@ buildPythonPackage rec {
 
   # Tests requires a server on localhost
   doCheck = false;
-  pythonImportsCheck = [ "axis" ];
+
+  pythonImportsCheck = [
+    "axis"
+  ];
 
   meta = with lib; {
     description = "Python library for communicating with devices from Axis Communications";


### PR DESCRIPTION
Diff: https://github.com/Kane610/axis/compare/refs/tags/v46...v47

Changelog: https://github.com/Kane610/axis/releases/tag/v47

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
