### PR TITLE
treewide: more manual fixups for

### DIFF
--- a/pkgs/applications/misc/keepassxc/default.nix
+++ b/pkgs/applications/misc/keepassxc/default.nix
@@ -49,11 +49,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-amedKK9nplLVJTldeabN3/c+g/QesrdH+qx+rba2/4s=";
   };
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang [
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang (toString [
     "-Wno-old-style-cast"
     "-Wno-error"
     "-D__BIG_ENDIAN__=${if stdenv.isBigEndian then "1" else "0"}"
-  ];
+  ]);
 
   NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-rpath ${libargon2}/lib";
 

--- a/pkgs/development/interpreters/kerf/default.nix
+++ b/pkgs/development/interpreters/kerf/default.nix
@@ -30,13 +30,13 @@ stdenv.mkDerivation rec {
   makeFlags = [ "kerf" "kerf_test" ];
 
   # avoid a huge amount of warnings to make failures clearer
-  env.NIX_CFLAGS_COMPILE = map (x: "-Wno-${x}") [
+  env.NIX_CFLAGS_COMPILE = toString (map (x: "-Wno-${x}") [
     "void-pointer-to-int-cast"
     "format"
     "implicit-function-declaration"
     "gnu-variable-sized-type-not-at-end"
     "unused-result"
-  ] ++ lib.optionals stdenv.isDarwin [ "-fcommon" ];
+  ] ++ lib.optionals stdenv.isDarwin [ "-fcommon" ]);
 
   patchPhase = ''
     substituteInPlace ./Makefile \

--- a/pkgs/development/libraries/liblastfm/default.nix
+++ b/pkgs/development/libraries/liblastfm/default.nix
@@ -23,10 +23,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ fftwSinglePrec libsamplerate qtbase ]
     ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.SystemConfiguration;
 
-  env.NIX_CFLAGS_COMPILE =
-    lib.optionals (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "11") [
-      "-std=c++11"
-    ];
+  env.NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "11") "-std=c++11";
 
   dontWrapQtApps = true;
 

--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -12,7 +12,7 @@ let param =
       rev = version;
       sha256 = "sha256-69Svno0qLaUifMscnVuPUJlCo9d8Lee+1qiYx34G3Po=";
     };
-    env.NIX_CFLAGS_COMPILE = null;
+    env = { };
     buildInputs = [ camlp-streams ];
   } else if check "3.12" then {
     version = "2.18.5";

--- a/pkgs/development/python-modules/py3exiv2/default.nix
+++ b/pkgs/development/python-modules/py3exiv2/default.nix
@@ -26,9 +26,7 @@ buildPythonPackage rec {
   ];
 
   # Work around Python distutils compiling C++ with $CC (see issue #26709)
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin [
-    "-I${lib.getDev libcxx}/include/c++/v1"
-  ];
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
 
   pythonImportsCheck = [
     "pyexiv2"


### PR DESCRIPTION
treewide: move NIX_CFLAGS_COMPILE to the env attrset

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
