### PR TITLE
vscode-utils: allow lldb to be used as vscode extension again

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -103,15 +103,15 @@ let
 
   toExtensionJsonEntry = ext: rec {
     identifier = {
-      id = ext.vscodeExtUniqueId;
+      id = ext.vscodeExtUniqueId or (lib.head (lib.attrNames (builtins.readDir "${ext}/share/vscode/extensions")));
       uuid = "";
     };
 
-    version = ext.version;
+    version = ext.version or (lib.getversion ext.name);
 
     location = {
       "$mid" = 1;
-      fsPath = ext.outPath + "/share/vscode/extensions/${ext.vscodeExtUniqueId}";
+      fsPath = "${ext.outPath}/share/vscode/extensions/${identifier.id}";
       path = location.fsPath;
       scheme = "file";
     };
@@ -119,7 +119,7 @@ let
     metadata = {
       id = "";
       publisherId = "";
-      publisherDisplayName = ext.vscodeExtPublisher;
+      publisherDisplayName = ext.vscodeExtPublisher or (lib.head (lib.splitString ''\.'' identifier.id));
       targetPlatform = "undefined";
       isApplicationScoped = false;
       updated = false;


### PR DESCRIPTION
###### Description of changes
Latest nixpkgs would not allow to install the lldb vscode extension as it would give the following error
```
       at /nix/store/c98l2kchjhranrv7l767j85zkzg2ng80-source/pkgs/applications/editors/vscode/extensions/vscode-utils.nix:132:21:

          131|
          132|   toExtensionJson = extensions: builtins.toJSON (map toExtensionJsonEntry extensions);
             |                     ^
          133| in

       error: attribute 'vscodeExtUniqueId' missing

       at /nix/store/c98l2kchjhranrv7l767j85zkzg2ng80-source/pkgs/applications/editors/vscode/extensions/vscode-utils.nix:106:12:

          105|     identifier = {
          106|       id = ext.vscodeExtUniqueId;
             |            ^
          107|       uuid = "";
```
if I try to add `programs.vscode.extensions = [ pkgs.vscode-extensions.llvm-org.lldb-vscode ]`. This PR fixes that.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
