### PR TITLE
mullvad: 2022.5 -> 2023.1

### DIFF
--- a/pkgs/applications/networking/mullvad/mullvad.nix
+++ b/pkgs/applications/networking/mullvad/mullvad.nix
@@ -3,6 +3,7 @@
 , writeText
 , rustPlatform
 , fetchFromGitHub
+, fetchpatch
 , pkg-config
 , protobuf
 , makeWrapper
@@ -16,16 +17,26 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "mullvad";
-  version = "2022.5";
+  version = "2023.1";
 
   src = fetchFromGitHub {
     owner = "mullvad";
     repo = "mullvadvpn-app";
     rev = version;
-    hash = "sha256-LiaELeEBIn/GZibKf25W3DHe+IkpaTY8UC7ca/7lp8k=";
+    hash = "sha256-BoduliiDOpzEPYHAjr636e7DbrhFnC/v9au6Mp9T/Qs=";
   };
 
-  cargoHash = "sha256-KpBhdZce8Ug3ws7f1qg+5LtOMQw2Mf/uJsBg/TZSYyk=";
+  cargoHash = "sha256-5kK2IA0Z1dQbHlnGXNZHD+BycurshfpqrwcIEveWKT0=";
+
+  patches = [
+    # https://github.com/mullvad/mullvadvpn-app/pull/4389
+    # can be removed after next release
+    (fetchpatch {
+      name = "mullvad-version-dont-check-git.patch";
+      url = "https://github.com/mullvad/mullvadvpn-app/commit/8062cc74fc94bbe073189e78328901606c859d41.patch";
+      hash = "sha256-1BhCId0J1dxhPM3oOmhZB+07N+k1GlvAT1h6ayfx174=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -51,7 +62,7 @@ rustPlatform.buildRustPackage rec {
     # Place all binaries in the 'mullvad-' namespace, even though these
     # specific binaries aren't used in the lifetime of the program.
     ''
-      for bin in relay_list translations-converter; do
+      for bin in relay_list translations-converter tunnel-obfuscation; do
         mv "$out/bin/$bin" "$out/bin/mullvad-$bin"
       done
     '' +

--- a/pkgs/applications/networking/mullvad/mullvad.nix
+++ b/pkgs/applications/networking/mullvad/mullvad.nix
@@ -12,6 +12,7 @@
 , libnftnl
 , libmnl
 , libwg
+, enableOpenvpn ? true
 , openvpn-mullvad
 , shadowsocks-rust
 }:
@@ -67,7 +68,7 @@ rustPlatform.buildRustPackage rec {
       done
     '' +
     # Files necessary for OpenVPN tunnels to work.
-    ''
+    lib.optionalString enableOpenvpn ''
       mkdir -p $out/share/mullvad
       cp dist-assets/ca.crt $out/share/mullvad
       ln -s ${openvpn-mullvad}/bin/openvpn $out/share/mullvad


### PR DESCRIPTION
###### Description of changes

https://github.com/mullvad/mullvadvpn-app/releases/tag/2023.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - Ran it on my system 
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
