### PR TITLE
arrow-cpp: disable failing test on darwin

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -235,6 +235,10 @@ stdenv.mkDerivation rec {
         "TestS3FS.*"
         "TestS3FSGeneric.*"
       ] ++ lib.optionals stdenv.isDarwin [
+        # TODO: revisit at 12.0.0 or when
+        # https://github.com/apache/arrow/commit/295c6644ca6b67c95a662410b2c7faea0920c989
+        # is available, see
+        # https://github.com/apache/arrow/pull/15288#discussion_r1071244661
         "ExecPlanExecution.StressSourceSinkStopped"
       ];
     in

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -234,6 +234,8 @@ stdenv.mkDerivation rec {
         "TestMinioServer.Connect"
         "TestS3FS.*"
         "TestS3FSGeneric.*"
+      ] ++ lib.optionals stdenv.isDarwin [
+        "ExecPlanExecution.StressSourceSinkStopped"
       ];
     in
     lib.optionalString doInstallCheck "-${lib.concatStringsSep ":" filteredTests}";


### PR DESCRIPTION
Failed on Hydra: https://hydra.nixos.org/build/210120744/nixlog/1