### PR TITLE
sonic-visualiser: 4.2 -> 4.5.1

### DIFF
--- a/pkgs/applications/audio/sonic-visualiser/default.nix
+++ b/pkgs/applications/audio/sonic-visualiser/default.nix
@@ -5,19 +5,19 @@
 , libsndfile, pkg-config, libpulseaudio, qtbase, qtsvg, redland
 , rubberband, serd, sord, vamp-plugin-sdk, fftwFloat
 , capnproto, liboggz, libfishsound, libid3tag, opusfile
-, wrapQtAppsHook
+, wrapQtAppsHook, meson, ninja, cmake
 }:
 
 stdenv.mkDerivation rec {
   pname = "sonic-visualiser";
-  version = "4.2";
+  version = "4.5.1";
 
   src = fetchurl {
-    url = "https://code.soundsoftware.ac.uk/attachments/download/2755/${pname}-${version}.tar.gz";
-    sha256 = "1wsvranhvdl21ksbinbgb55qvs3g2d4i57ssj1vx2aln6m01ms9q";
+    url = "https://code.soundsoftware.ac.uk/attachments/download/2841/${pname}-${version}.tar.gz";
+    sha256 = "1sgg4m3035a03ldipgysz7zqfa9pqaqa4j024gyvvcwh4ml8iasr";
   };
 
-  nativeBuildInputs = [ pkg-config wrapQtAppsHook ];
+  nativeBuildInputs = [ meson ninja cmake pkg-config wrapQtAppsHook ];
   buildInputs =
     [ libsndfile qtbase qtsvg fftw fftwFloat bzip2 lrdf rubberband
       libsamplerate vamp-plugin-sdk alsa-lib librdf_raptor librdf_rasqal redland
@@ -36,11 +36,6 @@ stdenv.mkDerivation rec {
       libid3tag
       opusfile
     ];
-
-  # comment out the tests
-  preConfigure = ''
-    sed -i 's/sub_test_svcore_/#sub_test_svcore_/' sonic-visualiser.pro
-  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Description of changes

This package update was mainly done because 4.2 doesn't compile with GCC 12 which was fixed upstream in [5a7b517](https://github.com/sonic-visualiser/svcore/commit/5a7b517e43b7f0b3f03b7fc3145102cf4e5b0ffc).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
