### PR TITLE
python3Packages.curio: Fix Linux build

### DIFF
--- a/pkgs/development/python-modules/curio/default.nix
+++ b/pkgs/development/python-modules/curio/default.nix
@@ -30,7 +30,6 @@ buildPythonPackage rec {
      "test_write_timeout" # flaky, does not always time out
      "test_aside_cancel" # fails because modifies PYTHONPATH and cant find pytest
      "test_ssl_outgoing" # touches network
-   ] ++ lib.optionals stdenv.isDarwin [
      "test_unix_echo" # socket bind error on hydra when built with other packages
      "test_unix_ssl_server" # socket bind error on hydra when built with other packages
    ];


### PR DESCRIPTION
In one of our internal mass rebuilds at work we noticed this package fail on Linux and the two tests that failed were exactly the ones that had already been disabled on macOS, so this also disables them on Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).