### PR TITLE
lib.lists: add `takeWhile` and `dropWhile`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -90,7 +90,7 @@ let
       concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range replicate partition zipListsWith zipLists
       reverseList listDfs toposort sort naturalSort compareLists take
-      drop sublist last init crossLists unique intersectLists
+      drop takeWhile dropWhile sublist last init crossLists unique intersectLists
       subtractLists mutuallyExclusive groupBy groupBy';
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
       intersperse concatStringsSep concatMapStringsSep

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -582,6 +582,45 @@ rec {
     # Input list
     list: sublist count (length list) list;
 
+  /* Return a list of all elements until a predicate matches an element.
+
+     Type: takeWhile :: (a -> Bool) -> [a] -> [a]
+
+     Example:
+       takeWhile (x: x < 3) [ 1 2 3 4 5 ]
+       => [ 1 2 ]
+       takeWhile (x: elem x ["a" "b"]) [ "a" "a" "b" "c" "a" ]
+       => [ "a" "a" "b" ]
+  */
+  takeWhile = pred: list: let
+    listWithIndices = imap0 (index: value: { inherit index value; }) list;
+    firstPredFailure = findFirst
+                         ({ index, value }: !(pred value))
+                         { index = length list; }
+                         listWithIndices;
+  in take firstPredFailure.index list;
+    # if list == [] || !(pred (head list))
+    #   then []
+    #   else [ (head list) ] ++ (takeWhile pred (tail list));
+
+  /* Return a list of all elements after a predicate matches an element.
+
+     Type: dropWhile :: (a -> Bool) -> [a] -> [a]
+
+     Example:
+       dropWhile (x: x < 3) [ 1 2 3 4 5 ]
+       => [ 3 4 5 ]
+       dropWhile (x: elem x ["a" "b"]) [ "a" "a" "b" "c" "a" ]
+       => [ "c" "a" ]
+  */
+  dropWhile = pred: list: let
+    listWithIndices = imap0 (index: value: { inherit index value; }) list;
+    firstPredFailure = findFirst
+                         ({ index, value }: !(pred value))
+                         { index = length list; }
+                         listWithIndices;
+  in drop firstPredFailure.index list;
+
   /* Return a list consisting of at most `count` elements of `list`,
      starting at index `start`.
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -466,6 +466,20 @@ runTests {
     ([ 1 2 3 ] == (take 4 [  1 2 3 ]))
   ];
 
+  testTakeWhile = testAllTrue [
+    ([ 1 2 ] == (takeWhile (x: x < 3) [ 1 2 3 4 5 ]))
+    ([ "a" "a" "b" ] == (takeWhile (x: elem x ["a" "b"]) [ "a" "a" "b" "c" "a" ]))
+    ([ 1 1 1 ] == (takeWhile (x: x < 3) [ 1 1 1 ]))
+    ([ ] == (takeWhile (x: x < 0) [ 1 1 1 ]))
+  ];
+
+  testDropWhile = testAllTrue [
+    ([ 3 4 5 ] == (dropWhile (x: x < 3) [ 1 2 3 4 5 ]))
+    ([ "c" "a" ] == (dropWhile (x: elem x ["a" "b"]) [ "a" "a" "b" "c" "a" ]))
+    ([ ] == (dropWhile (x: x < 3) [ 1 1 1 ]))
+    ([ 1 1 1 ] == (dropWhile (x: x < 0) [ 1 1 1 ]))
+  ];
+
   testFoldAttrs = {
     expr = foldAttrs (n: a: [n] ++ a) [] [
     { a = 2; b = 7; }


### PR DESCRIPTION
`takeWhile` and `dropWhile` are common functions for a functional language.

Although usually used for streams, they can be useful when working with normal lists.

`takeWhile` returns a list of all elements until a predicate matches an element.
`dropWhile` returns a list of all elements after a predicate matches an element.

###### Description of changes

- Added `takeWhile` and `dropWhile` to lib.lists.
- Added relevant tests to `lib/tests/misc.nix`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
