### PR TITLE
pantheon.granite7: 7.1.0 -> 7.2.0

### DIFF
--- a/pkgs/desktops/pantheon/granite/7/default.nix
+++ b/pkgs/desktops/pantheon/granite/7/default.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation rec {
   pname = "granite";
-  version = "7.1.0";
+  version = "7.2.0";
 
   outputs = [ "out" "dev" ];
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "sha256-tdZSiIK+BW8uhbRxLUcrGQt71jRfVLOTgFNOqeLK6ig=";
+    sha256 = "sha256-LU2eIeaNqO4/6dPUuzOQ/w4tx0dEm26JwZ87yQ16c4o=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION


###### Description of changes

This upgrade is needed for Epiphany 44 to support Pantheon.

- [<code>Add icon and use it (#629)</code>](https://github.com/elementary/granite/commit/1c51d311013a9c3fabd68426864295fa187d288d)
  - <sub>Files: <code>meson.build</code></sub>
  - <sub>Keywords: <code>exec</code></sub>
- [<code>actions/checkout@v3 (#630)</code>](https://github.com/elementary/granite/commit/fe41ada7b9c9bd5b43bbee36a00bf27d20b7ce96)
- [<code>Init: add ensure type (#632)</code>](https://github.com/elementary/granite/commit/2fa231174ce1b1b0113b5943ffeb7b6f186015a1)
- [<code>Update granite.appdata.xml.in (#633)</code>](https://github.com/elementary/granite/commit/f1deeb71c1a79abd6857cb069e05fb365a337ac1)
- [<code>Add 'since' annotations to things added in 7.1 (#635)</code>](https://github.com/elementary/granite/commit/caf98fd6108416e6eb444b92879b15fb845035ee)
- [<code>Add since annotation to new public init method (#636)</code>](https://github.com/elementary/granite/commit/e23f83b0cc4720b362da5d5e278cd5d6c662d3af)
- [<code>Release 7.2.0 (#634)</code>](https://github.com/elementary/granite/commit/e7447e373fa1d2906af4bfcebce30c6193ddaa8f)
  - <sub>Tags: <code>7.2.0</code></sub>
  - <sub>Files: <code>meson.build</code></sub>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
