### PR TITLE
SDL2_mixer: 2.0.4 -> 2.6.3

### DIFF
--- a/pkgs/development/libraries/SDL2_mixer/2_0.nix
+++ b/pkgs/development/libraries/SDL2_mixer/2_0.nix
@@ -1,0 +1,22 @@
+{ fetchurl
+, lzwolf
+, SDL2_mixer
+, timidity
+}:
+
+SDL2_mixer.overrideAttrs(oa: rec {
+  version = "2.0.4";
+
+  src = fetchurl {
+    url = "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${version}.tar.gz";
+    sha256 = "0694vsz5bjkcdgfdra6x9fq8vpzrl8m6q96gh58df7065hw5mkxl";
+  };
+
+  # fix default path to timidity.cfg so MIDI files could be played
+  postPatch = ''
+    substituteInPlace timidity/options.h \
+      --replace "/usr/share/timidity" "${timidity}/share/timidity"
+  '';
+
+  passthru.tests.lzwolf = lzwolf;
+})

--- a/pkgs/development/libraries/SDL2_mixer/default.nix
+++ b/pkgs/development/libraries/SDL2_mixer/default.nix
@@ -18,12 +18,24 @@
 
 stdenv.mkDerivation rec {
   pname = "SDL2_mixer";
-  version = "2.0.4";
+  version = "2.6.3";
 
   src = fetchurl {
     url = "https://www.libsdl.org/projects/SDL_mixer/release/${pname}-${version}.tar.gz";
-    sha256 = "0694vsz5bjkcdgfdra6x9fq8vpzrl8m6q96gh58df7065hw5mkxl";
+    sha256 = "sha256-emuoakeGSM5hfjpekncYG8Z/fOmHZgXupq/9Sg1u6o8=";
   };
+
+  configureFlags = [
+    "--disable-music-ogg-shared"
+    "--disable-music-flac-shared"
+    "--disable-music-mod-modplug-shared"
+    "--disable-music-mp3-mpg123-shared"
+    "--disable-music-opus-shared"
+    "--disable-music-midi-fluidsynth-shared"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "--disable-sdltest"
+    "--disable-smpegtest"
+  ];
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -49,28 +61,10 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  # fix default path to timidity.cfg so MIDI files could be played
-  postPatch = ''
-    substituteInPlace timidity/options.h \
-      --replace "/usr/share/timidity" "${timidity}/share/timidity"
-  '';
-
-  configureFlags = [
-    "--disable-music-ogg-shared"
-    "--disable-music-flac-shared"
-    "--disable-music-mod-modplug-shared"
-    "--disable-music-mp3-mpg123-shared"
-    "--disable-music-opus-shared"
-    "--disable-music-midi-fluidsynth-shared"
-  ] ++ lib.optionals stdenv.isDarwin [
-    "--disable-sdltest"
-    "--disable-smpegtest"
-  ];
-
   meta = with lib; {
     description = "SDL multi-channel audio mixer library";
     platforms = platforms.unix;
-    homepage = "https://www.libsdl.org/projects/SDL_mixer/";
+    homepage = "https://github.com/libsdl-org/SDL_mixer";
     maintainers = with maintainers; [ MP2E ];
     license = licenses.zlib;
   };

--- a/pkgs/games/lzwolf/default.nix
+++ b/pkgs/games/lzwolf/default.nix
@@ -5,6 +5,7 @@
 
 stdenv.mkDerivation rec {
   pname = "lzwolf";
+  # Fix-Me: Remember to remove SDL2_mixer pin (at top-level) on next lzwolf upgrade.
   version = "unstable-2022-01-04";
 
   src = fetchFromBitbucket {
@@ -13,6 +14,7 @@ stdenv.mkDerivation rec {
     rev = "6e470316382b87378966f441e233760ce0ff478c";
     sha256 = "sha256-IbZleY2FPyW3ORIGO2YFXQyAf1l9nDthpJjEKTTsilM=";
   };
+
   nativeBuildInputs = [ p7zip cmake ];
   buildInputs = [
     SDL2 bzip2 zlib libjpeg SDL2_mixer SDL2_net libsndfile mpg123

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9663,7 +9663,7 @@ with pkgs;
 
   lzop = callPackage ../tools/compression/lzop { };
 
-  lzwolf = callPackage ../games/lzwolf { };
+  lzwolf = callPackage ../games/lzwolf { SDL2_mixer = SDL2_mixer_2_0; };
 
   macchanger = callPackage ../os-specific/linux/macchanger { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23186,6 +23186,8 @@ with pkgs;
   SDL2_mixer = callPackage ../development/libraries/SDL2_mixer {
     inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit AudioToolbox;
   };
+  # SDL2_mixer_2_0 pinned for lzwolf
+  SDL2_mixer_2_0 = callPackage ../development/libraries/SDL2_mixer/2_0.nix { };
 
   SDL2_net = callPackage ../development/libraries/SDL2_net { };
 


### PR DESCRIPTION
SDL2_mixer: 2.0.4 -> 2.6.3

Release: https://github.com/libsdl-org/SDL_mixer/releases/tag/release-2.6.3

* Refactor: Re-ordered `configureFlags` to respect phases order.

Downstream breakage:
* lzwolf: pinning SDL2_mixer to 2.0.4 until next upgrade.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
