### PR TITLE
libmbim: support cross

### DIFF
--- a/pkgs/development/libraries/libmbim/default.nix
+++ b/pkgs/development/libraries/libmbim/default.nix
@@ -9,8 +9,10 @@
 , help2man
 , systemd
 , bash-completion
+, bash
 , buildPackages
 , withIntrospection ? stdenv.hostPlatform.emulatorAvailable buildPackages
+, withDocs ? stdenv.hostPlatform == stdenv.buildPlatform
 , gobject-introspection
 }:
 
@@ -18,7 +20,8 @@ stdenv.mkDerivation rec {
   pname = "libmbim";
   version = "1.28.2";
 
-  outputs = [ "out" "dev" "man" ];
+  outputs = [ "out" "dev" ]
+    ++ lib.optionals withDocs [ "man" ];
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
@@ -31,14 +34,19 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dudevdir=${placeholder "out"}/lib/udev"
     (lib.mesonBool "introspection" withIntrospection)
+    (lib.mesonBool "man" withDocs)
   ];
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
     python3
+  ] ++ lib.optionals withDocs [
     help2man
+  ] ++ lib.optionals withIntrospection [
     gobject-introspection
   ];
 
@@ -46,6 +54,7 @@ stdenv.mkDerivation rec {
     glib
     systemd
     bash-completion
+    bash
   ];
 
   doCheck = true;


### PR DESCRIPTION
###### Description of changes

We can now enable introspection without much issues. We have to disable help2man man page generation though, since it tries to run the cross-compiled binary, which doesn't work.

e.g.

```
libmbim-aarch64-unknown-linux-gnu> /nix/store/help2man-1.49.3/bin/help2man --output=docs/man/mbimcli.1 '--name=Control MBIM devices' '--help-option="--help-all"' /build/source/build/src/mbimcli/mbimcli
libmbim-aarch64-unknown-linux-gnu> help2man: can't get `"--help-all"' info from /build/source/build/src/mbimcli/mbimcli
libmbim-aarch64-unknown-linux-gnu> Try `--no-discard-stderr' if option outputs to stderr
```

I've seen libqmi do something similar, but have been fighting to get the mesonFlags to do something useful. So I'll save that for another PR.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
