### PR TITLE
nixos/tests/systemd-shutdown: ensure systemd-initrd variant actually enables it

### DIFF
--- a/nixos/tests/systemd-shutdown.nix
+++ b/nixos/tests/systemd-shutdown.nix
@@ -11,6 +11,7 @@ in {
     systemd.shutdownRamfs.contents."/etc/systemd/system-shutdown/shutdown-message".source = pkgs.writeShellScript "shutdown-message" ''
       echo "${msg}"
     '';
+    boot.initrd.systemd.enable = systemdStage1;
   };
 
   testScript = ''


### PR DESCRIPTION
###### Description of changes

It looks like the systemd-initrd variant of the systemd-shutdown test (systemd-initrd-shutdown) did not actually enable the systemd-initrd and so was just evaluating to the same derivation before this change

<details>
<summary>Evaluation results</summary>

Before this change:

```
$ nix eval --json .#nixosTests.systemd-shutdown
"/nix/store/qpg0wci29lmzc2fygxq0nvcqzd29akd9-vm-test-run-systemd-shutdown"
$ nix eval --json .#nixosTests.systemd-initrd-shutdown
"/nix/store/qpg0wci29lmzc2fygxq0nvcqzd29akd9-vm-test-run-systemd-shutdown"
```

After this change:

```
$ nix eval --json .#nixosTests.systemd-shutdown
"/nix/store/qpg0wci29lmzc2fygxq0nvcqzd29akd9-vm-test-run-systemd-shutdown"
$ nix eval --json .#nixosTests.systemd-initrd-shutdown
"/nix/store/ahf356nvnvs6dmvq9gifj38d5zankb7m-vm-test-run-systemd-shutdown"
```
</details>

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).