### PR TITLE
kb: init at 0.1.7

### DIFF
--- a/pkgs/tools/misc/kb/default.nix
+++ b/pkgs/tools/misc/kb/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "kb";
+  version = "0.1.7";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "gnebbia";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-K8EAqZbl2e0h03fFwaKIclZTZARDQp1tRo44znxwW0I=";
+  };
+
+  postPatch = ''
+    # `attr` module is not available. And `attrs` defines another `attr` package
+    # that shadows it.
+    substituteInPlace setup.py \
+      --replace \
+        "install_requires=[\"colored\",\"toml\",\"attr\",\"attrs\",\"gitpython\"]," \
+        "install_requires=[\"colored\",\"toml\",\"attrs\",\"gitpython\"],"
+
+    # pytest coverage reporting isn't necessary
+    substituteInPlace setup.cfg \
+      --replace \
+      "addopts = --cov=kb --cov-report term-missing" ""
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    colored
+    toml
+    attrs
+    gitpython
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "A minimalist command line knowledge base manager";
+    longDescription = ''
+      kb is a text-oriented minimalist command line knowledge base manager. kb
+      can be considered a quick note collection and access tool oriented toward
+      software developers, penetration testers, hackers, students or whoever has
+      to collect and organize notes in a clean way. Although kb is mainly
+      targeted on text-based note collection, it supports non-text files as well
+      (e.g., images, pdf, videos and others).
+    '';
+    homepage = "https://github.com/gnebbia/kb";
+    changelog = "https://github.com/gnebbia/kb/blob/v${version}/CHANGELOG.md";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ wesleyjrz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10229,6 +10229,8 @@ with pkgs;
 
   nb = callPackage ../tools/misc/nb { };
 
+  kb = callPackage ../tools/misc/kb { };
+
   notable = callPackage ../applications/misc/notable { };
 
   nth = with python3Packages; toPythonApplication name-that-hash;


### PR DESCRIPTION
###### Description of changes

This is a simple (and suckless) knowledge management tool.

![screenshot-20230226-184108](https://user-images.githubusercontent.com/60184588/221439146-3b7d11f5-c73b-40aa-ba90-f4b0dd995be2.png)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
