### PR TITLE
libcef: 100.0.24 -> 110.0.27

### DIFF
--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -61,26 +61,21 @@ let
       platformStr = "linuxarm64";
       projectArch = "arm64";
     };
-    "i686-linux" = {
-      platformStr = "linux32";
-      projectArch = "x86";
-    };
     "x86_64-linux" = {
       platformStr = "linux64";
       projectArch = "x86_64";
     };
   };
-  platforms."aarch64-linux".sha256 = "0gmnmr0zn2ffn7xbhmfh6rhmwmxy5zzlj0s3lyp99knjn47lg2fg";
-  platforms."i686-linux".sha256 = "1lp2z9db89qk2wh900c2dzlhflwmcbmp4m7xnlj04pq4q2kgfm9p";
-  platforms."x86_64-linux".sha256 = "1ljrp0iky7rrj04sbqicrg1jr938xnid6jlirbf7gwlmzliz3wfs";
+  platforms."aarch64-linux".sha256 = "1aacq9baw0hxf3h354fmws4v6008d3axxmri23vlvhzg7hza05n1";
+  platforms."x86_64-linux".sha256 = "17wpmvrbkdhnsk63f36yk6kq0mqhx63ih0mbhf8hl0qj6yndabgc";
 
   platformInfo = builtins.getAttr stdenv.targetPlatform.system platforms;
 in
 stdenv.mkDerivation rec {
   pname = "cef-binary";
-  version = "100.0.24";
-  gitRevision = "0783cf8";
-  chromiumVersion = "100.0.4896.127";
+  version = "110.0.27";
+  gitRevision = "1296c82";
+  chromiumVersion = "110.0.5481.100";
 
   src = fetchurl {
     url = "https://cef-builds.spotifycdn.com/cef_binary_${version}+g${gitRevision}+chromium-${chromiumVersion}_${platformInfo.platformStr}_minimal.tar.bz2";

--- a/pkgs/development/libraries/libcef/update.sh
+++ b/pkgs/development/libraries/libcef/update.sh
@@ -12,7 +12,6 @@ GIT_REVISION=$(echo ${VERSION_JSON} | jq -r '.cef_version' | cut -d'+' -f2 | cut
 CHROMIUM_VERSION=$(echo ${VERSION_JSON} | jq -r '.chromium_version')
 
 SHA256_LINUX64=$(nix-prefetch-url --quiet https://cef-builds.spotifycdn.com/cef_binary_${CEF_VERSION}+g${GIT_REVISION}+chromium-${CHROMIUM_VERSION}_linux64_minimal.tar.bz2)
-SHA256_LINUX32=$(nix-prefetch-url --quiet https://cef-builds.spotifycdn.com/cef_binary_${CEF_VERSION}+g${GIT_REVISION}+chromium-${CHROMIUM_VERSION}_linux32_minimal.tar.bz2)
 SHA256_LINUXARM64=$(nix-prefetch-url --quiet https://cef-builds.spotifycdn.com/cef_binary_${CEF_VERSION}+g${GIT_REVISION}+chromium-${CHROMIUM_VERSION}_linuxarm64_minimal.tar.bz2)
 
 setKV () {
@@ -23,5 +22,4 @@ setKV version ${CEF_VERSION}
 setKV gitRevision ${GIT_REVISION}
 setKV chromiumVersion ${CHROMIUM_VERSION}
 setKV 'platforms."aarch64-linux".sha256' ${SHA256_LINUXARM64}
-setKV 'platforms."i686-linux".sha256' ${SHA256_LINUX32}
 setKV 'platforms."x86_64-linux".sha256' ${SHA256_LINUX64}


### PR DESCRIPTION
i686-linux is no longer supported since chrome 101

###### Description of changes
Closes #171395

Did a smoke test in obs studio by adding a browser source.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
