### PR TITLE
Add nixpkgsUpdater, new helper for nixpkgs maintainers

### DIFF
--- a/pkgs/applications/misc/simple-pkg/default.nix
+++ b/pkgs/applications/misc/simple-pkg/default.nix
@@ -1,0 +1,68 @@
+# Original in external repo, but copied to nixpkgs by nixpkgsUpdater
+{ lib
+, stdenv
+, autoreconfHook
+
+  # New helper functions
+, nixpkgsUpdater
+, srcFromJSON
+
+  # projectSrc is overloaded, it can be:
+  # - Path to an "info.json" file (That's the case in nixpkgs)
+  # - The src attribute passed to mkDerivation (That's the case in upstream)
+, projectSrc ? ./info.json
+}:
+
+let
+  srcData = srcFromJSON projectSrc;
+in
+
+stdenv.mkDerivation {
+  pname = "simple";
+
+  inherit (srcData) src version;
+
+  nativeBuildInputs = [ autoreconfHook ];
+  preAutoreconf = "cd src";
+
+  passthru.updateScript = nixpkgsUpdater {
+    # See
+    # https://nixos.org/manual/nixpkgs/stable/#chap-pkgs-fetchers
+    # Supported fetchers: fetchFromGitHub
+    fetcher = "fetchFromGitHub";
+
+    # Extra args for the fetcher function
+    # All the arguments we want to pass to the underlaying fetch function (fetchgit, fetchFromGitHub, ...),
+    # except hash and rev
+    fetcherArgs = {
+      owner = "jlesquembre";
+      repo = "simple-flake";
+    };
+
+    # List of files to sync with nixpkgs, relative to the Git repository root.
+    # The most common case is to sync itself
+    syncFiles = [ "pkgs/default.nix" ];
+
+    # Optionally, we can provide a script to find the latest version. If not provided, the default one is used
+    # getLastVersion =
+    #   writeShellApplication {
+    #     name = "get-last-version";
+    #     runtimeInputs = [ curl jq ];
+    #     text =
+    #       ''
+    #         curl -s "https://api.github.com/repos/jlesquembre/simple-flake/tags" | jq -r '.[0].name'
+    #       '';
+    #   };
+
+
+  };
+  meta = with lib; {
+    description = "A simple package";
+    homepage = "https://test.com/";
+    license = licenses.epl10;
+    longDescription = ''
+    '';
+    maintainers = with maintainers; [ jlesquembre ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/misc/simple-pkg/info.json
+++ b/pkgs/applications/misc/simple-pkg/info.json
@@ -1,0 +1,13 @@
+{
+  "fetcher": "fetchFromGitHub",
+  "fetcherArgs": {
+    "owner": "jlesquembre",
+    "repo": "simple-flake",
+    "hash": "sha256-x9BrU5hj6HsnRudt7a7qEJOTX2WU1UdAxiPK40NLvew=",
+    "rev": "v1.0"
+  },
+  "syncFiles": [
+    "pkgs/default.nix"
+  ],
+  "version": "1.0"
+}

--- a/pkgs/nixpkgs-updater/default.nix
+++ b/pkgs/nixpkgs-updater/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenv
+, jq
+, curl
+, nurl
+, nix
+, writeShellApplication
+, runCommand
+}:
+
+{ fetcher, fetcherArgs, syncFiles, getLastVersion ? null }:
+
+let
+  submodules = fetcherArgs: if fetcherArgs.fetchSubmodules or false then "true" else "false";
+
+  userGetVersion =
+    ''
+      if [ ! -d "${getLastVersion}" ] && [ -x "${getLastVersion}" ]; then
+          ${getLastVersion}
+      else
+          bin=(${getLastVersion}/bin/*)
+          ''${bin[0]}
+      fi
+    '';
+
+  scriptArgs =
+    if fetcher == "fetchFromGitHub" then
+      assert fetcherArgs ? "owner";
+      assert fetcherArgs ? "repo";
+      let
+        repo = "${fetcherArgs.owner}/${fetcherArgs.repo}";
+        domain = fetcherArgs.domain or "github.com";
+      in
+      {
+        getVersionCmd = ''get_last_github_tag "${repo}" "${domain}"'';
+        upstreamUrl = "https://${domain}/${repo}";
+      }
+
+    else if fetcher == "fetchgit" then
+      assert fetcherArgs ? "url";
+      {
+        getVersionCmd = ''get_last_git_tag "${fetcherArgs.url}"'';
+        upstreamUrl = fetcherArgs.url;
+      }
+
+    else abort "Invalid fetcher: ${fetcher}";
+
+  nixpkgsUpdater = writeShellApplication
+    {
+      name = "nixpkgs-updater-script";
+
+      runtimeInputs = [ nix curl jq nurl ];
+
+      text =
+        let getVersionCmd = if !(builtins.isNull getLastVersion) then userGetVersion else scriptArgs.getVersionCmd; in
+        ''
+          # shellcheck disable=1091
+          source ${./utils.sh}
+          version=$(${getVersionCmd})
+          nurl_info=$(get_nurl_info "${fetcher}" "${scriptArgs.upstreamUrl}" "$version" "${submodules fetcherArgs}")
+          update_info '${builtins.toJSON fetcherArgs}' '${builtins.toJSON syncFiles}' "$nurl_info"
+        '';
+    };
+in
+runCommand "nixpkgs-updater" { }
+  ''
+    ln -s ${nixpkgsUpdater}/bin/nixpkgs-updater-script $out
+  ''

--- a/pkgs/nixpkgs-updater/src-from-json.nix
+++ b/pkgs/nixpkgs-updater/src-from-json.nix
@@ -1,0 +1,26 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+
+infoPath:
+
+if lib.isPath infoPath && (builtins.baseNameOf infoPath == "info.json")
+
+then
+
+  let info = lib.importJSON infoPath; in
+
+  if info.fetcher == "fetchFromGitHub" then
+    {
+      src = fetchFromGitHub info.fetcherArgs;
+      version = info.version;
+    }
+  else
+    abort "Invalid fetcher: ${info.fetcher}"
+
+else
+  {
+    src = infoPath;
+    version = "DEV";
+  }

--- a/pkgs/nixpkgs-updater/utils.sh
+++ b/pkgs/nixpkgs-updater/utils.sh
@@ -1,0 +1,92 @@
+# shellcheck shell=bash
+
+set -eu
+set -o pipefail
+
+get_last_github_tag() {
+    repo=$1
+    domain=${2:-github.com}
+    curl -s "https://api.${domain}/repos/${repo}/tags" | jq -r '.[0].name'
+}
+
+get_last_git_tag() {
+    repo=$1
+    git -c 'versionsort.suffix=-' \
+        ls-remote --exit-code --refs --sort='version:refname' --tags "$repo" |
+        tail --lines=1 |
+        cut --delimiter='/' --fields=3
+}
+
+# Convert a version string to a derivation version
+# e.g.: v1.0 -> 1.0
+derivation_version() {
+    version=$1
+    echo "${version#v}"
+}
+
+# Input:
+#  - fetcher: fetcher name. E.g.: fetchFromGitHub, fetchgit, ...
+#  - url: Upstream URL. E.g: https://github.com/NixOS/nix
+#  - version: Version to fetch. E.g.: 1.0
+#  - submodules: Fetch submodules, true or false.
+# Output:
+#  JSON with fetcher name, fetcher arguments, version and nix prefetch command
+get_nurl_info() {
+    fetcher=$1
+    url=$2
+    version=$3
+    submodules=$4
+
+    tmp_file="$(mktemp)"
+    trap 'rm -rf -- "$tmp_file"' EXIT
+
+    nurl_out=$(nurl --json --fetcher "$fetcher" "--submodules=$submodules" "$url" "$version" 2> >(tee "$tmp_file" >&2))
+    nix_prefetch_cmd=$(cat "$tmp_file")
+
+    # Remove '$ ' from the command
+    nix_prefetch_cmd=${nix_prefetch_cmd#"$ "}
+
+    jq -n \
+        --arg fetcher "$fetcher" \
+        --argjson nurl_out "$nurl_out" \
+        --arg nix_prefetch_cmd "$nix_prefetch_cmd" \
+        --arg version "$(derivation_version "$version")" \
+        '{"fetcher": $fetcher,
+          "fetcher_args": ($nurl_out.args),
+          "nix_prefetch_cmd": $nix_prefetch_cmd,
+          "version": $version
+         }'
+}
+
+# Input:
+#  - user_args: fetcherArgs values defined by the user
+#  - sync_files: list of files to sync defined by the user
+#  - nurl_info: get_nurl_info output
+# Output:
+#  Copies syncFiles, and generates a info.json file in the current working directory
+update_info() {
+    user_args=$1
+    sync_files=$2
+    nurl_info=$3
+
+    nix_prefetch_cmd="$(jq -r ".nix_prefetch_cmd" <<<"$nurl_info")"
+    storePath="$(eval "$nix_prefetch_cmd" | jq -r ".storePath")"
+
+    # JSON array to bash array
+    declare -a sync_files_array
+    mapfile -t sync_files_array < <(jq -r ".[]" <<<"$sync_files")
+
+    for f in "${sync_files_array[@]}"; do
+        cp -r --no-preserve=mode "${storePath}/${f}" .
+    done
+
+    jq -n \
+        --argjson user_args "$user_args" \
+        --argjson sync_files "$sync_files" \
+        --argjson nurl_info "$nurl_info" \
+        '{"fetcher": ($nurl_info.fetcher),
+          "fetcherArgs": ($user_args + $nurl_info.fetcher_args),
+          "syncFiles": $sync_files,
+          "version": ($nurl_info.version)
+         }' >info.json
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -120,6 +120,8 @@ with pkgs;
 
   ### Nixpkgs maintainer tools
 
+  simple-pkg = callPackage ../applications/misc/simple-pkg { };
+
   nixpkgsUpdater = callPackage ../nixpkgs-updater/default.nix { };
 
   srcFromJSON = callPackage ../nixpkgs-updater/src-from-json.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -120,6 +120,10 @@ with pkgs;
 
   ### Nixpkgs maintainer tools
 
+  nixpkgsUpdater = callPackage ../nixpkgs-updater/default.nix { };
+
+  srcFromJSON = callPackage ../nixpkgs-updater/src-from-json.nix { };
+
   nix-generate-from-cpan = callPackage ../../maintainers/scripts/nix-generate-from-cpan.nix { };
 
   nixpkgs-lint = callPackage ../../maintainers/scripts/nixpkgs-lint.nix { };


### PR DESCRIPTION
See rationale here: #217679

Example of external repository using it: https://github.com/jlesquembre/simple-flake

Only 2 fetcher are currently supported, `fetchFromGitHub` and `fetchgit`.

Probably I should add some documentation for nixpkgs, and remove the `simple-pkg` before merging, but I'd like to get some feedback first.



