### PR TITLE
libjxl: 0.7.0 -> 0.8.1

### DIFF
--- a/pkgs/development/libraries/libjxl/default.nix
+++ b/pkgs/development/libraries/libjxl/default.nix
@@ -1,5 +1,4 @@
 { stdenv, lib, fetchFromGitHub
-, fetchpatch
 , brotli
 , cmake
 , giflib
@@ -21,7 +20,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libjxl";
-  version = "0.7.0";
+  version = "0.8.1";
 
   outputs = [ "out" "dev" ];
 
@@ -29,19 +28,10 @@ stdenv.mkDerivation rec {
     owner = "libjxl";
     repo = "libjxl";
     rev = "v${version}";
-    sha256 = "sha256-9DBLQ/gMyy2ZUm7PCWYJ7XOzkgQM0cAewJZzMNo8UPs=";
+    hash = "sha256-WWuvUTMrlR6ePbEs01ulLnuMiUqGrh4qELWFh0QMaGU=";
     # There are various submodules in `third_party/`.
     fetchSubmodules = true;
   };
-
-  patches = [
-    # present in master
-    (fetchpatch {
-      name = "fix-test-failure-on-ia64-ppc64-riscv64";
-      url = "https://github.com/libjxl/libjxl/commit/bb8eac5d6acec223e44cf8cc72ae02f0816de311.patch";
-      hash = "sha256-DuUCStWEquhWo7bOss0RgZ7ouYE4FpWrIMFywYR424s=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -98,6 +88,9 @@ stdenv.mkDerivation rec {
 
     # Use our version of highway, though it is still statically linked in
     "-DJPEGXL_FORCE_SYSTEM_HWY=ON"
+
+    # Use our version of gtest
+    "-DJPEGXL_FORCE_SYSTEM_GTEST=ON"
 
     # TODO: Update this package to enable this (overridably via an option):
     # Viewer tools for evaluation.


### PR DESCRIPTION
###### Description of changes

Update libjxl to current latest version: https://github.com/libjxl/libjxl/releases/tag/v0.8.1.
This change was motivated by OSV item https://osv.dev/vulnerability/OSV-2022-836 identified by manual test run with [vulnxscan](https://github.com/tiiuae/sbomnix/blob/main/scripts/vulnxscan/README.md). 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
