### PR TITLE
cmocka: 1.1.5 -> 1.1.6

### DIFF
--- a/pkgs/development/libraries/cmocka/default.nix
+++ b/pkgs/development/libraries/cmocka/default.nix
@@ -1,26 +1,17 @@
 { fetchurl, fetchpatch, lib, stdenv, cmake }:
-let
-  # Temporary split to save rebuilds; see PR #217469
-  isUpdated = with stdenv; isDarwin && isAarch64;
-in
+
 stdenv.mkDerivation rec {
   pname = "cmocka";
   majorVersion = "1.1";
-  version = "${majorVersion}." + (if isUpdated then "6" else "5");
+  version = "${majorVersion}.6";
 
   src = fetchurl {
     url = "https://cmocka.org/files/${majorVersion}/cmocka-${version}.tar.xz";
-    sha256 = if isUpdated
-      then "0xksffx1w3pzm18ynf28cx8scrhylcbz43s1rgkkdqnyil1q6cjv"
-      else "1dm8pdvkyfa8dsbz9bpq7wwgixjij4sii9bbn5sgvqjm5ljdik7h";
+    sha256 = "0xksffx1w3pzm18ynf28cx8scrhylcbz43s1rgkkdqnyil1q6cjv";
   };
 
-  patches = lib.optionals (!isUpdated) [
-    (fetchpatch {
-      name = "musl-uintptr.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/cmocka/musl_uintptr.patch?id=6a15dd0d0ba9cc354a621fb359ca5e315ff2eabd";
-      sha256 = "sha256-fhb2Tax30kRTGuaKvzSzglSd/ntxiNeGFJt5I8poa24=";
-    })
+  patches = [
+    ./uintptr_t.patch
   ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/cmocka/uintptr_t.patch
+++ b/pkgs/development/libraries/cmocka/uintptr_t.patch
@@ -1,0 +1,16 @@
+Resolve messy situation with uintptr_t and stdint.h
+
+Platforms common in nixpkgs will have stdint.h - thereby we avoid problems
+that seem complicated to avoid.  References:
+https://gitlab.com/cmocka/cmocka/-/issues/38#note_1286565655
+https://git.alpinelinux.org/aports/plain/main/cmocka/musl_uintptr.patch?id=6a15dd0d0ba9cc354a621fb359ca5e315ff2eabd
+
+It isn't easy, as 1.1.6 codebase is missing stdint.h includes on many places,
+and HAVE_UINTPTR_T from cmake also wouldn't get on all places it needs to.
+--- a/include/cmocka.h
++++ b/include/cmocka.h
+@@ -18,2 +18,4 @@
+ #define CMOCKA_H_
++#include <stdint.h>
++#define HAVE_UINTPTR_T 1
+ 


### PR DESCRIPTION
> Version 1.1.6 has been released to fix several issues and a few small new features.

https://gitlab.com/cmocka/cmocka/-/blob/cmocka-1.1.6/ChangeLog

We might conditionalize the patch e.g. for musl only, but I don't think it could cause trouble elsewhere.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
