### PR TITLE
fragments: 2.0.2 -> 2.1, mark as broken

### DIFF
--- a/pkgs/applications/networking/p2p/fragments/default.nix
+++ b/pkgs/applications/networking/p2p/fragments/default.nix
@@ -31,14 +31,14 @@ let
   });
 in stdenv.mkDerivation rec {
   pname = "fragments";
-  version = "2.0.2";
+  version = "2.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "Fragments";
     rev = version;
-    sha256 = "sha256-CMa1yka0kOxMhxSuazlJxTk4fzxuuwKYLBpEMwHbBUE=";
+    sha256 = "sha256-/KtUcj41s9WeHzIgGWhYQv6oD/Df7WOnJAPuS6yGLHk=";
   };
 
   postPatch = ''
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-/rFZcbpITYkpSCEZp9XH253u90RGmuVLEBGIRNBgI/o=";
+    hash = "sha256-CMXEArSufRNb6Osk1hlk8AwcMW76AhaitEShf1QY938=";
   };
 
   nativeBuildInputs = [
@@ -87,5 +87,6 @@ in stdenv.mkDerivation rec {
     maintainers = with maintainers; [ emilytrau ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
+    broken = true;
   };
 }


### PR DESCRIPTION
**Note**: package is broken. Crashes with:

```
thread 'main' panicked at 'Failed to retrieve template child. Please check that it has been bound and has a #[template_child] attribute.', /build/fragments-2.1-vendor.tar.gz/gtk4/src/subclass/widget.rs:1305:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

###### Description of changes
Update fragments to [2.1](https://gitlab.gnome.org/World/Fragments/-/releases/2.1) and mark as broken due to it not launching. Closes #217170

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
