### PR TITLE
apfs-fuse: 2020-09-28 -> 2023-01-04

### DIFF
--- a/pkgs/tools/filesystems/apfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/apfs-fuse/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "apfs-fuse-unstable";
-  version = "2020-09-28";
+  version = "2023-01-04";
 
   src = fetchFromGitHub {
     owner  = "sgan81";
     repo   = "apfs-fuse";
-    rev    = "ee71aa5c87c0831c1ae17048951fe9cd7579c3db";
-    sha256 = "0wvsx708km1lnhghny5y69k694x0zy8vlbndswkb7sq81j1r6kwx";
+    rev    = "1f041d7af5df5423832e54e9f358fd9234773fcc";
+    hash = "sha256-EmhCvIwyVJvib/ZHzCsULh8bOjhzKRu47LojX+L40qQ=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Description of changes
This adds support for new compression algorithms and contains some bug fixes.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).