### PR TITLE
 nixos-render-docs: use packageOverrides to construct python packages 

### DIFF
--- a/pkgs/development/python-modules/markdown-it-py/default.nix
+++ b/pkgs/development/python-modules/markdown-it-py/default.nix
@@ -1,17 +1,24 @@
 { lib
 , attrs
 , buildPythonPackage
+, commonmark
 , fetchFromGitHub
 , flit-core
 , linkify-it-py
+, markdown
 , mdurl
-, psutil
-, py
-, pytest-benchmark
+, mistletoe
+, mistune
+, myst-parser
+, panflute
+, pyyaml
+, sphinx
+, sphinx-book-theme
+, sphinx-copybutton
+, sphinx-design
 , pytest-regressions
 , pytestCheckHook
 , pythonOlder
-, typing-extensions
 }:
 
 buildPythonPackage rec {
@@ -33,17 +40,13 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    attrs
-    linkify-it-py
     mdurl
-  ] ++ lib.optionals (pythonOlder "3.8") [
-    typing-extensions
   ];
 
   nativeCheckInputs = [
     pytest-regressions
     pytestCheckHook
-  ];
+  ] ++ passthru.optional-dependencies.linkify;
 
   # disable and remove benchmark tests
   preCheck = ''
@@ -53,6 +56,12 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "markdown_it"
   ];
+
+  passthru.optional-dependencies = {
+    compare = [ commonmark markdown mistletoe mistune panflute ];
+    linkify = [ linkify-it-py ];
+    rtd = [ attrs myst-parser pyyaml sphinx sphinx-copybutton sphinx-design sphinx-book-theme ];
+  };
 
   meta = with lib; {
     description = "Markdown parser in Python";

--- a/pkgs/development/python-modules/markdown-it-py/default.nix
+++ b/pkgs/development/python-modules/markdown-it-py/default.nix
@@ -12,9 +12,6 @@
 , pytestCheckHook
 , pythonOlder
 , typing-extensions
-# allow disabling tests for the nixos manual build.
-# the test suite closure is just too large.
-, disableTests ? false
 }:
 
 buildPythonPackage rec {
@@ -44,17 +41,14 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    psutil
-    py
-  ] ++ lib.optionals (! disableTests) [
-    pytest-benchmark
     pytest-regressions
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
-    "--benchmark-skip"
-  ];
+  # disable and remove benchmark tests
+  preCheck = ''
+    rm -r benchmarking
+  '';
 
   pythonImportsCheck = [
     "markdown_it"

--- a/pkgs/development/python-modules/mdit-py-plugins/default.nix
+++ b/pkgs/development/python-modules/mdit-py-plugins/default.nix
@@ -6,9 +6,6 @@
 , markdown-it-py
 , pytest-regressions
 , pytestCheckHook
-# allow disabling tests for the nixos manual build.
-# the test suite closure is just too large.
-, disableTests ? false
 }:
 
 buildPythonPackage rec {
@@ -33,7 +30,7 @@ buildPythonPackage rec {
     markdown-it-py
   ];
 
-  nativeCheckInputs = lib.optionals (!disableTests) [
+  nativeCheckInputs = [
     pytestCheckHook
     pytest-regressions
   ];

--- a/pkgs/development/python-modules/myst-parser/default.nix
+++ b/pkgs/development/python-modules/myst-parser/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     pytest-regressions
     sphinx-pytest
     pytestCheckHook
-  ];
+  ] ++ markdown-it-py.optional-dependencies.linkify;
 
   disabledTests = [
     # AssertionError due to different files


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
