### PR TITLE
speedtest-rs: init at 0.1.4

### DIFF
--- a/pkgs/tools/networking/speedtest-rs/default.nix
+++ b/pkgs/tools/networking/speedtest-rs/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, openssl
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "speedtest-rs";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "nelsonjchen";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-/d6A+Arlcc3SCKPSkYXwvqY2BRyAbA33Ah+GddHcc5M=";
+  };
+
+  buildInputs = [ openssl ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  cargoSha256 = "sha256-4TJEM+oMjx/aaZgY2Y679pYFTdEWWFpWDYrK/o2b5UM=";
+
+  meta = with lib; {
+    description = "Command line internet speedtest tool written in rust";
+    homepage = "https://github.com/nelsonjchen/speedtest-rs";
+    changelog = "https://github.com/nelsonjchen/speedtest-rs/blob/v${version}/CHANGELOG.md";
+    license = with licenses; [ mit asl20 ];
+    maintainers = with maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1578,6 +1578,8 @@ with pkgs;
 
   spectre-cli = callPackage ../tools/security/spectre-cli { };
 
+  speedtest-rs = callPackage ../tools/networking/speedtest-rs { };
+
   steamtinkerlaunch = callPackage ../tools/games/steamtinkerlaunch {};
 
   supermin = callPackage ../tools/virtualization/supermin { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added package `speedtest-rs`, a command line internet speedtest tool written in rust.
Homepage: https://github.com/nelsonjchen/speedtest-rs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
