### PR TITLE
nixos/pam: fprintd settings

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -938,12 +938,21 @@ let
                     ];
                   }
                 )
-                {
-                  name = "fprintd";
-                  enable = cfg.fprintAuth;
-                  control = "sufficient";
-                  modulePath = "${config.services.fprintd.package}/lib/security/pam_fprintd.so";
-                }
+                (
+                  let
+                    fprint = config.security.pam.fprint;
+                  in
+                  {
+                    name = "fprintd";
+                    enable = cfg.fprintAuth;
+                    control = "sufficient";
+                    modulePath = "${config.services.fprintd.package}/lib/security/pam_fprintd.so";
+                    settings = {
+                      inherit (fprint) timeout;
+                      max-tries = fprint.maxTries;
+                    };
+                  }
+                )
               ]
               ++
                 # Modules in this block require having the password set in PAM_AUTHTOK.
@@ -1799,6 +1808,26 @@ in
         description = ''
           This controls the hostname for the 9front authentication server
           that users will be authenticated against.
+        '';
+      };
+    };
+
+    security.pam.fprint = {
+      maxTries = lib.mkOption {
+        default = 3;
+        type = lib.types.int;
+        description = ''
+          The number of attempts at fingerprint authentication to try
+          before returning an authentication failure. The minimum number
+          of tries is 1.
+        '';
+      };
+      timeout = lib.mkOption {
+        default = 30;
+        type = lib.types.int;
+        description = ''
+          The amount of time (in seconds) before returning an authentication
+          failure, with 10 seconds being the minimum.
         '';
       };
     };


### PR DESCRIPTION
###### Description of changes

Exposes the settings described by [`man 8 pam_fprintd`](https://www.mankier.com/8/pam_fprintd)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).