### PR TITLE
cryptominisat: 5.8.0 -> 5.11.4

### DIFF
--- a/pkgs/applications/science/logic/cryptominisat/default.nix
+++ b/pkgs/applications/science/logic/cryptominisat/default.nix
@@ -1,32 +1,30 @@
-{ lib, stdenv, fetchFromGitHub, cmake, python3, xxd, boost, fetchpatch }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, python3
+, boost
+}:
 
 stdenv.mkDerivation rec {
   pname = "cryptominisat";
-  version = "5.8.0";
+  version = "5.11.4";
 
   src = fetchFromGitHub {
-    owner  = "msoos";
-    repo   = "cryptominisat";
-    rev    = version;
-    sha256 = "00hmxdlyhn7pwk9jlvc5g0l5z5xqfchjzf5jgn3pkj9xhl8yqq50";
+    owner = "msoos";
+    repo = "cryptominisat";
+    rev = version;
+    hash = "sha256-7JNfFKSYWgyyNnWNzXGLqWRwSW+5r6PBMelKeAmx8sc=";
   };
 
-  patches = [
-    (fetchpatch {
-      # https://github.com/msoos/cryptominisat/pull/621
-      url = "https://github.com/msoos/cryptominisat/commit/11a97003b0bfbfb61ed6c4e640212110d390c28c.patch";
-      sha256 = "0hdy345bwcbxz0jl1jdxfa6mmfh77s2pz9rnncsr0jzk11b3j0cw";
-    })
-  ];
-
   buildInputs = [ python3 boost ];
-  nativeBuildInputs = [ cmake xxd ];
+  nativeBuildInputs = [ cmake ];
 
   meta = with lib; {
     description = "An advanced SAT Solver";
-    homepage    = "https://github.com/msoos/cryptominisat";
-    license     = licenses.mit;
+    homepage = "https://github.com/msoos/cryptominisat";
+    license = licenses.mit;
     maintainers = with maintainers; [ mic92 ];
-    platforms   = platforms.unix;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes
https://github.com/msoos/cryptominisat/releases/tag/5.11.4

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).