### PR TITLE
swaynotificationcenter: 0.7.3 -> 0.8.0

### DIFF
--- a/pkgs/applications/misc/swaynotificationcenter/default.nix
+++ b/pkgs/applications/misc/swaynotificationcenter/default.nix
@@ -13,7 +13,9 @@
 , gtk-layer-shell
 , gtk3
 , json-glib
+, libgee
 , libhandy
+, libpulseaudio
 , librsvg
 , meson
 , ninja
@@ -26,13 +28,13 @@
 
 stdenv.mkDerivation (finalAttrs: rec {
   pname = "SwayNotificationCenter";
-  version = "0.7.3";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "ErikReider";
     repo = "SwayNotificationCenter";
     rev = "v${version}";
-    hash = "sha256-RU6zzhRu7YK+zcazxj2wZ5vSwLwlilBaG9l+rEstefc=";
+    hash = "sha256-E9CjNx/xzkkOZ39XbfIb1nJFheZVFpj/lwmITKtpb7A=";
   };
 
   nativeBuildInputs = [
@@ -58,7 +60,9 @@ stdenv.mkDerivation (finalAttrs: rec {
     gtk-layer-shell
     gtk3
     json-glib
+    libgee
     libhandy
+    libpulseaudio
     librsvg
     # systemd # ends with broken permission
   ];
@@ -76,6 +80,7 @@ stdenv.mkDerivation (finalAttrs: rec {
   meta = with lib; {
     description = "Simple notification daemon with a GUI built for Sway";
     homepage = "https://github.com/ErikReider/SwayNotificationCenter";
+    changelog = "https://github.com/ErikReider/SwayNotificationCenter/releases/tag/v${version}";
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ berbiche pedrohlc ];


### PR DESCRIPTION
###### Description of changes

Bumps to new version, including thsese changes:
- Includes new deps: libgee and libpulseaudio;
- Adds meta.changelog;
- Release changelog: https://github.com/ErikReider/SwayNotificationCenter/releases/tag/v0.8.0
- Full changelog: https://github.com/ErikReider/SwayNotificationCenter/compare/v0.7.3...v0.8.0

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```console
╭─pedrohlc at desktop in /home/pedrohlc/Projects/com.pedrohlc/nixpkgs (swaync-0.8.0 ✚1)
╰─λ ./result/bin/swaync &

** (swaync:1109033): CRITICAL **: 10:36:29.531: baseWidget.vala:36: title: Config not found! Using default config...

** Message: 10:36:29.531: factory.vala:42: Loading widget: title

** (swaync:1109033): CRITICAL **: 10:36:29.531: baseWidget.vala:36: dnd: Config not found! Using default config...

** Message: 10:36:29.531: factory.vala:42: Loading widget: dnd
╭─pedrohlc at desktop in ~/nixpkgs (swaync-0.8.0 ✚1)
╰─λ disown
╭─pedrohlc at desktop in ~/nixpkgs (swaync-0.8.0 ✚1)
╰─λ ./result/bin/swaync-client -c
0⏎                                                                                                                                                                                                                   ╭─pedrohlc at desktop in ~/nixpkgs (swaync-0.8.0 ✚1)
╰─λ notify-send 'test'
╭─pedrohlc at desktop in ~/nixpkgs (swaync-0.8.0 ✚1)
╰─λ ./result/bin/swaync-client -c
1⏎
```
