### PR TITLE
python311Packages.ipython: 8.4.0 -> 8.11.0

### DIFF
--- a/pkgs/development/python-modules/ipython/default.nix
+++ b/pkgs/development/python-modules/ipython/default.nix
@@ -28,25 +28,14 @@
 
 buildPythonPackage rec {
   pname = "ipython";
-  version = "8.4.0";
+  version = "8.11.0";
   format = "pyproject";
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f2db3a10254241d9b447232cec8b424847f338d9d36f9a577a6192c332a46abd";
+    sha256 = "735cede4099dbc903ee540307b9171fbfef4aa75cfcacc5a273b2cda2f02be04";
   };
-
-  patches = [
-    (fetchpatch {
-      # The original URL might not be very stable, so let's prefer a copy.
-      urls = [
-        "https://raw.githubusercontent.com/bmwiedemann/openSUSE/9b35e4405a44aa737dda623a7dabe5384172744c/packages/p/python-ipython/ipython-pr13714-xxlimited.patch"
-        "https://github.com/ipython/ipython/pull/13714.diff"
-      ];
-      sha256 = "XPOcBo3p8mzMnP0iydns9hX8qCQXTmRgRD0TM+FESCI=";
-    })
-  ];
 
   nativeBuildInputs = [
     setuptools


### PR DESCRIPTION
python311Packages.ipython: 8.4.0 -> 8.11.0

* Release: https://github.com/ipython/ipython/releases/tag/8.11.0

Targets `staging` because this package is broken there, errored as:
  > FAILED IPython/lib/tests/test_lexers.py::TestLexers::testIPythonLexer - AssertionError: Lists differ: [(Tok[78 chars] (Token.Name.Variable, '$HOME'...

Fixes:
- cmake-language-server
- python3.10-orjson
- tandoor-recipes
- python311Packages.slackclient
- [migraphx](https://hydra.nixos.org/build/210959081)
- home-assistant-component-tests.apple_tv
- nikola
- python3.10-cmaes
- python3.10-pdoc
- python3.10-dash
- python3.10-sagemaker
- python311Packages.myjwt
- **and a lot of other packages...**
