### PR TITLE
treewide: python{ => .pythonForBuild}.interpreter

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1019,7 +1019,7 @@ buildPythonPackage rec {
 
 The `buildPythonPackage` mainly does four things:
 
-* In the `buildPhase`, it calls `${python.interpreter} setup.py bdist_wheel` to
+* In the `buildPhase`, it calls `${python.pythonForBuild.interpreter} setup.py bdist_wheel` to
   build a wheel binary zipfile.
 * In the `installPhase`, it installs the wheel file using `pip install *.whl`.
 * In the `postFixup` phase, the `wrapPythonPrograms` bash function is called to
@@ -1546,7 +1546,7 @@ of such package using the feature is `pkgs/tools/X11/xpra/default.nix`.
 As workaround install it as an extra `preInstall` step:
 
 ```shell
-${python.interpreter} setup.py install_data --install-dir=$out --root=$out
+${python.pythonForBuild.interpreter} setup.py install_data --install-dir=$out --root=$out
 sed -i '/ = data\_files/d' setup.py
 ```
 

--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -149,7 +149,7 @@ stdenv.mkDerivation rec {
     export XDG_DATA_HOME=$out/share
     export XDG_UTILS_INSTALL_MODE="user"
 
-    ${python3Packages.python.interpreter} setup.py install --root=$out \
+    ${python3Packages.python.pythonForBuild.interpreter} setup.py install --root=$out \
       --prefix=$out \
       --libdir=$out/lib \
       --staging-root=$out \

--- a/pkgs/applications/networking/mailreaders/afew/default.nix
+++ b/pkgs/applications/networking/mailreaders/afew/default.nix
@@ -26,7 +26,7 @@ python3Packages.buildPythonApplication rec {
   outputs = [ "out" "doc" ];
 
   postBuild =  ''
-    ${python3Packages.python.interpreter} setup.py build_sphinx -b html,man
+    ${python3Packages.python.pythonForBuild.interpreter} setup.py build_sphinx -b html,man
   '';
 
   postInstall = ''

--- a/pkgs/applications/networking/p2p/zeronet-conservancy/default.nix
+++ b/pkgs/applications/networking/p2p/zeronet-conservancy/default.nix
@@ -23,7 +23,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   buildPhase = ''
-    ${python3Packages.python.interpreter} -O -m compileall .
+    ${python3Packages.python.pythonForBuild.interpreter} -O -m compileall .
   '';
 
   installPhase = ''

--- a/pkgs/applications/networking/p2p/zeronet/default.nix
+++ b/pkgs/applications/networking/p2p/zeronet/default.nix
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   buildPhase = ''
-    ${python3Packages.python.interpreter} -O -m compileall .
+    ${python3Packages.python.pythonForBuild.interpreter} -O -m compileall .
   '';
 
   installPhase = ''

--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -244,13 +244,13 @@ python.pkgs.buildPythonApplication rec {
   postBuild = ''
     # Compile manually because `pythonRecompileBytecodeHook` only works
     # for files in `python.sitePackages`
-    ${python.interpreter} -OO -m compileall src
+    ${python.pythonForBuild.interpreter} -OO -m compileall src
 
     # Collect static files
-    ${python.interpreter} src/manage.py collectstatic --clear --no-input
+    ${python.pythonForBuild.interpreter} src/manage.py collectstatic --clear --no-input
 
     # Compile string translations using gettext
-    ${python.interpreter} src/manage.py compilemessages
+    ${python.pythonForBuild.interpreter} src/manage.py compilemessages
   '';
 
   installPhase = ''

--- a/pkgs/applications/science/biology/quast/default.nix
+++ b/pkgs/applications/science/biology/quast/default.nix
@@ -27,7 +27,7 @@ pythonPackages.buildPythonApplication rec {
       --replace "/bin/bash" "${bash}/bin/bash"
     mkdir -p "$out/${python.sitePackages}"
     export PYTHONPATH="$out/${python.sitePackages}:$PYTHONPATH"
-    ${python.interpreter} setup.py install \
+    ${python.pythonForBuild.interpreter} setup.py install \
       --install-lib=$out/${python.sitePackages} \
       --prefix="$out"
   '';

--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -47,7 +47,7 @@ let common = { version, sha256, patches ? [ ], tag ? "z3" }:
 
     configurePhase = concatStringsSep " "
       (
-        [ "${python.interpreter} scripts/mk_make.py --prefix=$out" ]
+        [ "${python.pythonForBuild.interpreter} scripts/mk_make.py --prefix=$out" ]
           ++ optional javaBindings "--java"
           ++ optional ocamlBindings "--ml"
           ++ optional pythonBindings "--python --pypkgdir=$out/${python.sitePackages}"

--- a/pkgs/development/interpreters/renpy/default.nix
+++ b/pkgs/development/interpreters/renpy/default.nix
@@ -59,14 +59,14 @@ stdenv.mkDerivation rec {
 
   buildPhase = with python3.pkgs; ''
     runHook preBuild
-    ${python.interpreter} module/setup.py build --parallel=$NIX_BUILD_CORES
+    ${python.pythonForBuild.interpreter} module/setup.py build --parallel=$NIX_BUILD_CORES
     runHook postBuild
   '';
 
   installPhase = with python3.pkgs; ''
     runHook preInstall
 
-    ${python.interpreter} module/setup.py install --prefix=$out
+    ${python.pythonForBuild.interpreter} module/setup.py install --prefix=$out
     mkdir -p $out/share/renpy
     cp -vr sdk-fonts gui launcher renpy the_question tutorial renpy.py $out/share/renpy
 

--- a/pkgs/development/libraries/science/chemistry/openmm/default.nix
+++ b/pkgs/development/libraries/science/chemistry/openmm/default.nix
@@ -82,8 +82,8 @@ stdenv.mkDerivation rec {
       export OPENMM_LIB_PATH=$out/lib
       export OPENMM_INCLUDE_PATH=$out/include
       cd python
-      ${python3Packages.python.interpreter} setup.py build
-      ${python3Packages.python.interpreter} setup.py install --prefix=$out
+      ${python3Packages.python.pythonForBuild.interpreter} setup.py build
+      ${python3Packages.python.pythonForBuild.interpreter} setup.py install --prefix=$out
     '';
 
   postFixup = ''

--- a/pkgs/development/python-modules/bash_kernel/default.nix
+++ b/pkgs/development/python-modules/bash_kernel/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   '';
 
   postInstall = ''
-    ${python.interpreter} -m bash_kernel.install --prefix $out
+    ${python.pythonForBuild.interpreter} -m bash_kernel.install --prefix $out
   '';
 
   meta = {

--- a/pkgs/development/python-modules/bashlex/default.nix
+++ b/pkgs/development/python-modules/bashlex/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   # workaround https://github.com/idank/bashlex/issues/51
   preBuild = ''
-    ${python.interpreter} -c 'import bashlex'
+    ${python.pythonForBuild.interpreter} -c 'import bashlex'
   '';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/manimpango/default.nix
+++ b/pkgs/development/python-modules/manimpango/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
   '';
 
   preBuild = ''
-    ${python.interpreter} setup.py build_ext --inplace
+    ${python.pythonForBuild.interpreter} setup.py build_ext --inplace
   '';
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pycuda/default.nix
+++ b/pkgs/development/python-modules/pycuda/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   };
 
   preConfigure = with lib.versions; ''
-    ${python.interpreter} configure.py --boost-inc-dir=${boost.dev}/include \
+    ${python.pythonForBuild.interpreter} configure.py --boost-inc-dir=${boost.dev}/include \
                           --boost-lib-dir=${boost}/lib \
                           --no-use-shipped-boost \
                           --boost-python-libname=boost_python${major python.version}${minor python.version} \

--- a/pkgs/development/python-modules/pygame/default.nix
+++ b/pkgs/development/python-modules/pygame/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
   ];
 
   preConfigure = ''
-    ${python.interpreter} buildconfig/config.py
+    ${python.pythonForBuild.interpreter} buildconfig/config.py
   '';
 
   checkPhase = ''

--- a/pkgs/development/python-modules/pygeos/default.nix
+++ b/pkgs/development/python-modules/pygeos/default.nix
@@ -30,8 +30,8 @@ buildPythonPackage rec {
   # for the package to function. Therefore override of buildPhase was
   # necessary.
   buildPhase = ''
-    ${python.interpreter} setup.py build_ext --inplace
-    ${python.interpreter} setup.py bdist_wheel
+    ${python.pythonForBuild.interpreter} setup.py build_ext --inplace
+    ${python.pythonForBuild.interpreter} setup.py bdist_wheel
   '';
 
   nativeCheckInputs = [
@@ -50,4 +50,3 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ nialov ];
   };
 }
-

--- a/pkgs/development/python-modules/pymunk/default.nix
+++ b/pkgs/development/python-modules/pymunk/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   ];
 
   preBuild = ''
-    ${python.interpreter} setup.py build_ext --inplace
+    ${python.pythonForBuild.interpreter} setup.py build_ext --inplace
   '';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pyqt/4.x.nix
+++ b/pkgs/development/python-modules/pyqt/4.x.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     ''}
 
     chmod +x configure.py
-    sed -i '1i#!${python.interpreter}' configure.py
+    sed -i '1i#!${python.pythonForBuild.interpreter}' configure.py
   '';
 
   configureScript = "./configure.py";

--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     cd ../../..
-    ${python.interpreter} setup.py egg_info --build-type=pyside2
+    ${python.pythonForBuild.interpreter} setup.py egg_info --build-type=pyside2
     cp -r PySide2.egg-info $out/${python.sitePackages}/
   '';
 

--- a/pkgs/development/python-modules/pysvn/default.nix
+++ b/pkgs/development/python-modules/pysvn/default.nix
@@ -37,8 +37,8 @@ buildPythonPackage rec {
 
   preConfigure = ''
     cd Source
-    ${python.interpreter} setup.py backport
-    ${python.interpreter} setup.py configure \
+    ${python.pythonForBuild.interpreter} setup.py backport
+    ${python.pythonForBuild.interpreter} setup.py configure \
       --apr-inc-dir=${apr.dev}/include \
       --apu-inc-dir=${aprutil.dev}/include \
       --pycxx-dir=${pycxx.dev}/include \

--- a/pkgs/development/python-modules/python-efl/default.nix
+++ b/pkgs/development/python-modules/python-efl/default.nix
@@ -31,11 +31,11 @@ buildPythonPackage rec {
   '';
 
   preBuild = ''
-    ${python.interpreter} setup.py build_ext
+    ${python.pythonForBuild.interpreter} setup.py build_ext
   '';
 
   installPhase = ''
-    ${python.interpreter} setup.py install --prefix=$out --single-version-externally-managed
+    ${python.pythonForBuild.interpreter} setup.py install --prefix=$out --single-version-externally-managed
   '';
 
   doCheck = false;

--- a/pkgs/development/python-modules/python-fontconfig/default.nix
+++ b/pkgs/development/python-modules/python-fontconfig/default.nix
@@ -17,7 +17,7 @@ in buildPythonPackage rec {
   nativeBuildInputs = [ cython ];
 
   preBuild = ''
-    ${python.interpreter} setup.py build_ext -i
+    ${python.pythonForBuild.interpreter} setup.py build_ext -i
   '';
 
   checkPhase = ''

--- a/pkgs/development/python-modules/pywayland/default.nix
+++ b/pkgs/development/python-modules/pywayland/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   postBuild = ''
-    ${python.interpreter} pywayland/ffi_build.py
+    ${python.pythonForBuild.interpreter} pywayland/ffi_build.py
   '';
 
   # Tests need this to create sockets

--- a/pkgs/development/python-modules/pywlroots/default.nix
+++ b/pkgs/development/python-modules/pywlroots/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   postBuild = ''
-    ${python.interpreter} wlroots/ffi_build.py
+    ${python.pythonForBuild.interpreter} wlroots/ffi_build.py
   '';
 
   pythonImportsCheck = [ "wlroots" ];

--- a/pkgs/development/python-modules/shiboken2/default.nix
+++ b/pkgs/development/python-modules/shiboken2/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
 
   postInstall = ''
     cd ../../..
-    ${python.interpreter} setup.py egg_info --build-type=shiboken2
+    ${python.pythonForBuild.interpreter} setup.py egg_info --build-type=shiboken2
     cp -r shiboken2.egg-info $out/${python.sitePackages}/
     rm $out/bin/shiboken_tool.py
   '';

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -219,7 +219,7 @@ in buildPythonPackage rec {
 
   preBuild = ''
     export MAX_JOBS=$NIX_BUILD_CORES
-    ${python.interpreter} setup.py build --cmake-only
+    ${python.pythonForBuild.interpreter} setup.py build --cmake-only
     ${cmake}/bin/cmake build
   '';
 

--- a/pkgs/development/python-modules/wxPython/4.0.nix
+++ b/pkgs/development/python-modules/wxPython/4.0.nix
@@ -69,11 +69,11 @@ buildPythonPackage rec {
   '';
 
   buildPhase = ''
-    ${python.interpreter} build.py -v --use_syswx dox etg --nodoc sip build_py
+    ${python.pythonForBuild.interpreter} build.py -v --use_syswx dox etg --nodoc sip build_py
   '';
 
   installPhase = ''
-    ${python.interpreter} setup.py install --skip-build --prefix=$out
+    ${python.pythonForBuild.interpreter} setup.py install --skip-build --prefix=$out
   '';
 
   passthru = { wxWidgets = wxGTK; };

--- a/pkgs/development/python-modules/wxPython/4.1.nix
+++ b/pkgs/development/python-modules/wxPython/4.1.nix
@@ -129,11 +129,11 @@ buildPythonPackage rec {
   '';
 
   buildPhase = ''
-    ${python.interpreter} build.py -v build_wx dox etg --nodoc sip build_py
+    ${python.pythonForBuild.interpreter} build.py -v build_wx dox etg --nodoc sip build_py
   '';
 
   installPhase = ''
-    ${python.interpreter} setup.py install --skip-build --prefix=$out
+    ${python.pythonForBuild.interpreter} setup.py install --skip-build --prefix=$out
     wrapPythonPrograms
   '';
 

--- a/pkgs/development/python-modules/wxPython/4.2.nix
+++ b/pkgs/development/python-modules/wxPython/4.2.nix
@@ -102,7 +102,7 @@ buildPythonPackage rec {
     export PATH="${wxGTK}/bin:$PATH"
     export SDL_CONFIG="${SDL.dev}/bin/sdl-config"
 
-    ${python.interpreter} build.py -v --use_syswx dox etg sip --nodoc build_py
+    ${python.pythonForBuild.interpreter} build.py -v --use_syswx dox etg sip --nodoc build_py
 
     runHook postBuild
   '';
@@ -111,7 +111,7 @@ buildPythonPackage rec {
   installPhase = ''
     runHook preInstall
 
-    ${python.interpreter} setup.py install --skip-build --prefix=$out
+    ${python.pythonForBuild.interpreter} setup.py install --skip-build --prefix=$out
     wrapPythonPrograms
 
     runHook postInstall

--- a/pkgs/development/python-modules/xattr/default.nix
+++ b/pkgs/development/python-modules/xattr/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   postBuild = ''
-    ${python.interpreter} -m compileall -f xattr
+    ${python.pythonForBuild.interpreter} -m compileall -f xattr
   '';
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/xkbcommon/default.nix
+++ b/pkgs/development/python-modules/xkbcommon/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   postBuild = ''
-    ${python.interpreter} xkbcommon/ffi_build.py
+    ${python.pythonForBuild.interpreter} xkbcommon/ffi_build.py
   '';
 
   pythonImportsCheck = [ "xkbcommon" ];

--- a/pkgs/development/tools/fdroidserver/default.nix
+++ b/pkgs/development/tools/fdroidserver/default.nix
@@ -21,7 +21,7 @@ python.pkgs.buildPythonApplication rec {
   '';
 
   preConfigure = ''
-    ${python.interpreter} setup.py compile_catalog
+    ${python.pythonForBuild.interpreter} setup.py compile_catalog
   '';
 
   postInstall = ''

--- a/pkgs/development/tools/misc/ycmd/default.nix
+++ b/pkgs/development/tools/misc/ycmd/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
 
   buildPhase = ''
     export EXTRA_CMAKE_ARGS="-DPATH_TO_LLVM_ROOT=${llvmPackages.libllvm} -DUSE_SYSTEM_ABSEIL=true"
-    ${python.interpreter} build.py --system-libclang --clang-completer --ninja
+    ${python.pythonForBuild.interpreter} build.py --system-libclang --clang-completer --ninja
   '';
 
   dontConfigure = true;

--- a/pkgs/os-specific/linux/libnl/default.nix
+++ b/pkgs/os-specific/linux/libnl/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   postBuild = lib.optionalString (pythonSupport) ''
       cd python
-      ${python.interpreter} setup.py install --prefix=../pythonlib
+      ${python.pythonForBuild.interpreter} setup.py install --prefix=../pythonlib
       cd -
   '';
 

--- a/pkgs/servers/home-assistant/intents.nix
+++ b/pkgs/servers/home-assistant/intents.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   postInstall = ''
     pushd ..
     # https://github.com/home-assistant/intents/blob/main/script/package#L18
-    ${python.interpreter} -m script.intentfest merged_output $out/${python.sitePackages}/home_assistant_intents/data
+    ${python.pythonForBuild.interpreter} -m script.intentfest merged_output $out/${python.sitePackages}/home_assistant_intents/data
     popd
   '';
 

--- a/pkgs/tools/audio/tts/default.nix
+++ b/pkgs/tools/audio/tts/default.nix
@@ -95,7 +95,7 @@ python.pkgs.buildPythonApplication rec {
     # cython modules are not installed for some reasons
     (
       cd TTS/tts/utils/monotonic_align
-      ${python.interpreter} setup.py install --prefix=$out
+      ${python.pythonForBuild.interpreter} setup.py install --prefix=$out
     )
   '';
 

--- a/pkgs/tools/backup/s3ql/default.nix
+++ b/pkgs/tools/backup/s3ql/default.nix
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   preBuild = ''
-    ${python3Packages.python.interpreter} ./setup.py build_cython build_ext --inplace
+    ${python3Packages.python.pythonForBuild.interpreter} ./setup.py build_cython build_ext --inplace
   '';
 
   checkPhase = ''


### PR DESCRIPTION
###### Description of changes

It won't be enough to fix cross in all cases, but it is in at least one: pywayland.  I've only made the change in cases I'm confident it's correct, as it would be wrong to change this when python.interpreter is used in wrappers, and possibly when it's used for running tests.

Optimistically targeting master, but I've made sure to base this on a commit old enough that if we need to re-target to staging, we can just change the base without doing the draft dance.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
