### PR TITLE
ocamlPackages.mirage-stack: 2.2.0 → 4.0.0; ocamlPackages.mirage-protocols: 5.0.0 → 8.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/arp/default.nix
+++ b/pkgs/development/ocaml-modules/arp/default.nix
@@ -1,8 +1,22 @@
-{ lib, buildDunePackage, fetchurl
-, cstruct, ipaddr, macaddr, logs, lwt, duration
-, mirage-time, mirage-protocols, mirage-profile
-, alcotest, ethernet, fmt, mirage-vnetif, mirage-random
-, mirage-random-test, mirage-clock-unix, mirage-time-unix
+{ lib
+, buildDunePackage
+, fetchurl
+, cstruct
+, duration
+, ethernet
+, ipaddr
+, logs
+, lwt
+, macaddr
+, mirage-profile
+, mirage-time
+, alcotest
+, mirage-clock-unix
+, mirage-flow
+, mirage-random
+, mirage-random-test
+, mirage-time-unix
+, mirage-vnetif
 , bisect_ppx
 }:
 
@@ -31,7 +45,6 @@ buildDunePackage rec {
     lwt
     macaddr
     mirage-profile
-    mirage-protocols
     mirage-time
   ];
 
@@ -39,7 +52,7 @@ buildDunePackage rec {
   checkInputs = [
     alcotest
     mirage-clock-unix
-    mirage-profile
+    mirage-flow
     mirage-random
     mirage-random-test
     mirage-time-unix

--- a/pkgs/development/ocaml-modules/ethernet/default.nix
+++ b/pkgs/development/ocaml-modules/ethernet/default.nix
@@ -1,20 +1,26 @@
-{ lib, buildDunePackage, fetchurl
-, rresult, cstruct, ppx_cstruct, mirage-net, mirage-protocols
-, mirage-profile, macaddr, fmt, lwt, logs
+{ lib
+, buildDunePackage
+, fetchurl
+, cstruct
+, logs
+, lwt
+, macaddr
+, mirage-net
+, mirage-profile
+, ppx_cstruct
 }:
 
 buildDunePackage rec {
   pname = "ethernet";
   version = "3.0.0";
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
-  # necessary due to cstruct
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-v${version}.tbz";
-    sha256 = "0a898vp9dw42majsvzzvs8pc6x4ns01wlwhwbacixliv6vv78ng9";
+    hash = "sha256:0a898vp9dw42majsvzzvs8pc6x4ns01wlwhwbacixliv6vv78ng9";
   };
 
   buildInputs = [
@@ -22,13 +28,10 @@ buildDunePackage rec {
   ];
 
   propagatedBuildInputs = [
-    rresult
     cstruct
     mirage-net
-    mirage-protocols
     macaddr
     mirage-profile
-    fmt
     lwt
     logs
   ];

--- a/pkgs/development/ocaml-modules/mirage-protocols/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-protocols/default.nix
@@ -1,17 +1,24 @@
-{ lib, buildDunePackage, fetchurl, duration, ipaddr, mirage-device, mirage-flow }:
+{ lib
+, buildDunePackage
+, fetchurl
+, arp
+, ethernet
+, ipaddr
+, tcpip
+}:
 
 buildDunePackage rec {
   pname = "mirage-protocols";
-  version = "5.0.0";
+  version = "8.0.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-protocols/releases/download/v${version}/mirage-protocols-v${version}.tbz";
-    sha256 = "1bd6zgxhq2qliyzzarfvaj3ksr20ryghxq6h24i2hha7rwim63bk";
+    hash = "sha256-UDCR4Jq3tw9P/Ilw7T4+3+yi9Q7VFqnHhXeSCvg9dyw=";
   };
 
-  propagatedBuildInputs = [ duration ipaddr mirage-device mirage-flow ];
+  propagatedBuildInputs = [ arp ethernet ipaddr tcpip ];
 
   meta = {
     description = "MirageOS signatures for network protocols";

--- a/pkgs/development/ocaml-modules/mirage-stack/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-stack/default.nix
@@ -1,16 +1,16 @@
-{ lib, buildDunePackage, fetchurl, mirage-protocols }:
+{ lib, buildDunePackage, fetchurl, tcpip }:
 
 buildDunePackage rec {
   pname = "mirage-stack";
-  version = "2.2.0";
-  useDune2 = true;
+  version = "4.0.0";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-stack/releases/download/v${version}/mirage-stack-v${version}.tbz";
-    sha256 = "1qhi0ghcj4j3hw7yqn085ac6n18b6b66z5ih3k8p79m4cvn7cdq0";
+    hash = "sha256-q70zGQvT5KTqvL37bZjSD8Su0P72KCUesyfWJcI8zPw=";
   };
 
-  propagatedBuildInputs = [ mirage-protocols ];
+  propagatedBuildInputs = [ tcpip ];
 
   meta = {
     description = "MirageOS signatures for network stacks";

--- a/pkgs/development/ocaml-modules/tcpip/default.nix
+++ b/pkgs/development/ocaml-modules/tcpip/default.nix
@@ -1,7 +1,7 @@
 { lib, buildDunePackage, fetchurl
-, bisect_ppx, ppx_cstruct, pkg-config
-, rresult, cstruct, cstruct-lwt, mirage-net, mirage-clock
-, mirage-random, mirage-stack, mirage-protocols, mirage-time
+, ppx_cstruct, pkg-config
+, cstruct, cstruct-lwt, mirage-net, mirage-clock
+, mirage-random, mirage-time
 , ipaddr, macaddr, macaddr-cstruct, mirage-profile, fmt
 , lwt, lwt-dllist, logs, duration, randomconv, ethernet
 , alcotest, mirage-flow, mirage-vnetif, pcap-format
@@ -19,7 +19,7 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
-    sha256 = "sha256-lraur6NfFD9yddG+y21jlHKt82gLgYBBbedltlgcRm0=";
+    hash = "sha256-lraur6NfFD9yddG+y21jlHKt82gLgYBBbedltlgcRm0=";
   };
 
   nativeBuildInputs = [
@@ -27,17 +27,12 @@ buildDunePackage rec {
   ];
 
   propagatedBuildInputs = [
-    bisect_ppx
     ppx_cstruct
-    rresult
     cstruct
     cstruct-lwt
     mirage-net
     mirage-clock
     mirage-random
-    mirage-random-test
-    mirage-stack
-    mirage-protocols
     mirage-time
     ipaddr
     macaddr
@@ -53,13 +48,15 @@ buildDunePackage rec {
     lru
     metrics
     arp
+    mirage-flow
   ] ++ lib.optionals withFreestanding [
     ocaml-freestanding
   ];
 
-  doCheck = false;
+  doCheck = true;
   checkInputs = [
     alcotest
+    mirage-random-test
     mirage-flow
     mirage-vnetif
     pcap-format


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/mirage-stack/blob/v4.0.0/CHANGES.md
https://github.com/mirage/mirage-protocols/blob/v8.0.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
