### PR TITLE
tbb: Split into tbb_2020_3 and tbb_2021_8

### DIFF
--- a/pkgs/development/libraries/tbb/2020_3.nix
+++ b/pkgs/development/libraries/tbb/2020_3.nix
@@ -1,0 +1,106 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchFromGitHub
+, fixDarwinDylibNames
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tbb";
+  version = "2020.3";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "oneapi-src";
+    repo = "oneTBB";
+    rev = "v${version}";
+    sha256 = "prO2O5hd+Wz5iA0vfrqmyHFr0Ptzk64so5KpSpvuKmU=";
+  };
+
+  patches = [
+    # Fixes build with Musl.
+    (fetchurl {
+      url = "https://github.com/openembedded/meta-openembedded/raw/39185eb1d1615e919e3ae14ae63b8ed7d3e5d83f/meta-oe/recipes-support/tbb/tbb/GLIBC-PREREQ-is-not-defined-on-musl.patch";
+      sha256 = "gUfXQ9OZQ82qD6brgauBCsKdjLvyHafMc18B+KxZoYs=";
+    })
+
+    # Fixes build with Musl.
+    (fetchurl {
+      url = "https://github.com/openembedded/meta-openembedded/raw/39185eb1d1615e919e3ae14ae63b8ed7d3e5d83f/meta-oe/recipes-support/tbb/tbb/0001-mallinfo-is-glibc-specific-API-mark-it-so.patch";
+      sha256 = "fhorfqO1hHKZ61uq+yTR7eQ8KYdyLwpM3K7WpwJpV74=";
+    })
+
+    # Fixes build with upcoming gcc-13:
+    #  https://github.com/oneapi-src/oneTBB/pull/833
+    (fetchurl {
+      name = "gcc-13.patch";
+      url = "https://github.com/oneapi-src/oneTBB/pull/833/commits/c18342ba667d1f33f5e9a773aa86b091a9694b97.patch";
+      sha256 = "ZUExE3nsW80Z5GPWZnDNuDiHHaD1EF7qNl/G5M+Wcxg=";
+    })
+
+    # Fixes build for aarch64-darwin
+    (fetchurl {
+      name = "aarch64-darwin.patch";
+      url = "https://github.com/oneapi-src/oneTBB/pull/258/commits/86f6dcdc17a8f5ef2382faaef860cfa5243984fe.patch";
+      sha256 = "sha256-JXqrFPCb3q1vfxk752tQu7HhApCB4YH2LoVnGRwmspk=";
+    })
+  ];
+
+  nativeBuildInputs = (lib.optionals stdenv.isDarwin [
+    fixDarwinDylibNames
+  ]);
+
+  makeFlags = lib.optionals stdenv.cc.isClang [
+    "compiler=clang"
+  ] ++ (lib.optional (stdenv.buildPlatform != stdenv.hostPlatform)
+    (if stdenv.hostPlatform.isAarch64 then "arch=arm64"
+    else if stdenv.hostPlatform.isx86_64 then "arch=intel64"
+    else throw "Unsupported cross architecture"));
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp "build/"*release*"/"*${stdenv.hostPlatform.extensions.sharedLibrary}* $out/lib/
+    mv include $out/
+    rm $out/include/index.html
+
+    runHook postInstall
+  '';
+
+  postInstall = let
+    pcTemplate = fetchurl {
+      url = "https://github.com/oneapi-src/oneTBB/raw/478de5b1887c928e52f029d706af6ea640a877be/integration/pkg-config/tbb.pc.in";
+      sha256 = "2pCad9txSpNbzac0vp/VY3x7HNySaYkbH3Rx8LK53pI=";
+    };
+  in ''
+    # Generate pkg-config file based on upstream template.
+    # It should not be necessary with tbb after 2021.2.
+    mkdir -p "$out/lib/pkgconfig"
+    substitute "${pcTemplate}" "$out/lib/pkgconfig/tbb.pc" \
+      --subst-var-by CMAKE_INSTALL_PREFIX "$out" \
+      --subst-var-by CMAKE_INSTALL_LIBDIR "lib" \
+      --subst-var-by CMAKE_INSTALL_INCLUDEDIR "include" \
+      --subst-var-by TBB_VERSION "${version}" \
+      --subst-var-by TBB_LIB_NAME "tbb"
+  '';
+
+  meta = with lib; {
+    description = "Intel Thread Building Blocks C++ Library";
+    homepage = "http://threadingbuildingblocks.org/";
+    license = licenses.asl20;
+    longDescription = ''
+      Intel Threading Building Blocks offers a rich and complete approach to
+      expressing parallelism in a C++ program. It is a library that helps you
+      take advantage of multi-core processor performance without having to be a
+      threading expert. Intel TBB is not just a threads-replacement library. It
+      represents a higher-level, task-based parallelism that abstracts platform
+      details and threading mechanisms for scalability and performance.
+    '';
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ thoughtpolice tmarkus ];
+  };
+}

--- a/pkgs/development/libraries/tbb/default.nix
+++ b/pkgs/development/libraries/tbb/default.nix
@@ -1,13 +1,13 @@
 { lib
 , stdenv
-, fetchurl
 , fetchFromGitHub
-, fixDarwinDylibNames
+, fetchpatch
+, cmake
 }:
 
 stdenv.mkDerivation rec {
   pname = "tbb";
-  version = "2020.3";
+  version = "2021.8.0";
 
   outputs = [ "out" "dev" ];
 
@@ -15,77 +15,39 @@ stdenv.mkDerivation rec {
     owner = "oneapi-src";
     repo = "oneTBB";
     rev = "v${version}";
-    sha256 = "prO2O5hd+Wz5iA0vfrqmyHFr0Ptzk64so5KpSpvuKmU=";
+    hash = "sha256-7MjUdPB1GsPt7ZkYj7DCisq20X8psljsVCjDpCSTYT4=";
   };
 
+  nativeBuildInputs = [
+    cmake
+  ];
+
   patches = [
-    # Fixes build with Musl.
-    (fetchurl {
-      url = "https://github.com/openembedded/meta-openembedded/raw/39185eb1d1615e919e3ae14ae63b8ed7d3e5d83f/meta-oe/recipes-support/tbb/tbb/GLIBC-PREREQ-is-not-defined-on-musl.patch";
-      sha256 = "gUfXQ9OZQ82qD6brgauBCsKdjLvyHafMc18B+KxZoYs=";
+    # Fix musl build from https://github.com/oneapi-src/oneTBB/pull/899
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/oneapi-src/oneTBB/pull/899.patch";
+      hash = "sha256-kU6RRX+sde0NrQMKlNtW3jXav6J4QiVIUmD50asmBPU=";
     })
 
-    # Fixes build with Musl.
-    (fetchurl {
-      url = "https://github.com/openembedded/meta-openembedded/raw/39185eb1d1615e919e3ae14ae63b8ed7d3e5d83f/meta-oe/recipes-support/tbb/tbb/0001-mallinfo-is-glibc-specific-API-mark-it-so.patch";
-      sha256 = "fhorfqO1hHKZ61uq+yTR7eQ8KYdyLwpM3K7WpwJpV74=";
-    })
-
-    # Fixes build with upcoming gcc-13:
-    #  https://github.com/oneapi-src/oneTBB/pull/833
-    (fetchurl {
-      name = "gcc-13.patch";
-      url = "https://github.com/oneapi-src/oneTBB/pull/833/commits/c18342ba667d1f33f5e9a773aa86b091a9694b97.patch";
-      sha256 = "ZUExE3nsW80Z5GPWZnDNuDiHHaD1EF7qNl/G5M+Wcxg=";
-    })
-
-    # Fixes build for aarch64-darwin
-    (fetchurl {
-      name = "aarch64-darwin.patch";
-      url = "https://github.com/oneapi-src/oneTBB/pull/258/commits/86f6dcdc17a8f5ef2382faaef860cfa5243984fe.patch";
-      sha256 = "sha256-JXqrFPCb3q1vfxk752tQu7HhApCB4YH2LoVnGRwmspk=";
+    # Fix/suppress warnings on gcc12.1 from https://github.com/oneapi-src/oneTBB/pull/866
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/oneapi-src/oneTBB/pull/866.patch";
+      hash = "sha256-e44Yv84Hfl5xoxWWTnLJLSGeNA1RBbah4/L43gPLS+c=";
     })
   ];
 
-  nativeBuildInputs = lib.optionals stdenv.isDarwin [
-    fixDarwinDylibNames
-  ];
+  # Fix build with modern gcc
+  # In member function 'void std::__atomic_base<_IntTp>::store(__int_type, std::memory_order) [with _ITp = bool]',
+  NIX_CFLAGS_COMPILE = lib.optionals stdenv.cc.isGNU [ "-Wno-error=stringop-overflow" ] ++
+    # Workaround for gcc-12 ICE when using -O3
+    # https://gcc.gnu.org/PR108854
+    lib.optionals (stdenv.cc.isGNU && stdenv.isx86_32) [ "-O2" ];
 
-  makeFlags = lib.optionals stdenv.cc.isClang [
-    "compiler=clang"
-  ] ++ (lib.optional (stdenv.buildPlatform != stdenv.hostPlatform)
-    (if stdenv.hostPlatform.isAarch64 then "arch=arm64"
-    else if stdenv.hostPlatform.isx86_64 then "arch=intel64"
-    else throw "Unsupported cross architecture"));
-
-  enableParallelBuilding = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/lib
-    cp "build/"*release*"/"*${stdenv.hostPlatform.extensions.sharedLibrary}* $out/lib/
-    mv include $out/
-    rm $out/include/index.html
-
-    runHook postInstall
-  '';
-
-  postInstall = let
-    pcTemplate = fetchurl {
-      url = "https://github.com/oneapi-src/oneTBB/raw/478de5b1887c928e52f029d706af6ea640a877be/integration/pkg-config/tbb.pc.in";
-      sha256 = "2pCad9txSpNbzac0vp/VY3x7HNySaYkbH3Rx8LK53pI=";
-    };
-  in ''
-    # Generate pkg-config file based on upstream template.
-    # It should not be necessary with tbb after 2021.2.
-    mkdir -p "$out/lib/pkgconfig"
-    substitute "${pcTemplate}" "$out/lib/pkgconfig/tbb.pc" \
-      --subst-var-by CMAKE_INSTALL_PREFIX "$out" \
-      --subst-var-by CMAKE_INSTALL_LIBDIR "lib" \
-      --subst-var-by CMAKE_INSTALL_INCLUDEDIR "include" \
-      --subst-var-by TBB_VERSION "${version}" \
-      --subst-var-by TBB_LIB_NAME "tbb"
+  # Disable failing test on musl
+  # test/conformance/conformance_resumable_tasks.cpp:37:24: error: ‘suspend’ is not a member of ‘tbb::v1::task’; did you mean ‘tbb::detail::r1::suspend’?
+  postPatch = lib.optionalString stdenv.hostPlatform.isMusl ''
+    substituteInPlace test/CMakeLists.txt \
+      --replace 'conformance_resumable_tasks' ""
   '';
 
   meta = with lib; {
@@ -101,6 +63,6 @@ stdenv.mkDerivation rec {
       details and threading mechanisms for scalability and performance.
     '';
     platforms = platforms.unix;
-    maintainers = with maintainers; [ thoughtpolice ];
+    maintainers = with maintainers; [ thoughtpolice tmarkus ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16103,7 +16103,10 @@ with pkgs;
   };
   swiPrologWithGui = swiProlog.override { withGui = true; };
 
-  tbb = callPackage ../development/libraries/tbb { };
+  tbb_2020_3 = callPackage ../development/libraries/tbb/2020_3.nix { };
+  tbb_2021_8 = callPackage ../development/libraries/tbb { };
+  # many packages still fail with latest version
+  tbb = tbb_2020_3;
 
   terra = callPackage ../development/compilers/terra {
     llvmPackages = llvmPackages_11;


### PR DESCRIPTION
###### Description of changes

This is based on PR #214762.

For the new release 2021.8, see
https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-threading-building-blocks-release-notes.html
https://github.com/oneapi-src/oneTBB/releases/tag/v2021.5.0
https://github.com/oneapi-src/oneTBB/releases/tag/v2021.6.0
https://github.com/oneapi-src/oneTBB/releases/tag/v2021.7.0

Due to the significant breakage due to the update to TBB 2021.8, instead split the tbb package into tbb_2020_3 and tbb_2021_8, with the default tbb aliased to tbb_2020_3 in order to minimize breakage.

Also fixed build issues and improved code.

> The reason I went for this change is that I'd like to package [CCTag](https://github.com/alicevision/CCTag) which depends on TBB 2021. To me this solution seems like a good way to bridge the time until the packages incompatible with TBB 2021.8, but I'm not sure if there are any guidelines regarding splitting packages like this. So please comment if this discouraged for some reason.
> 
> I hope I got the split right. In particular, I'm wondering if there's a better solution for sharing `meta`. Also, I'm open to suggestions regarding the versioned package naming scheme.

Continuing https://github.com/NixOS/nixpkgs/pull/215689 and https://github.com/NixOS/nixpkgs/pull/216991

cc co-author @hesiod

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] i686-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
