### PR TITLE
nixos/webhook: add additional hook configuration options

### DIFF
--- a/nixos/modules/services/networking/webhook.nix
+++ b/nixos/modules/services/networking/webhook.nix
@@ -8,6 +8,19 @@ let
 
   hookFormat = pkgs.formats.json {};
 
+  source-name = {
+    options = {
+      name = mkOption {
+        type = types.str;
+        description = mdDoc "Name";
+      };
+      source = mkOption {
+        type = types.str;
+        description = mdDoc "Source";
+      };
+    };
+  };
+
   hookType = types.submodule ({ name, ... }: {
     freeformType = hookFormat.type;
     options = {
@@ -22,6 +35,58 @@ let
         type = types.str;
         description = mdDoc "The command that should be executed when the hook is triggered.";
       };
+      command-working-directory= mkOption {
+        type = types.str;
+        description = mdDoc "The working directory that will be used for the script when it's executed";
+      };
+      success-http-response-code = mkOption {
+        type = (types.ints.between 99 600);
+        default = 200;
+        description = mdDoc "The HTTP status code to be returned upon success";
+      };
+      http-methods = mkOption {
+        type = with types; listOf str;
+        default = [ "POST" "PUT" "GET" ];
+        description = mdDoc "The list of allowed HTTP methods, such as POST and GET";
+      };
+
+      pass-environment-to-command = mkOption {
+        type = with types; listOf (submodule {
+          options = {
+            envname = mkOption {
+              type = types.str;
+              description = mdDoc "Environment variable name";
+            };
+            name = mkOption {
+              type = types.str;
+              description = mdDoc "Name";
+            };
+            source = mkOption {
+              type = types.str;
+              description = mdDoc "Source";
+            };
+          };
+        });
+        default = [];
+        description = mdDoc "The list of arguments that will be passed to the command as environment variables.";
+      };
+
+      pass-arguments-to-command= mkOption {
+        type = with types; listOf (submodule source-name);
+        default = [];
+        description = mdDoc "The list of arguments that will be passed to the command.";
+      };
+
+      parse-parameters-as-json= mkOption {
+        type = with types; listOf (submodule source-name);
+        default = [];
+        description = mdDoc ''
+          The list of arguments that contain JSON strings. These parameters will
+          be decoded by webhook and you can access them like regular objects in
+          rules and pass-arguments-to-command.
+          '';
+      };
+
     };
   });
 

--- a/nixos/tests/webhook.nix
+++ b/nixos/tests/webhook.nix
@@ -20,6 +20,7 @@ in
           echo = {
             execute-command = "echo";
             response-message = "Webhook is reachable!";
+            success-http-response-code = 200;
           };
         };
         hooksTemplated = {


### PR DESCRIPTION
###### Description of changes

The webhook hook definitions allow for more configuration than expressed in the module. This change adds typed options for some of those hook configuration options.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
