### PR TITLE
dav1d: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/development/libraries/dav1d/default.nix
+++ b/pkgs/development/libraries/dav1d/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitLab
+{ lib, stdenv, fetchFromGitHub
 , meson, ninja, nasm, pkg-config
 , xxHash
 , withTools ? false # "dav1d" binary
@@ -10,14 +10,13 @@ assert useVulkan -> withExamples;
 
 stdenv.mkDerivation rec {
   pname = "dav1d";
-  version = "1.0.0";
+  version = "1.1.0";
 
-  src = fetchFromGitLab {
-    domain = "code.videolan.org";
+  src = fetchFromGitHub {
     owner = "videolan";
     repo = pname;
     rev = version;
-    sha256 = "sha256-RVr7NFVxY+6MBD8NV7eMW8TEWuCgcfqpula1o1VZe0o=";
+    hash = "sha256-1k6TsaXI9nwrBXTj3hncblkQuN/bvDudWDCsx4E4iwY=";
   };
 
   nativeBuildInputs = [ meson ninja nasm pkg-config ];


### PR DESCRIPTION
###### Description of changes

Update dav1d to current latest version: https://github.com/videolan/dav1d/releases/tag/1.1.0. Also, start using the read-only mirror for dav1d source https://github.com/videolan/dav1d instead of the origin https://code.videolan.org/videolan/dav1d/. The reason is that the origin https://code.videolan.org/videolan/dav1d/ connection appears unstable.

This change was motivated by OSV item https://osv.dev/vulnerability/OSV-2022-674 identified by manual test run with [vulnxscan](https://github.com/tiiuae/sbomnix/blob/main/scripts/vulnxscan/README.md).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
