### PR TITLE
nixos/opensearch: fix opensearch startup

### DIFF
--- a/nixos/modules/services/search/opensearch.nix
+++ b/nixos/modules/services/search/opensearch.nix
@@ -199,12 +199,16 @@ in
               # java.security.AccessControlException:
               # access denied ("java.io.FilePermission" "/var/lib/opensearch/config/opensearch.yml" "read")
 
+              rm -f ${configDir}/opensearch.yml
               cp ${opensearchYml} ${configDir}/opensearch.yml
 
               # Make sure the logging configuration for old OpenSearch versions is removed:
               rm -f "${configDir}/logging.yml"
+              rm -f ${configDir}/${loggingConfigFilename}
               cp ${loggingConfigFile} ${configDir}/${loggingConfigFilename}
               mkdir -p ${configDir}/scripts
+
+              rm -f ${configDir}/jvm.options
               cp ${cfg.package}/config/jvm.options ${configDir}/jvm.options
 
               # redirect jvm logs to the data directory


### PR DESCRIPTION
###### Description of changes

The second startup of opensearch does not work as the copied files aren't cleanup all.

```
Feb 27 15:10:13 chatbot w41v1w3yf0k96040rr7m1097kiyqph71-opensearch-start-pre-unprivileged[860]: cp: cannot create regular file '/var/lib/opensearch/config/opensearch.yml': Permission denied
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

