### PR TITLE
ifcopenshell: 210410 -> 0.7.0a9

### DIFF
--- a/pkgs/development/python-modules/ifcopenshell/default.nix
+++ b/pkgs/development/python-modules/ifcopenshell/default.nix
@@ -1,12 +1,15 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , buildPythonPackage
 , fetchFromGitHub
-, gcc10
 , cmake
 , boost179
 , icu
 , swig
 , pcre
+, gmp
+, mpfr
+, cgal_5
 , opencascade-occt
 , opencollada
 , libxml2
@@ -14,18 +17,18 @@
 
 buildPythonPackage rec {
   pname = "ifcopenshell";
-  version = "210410";
+  version = "0.7.0a10";
   format = "other";
 
   src = fetchFromGitHub {
-    owner  = "IfcOpenShell";
-    repo   = "IfcOpenShell";
-    rev    = "blenderbim-${version}";
+    owner = "IfcOpenShell";
+    repo = "IfcOpenShell";
+    rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "1g52asxrqcfj01iqvf03k3bb6rg3v04hh1wc3nmn329a2lwjbxpw";
+    hash = "sha256-wZhdU+yuWNEB2B574q2XAKjQdpvPHR+68hQRkNzhRvc=";
   };
 
-  nativeBuildInputs = [ gcc10 cmake ];
+  nativeBuildInputs = [ cmake ];
 
   buildInputs = [
     boost179
@@ -38,23 +41,34 @@ buildPythonPackage rec {
     cd cmake
   '';
 
-  PYTHONUSERBASE=".";
+  PYTHONUSERBASE = ".";
   cmakeFlags = [
     "-DUSERSPACE_PYTHON_PREFIX=ON"
+    "-DBUILD_EXAMPLES=OFF"
+    "-DENABLE_BUILD_OPTIMIZATIONS=ON"
     "-DOCC_INCLUDE_DIR=${opencascade-occt}/include/opencascade"
     "-DOCC_LIBRARY_DIR=${opencascade-occt}/lib"
+    "-DCOLLADA_SUPPORT=ON"
     "-DOPENCOLLADA_INCLUDE_DIR=${opencollada}/include/opencollada"
     "-DOPENCOLLADA_LIBRARY_DIR=${opencollada}/lib/opencollada"
+    "-DPCRE_LIBRARY_DIR=${pcre.out}/lib"
+    "-DHDF5_SUPPORT=OFF"
+    "-DBoost_INCLUDE_DIR=${boost179.dev}/include"
+    "-DBoost_LIBRARY_DIR=${boost179}/lib"
+    "-DCGAL_INCLUDE_DIR=${cgal_5}/include"
+    "-DGMP_LIBRARY_DIR=${gmp}/lib"
+    "-DGMP_INCLUDE_DIR=${gmp.dev}/include"
+    "-DMPFR_LIBRARY_DIR=${mpfr}/lib"
+    "-DMPFR_INCLUDE_DIR=${mpfr.dev}/include"
     "-DSWIG_EXECUTABLE=${swig}/bin/swig"
     "-DLIBXML2_INCLUDE_DIR=${libxml2.dev}/include/libxml2"
     "-DLIBXML2_LIBRARIES=${libxml2.out}/lib/libxml2${stdenv.hostPlatform.extensions.sharedLibrary}"
   ];
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Open source IFC library and geometry engine";
-    homepage    = "http://ifcopenshell.org/";
-    license     = licenses.lgpl3;
+    homepage = "http://ifcopenshell.org/";
+    license = licenses.lgpl3;
     maintainers = with maintainers; [ fehnomenal ];
   };
 }


### PR DESCRIPTION
###### Description of changes

ifcopenshell: 210410 -> 0.7.0a9

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).