### PR TITLE
crc: 2.13.1 -> 2.14.0

### DIFF
--- a/pkgs/applications/networking/cluster/crc/default.nix
+++ b/pkgs/applications/networking/cluster/crc/default.nix
@@ -10,22 +10,22 @@
 }:
 
 let
-  openShiftVersion = "4.12.0";
+  openShiftVersion = "4.12.1";
   okdVersion = "4.11.0-0.okd-2022-11-05-030711";
   podmanVersion = "4.3.1";
   writeKey = "cvpHsNcmGCJqVzf6YxrSnVlwFSAZaYtp";
 in
 buildGoModule rec {
-  version = "2.13.1";
+  version = "2.14.0";
   pname = "crc";
-  gitCommit = "b5b864fdd4ed047027f439db96c2658aa194d2bc";
+  gitCommit = "868d96cd4f73dad72df54475c52c65f9741dc240";
   modRoot = "cmd/crc";
 
   src = fetchFromGitHub {
     owner = "crc-org";
     repo = "crc";
     rev = "v${version}";
-    sha256 = "sha256-0e62mQ01pt0kClrEx4ss2T8BN1+0aQiCFPyDg5agbTU";
+    sha256 = "sha256-q1OJJTveXoNzW9lohQOY7LVR3jOyiQZX5nHBgRupxTM=";
   };
 
   vendorSha256 = null;
@@ -55,7 +55,6 @@ buildGoModule rec {
     export HOME=$(mktemp -d)
   '';
 
-
   passthru.tests.version = testers.testVersion {
     package = crc;
     command = ''
@@ -69,6 +68,6 @@ buildGoModule rec {
     description = "Manages a local OpenShift 4.x cluster or a Podman VM optimized for testing and development purposes";
     homepage = "https://crc.dev";
     license = licenses.asl20;
-    maintainers = with maintainers; [ shikanime tricktron ];
+    maintainers = with maintainers; [ matthewpi shikanime tricktron ];
   };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/crc-org/crc/releases/tag/v2.14.0

On another note, the automatic update script doesn't update the `sha256` for the git tag.  This causes problems in two ways, actually building the wrong version and breaking the `crc setup` command with an obscure `expected crc_libvirt_4.11.13_amd64.crcbundle but found crc_libvirt_4.12.1_amd64.crcbundle in Makefile` error, due to the mismatching versions.  I don't know what the solution to this is, but it is something that should likely be fixed as it causes issues if people are unaware of the problem and update the package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
