### PR TITLE
nixos/pounce: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6712,6 +6712,15 @@
     githubId = 372912;
     name = "Justin Bedő";
   };
+  jbellerb = {
+    email = "jbellerb@vt.edu";
+    github = "jbellerb";
+    githubId = 25756846;
+    name = "Jared Beller";
+    keys = [{
+      fingerprint = "0D26 C33F 8A6F 273F EFD1  CC56 044B 207F 4820 E3AE";
+    }];
+  };
   jbgi = {
     email = "jb@giraudeau.info";
     github = "jbgi";

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -44,6 +44,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [QDMR](https://dm3mat.darc.de/qdmr/), a GUI application and command line tool for programming DMR radios [programs.qdmr](#opt-programs.qdmr.enable)
 
+- [pounce](https://git.causal.agency/pounce/about/), a simple, multi-client, TLS-only IRC bouncer. Available as [services.pounce](#opt-services.pounce.enable).
+
 - [v2rayA](https://v2raya.org), a Linux web GUI client of Project V which supports V2Ray, Xray, SS, SSR, Trojan and Pingtunnel. Available as [services.v2raya](options.html#opt-services.v2raya.enable).
 
 - [ulogd](https://www.netfilter.org/projects/ulogd/index.html), a userspace logging daemon for netfilter/iptables related logging. Available as [services.ulogd](options.html#opt-services.ulogd.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -942,6 +942,7 @@
   ./services/networking/pixiecore.nix
   ./services/networking/pleroma.nix
   ./services/networking/polipo.nix
+  ./services/networking/pounce.nix
   ./services/networking/powerdns.nix
   ./services/networking/pppd.nix
   ./services/networking/pptpd.nix

--- a/nixos/modules/services/networking/pounce.md
+++ b/nixos/modules/services/networking/pounce.md
@@ -1,0 +1,62 @@
+# Pounce {#module-services-pounce}
+
+[Pounce](https://git.causal.agency/pounce/about/) is a multi-client, TLS-only
+IRC bouncer. Pounce includes the
+[Calico](https://git.causal.agency/pounce/about/calico.1) dispatcher for
+serving multiple networks over a single port.
+
+## Basic Usage {#module-services-pounce-quick-start}
+
+To support connecting to multiple networks, Pounce will always be configured
+to serve through Calico with each network's bouncer at a subdomain of
+{option}`service.pounce.host`.
+
+A complete list of Pounce's options is availiable in the
+[pounce(1)](https://git.causal.agency/pounce/about/pounce.1) manual page. For
+additional notes about connecting to various popular networks, see Pounce's
+[QUIRKS(7)](https://git.causal.agency/pounce/about/QUIRKS.7) document.
+
+Pounce must be served over TLS. By default, this module will generate a
+self-signed certificate valid for 100 years. To disable this, set
+{option}`services.pounce.generateCerts` to `false` and point
+{option}`services.pounce.certDir` to a folder containing TLS certificates in
+the certbot format (a {file}`fullchain.pem` and {file}`privkey.pem` in a
+folder named the full domain name of the instance). Certificates can be
+generated with certbot using {command}`certbot certonly -d ...`, or using
+NixOS's built-in ACME module.
+
+Below is an example configuration which joins #nixos and #nixos-chat on Libera
+Chat and #ascii.town on tilde.chat. The bouncer for Libera Chat can be reached
+at `libera.irc.example.org/6697`, and will and connect with CertFP using the
+certificate stored at {file}`/var/lib/pounce/certfp/libera.pem` (This
+certificate can be generated with
+{command}`pounce -g /var/lib/pounce/certfp/libera.pem`). The bouncer for
+tilde.chat is at `tilde.irc.example.org/6697` and is additionally configured
+to run the script {file}`/var/lib/pounce/notify.sh` when the user is messaged
+or mentioned and no clients are currently connected to the bouncer.
+
+```nix
+services.pounce = {
+  enable = true;
+  host = "irc.example.org";
+  openFirewall = true;
+  networks = {
+    libera.config = {
+      host = "irc.libera.chat";
+      port = 6697; # This is the default port. This field can be ommitted.
+      nick = "...";
+      client-cert = "/var/lib/pounce/certfp/libera.pem";
+      sasl-external = true;
+      join = "#nixos,#nixos-chat";
+    };
+    tilde = {
+      config = {
+        host = "irc.tilde.chat";
+        nick = "...";
+        join = "#ascii.town";
+      };
+      notify.command = "/var/lib/pounce/notify.sh";
+    };
+  };
+};
+```

--- a/nixos/modules/services/networking/pounce.nix
+++ b/nixos/modules/services/networking/pounce.nix
@@ -1,0 +1,382 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.pounce;
+
+  defaultUser = "pounce";
+
+  settingsFormat = {
+    type = types.attrsOf (types.nullOr
+      (types.oneOf [ types.bool types.int types.str ]));
+    generate = name: value:
+      let
+        mkKeyValue = k: v:
+          if true == v then k
+          else if false == v then "#${k}"
+          else lib.generators.mkKeyValueDefault {} " = " k v;
+        mkKeyValueList = values:
+          lib.generators.toKeyValue { inherit mkKeyValue; } values;
+      in pkgs.writeText name (mkKeyValueList value);
+  };
+
+  hardeningFlags = {
+    CapabilityBoundingSet = [ "" ];
+    NoNewPrivileges = true;
+    PrivateDevices = true;
+    PrivateMounts = true;
+    PrivateTmp = true;
+    PrivateUsers = true;
+    ProtectClock = true;
+    ProtectControlGroups = true;
+    ProtectKernelLogs = true;
+    ProtectKernelModules = true;
+    ProtectKernelTunables = true;
+    ProtectProc = "invisible";
+    RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+    RestrictNamespaces = true;
+    RestrictSUIDSGID = true;
+    SystemCallArchitectures = "native";
+    SystemCallFilter = [ "@system-service" "~@privileged" "~@resources" ];
+  };
+
+in {
+  options.services.pounce = {
+    enable = mkEnableOption
+      (lib.mdDoc "the Pounce IRC bouncer and Calico dispatcher");
+
+    user = mkOption {
+      type = types.str;
+      default = defaultUser;
+      description = lib.mdDoc ''
+        User account under which Pounce runs. If not specified, a default user
+        will be created.
+      '';
+    };
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "/run/pounce";
+      description = lib.mdDoc ''
+        Directory where each Pounce instance's UNIX-domain socket is stored for
+        Calico to route to.
+      '';
+    };
+
+    certDir = mkOption {
+      type = types.str;
+      default = "/var/lib/pounce/certs";
+      example = "/etc/letsencrypt/live";
+      description = lib.mdDoc ''
+        Directory where each Pounce instance's TLS certificates and private
+        keys are stored. Each instance should have a folder in the certbot
+        format: a {file}`fullchain.pem` and {file}`privkey.pem` in a folder
+        with the full domain name of the instance (ex:
+        {file}`libera.example.org/`). Self-signed certificates will be
+        generated in this folder if
+        {option}`services.pounce.generateCerts` is true.
+      '';
+    };
+
+    host = mkOption {
+      type = types.str;
+      default = "localhost";
+      example = "example.org";
+      description = lib.mdDoc ''
+        Base domain name for Calico to listen at. Each instance will be at a
+        subdomain of this.
+      '';
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 6697;
+      description = lib.mdDoc "Port for Calico to listen on.";
+    };
+
+    generateCerts = mkOption {
+      type = types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Generate a self-signed TLS certificate in the certificate directory.
+        If you would like to use {command}`certbot` instead, generate
+        certificates for each instance like this:
+        {command}`certbot certonly -d libera.example.org`.
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc "Open port in the firewall for Calico.";
+    };
+
+    timeout = mkOption {
+      type = types.ints.positive;
+      default = 1000;
+      description = lib.mdDoc ''
+        Timeout parameter (in milliseconds) for Calico to close a connection
+        if no `ClientHello` message is sent.
+      '';
+    };
+
+    networks = mkOption {
+      type = types.attrsOf (types.submodule {
+        options = {
+          config = mkOption {
+            type = settingsFormat.type;
+            default = {};
+            example = {
+              libera = {
+                host = "irc.libera.chat";
+                port = 6697;
+                sasl-plain = "testname:password";
+                join = "#nixos,#nixos-dev";
+              };
+            };
+            description = lib.mdDoc ''
+              Pounce configuration to user for the network. For information on
+              what options Pounce accepts, see the
+              [pounce(1)](https://git.causal.agency/pounce/about/pounce.1)
+              manual page.
+            '';
+          };
+
+          notify = mkOption {
+            type = types.submodule {
+              options = {
+                insecure = mkOption {
+                  type = types.bool;
+                  default = false;
+                  description = lib.mdDoc ''
+                    Disable certificate validation for connecting to the Pounce
+                    instance. Overrides
+                    {option}`services.pounce.networks.<name>.notify.trust-cert`.
+                  '';
+                };
+                trust-cert = mkOption {
+                  type = types.nullOr types.str;
+                  default = "";
+                  example = "/etc/letsencrypt/live/libera.irc.example.org/fullchain.pem";
+                  description = lib.mdDoc ''
+                    Pounce certificate for the pounce-notify client to trust.
+                    This is required if Pounce is using a self-signed
+                    certificate. If left blank, pounce-notify will use the
+                    appropriate certificate in
+                    {option}`services.pounce.certDir`. Set to `null` to disable
+                    certificate pinning.
+                  '';
+                };
+                client-cert = mkOption {
+                  type = types.str;
+                  default = "";
+                  description = lib.mdDoc ''
+                    Client certificate to use if Pounce is configured to require
+                    certificate authentication. If the relevant private key is
+                    stored in a separate file, load it with
+                    {option}`services.pounce.networks.<name>.notify.client-priv`.
+                  '';
+                };
+                client-priv = mkOption {
+                  type = types.str;
+                  default = "";
+                  description = lib.mdDoc ''
+                    Private key to use if Pounce is configured to require
+                    certificate authentication. If the certificate provided in
+                    {option}`services.pounce.networks.<name>.notify.client-cert`
+                    has an embedded private key, this option can be left
+                    empty.
+                  '';
+                };
+                user = mkOption {
+                  type = types.str;
+                  default = "pounce-notify";
+                  description = lib.mdDoc ''
+                    Username to present to Pounce when connecting.
+                  '';
+                };
+                script = mkOption {
+                  type = types.lines;
+                  default = "";
+                  example = ''
+                    # Pushover example
+
+                    if [ -z "$NOTIFY_CHANNEL" ]; then
+                      TITLE="Private Message"
+                      CONTEXT="$NOTIFY_NICK"
+                    else
+                      TITLE="Mention"
+                      CONTEXT="$NOTIFY_CHANNEL"
+                    fi
+
+                    $${pkgs.curl}/bin/curl \
+                      -X POST \
+                      --form-string token="API_TOKEN" \
+                      --form-string user="USER_KEY" \
+                      --form-string title="(libera/$CONTEXT) $TITLE" \
+                      --form-string timestamp="$NOTIFY_TIME" \
+                      --form-string message="$NOTIFY_NICK: $NOTIFY_MESSAGE" \
+                      https://api.pushover.net/1/messages.json
+                  '';
+                  description = lib.mdDoc ''
+                    Commands to run when a private message or a mention
+                    occurs. See
+                    [pounce-notify(1)](https://git.causal.agency/pounce/about/extra/notify/pounce-notify.1)
+                    for a list of environment variables containing information
+                    about the notification event.
+                  '';
+                };
+                command = mkOption {
+                  type = types.str;
+                  default = "";
+                  example = "/var/lib/pounce/notify.sh";
+                  description = lib.mdDoc ''
+                    Command to run when a private message or a mention occurs.
+                    Overrides
+                    {option}`services.pounce.notify.networks.<name>.notify.script`.
+                    See
+                    [pounce-notify(1)](https://git.causal.agency/pounce/about/extra/notify/pounce-notify.1)
+                    for a list of environment variables containing information
+                    about the notification event.
+                  '';
+                };
+              };
+            };
+            default = {};
+            example = { script = "/var/lib/pounce/notify.sh"; };
+            description = lib.mdDoc ''
+              Configuration for pounce-notify. A notification client will be
+              spawned if either
+              {option}`services.pounce.networks.<name>.notify.script` or
+              {option}`services.pounce.networks.<name>.notify.command` is set.
+            '';
+          };
+        };
+      });
+      default = {};
+      description = lib.mdDoc "Attribute set of IRC networks to connect to.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.tmpfiles.rules = [ "d ${cfg.dataDir} 0700 ${cfg.user} ${cfg.user} -" ];
+    systemd.services = mkMerge (
+      [
+        {
+          calico = {
+            wantedBy = [ "multi-user.target" ];
+            after = [ "network.target" ];
+
+            description = "Calico dispatcher for Pounce IRC bouncer.";
+
+            serviceConfig = {
+              User = cfg.user;
+              Group = cfg.user;
+              ExecStart = ''
+                ${pkgs.pounce}/bin/calico \
+                  -H ${cfg.host} -P ${toString cfg.port} \
+                  -t ${toString cfg.timeout} ${cfg.dataDir}
+              '';
+              Restart = "on-failure";
+            } // hardeningFlags;
+          };
+        }
+      ] ++ (mapAttrsToList (name: value: mkMerge [
+        {
+          "pounce-${name}" = {
+            wantedBy = [ "calico.service" ];
+            after = [ "network.target" ];
+            before = [ "calico.service" ];
+
+            description = "Pounce IRC bouncer for the ${name} network.";
+
+            serviceConfig = {
+              User = cfg.user;
+              Group = cfg.user;
+              ExecStart = ''
+                ${pkgs.pounce}/bin/pounce \
+                  -C ${cfg.certDir}/${name}.${cfg.host}/fullchain.pem \
+                  -K ${cfg.certDir}/${name}.${cfg.host}/privkey.pem \
+                  -U ${cfg.dataDir} -H ${name}.${cfg.host} \
+                  ${settingsFormat.generate "${name}.cfg" value.config}
+              '';
+              Restart = "on-failure";
+            } // hardeningFlags;
+            preStart = ''
+              mkdir -p ${cfg.certDir}/${name}.${cfg.host}
+
+              if ${boolToString cfg.generateCerts}; then
+                if [ ! -f ${cfg.certDir}/${name}.${cfg.host}/fullchain.pem ] || \
+                   [ ! -f ${cfg.certDir}/${name}.${cfg.host}/privkey.pem ]; then
+                  ${pkgs.libressl}/bin/openssl req -x509 -newkey rsa:4096 \
+                    -out ${cfg.certDir}/${name}.${cfg.host}/fullchain.pem \
+                    -keyout ${cfg.certDir}/${name}.${cfg.host}/privkey.pem \
+                    -nodes -sha256 -days 36500 -subj "/CN=${name}.${cfg.host}"
+                fi
+              fi
+            '';
+          };
+        }
+
+        (mkIf (value.notify.command != "" || value.notify.script != "") {
+          "pounce-${name}-notify" = {
+            wantedBy = [ "multi-user.target" ];
+            requires = [ "calico.service" "pounce-${name}.service" ];
+            after = [ "calico.service" "pounce-${name}.service" ];
+
+            description = "Pounce notification client for the ${name} network.";
+
+            serviceConfig = {
+              User = cfg.user;
+              Group = cfg.user;
+              Environment = "SHELL=${pkgs.bash}/bin/bash";
+              ExecStart = ''
+                ${pkgs.pounce-extra}/bin/pounce-notify \
+                   ${if value.notify.insecure then "-!" else
+                     if value.notify.trust-cert == "" then
+                       "-t ${cfg.certDir}/${name}.${cfg.host}/fullchain.pem"
+                     else if value.notify.trust-cert != null then
+                       "-t ${value.notify.trust-cert}" else ""} \
+                   ${if value.notify.client-cert != "" then "-c ${value.notify.client-cert}" else ""} \
+                   ${if value.notify.client-priv != "" then "-k ${value.notify.client-priv}" else ""} \
+                   -p ${toString cfg.port} \
+                   -u ${value.notify.user} \
+                   ${if cfg.networks.${name}.config ? local-pass then
+                     "-w ${cfg.networks.${name}.config.local-pass}" else ""} \
+                   ${name}.${cfg.host} \
+                   ${if value.notify.command != "" then "\"${value.notify.command}\"" else
+                     pkgs.writeShellScript "pounce-${name}-notify-script" value.notify.script}
+              '';
+              Restart = "on-failure";
+
+              # pounce will refuse all connections before it's connected to the
+              # IRC network, but there's no easy way for systemd to know when
+              # that's happened. The best I've come up with is starting
+              # pounce-notify anyways and retrying with a fairly long delay.
+              # This value works for me, hopefully it works for you too.
+              RestartSec = "15s";
+            } // hardeningFlags;
+          };
+        })
+      ]) cfg.networks)
+    );
+
+    users = optionalAttrs (cfg.user == defaultUser) {
+      users.${defaultUser} = {
+        group = defaultUser;
+        isSystemUser = true;
+      };
+
+      groups.${defaultUser} = { };
+    };
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
+    environment.systemPackages = [ pkgs.pounce ];
+  };
+
+  meta = {
+    doc = ./pounce.md;
+    maintainers = [ lib.maintainers.jbellerb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38079,7 +38079,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit;
   };
 
-  pounce = callPackage ../servers/pounce { };
+  inherit (callPackage ../servers/pounce { })
+    pounce pounce-extra;
 
   pt = callPackage ../applications/misc/pt { };
 


### PR DESCRIPTION
###### Description of changes

This PR is an updated version of #136002 and adds a module for the Pounce IRC bouncer. Usage is inspired by the ZNC module and this module similarly uses a generator to support all possible configuration options. All instances are served through Pounce's built-in dispatcher, Calico, to support hosting for multiple networks on the same port. A wrapper on top of pounce-notify is also provided. Usage is documented in a new NixOS manual entry. I've been running this module for almost two years and I feel it's pretty stable by now, but more testing on different setups doesn't hurt. This PR depends on #216222 for pounce-notify, so I'm marking this as a draft until that's merged. For testing, I've included the commits of that PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
