### PR TITLE
teller: init at 1.5.6

### DIFF
--- a/pkgs/development/tools/teller/default.nix
+++ b/pkgs/development/tools/teller/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "teller";
+  version = "1.5.6";
+
+  src = fetchFromGitHub {
+    owner = "tellerops";
+    repo = "teller";
+    rev = "v${version}";
+    sha256 = "sha256-vgrfWKKXf4C4qkbGiB3ndtJy1VyTx2NJs2QiOSFFZkE=";
+  };
+
+  # The package includes vendor folder
+  vendorSha256 = null;
+
+  tags = ["heroku" "go" "golang" "aws" "vault" "secret-management" "secrets" "hashicorp" "gce" "cyberark" "conjur"];
+
+  buildPhase = ''
+    mkdir -p $out/bin
+    go build -ldflags "-s -w -X main.version=${version} -X main.commit=0000000000000000000000000000000000000000 -X main.date=1970-01-01" -o $out/bin
+  '';
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/tellerops/teller";
+    description = "Cloud native secrets management for developers - never leave your command line for secrets. ";
+    maintainers = with maintainers; [ mrityunjaygr8 ];
+    license = licenses.asl20;
+    mainProgram = "teller";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26768,6 +26768,8 @@ with pkgs;
 
   teck-udev-rules = callPackage ../os-specific/linux/teck-udev-rules { };
 
+  teller = callPackage ../development/tools/teller { };
+
   tiptop = callPackage ../os-specific/linux/tiptop { };
 
   tpacpi-bat = callPackage ../os-specific/linux/tpacpi-bat { };


### PR DESCRIPTION
[teller](https://tlr.dev/): Cloud native secrets management for developers - never leave your command line for secrets.

###### Description of changes

Teller package added

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
