### PR TITLE
uboot: 2022.10 -> 2023.01

### DIFF
--- a/pkgs/misc/uboot/0001-configs-rpi-allow-for-bigger-kernels.patch
+++ b/pkgs/misc/uboot/0001-configs-rpi-allow-for-bigger-kernels.patch
@@ -1,17 +1,14 @@
-From 3d0ce353cf62efea11aa88f814aa23bf8c04acc9 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Milan=20P=C3=A4ssler?= <milan@petabyte.dev>
-Date: Mon, 11 Jan 2021 15:13:10 +0100
-Subject: [PATCH] configs/rpi: allow for bigger kernels
+commit 78eef95be18ade3587f29e562e00ed173142577f
+Author: takov751 <takov751@tutanota.com>
+Date:   Tue Feb 28 12:38:06 2023 +0000
 
----
- include/configs/rpi.h | 16 ++++++++--------
- 1 file changed, 8 insertions(+), 8 deletions(-)
+    patch kernel size
 
 diff --git a/include/configs/rpi.h b/include/configs/rpi.h
-index 834f1cd..10ab1e7 100644
+index 4da982f735..a187d25e81 100644
 --- a/include/configs/rpi.h
 +++ b/include/configs/rpi.h
-@@ -153,20 +153,20 @@
+@@ -107,20 +107,20 @@
   * more than ~700M away from the start of the kernel image but this number can
   * be larger OR smaller depending on e.g. the 'vmalloc=xxxM' command line
   * parameter given to the kernel. So reserving memory from low to high
@@ -21,25 +18,21 @@ index 834f1cd..10ab1e7 100644
 + * the DTB leaves rest of the free RAM to the initrd starting at 0x04800000.
   * Even with the smallest possible CPU-GPU memory split of the CPU getting
 - * only 64M, the remaining 25M starting at 0x02700000 should allow quite
-- * large initrds before they start colliding with U-Boot.
-+ * only 64M, the remaining 8M starting at 0x04800000 should allow reasonably
-+ * sized initrds before they start colliding with U-Boot.
++ * only 64M, the remaining 25M starting at 0x04800000 should allow quite
+  * large initrds before they start colliding with U-Boot.
   */
  #define ENV_MEM_LAYOUT_SETTINGS \
- 	"fdt_high=" FDT_HIGH "\0" \
- 	"initrd_high=" INITRD_HIGH "\0" \
- 	"kernel_addr_r=0x00080000\0" \
--	"scriptaddr=0x02400000\0" \
--	"pxefile_addr_r=0x02500000\0" \
--	"fdt_addr_r=0x02600000\0" \
--	"ramdisk_addr_r=0x02700000\0"
-+	"scriptaddr=0x04500000\0" \
-+	"pxefile_addr_r=0x04600000\0" \
-+	"fdt_addr_r=0x04700000\0" \
-+	"ramdisk_addr_r=0x04800000\0"
+        "fdt_high=" FDT_HIGH "\0" \
+        "initrd_high=" INITRD_HIGH "\0" \
+        "kernel_addr_r=0x00080000\0" \
+-       "scriptaddr=0x02400000\0" \
+-       "pxefile_addr_r=0x02500000\0" \
+-       "fdt_addr_r=0x02600000\0" \
+-       "ramdisk_addr_r=0x02700000\0"
++       "scriptaddr=0x04500000\0" \
++       "pxefile_addr_r=0x04600000\0" \
++       "fdt_addr_r=0x04700000\0" \
++       "ramdisk_addr_r=0x04800000\0"
  
- #if CONFIG_IS_ENABLED(CMD_MMC)
- 	#define BOOT_TARGET_MMC(func) \
--- 
-2.29.2
-
+ #if IS_ENABLED(CONFIG_CMD_MMC)
+        #define BOOT_TARGET_MMC(func) \

--- a/pkgs/misc/uboot/0001-configs-rpi-allow-for-bigger-kernels.patch
+++ b/pkgs/misc/uboot/0001-configs-rpi-allow-for-bigger-kernels.patch
@@ -3,7 +3,7 @@ Author: takov751 <takov751@tutanota.com>
 Date:   Tue Feb 28 12:38:06 2023 +0000
 
     patch kernel size
-
+---
 diff --git a/include/configs/rpi.h b/include/configs/rpi.h
 index 4da982f735..a187d25e81 100644
 --- a/include/configs/rpi.h
@@ -36,3 +36,4 @@ index 4da982f735..a187d25e81 100644
  
  #if IS_ENABLED(CONFIG_CMD_MMC)
         #define BOOT_TARGET_MMC(func) \
+---

--- a/pkgs/misc/uboot/0001-rpi-Copy-properties-from-firmware-dtb-to-the-loaded-.patch
+++ b/pkgs/misc/uboot/0001-rpi-Copy-properties-from-firmware-dtb-to-the-loaded-.patch
@@ -25,68 +25,68 @@ Origin: https://patchwork.ozlabs.org/project/uboot/patch/20210822143656.289891-1
  1 file changed, 48 insertions(+)
 
 diff --git a/board/raspberrypi/rpi/rpi.c b/board/raspberrypi/rpi/rpi.c
-index 372b26b6f2..64b8684b68 100644
+index 8603c93de7..71fd025b09 100644
 --- a/board/raspberrypi/rpi/rpi.c
 +++ b/board/raspberrypi/rpi/rpi.c
-@@ -495,10 +495,58 @@ void *board_fdt_blob_setup(void)
- 	return (void *)fw_dtb_pointer;
- }
+@@ -502,11 +502,56 @@ void *board_fdt_blob_setup(int *err)
  
+        return (void *)fw_dtb_pointer;
+ }
 +int copy_property(void *dst, void *src, char *path, char *property)
 +{
-+	int dst_offset, src_offset;
-+	const fdt32_t *prop;
-+	int len;
++       int dst_offset, src_offset;
++       const fdt32_t *prop;
++       int len;
 +
-+	src_offset = fdt_path_offset(src, path);
-+	dst_offset = fdt_path_offset(dst, path);
++       src_offset = fdt_path_offset(src, path);
++       dst_offset = fdt_path_offset(dst, path);
 +
-+	if (src_offset < 0 || dst_offset < 0)
-+		return -1;
++       if (src_offset < 0 || dst_offset < 0)
++               return -1;
 +
-+	prop = fdt_getprop(src, src_offset, property, &len);
-+	if (!prop)
-+		return -1;
++       prop = fdt_getprop(src, src_offset, property, &len);
++       if (!prop)
++               return -1;
 +
-+	return fdt_setprop(dst, dst_offset, property, prop, len);
++       return fdt_setprop(dst, dst_offset, property, prop, len);
 +}
 +
 +/* Copy tweaks from the firmware dtb to the loaded dtb */
 +void  update_fdt_from_fw(void *fdt, void *fw_fdt)
 +{
-+	/* Using dtb from firmware directly; leave it alone */
-+	if (fdt == fw_fdt)
-+		return;
++       /* Using dtb from firmware directly; leave it alone */
++       if (fdt == fw_fdt)
++               return;
 +
-+	/* The firmware provides a more precie model; so copy that */
-+	copy_property(fdt, fw_fdt, "/", "model");
++       /* The firmware provides a more precie model; so copy that */
++       copy_property(fdt, fw_fdt, "/", "model");
 +
-+	/* memory reserve as suggested by the firmware */
-+	copy_property(fdt, fw_fdt, "/", "memreserve");
++       /* memory reserve as suggested by the firmware */
++       copy_property(fdt, fw_fdt, "/", "memreserve");
 +
-+	/* Adjust dma-ranges for the SD card and PCI bus as they can depend on
-+	 * the SoC revision
-+	 */
-+	copy_property(fdt, fw_fdt, "emmc2bus", "dma-ranges");
-+	copy_property(fdt, fw_fdt, "pcie0", "dma-ranges");
++       /* Adjust dma-ranges for the SD card and PCI bus as they can depend on
++        * the SoC revision
++        */
++       copy_property(fdt, fw_fdt, "emmc2bus", "dma-ranges");
++       copy_property(fdt, fw_fdt, "pcie0", "dma-ranges");
 +
-+	/* Bootloader configuration template exposes as nvmem */
-+	if (copy_property(fdt, fw_fdt, "blconfig", "reg") == 0)
-+		copy_property(fdt, fw_fdt, "blconfig", "status");
++       /* Bootloader configuration template exposes as nvmem */
++       if (copy_property(fdt, fw_fdt, "blconfig", "reg") == 0)
++               copy_property(fdt, fw_fdt, "blconfig", "status");
 +
-+	/* kernel address randomisation seed as provided by the firmware */
-+	copy_property(fdt, fw_fdt, "/chosen", "kaslr-seed");
++       /* kernel address randomisation seed as provided by the firmware */
++       copy_property(fdt, fw_fdt, "/chosen", "kaslr-seed");
 +}
-+
+ 
  int ft_board_setup(void *blob, struct bd_info *bd)
  {
- 	int node;
- 
-+	update_fdt_from_fw(blob, (void *)fw_dtb_pointer);
-+
- 	node = fdt_node_offset_by_compatible(blob, -1, "simple-framebuffer");
- 	if (node < 0)
- 		lcd_dt_simplefb_add_node(blob);
+        int node;
+-
++    update_fdt_from_fw(blob, (void *)fw_dtb_pointer);
+        node = fdt_node_offset_by_compatible(blob, -1, "simple-framebuffer");
+        if (node < 0)
+                fdt_simplefb_add_node(blob);
+
 -- 
 2.32.0
 

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -23,10 +23,11 @@
 }:
 
 let
-  defaultVersion = "2022.10";
+  defaultVersion = "2023.01";
   defaultSrc = fetchurl {
     url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${defaultVersion}.tar.bz2";
-    hash = "sha256-ULRIKlBbwoG6hHDDmaPCbhReKbI1ALw1xQ3r1/pGvfg=";
+    hash = "sha256-aUI7rTgPiaCRZjbonm3L0uRRLVhDCNki0QOdHkMxlQ8=";
+    #sha256 = "69423bad380f89a0916636e89e6dcbd2e4512d584308d922d1039d1e4331950f";
   };
   buildUBoot = lib.makeOverridable ({
     version ? null
@@ -46,12 +47,12 @@ let
     src = if src == null then defaultSrc else src;
 
     patches = [
-      ./0001-configs-rpi-allow-for-bigger-kernels.patch
+      #./0001-configs-rpi-allow-for-bigger-kernels.patch
 
       # Make U-Boot forward some important settings from the firmware-provided FDT. Fixes booting on BCM2711C0 boards.
       # See also: https://github.com/NixOS/nixpkgs/issues/135828
       # Source: https://patchwork.ozlabs.org/project/uboot/patch/20210822143656.289891-1-sjoerd@collabora.com/
-      ./0001-rpi-Copy-properties-from-firmware-dtb-to-the-loaded-.patch
+      #./0001-rpi-Copy-properties-from-firmware-dtb-to-the-loaded-.patch
     ] ++ extraPatches;
 
     postPatch = ''
@@ -467,7 +468,7 @@ in {
   };
 
   ubootRaspberryPi4_64bit = buildUBoot {
-    defconfig = "rpi_4_defconfig";
+    defconfig = "rpi_arm64_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
     filesToInstall = ["u-boot.bin"];
   };

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -51,7 +51,7 @@ let
       # Make U-Boot forward some important settings from the firmware-provided FDT. Fixes booting on BCM2711C0 boards.
       # See also: https://github.com/NixOS/nixpkgs/issues/135828
       # Source: https://patchwork.ozlabs.org/project/uboot/patch/20210822143656.289891-1-sjoerd@collabora.com/
-      #./0001-rpi-Copy-properties-from-firmware-dtb-to-the-loaded-.patch
+      ./0001-rpi-Copy-properties-from-firmware-dtb-to-the-loaded-.patch
     ] ++ extraPatches;
 
     postPatch = ''

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -47,8 +47,7 @@ let
     src = if src == null then defaultSrc else src;
 
     patches = [
-      #./0001-configs-rpi-allow-for-bigger-kernels.patch
-
+      ./0001-configs-rpi-allow-for-bigger-kernels.patch
       # Make U-Boot forward some important settings from the firmware-provided FDT. Fixes booting on BCM2711C0 boards.
       # See also: https://github.com/NixOS/nixpkgs/issues/135828
       # Source: https://patchwork.ozlabs.org/project/uboot/patch/20210822143656.289891-1-sjoerd@collabora.com/


### PR DESCRIPTION
###### Description of changes

Updated u-boot to the latest stable release, due to a bug in u-boot which led the booting process hang usb SSD connected.
After updating the new 2023.01 version and removing rpi specific patches from the nix file temporarily for testing. And It does compiles and raspberrypi4 tested booting from the USB SSD that previously made the u-boot hang.

###### Things done
- Changed u-boot version and updated checksum.
- Removed Rpi specific custom patches done to u-boot 
These two files seems to obsolete, but until further testing I won't remove
```
0001-configs-rpi-allow-for-bigger-kernels.patch
0001-rpi-Copy-properties-from-firmware-dtb-to-the-loaded-.patch
```
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
