### PR TITLE
python310Packages.nestedtext: 1.2 -> 3.5 

### DIFF
--- a/pkgs/development/python-modules/nestedtext/default.nix
+++ b/pkgs/development/python-modules/nestedtext/default.nix
@@ -2,17 +2,20 @@
 , buildPythonPackage
 , docopt
 , fetchFromGitHub
+, flitBuildHook
+, hypothesis
 , inform
-, natsort
+, nestedtext
 , pytestCheckHook
 , pythonOlder
+, quantiphy
 , voluptuous
 }:
 
 buildPythonPackage rec {
   pname = "nestedtext";
-  version = "1.2";
-  format = "setuptools";
+  version = "3.5";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
@@ -20,24 +23,45 @@ buildPythonPackage rec {
     owner = "KenKundert";
     repo = "nestedtext";
     rev = "refs/tags/v${version}";
-    fetchSubmodules = true;
-    sha256 = "1dwks5apghg29aj90nc4qm0chk195jh881297zr1wk7mqd2n159y";
+    hash = "sha256-RGCcrGsDkBhThuUZd2LuuyXG9r1S7iOA75HYRxkwUrU=";
   };
 
-  propagatedBuildInputs = [ 
+  nativeBuildInputs = [
+    flitBuildHook
+  ];
+
+  propagatedBuildInputs = [
     inform
   ];
 
   nativeCheckInputs = [
     docopt
-    natsort
+    hypothesis
+    quantiphy
     pytestCheckHook
     voluptuous
   ];
 
+  # Tests depend on quantiphy. To avoid infinite recursion, tests are only
+  # enabled when building passthru.tests.
+  doCheck = false;
+
   pytestFlagsArray = [
     # Avoids an ImportMismatchError.
     "--ignore=build"
+  ];
+
+  disabledTestPaths = [
+    # Examples are prefixed with test_
+    "examples/"
+  ];
+
+  passthru.tests = {
+    runTests = nestedtext.overrideAttrs (_: { doCheck = true; });
+  };
+
+  pythonImportsCheck = [
+    "nestedtext"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/nestedtext/default.nix
+++ b/pkgs/development/python-modules/nestedtext/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage rec {
       non-programmers.
     '';
     homepage = "https://nestedtext.org";
+    changelog = "https://github.com/KenKundert/nestedtext/blob/v${version}/doc/releases.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ jeremyschlatter ];
   };

--- a/pkgs/development/python-modules/nestedtext/default.nix
+++ b/pkgs/development/python-modules/nestedtext/default.nix
@@ -1,8 +1,10 @@
-{ lib, buildPythonPackage, fetchFromGitHub
-, inform
-, pytestCheckHook
+{ lib
+, buildPythonPackage
 , docopt
+, fetchFromGitHub
+, inform
 , natsort
+, pytestCheckHook
 , voluptuous
 }:
 
@@ -13,15 +15,26 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "KenKundert";
     repo = "nestedtext";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     fetchSubmodules = true;
     sha256 = "1dwks5apghg29aj90nc4qm0chk195jh881297zr1wk7mqd2n159y";
   };
 
-  propagatedBuildInputs = [ inform ];
+  propagatedBuildInputs = [ 
+    inform
+  ];
 
-  nativeCheckInputs = [ pytestCheckHook docopt natsort voluptuous ];
-  pytestFlagsArray = [ "--ignore=build" ]; # Avoids an ImportMismatchError.
+  nativeCheckInputs = [
+    docopt
+    natsort
+    pytestCheckHook
+    voluptuous
+  ];
+
+  pytestFlagsArray = [
+    # Avoids an ImportMismatchError.
+    "--ignore=build"
+  ];
 
   meta = with lib; {
     description = "A human friendly data format";

--- a/pkgs/development/python-modules/nestedtext/default.nix
+++ b/pkgs/development/python-modules/nestedtext/default.nix
@@ -5,12 +5,16 @@
 , inform
 , natsort
 , pytestCheckHook
+, pythonOlder
 , voluptuous
 }:
 
 buildPythonPackage rec {
   pname = "nestedtext";
   version = "1.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "KenKundert";

--- a/pkgs/development/python-modules/parametrize-from-file/default.nix
+++ b/pkgs/development/python-modules/parametrize-from-file/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit version;
     pname = "parametrize_from_file";
-    sha256 = "1c91j869n2vplvhawxc1sv8km8l53bhlxhhms43fyjsqvy351v5j";
+    hash = "sha256-suxQht9YS+8G0RXCTuEahaI60daBda7gpncLmwySIbE=";
   };
 
   patches = [
@@ -54,7 +54,14 @@ buildPythonPackage rec {
     toml
   ];
 
-  pythonImportsCheck = [ "parametrize_from_file" ];
+  pythonImportsCheck = [
+    "parametrize_from_file"
+  ];
+
+  disabledTests = [
+    # https://github.com/kalekundert/parametrize_from_file/issues/19
+    "test_load_suite_params_err"
+  ];
 
   meta = with lib; {
     description = "Read unit test parameters from config files";


### PR DESCRIPTION
Changelog: https://github.com/KenKundert/nestedtext/blob/v3.5/doc/releases.rst

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
