### PR TITLE
nfs: declare request-key.conf as text

### DIFF
--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -14,7 +14,7 @@ let
 
   idmapdConfFile = format.generate "idmapd.conf" cfg.idmapd.settings;
   nfsConfFile = pkgs.writeText "nfs.conf" cfg.extraConfig;
-  requestKeyConfFile = pkgs.writeText "request-key.conf" ''
+  requestKeyConf = ''
     create id_resolver * * ${pkgs.nfs-utils}/bin/nfsidmap -t 600 %k %d
   '';
 
@@ -87,7 +87,7 @@ in
     environment.etc = {
       "idmapd.conf".source = idmapdConfFile;
       "nfs.conf".source = nfsConfFile;
-      "request-key.conf".source = requestKeyConfFile;
+      "request-key.conf".text = requestKeyConf;
     };
 
     systemd.services.nfs-blkmap =


### PR DESCRIPTION
this allows to properly merge the request-key.conf with other modules declaring their own

e.g. this allows the usage of both nfs and cifs with the workaround documented here:
https://github.com/NixOS/nixpkgs/issues/34638#issuecomment-524688091

without this change, using both nfs and cifs shares with the above workaroung, we end up with the following error:

```
error: The option `environment.etc."request-key.conf".source' has conflicting definition values:
       - In `/nix/store/3sjyxv7vn9qh90ab4pz79w8cd0bgks6s-source/nixos/modules/system/etc/etc.nix': <derivation etc-request-key.conf>
       - In `/nix/store/3sjyxv7vn9qh90ab4pz79w8cd0bgks6s-source/nixos/modules/tasks/filesystems/nfs.nix': <derivation request-key.conf>
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```