### PR TITLE
vimPlugins.vim-trailing-whitespace: fix add dynamic TerminalOpen for …

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1348,6 +1348,15 @@ self: super: {
     dependencies = with self; [ vimproc-vim ];
   });
 
+  vim-trailing-whitespace = super.vim-trailing-whitespace.overrideAttrs (old: {
+    patches = [(fetchpatch {
+      # https://github.com/bronson/vim-trailing-whitespace/pull/30
+      name = "fix-add-dynamic-TerminalOpen-for-both-vim-and-nvim.patch";
+      url = "https://github.com/bronson/vim-trailing-whitespace/commit/99ef803ebdc01d62b418a3e9386d5f10797bfac3.patch";
+      hash = "sha256-cyanHUKxhbY8c6EkAbpUq7QcEBQABCwZ6NoEUOpd2F8=";
+    })];
+  });
+
   vim-zettel = super.vim-zettel.overrideAttrs (old: {
     dependencies = with self; [ vimwiki fzf-vim ];
   });


### PR DESCRIPTION
vimPlugins.vim-trailing-whitespace: fix add dynamic TerminalOpen for both vim and nvim

Patch: https://github.com/bronson/vim-trailing-whitespace/pull/30

(or else this plugin errors every time a file is opened at neovim)