### PR TITLE
netdata: fix start cgroup-network-helper.sh

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -107,6 +107,7 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     wrapProgram $out/bin/netdata-claim.sh --prefix PATH : ${lib.makeBinPath [ openssl ]}
+    wrapProgram $out/libexec/netdata/plugins.d/cgroup-network-helper.sh --prefix PATH : ${lib.makeBinPath [ bash ]}
   '';
 
   enableParallelBuild = true;


### PR DESCRIPTION
###### Description of changes
Fix this error:
```
/nix/store/5qzqdmbf5c87h0amsxxpcnqv75kcw4yz-wrapped-plugins/libexec/netdata/plugins.d/cgroup-network ERROR : MAIN : child pid 25934 exited with code 127.
/nix/store/5qzqdmbf5c87h0amsxxpcnqv75kcw4yz-wrapped-plugins/libexec/netdata/plugins.d/cgroup-network INFO  : MAIN : there are no double-linked host interfaces available.
cgroup-name.sh: INFO: cgroup 'machine.slice_machine-qemu_x2d2_x2dvm02_x2dmail.scope_libvirt' is called 'qemu_vm02mail_libvirt'
cgroup-name.sh: INFO: cgroup 'machine.slice_machine-qemu_x2d2_x2dvm02_x2dmail.scope_libvirt_vcpu1' is called 'qemu_vm02mail_libvirt_vcpu1'
cgroup-name.sh: INFO: cgroup 'machine.slice_machine-qemu_x2d2_x2dvm02_x2dmail.scope_libvirt_vcpu0' is called 'qemu_vm02mail_libvirt_vcpu0'
cgroup-name.sh: INFO: cgroup 'machine.slice_machine-qemu_x2d2_x2dvm02_x2dmail.scope_libvirt_emulator' is called 'qemu_vm02mail_libvirt_emulator'
cgroup-name.sh: INFO: cgroup 'machine.slice_machine-qemu_x2d3_x2dvm01_x2dweb.scope' is called 'qemu_vm01web'
/nix/store/5qzqdmbf5c87h0amsxxpcnqv75kcw4yz-wrapped-plugins/libexec/netdata/plugins.d/cgroup-network ERROR : MAIN : Cannot open pid_from_cgroup() file '/sys/fs/cgroup/machine.slice/machine-qemu\x2d3\x2dvm01\x2dweb.scope/tasks'. (errno 2, No such file or directory)
/nix/store/5qzqdmbf5c87h0amsxxpcnqv75kcw4yz-wrapped-plugins/libexec/netdata/plugins.d/cgroup-network INFO  : MAIN : running: exec /nix/store/9y66swks0vb4l6fd2094cpfklrmby2cq-netdata-1.38.1/libexec/netdata/plugins.d/cgroup-network-helper.sh --cgroup '/sys/fs/cgroup/machine.slice/machine-qemu\x2d3\x2dvm01\x2dweb.scope'
/usr/bin/env: 'bash': No such file or directory
/nix/store/5qzqdmbf5c87h0amsxxpcnqv75kcw4yz-wrapped-plugins/libexec/netdata/plugins.d/cgroup-network ERROR : MAIN : child pid 32504 exited with code 127.
/nix/store/5qzqdmbf5c87h0amsxxpcnqv75kcw4yz-wrapped-plugins/libexec/netdata/plugins.d/cgroup-network INFO  : MAIN : there are no double-linked host interfaces available.
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
