### PR TITLE
llvm_14,llvmPackages_git.llvm: enable polly by default

### DIFF
--- a/pkgs/development/compilers/llvm/14/default.nix
+++ b/pkgs/development/compilers/llvm/14/default.nix
@@ -1,6 +1,6 @@
 { lowPrio, newScope, pkgs, lib, stdenv, cmake
 , gccForLibs, preLibcCrossHeaders
-, libxml2, python3, isl, fetchFromGitHub, overrideCC, wrapCCWith, wrapBintoolsWith
+, libxml2, python3, fetchFromGitHub, overrideCC, wrapCCWith, wrapBintoolsWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
 , targetLlvm
@@ -41,7 +41,7 @@ let
   };
 
   tools = lib.makeExtensible (tools: let
-    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python3 isl release_version version monorepoSrc buildLlvmTools; });
+    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python3 release_version version monorepoSrc buildLlvmTools; });
     mkExtraBuildCommands0 = cc: ''
       rsrc="$out/resource-root"
       mkdir "$rsrc"
@@ -221,7 +221,7 @@ let
   });
 
   libraries = lib.makeExtensible (libraries: let
-    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python3 isl release_version version monorepoSrc; });
+    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python3 release_version version monorepoSrc; });
   in {
 
     compiler-rt-libc = callPackage ./compiler-rt {

--- a/pkgs/development/compilers/llvm/14/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/14/llvm/default.nix
@@ -22,7 +22,7 @@
 # broken for Ampere eMAG 8180 (c2.large.arm on Packet) #56245
 # broken for the armv7l builder
 , enablePFM ? stdenv.isLinux && !stdenv.hostPlatform.isAarch
-, enablePolly ? false
+, enablePolly ? true
 } @args:
 
 let
@@ -42,7 +42,8 @@ in stdenv.mkDerivation (rec {
     cp -r ${monorepoSrc}/${pname} "$out"
     cp -r ${monorepoSrc}/third-party "$out"
   '' + lib.optionalString enablePolly ''
-    cp -r ${monorepoSrc}/polly "$out/llvm/tools"
+    chmod u+w "$out/${pname}/tools"
+    cp -r ${monorepoSrc}/polly "$out/${pname}/tools"
   '');
 
   sourceRoot = "${src.name}/${pname}";

--- a/pkgs/development/compilers/llvm/14/llvm/gnu-install-dirs-polly.patch
+++ b/pkgs/development/compilers/llvm/14/llvm/gnu-install-dirs-polly.patch
@@ -1,77 +1,7 @@
-diff --git a/tools/polly/CMakeLists.txt b/tools/polly/CMakeLists.txt
-index ca7c04c565bb..6a6155806ffa 100644
---- a/tools/polly/CMakeLists.txt
-+++ b/tools/polly/CMakeLists.txt
-@@ -3,6 +3,8 @@ if (NOT DEFINED LLVM_MAIN_SRC_DIR)
-   project(Polly)
-   cmake_minimum_required(VERSION 3.13.4)
- 
-+  include(GNUInstallDirs)
-+
-   # Where is LLVM installed?
-   find_package(LLVM CONFIG REQUIRED)
-   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${LLVM_CMAKE_DIR})
-@@ -122,13 +124,13 @@ include_directories(
- 
- if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
-   install(DIRECTORY include/
--    DESTINATION include
-+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-     FILES_MATCHING
-     PATTERN "*.h"
-     )
- 
-   install(DIRECTORY ${POLLY_BINARY_DIR}/include/
--    DESTINATION include
-+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-     FILES_MATCHING
-     PATTERN "*.h"
-     PATTERN "CMakeFiles" EXCLUDE
-diff --git a/tools/polly/cmake/CMakeLists.txt b/tools/polly/cmake/CMakeLists.txt
-index 7cc129ba2e90..137be25e4b80 100644
---- a/tools/polly/cmake/CMakeLists.txt
-+++ b/tools/polly/cmake/CMakeLists.txt
-@@ -79,18 +79,18 @@ file(GENERATE
- 
- # Generate PollyConfig.cmake for the install tree.
- unset(POLLY_EXPORTS)
--set(POLLY_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
-+set(POLLY_INSTALL_PREFIX "")
- set(POLLY_CONFIG_LLVM_CMAKE_DIR "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
--set(POLLY_CONFIG_CMAKE_DIR "${POLLY_INSTALL_PREFIX}/${POLLY_INSTALL_PACKAGE_DIR}")
--set(POLLY_CONFIG_LIBRARY_DIRS "${POLLY_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}")
-+set(POLLY_CONFIG_CMAKE_DIR "${POLLY_INSTALL_PREFIX}${CMAKE_INSTALL_PREFIX}/${POLLY_INSTALL_PACKAGE_DIR}")
-+set(POLLY_CONFIG_LIBRARY_DIRS "${POLLY_INSTALL_PREFIX}${CMAKE_INSTALL_FULL_LIBDIR}${LLVM_LIBDIR_SUFFIX}")
- if (POLLY_BUNDLED_ISL)
-   set(POLLY_CONFIG_INCLUDE_DIRS
--    "${POLLY_INSTALL_PREFIX}/include"
--    "${POLLY_INSTALL_PREFIX}/include/polly"
-+    "${POLLY_INSTALL_PREFIX}${CMAKE_INSTALL_FULL_LIBDIR}"
-+    "${POLLY_INSTALL_PREFIX}${CMAKE_INSTALL_FULL_LIBDIR}/polly"
-     )
- else()
-   set(POLLY_CONFIG_INCLUDE_DIRS
--    "${POLLY_INSTALL_PREFIX}/include"
-+    "${POLLY_INSTALL_PREFIX}${CMAKE_INSTALL_FULL_INCLUDEDIR}"
-     ${ISL_INCLUDE_DIRS}
-     )
- endif()
-@@ -100,12 +100,12 @@ endif()
- foreach(tgt IN LISTS POLLY_CONFIG_EXPORTED_TARGETS)
-   get_target_property(tgt_type ${tgt} TYPE)
-   if (tgt_type STREQUAL "EXECUTABLE")
--    set(tgt_prefix "bin/")
-+    set(tgt_prefix "${CMAKE_INSTALL_BINDIR}/")
-   else()
--    set(tgt_prefix "lib/")
-+    set(tgt_prefix "${CMAKE_INSTALL_LIBDIR}/")
-   endif()
- 
--  set(tgt_path "${CMAKE_INSTALL_PREFIX}/${tgt_prefix}$<TARGET_FILE_NAME:${tgt}>")
-+  set(tgt_path "${tgt_prefix}$<TARGET_FILE_NAME:${tgt}>")
-   file(RELATIVE_PATH tgt_path ${POLLY_CONFIG_CMAKE_DIR} ${tgt_path})
- 
-   if (NOT tgt_type STREQUAL "INTERFACE_LIBRARY")
+This is the one remaining Polly install dirs related change that hasn't made it
+into upstream yet; previously this patch file also included:
+https://reviews.llvm.org/D117541
+
 diff --git a/tools/polly/cmake/polly_macros.cmake b/tools/polly/cmake/polly_macros.cmake
 index 518a09b45a42..bd9d6f5542ad 100644
 --- a/tools/polly/cmake/polly_macros.cmake
@@ -87,16 +17,3 @@ index 518a09b45a42..bd9d6f5542ad 100644
    endif()
    set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${name})
  endmacro(add_polly_library)
-diff --git a/tools/polly/lib/External/CMakeLists.txt b/tools/polly/lib/External/CMakeLists.txt
-index e3a5683fccdc..293b482eb28a 100644
---- a/tools/polly/lib/External/CMakeLists.txt
-+++ b/tools/polly/lib/External/CMakeLists.txt
-@@ -290,7 +290,7 @@ if (POLLY_BUNDLED_ISL)
-     install(DIRECTORY
-       ${ISL_SOURCE_DIR}/include/
-       ${ISL_BINARY_DIR}/include/
--      DESTINATION include/polly
-+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/polly
-       FILES_MATCHING
-       PATTERN "*.h"
-       PATTERN "CMakeFiles" EXCLUDE

--- a/pkgs/development/compilers/llvm/git/default.nix
+++ b/pkgs/development/compilers/llvm/git/default.nix
@@ -1,6 +1,6 @@
 { lowPrio, newScope, pkgs, lib, stdenv, cmake, ninja
 , gccForLibs, preLibcCrossHeaders
-, libxml2, python3, isl, fetchFromGitHub, overrideCC, wrapCCWith, wrapBintoolsWith
+, libxml2, python3, fetchFromGitHub, overrideCC, wrapCCWith, wrapBintoolsWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
 # This is the default binutils, but with *this* version of LLD rather
@@ -40,7 +40,7 @@ let
   };
 
   tools = lib.makeExtensible (tools: let
-    callPackage = newScope (tools // { inherit stdenv cmake ninja libxml2 python3 isl release_version version monorepoSrc buildLlvmTools; });
+    callPackage = newScope (tools // { inherit stdenv cmake ninja libxml2 python3 release_version version monorepoSrc buildLlvmTools; });
     mkExtraBuildCommands0 = cc: ''
       rsrc="$out/resource-root"
       mkdir "$rsrc"
@@ -220,7 +220,7 @@ let
   });
 
   libraries = lib.makeExtensible (libraries: let
-    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake ninja libxml2 python3 isl release_version version monorepoSrc; });
+    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake ninja libxml2 python3 release_version version monorepoSrc; });
   in {
 
     compiler-rt-libc = callPackage ./compiler-rt {

--- a/pkgs/development/compilers/llvm/git/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/git/llvm/default.nix
@@ -24,7 +24,7 @@
   || stdenv.isAarch64 # broken for Ampere eMAG 8180 (c2.large.arm on Packet) #56245
   || stdenv.isAarch32 # broken for the armv7l builder
 )
-, enablePolly ? false
+, enablePolly ? true
 } @args:
 
 let
@@ -44,7 +44,8 @@ in stdenv.mkDerivation (rec {
     cp -r ${monorepoSrc}/${pname} "$out"
     cp -r ${monorepoSrc}/third-party "$out"
   '' + lib.optionalString enablePolly ''
-    cp -r ${monorepoSrc}/polly "$out/llvm/tools"
+    chmod u+w "$out/${pname}/tools"
+    cp -r ${monorepoSrc}/polly "$out/${pname}/tools"
   '');
 
   sourceRoot = "${src.name}/${pname}";

--- a/pkgs/development/compilers/llvm/git/llvm/gnu-install-dirs-polly.patch
+++ b/pkgs/development/compilers/llvm/git/llvm/gnu-install-dirs-polly.patch
@@ -1,77 +1,7 @@
-diff --git a/tools/polly/CMakeLists.txt b/tools/polly/CMakeLists.txt
-index ca7c04c565bb..6a6155806ffa 100644
---- a/tools/polly/CMakeLists.txt
-+++ b/tools/polly/CMakeLists.txt
-@@ -3,6 +3,8 @@ if (NOT DEFINED LLVM_MAIN_SRC_DIR)
-   project(Polly)
-   cmake_minimum_required(VERSION 3.13.4)
- 
-+  include(GNUInstallDirs)
-+
-   # Where is LLVM installed?
-   find_package(LLVM CONFIG REQUIRED)
-   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${LLVM_CMAKE_DIR})
-@@ -122,13 +124,13 @@ include_directories(
- 
- if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
-   install(DIRECTORY include/
--    DESTINATION include
-+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-     FILES_MATCHING
-     PATTERN "*.h"
-     )
- 
-   install(DIRECTORY ${POLLY_BINARY_DIR}/include/
--    DESTINATION include
-+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-     FILES_MATCHING
-     PATTERN "*.h"
-     PATTERN "CMakeFiles" EXCLUDE
-diff --git a/tools/polly/cmake/CMakeLists.txt b/tools/polly/cmake/CMakeLists.txt
-index 7cc129ba2e90..137be25e4b80 100644
---- a/tools/polly/cmake/CMakeLists.txt
-+++ b/tools/polly/cmake/CMakeLists.txt
-@@ -79,18 +79,18 @@ file(GENERATE
- 
- # Generate PollyConfig.cmake for the install tree.
- unset(POLLY_EXPORTS)
--set(POLLY_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
-+set(POLLY_INSTALL_PREFIX "")
- set(POLLY_CONFIG_LLVM_CMAKE_DIR "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
--set(POLLY_CONFIG_CMAKE_DIR "${POLLY_INSTALL_PREFIX}/${POLLY_INSTALL_PACKAGE_DIR}")
--set(POLLY_CONFIG_LIBRARY_DIRS "${POLLY_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}")
-+set(POLLY_CONFIG_CMAKE_DIR "${POLLY_INSTALL_PREFIX}${CMAKE_INSTALL_PREFIX}/${POLLY_INSTALL_PACKAGE_DIR}")
-+set(POLLY_CONFIG_LIBRARY_DIRS "${POLLY_INSTALL_PREFIX}${CMAKE_INSTALL_FULL_LIBDIR}${LLVM_LIBDIR_SUFFIX}")
- if (POLLY_BUNDLED_ISL)
-   set(POLLY_CONFIG_INCLUDE_DIRS
--    "${POLLY_INSTALL_PREFIX}/include"
--    "${POLLY_INSTALL_PREFIX}/include/polly"
-+    "${POLLY_INSTALL_PREFIX}${CMAKE_INSTALL_FULL_LIBDIR}"
-+    "${POLLY_INSTALL_PREFIX}${CMAKE_INSTALL_FULL_LIBDIR}/polly"
-     )
- else()
-   set(POLLY_CONFIG_INCLUDE_DIRS
--    "${POLLY_INSTALL_PREFIX}/include"
-+    "${POLLY_INSTALL_PREFIX}${CMAKE_INSTALL_FULL_INCLUDEDIR}"
-     ${ISL_INCLUDE_DIRS}
-     )
- endif()
-@@ -100,12 +100,12 @@ endif()
- foreach(tgt IN LISTS POLLY_CONFIG_EXPORTED_TARGETS)
-   get_target_property(tgt_type ${tgt} TYPE)
-   if (tgt_type STREQUAL "EXECUTABLE")
--    set(tgt_prefix "bin/")
-+    set(tgt_prefix "${CMAKE_INSTALL_BINDIR}/")
-   else()
--    set(tgt_prefix "lib/")
-+    set(tgt_prefix "${CMAKE_INSTALL_LIBDIR}/")
-   endif()
- 
--  set(tgt_path "${CMAKE_INSTALL_PREFIX}/${tgt_prefix}$<TARGET_FILE_NAME:${tgt}>")
-+  set(tgt_path "${tgt_prefix}$<TARGET_FILE_NAME:${tgt}>")
-   file(RELATIVE_PATH tgt_path ${POLLY_CONFIG_CMAKE_DIR} ${tgt_path})
- 
-   if (NOT tgt_type STREQUAL "INTERFACE_LIBRARY")
+This is the one remaining Polly install dirs related change that hasn't made it
+into upstream yet; previously this patch file also included:
+https://reviews.llvm.org/D117541
+
 diff --git a/tools/polly/cmake/polly_macros.cmake b/tools/polly/cmake/polly_macros.cmake
 index 518a09b45a42..bd9d6f5542ad 100644
 --- a/tools/polly/cmake/polly_macros.cmake
@@ -87,16 +17,3 @@ index 518a09b45a42..bd9d6f5542ad 100644
    endif()
    set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${name})
  endmacro(add_polly_library)
-diff --git a/tools/polly/lib/External/CMakeLists.txt b/tools/polly/lib/External/CMakeLists.txt
-index e3a5683fccdc..293b482eb28a 100644
---- a/tools/polly/lib/External/CMakeLists.txt
-+++ b/tools/polly/lib/External/CMakeLists.txt
-@@ -290,7 +290,7 @@ if (POLLY_BUNDLED_ISL)
-     install(DIRECTORY
-       ${ISL_SOURCE_DIR}/include/
-       ${ISL_BINARY_DIR}/include/
--      DESTINATION include/polly
-+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/polly
-       FILES_MATCHING
-       PATTERN "*.h"
-       PATTERN "CMakeFiles" EXCLUDE


### PR DESCRIPTION
###### Description of changes

Port of 2a58596dd24 ("llvmPackages_15.llvm: enable polly by default").

It should be ported all the back to LLVM 12, but I haven't done that here because going further back than 14 requires fixing patches, and I'm focused on my goal of getting the delta between LLVM 15 and LLVM git under control — it's going to be hard enough to accomplish that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
