### PR TITLE
rtx: init at 1.30.5

### DIFF
--- a/pkgs/tools/misc/rtx/default.nix
+++ b/pkgs/tools/misc/rtx/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, installShellFiles
+, stdenv
+, coreutils
+, bash
+, direnv
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rtx";
+  version = "1.30.5";
+
+  src = fetchFromGitHub {
+    owner = "jdxcode";
+    repo = "rtx";
+    rev = "v${version}";
+    sha256 = "sha256-xJecTvhRMHyGOT1JJPSp+k5bI0FvIP2uySBt1R0YZ30=";
+  };
+
+  cargoSha256 = "sha256-29aGVKINVemppy+3nGDf5okvmJm72pVYUVbefuey0H8=";
+
+  nativeBuildInputs = [ installShellFiles ];
+  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
+
+  postPatch = ''
+    patchShebangs --build ./test/data/plugins/**/bin/* ./src/fake_asdf.rs ./src/cli/reshim.rs
+
+    substituteInPlace ./src/env_diff.rs \
+      --replace '"bash"' '"${bash}/bin/bash"'
+
+    substituteInPlace ./src/cli/direnv/exec.rs \
+      --replace '"env"' '"${coreutils}/bin/env"' \
+      --replace 'cmd!("direnv"' 'cmd!("${direnv}/bin/direnv"'
+  '';
+
+  checkFlags = [
+    # Requires .git directory to be present
+    "--skip=cli::plugins::ls::tests::test_plugin_list_urls"
+  ];
+  cargoTestFlags = [ "--all-features" ];
+  # some tests access the same folders, don't test in parallel to avoid race conditions
+  dontUseCargoParallelTests = true;
+
+  postInstall = ''
+    installManPage ./man/man1/rtx.1
+
+    installShellCompletion \
+      --bash ./completions/rtx.bash \
+      --fish ./completions/rtx.fish \
+      --zsh ./completions/_rtx
+  '';
+
+  meta = rec {
+    homepage = "https://github.com/jdxcode/rtx";
+    description = "Polyglot runtime manager (asdf rust clone)";
+    changelog = "https://github.com/jdxcode/rtx/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ konradmalik ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17600,6 +17600,10 @@ with pkgs;
 
   asdf-vm = callPackage ../tools/misc/asdf-vm { };
 
+  rtx = callPackage ../tools/misc/rtx {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   ### DEVELOPMENT / TOOLS
 
   abi-compliance-checker = callPackage ../development/tools/misc/abi-compliance-checker { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

From [rtx repo](https://github.com/jdxcode/rtx): Polyglot runtime manager ([asdf](https://github.com/asdf-vm/asdf) rust clone).
More performant and dumps shims which makes it easier to work with and integrate with nix-based systems.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
