### PR TITLE
python310Packages.pygame: fix build by pinning SDL2 to 2.24.2

### DIFF
--- a/pkgs/development/libraries/SDL2/2_24.nix
+++ b/pkgs/development/libraries/SDL2/2_24.nix
@@ -1,0 +1,14 @@
+{ fetchFromGitHub
+, SDL2
+}:
+
+SDL2.overrideAttrs(oa: rec {
+  version = "2.24.2";
+
+  src = fetchFromGitHub {
+    owner = "libsdl-org";
+    repo = "SDL";
+    rev = "refs/tags/release-${version}";
+    hash = "sha256-DABzMQLVI/lnjijq0XJtZYUtMKX7E0WtFQCcnUXMZnY=";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23286,6 +23286,8 @@ with pkgs;
   SDL2 = callPackage ../development/libraries/SDL2 {
     inherit (darwin.apple_sdk.frameworks) AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL;
   };
+  # SDL2_2_24 pinned for pygame
+  SDL2_2_24 = callPackage ../development/libraries/SDL2/2_24.nix { };
 
   SDL2_image = callPackage ../development/libraries/SDL2_image {
     inherit (darwin.apple_sdk.frameworks) Foundation;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8162,6 +8162,7 @@ self: super: with self; {
 
   pygame = callPackage ../development/python-modules/pygame {
     inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
+    SDL2 = pkgs.SDL2_2_24;
     SDL2_image = pkgs.SDL2_image_2_0_5;
   };
 


### PR DESCRIPTION
* python310Packages.pygame: fix build by pinning SDL2 to 2.24.2
* SDL2_2_24: init at 2.24.2

Notes:

* This PR targets staging to avoid possible conflict with: #218725 ([tracking](https://nixpk.gs/pr-tracker.html?pr=218725))

* The name `SDL2_2_24` is odd, because version starts after `_`. Then, SDL2, 2 is also version, but also, not really? For example, with `SDL2_image_2_24`. So I followed that pattern. Version starting after `_`.
  -  Maybe SDL2 should be named `SDL_2`? That would make sense. Don't blame me!

* Can't fix `python311Packages.pygame`, which errors as:
  - `fatal error: longintrepr.h: No such file or directory`
