### PR TITLE
molly-guard: Reduce closure size by stripping unneeded dependeicies

### DIFF
--- a/pkgs/os-specific/linux/molly-guard/default.nix
+++ b/pkgs/os-specific/linux/molly-guard/default.nix
@@ -11,10 +11,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ dpkg ];
 
-  sourceRoot = ".";
-
   unpackCmd = ''
-    dpkg-deb -x "$src" .
+    dpkg-deb -x "$src" source
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Description of changes

Currently, the molly-guard package has a closure size of over 500M (making it even bigger than e.g. grafana at ~300M). This appears to be due to the `env-vars` file, containing references to gcc and everything, being copied into `$out` and thus pulling references on `stdenv-linux` (300M+) and so on. This PR achieves a reduction in closure size by over 60% (and reducing the system closure size for one of my servers from 2G to 1.7G (-~17%)):

```shell
➜  nixpkgs git:(molly-guard-less-deps) nix path-info github:NixOS/nixpkgs/5f4e07deb7c44f27d498f8df9c5f34750acf52d2#molly-guard .#molly-guard -Sh          
/nix/store/6qfswfhybgjpxkpijmrcqk2cdybkniq5-molly-guard-0.7.2	 506.6M # <-- Prior
/nix/store/gm3c03bk81701l98hcnii1b8pn2ayyqn-molly-guard-0.7.2	 173.8M # <-- With changes
```

<details>
<summary>nix store diff-closures</summary>

```shell
➜  nixpkgs git:(molly-guard-less-deps) nix store diff-closures github:NixOS/nixpkgs/5f4e07deb7c44f27d498f8df9c5f34750acf52d2#molly-guard .#molly-guard
evaluating derivation 'git+file:///home/e1mo/Documents/dev/nixpkgs#molly-guard'
audit-tmpdir.sh: ε → ∅
binutils: 2.40 → ∅, -31644.3 KiB
binutils-wrapper: 2.40 → ∅, -48.5 KiB
compress-man-pages.sh: ε → ∅
diffutils: 3.8 → ∅, -1450.4 KiB
dpkg: 1.21.1ubuntu2.1 → ∅, -7481.4 KiB
ed: 1.19 → ∅, -135.5 KiB
expand-response: ε → ∅, -17.0 KiB
file: 5.44 → ∅, -8303.1 KiB
findutils: 4.9.0 → ∅, -1361.0 KiB
gawk: 5.2.1 → ∅, -2632.1 KiB
gcc: -221484.5 KiB
gcc-wrapper: 12.2.0 → ∅, -55.2 KiB
glibc: -2243.5 KiB
gnumake: 4.4 → ∅, -1506.1 KiB
gnused: 4.9 → ∅, -710.5 KiB
linux-headers: 6.1 → ∅, -6182.9 KiB
make-symlinks-relative.sh: ε → ∅
molly-guard_0.7.2_all.deb: ε → ∅, -12.1 KiB
move-docs.sh: ε → ∅
move-lib64.sh: ε → ∅
move-sbin.sh: ε → ∅
move-systemd-user-units.sh: ε → ∅
multiple-outputs.sh: ε → ∅, -8.2 KiB
patch: 2.7.6 → ∅, -222.3 KiB
patch-shebangs.sh: ε → ∅
patchelf: 0.15.0 → ∅, -212.8 KiB
perl: 5.36.0 → ∅, -54987.5 KiB
prune-libtool-files.sh: ε → ∅
reproducible-builds.sh: ε → ∅
set-source-date-epoch-to-latest.sh: ε → ∅
stdenv: ε → ∅, -49.6 KiB
strip.sh: ε → ∅
```

</details>

In my testing, functionality didn't seem to be impaired.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
