### PR TITLE
python3Packages.dnspython: fix tests (again)

### DIFF
--- a/pkgs/development/python-modules/dnspython/default.nix
+++ b/pkgs/development/python-modules/dnspython/default.nix
@@ -64,10 +64,8 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-  ] ++ passthru.optional-dependencies.DNSSEC
-  ++ lib.optionals stdenv.isDarwin [
     cacert
-  ];
+  ] ++ passthru.optional-dependencies.DNSSEC;
 
   disabledTests = [
     # dns.exception.SyntaxError: protocol not found


### PR DESCRIPTION
This is essentially the same fix as #161740, except not just for macOS.

The `dnspython` build was failing on Linux with a certificate verification failure just like in #161740:

```ShellSession
$ nix build nixpkgs#python3Packages.dnspython --rebuild
error: builder for '/nix/store/c1v553fzq3yybsd0lm398qf87jmy47qd-python3.10-dnspython-2.3.0.drv' failed with exit code 1;
       last 10 log lines:
       >
       > /nix/store/iw1vmh509hcbby8dbpsaanbri4zsq7dj-python3-3.10.10/lib/python3.10/ssl.py:1342: SSLCertVerificationError
…
```

… and this change fixes that build failure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).