### PR TITLE
proj: fix test suite

### DIFF
--- a/pkgs/development/libraries/proj/default.nix
+++ b/pkgs/development/libraries/proj/default.nix
@@ -12,6 +12,7 @@
 , gtest
 , nlohmann_json
 , python3
+, cacert
 }:
 
 stdenv.mkDerivation (finalAttrs: rec {
@@ -40,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: rec {
 
   buildInputs = [ sqlite libtiff curl nlohmann_json ];
 
-  nativeCheckInputs = [ gtest ];
+  nativeCheckInputs = [ cacert gtest ];
 
   cmakeFlags = [
     "-DUSE_EXTERNAL_GTEST=ON"


### PR DESCRIPTION
When testing #213831 internally we ran into a build failure caused by that change for the `proj` package (on `x86_64-linux`).  We're not sure how that's possible, but the nature of the build failure was that the network tests for the `proj` package were failing due to missing certificates, so I fixed the build failure by adding `cacert` as a test dependency.

It's still not clear (A) why the cert suddenly became necessary after the change in #213831 or (B) why the build worked at all before, but this is probably the right thing to do regardless because the test suite does have a network component.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).