### PR TITLE
ocamlPackages.xml-light: 2.4 → 2.5

### DIFF
--- a/pkgs/development/ocaml-modules/xml-light/default.nix
+++ b/pkgs/development/ocaml-modules/xml-light/default.nix
@@ -1,34 +1,19 @@
-{ stdenv, lib, fetchFromGitHub, ocaml, findlib, gitUpdater }:
+{ lib
+, buildDunePackage
+, fetchurl
+}:
 
-lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
-  "xml-light is not available for OCaml ${ocaml.version}"
+buildDunePackage rec {
+  pname = "xml-light";
+  version = "2.5";
 
-stdenv.mkDerivation rec {
-  pname = "ocaml${ocaml.version}-xml-light";
-  version = "2.4";
+  duneVersion = "3";
+  minimalOCamlVersion = "4.03";
 
-  src = fetchFromGitHub {
-    owner = "ncannasse";
-    repo = "xml-light";
-    rev = version;
-    sha256 = "sha256-2txmkl/ZN5RGaLQJmr+orqwB4CbFk2RpLJd4gr7kPiE=";
+  src = fetchurl {
+    url = "https://github.com/ncannasse/xml-light/releases/download/${version}/xml-light-${version}.tbz";
+    hash = "sha256-9YwrPbcK0boICw0wauMvgsy7ldq7ksWZzcRn0eROAD0=";
   };
-
-  nativeBuildInputs = [ ocaml findlib ];
-
-  strictDeps = true;
-
-  createFindlibDestdir = true;
-
-  installPhase = ''
-    runHook preInstall
-    make install_ocamlfind
-    mkdir -p $out/share
-    cp -vai doc $out/share/
-    runHook postInstall
-  '';
-
-  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Minimal Xml parser and printer for OCaml";
@@ -42,6 +27,5 @@ stdenv.mkDerivation rec {
     homepage = "http://tech.motion-twin.com/xmllight.html";
     license = lib.licenses.lgpl21;
     maintainers = [ lib.maintainers.romildo ];
-    inherit (ocaml.meta) platforms;
   };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/ncannasse/xml-light/blob/2.5/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
