### PR TITLE
libgee: clean up

### DIFF
--- a/pkgs/development/libraries/libgee/default.nix
+++ b/pkgs/development/libraries/libgee/default.nix
@@ -1,27 +1,46 @@
-{ lib, stdenv, fetchurl, autoconf, vala, pkg-config, glib, gobject-introspection, gnome }:
+{ stdenv
+, lib
+, fetchurl
+, autoconf
+, vala
+, pkg-config
+, glib
+, gobject-introspection
+, gnome
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libgee";
   version = "0.20.6";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/libgee/${lib.versions.majorMinor finalAttrs.version}/libgee-${finalAttrs.version}.tar.xz";
     sha256 = "G/g09eENYMxhJNdO08HdONpkZ4f794ciILi0Bo5HbU0=";
   };
 
+  nativeBuildInputs = [
+    pkg-config
+    autoconf
+    vala
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    glib
+  ];
+
   doCheck = true;
 
-  nativeBuildInputs = [ pkg-config autoconf vala gobject-introspection ];
-  buildInputs = [ glib ];
-
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "${placeholder "dev"}/share/gir-1.0";
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "${placeholder "out"}/lib/girepository-1.0";
+  env = {
+    PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "${placeholder "dev"}/share/gir-1.0";
+    PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "${placeholder "out"}/lib/girepository-1.0";
+  };
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "libgee";
       versionPolicy = "odd-unstable";
     };
   };
@@ -33,4 +52,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     maintainers = teams.gnome.members;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

- format the expression (one dependency per line)
- re-order the expression
- use finalAttrs
- shove environment variables to env


I initially wanted to enable building docs but that just fails (both from tarball and git) and I could not be bothered to try to fix it when the build system will be eventually replaced.

```
make[2]: Entering directory '/build/libgee/doc'
/nix/store/rvb6yj6zw1vdil5w4hbm0nvc27r7shn1-vala-0.56.3/bin/valadoc -o gee-0.8/ --wiki ./ --force -b .. ../gee/*.vala
arraylist.vala:28.7-28.15: error: The symbol `Utils' could not be found
arraylist.vala:28.7-28.22: error: The namespace name `Gee.Utils.Assume' could not be found
linkedlist.vala:28.7-28.15: error: The symbol `Utils' could not be found
linkedlist.vala:28.7-28.22: error: The namespace name `Gee.Utils.Assume' could not be found
unrolledlinkedlist.vala:23.7-23.15: error: The symbol `Utils' could not be found
unrolledlinkedlist.vala:23.7-23.22: error: The namespace name `Gee.Utils.Assume' could not be found
Failed: 6 error(s), 0 warning(s)
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
