### PR TITLE
slimserver: 7.9.2 -> 8.3.1

### DIFF
--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -25,7 +25,7 @@ perl534Packages.buildPerlPackage rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [ perl534Packages.IOSocketSSL ];
+  buildInputs = [ perl534Packages.CryptOpenSSLRSA perl534Packages.IOSocketSSL ];
 
   prePatch = ''
     rm -rf Bin

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -49,7 +49,7 @@ perl534Packages.buildPerlPackage rec {
     # the firmware is not under a free license!
     # https://github.com/Logitech/slimserver/blob/public/8.3/License.txt
     license = licenses.unfree;
-    maintainers = with maintainers; [ jecaro ];
+    maintainers = with maintainers; [ adamcstephens jecaro ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -1,98 +1,35 @@
-{ lib
+{ faad2
 , fetchFromGitHub
-, makeWrapper
-, perlPackages
 , flac
-, faad2
-, sox
 , lame
+, lib
+, makeWrapper
 , monkeysAudio
+, perl534Packages
+, sox
+, stdenv
 , wavpack
+, zlib
 }:
 
-perlPackages.buildPerlPackage rec {
+perl534Packages.buildPerlPackage rec {
   pname = "slimserver";
-  version = "7.9.2";
+  version = "8.3.1";
 
   src = fetchFromGitHub {
     owner = "Logitech";
     repo = "slimserver";
     rev = version;
-    hash = "sha256-P4CSu/ff6i48uWV5gXsJgayZ1S1s0RAqa5O5y3Y0g9Y=";
+    hash = "sha256-yMFOwh/oPiJnUsKWBGvd/GZLjkWocMAUK0r+Hx/SUPo=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [
-    perlPackages.perl
-    perlPackages.AnyEvent
-    perlPackages.ArchiveZip
-    perlPackages.AudioScan
-    perlPackages.CarpClan
-    perlPackages.CGI
-    perlPackages.ClassXSAccessor
-    perlPackages.DataDump
-    perlPackages.DataURIEncode
-    perlPackages.DBDSQLite
-    perlPackages.DBI
-    perlPackages.DBIxClass
-    perlPackages.DigestSHA1
-    perlPackages.EV
-    perlPackages.ExporterLite
-    perlPackages.FileBOM
-    perlPackages.FileCopyRecursive
-    perlPackages.FileNext
-    perlPackages.FileReadBackwards
-    perlPackages.FileSlurp
-    perlPackages.FileWhich
-    perlPackages.HTMLParser
-    perlPackages.HTTPCookies
-    perlPackages.HTTPDaemon
-    perlPackages.HTTPMessage
-    perlPackages.ImageScale
-    perlPackages.IOSocketSSL
-    perlPackages.IOString
-    perlPackages.JSONXSVersionOneAndTwo
-    perlPackages.LogLog4perl
-    perlPackages.LWP
-    perlPackages.NetHTTP
-    perlPackages.NetHTTPSNB
-    perlPackages.ProcBackground
-    perlPackages.SubName
-    perlPackages.TemplateToolkit
-    perlPackages.TextUnidecode
-    perlPackages.TieCacheLRU
-    perlPackages.TieCacheLRUExpires
-    perlPackages.TieRegexpHash
-    perlPackages.TimeDate
-    perlPackages.URI
-    perlPackages.URIFind
-    perlPackages.UUIDTiny
-    perlPackages.XMLParser
-    perlPackages.XMLSimple
-    perlPackages.YAMLLibYAML
-  ];
 
+  buildInputs = [ perl534Packages.IOSocketSSL ];
 
   prePatch = ''
-    mkdir CPAN_used
-    # slimserver doesn't work with current DBIx/SQL versions, use bundled copies
-    mv CPAN/DBIx CPAN/SQL CPAN_used
-    rm -rf CPAN
     rm -rf Bin
     touch Makefile.PL
-
-    # relax audio scan version constraints
-    substituteInPlace lib/Audio/Scan.pm --replace "0.93" "1.01"
-    substituteInPlace modules.conf --replace "Audio::Scan 0.93 0.95" "Audio::Scan 0.93"
-  '';
-
-  preConfigurePhase = "";
-
-  buildPhase = ''
-    mv lib tmp
-    mkdir -p ${perlPackages.perl.libPrefix}
-    mv CPAN_used/* ${perlPackages.perl.libPrefix}
-    cp -rf tmp/* ${perlPackages.perl.libPrefix}
   '';
 
   doCheck = false;
@@ -100,6 +37,7 @@ perlPackages.buildPerlPackage rec {
   installPhase = ''
     cp -r . $out
     wrapProgram $out/slimserver.pl \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ zlib stdenv.cc.cc.lib ]}" \
       --prefix PATH : "${lib.makeBinPath [ lame flac faad2 sox monkeysAudio wavpack ]}"
   '';
 
@@ -109,9 +47,9 @@ perlPackages.buildPerlPackage rec {
     homepage = "https://github.com/Logitech/slimserver";
     description = "Server for Logitech Squeezebox players. This server is also called Logitech Media Server";
     # the firmware is not under a free license!
-    # https://github.com/Logitech/slimserver/blob/public/7.9/License.txt
+    # https://github.com/Logitech/slimserver/blob/public/8.3/License.txt
     license = licenses.unfree;
-    maintainers = [ ];
+    maintainers = with maintainers; [ jecaro ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
Slimserver aka LogitechMediaServer was broken (see #178494)

This PR brings it to the latest version making the package usable again. I'm currently using this on nixOS running on a RPI4 and it's been working fine for the last few weeks.

I added myself as a maintainer as I'd be happy to fix the package if any new issue arises.

###### Description of changes

- Fix #178494
- upstream [changlog](https://htmlpreview.github.io/?https://github.com/Logitech/slimserver/blob/4f40dde1fdb0cc38e361e0a28e599c8e42e54ecc/Changelog8.html)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

