### PR TITLE
ocamlPackages.functoria: 4.2.0 → 4.3.4

### DIFF
--- a/pkgs/development/ocaml-modules/functoria/default.nix
+++ b/pkgs/development/ocaml-modules/functoria/default.nix
@@ -4,13 +4,14 @@
 
 buildDunePackage rec {
   pname   = "functoria";
-  version = "4.2.0";
+  version = "4.3.4";
 
+  duneVersion = "3";
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage/releases/download/v${version}/mirage-${version}.tbz";
-    sha256 = "sha256-rZ9y8+wbDjqjY1sx+TmSoR42hUKRMGpehCCR2cEgbv8=";
+    hash = "sha256-ZN8La2+N19wVo/vBUfIj17JU6FSp0jX7h2nDoIpR1XY=";
   };
 
   propagatedBuildInputs = [ cmdliner rresult astring fmt logs bos fpath emile uri ];

--- a/pkgs/development/ocaml-modules/mirage/default.nix
+++ b/pkgs/development/ocaml-modules/mirage/default.nix
@@ -8,6 +8,7 @@ buildDunePackage rec {
   inherit (mirage-runtime) version src;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/mirage/blob/v4.3.3/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
