### PR TITLE
configuration.nix: suggest a command line program

### DIFF
--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -180,7 +180,7 @@ in
         #   extraGroups = [ "wheel" ]; # Enable ‘sudo’ for the user.
         #   packages = with pkgs; [
         #     firefox
-        #     thunderbird
+        #     tree
         #   ];
         # };
 


### PR DESCRIPTION
adding two graphical programs makes a strong assmuption that users will
use a graphical environment.

related: https://github.com/NixOS/nix.dev/pull/334/files#r988695366

making trivial examples is easier with smaller closures.
I don't want people to have to download gigabytes of data in order to use defaults for first steps.

###### Description of changes

add a command line program as an alternative suggestion that is easy to
comment in as a first-steps measure.

the choice of program is almost arbitrary, only with the following constraints:
- useful not only for developers
- small closure size
- non entirely trivial to obtain on conventional systems


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->