### PR TITLE
setup-hooks/strip: add stripExclude

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -937,6 +937,28 @@ Like `stripDebugList`, but only applies to packages’ target platform. By defau
 
 Flags passed to the `strip` command applied to the files in the directories listed in `stripDebugList`. Defaults to `-S` (i.e. `--strip-debug`).
 
+##### `stripExclude` {#var-stdenv-stripExclude}
+
+A list of filenames or path patterns to avoid stripping. A file is excluded if its name _or_ path (from the derivation root) matches.
+
+This example prevents all `*.rlib` files from being stripped:
+
+```nix
+stdenv.mkDerivation {
+  # ...
+  stripExclude = [ "*.rlib" ]
+}
+```
+
+This example prevents files within certain paths from being stripped:
+
+```nix
+stdenv.mkDerivation {
+  # ...
+  stripExclude = [ "lib/modules/*/build/* ]
+}
+```
+
 ##### `dontPatchELF` {#var-stdenv-dontPatchELF}
 
 If set, the `patchelf` command is not used to remove unnecessary `RPATH` entries. Only applies to Linux.

--- a/pkgs/build-support/setup-hooks/strip.sh
+++ b/pkgs/build-support/setup-hooks/strip.sh
@@ -49,10 +49,18 @@ stripDirs() {
     local ranlibCmd="$2"
     local paths="$3"
     local stripFlags="$4"
+    local excludeFlags=()
     local pathsNew=
 
     [ -z "$cmd" ] && echo "stripDirs: Strip command is empty" 1>&2 && exit 1
     [ -z "$ranlibCmd" ] && echo "stripDirs: Ranlib command is empty" 1>&2 && exit 1
+
+    local pattern
+    if [ -n "${stripExclude:-}" ]; then
+        for pattern in "${stripExclude[@]}"; do
+            excludeFlags+=(-a '!' '(' -name "$pattern" -o -wholename "$prefix/$pattern" ')' )
+        done
+    fi
 
     local p
     for p in ${paths}; do
@@ -67,7 +75,7 @@ stripDirs() {
         local striperr
         striperr="$(mktemp --tmpdir="$TMPDIR" 'striperr.XXXXXX')"
         # Do not strip lib/debug. This is a directory used by setup-hooks/separate-debug-info.sh.
-        find $paths -type f -a '!' -path "$prefix/lib/debug/*" -print0 |
+        find $paths -type f "${excludeFlags[@]}" -a '!' -path "$prefix/lib/debug/*" -print0 |
             # Make sure we process files under symlinks only once. Otherwise
             # 'strip` can corrupt files when writes to them in parallel:
             #   https://github.com/NixOS/nixpkgs/issues/246147#issuecomment-1657072039


### PR DESCRIPTION
###### Description of changes

**This is a mass rebuild** as it alters a stdenv hook.

Originally suggested in https://github.com/NixOS/nixpkgs/pull/34227#discussion_r163770892, and reappeared recently in https://github.com/NixOS/nixpkgs/issues/218712

### Pre-merge

 - [x] confirm that this does indeed fix #218712 (see [comment](https://github.com/NixOS/nixpkgs/pull/218783#issuecomment-1453283401))
