### PR TITLE
python310Packages.nextcord: 2.3.3 -> 2.4.0

### DIFF
--- a/pkgs/development/python-modules/nextcord/default.nix
+++ b/pkgs/development/python-modules/nextcord/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "nextcord";
-  version = "2.3.3";
+  version = "2.4.0";
 
   format = "setuptools";
 
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "nextcord";
     repo = "nextcord";
     rev = "refs/tags/v${version}";
-    hash = "sha256-0ZWPoDLlGwLWReOeZc2GgW1FbUufrxTzUndNe5h7Kas=";
+    hash = "sha256-TePUsyQ4DCuvfRQD4KAUs94o3MJRmZmu6jMPv4lJtHE=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/nextcord/paths.patch
+++ b/pkgs/development/python-modules/nextcord/paths.patch
@@ -1,8 +1,8 @@
 diff --git a/nextcord/opus.py b/nextcord/opus.py
-index 52e4ddbd..d8b8090b 100644
+index b1119a8e..b7c9c713 100644
 --- a/nextcord/opus.py
 +++ b/nextcord/opus.py
-@@ -255,7 +255,7 @@ def _load_default() -> bool:
+@@ -233,7 +233,7 @@ def _load_default() -> bool:
              _filename = os.path.join(_basedir, "bin", f"libopus-0.{_target}.dll")
              _lib = libopus_loader(_filename)
          else:
@@ -12,10 +12,10 @@ index 52e4ddbd..d8b8090b 100644
              if opus is None:
                  _lib = None
 diff --git a/nextcord/player.py b/nextcord/player.py
-index 5d0674cc..fd1c20ef 100644
+index 5c7daf52..48a11eb7 100644
 --- a/nextcord/player.py
 +++ b/nextcord/player.py
-@@ -148,7 +148,7 @@ class FFmpegAudio(AudioSource):
+@@ -127,7 +127,7 @@ class FFmpegAudio(AudioSource):
          self,
          source: Union[str, io.BufferedIOBase],
          *,
@@ -23,8 +23,8 @@ index 5d0674cc..fd1c20ef 100644
 +        executable: str = "@ffmpeg@",
          args: Any,
          **subprocess_kwargs: Any,
-     ):
-@@ -275,7 +275,7 @@ class FFmpegPCMAudio(FFmpegAudio):
+     ) -> None:
+@@ -254,7 +254,7 @@ class FFmpegPCMAudio(FFmpegAudio):
          self,
          source: Union[str, io.BufferedIOBase],
          *,
@@ -33,16 +33,16 @@ index 5d0674cc..fd1c20ef 100644
          pipe: bool = False,
          stderr: Optional[IO[str]] = None,
          before_options: Optional[str] = None,
-@@ -378,7 +378,7 @@ class FFmpegOpusAudio(FFmpegAudio):
+@@ -357,7 +357,7 @@ class FFmpegOpusAudio(FFmpegAudio):
          *,
          bitrate: int = 128,
          codec: Optional[str] = None,
 -        executable: str = "ffmpeg",
 +        executable: str = "@ffmpeg@",
-         pipe=False,
+         pipe: bool = False,
          stderr=None,
          before_options=None,
-@@ -532,7 +532,7 @@ class FFmpegOpusAudio(FFmpegAudio):
+@@ -510,7 +510,7 @@ class FFmpegOpusAudio(FFmpegAudio):
          """
  
          method = method or "native"
@@ -51,16 +51,19 @@ index 5d0674cc..fd1c20ef 100644
          probefunc = fallback = None
  
          if isinstance(method, str):
-@@ -577,7 +577,7 @@ class FFmpegOpusAudio(FFmpegAudio):
+@@ -555,9 +555,9 @@ class FFmpegOpusAudio(FFmpegAudio):
  
      @staticmethod
      def _probe_codec_native(
 -        source, executable: str = "ffmpeg"
 +        source, executable: str = "@ffmpeg@"
      ) -> Tuple[Optional[str], Optional[int]]:
-         exe = executable[:2] + "probe" if executable in ("ffmpeg", "avconv") else executable
+-        exe = executable[:2] + "probe" if executable in ("ffmpeg", "avconv") else executable
++        exe = executable[:-4] + "probe" if executable.endswith(("ffmpeg", "avconv")) else executable
          args = [
-@@ -606,7 +606,7 @@ class FFmpegOpusAudio(FFmpegAudio):
+             exe,
+             "-v",
+@@ -584,7 +584,7 @@ class FFmpegOpusAudio(FFmpegAudio):
  
      @staticmethod
      def _probe_codec_fallback(


### PR DESCRIPTION
###### Description of changes
Diff: https://github.com/nextcord/nextcord/compare/refs/tags/v2.3.3...v2.4.0

Changelog: https://github.com/nextcord/nextcord/blob/refs/tags/v2.4.0/docs/whats_new.rst


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
