### PR TITLE
kaniko: restrict platform to linux

### DIFF
--- a/pkgs/applications/networking/cluster/kaniko/default.nix
+++ b/pkgs/applications/networking/cluster/kaniko/default.nix
@@ -46,7 +46,7 @@ buildGoModule rec {
     description = "A tool to build container images from a Dockerfile, inside a container or Kubernetes cluster";
     homepage = "https://github.com/GoogleContainerTools/kaniko";
     license = lib.licenses.asl20;
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.superherointj ];
     mainProgram = "executor";
   };


### PR DESCRIPTION
kaniko: restrict platform to linux

Co-authored-by: @bryanasdev000

Fixes: https://github.com/NixOS/nixpkgs/pull/216654#issuecomment-1441862129
