### PR TITLE
spotify-player: make build options configurable

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16234,6 +16234,12 @@
     github = "XYenon";
     githubId = 20698483;
   };
+  xyven1 = {
+    name = "Xyven";
+    email = "maritimus987@gmail.com";
+    github = "xyven1";
+    githubId = 35360746;
+  };
   xzfc = {
     email = "xzfcpw@gmail.com";
     github = "xzfc";

--- a/pkgs/applications/audio/spotify-player/default.nix
+++ b/pkgs/applications/audio/spotify-player/default.nix
@@ -7,6 +7,15 @@
 , alsa-lib
 , dbus
 , fontconfig
+
+# build options
+, withStreaming ? true
+, withAudioBackend ? "rodio"
+, withMediaControl ? true
+, withLyrics ? false
+, withImage ? false
+, withNotify ? false
+, withSixel ? false
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -36,18 +45,20 @@ rustPlatform.buildRustPackage rec {
 
   buildNoDefaultFeatures = true;
 
-  buildFeatures = [
-    "rodio-backend"
-    "media-control"
-    "image"
-    "lyric-finder"
-  ];
+  buildFeatures = [ ]
+    ++ lib.optionals withStreaming [ "streaming" ]
+    ++ lib.optionals (withAudioBackend != "") [ "${withAudioBackend}-backend" ]
+    ++ lib.optionals withMediaControl [ "media-control" ]
+    ++ lib.optionals withLyrics [ "lyric-finder" ]
+    ++ lib.optionals withImage [ "image" ]
+    ++ lib.optionals withNotify [ "notify" ]
+    ++ lib.optionals withSixel [ "sixel" ];
 
   meta = with lib; {
-    description = "A command driven spotify player";
+    description = "A fast, easy to use, and configurable terminal music player";
     homepage = "https://github.com/aome510/spotify-player";
     mainProgram = "spotify_player";
     license = licenses.mit;
-    maintainers = with maintainers; [ dit7ya ];
+    maintainers = with maintainers; [ dit7ya Xyven1 ];
   };
 }


### PR DESCRIPTION
###### Description of changes

All the cargo build options are surfaced as configurable options in the package.

The package description was also updated as spotify-player is clearly not command driven anymore, it is a TUI. The new description is pulled [directly form the homepage README](https://github.com/aome510/spotify-player#introduction).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
