### PR TITLE
nifi: 1.16.3 -> 1.20.0

### DIFF
--- a/pkgs/servers/web-apps/nifi/default.nix
+++ b/pkgs/servers/web-apps/nifi/default.nix
@@ -1,16 +1,16 @@
-{ lib, stdenv, fetchurl, makeWrapper, jre8, nixosTests }:
+{ lib, stdenv, fetchzip, makeWrapper, jdk11, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "nifi";
-  version = "1.16.3";
+  version = "1.20.0";
 
-  src = fetchurl {
-    url = "https://archive.apache.org/dist/nifi/${version}/nifi-${version}-bin.tar.gz";
-    sha256 = "sha256-57ZtgK1Z8G/nX2rtf7osmymvE4RukGi7CIvCvRQNKuE=";
+  src = fetchzip {
+    url = "mirror://apache/nifi/${version}/nifi-${version}-bin.zip";
+    sha256 = "sha256-xeBu20AeG035nB/jUsOsAvqDtwklM+9ZsZlJoAZ4iu4=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jre8 ];
+  buildInputs = [ jdk11 ];
 
   installPhase = ''
     mv ../$sourceRoot $out
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/bin/nifi.sh \
       --replace "/bin/sh" "${stdenv.shell}"
     substituteInPlace $out/bin/nifi-env.sh \
-      --replace "#export JAVA_HOME=/usr/java/jdk1.8.0/" "export JAVA_HOME=${jre8}"
+      --replace "#export JAVA_HOME=/usr/java/jdk1.8.0/" "export JAVA_HOME=${jdk11}"
   '';
 
   passthru = {


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2023-22832.

https://cwiki.apache.org/confluence/display/NIFI/Release+Notes#ReleaseNotes-Version1.20.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>nifi</li>
  </ul>
</details>