### PR TITLE
treewide: don't reimplement pythonImportsCheck

### DIFF
--- a/pkgs/development/libraries/physics/hepmc3/default.nix
+++ b/pkgs/development/libraries/physics/hepmc3/default.nix
@@ -25,7 +25,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-  ];
+  ]
+  ++ lib.optional withPython python.pkgs.pythonImportsCheckHook;
 
   buildInputs = [
     root_py
@@ -50,11 +51,7 @@ stdenv.mkDerivation rec {
       --replace 'readlink' '${coreutils}/bin/readlink'
   '';
 
-  doInstallCheck = withPython;
-  # prevent nix from trying to dereference a null python
-  installCheckPhase = lib.optionalString withPython ''
-    PYTHONPATH=${placeholder "out"}/${python.sitePackages} python -c 'import pyHepMC3'
-  '';
+  pythonImportsCheck = [ "pyHepMC3" ];
 
   meta = with lib; {
     description = "The HepMC package is an object oriented, C++ event record for High Energy Physics Monte Carlo generators and simulation";

--- a/pkgs/development/python-modules/mpv/default.nix
+++ b/pkgs/development/python-modules/mpv/default.nix
@@ -23,7 +23,8 @@ buildPythonPackage rec {
   '';
 
   # tests impure, will error if it can't load libmpv.so
-  checkPhase = "${python.interpreter} -c 'import mpv'";
+  doCheck = false;
+  pythonImportsCheck = [ "mpv" ];
 
   meta = with lib; {
     description = "A python interface to the mpv media player";

--- a/pkgs/development/python-modules/sip/4.x.nix
+++ b/pkgs/development/python-modules/sip/4.x.nix
@@ -21,16 +21,7 @@ buildPythonPackage rec {
 
   enableParallelBuilding = true;
 
-  installCheckPhase = let
-    modules = [
-      sip-module
-      "sipconfig"
-    ];
-    imports = lib.concatMapStrings (module: "import ${module};") modules;
-  in ''
-    echo "Checking whether modules can be imported..."
-    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH ${python.interpreter} -c "${imports}"
-  '';
+  pythonImportsCheck = [ sip-module "sipconfig" ];
 
   doCheck = true;
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
