### PR TITLE
gitea/forgejo: create static gzip and brotli files

### DIFF
--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -71,7 +71,7 @@ buildGoModule rec {
   '';
 
   passthru = {
-    data-compressed = runCommand "data-compressed" {
+    data-compressed = runCommand "forgejo-data-compressed" {
       nativeBuildInputs = [ brotli xorg.lndir ];
     } ''
       mkdir $out

--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -1,9 +1,11 @@
 { bash
+, brotli
 , buildGoModule
 , common-updater-scripts
 , coreutils
 , curl
 , fetchurl
+, forgejo
 , git
 , gzip
 , jq
@@ -15,6 +17,8 @@
 , pam
 , pamSupport ? true
 , sqliteSupport ? true
+, xorg
+, runCommand
 , stdenv
 , writeShellApplication
 }:
@@ -66,46 +70,60 @@ buildGoModule rec {
       --prefix PATH : ${lib.makeBinPath [ bash git gzip openssh ]}
   '';
 
-  passthru.tests = nixosTests.forgejo;
+  passthru = {
+    data-compressed = runCommand "data-compressed" {
+      nativeBuildInputs = [ brotli xorg.lndir ];
+    } ''
+      mkdir $out
+      lndir ${forgejo.data}/ $out/
 
-  passthru.updateScript = lib.getExe (writeShellApplication {
-    name = "update-forgejo";
-    runtimeInputs = [
-      common-updater-scripts
-      coreutils
-      curl
-      jq
-      nix
-    ];
-    text = ''
-      releases=$(curl "https://codeberg.org/api/v1/repos/forgejo/forgejo/releases?draft=false&pre-release=false&limit=1" \
-        --silent \
-        --header "accept: application/json")
-
-      stable=$(jq '.[0]
-        | .tag_name[1:] as $version
-        | ("forgejo-src-\($version).tar.gz") as $filename
-        | { $version, html_url } + (.assets | map(select(.name | startswith($filename)) | {(.name | split(".") | last): .browser_download_url}) | add)' \
-        <<< "$releases")
-
-      archive_url=$(jq -r .gz <<< "$stable")
-      checksum_url=$(jq -r .sha256 <<< "$stable")
-      release_url=$(jq -r .html_url <<< "$stable")
-      version=$(jq -r .version <<< "$stable")
-
-      if [[ "${version}" = "$version" ]]; then
-        echo "No new version found (already at $version)"
-        exit 0
-      fi
-
-      echo "Release: $release_url"
-
-      sha256=$(curl "$checksum_url" --silent | cut --delimiter " " --fields 1)
-      sri_hash=$(nix hash to-sri --type sha256 "$sha256")
-
-      update-source-version "${pname}" "$version" "$sri_hash" "$archive_url"
+      # Create static gzip and brotli files
+      find -L $out -type f -regextype posix-extended -iregex '.*\.(css|html|js|svg|ttf|txt)' \
+        -exec gzip --best --keep --force {} ';' \
+        -exec brotli --best --keep --no-copy-stat {} ';'
     '';
-  });
+
+    tests = nixosTests.forgejo;
+
+    updateScript = lib.getExe (writeShellApplication {
+      name = "update-forgejo";
+      runtimeInputs = [
+        common-updater-scripts
+        coreutils
+        curl
+        jq
+        nix
+      ];
+      text = ''
+        releases=$(curl "https://codeberg.org/api/v1/repos/forgejo/forgejo/releases?draft=false&pre-release=false&limit=1" \
+          --silent \
+          --header "accept: application/json")
+
+        stable=$(jq '.[0]
+          | .tag_name[1:] as $version
+          | ("forgejo-src-\($version).tar.gz") as $filename
+          | { $version, html_url } + (.assets | map(select(.name | startswith($filename)) | {(.name | split(".") | last): .browser_download_url}) | add)' \
+          <<< "$releases")
+
+        archive_url=$(jq -r .gz <<< "$stable")
+        checksum_url=$(jq -r .sha256 <<< "$stable")
+        release_url=$(jq -r .html_url <<< "$stable")
+        version=$(jq -r .version <<< "$stable")
+
+        if [[ "${version}" = "$version" ]]; then
+          echo "No new version found (already at $version)"
+          exit 0
+        fi
+
+        echo "Release: $release_url"
+
+        sha256=$(curl "$checksum_url" --silent | cut --delimiter " " --fields 1)
+        sri_hash=$(nix hash to-sri --type sha256 "$sha256")
+
+        update-source-version "${pname}" "$version" "$sri_hash" "$archive_url"
+      '';
+    });
+  };
 
   meta = with lib; {
     description = "A self-hosted lightweight software forge";

--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -66,7 +66,7 @@ buildGoModule rec {
   '';
 
   passthru = {
-    data-compressed = runCommand "data-compressed" {
+    data-compressed = runCommand "gitea-data-compressed" {
       nativeBuildInputs = [ brotli xorg.lndir ];
     } ''
       mkdir $out

--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -5,11 +5,15 @@
 , makeWrapper
 , git
 , bash
+, gitea
 , gzip
 , openssh
 , pam
 , sqliteSupport ? true
 , pamSupport ? true
+, runCommand
+, brotli
+, xorg
 , nixosTests
 }:
 
@@ -61,7 +65,21 @@ buildGoModule rec {
       --prefix PATH : ${lib.makeBinPath [ bash git gzip openssh ]}
   '';
 
-  passthru.tests = nixosTests.gitea;
+  passthru = {
+    data-compressed = runCommand "data-compressed" {
+      nativeBuildInputs = [ brotli xorg.lndir ];
+    } ''
+      mkdir $out
+      lndir ${gitea.data}/ $out/
+
+      # Create static gzip and brotli files
+      find -L $out -type f -regextype posix-extended -iregex '.*\.(css|html|js|svg|ttf|txt)' \
+        -exec gzip --best --keep --force {} ';' \
+        -exec brotli --best --keep --no-copy-stat {} ';'
+    '';
+
+    tests = nixosTests.gitea;
+  };
 
   meta = with lib; {
     description = "Git with a cup of tea";


### PR DESCRIPTION
###### Description of changes
Create static gzip and brotli files.
Recommended for use with parameters `services.nginx.recommendedGzipSettings` and `services.nginx.recommendedBrotliSettings`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
