### PR TITLE
zsh-nix-shell: changed directory layout

### DIFF
--- a/pkgs/shells/zsh/zsh-nix-shell/default.nix
+++ b/pkgs/shells/zsh/zsh-nix-shell/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, bash }:
 
 # To make use of this derivation, use
-# `programs.zsh.interactiveShellInit = "source ${pkgs.zsh-nix-shell}/share/zsh-nix-shell/nix-shell.plugin.zsh";`
+# `programs.zsh.interactiveShellInit = "source ${pkgs.zsh-nix-shell}/share/zsh/plugins/nix-shell/nix-shell.plugin.zsh";`
 
 stdenv.mkDerivation rec {
   pname = "zsh-nix-shell";
@@ -17,8 +17,15 @@ stdenv.mkDerivation rec {
   strictDeps = true;
   buildInputs = [ bash ];
   installPhase = ''
-    install -D nix-shell.plugin.zsh --target-directory=$out/share/zsh-nix-shell
-    install -D scripts/* --target-directory=$out/share/zsh-nix-shell/scripts
+    install -D nix-shell.plugin.zsh --target-directory=$out/share/zsh/plugins/nix-shell
+    install -D scripts/* --target-directory=$out/share/zsh/plugins/nix-shell/scripts
+
+    #preparing a compatibility warning, and then redirect to a new location. Remove after 23.11 release.
+    mkdir -p $out/share/zsh-nix-shell
+    cat <<EOF > "$out/share/zsh-nix-shell/nix-shell.plugin.zsh"
+    echo "WARN: zsh-nix-shell plugin files were moved to a different directory in order to make plugin installation through ohMyZsh.customPkgs possible. Please use new installation method or change source path to: $out/share/zsh/plugins/nix-shell/nix-shell.plugin.zsh"
+    source $out/share/zsh/plugins/nix-shell/nix-shell.plugin.zsh
+    EOF
   '';
 
   meta = with lib; {


### PR DESCRIPTION
zsh-nix-shell is an oh-my-zsh plugin that makes nix-shell invocation to load into zsh rather than bash. 

###### Description of changes
Directory layout of this package was not compatible with installation through ohMyZsh.customPkgs option. Description of this mechanism is [here](https://github.com/NixOS/nixpkgs/commit/39b85451de2daa7927629dbac7b641becffc839e). Basically, it uses linkFarm to combine all default ohMyZsh plugins with non-default ones from customPkgs. In order for it to work custom pkgs must conform to the specific directory structure.
Current suggested method of installation for this plugin requires manual source of the plugin file in init script, so I've made a warning inside of an old location and re-directed source call to a new file, this should help users upgrade their config.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
