### PR TITLE
powerdns, pdns-recursor: find config in /etc by default

### DIFF
--- a/nixos/modules/services/networking/pdns-recursor.nix
+++ b/nixos/modules/services/networking/pdns-recursor.nix
@@ -159,6 +159,8 @@ in {
 
   config = mkIf cfg.enable {
 
+    environment.etc."powerdns-recursor".source = configDir;
+
     services.pdns-recursor.settings = mkDefaultAttrs {
       local-address = cfg.dns.address;
       local-port    = cfg.dns.port;

--- a/nixos/modules/services/networking/pdns-recursor.nix
+++ b/nixos/modules/services/networking/pdns-recursor.nix
@@ -159,7 +159,7 @@ in {
 
   config = mkIf cfg.enable {
 
-    environment.etc."powerdns-recursor".source = configDir;
+    environment.etc."pdns-recursor".source = configDir;
 
     services.pdns-recursor.settings = mkDefaultAttrs {
       local-address = cfg.dns.address;

--- a/nixos/modules/services/networking/powerdns.nix
+++ b/nixos/modules/services/networking/powerdns.nix
@@ -38,7 +38,7 @@ in {
 
   config = mkIf cfg.enable {
 
-    environment.etc.powerdns.source = finalConfigDir;
+    environment.etc.pdns.source = finalConfigDir;
 
     systemd.packages = [ pkgs.pdns ];
 

--- a/nixos/modules/services/networking/powerdns.nix
+++ b/nixos/modules/services/networking/powerdns.nix
@@ -38,6 +38,8 @@ in {
 
   config = mkIf cfg.enable {
 
+    environment.etc.powerdns.source = finalConfigDir;
+
     systemd.packages = [ pkgs.pdns ];
 
     systemd.services.pdns = {

--- a/nixos/tests/powerdns.nix
+++ b/nixos/tests/powerdns.nix
@@ -28,8 +28,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
   };
 
   testScript = ''
-    import re
-
     with subtest("PowerDNS database exists"):
         server.wait_for_unit("mysql")
         server.succeed("echo 'SHOW DATABASES;' | sudo -u pdns mysql -u pdns >&2")
@@ -46,11 +44,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
 
     with subtest("Adding an example zone works"):
         # Extract configuration file needed by pdnsutil
-        unit = server.succeed("systemctl cat pdns")
-        match = re.search("(--config-dir=[^ ]+)", unit)
-        assert(match is not None)
-        conf = match.group(1)
-        pdnsutil = "sudo -u pdns pdnsutil " + conf
+        pdnsutil = "sudo -u pdns pdnsutil "
         server.succeed(f"{pdnsutil} create-zone example.com ns1.example.com")
         server.succeed(f"{pdnsutil} add-record  example.com ns1 A 192.168.1.2")
 

--- a/pkgs/servers/dns/pdns-recursor/default.nix
+++ b/pkgs/servers/dns/pdns-recursor/default.nix
@@ -21,10 +21,10 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-reproducible"
     "--enable-systemd"
-    "sysconfdir=/etc/powerdns-recursor"
+    "sysconfdir=/etc/pdns-recursor"
   ];
 
-  installFlags = [ "sysconfdir=$(out)/etc/powerdns-recursor" ];
+  installFlags = [ "sysconfdir=$(out)/etc/pdns-recursor" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/servers/dns/pdns-recursor/default.nix
+++ b/pkgs/servers/dns/pdns-recursor/default.nix
@@ -21,7 +21,10 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-reproducible"
     "--enable-systemd"
+    "sysconfdir=/etc/powerdns-recursor"
   ];
+
+  installFlags = [ "sysconfdir=$(out)/etc/powerdns-recursor" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/servers/dns/pdns/default.nix
+++ b/pkgs/servers/dns/pdns/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-libsodium"
     "--with-sqlite3"
     "--with-libcrypto=${openssl.dev}"
-    "sysconfdir=/etc/powerdns"
+    "sysconfdir=/etc/pdns"
   ];
 
   # nix destroy with-modules arguments, when using configureFlags
@@ -81,9 +81,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # We want the various utilities to look for the powerdns config in
-  # /etc/powerdns, but to actually install the sample config file in
+  # /etc/pdns, but to actually install the sample config file in
   # $out
-  installFlags = [ "sysconfdir=$(out)/etc/powerdns" ];
+  installFlags = [ "sysconfdir=$(out)/etc/pdns" ];
 
   enableParallelBuilding = true;
   doCheck = true;

--- a/pkgs/servers/dns/pdns/default.nix
+++ b/pkgs/servers/dns/pdns/default.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-libsodium"
     "--with-sqlite3"
     "--with-libcrypto=${openssl.dev}"
+    "sysconfdir=/etc/powerdns"
   ];
 
   # nix destroy with-modules arguments, when using configureFlags
@@ -78,6 +79,11 @@ stdenv.mkDerivation (finalAttrs: {
       "--with-dynmodules=bind geoip gmysql godbc gpgsql gsqlite3 ldap lmdb lua2 pipe remote tinydns"
     )
   '';
+
+  # We want the various utilities to look for the powerdns config in
+  # /etc/powerdns, but to actually install the sample config file in
+  # $out
+  installFlags = [ "sysconfdir=$(out)/etc/powerdns" ];
 
   enableParallelBuilding = true;
   doCheck = true;


### PR DESCRIPTION
###### Description of changes

This makes the powerdns and pdns-recursor services find their config in /etc by default.

The prior configuration would look in the nix store for the config; this was never useful, as the configuration would need to be built with the server package to even exist. Further, this resulted in admins of systems running either service needing to run the administration tools (pdns_control or rec_control) with an explicit config path, which was itself in the nix store, under an unpredictable (from the admin's perspective) path. 

With these changes, the packages look for their configuration in /etc by default, and the associated nixos modules create a symlink from /etc/powerdns (or /etc/powerdns-recursor) to the actual running configuration, which allows admins to simply use pdns_control with no flags to control the running service.

No release note was created, as I'm not sure whether this is considered a "significant" change; the complete uselessness of the prior defaults mean that there cannot have been any users who depend on that behaviour.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
