### PR TITLE
quickmu: fix for spice-client-glib-usb-acl-helper

### DIFF
--- a/pkgs/development/quickemu/default.nix
+++ b/pkgs/development/quickemu/default.nix
@@ -39,7 +39,6 @@ let
     util-linux
     unzip
     socat
-    spice-gtk
     swtpm
     wget
     xdg-user-dirs
@@ -75,8 +74,12 @@ stdenv.mkDerivation rec {
 
     install -Dm755 -t "$out/bin" macrecovery quickemu quickget windowskey
 
+    # spice-gtk needs to be put in suffix so that when virtualisation.spiceUSBRedirection
+    # is enabled, the wrapped spice-client-glib-usb-acl-helper is used
     for f in macrecovery quickget quickemu windowskey; do
-      wrapProgram $out/bin/$f --prefix PATH : "${lib.makeBinPath runtimePaths}"
+      wrapProgram $out/bin/$f \
+        --prefix PATH : "${lib.makeBinPath runtimePaths}" \
+        --suffix PATH : "${lib.makeBinPath [ spice-gtk ]}"
     done
 
     runHook postInstall


### PR DESCRIPTION
###### Description of changes
spice-client-glib-usb-acl-helper in spice-gtk needs to be wrapped. When it's added to prefix the wrapper is not used. So put it in suffix instead.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
