### PR TITLE
wezterm: add vulkan-loader to library path

### DIFF
--- a/pkgs/applications/terminal-emulators/wezterm/default.nix
+++ b/pkgs/applications/terminal-emulators/wezterm/default.nix
@@ -28,7 +28,6 @@
 , nixosTests
 , runCommand
 , vulkan-loader
-, makeWrapper
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -65,7 +64,6 @@ rustPlatform.buildRustPackage rec {
     ncurses # tic for terminfo
     pkg-config
     python3
-    makeWrapper
   ] ++ lib.optional stdenv.isDarwin perl;
 
   buildInputs = [
@@ -106,13 +104,13 @@ rustPlatform.buildRustPackage rec {
       --zsh assets/shell-completion/zsh
 
     install -Dm644 assets/wezterm-nautilus.py -t $out/share/nautilus-python/extensions
-  '' + lib.optionalString stdenv.isLinux ''
-    wrapProgram $out/bin/wezterm \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
   '';
 
   preFixup = lib.optionalString stdenv.isLinux ''
-    patchelf --add-needed "${libGL}/lib/libEGL.so.1" $out/bin/wezterm-gui
+    patchelf \
+      --add-needed "${libGL}/lib/libEGL.so.1" \
+      --add-needed "${vulkan-loader}/lib/libvulkan.so.1" \
+      $out/bin/wezterm-gui
   '' + lib.optionalString stdenv.isDarwin ''
     mkdir -p "$out/Applications"
     OUT_APP="$out/Applications/WezTerm.app"

--- a/pkgs/applications/terminal-emulators/wezterm/default.nix
+++ b/pkgs/applications/terminal-emulators/wezterm/default.nix
@@ -27,6 +27,8 @@
 , UserNotifications
 , nixosTests
 , runCommand
+, vulkan-loader
+, makeWrapper
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -63,6 +65,7 @@ rustPlatform.buildRustPackage rec {
     ncurses # tic for terminfo
     pkg-config
     python3
+    makeWrapper
   ] ++ lib.optional stdenv.isDarwin perl;
 
   buildInputs = [
@@ -103,6 +106,9 @@ rustPlatform.buildRustPackage rec {
       --zsh assets/shell-completion/zsh
 
     install -Dm644 assets/wezterm-nautilus.py -t $out/share/nautilus-python/extensions
+  '' + lib.optionalString stdenv.isLinux ''
+    wrapProgram $out/bin/wezterm \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
   '';
 
   preFixup = lib.optionalString stdenv.isLinux ''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

WezTerm can render using Vulkan which requires vulkan-loader to work. https://wezfurlong.org/wezterm/config/lua/config/front_end.html?highlight=webgpu#webgpu

This allows for Nvidia GPUs to work natively on Wayland. https://github.com/wez/wezterm/issues/2011

###### Things done

Wrapped $out/bin/wezterm to add vulkan-loader to its library path allowing Vulkan cards/drivers to be detected.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
