### PR TITLE
fwupd: 1.8.10 -> 1.8.12

### DIFF
--- a/pkgs/development/libraries/libjcat/default.nix
+++ b/pkgs/development/libraries/libjcat/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     description = "Library for reading and writing Jcat files";
     homepage = "https://github.com/hughsie/libjcat";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libxmlb/default.nix
+++ b/pkgs/development/libraries/libxmlb/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     description = "A library to help create and query binary XML blobs";
     homepage = "https://github.com/hughsie/libxmlb";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -113,287 +113,284 @@ let
             pos.file + ":" + toString pos.line;
         };
       };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fwupd";
+  version = "1.8.10";
 
+  # libfwupd goes to lib
+  # daemon, plug-ins and libfwupdplugin go to out
+  # CLI programs go to out
+  outputs = [ "out" "lib" "dev" "devdoc" "man" "installedTests" ];
 
-  self = stdenv.mkDerivation rec {
-    pname = "fwupd";
-    version = "1.8.10";
+  src = fetchurl {
+    url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${finalAttrs.version}.tar.xz";
+    hash = "sha256-vvNUidNdhW9xeksjEVnkIR7CZ4oBQizZJRMFtZUq6Ow=";
+  };
 
-    # libfwupd goes to lib
-    # daemon, plug-ins and libfwupdplugin go to out
-    # CLI programs go to out
-    outputs = [ "out" "lib" "dev" "devdoc" "man" "installedTests" ];
+  patches = [
+    # Since /etc is the domain of NixOS, not Nix,
+    # we cannot install files there.
+    # Let’s install the files to $prefix/etc
+    # while still reading them from /etc.
+    # NixOS module for fwupd will take take care of copying the files appropriately.
+    ./add-option-for-installation-sysconfdir.patch
 
-    src = fetchurl {
-      url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-      hash = "sha256-vvNUidNdhW9xeksjEVnkIR7CZ4oBQizZJRMFtZUq6Ow=";
-    };
+    # Install plug-ins and libfwupdplugin to $out output,
+    # they are not really part of the library.
+    ./install-fwupdplugin-to-out.patch
 
-    patches = [
-      # Since /etc is the domain of NixOS, not Nix,
-      # we cannot install files there.
-      # Let’s install the files to $prefix/etc
-      # while still reading them from /etc.
-      # NixOS module for fwupd will take take care of copying the files appropriately.
-      ./add-option-for-installation-sysconfdir.patch
+    # Installed tests are installed to different output
+    # we also cannot have fwupd-tests.conf in $out/etc since it would form a cycle.
+    ./installed-tests-path.patch
 
-      # Install plug-ins and libfwupdplugin to $out output,
-      # they are not really part of the library.
-      ./install-fwupdplugin-to-out.patch
+    # EFI capsule is located in fwupd-efi now.
+    ./efi-app-path.patch
+  ];
 
-      # Installed tests are installed to different output
-      # we also cannot have fwupd-tests.conf in $out/etc since it would form a cycle.
-      ./installed-tests-path.patch
+  nativeBuildInputs = [
+    # required for firmware zipping
+    ensureNewerSourcesForZipFilesHook
+    meson
+    ninja
+    gi-docgen
+    pkg-config
+    gobject-introspection
+    gettext
+    shared-mime-info
+    valgrind
+    gcab
+    gnutls
+    protobufc # for protoc
+    python
+    wrapGAppsNoGuiHook
+    vala
+  ];
 
-      # EFI capsule is located in fwupd-efi now.
-      ./efi-app-path.patch
-    ];
+  buildInputs = [
+    polkit
+    libxmlb
+    gusb
+    sqlite
+    libarchive
+    curl
+    elfutils
+    libgudev
+    colord
+    libjcat
+    libuuid
+    json-glib
+    umockdev
+    bash-completion
+    pango
+    tpm2-tss
+    efivar
+    fwupd-efi
+    protobufc
+    modemmanager
+    libmbim
+    libcbor
+    libqmi
+    xz # for liblzma
+  ] ++ lib.optionals haveDell [
+    libsmbios
+  ] ++ lib.optionals haveFlashrom [
+    flashrom
+  ];
 
-    nativeBuildInputs = [
-      # required for firmware zipping
-      ensureNewerSourcesForZipFilesHook
-      meson
-      ninja
-      gi-docgen
-      pkg-config
-      gobject-introspection
-      gettext
-      shared-mime-info
-      valgrind
-      gcab
-      gnutls
-      protobufc # for protoc
-      python
-      wrapGAppsNoGuiHook
-      vala
-    ];
+  mesonFlags = [
+    "-Ddocs=enabled"
+    "-Dplugin_dummy=true"
+    # We are building the official releases.
+    "-Dsupported_build=enabled"
+    # Would dlopen libsoup to preserve compatibility with clients linking against older fwupd.
+    # https://github.com/fwupd/fwupd/commit/173d389fa59d8db152a5b9da7cc1171586639c97
+    "-Dsoup_session_compat=false"
+    "-Dudevdir=lib/udev"
+    "-Dsystemd_root_prefix=${placeholder "out"}"
+    "-Dinstalled_test_prefix=${placeholder "installedTests"}"
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+    "-Dsysconfdir_install=${placeholder "out"}/etc"
+    "-Defi_os_dir=nixos"
+    "-Dplugin_modem_manager=enabled"
 
-    buildInputs = [
-      polkit
-      libxmlb
-      gusb
-      sqlite
-      libarchive
-      curl
-      elfutils
-      libgudev
-      colord
-      libjcat
-      libuuid
-      json-glib
-      umockdev
-      bash-completion
-      pango
-      tpm2-tss
-      efivar
-      fwupd-efi
-      protobufc
-      modemmanager
-      libmbim
-      libcbor
-      libqmi
-      xz # for liblzma
-    ] ++ lib.optionals haveDell [
-      libsmbios
-    ] ++ lib.optionals haveFlashrom [
-      flashrom
-    ];
+    # We do not want to place the daemon into lib (cyclic reference)
+    "--libexecdir=${placeholder "out"}/libexec"
+  ] ++ lib.optionals (!haveDell) [
+    "-Dplugin_dell=disabled"
+    "-Dplugin_synaptics_mst=disabled"
+  ] ++ lib.optionals (!haveRedfish) [
+    "-Dplugin_redfish=disabled"
+  ] ++ lib.optionals (!haveFlashrom) [
+    "-Dplugin_flashrom=disabled"
+  ] ++ lib.optionals (!haveMSR) [
+    "-Dplugin_msr=disabled"
+  ];
 
-    mesonFlags = [
-      "-Ddocs=enabled"
-      "-Dplugin_dummy=true"
-      # We are building the official releases.
-      "-Dsupported_build=enabled"
-      # Would dlopen libsoup to preserve compatibility with clients linking against older fwupd.
-      # https://github.com/fwupd/fwupd/commit/173d389fa59d8db152a5b9da7cc1171586639c97
-      "-Dsoup_session_compat=false"
-      "-Dudevdir=lib/udev"
-      "-Dsystemd_root_prefix=${placeholder "out"}"
-      "-Dinstalled_test_prefix=${placeholder "installedTests"}"
-      "--localstatedir=/var"
-      "--sysconfdir=/etc"
-      "-Dsysconfdir_install=${placeholder "out"}/etc"
-      "-Defi_os_dir=nixos"
-      "-Dplugin_modem_manager=enabled"
+  # TODO: wrapGAppsHook wraps efi capsule even though it is not ELF
+  dontWrapGApps = true;
 
-      # We do not want to place the daemon into lib (cyclic reference)
-      "--libexecdir=${placeholder "out"}/libexec"
-    ] ++ lib.optionals (!haveDell) [
-      "-Dplugin_dell=disabled"
-      "-Dplugin_synaptics_mst=disabled"
-    ] ++ lib.optionals (!haveRedfish) [
-      "-Dplugin_redfish=disabled"
-    ] ++ lib.optionals (!haveFlashrom) [
-      "-Dplugin_flashrom=disabled"
-    ] ++ lib.optionals (!haveMSR) [
-      "-Dplugin_msr=disabled"
-    ];
+  doCheck = true;
 
-    # TODO: wrapGAppsHook wraps efi capsule even though it is not ELF
-    dontWrapGApps = true;
+  # Environment variables
 
-    doCheck = true;
-
-    # Environment variables
-
-    # Fontconfig error: Cannot load default config file
-    FONTCONFIG_FILE =
-      let
-        fontsConf = makeFontsConf {
-          fontDirectories = [ freefont_ttf ];
-        };
-      in fontsConf;
-
-    # error: “PolicyKit files are missing”
-    # https://github.com/NixOS/nixpkgs/pull/67625#issuecomment-525788428
-    PKG_CONFIG_POLKIT_GOBJECT_1_ACTIONDIR = "/run/current-system/sw/share/polkit-1/actions";
-
-    # Phase hooks
-
-    postPatch = ''
-      patchShebangs \
-        contrib/generate-version-script.py \
-        po/test-deps
-
-      substituteInPlace data/installed-tests/fwupdmgr-p2p.sh \
-        --replace "gdbus" ${glib.bin}/bin/gdbus
-
-      # tests fail with: Failed to load SMBIOS: neither SMBIOS or DT found
-      sed -i 's/test(.*)//' plugins/lenovo-thinklmi/meson.build
-      sed -i 's/test(.*)//' plugins/mtd/meson.build
-      # fails on amd cpu
-      sed -i 's/test(.*)//' libfwupdplugin/meson.build
-      # in nixos test tries to chmod 0777 $out/share/installed-tests/fwupd/tests/redfish.conf
-      sed -i "s/get_option('tests')/false/" plugins/redfish/meson.build
-    '';
-
-    preBuild = ''
-      # jcat-tool at buildtime requires a home directory
-      export HOME="$(mktemp -d)"
-    '';
-
-    preCheck = ''
-      addToSearchPath XDG_DATA_DIRS "${shared-mime-info}/share"
-
-      echo "12345678901234567890123456789012" > machine-id
-      export NIX_REDIRECTS=/etc/machine-id=$(realpath machine-id) \
-      LD_PRELOAD=${libredirect}/lib/libredirect.so
-    '';
-
-    preInstall = ''
-      # We have pkexec on PATH so Meson will try to use it when installation fails
-      # due to being unable to write to e.g. /etc.
-      # Let’s pretend we already ran pkexec –
-      # the pkexec on PATH would complain it lacks setuid bit,
-      # obscuring the underlying error.
-      # https://github.com/mesonbuild/meson/blob/492cc9bf95d573e037155b588dc5110ded4d9a35/mesonbuild/minstall.py#L558
-      export PKEXEC_UID=-1
-    '';
-
-    postInstall = ''
-      # These files have weird licenses so they are shipped separately.
-      cp --recursive --dereference "${test-firmware}/installed-tests/tests" "$installedTests/libexec/installed-tests/fwupd"
-    '';
-
-    preFixup = let
-      binPath = [
-        efibootmgr
-        bubblewrap
-        tpm2-tools
-      ];
-    in ''
-      gappsWrapperArgs+=(
-        --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
-        # See programs reached with fu_common_find_program_in_path in source
-        --prefix PATH : "${lib.makeBinPath binPath}"
-      )
-    '';
-
-    postFixup = ''
-      # Since we had to disable wrapGAppsHook, we need to wrap the executables manually.
-      find -L "$out/bin" "$out/libexec" -type f -executable -print0 \
-        | while IFS= read -r -d ''' file; do
-        if [[ "$file" != *.efi ]]; then
-          echo "Wrapping program $file"
-          wrapGApp "$file"
-        fi
-      done
-
-      # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-      moveToOutput "share/doc" "$devdoc"
-    '';
-
-    separateDebugInfo = true;
-
-    passthru = {
-      filesInstalledToEtc = [
-        "fwupd/bios-settings.d/README.md"
-        "fwupd/daemon.conf"
-        "fwupd/remotes.d/lvfs-testing.conf"
-        "fwupd/remotes.d/lvfs.conf"
-        "fwupd/remotes.d/vendor.conf"
-        "fwupd/remotes.d/vendor-directory.conf"
-        "fwupd/uefi_capsule.conf"
-        "pki/fwupd/GPG-KEY-Linux-Foundation-Firmware"
-        "pki/fwupd/GPG-KEY-Linux-Vendor-Firmware-Service"
-        "pki/fwupd/LVFS-CA.pem"
-        "pki/fwupd-metadata/GPG-KEY-Linux-Foundation-Metadata"
-        "pki/fwupd-metadata/GPG-KEY-Linux-Vendor-Firmware-Service"
-        "pki/fwupd-metadata/LVFS-CA.pem"
-        "grub.d/35_fwupd"
-      ] ++ lib.optionals haveDell [
-        "fwupd/remotes.d/dell-esrt.conf"
-      ] ++ lib.optionals haveRedfish [
-        "fwupd/redfish.conf"
-      ] ++ lib.optionals haveMSR [
-        "fwupd/msr.conf"
-      ] ++ lib.optionals isx86 [
-        "fwupd/thunderbolt.conf"
-      ];
-
-      # DisabledPlugins key in fwupd/daemon.conf
-      defaultDisabledPlugins = [
-        "test"
-        "test_ble"
-      ];
-
-      # For updating.
-      inherit test-firmware;
-
-      tests = let
-        listToPy = list: "[${lib.concatMapStringsSep ", " (f: "'${f}'") list}]";
-      in {
-        installedTests = nixosTests.installed-tests.fwupd;
-
-        passthruMatches = runPythonCommand "fwupd-test-passthru-matches" ''
-          import itertools
-          import configparser
-          import os
-          import pathlib
-
-          etc = '${self}/etc'
-          package_etc = set(itertools.chain.from_iterable([[os.path.relpath(os.path.join(prefix, file), etc) for file in files] for (prefix, dirs, files) in os.walk(etc)]))
-          passthru_etc = set(${listToPy passthru.filesInstalledToEtc})
-          assert len(package_etc - passthru_etc) == 0, f'fwupd package contains the following paths in /etc that are not listed in passthru.filesInstalledToEtc: {package_etc - passthru_etc}'
-          assert len(passthru_etc - package_etc) == 0, f'fwupd package lists the following paths in passthru.filesInstalledToEtc that are not contained in /etc: {passthru_etc - package_etc}'
-
-          config = configparser.RawConfigParser()
-          config.read('${self}/etc/fwupd/daemon.conf')
-          package_disabled_plugins = config.get('fwupd', 'DisabledPlugins').rstrip(';').split(';')
-          passthru_disabled_plugins = ${listToPy passthru.defaultDisabledPlugins}
-          assert package_disabled_plugins == passthru_disabled_plugins, f'Default disabled plug-ins in the package {package_disabled_plugins} do not match those listed in passthru.defaultDisabledPlugins {passthru_disabled_plugins}'
-
-          pathlib.Path(os.getenv('out')).touch()
-        '';
+  # Fontconfig error: Cannot load default config file
+  FONTCONFIG_FILE =
+    let
+      fontsConf = makeFontsConf {
+        fontDirectories = [ freefont_ttf ];
       };
-    };
+    in fontsConf;
 
-    meta = with lib; {
-      homepage = "https://fwupd.org/";
-      maintainers = with maintainers; [ jtojnar ];
-      license = licenses.lgpl21Plus;
-      platforms = platforms.linux;
+  # error: “PolicyKit files are missing”
+  # https://github.com/NixOS/nixpkgs/pull/67625#issuecomment-525788428
+  PKG_CONFIG_POLKIT_GOBJECT_1_ACTIONDIR = "/run/current-system/sw/share/polkit-1/actions";
+
+  # Phase hooks
+
+  postPatch = ''
+    patchShebangs \
+      contrib/generate-version-script.py \
+      po/test-deps
+
+    substituteInPlace data/installed-tests/fwupdmgr-p2p.sh \
+      --replace "gdbus" ${glib.bin}/bin/gdbus
+
+    # tests fail with: Failed to load SMBIOS: neither SMBIOS or DT found
+    sed -i 's/test(.*)//' plugins/lenovo-thinklmi/meson.build
+    sed -i 's/test(.*)//' plugins/mtd/meson.build
+    # fails on amd cpu
+    sed -i 's/test(.*)//' libfwupdplugin/meson.build
+    # in nixos test tries to chmod 0777 $out/share/installed-tests/fwupd/tests/redfish.conf
+    sed -i "s/get_option('tests')/false/" plugins/redfish/meson.build
+  '';
+
+  preBuild = ''
+    # jcat-tool at buildtime requires a home directory
+    export HOME="$(mktemp -d)"
+  '';
+
+  preCheck = ''
+    addToSearchPath XDG_DATA_DIRS "${shared-mime-info}/share"
+
+    echo "12345678901234567890123456789012" > machine-id
+    export NIX_REDIRECTS=/etc/machine-id=$(realpath machine-id) \
+    LD_PRELOAD=${libredirect}/lib/libredirect.so
+  '';
+
+  preInstall = ''
+    # We have pkexec on PATH so Meson will try to use it when installation fails
+    # due to being unable to write to e.g. /etc.
+    # Let’s pretend we already ran pkexec –
+    # the pkexec on PATH would complain it lacks setuid bit,
+    # obscuring the underlying error.
+    # https://github.com/mesonbuild/meson/blob/492cc9bf95d573e037155b588dc5110ded4d9a35/mesonbuild/minstall.py#L558
+    export PKEXEC_UID=-1
+  '';
+
+  postInstall = ''
+    # These files have weird licenses so they are shipped separately.
+    cp --recursive --dereference "${test-firmware}/installed-tests/tests" "$installedTests/libexec/installed-tests/fwupd"
+  '';
+
+  preFixup = let
+    binPath = [
+      efibootmgr
+      bubblewrap
+      tpm2-tools
+    ];
+  in ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
+      # See programs reached with fu_common_find_program_in_path in source
+      --prefix PATH : "${lib.makeBinPath binPath}"
+    )
+  '';
+
+  postFixup = ''
+    # Since we had to disable wrapGAppsHook, we need to wrap the executables manually.
+    find -L "$out/bin" "$out/libexec" -type f -executable -print0 \
+      | while IFS= read -r -d ''' file; do
+      if [[ "$file" != *.efi ]]; then
+        echo "Wrapping program $file"
+        wrapGApp "$file"
+      fi
+    done
+
+    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+    moveToOutput "share/doc" "$devdoc"
+  '';
+
+  separateDebugInfo = true;
+
+  passthru = {
+    filesInstalledToEtc = [
+      "fwupd/bios-settings.d/README.md"
+      "fwupd/daemon.conf"
+      "fwupd/remotes.d/lvfs-testing.conf"
+      "fwupd/remotes.d/lvfs.conf"
+      "fwupd/remotes.d/vendor.conf"
+      "fwupd/remotes.d/vendor-directory.conf"
+      "fwupd/uefi_capsule.conf"
+      "pki/fwupd/GPG-KEY-Linux-Foundation-Firmware"
+      "pki/fwupd/GPG-KEY-Linux-Vendor-Firmware-Service"
+      "pki/fwupd/LVFS-CA.pem"
+      "pki/fwupd-metadata/GPG-KEY-Linux-Foundation-Metadata"
+      "pki/fwupd-metadata/GPG-KEY-Linux-Vendor-Firmware-Service"
+      "pki/fwupd-metadata/LVFS-CA.pem"
+      "grub.d/35_fwupd"
+    ] ++ lib.optionals haveDell [
+      "fwupd/remotes.d/dell-esrt.conf"
+    ] ++ lib.optionals haveRedfish [
+      "fwupd/redfish.conf"
+    ] ++ lib.optionals haveMSR [
+      "fwupd/msr.conf"
+    ] ++ lib.optionals isx86 [
+      "fwupd/thunderbolt.conf"
+    ];
+
+    # DisabledPlugins key in fwupd/daemon.conf
+    defaultDisabledPlugins = [
+      "test"
+      "test_ble"
+    ];
+
+    # For updating.
+    inherit test-firmware;
+
+    tests = let
+      listToPy = list: "[${lib.concatMapStringsSep ", " (f: "'${f}'") list}]";
+    in {
+      installedTests = nixosTests.installed-tests.fwupd;
+
+      passthruMatches = runPythonCommand "fwupd-test-passthru-matches" ''
+        import itertools
+        import configparser
+        import os
+        import pathlib
+
+        etc = '${finalAttrs.finalPackage}/etc'
+        package_etc = set(itertools.chain.from_iterable([[os.path.relpath(os.path.join(prefix, file), etc) for file in files] for (prefix, dirs, files) in os.walk(etc)]))
+        passthru_etc = set(${listToPy finalAttrs.passthru.filesInstalledToEtc})
+        assert len(package_etc - passthru_etc) == 0, f'fwupd package contains the following paths in /etc that are not listed in passthru.filesInstalledToEtc: {package_etc - passthru_etc}'
+        assert len(passthru_etc - package_etc) == 0, f'fwupd package lists the following paths in passthru.filesInstalledToEtc that are not contained in /etc: {passthru_etc - package_etc}'
+
+        config = configparser.RawConfigParser()
+        config.read('${finalAttrs.finalPackage}/etc/fwupd/daemon.conf')
+        package_disabled_plugins = config.get('fwupd', 'DisabledPlugins').rstrip(';').split(';')
+        passthru_disabled_plugins = ${listToPy finalAttrs.passthru.defaultDisabledPlugins}
+        assert package_disabled_plugins == passthru_disabled_plugins, f'Default disabled plug-ins in the package {package_disabled_plugins} do not match those listed in passthru.defaultDisabledPlugins {passthru_disabled_plugins}'
+
+        pathlib.Path(os.getenv('out')).touch()
+      '';
     };
   };
 
-in self
+  meta = with lib; {
+    homepage = "https://fwupd.org/";
+    maintainers = with maintainers; [ jtojnar ];
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -414,7 +414,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     homepage = "https://fwupd.org/";
-    maintainers = with maintainers; [ jtojnar ];
+    maintainers = with maintainers; [ ];
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Description of changes

Changelog: https://github.com/fwupd/fwupd/releases/tag/1.8.12

Added pandoc as a native build dependency because it is now required to generate the manpages (see fwupd/fwupd#5566).

Separate commit to reformat the file using nixpkgs-fmt.

@jtojnar I disabled the new device-tests that require network access to download emulation data to emulate different devices. I think that these tests are more useful for the fwupd CI than for our NixOS CI, but I'd like to hear your opinion on this.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
