### PR TITLE
frogatto: mark broken

### DIFF
--- a/pkgs/games/frogatto/default.nix
+++ b/pkgs/games/frogatto/default.nix
@@ -39,5 +39,7 @@ in buildEnv {
     license = with licenses; [ cc-by-30 unfree ];
     platforms = platforms.linux;
     maintainers = with maintainers; [ astro ];
+    # error: std::bind2nd is deprecated: use std::bind instead
+    broken = true; # At 2023-02-27
   };
 }


### PR DESCRIPTION
frogatto: mark broken

> error: 'std::binder2nd<_Operation> std::bind2nd(const _Operation&, const _Tp&) [with _Operation = equal_to<char>; _Tp = char]' is deprecated: use 'std::bind' instead []8;;


logs: https://termbin.com/01oc

It is broken at master. I'm only reporting package is broken for lowering noise in downstream builds.
I have no interest in this package.