### PR TITLE
libtiff: add patches for many related CVEs

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -44,6 +44,27 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.com/libtiff/libtiff/-/commit/d1b6b9c1b3cae2d9e37754506c1ad8f4f7b646b5.diff";
       sha256 = "sha256-FWUlyJyHXac6fuM5f9PG33kcF5Bm4fyFmYnaDal46iM=";
     })
+    (fetchpatch {
+      name = "CVE-2023-0800.CVE-2023-0801.CVE-2023-0802.CVE-2023-0803.CVE-2023-0804.patch";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/33aee1275d9d1384791d2206776eb8152d397f00.patch";
+      sha256 = "sha256-wNSa1D9EWObTs331utjIKgo9p9PUWqTM54qG+1Hhm1A=";
+    })
+    (fetchpatch {
+      name = "CVE-2023-0795.CVE-2023-0796.CVE-2023-0797.CVE-2023-0798.CVE-2023-0799.prerequisite-0.patch";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/9c22495e5eeeae9e00a1596720c969656bb8d678.patch";
+      sha256 = "sha256-NTs+dCUweKddQDzJLqbdIdvNbaSweGG0cSVt57tntoI=";
+    })
+    (fetchpatch {
+      name = "CVE-2023-0795.CVE-2023-0796.CVE-2023-0797.CVE-2023-0798.CVE-2023-0799.prerequisite-1.patch";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/d63de61b1ec3385f6383ef9a1f453e4b8b11d536.patch";
+      includes = [ "tools/tiffcrop.c" ];
+      sha256 = "sha256-VHg5aAcHKwRkDFDyC1rLjCjj1rMzcq/2SUR/r1fQubQ=";
+    })
+    (fetchpatch {
+      name = "CVE-2023-0795.CVE-2023-0796.CVE-2023-0797.CVE-2023-0798.CVE-2023-0799.patch";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/afaabc3e50d4e5d80a94143f7e3c997e7e410f68.patch";
+      sha256 = "sha256-9+oXKVJEeaIuMBdtvhNlUBNpw9uzg31s+zxt4GJo6Lo=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2023-0795
https://nvd.nist.gov/vuln/detail/CVE-2023-0796
https://nvd.nist.gov/vuln/detail/CVE-2023-0797
https://nvd.nist.gov/vuln/detail/CVE-2023-0798
https://nvd.nist.gov/vuln/detail/CVE-2023-0799
https://nvd.nist.gov/vuln/detail/CVE-2023-0800
https://nvd.nist.gov/vuln/detail/CVE-2023-0801
https://nvd.nist.gov/vuln/detail/CVE-2023-0802
https://nvd.nist.gov/vuln/detail/CVE-2023-0803
https://nvd.nist.gov/vuln/detail/CVE-2023-0804

Built `passthru.tests` on indicated platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
