### PR TITLE
medfile: build with hdf5 1.14

### DIFF
--- a/pkgs/development/libraries/medfile/default.nix
+++ b/pkgs/development/libraries/medfile/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    ./hdf5-1.12.patch
+    ./hdf5-1.14.patch
   ];
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/medfile/hdf5-1.14.patch
+++ b/pkgs/development/libraries/medfile/hdf5-1.14.patch
@@ -25,7 +25,7 @@
  #error "Don't forget to update the test version here when you change the major version of the library !"
  #endif
 -#if H5_VERS_MINOR > 10
-+#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
  #error "Don't forget to check the compatibility version of the library, depending on the internal hdf model choice !"
  #error "Cf. _MEDfileCreate ..."
  #endif
@@ -36,7 +36,7 @@
     * Un test autoconf permet de fixer un intervalle de version HDF à MED.
     */
 -#if H5_VERS_MINOR > 10
-+#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
  #error "Don't forget to change the compatibility version of the library !"
  #endif
     
@@ -47,7 +47,7 @@
     •   The creation order tracking property, H5P_CRT_ORDER_TRACKED, has been set in the group creation property list (see H5Pset_link_creation_order). 
    */
 -#if H5_VERS_MINOR > 10
-+#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
  #error "Don't forget to change the compatibility version of the library !"
  #endif
  /* L'avantage de bloquer le modèle interne HDF5 
@@ -58,7 +58,7 @@
    }
  
 -#if H5_VERS_MINOR > 10
-+#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
  #error "Don't forget to change the compatibility version of the library !"
  #endif
    if ( H5Pset_libver_bounds( _fapl, H5F_LIBVER_18, H5F_LIBVER_18) ) {
@@ -69,7 +69,7 @@
     * Un test autoconf permet de fixer un intervalle de version HDF à MED.
     */
 -#if H5_VERS_MINOR > 10
-+#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
  #error "Don't forget to change the compatibility version of the library !"
  #endif
     
@@ -80,7 +80,7 @@
      goto ERROR;
    }
 -#if H5_VERS_MINOR > 10
-+#if H5_VERS_MINOR > 12
++#if H5_VERS_MINOR > 14
  #error "Don't forget to change the compatibility version of the library !"
  #endif
    if ( H5Pset_libver_bounds( _fapl, H5F_LIBVER_18, H5F_LIBVER_18 ) ) {


### PR DESCRIPTION
###### Description of changes

medfile no longer builds with the latest HDF5 version, which contains security fixes.  See #119171 for the last HDF5 bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
