### PR TITLE
insomnia: add support for aarch64-darwin

### DIFF
--- a/pkgs/development/web/insomnia/default.nix
+++ b/pkgs/development/web/insomnia/default.nix
@@ -3,7 +3,8 @@
 , at-spi2-atk, gsettings-desktop-schemas, gobject-introspection, wrapGAppsHook
 , libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
 , libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb, libxshmfence, nghttp2
-, libudev0-shim, glibc, curl, openssl, autoPatchelfHook }:
+, libudev0-shim, glibc, curl, openssl, autoPatchelfHook ,undmg ,xar ,cpio
+}:
 
 let
   runtimeLibs = lib.makeLibraryPath [
@@ -13,84 +14,113 @@ let
     nghttp2
     openssl
   ];
-in stdenv.mkDerivation rec {
+
   pname = "insomnia";
   version = "2022.7.5";
-
-  src = fetchurl {
-    url =
-      "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.deb";
-    sha256 = "sha256-BJAiDv+Zg+wU6ovAkuMVTGN9WElOlC96m/GEYrg6exE=";
-  };
-
-  nativeBuildInputs = [
-    autoPatchelfHook
-    dpkg
-    makeWrapper
-    gobject-introspection
-    wrapGAppsHook
-  ];
-
-  buildInputs = [
-    alsa-lib
-    at-spi2-atk
-    atk
-    cairo
-    cups
-    dbus
-    expat
-    fontconfig
-    freetype
-    gdk-pixbuf
-    glib
-    pango
-    gtk3
-    gsettings-desktop-schemas
-    libX11
-    libXScrnSaver
-    libXcomposite
-    libXcursor
-    libXdamage
-    libXext
-    libXfixes
-    libXi
-    libXrandr
-    libXrender
-    libXtst
-    libxcb
-    libxshmfence
-    mesa # for libgbm
-    nspr
-    nss
-  ];
-
-  dontBuild = true;
-  dontConfigure = true;
-  dontWrapGApps = true;
-
-  unpackPhase = "dpkg-deb -x $src .";
-
-  installPhase = ''
-    mkdir -p $out/share/insomnia $out/lib $out/bin
-
-    mv usr/share/* $out/share/
-    mv opt/Insomnia/* $out/share/insomnia
-
-    ln -s $out/share/insomnia/insomnia $out/bin/insomnia
-    sed -i 's|\/opt\/Insomnia|'$out'/bin|g' $out/share/applications/insomnia.desktop
-  '';
-
-  preFixup = ''
-    wrapProgram "$out/bin/insomnia" --prefix LD_LIBRARY_PATH : ${runtimeLibs}
-  '';
+  nameApp = "Insomnia";
 
   meta = with lib; {
     homepage = "https://insomnia.rest/";
     description = "The most intuitive cross-platform REST API Client";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = licenses.mit;
-    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ markus1189 babariviere ];
   };
 
-}
+  src = if stdenv.hostPlatform.system == "x86_64-linux" then fetchurl {
+    url =
+      "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.deb";
+    sha256 = "sha256-BJAiDv+Zg+wU6ovAkuMVTGN9WElOlC96m/GEYrg6exE=";
+  } else if stdenv.isDarwin then fetchurl {
+    url = 
+      "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.dmg";
+    sha256 = "sha256-sAsSuCMFJL41GRGdXJgECPVKcCHkDM3lVHYiSqkM/K8=";
+  } else throw "Not supported on ${stdenv.hostPlatform.system}.";
+
+  linux = stdenv.mkDerivation rec {
+    inherit pname version src;
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      dpkg
+      makeWrapper
+      gobject-introspection
+      wrapGAppsHook
+    ];
+
+    buildInputs = [
+      alsa-lib
+      at-spi2-atk
+      atk
+      cairo
+      cups
+      dbus
+      expat
+      fontconfig
+      freetype
+      gdk-pixbuf
+      glib
+      pango
+      gtk3
+      gsettings-desktop-schemas
+      libX11
+      libXScrnSaver
+      libXcomposite
+      libXcursor
+      libXdamage
+      libXext
+      libXfixes
+      libXi
+      libXrandr
+      libXrender
+      libXtst
+      libxcb
+      libxshmfence
+      mesa # for libgbm
+      nspr
+      nss
+    ];
+
+    dontBuild = true;
+    dontConfigure = true;
+    dontWrapGApps = true;
+
+    unpackPhase = "dpkg-deb -x $src .";
+
+    installPhase = ''
+      mkdir -p $out/share/insomnia $out/lib $out/bin
+
+      mv usr/share/* $out/share/
+      mv opt/Insomnia/* $out/share/insomnia
+
+      ln -s $out/share/insomnia/insomnia $out/bin/insomnia
+      sed -i 's|\/opt\/Insomnia|'$out'/bin|g' $out/share/applications/insomnia.desktop
+    '';
+
+    preFixup = ''
+      wrapProgram "$out/bin/insomnia" --prefix LD_LIBRARY_PATH : ${runtimeLibs}
+    '';
+
+    meta = meta // { platforms = lib.platforms.darwin; };
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit pname version src;
+
+    # Archive extraction via undmg fails for this particular version.
+    nativeBuildInputs = [ makeWrapper undmg ];
+
+    sourceRoot = "${nameApp}.app";
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/{Applications/${nameApp}.app,bin}
+      cp -R . $out/Applications/${nameApp}.app
+      makeWrapper $out/Applications/${nameApp}.app/Contents/MacOS/Insomnia $out/bin/${pname}
+      runHook postInstall
+    '';
+
+    meta = meta // { platforms = lib.platforms.darwin; };
+  };
+in
+if stdenv.isDarwin then darwin else linux

--- a/pkgs/development/web/insomnia/default.nix
+++ b/pkgs/development/web/insomnia/default.nix
@@ -32,7 +32,7 @@ let
       "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.deb";
     sha256 = "sha256-BJAiDv+Zg+wU6ovAkuMVTGN9WElOlC96m/GEYrg6exE=";
   } else if stdenv.isDarwin then fetchurl {
-    url = 
+    url =
       "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.dmg";
     sha256 = "sha256-sAsSuCMFJL41GRGdXJgECPVKcCHkDM3lVHYiSqkM/K8=";
   } else throw "Not supported on ${stdenv.hostPlatform.system}.";


### PR DESCRIPTION
###### Description of changes

This PR adds support for aarch64-darwin platforms

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
