### PR TITLE
nixos/gitea: add nginx configuration

### DIFF
--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -629,6 +629,10 @@ in
         );
       in
       {
+        camo = mkIf (cfg.camoHmacKeyFile != null) {
+          HMAC_KEY = "#hmackey#";
+        };
+
         "cron.update_checker".ENABLED = lib.mkDefault false;
 
         database = mkMerge [
@@ -653,6 +657,24 @@ in
           })
         ];
 
+        lfs = mkIf cfg.lfs.enable {
+          PATH = cfg.lfs.contentDir;
+        };
+
+        mailer = mkIf (cfg.mailerPasswordFile != null) {
+          PASSWD = "#mailerpass#";
+        };
+
+        metrics = mkIf (cfg.metricsTokenFile != null) {
+          TOKEN = "#metricstoken#";
+        };
+
+        oauth2 = {
+          JWT_SECRET = "#oauth2jwtsecret#";
+        };
+
+        packages.CHUNKED_UPLOAD_PATH = "${cfg.stateDir}/tmp/package-upload";
+
         repository = {
           ROOT = cfg.repositoryRoot;
         };
@@ -660,10 +682,6 @@ in
         server = mkIf cfg.lfs.enable {
           LFS_START_SERVER = true;
           LFS_JWT_SECRET = "#lfsjwtsecret#";
-        };
-
-        camo = mkIf (cfg.camoHmacKeyFile != null) {
-          HMAC_KEY = "#hmackey#";
         };
 
         session = {
@@ -693,24 +711,6 @@ in
             "${captchaPrefix}_URL" = cfg.captcha.url;
           })
         ]);
-
-        mailer = mkIf (cfg.mailerPasswordFile != null) {
-          PASSWD = "#mailerpass#";
-        };
-
-        metrics = mkIf (cfg.metricsTokenFile != null) {
-          TOKEN = "#metricstoken#";
-        };
-
-        oauth2 = {
-          JWT_SECRET = "#oauth2jwtsecret#";
-        };
-
-        lfs = mkIf cfg.lfs.enable {
-          PATH = cfg.lfs.contentDir;
-        };
-
-        packages.CHUNKED_UPLOAD_PATH = "${cfg.stateDir}/tmp/package-upload";
 
         storage = mkMerge [
           (mkIf (cfg.minioAccessKeyId != null) {

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -786,7 +786,7 @@ in
         ];
       };
 
-    services.postgresql = lib.optionalAttrs (usePostgresql && cfg.database.createDatabase) {
+    services.postgresql = lib.mkIf (usePostgresql && cfg.database.createDatabase) {
       enable = lib.mkDefault true;
 
       ensureDatabases = [ cfg.database.name ];
@@ -798,7 +798,7 @@ in
       ];
     };
 
-    services.mysql = lib.optionalAttrs (useMysql && cfg.database.createDatabase) {
+    services.mysql = lib.mkIf (useMysql && cfg.database.createDatabase) {
       enable = lib.mkDefault true;
       package = lib.mkDefault pkgs.mariadb;
 

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -674,16 +674,16 @@ in
 
     services.gitea.settings =
       let
-        captchaPrefix = lib.optionalString cfg.captcha.enable (
-          {
-            image = "IMAGE";
-            recaptcha = "RECAPTCHA";
-            hcaptcha = "HCAPTCHA";
-            mcaptcha = "MCAPTCHA";
-            cfturnstile = "CF_TURNSTILE";
-          }
-          ."${cfg.captcha.type}"
-        );
+        captchaPrefix =
+          lib.optionalString cfg.captcha.enable
+            {
+              image = "IMAGE";
+              recaptcha = "RECAPTCHA";
+              hcaptcha = "HCAPTCHA";
+              mcaptcha = "MCAPTCHA";
+              cfturnstile = "CF_TURNSTILE";
+            }
+            ."${cfg.captcha.type}";
       in
       {
         camo = lib.mkIf (cfg.camoHmacKeyFile != null) {

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -6,8 +6,6 @@
   ...
 }:
 
-with lib;
-
 let
   cfg = config.services.gitea;
   opt = options.services.gitea;
@@ -24,9 +22,9 @@ let
     RUN_MODE = prod
     WORK_PATH = ${cfg.stateDir}
 
-    ${generators.toINI { } cfg.settings}
+    ${lib.generators.toINI { } cfg.settings}
 
-    ${optionalString (cfg.extraConfig != null) cfg.extraConfig}
+    ${lib.optionalString (cfg.extraConfig != null) cfg.extraConfig}
   '';
 
   inherit (cfg.settings) mailer;
@@ -35,57 +33,57 @@ in
 
 {
   imports = [
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "gitea" "cookieSecure" ]
       [ "services" "gitea" "settings" "session" "COOKIE_SECURE" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "gitea" "disableRegistration" ]
       [ "services" "gitea" "settings" "service" "DISABLE_REGISTRATION" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "gitea" "domain" ]
       [ "services" "gitea" "settings" "server" "DOMAIN" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "gitea" "httpAddress" ]
       [ "services" "gitea" "settings" "server" "HTTP_ADDR" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "gitea" "httpPort" ]
       [ "services" "gitea" "settings" "server" "HTTP_PORT" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "gitea" "log" "level" ]
       [ "services" "gitea" "settings" "log" "LEVEL" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "gitea" "log" "rootPath" ]
       [ "services" "gitea" "settings" "log" "ROOT_PATH" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "gitea" "rootUrl" ]
       [ "services" "gitea" "settings" "server" "ROOT_URL" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "gitea" "ssh" "clonePort" ]
       [ "services" "gitea" "settings" "server" "SSH_PORT" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "gitea" "staticRootPath" ]
       [ "services" "gitea" "settings" "server" "STATIC_ROOT_PATH" ]
     )
 
-    (mkChangedOptionModule
+    (lib.mkChangedOptionModule
       [ "services" "gitea" "enableUnixSocket" ]
       [ "services" "gitea" "settings" "server" "PROTOCOL" ]
       (config: if config.services.gitea.enableUnixSocket then "http+unix" else "http")
     )
 
-    (mkRemovedOptionModule [ "services" "gitea" "ssh" "enable" ]
+    (lib.mkRemovedOptionModule [ "services" "gitea" "ssh" "enable" ]
       "It has been migrated into freeform setting services.gitea.settings.server.DISABLE_SSH. Keep in mind that the setting is inverted."
     )
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "gitea"
       "useWizard"
@@ -94,42 +92,42 @@ in
 
   options = {
     services.gitea = {
-      enable = mkOption {
+      enable = lib.mkOption {
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = "Enable Gitea Service.";
       };
 
-      package = mkPackageOption pkgs "gitea" { };
+      package = lib.mkPackageOption pkgs "gitea" { };
 
-      stateDir = mkOption {
+      stateDir = lib.mkOption {
         default = "/var/lib/gitea";
-        type = types.str;
+        type = lib.types.str;
         description = "Gitea data directory.";
       };
 
-      customDir = mkOption {
+      customDir = lib.mkOption {
         default = "${cfg.stateDir}/custom";
-        defaultText = literalExpression ''"''${config.${opt.stateDir}}/custom"'';
-        type = types.str;
+        defaultText = lib.literalExpression ''"''${config.${opt.stateDir}}/custom"'';
+        type = lib.types.str;
         description = "Gitea custom directory. Used for config, custom templates and other options.";
       };
 
-      user = mkOption {
-        type = types.str;
+      user = lib.mkOption {
+        type = lib.types.str;
         default = "gitea";
         description = "User account under which gitea runs.";
       };
 
-      group = mkOption {
-        type = types.str;
+      group = lib.mkOption {
+        type = lib.types.str;
         default = "gitea";
         description = "Group under which gitea runs.";
       };
 
       database = {
-        type = mkOption {
-          type = types.enum [
+        type = lib.mkOption {
+          type = lib.types.enum [
             "sqlite3"
             "mysql"
             "postgres"
@@ -139,14 +137,14 @@ in
           description = "Database engine to use.";
         };
 
-        host = mkOption {
-          type = types.str;
+        host = lib.mkOption {
+          type = lib.types.str;
           default = "127.0.0.1";
           description = "Database host address.";
         };
 
-        port = mkOption {
-          type = types.port;
+        port = lib.mkOption {
+          type = lib.types.port;
           default = if usePostgresql then pg.settings.port else 3306;
           defaultText = literalExpression ''
             if config.${opt.database.type} != "postgresql"
@@ -156,20 +154,20 @@ in
           description = "Database host port.";
         };
 
-        name = mkOption {
-          type = types.str;
+        name = lib.mkOption {
+          type = lib.types.str;
           default = "gitea";
           description = "Database name.";
         };
 
-        user = mkOption {
-          type = types.str;
+        user = lib.mkOption {
+          type = lib.types.str;
           default = "gitea";
           description = "Database user.";
         };
 
-        password = mkOption {
-          type = types.str;
+        password = lib.mkOption {
+          type = lib.types.str;
           default = "";
           description = ''
             The password corresponding to {option}`database.user`.
@@ -178,8 +176,8 @@ in
           '';
         };
 
-        passwordFile = mkOption {
-          type = types.nullOr types.path;
+        passwordFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
           default = null;
           example = "/run/keys/gitea-dbpassword";
           description = ''
@@ -188,8 +186,8 @@ in
           '';
         };
 
-        socket = mkOption {
-          type = types.nullOr types.path;
+        socket = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
           default =
             if (cfg.database.createDatabase && usePostgresql) then
               "/run/postgresql"
@@ -197,57 +195,57 @@ in
               "/run/mysqld/mysqld.sock"
             else
               null;
-          defaultText = literalExpression "null";
+          defaultText = lib.literalExpression "null";
           example = "/run/mysqld/mysqld.sock";
           description = "Path to the unix socket file to use for authentication.";
         };
 
-        path = mkOption {
-          type = types.str;
+        path = lib.mkOption {
+          type = lib.types.str;
           default = "${cfg.stateDir}/data/gitea.db";
-          defaultText = literalExpression ''"''${config.${opt.stateDir}}/data/gitea.db"'';
+          defaultText = lib.literalExpression ''"''${config.${opt.stateDir}}/data/gitea.db"'';
           description = "Path to the sqlite3 database file.";
         };
 
-        createDatabase = mkOption {
-          type = types.bool;
+        createDatabase = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = "Whether to create a local database automatically.";
         };
       };
 
       captcha = {
-        enable = mkOption {
-          type = types.bool;
+        enable = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Enables Gitea to display a CAPTCHA challenge on registration.
           '';
         };
 
-        secretFile = mkOption {
-          type = types.nullOr types.str;
+        secretFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
           default = null;
           example = "/var/lib/secrets/gitea/captcha_secret";
           description = "Path to a file containing the CAPTCHA secret key.";
         };
 
-        siteKey = mkOption {
-          type = types.nullOr types.str;
+        siteKey = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
           default = null;
           example = "my_site_key";
           description = "CAPTCHA site key to use for Gitea.";
         };
 
-        url = mkOption {
-          type = types.nullOr types.str;
+        url = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
           default = null;
           example = "https://google.com/recaptcha";
           description = "CAPTCHA url to use for Gitea. Only relevant for `recaptcha` and `mcaptcha`.";
         };
 
-        type = mkOption {
-          type = types.enum [
+        type = lib.mkOption {
+          type = lib.types.enum [
             "image"
             "recaptcha"
             "hcaptcha"
@@ -259,15 +257,15 @@ in
           description = "The type of CAPTCHA to use for Gitea.";
         };
 
-        requireForLogin = mkOption {
-          type = types.bool;
+        requireForLogin = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           example = true;
           description = "Displays a CAPTCHA challenge whenever a user logs in.";
         };
 
-        requireForExternalRegistration = mkOption {
-          type = types.bool;
+        requireForExternalRegistration = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           example = true;
           description = "Displays a CAPTCHA challenge for users that register externally.";
@@ -275,8 +273,8 @@ in
       };
 
       dump = {
-        enable = mkOption {
-          type = types.bool;
+        enable = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Enable a timer that runs gitea dump to generate backup-files of the
@@ -284,8 +282,8 @@ in
           '';
         };
 
-        interval = mkOption {
-          type = types.str;
+        interval = lib.mkOption {
+          type = lib.types.str;
           default = "04:31";
           example = "hourly";
           description = ''
@@ -296,15 +294,15 @@ in
           '';
         };
 
-        backupDir = mkOption {
-          type = types.str;
+        backupDir = lib.mkOption {
+          type = lib.types.str;
           default = "${cfg.stateDir}/dump";
-          defaultText = literalExpression ''"''${config.${opt.stateDir}}/dump"'';
+          defaultText = lib.literalExpression ''"''${config.${opt.stateDir}}/dump"'';
           description = "Path to the dump files.";
         };
 
-        type = mkOption {
-          type = types.enum [
+        type = lib.mkOption {
+          type = lib.types.enum [
             "zip"
             "rar"
             "tar"
@@ -320,8 +318,8 @@ in
           description = "Archive format used to store the dump file.";
         };
 
-        file = mkOption {
-          type = types.nullOr types.str;
+        file = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
           default = null;
           description = "Filename to be used for the dump. If `null` a default name is chosen by gitea.";
           example = "gitea-dump";
@@ -329,75 +327,75 @@ in
       };
 
       lfs = {
-        enable = mkOption {
-          type = types.bool;
+        enable = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = "Enables git-lfs support.";
         };
 
-        contentDir = mkOption {
-          type = types.str;
+        contentDir = lib.mkOption {
+          type = lib.types.str;
           default = "${cfg.stateDir}/data/lfs";
-          defaultText = literalExpression ''"''${config.${opt.stateDir}}/data/lfs"'';
+          defaultText = lib.literalExpression ''"''${config.${opt.stateDir}}/data/lfs"'';
           description = "Where to store LFS files.";
         };
       };
 
-      appName = mkOption {
-        type = types.str;
+      appName = lib.mkOption {
+        type = lib.types.str;
         default = "gitea: Gitea Service";
         description = "Application name.";
       };
 
-      repositoryRoot = mkOption {
-        type = types.str;
+      repositoryRoot = lib.mkOption {
+        type = lib.types.str;
         default = "${cfg.stateDir}/repositories";
-        defaultText = literalExpression ''"''${config.${opt.stateDir}}/repositories"'';
+        defaultText = lib.literalExpression ''"''${config.${opt.stateDir}}/repositories"'';
         description = "Path to the git repositories.";
       };
 
-      camoHmacKeyFile = mkOption {
-        type = types.nullOr types.str;
+      camoHmacKeyFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         example = "/var/lib/secrets/gitea/camoHmacKey";
         description = "Path to a file containing the camo HMAC key.";
       };
 
-      mailerPasswordFile = mkOption {
-        type = types.nullOr types.str;
+      mailerPasswordFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         example = "/var/lib/secrets/gitea/mailpw";
         description = "Path to a file containing the SMTP password.";
       };
 
-      metricsTokenFile = mkOption {
-        type = types.nullOr types.str;
+      metricsTokenFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         example = "/var/lib/secrets/gitea/metrics_token";
         description = "Path to a file containing the metrics authentication token.";
       };
 
-      minioAccessKeyId = mkOption {
-        type = types.nullOr types.str;
+      minioAccessKeyId = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         example = "/var/lib/secrets/gitea/minio_access_key_id";
         description = "Path to a file containing the Minio access key id.";
       };
 
-      minioSecretAccessKey = mkOption {
-        type = types.nullOr types.str;
+      minioSecretAccessKey = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         example = "/var/lib/secrets/gitea/minio_secret_access_key";
         description = "Path to a file containing the Minio secret access key.";
       };
 
-      settings = mkOption {
+      settings = lib.mkOption {
         default = { };
         description = ''
           Gitea configuration. Refer to <https://docs.gitea.io/en-us/config-cheat-sheet/>
           for details on supported values.
         '';
-        example = literalExpression ''
+        example = lib.literalExpression ''
           {
             "cron.sync_external_users" = {
               RUN_AT_START = true;
@@ -417,21 +415,21 @@ in
             };
           }
         '';
-        type = types.submodule (
+        type = lib.types.submodule (
           { config, options, ... }:
           {
             freeformType = format.type;
             options = {
               log = {
-                ROOT_PATH = mkOption {
+                ROOT_PATH = lib.mkOption {
                   default = "${cfg.stateDir}/log";
-                  defaultText = literalExpression ''"''${config.${opt.stateDir}}/log"'';
-                  type = types.str;
+                  defaultText = lib.literalExpression ''"''${config.${opt.stateDir}}/log"'';
+                  type = lib.types.str;
                   description = "Root path for log files.";
                 };
-                LEVEL = mkOption {
+                LEVEL = lib.mkOption {
                   default = "Info";
-                  type = types.enum [
+                  type = lib.types.enum [
                     "Trace"
                     "Debug"
                     "Info"
@@ -506,8 +504,8 @@ in
               };
 
               server = {
-                PROTOCOL = mkOption {
-                  type = types.enum [
+                PROTOCOL = lib.mkOption {
+                  type = lib.types.enum [
                     "http"
                     "https"
                     "fcgi"
@@ -515,54 +513,54 @@ in
                     "fcgi+unix"
                   ];
                   default = if cfg.configureNginx then "http+unix" else "http";
-                  defaultText = literalExpression ''if config.services.gitea.configureNginx then "http+unix" else "http"'';
+                  defaultText = lib.literalExpression ''if config.services.gitea.configureNginx then "http+unix" else "http"'';
                   description = ''Listen protocol. `+unix` means "over unix", not "in addition to."'';
                 };
 
-                HTTP_ADDR = mkOption {
-                  type = types.either types.str types.path;
+                HTTP_ADDR = lib.mkOption {
+                  type = lib.types.either lib.types.str lib.types.path;
                   default =
                     if lib.hasSuffix "+unix" cfg.settings.server.PROTOCOL then "/run/gitea/gitea.sock" else "0.0.0.0";
-                  defaultText = literalExpression ''if lib.hasSuffix "+unix" cfg.settings.server.PROTOCOL then "/run/gitea/gitea.sock" else "0.0.0.0"'';
+                  defaultText = lib.literalExpression ''if lib.hasSuffix "+unix" cfg.settings.server.PROTOCOL then "/run/gitea/gitea.sock" else "0.0.0.0"'';
                   description = "Listen address. Must be a path when using a unix socket.";
                 };
 
-                HTTP_PORT = mkOption {
-                  type = types.port;
+                HTTP_PORT = lib.mkOption {
+                  type = lib.types.port;
                   default = 3000;
                   description = "Listen port. Ignored when using a unix socket.";
                 };
 
-                DOMAIN = mkOption {
-                  type = types.str;
+                DOMAIN = lib.mkOption {
+                  type = lib.types.str;
                   default = "localhost";
                   description = "Domain name of your server.";
                 };
 
-                ROOT_URL = mkOption {
-                  type = types.str;
+                ROOT_URL = lib.mkOption {
+                  type = lib.types.str;
                   default = "http://${cfg.settings.server.DOMAIN}:${toString cfg.settings.server.HTTP_PORT}/";
-                  defaultText = literalExpression ''"http://''${config.services.gitea.settings.server.DOMAIN}:''${toString config.services.gitea.settings.server.HTTP_PORT}/"'';
+                  defaultText = lib.literalExpression ''"http://''${config.services.gitea.settings.server.DOMAIN}:''${toString config.services.gitea.settings.server.HTTP_PORT}/"'';
                   description = "Full public URL of gitea server.";
                 };
 
-                STATIC_ROOT_PATH = mkOption {
-                  type = types.either types.str types.path;
+                STATIC_ROOT_PATH = lib.mkOption {
+                  type = lib.types.either lib.types.str lib.types.path;
                   default =
                     if cfg.configureNginx then "${pkgs.compressDrvWeb cfg.package.data { }}" else "${cfg.package.data}";
-                  defaultText = literalExpression ''if config.services.gitea.configureNginx then ''${pkgs.compressDrvWeb config.services.gitea.package.data {}} else config.services.gitea.package.data'';
+                  defaultText = lib.literalExpression ''if config.services.gitea.configureNginx then ''${pkgs.compressDrvWeb config.services.gitea.package.data {}} else config.services.gitea.package.data'';
                   example = "/var/lib/gitea/data";
                   description = "Upper level of template and static files path.";
                 };
 
-                DISABLE_SSH = mkOption {
-                  type = types.bool;
+                DISABLE_SSH = lib.mkOption {
+                  type = lib.types.bool;
                   default = false;
                   description = "Disable external SSH feature.";
                 };
 
-                SSH_PORT = mkOption {
-                  type = types.port;
+                SSH_PORT = lib.mkOption {
+                  type = lib.types.port;
                   default = 22;
                   example = 2222;
                   description = ''
@@ -574,7 +572,7 @@ in
               };
 
               service = {
-                DISABLE_REGISTRATION = mkEnableOption "the registration lock" // {
+                DISABLE_REGISTRATION = lib.mkEnableOption "the registration lock" // {
                   description = ''
                     By default any user can create an account on this `gitea` instance.
                     This can be disabled by using this option.
@@ -586,8 +584,8 @@ in
               };
 
               session = {
-                COOKIE_SECURE = mkOption {
-                  type = types.bool;
+                COOKIE_SECURE = lib.mkOption {
+                  type = lib.types.bool;
                   default =
                     if cfg.configureNginx then nginx.virtualHosts.${cfg.settings.server.DOMAIN}.forceSSL else false;
                   defaultText = lib.literalExpression ''if config.services.gitea.configureNginx then config.services.nginx.virtualHosts.''${cfg.settings.server.DOMAIN}.forceSSL else false'';
@@ -631,15 +629,15 @@ in
         '';
       };
 
-      extraConfig = mkOption {
-        type = with types; nullOr str;
+      extraConfig = lib.mkOption {
+        type = with lib.types; nullOr str;
         default = null;
         description = "Configuration lines appended to the generated gitea configuration file.";
       };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = cfg.database.createDatabase -> useSqlite || cfg.database.user == cfg.user;
@@ -679,7 +677,7 @@ in
 
     services.gitea.settings =
       let
-        captchaPrefix = optionalString cfg.captcha.enable (
+        captchaPrefix = lib.optionalString cfg.captcha.enable (
           {
             image = "IMAGE";
             recaptcha = "RECAPTCHA";
@@ -691,17 +689,17 @@ in
         );
       in
       {
-        camo = mkIf (cfg.camoHmacKeyFile != null) {
+        camo = lib.mkIf (cfg.camoHmacKeyFile != null) {
           HMAC_KEY = "#hmackey#";
         };
 
         "cron.update_checker".ENABLED = lib.mkDefault false;
 
-        database = mkMerge [
+        database = lib.mkMerge [
           {
             DB_TYPE = cfg.database.type;
           }
-          (mkIf (useMysql || usePostgresql) {
+          (lib.mkIf (useMysql || usePostgresql) {
             HOST =
               if cfg.database.socket != null then
                 cfg.database.socket
@@ -711,23 +709,23 @@ in
             USER = cfg.database.user;
             PASSWD = "#dbpass#";
           })
-          (mkIf useSqlite {
+          (lib.mkIf useSqlite {
             PATH = cfg.database.path;
           })
-          (mkIf usePostgresql {
+          (lib.mkIf usePostgresql {
             SSL_MODE = "disable";
           })
         ];
 
-        lfs = mkIf cfg.lfs.enable {
+        lfs = lib.mkIf cfg.lfs.enable {
           PATH = cfg.lfs.contentDir;
         };
 
-        mailer = mkIf (cfg.mailerPasswordFile != null) {
+        mailer = lib.mkIf (cfg.mailerPasswordFile != null) {
           PASSWD = "#mailerpass#";
         };
 
-        metrics = mkIf (cfg.metricsTokenFile != null) {
+        metrics = lib.mkIf (cfg.metricsTokenFile != null) {
           TOKEN = "#metricstoken#";
         };
 
@@ -741,11 +739,11 @@ in
           ROOT = cfg.repositoryRoot;
         };
 
-        server = mkMerge [
-          (mkIf cfg.configureNginx {
+        server = lib.mkMerge [
+          (lib.mkIf cfg.configureNginx {
             STATIC_URL_PREFIX = lib.mkDefault "/static";
           })
-          (mkIf cfg.lfs.enable {
+          (lib.mkIf cfg.lfs.enable {
             LFS_START_SERVER = true;
             LFS_JWT_SECRET = "#lfsjwtsecret#";
           })
@@ -761,36 +759,38 @@ in
           INSTALL_LOCK = true;
         };
 
-        service = mkIf cfg.captcha.enable (mkMerge [
-          {
-            ENABLE_CAPTCHA = true;
-            CAPTCHA_TYPE = cfg.captcha.type;
-            REQUIRE_CAPTCHA_FOR_LOGIN = cfg.captcha.requireForLogin;
-            REQUIRE_EXTERNAL_REGISTRATION_CAPTCHA = cfg.captcha.requireForExternalRegistration;
-          }
-          (mkIf (cfg.captcha.secretFile != null) {
-            "${captchaPrefix}_SECRET" = "#captchasecret#";
-          })
-          (mkIf (cfg.captcha.siteKey != null) {
-            "${captchaPrefix}_SITEKEY" = cfg.captcha.siteKey;
-          })
-          (mkIf (cfg.captcha.url != null) {
-            "${captchaPrefix}_URL" = cfg.captcha.url;
-          })
-        ]);
+        service = lib.mkIf cfg.captcha.enable (
+          lib.mkMerge [
+            {
+              ENABLE_CAPTCHA = true;
+              CAPTCHA_TYPE = cfg.captcha.type;
+              REQUIRE_CAPTCHA_FOR_LOGIN = cfg.captcha.requireForLogin;
+              REQUIRE_EXTERNAL_REGISTRATION_CAPTCHA = cfg.captcha.requireForExternalRegistration;
+            }
+            (lib.mkIf (cfg.captcha.secretFile != null) {
+              "${captchaPrefix}_SECRET" = "#captchasecret#";
+            })
+            (lib.mkIf (cfg.captcha.siteKey != null) {
+              "${captchaPrefix}_SITEKEY" = cfg.captcha.siteKey;
+            })
+            (lib.mkIf (cfg.captcha.url != null) {
+              "${captchaPrefix}_URL" = cfg.captcha.url;
+            })
+          ]
+        );
 
-        storage = mkMerge [
-          (mkIf (cfg.minioAccessKeyId != null) {
+        storage = lib.mkMerge [
+          (lib.mkIf (cfg.minioAccessKeyId != null) {
             MINIO_ACCESS_KEY_ID = "#minioaccesskeyid#";
           })
-          (mkIf (cfg.minioSecretAccessKey != null) {
+          (lib.mkIf (cfg.minioSecretAccessKey != null) {
             MINIO_SECRET_ACCESS_KEY = "#miniosecretaccesskey#";
           })
         ];
       };
 
-    services.postgresql = optionalAttrs (usePostgresql && cfg.database.createDatabase) {
-      enable = mkDefault true;
+    services.postgresql = lib.optionalAttrs (usePostgresql && cfg.database.createDatabase) {
+      enable = lib.mkDefault true;
 
       ensureDatabases = [ cfg.database.name ];
       ensureUsers = [
@@ -801,9 +801,9 @@ in
       ];
     };
 
-    services.mysql = optionalAttrs (useMysql && cfg.database.createDatabase) {
-      enable = mkDefault true;
-      package = mkDefault pkgs.mariadb;
+    services.mysql = lib.optionalAttrs (useMysql && cfg.database.createDatabase) {
+      enable = lib.mkDefault true;
+      package = lib.mkDefault pkgs.mariadb;
 
       ensureDatabases = [ cfg.database.name ];
       ensureUsers = [
@@ -943,11 +943,11 @@ in
       description = "gitea";
       after =
         [ "network.target" ]
-        ++ optional usePostgresql "postgresql.target"
-        ++ optional useMysql "mysql.service";
+        ++ lib.optional usePostgresql "postgresql.target"
+        ++ lib.optional useMysql "mysql.service";
       requires =
-        optional (cfg.database.createDatabase && usePostgresql) "postgresql.target"
-        ++ optional (cfg.database.createDatabase && useMysql) "mysql.service";
+        lib.optional (cfg.database.createDatabase && usePostgresql) "postgresql.target"
+        ++ lib.optional (cfg.database.createDatabase && useMysql) "mysql.service";
       wantedBy = [ "multi-user.target" ];
       path = [
         cfg.package
@@ -1120,7 +1120,7 @@ in
       };
     };
 
-    users.users = mkIf (cfg.user == "gitea") {
+    users.users = lib.mkIf (cfg.user == "gitea") {
       gitea = {
         description = "Gitea Service";
         home = cfg.stateDir;
@@ -1130,26 +1130,26 @@ in
       };
     };
 
-    users.groups = mkIf (cfg.group == "gitea") {
+    users.groups = lib.mkIf (cfg.group == "gitea") {
       gitea = {
         members = lib.optional cfg.configureNginx nginx.user;
       };
     };
 
     warnings =
-      optional (cfg.database.password != "")
+      lib.optional (cfg.database.password != "")
         "config.services.gitea.database.password will be stored as plaintext in the Nix store. Use database.passwordFile instead."
-      ++ optional (cfg.extraConfig != null) ''
+      ++ lib.optional (cfg.extraConfig != null) ''
         services.gitea.`extraConfig` is deprecated, please use services.gitea.`settings`.
       ''
-      ++ optional (lib.getName cfg.package == "forgejo") ''
+      ++ lib.optional (lib.getName cfg.package == "forgejo") ''
         Running forgejo via services.gitea.package is no longer supported.
         Please use services.forgejo instead.
         See https://nixos.org/manual/nixos/unstable/#module-forgejo for migration instructions.
       '';
 
     # Create database passwordFile default when password is configured.
-    services.gitea.database.passwordFile = mkDefault (
+    services.gitea.database.passwordFile = lib.mkDefault (
       toString (
         pkgs.writeTextFile {
           name = "gitea-database-password";
@@ -1158,7 +1158,7 @@ in
       )
     );
 
-    systemd.services.gitea-dump = mkIf cfg.dump.enable {
+    systemd.services.gitea-dump = lib.mkIf cfg.dump.enable {
       description = "gitea dump";
       after = [ "gitea.service" ];
       path = [ cfg.package ];
@@ -1175,12 +1175,12 @@ in
         User = cfg.user;
         ExecStart =
           "${exe} dump --type ${cfg.dump.type}"
-          + optionalString (cfg.dump.file != null) " --file ${cfg.dump.file}";
+          + lib.optionalString (cfg.dump.file != null) " --file ${cfg.dump.file}";
         WorkingDirectory = cfg.dump.backupDir;
       };
     };
 
-    systemd.timers.gitea-dump = mkIf cfg.dump.enable {
+    systemd.timers.gitea-dump = lib.mkIf cfg.dump.enable {
       description = "Update timer for gitea-dump";
       partOf = [ "gitea-dump.service" ];
       wantedBy = [ "timers.target" ];

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -34,8 +34,8 @@ let
     nameValuePair type (makeTest {
       name = "${giteaPackage.pname}-${type}";
       meta.maintainers = with maintainers; [
-        aanderse
-        kolaente
+        SuperSandro2000
+        techknowlogick
       ];
 
       nodes = {


### PR DESCRIPTION
###### Description of changes
Add nginx configuration.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
