### PR TITLE
scala-cli: 0.1.20 -> 0.2.0

### DIFF
--- a/pkgs/development/tools/build-managers/scala-cli/sources.json
+++ b/pkgs/development/tools/build-managers/scala-cli/sources.json
@@ -1,21 +1,21 @@
 {
-  "version": "0.1.20",
+  "version": "0.2.0",
   "assets": {
     "aarch64-darwin": {
       "asset": "scala-cli-aarch64-apple-darwin.gz",
-      "sha256": "0gb6xmv5qm77nfn49p7r180hz91a3kpilw27s9all8zcmca2xhml"
+      "sha256": "0fv4ph1pf924wf3vmzri68s79i4kxgmp2fl9qy9v14ff71bbnyv5"
     },
     "aarch64-linux": {
       "asset": "scala-cli-aarch64-pc-linux.gz",
-      "sha256": "1ax9yqzp4l7aa74x3lgr75h58pl3w92921fjsg8yw3imi2j57h09"
+      "sha256": "1h5kvd1wf6x3xis15bdrsvrivs8zmbvggcaspr9brsjw38q13c7q"
     },
     "x86_64-darwin": {
       "asset": "scala-cli-x86_64-apple-darwin.gz",
-      "sha256": "1i5g8afgcg701g7n22sgbs2639mlwgjmr5jhmw7bz6wvj8h5nz1z"
+      "sha256": "1p4gkghbfs5cac4k7760nnsdf7m5i5d4f568m8xsyfx8nkhpyw1w"
     },
     "x86_64-linux": {
       "asset": "scala-cli-x86_64-pc-linux.gz",
-      "sha256": "0a53kxhl9n6p9mblk4r0zy8aklhpsvkg0g42il8hqvf72y0kl4ks"
+      "sha256": "0xk4n71lgg91kkjk0633sz04s2ypyjkig9vsxg60b16gzm7z4j22"
     }
   }
 }


### PR DESCRIPTION
###### Description of changes

Update scala-cli from 0.1.20 to [0.2.0](https://github.com/VirtusLab/scala-cli/releases/tag/v0.2.0).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).