### PR TITLE
ubports-click: init at 22-02-2023

### DIFF
--- a/pkgs/development/tools/click/dbus-test-runner.patch
+++ b/pkgs/development/tools/click/dbus-test-runner.patch
@@ -1,0 +1,23 @@
+diff --git a/click_package/Makefile.am b/click_package/Makefile.am
+index 4981d74..9df9e79 100644
+--- a/click_package/Makefile.am
++++ b/click_package/Makefile.am
+@@ -1,5 +1,3 @@
+-SUBDIRS = tests
+-
+ noinst_SCRIPTS = paths.py
+ CLEANFILES = $(noinst_SCRIPTS)
+ 
+diff --git a/configure.ac b/configure.ac
+index 8f4dc9e..adbd366 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -52,8 +52,6 @@ PKG_CHECK_MODULES([SERVICE], [
+ AC_SUBST([SERVICE_CFLAGS])
+ AC_SUBST([SERVICE_LIBS])
+ 
+-AC_CHECK_PROG(DBUS_TEST_RUNNER_CHECK,dbus-test-runner,yes)
+-AS_IF([test "${DBUS_TEST_RUNNER_CHECK}" != "yes"], [AC_MSG_ERROR([dbus-test-runner not found])])
+ AC_CHECK_PROG(GDBUS_CHECK,gdbus,yes)
+ AS_IF([test "${GDBUS_CHECK}" != "yes"], [AC_MSG_ERROR([gdbus (glib) not found])])
+ 

--- a/pkgs/development/tools/click/default.nix
+++ b/pkgs/development/tools/click/default.nix
@@ -1,0 +1,86 @@
+{ lib
+, fetchFromGitLab
+, buildPythonApplication
+, autoreconfHook
+, debian
+, perl
+, vala
+, pkg-config
+, libgee
+, json-glib
+, properties-cpp
+, gobject-introspection
+, getopt
+, setuptools
+, pygobject3
+, wrapGAppsHook
+}:
+
+buildPythonApplication {
+  pname = "click";
+  version = "unstable-2023-02-22";
+  format = "other";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/click";
+    rev = "aaf2735e8e6cbeaf2e429c70136733513a81718a";
+    sha256 = "sha256-pNu995/w3tbz15QQVdVYBnWnAoZmqWj1DN/5PZZ0iZw=";
+  };
+
+  configureFlags = [
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+    "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user"
+  ];
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : "$out/lib"
+    )
+  '';
+
+  preConfigure = ''
+    export click_cv_perl_vendorlib=$out/${perl.libPrefix}
+    export PYTHON_INSTALL_FLAGS="--prefix=$out"
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    perl
+    pkg-config
+    gobject-introspection
+    vala
+    getopt
+    wrapGAppsHook
+  ];
+
+  # Tests were omitted for time constraint reasons
+  doCheck = false;
+
+  enableParallelBuilding = true;
+
+  patches = [
+    # dbus-test-runner not packaged yet, otherwise build-time dependency even when not running tests
+    ./dbus-test-runner.patch
+  ];
+
+  buildInputs = [
+    libgee
+    json-glib
+    properties-cpp
+  ];
+
+  propagatedBuildInputs = [
+    debian
+    pygobject3
+    setuptools
+  ];
+
+  meta = {
+    description = "A tool to build click packages. Mainly used for Ubuntu Touch.";
+    homepage = "https://gitlab.com/ubports/development/core/click";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ilyakooo0 OPNA2608 ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16121,6 +16121,8 @@ with pkgs;
 
   bupc = callPackage ../development/compilers/bupc { };
 
+  ubports-click = python3Packages.callPackage ../development/tools/click { };
+
   uasm = callPackage ../development/compilers/uasm { };
 
   urn = callPackage ../development/compilers/urn { };


### PR DESCRIPTION
###### Description of changes

Click is a tool to build click packages. It is mainly used for Ubuntu Touch today.

I plan to build the infrastructure for building click packages with nix. Having `click` be in nixpkgs would be very useful.

I named the package `ubport-click` since `click` was already taken and ubports is the initiative responsible for maintaining it today: https://docs.ubports.com/en/latest/appdev/platform/click.html  

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).