### PR TITLE
ocamlPackages.base64: 3.5.0 → 3.5.1

### DIFF
--- a/pkgs/development/ocaml-modules/base64/default.nix
+++ b/pkgs/development/ocaml-modules/base64/default.nix
@@ -2,13 +2,14 @@
 
 buildDunePackage rec {
   pname = "base64";
-  version = "3.5.0";
+  version = "3.5.1";
 
   minimalOCamlVersion = "4.03";
+  duneVersion = "3";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-base64/releases/download/v${version}/base64-v${version}.tbz";
-    sha256 = "sha256-WJ3pwAV46/54QZismBjTWGxHSyMWts0+HEbMsfYq46Q=";
+    url = "https://github.com/mirage/ocaml-base64/releases/download/v${version}/base64-${version}.tbz";
+    hash = "sha256-2P7apZvRL+rnrMCLWSjdR4qsUj9MqNJARw0lAGUcZe0=";
   };
 
   nativeBuildInputs = [ findlib ];

--- a/pkgs/development/ocaml-modules/bistro/default.nix
+++ b/pkgs/development/ocaml-modules/bistro/default.nix
@@ -20,7 +20,7 @@ buildDunePackage rec {
   pname = "bistro";
   version = "unstable-2022-05-07";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "pveber";

--- a/pkgs/development/ocaml-modules/emile/default.nix
+++ b/pkgs/development/ocaml-modules/emile/default.nix
@@ -15,11 +15,12 @@ buildDunePackage rec {
   pname = "emile";
   version = "1.1";
 
-  useDune2 = true;
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/dinosaure/emile/releases/download/v${version}/emile-v${version}.tbz";
-    sha256 = "0r1141makr0b900aby1gn0fccjv1qcqgyxib3bzq8fxmjqwjan8p";
+    hash = "sha256:0r1141makr0b900aby1gn0fccjv1qcqgyxib3bzq8fxmjqwjan8p";
   };
 
   buildInputs = [ cmdliner ];
@@ -32,10 +33,7 @@ buildDunePackage rec {
     uutf
   ];
 
-  # technically emile is available for ocaml >= 4.03, but alcotest
-  # and angstrom (fmt) are only available for >= 4.08. Disabling
-  # tests for < 4.08 at least improves the error message
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
   checkInputs = [ alcotest ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/h2/default.nix
+++ b/pkgs/development/ocaml-modules/h2/default.nix
@@ -30,6 +30,7 @@ buildDunePackage rec {
     src
     ;
 
+  duneVersion = "3";
   minimalOCamlVersion = "4.06";
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/index/default.nix
+++ b/pkgs/development/ocaml-modules/index/default.nix
@@ -10,10 +10,11 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/mirage/index/releases/download/${version}/index-${version}.tbz";
-    sha256 = "sha256-rPwNzqkWqDak2mDTDIBqIvachY1vfOIzFmwaXjZea+4=";
+    hash = "sha256-rPwNzqkWqDak2mDTDIBqIvachY1vfOIzFmwaXjZea+4=";
   };
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   buildInputs = [
     stdlib-shims

--- a/pkgs/development/ocaml-modules/otr/default.nix
+++ b/pkgs/development/ocaml-modules/otr/default.nix
@@ -6,14 +6,14 @@ buildDunePackage rec {
   pname = "otr";
   version = "0.3.10";
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/hannesm/ocaml-otr/releases/download/v${version}/otr-v${version}.tbz";
-    sha256 = "0dssc7p6s7z53n0mddyipjghzr8ld8bb7alaxqrx9gdpspwab1gq";
+    hash = "sha256:0dssc7p6s7z53n0mddyipjghzr8ld8bb7alaxqrx9gdpspwab1gq";
   };
 
-  useDune2 = true;
+  duneVersion = "3";
 
   propagatedBuildInputs = [ cstruct sexplib0 mirage-crypto mirage-crypto-pk
                             astring base64 ];

--- a/pkgs/development/ocaml-modules/progress/default.nix
+++ b/pkgs/development/ocaml-modules/progress/default.nix
@@ -7,7 +7,7 @@ buildDunePackage rec {
   pname = "progress";
 
   minimalOCamlVersion = "4.08";
-  useDune2 = true;
+  duneVersion = "3";
 
   inherit (terminal) version src;
 

--- a/pkgs/development/ocaml-modules/repr/default.nix
+++ b/pkgs/development/ocaml-modules/repr/default.nix
@@ -8,10 +8,11 @@ buildDunePackage rec {
     owner = "mirage";
     repo = "repr";
     rev = version;
-    sha256 = "sha256-jF8KmaG07CT26O/1ANc6s1yHFJqhXDtd0jgTA04tIgw=";
+    hash = "sha256-jF8KmaG07CT26O/1ANc6s1yHFJqhXDtd0jgTA04tIgw=";
   };
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
   strictDeps = true;
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/repr/ppx.nix
+++ b/pkgs/development/ocaml-modules/repr/ppx.nix
@@ -4,6 +4,7 @@ buildDunePackage {
   pname = "ppx_repr";
 
   inherit (repr) src version strictDeps;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     ppx_deriving


### PR DESCRIPTION
###### Description of changes

Better compatibility with OCaml 5.0
https://github.com/mirage/ocaml-base64/releases/tag/v3.5.1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
