### PR TITLE
lib/types: allow changing the name of `name`

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -696,6 +696,7 @@ rec {
       , specialArgs ? {}
       , shorthandOnlyDefinesConfig ? false
       , description ? null
+      , nameArgument ? "name"
       }@attrs:
       let
         inherit (lib.modules) evalModules;
@@ -724,7 +725,7 @@ rec {
             # &gt; and &lt; wouldn't be encoded correctly so the encoded values
             # would be used, and use of `<` and `>` would break the XML document.
             # It shouldn't cause an issue since this is cosmetic for the manual.
-            _module.args.name = lib.mkOptionDefault "‹name›";
+            _module.args.${nameArgument} = lib.mkOptionDefault "‹name›";
           }] ++ modules;
         };
 
@@ -741,7 +742,7 @@ rec {
         check = x: isAttrs x || isFunction x || path.check x;
         merge = loc: defs:
           (base.extendModules {
-            modules = [ { _module.args.name = last loc; } ] ++ allModules defs;
+            modules = [ { _module.args.${nameArgument} = last loc; } ] ++ allModules defs;
             prefix = loc;
           }).config;
         emptyValue = { value = {}; };


### PR DESCRIPTION
Provides a way to fïx https://github.com/nix-community/home-manager/issues/3716

Adds a new `nameArgument` argument to `submoduleWith` that allows changing which argument the "name" (last item of `loc`, i.e. attribute name or option name this submodule appears under) is bound to.

This avoids conflicts when `moduleType` is used inside a submodule, where `name` would be set to both the outer submodule's name and the inner one's. If the outer submodule type sets `nameArgument` to something different, `moduleType` will continue using `name`, avoiding the conflict.

Ideally, there should probably be a way to change the inner `name` too to remove all ambiguity.