### PR TITLE
Fix weston and colord cross-compilation

### DIFF
--- a/pkgs/applications/window-managers/weston/default.nix
+++ b/pkgs/applications/window-managers/weston/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "078y14ff9wmmbzq314f7bq1bxx0rc12xy4j362n60iamr56qs4x6";
   };
 
+  depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [ meson ninja pkg-config python3 wayland-scanner ];
   buildInputs = [
     cairo colord dbus freerdp lcms2 libGL libXcursor libdrm libevdev libinput

--- a/pkgs/tools/misc/colord/default.nix
+++ b/pkgs/tools/misc/colord/default.nix
@@ -15,6 +15,7 @@
 , gobject-introspection
 , argyllcms
 , meson
+, mesonEmulatorHook
 , ninja
 , vala
 , libgudev
@@ -75,6 +76,8 @@ stdenv.mkDerivation rec {
     shared-mime-info
     vala
     wrapGAppsNoGuiHook
+  ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    mesonEmulatorHook
   ];
 
   buildInputs = [


### PR DESCRIPTION
###### Description of changes

Before the changes, running `nix build .#legacyPackages.x86_64-linux.pkgsCross.aarch64-multiplatform.weston` resulted in:

```
builder for '/nix/store/s8i70bfkl58xvph2x7kssjmnrvvqnjhr-colord-aarch64-unknown-linux-gnu-1.4.6.drv' failed with exit code 1;
       last 10 log lines:
       >     installed_tests: true
       >     libcolordcompat: true
       >     sane           : true
       >     vapi           : true
       >
       > Found ninja-1.11.1 at /nix/store/sdynpmwb7917axidiz4h73698m5drr1i-ninja-1.11.1/bin/ninja
       >
       > ERROR: An exe_wrapper is needed but was not found. Please define one in cross file and check the command and/or add it to PATH.
       >
       > A full log can be found at /build/colord-1.4.6/build/meson-logs/meson-log.txt
       For full logs, run 'nix log /nix/store/s8i70bfkl58xvph2x7kssjmnrvvqnjhr-colord-aarch64-unknown-linux-gnu-1.4.6.drv'.
error: builder for '/nix/store/s8i70bfkl58xvph2x7kssjmnrvvqnjhr-colord-aarch64-unknown-linux-gnu-1.4.6.drv' failed with exit code 1
error: 1 dependencies of derivation '/nix/store/cwf4hsj4pvspa0a54l9m1x6j43bj4xg0-weston-aarch64-unknown-linux-gnu-11.0.0.drv' failed to build
```

After fixing the colord, the weston failed:

```
builder for '/nix/store/ll33k902aavbvhzayz2i5k3gr4n4lwdx-weston-aarch64-unknown-linux-gnu-11.0.0.drv' failed with exit code 1;
       last 10 log lines:
       > Configuring version.h using configuration
       > Did not find pkg-config by name 'pkg-config'
       > Found Pkg-config: NO
       > Did not find CMake 'cmake'
       > Found CMake: NO
       > Build-time dependency wayland-scanner found: NO
       >
       > protocol/meson.build:1:0: ERROR: Dependency lookup for wayland-scanner with method 'pkgconfig' failed: Pkg-config binary for machine 0 not found. Giving up.
       >
       > A full log can be found at /build/weston-11.0.0/build/meson-logs/meson-log.txt
       For full logs, run 'nix log /nix/store/ll33k902aavbvhzayz2i5k3gr4n4lwdx-weston-aarch64-unknown-linux-gnu-11.0.0.drv'.
error: builder for '/nix/store/ll33k902aavbvhzayz2i5k3gr4n4lwdx-weston-aarch64-unknown-linux-gnu-11.0.0.drv' failed with exit code 1
```

###### Things done

For colord: optionally add mesonEmulatorHook to nativeBuildInputs
For weston: added pkg-config to depsBuildBuild

- Built on platform(s)
  - [X] Only built  `nix build .#legacyPackages.x86_64-linux.pkgsCross.aarch64-multiplatform.weston`
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
