### PR TITLE
Allow overriding features

### DIFF
--- a/pkgs/applications/version-management/git-credential-keepassxc/default.nix
+++ b/pkgs/applications/version-management/git-credential-keepassxc/default.nix
@@ -4,6 +4,10 @@
 , fetchFromGitHub
 , DiskArbitration
 , Foundation
+, withNotification ? false
+, withYubikey ? false
+, withStrictCaller ? false
+, withAll ? false
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -20,6 +24,12 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-QMAAKkjWgM/UiOfkNMLQxyGEYYmiSvE0Pd8fZXYyN48=";
 
   buildInputs = lib.optionals stdenv.isDarwin [ DiskArbitration Foundation ];
+
+  buildFeatures = []
+    ++ lib.optional withNotification "notification"
+    ++ lib.optional withYubikey "yubikey"
+    ++ lib.optional withStrictCaller "strict-caller"
+    ++ lib.optional withAll "all";
 
   meta = with lib; {
     description = "Helper that allows Git (and shell scripts) to use KeePassXC as credential store";


### PR DESCRIPTION
###### Description of changes

This PR allows overriding crate features, for instance:

```
pkgs.git-credential-keepassxc.override { withNotification = true; withYubikey = true; };
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
