### PR TITLE
texlive.combine: move dependencies to attribute tlDeps, resolve them …

### DIFF
--- a/doc/languages-frameworks/texlive.section.md
+++ b/doc/languages-frameworks/texlive.section.md
@@ -40,17 +40,24 @@ Since release 15.09 there is a new TeX Live packaging that lives entirely under 
 
 ## Custom packages {#sec-language-texlive-custom-packages}
 
+You may find that you need to use an external TeX package. A derivation for such package has to provide the contents of the "texmf" directory in its output and provide the appropriate `tlType` attribute (one of `"run"`, `"bin"`, `"doc"`, `"source"`). Dependencies on other TeX packages can be listed in the attribute `tlDeps`.
 
-You may find that you need to use an external TeX package. A derivation for such package has to provide contents of the "texmf" directory in its output and provide the `tlType` attribute. Here is a (very verbose) example:
+Such derivation must then be listed in the attribute `pkgs` of an attribute set passed to `texlive.combine`, for instance by passing `extraPkgs = { pkgs = [ custom_package ]; };`. Within Nixpkgs, `pkgs` should be part of the derivation itself, allowing users to call `texlive.combine { inherit (texlive) scheme-small; inherit some_tex_package; }`.
+
+Here is a (very verbose) example where the attribute `pkgs` is attached to the derivation itself, which requires creating a fixed point. See also the packages `auctex`, `eukleides`, `mftrace` for more examples.
 
 ```nix
 with import <nixpkgs> {};
 
 let
-  foiltex_run = stdenvNoCC.mkDerivation {
+  foiltex = stdenvNoCC.mkDerivation (finalAttrs: {
     pname = "latex-foiltex";
     version = "2.1.4b";
-    passthru.tlType = "run";
+    passthru = {
+      pkgs = [ finalAttrs.finalPackage ];
+      tlDeps = with texlive; [ latex ];
+      tlType = "run";
+    };
 
     srcs = [
       (fetchurl {
@@ -102,8 +109,7 @@ let
       maintainers = with maintainers; [ veprbl ];
       platforms = platforms.all;
     };
-  };
-  foiltex = { pkgs = [ foiltex_run ]; };
+  });
 
   latex_with_foiltex = texlive.combine {
     inherit (texlive) scheme-small;

--- a/pkgs/applications/misc/auto-multiple-choice/default.nix
+++ b/pkgs/applications/misc/auto-multiple-choice/default.nix
@@ -23,14 +23,13 @@
 , poppler
 , auto-multiple-choice
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: rec {
   pname = "auto-multiple-choice";
   version = "1.5.2";
   src = fetchurl {
     url = "https://download.auto-multiple-choice.net/${pname}_${version}_precomp.tar.gz";
     sha256 = "sha256-AjonJOooSe53Fww3QU6Dft95ojNqWrTuPul3nkIbctM=";
   };
-  tlType = "run";
 
   # There's only the Makefile
   dontConfigure = true;
@@ -137,6 +136,11 @@ stdenv.mkDerivation rec {
     XMLWriter
   ]);
 
+  passthru = {
+    tlType = "run";
+    pkgs = [ finalAttrs.finalPackage ];
+  };
+
   meta = with lib; {
     description = "Create and manage multiple choice questionnaires with automated marking.";
     longDescription = ''
@@ -156,10 +160,7 @@ stdenv.mkDerivation rec {
         auto-multiple-choice
         (texlive.combine {
           inherit (pkgs.texlive) scheme-full;
-          extra =
-            {
-              pkgs = [ auto-multiple-choice ];
-            };
+          inherit auto-multiple-choice;
         })
       ];
       </screen>
@@ -172,4 +173,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.thblt ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/applications/science/math/eukleides/default.nix
+++ b/pkgs/applications/science/math/eukleides/default.nix
@@ -49,10 +49,12 @@ stdenv.mkDerivation (finalAttrs: rec {
 
   outputs = [ "out" "doc" "tex" ];
 
-  passthru.tlType = "run";
-  passthru.pkgs = [ finalAttrs.finalPackage.tex ]
+  passthru = {
+    tlType = "run";
     # packages needed by euktoeps, euktopdf and eukleides.sty
-    ++ (with texlive; collection-pstricks.pkgs ++ epstopdf.pkgs ++ iftex.pkgs ++ moreverb.pkgs);
+    tlDeps = with texlive; [ collection-pstricks epstopdf iftex moreverb ];
+    pkgs = [ finalAttrs.finalPackage.tex ];
+  };
 
   meta = {
     description = "Geometry Drawing Language";

--- a/pkgs/applications/science/math/eukleides/default.nix
+++ b/pkgs/applications/science/math/eukleides/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, bison, flex, makeWrapper, texinfo4, getopt, readline, texlive }:
 
-lib.fix (eukleides: stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: rec {
   pname = "eukleides";
   version = "1.5.4";
 
@@ -50,7 +50,7 @@ lib.fix (eukleides: stdenv.mkDerivation rec {
   outputs = [ "out" "doc" "tex" ];
 
   passthru.tlType = "run";
-  passthru.pkgs = [ eukleides.tex ]
+  passthru.pkgs = [ finalAttrs.finalPackage.tex ]
     # packages needed by euktoeps, euktopdf and eukleides.sty
     ++ (with texlive; collection-pstricks.pkgs ++ epstopdf.pkgs ++ iftex.pkgs ++ moreverb.pkgs);
 

--- a/pkgs/development/tools/literate-programming/noweb/default.nix
+++ b/pkgs/development/tools/literate-programming/noweb/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, nawk, groff, icon-lang, useIcon ? true }:
 
-lib.fix (noweb: stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: rec {
   pname = "noweb";
   version = "2.12";
 
@@ -70,8 +70,10 @@ lib.fix (noweb: stdenv.mkDerivation rec {
 
   outputs = [ "out" "tex" ];
 
-  tlType = "run";
-  passthru.pkgs = [ noweb.tex ];
+  passthru = {
+    tlType = "run";
+    pkgs = [ finalAttrs.finalPackage.tex ];
+  };
 
   meta = with lib; {
     description = "A simple, extensible literate-programming tool";

--- a/pkgs/misc/sagetex/default.nix
+++ b/pkgs/misc/sagetex/default.nix
@@ -4,10 +4,9 @@
 , texlive
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: rec {
   pname = "sagetex";
   version = "3.6.1";
-  passthru.tlType = "run";
 
   src = fetchFromGitHub {
     owner = "sagemath";
@@ -30,6 +29,11 @@ stdenv.mkDerivation rec {
     cp -va *.sty *.cfg *.def "$path/"
   '';
 
+  passthru = {
+    tlType = "run";
+    pkgs = [ finalAttrs.finalPackage ];
+  };
+
   meta = with lib; {
     description = "Embed code, results of computations, and plots from Sage into LaTeX documents";
     homepage = "https://github.com/sagemath/sagetex";
@@ -37,4 +41,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ alexnortung ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/tools/typesetting/tex/mftrace/default.nix
+++ b/pkgs/tools/typesetting/tex/mftrace/default.nix
@@ -44,9 +44,11 @@ stdenv.mkDerivation (finalAttrs: rec {
 
   # experimental texlive.combine support
   # (note that only the bin/ folder will be combined into texlive)
-  passthru.tlType = "bin";
-  passthru.pkgs = [ finalAttrs.finalPackage ] ++
-    (with texlive; kpathsea.pkgs ++ t1utils.pkgs ++ metafont.pkgs);
+  passthru = {
+    tlType = "bin";
+    tlDeps = with texlive; [ kpathsea t1utils metafont ];
+    pkgs = [ finalAttrs.finalPackage ];
+  };
 
   meta = with lib; {
     description = "Scalable PostScript Fonts for MetaFont";

--- a/pkgs/tools/typesetting/tex/mftrace/default.nix
+++ b/pkgs/tools/typesetting/tex/mftrace/default.nix
@@ -20,7 +20,7 @@
   - fontforge = null (limited functionality)
 */
 
-let self = stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: rec {
   pname = "mftrace";
   version = "1.2.20";
 
@@ -39,13 +39,13 @@ let self = stdenv.mkDerivation rec {
   buildInputs = [ fontforge potrace ];
 
   postInstall = ''
-    wrapProgram $out/bin/mftrace --prefix PATH : ${lib.makeBinPath buildInputs}
+    wrapProgram $out/bin/mftrace --prefix PATH : ${lib.makeBinPath finalAttrs.buildInputs}
   '';
 
   # experimental texlive.combine support
   # (note that only the bin/ folder will be combined into texlive)
   passthru.tlType = "bin";
-  passthru.pkgs = [ self ] ++
+  passthru.pkgs = [ finalAttrs.finalPackage ] ++
     (with texlive; kpathsea.pkgs ++ t1utils.pkgs ++ metafont.pkgs);
 
   meta = with lib; {
@@ -60,4 +60,4 @@ let self = stdenv.mkDerivation rec {
     maintainers = with maintainers; [ xworld21 ];
     platforms = platforms.all;
   };
-}; in self
+})

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -33,8 +33,6 @@ let
       ++ lib.optional (lib.any pkgNeedsRuby splitBin.wrong) ruby;
   };
 
-  sortedUniqueStrings = list: lib.sort (a: b: a < b) (lib.unique list);
-
   name = "texlive-${extraName}-${bin.texliveYear}${extraVersion}";
 
   texmf = (buildEnv {
@@ -123,9 +121,9 @@ in (buildEnv {
     # now filter hyphenation patterns and formats
   (let
     hyphens = lib.filter (p: p.hasHyphens or false && p.tlType == "run") pkgList.splitBin.wrong;
-    hyphenPNames = sortedUniqueStrings (map (p: p.pname) hyphens);
+    hyphenPNames = lib.sort (a: b: a < b) (map (p: p.pname) hyphens);
     formats = lib.filter (p: p.hasFormats or false && p.tlType == "run") pkgList.splitBin.wrong;
-    formatPNames = sortedUniqueStrings (map (p: p.pname) formats);
+    formatPNames = lib.sort (a: b: a < b) (map (p: p.pname) formats);
     # sed expression that prints the lines in /start/,/end/ except for /end/
     section = start: end: "/${start}/,/${end}/{ /${start}/p; /${end}/!p; };\n";
     script =

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -121,9 +121,9 @@ in (buildEnv {
     # now filter hyphenation patterns and formats
   (let
     hyphens = lib.filter (p: p.hasHyphens or false && p.tlType == "run") pkgList.splitBin.wrong;
-    hyphenPNames = lib.sort (a: b: a < b) (map (p: p.pname) hyphens);
+    hyphenPNames = map (p: p.pname) hyphens;
     formats = lib.filter (p: p.hasFormats or false && p.tlType == "run") pkgList.splitBin.wrong;
-    formatPNames = lib.sort (a: b: a < b) (map (p: p.pname) formats);
+    formatPNames = map (p: p.pname) formats;
     # sed expression that prints the lines in /start/,/end/ except for /end/
     section = start: end: "/${start}/,/${end}/{ /${start}/p; /${end}/!p; };\n";
     script =

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -10,18 +10,18 @@ let
   pkgSet = removeAttrs args [ "pkgFilter" "extraName" "extraVersion" ] // {
     # include a fake "core" package
     core.pkgs = [
-      (bin.core.out // { pname = "core"; tlType = "bin"; })
-      (bin.core.doc // { pname = "core"; tlType = "doc"; })
+      (bin.core.out // { pname = "core"; version = "0"; tlType = "bin"; })
+      (bin.core.doc // { pname = "core"; version = "0"; tlType = "doc"; })
     ];
   };
   pkgList = rec {
     all = lib.filter pkgFilter (combinePkgs (lib.attrValues pkgSet));
     splitBin = builtins.partition (p: p.tlType == "bin") all;
-    bin = mkUniqueOutPaths splitBin.right
+    bin = splitBin.right
       ++ lib.optional
           (lib.any (p: p.tlType == "run" && p.pname == "pdfcrop") splitBin.wrong)
           (lib.getBin ghostscript);
-    nonbin = mkUniqueOutPaths splitBin.wrong;
+    nonbin = splitBin.wrong;
 
     # extra interpreters needed for shebangs, based on 2015 schemes "medium" and "tetex"
     # (omitted tk needed in pname == "epspdf", bin/epspdftk)
@@ -35,15 +35,13 @@ let
 
   sortedUniqueStrings = list: lib.sort (a: b: a < b) (lib.unique list);
 
-  mkUniqueOutPaths = pkgs: lib.unique
-    (map (p: p.outPath) (builtins.filter lib.isDerivation pkgs));
-
   name = "texlive-${extraName}-${bin.texliveYear}${extraVersion}";
 
   texmf = (buildEnv {
     name = "${name}-texmf";
 
-    paths = pkgList.nonbin;
+    # remove fake derivations (without 'outPath') to avoid undesired build dependencies
+    paths = lib.catAttrs "outPath" pkgList.nonbin;
 
     nativeBuildInputs = [ perl bin.core.out ];
 
@@ -72,7 +70,9 @@ in (buildEnv {
   inherit name;
 
   ignoreCollisions = false;
-  paths = pkgList.bin ++ [ doc ];
+
+  # remove fake derivations (without 'outPath') to avoid undesired build dependencies
+  paths = lib.catAttrs "outPath" pkgList.bin ++ [ doc ];
   pathsToLink = [
     "/"
     "/bin" # ensure these are writeable directories


### PR DESCRIPTION
###### Description of changes
Fix #167226 and probably make the evaluation faster and less memory hungry.

To explain what's happening, in the current TeX Live, a TeX package is (essentially) an attribute set `{ pkgs = [ ...]; }` where `pkgs` contains the derivations of the package itself ('run', 'doc', etc.), as well as its dependencies.

I am moving the dependencies away from `pkgs`. Thus, after this PR:
1. The arguments of `texlive.combine` **should** be attribute sets with attribute `.pkgs`, where `.pkgs` is a list of derivations that make up *a single TeX package*.
2. If a TeX package outside `texlive` wants to specify dependencies, it **should** have an attribute `.tlDeps` whose value is a list of other TeX packages (for the above meaning of TeX package).

This has various benefits, ~above all reduced memory usage because packages don't store their dependency tree anymore,~ and we can deal easily with cyclic dependencies. ~Hopefully OfBorg will confirm this.~ Edit: performance is unpredictable apparently (10% faster on my desktop, 5% slower on OfBorg).

The code is backward compatible, however, so user packages where `.pkgs` pulls dependencies should behave correctly. In the meanwhile, I have updated the few nixpkgs entries that create TeX packages so that they conform to the new behaviour.


PS: my goal is to remove `pkgs` altogether and assemble the fixed output derivations in a fake multi-output derivation, which will make `texlive.combine` a lot more obvious (basically identical to `buildEnv`).


###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).