### PR TITLE
lexicon: 3.9.4 -> 3.11.7

### DIFF
--- a/pkgs/tools/admin/lexicon/default.nix
+++ b/pkgs/tools/admin/lexicon/default.nix
@@ -7,13 +7,13 @@ with python3.pkgs;
 
 buildPythonApplication rec {
   pname = "lexicon";
-  version = "3.9.4";
+  version = "3.11.7";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "AnalogJ";
     repo = pname;
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-TySgIxBEl2RolndAkEN4vCIDKaI48vrh2ocd+CTn7Ow=";
   };
 
@@ -23,32 +23,54 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = [
     beautifulsoup4
-    boto3
     cryptography
-    dnspython
-    future
-    localzone
-    oci
-    pynamecheap
+    importlib-metadata
     pyyaml
     requests
-    softlayer
     tldextract
-    transip
-    xmltodict
-    zeep
   ];
+
+  passthru.optional-dependencies = {
+    route53 = [
+      boto3
+    ];
+    localzone = [
+      localzone
+    ];
+    softlayer = [
+      softlayer
+    ];
+    gransy = [
+      zeep
+    ];
+    ddns = [
+      dnspython
+    ];
+    oci = [
+      oci
+    ];
+    full = [
+      boto3
+      dnspython
+      localzone
+      oci
+      softlayer
+      zeep
+    ];
+  };
 
   nativeCheckInputs = [
     mock
     pytestCheckHook
     pytest-xdist
     vcrpy
-  ];
+  ] ++ passthru.optional-dependencies.full;
 
   disabledTestPaths = [
     # Tests require network access
     "lexicon/tests/providers/test_auto.py"
+    # Tests require an additional setup
+    "lexicon/tests/providers/test_localzone.py"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/tools/admin/lexicon/default.nix
+++ b/pkgs/tools/admin/lexicon/default.nix
@@ -58,6 +58,7 @@ buildPythonApplication rec {
   meta = with lib; {
     description = "Manipulate DNS records of various DNS providers in a standardized way";
     homepage = "https://github.com/AnalogJ/lexicon";
+    changelog = "https://github.com/AnalogJ/lexicon/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ flyfloh ];
   };


### PR DESCRIPTION
Diff: https://github.com/AnalogJ/lexicon/compare/refs/tags/v3.9.4...v3.11.7

Changelog: https://github.com/AnalogJ/lexicon/blob/v3.11.7/CHANGELOG.md

###### Description of changes

No longer depend on `transip` (#218615).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
