### PR TITLE
testkube: init at 1.10.40

### DIFF
--- a/pkgs/development/tools/testkube/default.nix
+++ b/pkgs/development/tools/testkube/default.nix
@@ -1,0 +1,31 @@
+{ buildGoModule, fetchFromGitHub, lib, stdenv }:
+
+buildGoModule rec {
+  pname = "testkube";
+  version = "1.10.40";
+
+  src = fetchFromGitHub {
+    owner = "kubeshop";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-6U9tbn1hp4OEI5ZNcknXBm64nJtZtC9nuIpsHSl1rQw=";
+  };
+
+  subPackages = [ "cmd/kubectl-testkube/main.go" ];
+
+  vendorSha256 = "sha256-DLh4uKT4/YbA0ZjEZXmryyB5BnlL2XD+8JvHy+Su6pM=";
+
+  ldflags = [ "-s" "-w" ];
+
+  postInstall = ''
+    mv $out/bin/main $out/bin/kubectl-testkube
+  '';
+
+  meta = with lib; {
+    description = "Kubernetes-native testing framework for test execution and orchestration";
+    homepage = "https://testkube.io/";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mausch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1639,6 +1639,8 @@ with pkgs;
 
   termusic = callPackage ../applications/audio/termusic { };
 
+  testkube = callPackage ../development/tools/testkube { };
+
   tfk8s = callPackage ../tools/misc/tfk8s { };
 
   tfplugindocs = callPackage ../development/tools/tfplugindocs { };


### PR DESCRIPTION
###### Description of changes


https://testkube.io/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
