### PR TITLE
tiny-cuda-nn,python3Packages.tiny-cuda-nn: init 1.6

### DIFF
--- a/pkgs/development/libraries/science/math/tiny-cuda-nn/default.nix
+++ b/pkgs/development/libraries/science/math/tiny-cuda-nn/default.nix
@@ -1,0 +1,152 @@
+{ cmake
+, cudaPackages
+, fetchFromGitHub
+, lib
+, ninja
+, pkgs
+, python3Packages ? { }
+, pythonSupport ? false
+, stdenv
+, symlinkJoin
+, which
+}:
+let
+  inherit (lib) lists strings;
+  inherit (cudaPackages) backendStdenv cudaFlags;
+
+  cuda-common-redist = with cudaPackages; [
+    libcublas # cublas_v2.h
+    libcusolver # cusolverDn.h
+    libcusparse # cusparse.h
+  ];
+
+  cuda-native-redist = symlinkJoin {
+    name = "cuda-redist";
+    paths = with cudaPackages; [
+      cuda_cudart # cuda_runtime.h
+      cuda_nvcc
+    ] ++ cuda-common-redist;
+  };
+
+  cuda-redist = symlinkJoin {
+    name = "cuda-redist";
+    paths = cuda-common-redist;
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  name = "tiny-cuda-nn";
+  version = "1.6";
+
+  format = strings.optionalString pythonSupport "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "NVlabs";
+    repo = finalAttrs.name;
+    rev = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-qW6Fk2GB71fvZSsfu+mykabSxEKvaikZ/pQQZUycOy0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    cuda-native-redist
+    ninja
+    which
+  ] ++ lists.optionals pythonSupport (with python3Packages; [
+    pip
+    setuptools
+    wheel
+  ]);
+
+  buildInputs = [
+    cuda-redist
+  ] ++ lib.optionals pythonSupport (
+    with python3Packages; [
+      pybind11
+      python
+    ]
+  );
+
+  propagatedBuildInputs = lib.optionals pythonSupport (
+    with python3Packages; [
+      torch
+    ]
+  );
+
+  # NOTE: We cannot use pythonImportsCheck for this module because it uses torch to immediately
+  #   initailize CUDA and GPU access is not allowed in the nix build environment.
+  # NOTE: There are no tests for the C++ library or the python bindings, so we just skip the check
+  #   phase -- we're not missing anything.
+  doCheck = false;
+
+  preConfigure = ''
+    export TCNN_CUDA_ARCHITECTURES=${
+      strings.concatStringsSep ";" (lists.map cudaFlags.dropDot cudaFlags.cudaCapabilities)
+    }
+    export CUDA_HOME=${cuda-native-redist}
+    export LIBRARY_PATH=${cuda-native-redist}/lib/stubs:$LIBRARY_PATH
+    export CC=${backendStdenv.cc}/bin/cc
+    export CXX=${backendStdenv.cc}/bin/c++
+  '';
+
+  # When building the python bindings, we cannot re-use the artifacts from the C++ build so we
+  # skip the CMake confurePhase and the buildPhase.
+  dontUseCmakeConfigure = pythonSupport;
+
+  # The configurePhase usually puts you in the build directory, so for the python bindings we
+  # need to change directories to the source directory.
+  configurePhase = strings.optionalString pythonSupport ''
+    runHook preConfigure
+    mkdir -p $NIX_BUILD_TOP/build
+    cd $NIX_BUILD_TOP/build
+    runHook postConfigure
+  '';
+
+  buildPhase = strings.optionalString pythonSupport ''
+    runHook preBuild
+    python -m pip wheel \
+      --no-build-isolation \
+      --no-clean \
+      --no-deps \
+      --no-index \
+      --verbose \
+      --wheel-dir $NIX_BUILD_TOP/build \
+      $NIX_BUILD_TOP/source/bindings/torch
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib
+  ''
+  # Installing the C++ library just requires copying the static library to the output directory
+  + strings.optionalString (!pythonSupport) ''
+    cp libtiny-cuda-nn.a $out/lib/
+  ''
+  # Installing the python bindings requires building the wheel and installing it
+  + strings.optionalString pythonSupport ''
+    python -m pip install \
+      --no-build-isolation \
+      --no-cache-dir \
+      --no-deps \
+      --no-index \
+      --no-warn-script-location \
+      --prefix="$out" \
+      --verbose \
+      ./*.whl
+  '' + ''
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit cudaPackages;
+  };
+
+  meta = with lib; {
+    description = "Lightning fast C++/CUDA neural network framework";
+    homepage = "https://github.com/NVlabs/tiny-cuda-nn";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ connorbaker ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3812,6 +3812,8 @@ with pkgs;
 
   tensorflow-lite = callPackage ../development/libraries/science/math/tensorflow-lite { };
 
+  tiny-cuda-nn = callPackage ../development/libraries/science/math/tiny-cuda-nn { };
+
   tezos-rust-libs = callPackage ../development/libraries/tezos-rust-libs { };
 
   behave = with python3Packages; toPythonApplication behave;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11694,6 +11694,12 @@ self: super: with self; {
 
   timm = callPackage ../development/python-modules/timm { };
 
+  tiny-cuda-nn = toPythonModule (pkgs.tiny-cuda-nn.override {
+    cudaPackages = self.torch.cudaPackages;
+    python3Packages = self;
+    pythonSupport = true;
+  });
+
   tinycss2 = callPackage ../development/python-modules/tinycss2 { };
 
   tinycss = callPackage ../development/python-modules/tinycss { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds `tiny-cuda-nn`, both as a C++ library (which I haven't tested because I don't know C++) and as a Python module (which I have tested -- see the end of this post for a flake to reproduce).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Here's a reproducer with a flake: https://github.com/ConnorBaker/tiny-cuda-nn.

You may need to change the `cudaCapabilities` in the flake to your card.

Functionality can be verified by running the sample from the devShell:

```bash
[connorbaker@fedora tiny-cuda-nn]$ python samples/mlp_learning_an_image_pytorch.py
================================================================
This script replicates the behavior of the native CUDA example  
mlp_learning_an_image.cu using tiny-cuda-nn's PyTorch extension.
================================================================
NetworkWithInputEncoding(n_input_dims=2, n_output_dims=1, seed=1337, dtype=torch.float16, hyperparams={'encoding': {'base_resolution': 16, 'hash': 'CoherentPrime', 'interpolation': 'Linear', 'log2_hashmap_size': 15, 'n_features_per_level': 2, 'n_levels': 16, 'otype': 'Grid', 'per_level_scale': 1.5, 'type': 'Hash'}, 'network': {'activation': 'ReLU', 'n_hidden_layers': 2, 'n_neurons': 64, 'otype': 'FullyFusedMLP', 'output_activation': 'None'}, 'otype': 'NetworkWithInputEncoding'})
/nix/store/rhkj4djr20zwqdfnp2ys23p90gif8dqy-python3-3.10.9-env/lib/python3.10/site-packages/torch/functional.py:504: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /tmp/nix-build-python3.10-torch-1.13.1.drv-0/source/aten/src/ATen/native/TensorShape.cpp:3190.)
  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]
Writing 'reference.jpg'... done.
Beginning optimization with 10000000 training steps.
/home/connorbaker/Documents/tiny-cuda-nn/samples/mlp_learning_an_image_pytorch.py:70: TracerWarning: torch.tensor results are registered as constants in the trace. You can safely ignore this warning if you use this function to create tensors out of constant variables that would be the same every time you call this function. In any other case, this might cause the trace to be incorrect.
  xs = xs * torch.tensor([shape[1], shape[0]], device=xs.device).float()
Step#0: loss=9.1796875 time=464315[µs]
Writing '0.jpg'... done.
Step#10: loss=0.229736328125 time=14935[µs]
Writing '10.jpg'... done.
Step#100: loss=0.01377105712890625 time=130469[µs]
Writing '100.jpg'... done.
Step#1000: loss=0.0027217864990234375 time=1239846[µs]
Writing '1000.jpg'... done.
```