### PR TITLE
workflows: pin nix to 2.13.3

### DIFF
--- a/.github/workflows/basic-eval.yml
+++ b/.github/workflows/basic-eval.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v19
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - uses: cachix/cachix-action@v12
       with:
         # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -33,6 +33,7 @@ jobs:
         # nixpkgs commit is pinned so that it doesn't break
         # editorconfig-checker 2.4.0
         nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/c473cc8714710179df205b153f4e9fa007107ff9.tar.gz
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - name: Checking EditorConfig
       run: |
         cat "$HOME/changed_files" | nix-shell -p editorconfig-checker --run 'xargs -r editorconfig-checker -disable-indent-size'

--- a/.github/workflows/manual-nixos.yml
+++ b/.github/workflows/manual-nixos.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           # explicitly enable sandbox
           extra_nix_config: sandbox = true
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
       - uses: cachix/cachix-action@v12
         with:
           # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.

--- a/.github/workflows/manual-nixpkgs.yml
+++ b/.github/workflows/manual-nixpkgs.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           # explicitly enable sandbox
           extra_nix_config: sandbox = true
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
       - uses: cachix/cachix-action@v12
         with:
           # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.

--- a/.github/workflows/manual-rendering.yml
+++ b/.github/workflows/manual-rendering.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           # explicitly enable sandbox
           extra_nix_config: sandbox = true
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
       - uses: cachix/cachix-action@v12
         with:
           # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.

--- a/.github/workflows/update-terraform-providers.yml
+++ b/.github/workflows/update-terraform-providers.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: cachix/install-nix-action@v19
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
       - name: setup
         id: setup
         run: |


### PR DESCRIPTION
###### Description of changes

same reasoning as https://github.com/NixOS/nixpkgs/pull/218858, only now for an action we depend on and can't fix quite as easily. cachix-action also uses nix-env and will thus not work correctly, so pin the nix version used to the last known good one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
