### PR TITLE
openscenegraph: switch from OCE to OCC

### DIFF
--- a/pkgs/development/libraries/openscenegraph/default.nix
+++ b/pkgs/development/libraries/openscenegraph/default.nix
@@ -1,29 +1,68 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, doxygen,
-  libX11, libXinerama, libXrandr, libGLU, libGL,
-  glib, ilmbase, libxml2, pcre, zlib,
-  AGL, Accelerate, Carbon, Cocoa, Foundation,
-  boost,
-  jpegSupport ? true, libjpeg,
-  exrSupport ? false, openexr,
-  gifSupport ? true, giflib,
-  pngSupport ? true, libpng,
-  tiffSupport ? true, libtiff,
-  gdalSupport ? false, gdal,
-  curlSupport ? true, curl,
-  colladaSupport ? false, collada-dom,
-  opencascadeSupport ? false, opencascade,
-  ffmpegSupport ? false, ffmpeg,
-  nvttSupport ? false, nvidia-texture-tools,
-  freetypeSupport ? true, freetype,
-  svgSupport ? false, librsvg,
-  pdfSupport ? false, poppler,
-  vncSupport ? false, libvncserver,
-  lasSupport ? false, libLAS,
-  luaSupport ? false, lua,
-  sdlSupport ? false, SDL2,
-  restSupport ? false, asio,
-  withApps ? false,
-  withExamples ? false, fltk,
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, pkg-config
+, doxygen
+, libX11
+, libXinerama
+, libXrandr
+, libGLU
+, libGL
+, glib
+, ilmbase
+, libxml2
+, pcre
+, zlib
+, AGL
+, Accelerate
+, Carbon
+, Cocoa
+, Foundation
+, boost
+, jpegSupport ? true
+, libjpeg
+, exrSupport ? false
+, openexr
+, gifSupport ? true
+, giflib
+, pngSupport ? true
+, libpng
+, tiffSupport ? true
+, libtiff
+, gdalSupport ? false
+, gdal
+, curlSupport ? true
+, curl
+, colladaSupport ? false
+, collada-dom
+, opencascadeSupport ? false
+, opencascade-occt
+, ffmpegSupport ? false
+, ffmpeg
+, nvttSupport ? false
+, nvidia-texture-tools
+, freetypeSupport ? true
+, freetype
+, svgSupport ? false
+, librsvg
+, pdfSupport ? false
+, poppler
+, vncSupport ? false
+, libvncserver
+, lasSupport ? false
+, libLAS
+, luaSupport ? false
+, lua
+, sdlSupport ? false
+, SDL2
+, restSupport ? false
+, asio
+, withApps ? false
+, withExamples ? false
+, fltk
+,
 }:
 
 stdenv.mkDerivation rec {
@@ -37,35 +76,47 @@ stdenv.mkDerivation rec {
     sha256 = "00i14h82qg3xzcyd8p02wrarnmby3aiwmz0z43l50byc9f8i05n1";
   };
 
+  patches = lib.optional opencascadeSupport (fetchpatch {
+    url = "https://github.com/openscenegraph/OpenSceneGraph/pull/1144.patch";
+    sha256 = "sha256-VR8YKOV/YihB5eEGZOGaIfJNrig1EPS/PJmpKsK284c=";
+  });
+
   nativeBuildInputs = [ pkg-config cmake doxygen ];
 
   buildInputs = lib.optionals (!stdenv.isDarwin) [
-    libX11 libXinerama libXrandr libGLU libGL
+    libX11
+    libXinerama
+    libXrandr
+    libGLU
+    libGL
   ] ++ [
-    glib ilmbase libxml2 pcre zlib
+    glib
+    ilmbase
+    libxml2
+    pcre
+    zlib
   ] ++ lib.optional jpegSupport libjpeg
-    ++ lib.optional exrSupport openexr
-    ++ lib.optional gifSupport giflib
-    ++ lib.optional pngSupport libpng
-    ++ lib.optional tiffSupport libtiff
-    ++ lib.optional gdalSupport gdal
-    ++ lib.optional curlSupport curl
-    ++ lib.optional colladaSupport collada-dom
-    ++ lib.optional opencascadeSupport opencascade
-    ++ lib.optional ffmpegSupport ffmpeg
-    ++ lib.optional nvttSupport nvidia-texture-tools
-    ++ lib.optional freetypeSupport freetype
-    ++ lib.optional svgSupport librsvg
-    ++ lib.optional pdfSupport poppler
-    ++ lib.optional vncSupport libvncserver
-    ++ lib.optional lasSupport libLAS
-    ++ lib.optional luaSupport lua
-    ++ lib.optional sdlSupport SDL2
-    ++ lib.optional restSupport asio
-    ++ lib.optionals withExamples [ fltk ]
-    ++ lib.optionals (!stdenv.isDarwin) [  ]
-    ++ lib.optionals stdenv.isDarwin [ AGL Accelerate Carbon Cocoa Foundation ]
-    ++ lib.optional (restSupport || colladaSupport) boost
+  ++ lib.optional exrSupport openexr
+  ++ lib.optional gifSupport giflib
+  ++ lib.optional pngSupport libpng
+  ++ lib.optional tiffSupport libtiff
+  ++ lib.optional gdalSupport gdal
+  ++ lib.optional curlSupport curl
+  ++ lib.optional colladaSupport collada-dom
+  ++ lib.optional opencascadeSupport opencascade-occt
+  ++ lib.optional ffmpegSupport ffmpeg
+  ++ lib.optional nvttSupport nvidia-texture-tools
+  ++ lib.optional freetypeSupport freetype
+  ++ lib.optional svgSupport librsvg
+  ++ lib.optional pdfSupport poppler
+  ++ lib.optional vncSupport libvncserver
+  ++ lib.optional lasSupport libLAS
+  ++ lib.optional luaSupport lua
+  ++ lib.optional sdlSupport SDL2
+  ++ lib.optional restSupport asio
+  ++ lib.optionals withExamples [ fltk ]
+  ++ lib.optionals stdenv.isDarwin [ AGL Accelerate Carbon Cocoa Foundation ]
+  ++ lib.optional (restSupport || colladaSupport) boost
   ;
 
   cmakeFlags = lib.optional (!withApps) "-DBUILD_OSG_APPLICATIONS=OFF" ++ lib.optional withExamples "-DBUILD_OSG_EXAMPLES=ON";


### PR DESCRIPTION
###### Description of changes

Make openscenegraph stop using OCE (no longer maintained)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).