### PR TITLE
brewtarget: 2.3.1 -> 3.0.6

### DIFF
--- a/pkgs/applications/misc/brewtarget/default.nix
+++ b/pkgs/applications/misc/brewtarget/default.nix
@@ -2,27 +2,29 @@
 , mkDerivation
 , fetchFromGitHub
 , bash
+, boost
 , cmake
 , qtbase
 , qttools
 , qtmultimedia
-, qtwebkit
 , qtsvg
+, xalanc
+, xercesc
 }:
 
 mkDerivation rec {
   pname = "brewtarget";
-  version = "2.3.1";
+  version = "3.0.6";
 
   src = fetchFromGitHub {
     owner = "Brewtarget";
     repo = pname;
     rev = "v${version}";
-    sha256 = "14xmm6f8xmvypagx4qdw8q9llzmyi9zzfhnzh4kbbflhjbcr7isz";
+    sha256 = "sha256-qgwzRjRVEk8hM1CmkoWrJT285RQnk5zq16dfSijai1Q=";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ qtbase qttools qtmultimedia qtwebkit qtsvg ];
+  buildInputs = [ boost qtbase qttools qtmultimedia qtsvg xalanc xercesc ];
 
   preConfigure = ''
     chmod +x configure

--- a/pkgs/applications/misc/brewtarget/default.nix
+++ b/pkgs/applications/misc/brewtarget/default.nix
@@ -1,18 +1,15 @@
 { lib
-, mkDerivation
+, stdenv
 , fetchFromGitHub
 , bash
 , boost
 , cmake
-, qtbase
-, qttools
-, qtmultimedia
-, qtsvg
+, qt5
 , xalanc
 , xercesc
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "brewtarget";
   version = "3.0.6";
 
@@ -20,11 +17,12 @@ mkDerivation rec {
     owner = "Brewtarget";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-qgwzRjRVEk8hM1CmkoWrJT285RQnk5zq16dfSijai1Q=";
+    hash = "sha256-qgwzRjRVEk8hM1CmkoWrJT285RQnk5zq16dfSijai1Q=";
   };
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ boost qtbase qttools qtmultimedia qtsvg xalanc xercesc ];
+  nativeBuildInputs = [ cmake qt5.wrapQtAppsHook ];
+  buildInputs = [ boost xalanc xercesc ] ++
+    (with qt5; [ qtbase qttools qtmultimedia qtsvg xalanc xercesc ]);
 
   preConfigure = ''
     chmod +x configure

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2958,7 +2958,7 @@ with pkgs;
 
   brakeman = callPackage ../development/tools/analysis/brakeman { };
 
-  brewtarget = libsForQt5.callPackage ../applications/misc/brewtarget { } ;
+  brewtarget = callPackage ../applications/misc/brewtarget { } ;
 
   bootspec = callPackage ../tools/misc/bootspec { };
 


### PR DESCRIPTION
Upgrade to 3.0.6
Also drop "insecure" qtwebkit

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
