### PR TITLE
python311Packages.karton-dashboard: move to pythonRelaxDepsHook

### DIFF
--- a/pkgs/development/python-modules/karton-dashboard/default.nix
+++ b/pkgs/development/python-modules/karton-dashboard/default.nix
@@ -8,6 +8,7 @@
 , networkx
 , prometheus-client
 , pythonOlder
+, pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
@@ -25,11 +26,23 @@ buildPythonPackage rec {
   };
 
   patches = [
+    # Allow later mistune, https://github.com/CERT-Polska/karton-dashboard/pull/68
     (fetchpatch {
       name = "update-mistune.patch";
       url = "https://github.com/CERT-Polska/karton-dashboard/commit/d0a2a1ffd21e9066acca77434acaff7b20e460d0.patch";
       hash = "sha256-LOqeLWoCXmVTthruBiQUYR03yPOPHhgYF/fJMhhT6Wo=";
     })
+  ];
+
+  pythonRelaxDeps = [
+    "Flask"
+    "mistune"
+    "networkx"
+    "prometheus-client"
+  ];
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = [
@@ -39,13 +52,6 @@ buildPythonPackage rec {
     networkx
     prometheus-client
   ];
-
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "Flask==2.0.3" "Flask" \
-      --replace "networkx==2.6.3" "networkx" \
-      --replace "prometheus_client==0.11.0" "prometheus_client"
-  '';
 
   # Project has no tests. pythonImportsCheck requires MinIO configuration
   doCheck = false;


### PR DESCRIPTION
- relax mistune constraint as we have a patch already

###### Description of changes
Fix build (https://hydra.nixos.org/build/210130839)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
