### PR TITLE
linuxKernel: fix eval

### DIFF
--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -1,11 +1,6 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, kernel }:
 
 stdenv.mkDerivation rec {
-  # linux kernel above 5.7 comes with its own exfat implementation https://github.com/arter97/exfat-linux/issues/27
-  # Assertion moved here due to some tests unintenionally triggering it,
-  # e.g. nixosTests.kernel-latest; it's unclear how/why so far.
-  assertion = assert lib.versionOlder kernel.version "5.8"; null;
-
   name = "exfat-nofuse-${version}-${kernel.version}";
   version = "2020-04-15";
 

--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -15,7 +15,6 @@ with lib.kernel;
 with (lib.kernel.whenHelpers version);
 
 assert (versionAtLeast version "4.9");
-assert (stdenv.hostPlatform.isx86_64 -> versions.majorMinor version != "5.4");
 
 {
   # Report BUG() conditions and kill the offending process.

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -327,7 +327,7 @@ in {
 
     dpdk = pkgs.dpdk.override { inherit kernel; };
 
-    exfat-nofuse = callPackage ../os-specific/linux/exfat { };
+    exfat-nofuse = if lib.versionOlder kernel.version "5.8" then callPackage ../os-specific/linux/exfat { } else null;
 
     evdi = callPackage ../os-specific/linux/evdi { };
 

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -96,8 +96,6 @@ in {
       rpiVersion = 4;
     };
 
-    linux_4_9 = throw "linux 4.9 was removed because it will reach its end of life within 22.11";
-
     linux_4_14 = callPackage ../os-specific/linux/kernel/linux-4.14.nix {
       kernelPatches =
         [ kernelPatches.bridge_stp_helper
@@ -162,12 +160,6 @@ in {
         kernelPatches.export-rt-sched-migrate
       ];
     };
-
-    linux_5_18 = throw "linux 5.18 was removed because it has reached its end of life upstream";
-
-    linux_5_19 = throw "linux 5.19 was removed because it has reached its end of life upstream";
-
-    linux_6_0 = throw "linux 6.0 was removed because it has reached its end of life upstream";
 
     linux_6_1 = callPackage ../os-specific/linux/kernel/linux-6.1.nix {
       kernelPatches = [
@@ -248,7 +240,6 @@ in {
     linux_xanmod = xanmodKernels.lts;
     linux_xanmod_stable = xanmodKernels.main;
     linux_xanmod_latest = xanmodKernels.main;
-    linux_xanmod_tt = throw "linux_xanmod_tt was removed because upstream no longer offers this option";
 
     linux_libre = deblobKernel packageAliases.linux_default.kernel;
 
@@ -261,11 +252,19 @@ in {
     linux_5_4_hardened = hardenedKernelFor kernels.linux_5_4 { };
     linux_5_10_hardened = hardenedKernelFor kernels.linux_5_10 { };
     linux_5_15_hardened = hardenedKernelFor kernels.linux_5_15 { };
+    linux_6_1_hardened = hardenedKernelFor kernels.linux_6_1 { };
+
+  } // lib.optionalAttrs config.allowAliases {
+    linux_4_9 = throw "linux 4.9 was removed because it will reach its end of life within 22.11";
+    linux_5_18 = throw "linux 5.18 was removed because it has reached its end of life upstream";
+    linux_5_19 = throw "linux 5.19 was removed because it has reached its end of life upstream";
+    linux_6_0 = throw "linux 6.0 was removed because it has reached its end of life upstream";
+
+    linux_xanmod_tt = throw "linux_xanmod_tt was removed because upstream no longer offers this option";
+
     linux_5_18_hardened = throw "linux 5.18 was removed because it has reached its end of life upstream";
     linux_5_19_hardened = throw "linux 5.19 was removed because it has reached its end of life upstream";
     linux_6_0_hardened = throw "linux 6.0 was removed because it has reached its end of life upstream";
-    linux_6_1_hardened = hardenedKernelFor kernels.linux_6_1 { };
-
   }));
   /*  Linux kernel modules are inherently tied to a specific kernel.  So
     rather than provide specific instances of those packages for a
@@ -541,17 +540,18 @@ in {
 
   vanillaPackages = {
     # recurse to build modules for the kernels
-    linux_4_9 = throw "linux 4.9 was removed because it will reach its end of life within 22.11"; # Added 2022-11-08
     linux_4_14 = recurseIntoAttrs (packagesFor kernels.linux_4_14);
     linux_4_19 = recurseIntoAttrs (packagesFor kernels.linux_4_19);
     linux_5_4 = recurseIntoAttrs (packagesFor kernels.linux_5_4);
     linux_5_10 = recurseIntoAttrs (packagesFor kernels.linux_5_10);
     linux_5_15 = recurseIntoAttrs (packagesFor kernels.linux_5_15);
+    linux_6_1 = recurseIntoAttrs (packagesFor kernels.linux_6_1);
+    linux_6_2 = recurseIntoAttrs (packagesFor kernels.linux_6_2);
+  } // lib.optionalAttrs config.allowAliases {
+    linux_4_9 = throw "linux 4.9 was removed because it will reach its end of life within 22.11"; # Added 2022-11-08
     linux_5_18 = throw "linux 5.18 was removed because it reached its end of life upstream"; # Added 2022-09-17
     linux_5_19 = throw "linux 5.19 was removed because it reached its end of life upstream"; # Added 2022-11-01
     linux_6_0 = throw "linux 6.0 was removed because it reached its end of life upstream"; # Added 2023-01-20
-    linux_6_1 = recurseIntoAttrs (packagesFor kernels.linux_6_1);
-    linux_6_2 = recurseIntoAttrs (packagesFor kernels.linux_6_2);
   };
 
   rtPackages = {
@@ -590,9 +590,6 @@ in {
     });
     linux_5_10_hardened = recurseIntoAttrs (hardenedPackagesFor kernels.linux_5_10 { });
     linux_5_15_hardened = recurseIntoAttrs (hardenedPackagesFor kernels.linux_5_15 { });
-    linux_5_18_hardened = throw "linux 5.18 was removed because it has reached its end of life upstream";
-    linux_5_19_hardened = throw "linux 5.19 was removed because it has reached its end of life upstream";
-    linux_6_0_hardened = throw "linux 6.0 was removed because it has reached its end of life upstream";
     linux_6_1_hardened = recurseIntoAttrs (hardenedPackagesFor kernels.linux_6_1 { });
 
     linux_zen = recurseIntoAttrs (packagesFor kernels.linux_zen);
@@ -600,13 +597,17 @@ in {
     linux_xanmod = recurseIntoAttrs (packagesFor kernels.linux_xanmod);
     linux_xanmod_stable = recurseIntoAttrs (packagesFor kernels.linux_xanmod_stable);
     linux_xanmod_latest = recurseIntoAttrs (packagesFor kernels.linux_xanmod_latest);
-    linux_xanmod_tt = throw "linux_xanmod_tt was removed because upstream no longer offers this option";
 
     hardkernel_4_14 = recurseIntoAttrs (packagesFor kernels.linux_hardkernel_4_14);
 
     linux_libre = recurseIntoAttrs (packagesFor kernels.linux_libre);
 
     linux_latest_libre = recurseIntoAttrs (packagesFor kernels.linux_latest_libre);
+  } // lib.optionalAttrs config.allowAliases {
+    linux_5_18_hardened = throw "linux 5.18 was removed because it has reached its end of life upstream";
+    linux_5_19_hardened = throw "linux 5.19 was removed because it has reached its end of life upstream";
+    linux_6_0_hardened = throw "linux 6.0 was removed because it has reached its end of life upstream";
+    linux_xanmod_tt = throw "linux_xanmod_tt was removed because upstream no longer offers this option";
   });
 
   packageAliases = {

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -45,6 +45,9 @@ let
           url = "mirror://kernel/linux/kernel/v${major}.x/linux-${version}.tar.xz";
           inherit sha256;
         };
+        extraMeta = {
+          broken = kernel.meta.broken || (stdenv.isx86_64 && lib.versions.majorMinor version == "5.4");
+        };
       };
       kernelPatches = kernel.kernelPatches ++ [
         kernelPatches.hardened.${kernel.meta.branch}


### PR DESCRIPTION
###### Description of changes

When doing refactoring and suff, it's useful to be able to test evaluation of every package in the attribute set, as a smoke test.  Various things in linuxKernel didn't evaluate, but in each case it just required some small cleanup. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
