### PR TITLE
Typing stubs for home-assistant type checks

### DIFF
--- a/pkgs/development/python-modules/voluptuous-stubs/default.nix
+++ b/pkgs/development/python-modules/voluptuous-stubs/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, mypy
+}:
+
+buildPythonPackage rec {
+  pname = "voluptuous-stubs";
+  version = "0.1.1";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-cPscCIJC8g4RAjJStWSM13+DH2ks2RDI+XE8wTXPjMg=";
+  };
+
+  nativeBuildInputs = [
+    mypy
+  ];
+
+  pythonImportsCheck = [
+    "voluptuous-stubs"
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Typing stubs for voluptuous";
+    homepage = "https://github.com/ryanwang520/voluptuous-stubs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, home-assistant
+}:
+
+buildPythonPackage rec {
+  pname = "homeassistant-stubs";
+  version = "2023.2.5";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "KapJI";
+    repo = "homeassistant-stubs";
+    rev = "refs/tags/${version}";
+    hash = "sha256-MQYk4DWvmqtPl00L1c00JclKkTZe9EYMrm/LucUHBE0=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+    home-assistant
+  ];
+
+  pythonImportsCheck = [
+    "homeassistant-stubs"
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Typing stubs for Home Assistant Core";
+    homepage = "https://github.com/KapJI/homeassistant-stubs";
+    changelog = "https://github.com/KapJI/homeassistant-stubs/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = teams.home-assistant.members;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4378,6 +4378,8 @@ self: super: with self; {
 
   homeassistant-pyozw = callPackage ../development/python-modules/homeassistant-pyozw { };
 
+  homeassistant-stubs = callPackage ../servers/home-assistant/stubs.nix { };
+
   homeconnect = callPackage ../development/python-modules/homeconnect { };
 
   homematicip = callPackage ../development/python-modules/homematicip { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12179,6 +12179,8 @@ self: super: with self; {
 
   voluptuous-serialize = callPackage ../development/python-modules/voluptuous-serialize { };
 
+  voluptuous-stubs = callPackage ../development/python-modules/voluptuous-stubs { };
+
   volvooncall = callPackage ../development/python-modules/volvooncall { };
 
   vowpalwabbit = callPackage ../development/python-modules/vowpalwabbit { };


### PR DESCRIPTION
- Typing hints for the voluptuous package.
- Typing hints for Home Assistant core. Freshly generated out of
our home-assistant package.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
