### PR TITLE
Revert "llvmPackages_15: update licenses"

### DIFF
--- a/pkgs/development/compilers/llvm/15/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/15/compiler-rt/default.nix
@@ -151,5 +151,8 @@ stdenv.mkDerivation {
       implementations of run-time libraries for dynamic testing tools such as
       AddressSanitizer, ThreadSanitizer, MemorySanitizer, and DataFlowSanitizer.
     '';
+    # "All of the code in the compiler-rt project is dual licensed under the MIT
+    # license and the UIUC License (a BSD-like license)":
+    license = with lib.licenses; [ mit ncsa ];
   };
 }

--- a/pkgs/development/compilers/llvm/15/default.nix
+++ b/pkgs/development/compilers/llvm/15/default.nix
@@ -84,7 +84,7 @@ in let
   inherit (releaseInfo) release_version version;
 
   llvm_meta = {
-    license     = with lib.licenses; [ ncsa asl20-llvm ];
+    license     = lib.licenses.ncsa;
     maintainers = lib.teams.llvm.members;
     platforms   = lib.platforms.all;
   };

--- a/pkgs/development/compilers/llvm/15/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/15/libcxx/default.nix
@@ -103,5 +103,8 @@ stdenv.mkDerivation rec {
       libc++ is an implementation of the C++ standard library, targeting C++11,
       C++14 and above.
     '';
+    # "All of the code in libc++ is dual licensed under the MIT license and the
+    # UIUC License (a BSD-like license)":
+    license = with lib.licenses; [ mit ncsa ];
   };
 }

--- a/pkgs/development/compilers/llvm/15/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/15/libcxxabi/default.nix
@@ -100,6 +100,9 @@ stdenv.mkDerivation rec {
     longDescription = ''
       libc++abi is a new implementation of low level support for a standard C++ library.
     '';
+    # "All of the code in libc++abi is dual licensed under the MIT license and
+    # the UIUC License (a BSD-like license)":
+    license = with lib.licenses; [ mit ncsa ];
     maintainers = llvm_meta.maintainers ++ [ lib.maintainers.vlstill ];
   };
 }

--- a/pkgs/development/compilers/llvm/15/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/15/openmp/default.nix
@@ -67,5 +67,8 @@ stdenv.mkDerivation rec {
       "clang -fopenmp" must be linked before it can run and the library that
       supports offload to target devices.
     '';
+    # "All of the code is dual licensed under the MIT license and the UIUC
+    # License (a BSD-like license)":
+    license = with lib.licenses; [ mit ncsa ];
   };
 }


### PR DESCRIPTION
This reverts commit 386aba3115176b11eb49a0606e9dd17506273776.

As I understand it from reading
<https://llvm.org/docs/DeveloperPolicy.html#copyright-license-and-patents>, the structure of LLVM licensing is as follows:

 - They're in the process of relicensing to Apache-2.0 WITH LLVM-exception, but they haven't got permission to relicense all the code yet. This means that some of the code can be used under the new license, but not all of it, and it's difficult to know which is which.  This license is therefore probably not useful yet, until the relicensing effort is commit.

 - While the relicensing effort is ongoing, code being contributed to LLVM has to have permission to be used under the old and new licensing schemes.  Since the new licensing scheme can't be used for all code yet, it only makes sense to use LLVM's code under the old licensing scheme at the moment.

 - The old licensing scheme is that code for the LLVM components we care about is all available under the NCSA license, and some components are optionally available under a different license, usually the MIT license, instead.

So I think we should go back to just listing NCSA, or NCSA/MIT, and forget about the new license until it actually becomes useful, i.e. LLVM's relicensing effort is complete.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
