### PR TITLE
lld: build with 2M stack size on musl

### DIFF
--- a/pkgs/development/compilers/llvm/10/lld/default.nix
+++ b/pkgs/development/compilers/llvm/10/lld/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+
+  # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/development/compilers/llvm/10/lld/default.nix
+++ b/pkgs/development/compilers/llvm/10/lld/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+  LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];
 

--- a/pkgs/development/compilers/llvm/11/lld/default.nix
+++ b/pkgs/development/compilers/llvm/11/lld/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+
+  # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/development/compilers/llvm/11/lld/default.nix
+++ b/pkgs/development/compilers/llvm/11/lld/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+  LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];
 

--- a/pkgs/development/compilers/llvm/12/lld/default.nix
+++ b/pkgs/development/compilers/llvm/12/lld/default.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+
+  # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/development/compilers/llvm/12/lld/default.nix
+++ b/pkgs/development/compilers/llvm/12/lld/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+  LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];
 

--- a/pkgs/development/compilers/llvm/13/lld/default.nix
+++ b/pkgs/development/compilers/llvm/13/lld/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+  LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];
 

--- a/pkgs/development/compilers/llvm/13/lld/default.nix
+++ b/pkgs/development/compilers/llvm/13/lld/default.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+
+  # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/development/compilers/llvm/14/lld/default.nix
+++ b/pkgs/development/compilers/llvm/14/lld/default.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
   cmakeFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+
+  # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/development/compilers/llvm/15/lld/default.nix
+++ b/pkgs/development/compilers/llvm/15/lld/default.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+
+  # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/development/compilers/llvm/5/lld/default.nix
+++ b/pkgs/development/compilers/llvm/5/lld/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+  LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];
 

--- a/pkgs/development/compilers/llvm/5/lld/default.nix
+++ b/pkgs/development/compilers/llvm/5/lld/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+
+  # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/development/compilers/llvm/6/lld/default.nix
+++ b/pkgs/development/compilers/llvm/6/lld/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+
+  # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/development/compilers/llvm/6/lld/default.nix
+++ b/pkgs/development/compilers/llvm/6/lld/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+  LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];
 

--- a/pkgs/development/compilers/llvm/7/lld/default.nix
+++ b/pkgs/development/compilers/llvm/7/lld/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+
+  # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/development/compilers/llvm/7/lld/default.nix
+++ b/pkgs/development/compilers/llvm/7/lld/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+  LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];
 

--- a/pkgs/development/compilers/llvm/8/lld/default.nix
+++ b/pkgs/development/compilers/llvm/8/lld/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+
+  # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/development/compilers/llvm/8/lld/default.nix
+++ b/pkgs/development/compilers/llvm/8/lld/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+  LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];
 

--- a/pkgs/development/compilers/llvm/9/lld/default.nix
+++ b/pkgs/development/compilers/llvm/9/lld/default.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+
+  # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/development/compilers/llvm/9/lld/default.nix
+++ b/pkgs/development/compilers/llvm/9/lld/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+  LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];
 

--- a/pkgs/development/compilers/llvm/git/lld/default.nix
+++ b/pkgs/development/compilers/llvm/git/lld/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+  LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];
 

--- a/pkgs/development/compilers/llvm/git/lld/default.nix
+++ b/pkgs/development/compilers/llvm/git/lld/default.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
   ];
+
+  # Musl's default stack size is too small for lld to be able to link Firefox.
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-Wl,-z,stack-size=2097152";
 
   outputs = [ "out" "lib" "dev" ];


### PR DESCRIPTION
###### Description of changes

Port of 6485a02fb3c ("llvm 14 lld: build with 2M stack size to fix firefox lto").

LLVM 7 doesn't build for Musl for unrelated reasons, as it segfaults during a test.  I gave up trying to fix it when I realised it doesn't do that if I `enableDebugging`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
