### PR TITLE
nixos/networkd-dispatcher: add rules option

### DIFF
--- a/pkgs/tools/networking/networkd-dispatcher/default.nix
+++ b/pkgs/tools/networking/networkd-dispatcher/default.nix
@@ -19,6 +19,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-yO9/HlUkaQmW/n9N3vboHw//YMzBjxIHA2zAxgZNEv0=";
   };
 
+  patches = [
+    # Support rule files in NixOS store paths. Required for the networkd-dispatcher
+    # module to work
+    ./support_nix_store_path.patch
+  ];
+
   postPatch = ''
     # Fix paths in systemd unit file
     substituteInPlace networkd-dispatcher.service \

--- a/pkgs/tools/networking/networkd-dispatcher/support_nix_store_path.patch
+++ b/pkgs/tools/networking/networkd-dispatcher/support_nix_store_path.patch
@@ -1,0 +1,13 @@
+diff --git a/networkd-dispatcher b/networkd-dispatcher
+index ef877ce..8c341f2 100755
+--- a/networkd-dispatcher
++++ b/networkd-dispatcher
+@@ -171,6 +171,8 @@ def check_perms(path, mode=0o755, uid=0, gid=0):
+ 
+     if not os.path.exists(path):
+         raise FileNotFoundError
++    if re.search('^/nix/store/.*', str(path)):
++        return True
+     st = os.stat(path, follow_symlinks=False)
+     st_mode = st.st_mode & 0x00FFF
+     if st.st_uid == uid and st.st_gid == gid and st_mode == mode:


### PR DESCRIPTION
###### Description of changes

The following PR adds a rule option to the [networkd-dispatcher](https://gitlab.com/craftyguy/networkd-dispatcher) module. Using this, it is possible to configure scripts which are triggered on specific systemd-networkd operational changes.

Currently the implementation design looks like this
```
networkd-dispatcher = {
  enable = true;
  rules = {
    "restart-tor" = {
      onState = ["routable" "off"];
      script = ''
        #!${pkgs.runtimeShell}
        if [[ $IFACE == "wlan0" && $AdministrativeState == "configured" ]]; then
          echo "Restarting Tor ..."
          systemctl restart tor
        fi
        exit 0
      '';
    };
  };
};
```

Fixes https://github.com/NixOS/nixpkgs/issues/218930

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
