### PR TITLE
tensorflow-lite: Fix build by downgrading flatbuffers

### DIFF
--- a/pkgs/development/libraries/science/math/tensorflow-lite/default.nix
+++ b/pkgs/development/libraries/science/math/tensorflow-lite/default.nix
@@ -63,6 +63,16 @@ let
     rev = "5916273f79a21551890fd3d56fc5375a78d1598d";
     sha256 = "0q6760xdxsg18acdv8vq3yrq7ksr7wsm8zbyan01zf2khnb6fw4x";
   };
+
+  flatbuffers' = flatbuffers.overrideAttrs (_: {
+    version = "2.0.0";
+    src = fetchFromGitHub {
+      owner = "google";
+      repo = "flatbuffers";
+      rev = "refs/tags/v2.0.0";
+      hash = "sha256-6Du6STEPR7SuYhIx5qmyEpWbe44AUBxyMgPpe9sybv0=";
+    };
+  });
 in
 stdenv.mkDerivation rec {
   pname = "tensorflow-lite";
@@ -90,7 +100,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  buildInputs = [ zlib flatbuffers ];
+  buildInputs = [ zlib flatbuffers' ];
 
   dontConfigure = true;
 
@@ -140,7 +150,7 @@ stdenv.mkDerivation rec {
       ln -s ${tflite-eigen} "$prefix/eigen"
 
       # tensorflow lite is using the *source* of flatbuffers
-      ln -s ${flatbuffers.src} "$prefix/flatbuffers"
+      ln -s ${flatbuffers'.src} "$prefix/flatbuffers"
 
       # tensorflow lite expects to compile abseil into `libtensorflow-lite.a`
       ln -s ${abseil-cpp.src} "$prefix/absl"
@@ -169,6 +179,10 @@ stdenv.mkDerivation rec {
       chmod -x "$path"
     done
   '';
+
+  passthru = {
+    flatbuffers = flatbuffers';
+  };
 
   meta = with lib; {
     description = "An open source deep learning framework for on-device inference.";


### PR DESCRIPTION
When flatbuffers was upgraded past 2.0.0 the build of tflite broke.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (with gcc11, fails with gcc12)
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
