### PR TITLE
stdenv/generic/setup.sh: enable parallel installs for parallel builds

### DIFF
--- a/pkgs/applications/audio/qsynth/default.nix
+++ b/pkgs/applications/audio/qsynth/default.nix
@@ -16,6 +16,10 @@ mkDerivation  rec {
   buildInputs = [ alsa-lib fluidsynth libjack2 qtbase qttools qtx11extras ];
 
   enableParallelBuilding = true;
+  # Missing install depends:
+  #   lrelease error: Parse error at src/translations/qsynth_ru.ts:1503:33: Premature end of document.
+  #   make: *** [Makefile:107: src/translations/qsynth_ru.qm] Error 1
+  enableParallelInstalling = false;
 
   meta = with lib; {
     description = "Fluidsynth GUI";

--- a/pkgs/applications/science/math/gretl/default.nix
+++ b/pkgs/applications/science/math/gretl/default.nix
@@ -28,6 +28,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
 
   enableParallelBuilding = true;
+  # Missing install depends:
+  #  cp: cannot stat '...-gretl-2022c/share/gretl/data/plotbars': Not a directory
+  #  make[1]: *** [Makefile:73: install_datafiles] Error 1
+  enableParallelInstalling = false;
 
   meta = with lib; {
     description = "A software package for econometric analysis";

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -100,6 +100,10 @@ let
     inherit perlBindings pythonBindings;
 
     enableParallelBuilding = true;
+    # Missing install dependencies:
+    # libtool:   error: error: relink 'libsvn_ra_serf-1.la' with the above command before installing it
+    # make: *** [build-outputs.mk:1316: install-serf-lib] Error 1
+    enableParallelInstalling = false;
 
     nativeCheckInputs = [ python3 ];
     doCheck = false; # fails 10 out of ~2300 tests

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -87,6 +87,11 @@ stdenv.mkDerivation (args // {
   #  make[2]: *** [Makefile:199: backup] Error 1
   enableParallelBuilding = lib.versionAtLeast version "4.08";
 
+  # Workaround missing dependencies for install parallelism:
+  #  install: target '...-ocaml-4.14.0/lib/ocaml/threads': No such file or directory
+  #  make[1]: *** [Makefile:140: installopt] Error 1
+  enableParallelInstalling = false;
+
   # Workaround lack of parallelism support among top-level targets:
   # we place nixpkgs-specific targets to a separate file and set
   # sequential order among them as a single rule.

--- a/pkgs/development/interpreters/s9fes/default.nix
+++ b/pkgs/development/interpreters/s9fes/default.nix
@@ -24,6 +24,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses ];
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" "PREFIX=$(out)" ];
   enableParallelBuilding = true;
+  # ...-bash-5.2-p15/bin/bash: line 1: ...-s9fes-20181205/bin/s9help: No such file or directory
+  # make: *** [Makefile:157: install-util] Error 1
+  enableParallelInstalling = false;
 
   meta = with lib; {
     description = "Scheme 9 From Empty Space, an interpreter for R4RS Scheme";

--- a/pkgs/development/libraries/qt-4.x/4.8/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-4.x/4.8/qmake-hook.sh
@@ -8,6 +8,11 @@ qmakeConfigurePhase() {
         echo "qmake4Hook: enabled parallel building"
     fi
 
+    if ! [[ -v enableParallelInstalling ]]; then
+        enableParallelInstalling=1
+        echo "qmake: enabled parallel installing"
+    fi
+
     runHook postConfigure
 }
 

--- a/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
@@ -38,6 +38,11 @@ qmakeConfigurePhase() {
         echo "qmake: enabled parallel building"
     fi
 
+    if ! [[ -v enableParallelInstalling ]]; then
+        enableParallelInstalling=1
+        echo "qmake: enabled parallel installing"
+    fi
+
     runHook postConfigure
 }
 

--- a/pkgs/development/libraries/qt-6/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qmake-hook.sh
@@ -40,6 +40,11 @@ qmakeConfigurePhase() {
         echo "qmake: enabled parallel building"
     fi
 
+    if ! [[ -v enableParallelInstalling ]]; then
+        enableParallelInstalling=1
+        echo "qmake: enabled parallel installing"
+    fi
+
     runHook postConfigure
 }
 

--- a/pkgs/development/tools/analysis/eresi/default.nix
+++ b/pkgs/development/tools/analysis/eresi/default.nix
@@ -60,6 +60,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ which ];
   buildInputs = [ openssl readline ];
   enableParallelBuilding = true;
+  # ln: failed to create symbolic link '...-eresi-0.83-a3-phoenix//bin/elfsh': No such file or directory
+  # make: *** [Makefile:108: install64] Error 1
+  enableParallelInstalling = false;
 
   installTargets = lib.singleton "install"
                 ++ lib.optional stdenv.is64bit "install64";

--- a/pkgs/development/tools/build-managers/bmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/bmake/setup-hook.sh
@@ -76,6 +76,7 @@ bmakeInstallPhase() {
 
     # shellcheck disable=SC2086
     local flagsArray=(
+        ${enableParallelInstalling:+-j${NIX_BUILD_CORES}}
         SHELL=$SHELL
         # Old bash empty array hack
         $makeFlags ${makeFlagsArray+"${makeFlagsArray[@]}"}

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -130,6 +130,11 @@ cmakeConfigurePhase() {
         echo "cmake: enabled parallel building"
     fi
 
+    if ! [[ -v enableParallelInstalling ]]; then
+        enableParallelInstalling=1
+        echo "cmake: enabled parallel installing"
+    fi
+
     runHook postConfigure
 }
 

--- a/pkgs/development/tools/build-managers/meson/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/meson/setup-hook.sh
@@ -28,6 +28,11 @@ mesonConfigurePhase() {
         echo "meson: enabled parallel building"
     fi
 
+    if ! [[ -v enableParallelInstalling ]]; then
+        enableParallelInstalling=1
+        echo "meson: enabled parallel installing"
+    fi
+
     runHook postConfigure
 }
 

--- a/pkgs/development/tools/build-managers/ninja/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/ninja/setup-hook.sh
@@ -53,8 +53,16 @@ ninjaCheckPhase() {
 ninjaInstallPhase() {
     runHook preInstall
 
+    local buildCores=1
+
+    # Parallel building is enabled by default.
+    if [ "${enableParallelInstalling-1}" ]; then
+        buildCores="$NIX_BUILD_CORES"
+    fi
+
     # shellcheck disable=SC2086
     local flagsArray=(
+        -j$buildCores
         $ninjaFlags "${ninjaFlagsArray[@]}"
         ${installTargets:-install}
     )

--- a/pkgs/development/tools/build-managers/scons/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/scons/setup-hook.sh
@@ -33,6 +33,7 @@ sconsInstallPhase() {
     fi
 
     local flagsArray=(
+        ${enableParallelInstalling:+-j${NIX_BUILD_CORES}}
         $sconsFlags ${sconsFlagsArray[@]}
         $installFlags ${installFlagsArray[@]}
         ${installTargets:-install}

--- a/pkgs/development/tools/build-managers/wafHook/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/wafHook/setup-hook.sh
@@ -30,6 +30,11 @@ wafConfigurePhase() {
         echo "waf: enabled parallel building"
     fi
 
+    if ! [[ -v enableParallelInstalling ]]; then
+        enableParallelInstalling=1
+        echo "waf: enabled parallel installing"
+    fi
+
     runHook postConfigure
 }
 
@@ -68,6 +73,7 @@ wafInstallPhase() {
     fi
 
     local flagsArray=(
+        ${enableParallelInstalling:+-j ${NIX_BUILD_CORES}}
         $wafFlags ${wafFlagsArray[@]}
         $installFlags ${installFlagsArray[@]}
         ${installTargets:-install}

--- a/pkgs/os-specific/linux/sssd/default.nix
+++ b/pkgs/os-specific/linux/sssd/default.nix
@@ -54,6 +54,9 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+  # Disable parallel install due to missing depends:
+  #   libtool:   error: error: relink '_py3sss.la' with the above command before installing i
+  enableParallelInstalling = false;
   nativeBuildInputs = [ autoreconfHook makeWrapper pkg-config doxygen ];
   buildInputs = [ augeas dnsutils c-ares curl cyrus_sasl ding-libs libnl libunistring nss
                   samba nfs-utils p11-kit python3 popt

--- a/pkgs/servers/irc/solanum/default.nix
+++ b/pkgs/servers/irc/solanum/default.nix
@@ -57,6 +57,11 @@ stdenv.mkDerivation rec {
   doCheck = !stdenv.isDarwin;
 
   enableParallelBuilding = true;
+  # Missing install depends:
+  #   ...-binutils-2.40/bin/ld: cannot find ./.libs/libircd.so: No such file or directory
+  #   collect2: error: ld returned 1 exit status
+  #   make[4]: *** [Makefile:634: solanum] Error 1
+  enableParallelInstalling = false;
 
   meta = with lib; {
     description = "An IRCd for unified networks";

--- a/pkgs/servers/monitoring/net-snmp/default.nix
+++ b/pkgs/servers/monitoring/net-snmp/default.nix
@@ -49,6 +49,9 @@ in stdenv.mkDerivation rec {
     ++ lib.optional withPerlTools perlWithPkgs;
 
   enableParallelBuilding = true;
+  # Missing dependencies during relinking:
+  #   ./.libs/libnetsnmpagent.so: file not recognized: file format not recognized
+  enableParallelInstalling = false;
   doCheck = false;  # tries to use networking
 
   postInstall = ''

--- a/pkgs/servers/x11/xorg/builder.sh
+++ b/pkgs/servers/x11/xorg/builder.sh
@@ -37,5 +37,6 @@ fi
 
 
 enableParallelBuilding=1
+enableParallelInstalling=1
 
 genericBuild

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -433,6 +433,7 @@ else let
     } // lib.optionalAttrs (enableParallelBuilding) {
       inherit enableParallelBuilding;
       enableParallelChecking = attrs.enableParallelChecking or true;
+      enableParallelInstalling = attrs.enableParallelInstalling or true;
     } // lib.optionalAttrs (hardeningDisable != [] || hardeningEnable != [] || stdenv.hostPlatform.isMusl) {
       NIX_HARDENING_ENABLE = enabledHardeningOptions;
     } // lib.optionalAttrs (stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform ? gcc.arch) {

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1376,6 +1376,7 @@ installPhase() {
 
     # shellcheck disable=SC2086
     local flagsArray=(
+        ${enableParallelInstalling:+-j${NIX_BUILD_CORES}}
         SHELL=$SHELL
     )
     _accumFlagsArray makeFlags makeFlagsArray installFlags installFlagsArray

--- a/pkgs/tools/filesystems/xfsprogs/default.nix
+++ b/pkgs/tools/filesystems/xfsprogs/default.nix
@@ -23,6 +23,9 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ libuuid ]; # Dev headers include <uuid/uuid.h>
 
   enableParallelBuilding = true;
+  # Install fails as:
+  #   make[1]: *** No rule to make target '\', needed by 'kmem.lo'.  Stop.
+  enableParallelInstalling = false;
 
   # @sbindir@ is replaced with /run/current-system/sw/bin to fix dependency cycles
   preConfigure = ''

--- a/pkgs/tools/graphics/asymptote/default.nix
+++ b/pkgs/tools/graphics/asymptote/default.nix
@@ -67,6 +67,10 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+  # Missing install depends:
+  #   ...-coreutils-9.1/bin/install: cannot stat 'asy-keywords.el': No such file or directory
+  #   make: *** [Makefile:272: install-asy] Error 1
+  enableParallelInstalling = false;
 
   meta = with lib; {
     description =  "A tool for programming graphics intended to replace Metapost";

--- a/pkgs/tools/networking/vpnc/default.nix
+++ b/pkgs/tools/networking/vpnc/default.nix
@@ -32,6 +32,10 @@ stdenv.mkDerivation {
   '';
 
   enableParallelBuilding = true;
+  # Missing install depends:
+  #   install: target '...-vpnc-unstable-2021-11-04/share/doc/vpnc': No such file or directory
+  #   make: *** [Makefile:149: install-doc] Error 1
+  enableParallelInstalling = false;
 
   meta = with lib; {
     homepage = "https://davidepucci.it/doc/vpnc/";


### PR DESCRIPTION
The primary motivating example is openssl:

Before the change full package build took 1m54s minutes. After the change full package build takes 59s.

About a 2x speedup.

The difference is visible because openssl builds hundreds of manpages spawning a perl process per manual in `install` phase. Such a workload is very easy to parallelize.

Another example would be `autotools`+`libtool` based build system where install step requires relinking. The more binaries there are to relink the more gain it will be to do it in parallel.

The change enables parallel installs by default only for buiilds that already have parallel builds enabled. There is a high chance those build systems already handle parallelism well but some packages will fail.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
