### PR TITLE
coreboot-configurator: 2022-08-22 -> 2023-01-17, use pkexec instead of sudo.

### DIFF
--- a/pkgs/tools/misc/coreboot-configurator/default.nix
+++ b/pkgs/tools/misc/coreboot-configurator/default.nix
@@ -3,24 +3,27 @@
 , fetchFromGitHub
 , inkscape
 , meson
+, mkDerivation
 , ninja
 , pkg-config
+, pkexecPath ? "/run/wrappers/bin/pkexec"
 , yaml-cpp
 , nvramtool
+, systemd
 , qtbase
 , qtsvg
 , wrapQtAppsHook
 }:
 
-stdenv.mkDerivation {
+mkDerivation {
   pname = "coreboot-configurator";
-  version = "unstable-2022-08-22";
+  version = "unstable-2023-01-17";
 
   src = fetchFromGitHub {
     owner = "StarLabsLtd";
     repo = "coreboot-configurator";
-    rev = "37c93e7e101a20f85be309904177b9404875cfd8";
-    sha256 = "2pk+uJk1EnVNO2vO1zF9Q6TLpij69iRdr5DFiNcZlM0=";
+    rev = "944b575dc873c78627c352f9c1a1493981431a58";
+    sha256 = "sha256-ReWQNzeoyTF66hVnevf6Kkrnt0/PqRHd3oyyPYtx+0M=";
   };
 
   nativeBuildInputs = [ inkscape meson ninja pkg-config wrapQtAppsHook ];
@@ -28,9 +31,15 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace src/application/*.cpp \
-      --replace '/usr/bin/pkexec' 'sudo' \
-      --replace '/usr/bin/systemctl' 'systemctl' \
-      --replace '/usr/sbin/nvramtool' '${nvramtool}/bin/nvramtool'
+      --replace '/usr/bin/pkexec' '${pkexecPath}' \
+      --replace '/usr/bin/systemctl' '${lib.getBin systemd}/systemctl' \
+      --replace '/usr/sbin/nvramtool' '${lib.getExe nvramtool}'
+
+    substituteInPlace src/resources/org.coreboot.nvramtool.policy \
+      --replace '/usr/sbin/nvramtool' '${lib.getExe nvramtool}'
+
+    substituteInPlace src/resources/org.coreboot.reboot.policy \
+      --replace '/usr/sbin/reboot' '${lib.getBin systemd}/reboot'
   '';
 
   postFixup = ''

--- a/pkgs/tools/misc/coreboot-configurator/default.nix
+++ b/pkgs/tools/misc/coreboot-configurator/default.nix
@@ -5,8 +5,12 @@
 , meson
 , mkDerivation
 , ninja
+  # We will resolve pkexec from the path because it has a setuid wrapper on
+  # NixOS meaning that we cannot just use the path from the nix store.
+  # Using the path to the wrapper here would make the package incompatible
+  # with non-NixOS systems.
+, pkexecPath ? "pkexec"
 , pkg-config
-, pkexecPath ? "/run/wrappers/bin/pkexec"
 , yaml-cpp
 , nvramtool
 , systemd


### PR DESCRIPTION
###### Description of changes

Bump version.

Use pkexec instead of sudo, as in the upstream code. Using pkexec makes it possible to launch the application using its .desktop file, instead of needing to run it from the terminal.

For usage on non NixOS systems, we add an argument for the pkexec path. On such systems, the polkit policy files will also need to be included in the system's config.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
