### PR TITLE
quake3demo: fix binary paths in the wrapper

### DIFF
--- a/pkgs/games/quake3/wrapper/default.nix
+++ b/pkgs/games/quake3/wrapper/default.nix
@@ -20,11 +20,11 @@ in stdenv.mkDerivation {
     # We add Mesa to the end of $LD_LIBRARY_PATH to provide fallback
     # software rendering. GCC is needed so that libgcc_s.so can be found
     # when Mesa is used.
-    makeWrapper ${env}/ioquake3.* $out/bin/quake3 \
+    makeWrapper ${env}/bin/ioquake3.* $out/bin/quake3 \
       --suffix-each LD_LIBRARY_PATH ':' "${libPath}" \
       --add-flags "+set fs_basepath ${env} +set r_allowSoftwareGL 1"
 
-    makeWrapper ${env}/ioq3ded.* $out/bin/quake3-server \
+    makeWrapper ${env}/bin/ioq3ded.* $out/bin/quake3-server \
       --add-flags "+set fs_basepath ${env}"
   '';
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/209008 moved quake3 binaries to $out/bin. This broke wrappers as:

    $ NIXPKGS_ALLOW_UNFREE=1 nix build -f. quake3demo -L
    ...
    quake3-demo> Builder called die: Cannot wrap '/nix/store/khlq2wa0i7rab4vkzvk4pl54lyi6c36d-quake3-demo-1.11-6-ioquake3-unstable-2022-11-24/bin/quake3' because it is not an executable file

The change fixes wrapper to point to new locations.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
