### PR TITLE
cudaPackages.nccl: refactor to fix #220340 and #221895

### DIFF
--- a/pkgs/development/libraries/science/math/nccl/default.nix
+++ b/pkgs/development/libraries/science/math/nccl/default.nix
@@ -2,24 +2,25 @@
 , backendStdenv
 , fetchFromGitHub
 , which
-, cudaPackages ? { }
-, addOpenGLRunpath
+, autoAddOpenGLRunpathHook
+, cuda_cccl
+, cuda_cudart
+, cuda_nvcc
+, cudaFlags
+, cudaVersion
 }:
-
-with cudaPackages;
-
 let
   # Output looks like "-gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_86,code=compute_86"
   gencode = lib.concatStringsSep " " cudaFlags.gencode;
 in
-backendStdenv.mkDerivation rec {
-  name = "nccl-${version}-cuda-${cudaPackages.cudaMajorVersion}";
+backendStdenv.mkDerivation (finalAttrs: {
+  name = "nccl-${finalAttrs.version}-cuda-${cudaVersion}";
   version = "2.16.5-1";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "nccl";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-JyhhYKSVIqUKIbC1rCJozPT1IrIyRLGrTjdPjJqsYaU=";
   };
 
@@ -27,13 +28,18 @@ backendStdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     which
-    addOpenGLRunpath
+    autoAddOpenGLRunpathHook
     cuda_nvcc
   ];
 
   buildInputs = [
     cuda_cudart
-  ] ++ lib.optionals (lib.versionAtLeast cudaVersion "12.0.0") [
+  ]
+  # NOTE: CUDA versions in Nixpkgs only use a major and minor version. When we do comparisons
+  # against other version, like below, it's important that we use the same format. Otherwise,
+  # we'll get incorrect results.
+  # For example, lib.versionAtLeast "12.0" "12.0.0" == false.
+  ++ lib.optionals (lib.versionAtLeast cudaVersion "12.0") [
     cuda_cccl
   ];
 
@@ -46,26 +52,18 @@ backendStdenv.mkDerivation rec {
 
   makeFlags = [
     "CUDA_HOME=${cuda_nvcc}"
-    "CUDA_LIB=${cuda_cudart}/lib64"
-    "CUDA_INC=${cuda_cudart}/include"
+    "CUDA_LIB=${lib.getLib cuda_cudart}/lib"
+    "CUDA_INC=${lib.getDev cuda_cudart}/include"
     "PREFIX=$(out)"
   ];
 
   postFixup = ''
     moveToOutput lib/libnccl_static.a $dev
-
-    # Set RUNPATH so that libnvidia-ml in /run/opengl-driver(-32)/lib can be found.
-    # See the explanation in addOpenGLRunpath.
-    addOpenGLRunpath $out/lib/lib*.so
   '';
 
   env.NIX_CFLAGS_COMPILE = toString [ "-Wno-unused-function" ];
 
   enableParallelBuilding = true;
-
-  passthru = {
-    inherit cudaPackages;
-  };
 
   meta = with lib; {
     description = "Multi-GPU and multi-node collective communication primitives for NVIDIA GPUs";
@@ -74,4 +72,4 @@ backendStdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ mdaiter orivej ];
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

- moves to `autoAddOpenGLRunpathHook` instead of manual invocation of `addOpenGLRunpath`
  - closes #220340.
- corrects bug where `nccl` was only built with default version of `cudaPackages` by changing the `nccl` derivation to accept the actual CUDA packages it requires as arguments
  - closes #221895
  - fixes a bug where NCCL would not build with CUDA 12 or newer without overriding the default version of `cudaPackages` in Nixpkgs
- fixes paths given to the environment for `cuda_cudart` to prevent breakage when https://github.com/NixOS/nixpkgs/pull/240498 is merged
- fixes a bug where NCCL would not build with CUDA 12.0 due to a comparison with a version string of the wrong precision
- ~~removed unnecessary `which` entry in `nativeBuildInputs`~~
  - NOTE: While it seems like `which` is unused, it's used to locate NVCC and extract the CUDA version. This is in turn used for conditional compilation.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
