### PR TITLE
python311Packages.pygame: marked broken for python >3.11

### DIFF
--- a/pkgs/development/python-modules/pygame/default.nix
+++ b/pkgs/development/python-modules/pygame/default.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, substituteAll, fetchFromGitHub, buildPythonPackage, python, pkg-config, libX11
 , SDL2, SDL2_image, SDL2_mixer, SDL2_ttf, libpng, libjpeg, portmidi, freetype, fontconfig
 , AppKit
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
@@ -75,5 +76,7 @@ buildPythonPackage rec {
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ emilytrau ];
     platforms = platforms.unix;
+    # fatal error: longintrepr.h: No such file or directory.
+    broken = pythonAtLeast "3.11"; # At 2022-02-27
   };
 }


### PR DESCRIPTION
python311Packages.pygame: mark broken for python >3.11

> src_c/pypm.c:209:12: fatal error: longintrepr.h: No such file or directory

* It is already broken in master.
* `python310Packages.pygame` builds fine. Seems some issue specific to 3.11. (But don't ask me!)

Logs: https://termbin.com/l71yq

Only marking broken to reduce false positives in downstream builds.