### PR TITLE
stdenv: run toString on lists in env to allow lists in env

### DIFF
--- a/pkgs/applications/misc/keepassxc/default.nix
+++ b/pkgs/applications/misc/keepassxc/default.nix
@@ -49,11 +49,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-amedKK9nplLVJTldeabN3/c+g/QesrdH+qx+rba2/4s=";
   };
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang [
+  __structuredAttrs = true;
+  env.NIX_CFLAGS_COMPILE = lib.optionals true [
     "-Wno-old-style-cast"
     "-Wno-error"
     "-D__BIG_ENDIAN__=${if stdenv.isBigEndian then "1" else "0"}"
   ];
+
+  postConfigure = ''
+    typeset -p NIX_CFLAGS_COMPILE
+  '';
 
   NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-rpath ${libargon2}/lib";
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -537,8 +537,8 @@ else let
     assert lib.assertMsg (overlappingNames == [ ])
       "The ‘env’ attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping: ${lib.concatStringsSep ", " overlappingNames}";
     lib.mapAttrs
-      (n: v: assert lib.assertMsg (lib.isString v || lib.isBool v || lib.isInt v || lib.isDerivation v)
-        "The ‘env’ attribute set can only contain derivation, string, boolean or integer attributes. The ‘${n}’ attribute is of type ${builtins.typeOf v}."; v)
+      (n: v: assert lib.assertMsg (lib.isString v || lib.isBool v || lib.isInt v || lib.isDerivation v || lib.isList v)
+        "The ‘env’ attribute set can only contain derivation, list, string, boolean or integer attributes. The ‘${n}’ attribute is of type ${builtins.typeOf v}."; (if lib.isList v then toString v else v))
       env;
 
 in


### PR DESCRIPTION
will make appending to lists in env in overrideAttrs more ergonomic due
to no longer needing to add spaces manually

```
nix-repl> keepassxc.NIX_CFLAGS_COMPILE
"-Wno-old-style-cast -Wno-error -D__BIG_ENDIAN__=0"

nix-repl> (keepassxc.overrideAttrs(oA: { passthru.oA = oA; })).oA.env.NIX_CFLAGS_COMPILE
[ "-Wno-old-style-cast" "-Wno-error" "-D__BIG_ENDIAN__=0" ]

nix-repl> (keepassxc.overrideAttrs(oA: { passthru.oA = oA; })).oA.NIX_CFLAGS_COMPILE
error:
       … while evaluating the attribute 'oA.NIX_CFLAGS_COMPILE'

         at «string»:1:32:

            1| (keepassxc.overrideAttrs(oA: { passthru.oA = oA; })).oA.NIX_CFLAGS_COMPILE
             |                                ^

       error: attribute 'NIX_CFLAGS_COMPILE' missing

       at «string»:1:1:

            1| (keepassxc.overrideAttrs(oA: { passthru.oA = oA; })).oA.NIX_CFLAGS_COMPILE
             | ^
```

if merged revert most changes in https://github.com/NixOS/nixpkgs/pull/217206

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
