### PR TITLE
gmic-qt: fix build with 3.2.1

### DIFF
--- a/pkgs/tools/graphics/gmic/default.nix
+++ b/pkgs/tools/graphics/gmic/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , fetchurl
 , cmake
 , ninja
@@ -14,6 +15,7 @@
 , libjpeg
 , libtiff
 , libpng
+, libX11
 , writeShellScript
 , common-updater-scripts
 , curl
@@ -37,6 +39,14 @@ stdenv.mkDerivation rec {
     hash = "sha256-oEH4GlSV+642TGSJJhV4yzydh1hAQZfzwaiPAZFNQtI=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "gmic-3.2.1-fix-system-gmic.patch";
+      url = "https://github.com/GreycLab/gmic/commit/1fc184b40b7c31e7b100722d32cb9f7c5a79c90f.patch";
+      hash = "sha256-xLlZ87QUiBrfioG7DNXf0HioxqOu6HX+57LW2FGdbLI=";
+    })
+  ];
+
   # TODO: build this from source
   # https://github.com/dtschump/gmic/blob/b36b2428db5926af5eea5454f822f369c2d9907e/src/Makefile#L675-L729
   gmic_stdlib = fetchurl {
@@ -58,6 +68,7 @@ stdenv.mkDerivation rec {
     libjpeg
     libtiff
     libpng
+    libX11
     opencv
     openexr
     graphicsmagick

--- a/pkgs/tools/graphics/gmic/default.nix
+++ b/pkgs/tools/graphics/gmic/default.nix
@@ -15,7 +15,6 @@
 , libjpeg
 , libtiff
 , libpng
-, libX11
 , writeShellScript
 , common-updater-scripts
 , curl
@@ -42,8 +41,8 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       name = "gmic-3.2.1-fix-system-gmic.patch";
-      url = "https://github.com/GreycLab/gmic/commit/1fc184b40b7c31e7b100722d32cb9f7c5a79c90f.patch";
-      hash = "sha256-xLlZ87QUiBrfioG7DNXf0HioxqOu6HX+57LW2FGdbLI=";
+      url = "https://github.com/GreycLab/gmic/commit/9db3f6a39d9ed67b4279654da88993a8057575ff.patch";
+      hash = "sha256-JznKCs56t6cJ4HLqlhMZjSOupEB8cdkn3j6RgZpcpzo=";
     })
   ];
 
@@ -68,7 +67,6 @@ stdenv.mkDerivation rec {
     libjpeg
     libtiff
     libpng
-    libX11
     opencv
     openexr
     graphicsmagick


### PR DESCRIPTION
###### Description of changes

Fixes currently broken gmic-qt v3.2.1

How the build was fixed:
* Fetch tarball instead since that is what upstream supports to build gmic-qt from
* Set `sourceRoot` within tarball
* Fetch patch from GreycLab/gmic#435 into gmic
* Fetch patch from c-koi/gmic-qt#175 into gmic-qt

Fixes #212563
Fixes #211721

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>6 packages built:</summary>
  <ul>
    <li>darktable</li>
    <li>gimp-with-plugins</li>
    <li>gimpPlugins.gmic</li>
    <li>gmic</li>
    <li>gmic-qt</li>
    <li>photoprism</li>
  </ul>
</details>