### PR TITLE
{matrix-synapse-tools.matrix-synapse-diskspace-janitor,nixos/matrix-synapse-diskspace-janitor}: init

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -356,6 +356,7 @@ in
       rstudio-server = 324;
       localtimed = 325;
       automatic-timezoned = 326;
+      synapse-diskspace-janitor = 400; # TODO: change to next sequential before merge!!!!!!!!!!!!!
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -667,6 +668,7 @@ in
       rstudio-server = 324;
       localtimed = 325;
       automatic-timezoned = 326;
+      synapse-diskspace-janitor = 400; # TODO: change to next sequential before merge!!!!!!!!!!!!!
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -568,6 +568,7 @@
   ./services/matrix/mx-puppet-discord.nix
   ./services/matrix/pantalaimon.nix
   ./services/matrix/synapse.nix
+  ./services/matrix/synapse-diskspace-janitor.nix
   ./services/misc/airsonic.nix
   ./services/misc/ananicy.nix
   ./services/misc/ankisyncd.nix

--- a/nixos/modules/services/matrix/synapse-diskspace-janitor.nix
+++ b/nixos/modules/services/matrix/synapse-diskspace-janitor.nix
@@ -70,7 +70,7 @@ in
         ''}
 
         ln -fs "${configFile}" config.json
-        rm frontend; ln -fs "${cfg.package.src}/frontend" frontend
+        rm frontend || ln -fs "${cfg.package.src}/frontend" frontend
         exec ${cfg.package}/bin/matrix-synapse-diskspace-janitor
       '';
 

--- a/nixos/modules/services/matrix/synapse-diskspace-janitor.nix
+++ b/nixos/modules/services/matrix/synapse-diskspace-janitor.nix
@@ -1,0 +1,110 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.matrix-synapse-diskspace-janitor;
+
+  format = pkgs.formats.json { };
+  configFile = format.generate "synapse-diskspace-janitor-config.json" cfg.settings;
+in
+{
+  meta.maintainers = with maintainers; [ ckie ];
+  options.services.matrix-synapse-diskspace-janitor = {
+    enable = mkEnableOption (lib.mdDoc "matrix-synapse-diskspace-janitor");
+    package = mkOption {
+      type = types.package;
+      default = pkgs.matrix-synapse-tools.matrix-synapse-diskspace-janitor;
+      defaultText = lib.literalExpression "pkgs.matrix-synapse-tools.matrix-synapse-diskspace-janitor";
+      description = lib.mdDoc "matrix-synapse-diskspace-janitor package to use";
+    };
+
+    adminTokenFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = lib.mdDoc ''
+        Path to a file containing the value of `MatrixAdminToken`. This should be used
+        to avoid exposing the `MatrixAdminToken` to the Nix store.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = format.type;
+      };
+      default = { };
+      description = lib.mdDoc ''
+        Generates the configuration file. Refer to
+        <https://git.cyberia.club/cyberia/matrix-synapse-diskspace-janitor#configuration-overview>
+        for details on supported values.
+      '';
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/matrix-synapse-diskspace-janitor";
+      description = lib.mdDoc ''
+        Data directory for matrix-synapse-diskspace-janitor.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # error: evaluation aborted with the following error message: 'Group name 'matrix-synapse-diskspace-janitor' is longer than 31 characters which is not allowed!'
+    users.users.synapse-diskspace-janitor = {
+      group = "matrix-synapse";
+      home = cfg.dataDir;
+      createHome = true;
+      uid = config.ids.uids.synapse-diskspace-janitor;
+    };
+
+    systemd.services.matrix-synapse-diskspace-janitor = {
+      description = "Matrix Synapse Disk Space Janitor";
+      documentation = [ "https://git.cyberia.club/cyberia/matrix-synapse-diskspace-janitor" ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      script = ''
+        ${lib.optionalString (cfg.adminTokenFile != null) ''
+          # Environment variables override the config file.
+          export JANITOR_MATRIXADMINTOKEN=$(cat "''${CREDENTIALS_DIRECTORY}/admin-token-file")
+        ''}
+
+        ln -fs "${configFile}" config.json
+        rm frontend; ln -fs "${cfg.package.src}/frontend" frontend
+        exec ${cfg.package}/bin/matrix-synapse-diskspace-janitor
+      '';
+
+      serviceConfig = {
+        LoadCredential = lib.mkIf (cfg.adminTokenFile != null) "admin-token-file:${cfg.adminTokenFile}";
+
+        StateDirectory = "matrix-synapse-diskspace-janitor";
+        WorkingDirectory = "/var/lib/matrix-synapse-diskspace-janitor";
+        # DynamicUser = true;
+        User = "synapse-diskspace-janitor";
+        Group = "matrix-synapse";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateUsers = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+        ];
+        Restart = "on-failure";
+        RestartSec = 10;
+        StartLimitBurst = 5;
+      };
+    };
+  };
+}

--- a/pkgs/servers/matrix-synapse/tools/default.nix
+++ b/pkgs/servers/matrix-synapse/tools/default.nix
@@ -2,5 +2,7 @@
 {
   rust-synapse-compress-state = callPackage ./rust-synapse-compress-state.nix { };
 
+  matrix-synapse-diskspace-janitor = callPackage ./matrix-synapse-diskspace-janitor.nix { };
+
   synadm = callPackage ./synadm.nix { };
 }

--- a/pkgs/servers/matrix-synapse/tools/matrix-synapse-diskspace-janitor.nix
+++ b/pkgs/servers/matrix-synapse/tools/matrix-synapse-diskspace-janitor.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitea }:
+
+buildGoModule rec {
+  pname = "matrix-synapse-diskspace-janitor";
+  version = "unstable-2023-01-16";
+
+  src = fetchFromGitea {
+    domain = "git.cyberia.club";
+    owner = "cyberia";
+    repo = "matrix-synapse-diskspace-janitor";
+    rev = "7c9297931104d31c4fc9740d32dfce7b8262a189";
+    sha256 = "sha256-rsSJsvBbz8yJ+AcSInUxGN660WUrHicslwv4NU+1M9I=";
+  };
+
+  vendorHash = "sha256-oxEzqqKU/pCbt9i6M4nirCjo6T9UZTiknoo9CigbO1I=";
+
+  # Note there is a systemd service included in the upstream repository, but it
+  # assumes too many things about the system environment to meaningfully include
+  # in this package.
+
+  meta = with lib; {
+    description = "A program designed to fix the disk-space consumption issues that matrix-synapse continues to suffer";
+    homepage = "https://git.cyberia.club/cyberia/matrix-synapse-diskspace-janitor";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ckie ];
+  };
+}


### PR DESCRIPTION
(2023-06-29: *This may now be redundant, as anecdotally disk space usage hasn't been as big of a problem for me and cyberia recently*)

###### Description of changes

I had no intention to work on this but the Matrix gods decided it'd be a great time to fill up my whole disk.. (albeit RELATIVELY slowly)

Might undraft one day but code reviews will be dismissed for now— anyone can take over if they want and finish this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
