### PR TITLE
p2pool: 2.7 -> 3.0

### DIFF
--- a/pkgs/applications/misc/p2pool/default.nix
+++ b/pkgs/applications/misc/p2pool/default.nix
@@ -19,13 +19,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "p2pool";
-  version = "2.7";
+  version = "3.0";
 
   src = fetchFromGitHub {
     owner = "SChernykh";
     repo = "p2pool";
     rev = "v${version}";
-    sha256 = "sha256-j3SVwat/LGw/iGcyNn8acR29Ob/WXDKyeCfDTsH+gxA=";
+    sha256 = "sha256-gRbRUQCEnqKjSCgnrIsXbKoxiQIG6uYKifygWuZoTXw=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Description of changes

p2pool version < 3.0 will be no longer be functional after March due to [planned hardfork](https://www.reddit.com/r/MoneroMining/comments/1095730/psa_p2pool_network_upgrade_aka_hardfork_on_march/).


###### Things done
Bump package version.
