### PR TITLE
python310Packages.neo4j: 5.5.0 -> 5.6.0

### DIFF
--- a/pkgs/development/python-modules/neo4j/default.nix
+++ b/pkgs/development/python-modules/neo4j/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "neo4j";
-  version = "5.5.0";
+  version = "5.6.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "neo4j";
     repo = "neo4j-python-driver";
     rev = "refs/tags/${version}";
-    hash = "sha256-K3ggXXDDdyPIcWL4eLo1HrpZB05tA9oYWpbOohcCF/w=";
+    hash = "sha256-OjGLV7xHyF8kB++juXTM40aUl4OK+xwhnFaLSyxHMo4=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/psrpcore/default.nix
+++ b/pkgs/development/python-modules/psrpcore/default.nix
@@ -3,6 +3,7 @@
 , cryptography
 , fetchFromGitHub
 , pytestCheckHook
+, pythonAtLeast
 , pythonOlder
 , xmldiff
 }:
@@ -30,10 +31,16 @@ buildPythonPackage rec {
     xmldiff
   ];
 
-
   pythonImportsCheck = [
     "psrpcore"
   ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.11") [
+    # https://github.com/jborean93/psrpcore/issues/22
+    "test_remote_stream_options"
+    "test_ps_flags"
+  ];
+
 
   meta = with lib; {
     description = "Library for the PowerShell Remoting Protocol (PSRP)";

--- a/pkgs/development/python-modules/pypsrp/default.nix
+++ b/pkgs/development/python-modules/pypsrp/default.nix
@@ -70,6 +70,13 @@ buildPythonPackage rec {
     "pypsrp"
   ];
 
+  disabledTests = [
+    # TypeError: Backend.load_rsa_private_numbers() missing 1 required...
+    "test_psrp_pshost_ui_mocked_methods"
+    "test_psrp_key_exchange_timeout"
+    "test_psrp_multiple_commands"
+  ];
+
   meta = with lib; {
     description = "PowerShell Remoting Protocol Client library";
     homepage = "https://github.com/jborean93/pypsrp";

--- a/pkgs/development/python-modules/pypsrp/default.nix
+++ b/pkgs/development/python-modules/pypsrp/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "jborean93";
     repo = pname;
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-Pwfc9e39sYPdcHN1cZtxxGEglEYzPp4yOYLD5/4SSiU=";
   };
 
@@ -73,6 +73,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "PowerShell Remoting Protocol Client library";
     homepage = "https://github.com/jborean93/pypsrp";
+    changelog = "https://github.com/jborean93/pypsrp/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };


### PR DESCRIPTION
Changelog: https://github.com/neo4j/neo4j-python-driver/releases/tag/5.6.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
