### PR TITLE
Fix libglibutil, libgbinder and gbinder-python cross-compilation

### DIFF
--- a/pkgs/development/libraries/libgbinder/default.nix
+++ b/pkgs/development/libraries/libgbinder/default.nix
@@ -22,6 +22,13 @@ stdenv.mkDerivation rec {
     libglibutil
   ];
 
+  postPatch = ''
+    # Fix pkg-config and ranlib names for cross-compilation
+    substituteInPlace Makefile \
+      --replace "pkg-config" "$PKG_CONFIG" \
+      --replace "ranlib" "$RANLIB"
+  '';
+
   makeFlags = [
     "LIBDIR=$(out)/lib"
     "INSTALL_INCLUDE_DIR=$(dev)/include/gbinder"

--- a/pkgs/development/libraries/libglibutil/default.nix
+++ b/pkgs/development/libraries/libglibutil/default.nix
@@ -21,6 +21,11 @@ stdenv.mkDerivation rec {
     glib
   ];
 
+  postPatch = ''
+    # Fix pkg-config name for cross-compilation
+    substituteInPlace Makefile --replace "pkg-config" "$PKG_CONFIG"
+  '';
+
   makeFlags = [
     "LIBDIR=$(out)/lib"
     "INSTALL_INCLUDE_DIR=$(dev)/include/gutil"

--- a/pkgs/development/python-modules/gbinder-python/default.nix
+++ b/pkgs/development/python-modules/gbinder-python/default.nix
@@ -26,6 +26,11 @@ buildPythonPackage rec {
     pkg-config
   ];
 
+  postPatch = ''
+    # Fix pkg-config name for cross-compilation
+    substituteInPlace setup.py --replace "pkg-config" "$PKG_CONFIG"
+  '';
+
   setupPyGlobalFlags = [ "--cython" ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

Fixed pkg-config paths and ranlib path, so that they can be found during cross-compilation

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-linux.pkgsCross.aarch64-multiplatform
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
