### PR TITLE
frogatto: unstable-2020-12-04 -> unstable-2023-02-27

### DIFF
--- a/pkgs/games/frogatto/data.nix
+++ b/pkgs/games/frogatto/data.nix
@@ -2,18 +2,18 @@
 
 stdenv.mkDerivation {
   pname = "frogatto-data";
-  version = "unstable-2022-04-13";
+  version = "unstable-2023-02-27";
 
   src = fetchFromGitHub {
     owner = "frogatto";
     repo = "frogatto";
-    rev = "655493961c4ad57ba9cccdc24d23a2ded294b5f2";
-    sha256 = "0irn7p61cs8nm7dxsx84b2c3wryf2h12k2kclywdhy6xmh53w8k1";
+    rev = "5ca339f4b97e5004dc07394407bf1da43fbd6204";
+    sha256 = "sha256-6wqCFc7DlDt0u0JnPg4amVemc9HOjsB/U4s9n7N84QA=";
   };
 
   installPhase = ''
     mkdir -p $out/share/frogatto/modules
-    cp -ar . $out/share/frogatto/modules/frogatto
+    cp -ar . $out/share/frogatto/modules/frogatto4
   '';
 
   meta = with lib; {

--- a/pkgs/games/frogatto/default.nix
+++ b/pkgs/games/frogatto/default.nix
@@ -14,7 +14,7 @@ let
     genericName = "frogatto";
     categories = [ "Game" "ArcadeGame" ];
   };
-  version = "unstable-2020-12-04";
+  inherit (data) version;
 in buildEnv {
   name = "frogatto-${version}";
 

--- a/pkgs/games/frogatto/engine.nix
+++ b/pkgs/games/frogatto/engine.nix
@@ -1,25 +1,19 @@
 { lib, stdenv, fetchFromGitHub, fetchurl, which
 , boost, SDL2, SDL2_image, SDL2_mixer, SDL2_ttf
-, glew, zlib, icu, pkg-config, cairo, libvpx }:
+, glew, zlib, icu, pkg-config, cairo, libvpx, glm
+}:
 
 stdenv.mkDerivation {
   pname = "anura-engine";
-  version = "unstable-2022-04-09";
+  version = "unstable-2023-02-27";
 
   src = fetchFromGitHub {
     owner = "anura-engine";
     repo = "anura";
-    rev = "5ac7f6fe63114274f0da7dad4c1ed673651e6424";
-    sha256 = "1yrcbvzgxdvn893qk1qcpb53pjns366fdls5qjal7lhq71kkfc67";
+    rev = "65d85b6646099db1d5cd25d31321bb434a3f94f1";
+    sha256 = "sha256-hb4Sn7uI+eXLaGb4zkEy4w+ByQJ6FqkoMUYFsyiFCeE=";
     fetchSubmodules = true;
   };
-  patches = [
-    # https://github.com/anura-engine/anura/issues/321
-    (fetchurl {
-      url = "https://github.com/anura-engine/anura/commit/627d08fb5254b5c66d315f1706089905c2704059.patch";
-      sha256 = "052m58qb3lg0hnxacpnjz2sz89dk0x6b5qi2q9bkzkvg38f237rr";
-    })
-  ];
 
   nativeBuildInputs = [
     which pkg-config
@@ -36,6 +30,7 @@ stdenv.mkDerivation {
     icu
     cairo
     libvpx
+    glm
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Description of changes

Replaces #218678. This PR makes it build. The game still doesn't start for me on Wayland/Sway:
```
CRITICAL: DisplayDeviceOGL.cpp:136 ASSERTION FAILED: Could not initialise GLEW: Unknown error

CRITICAL:
---
CRITICAL: stack trace:
CRITICAL:   /nix/store/3vn3h29p4rsl3ryxzl6d3f9q132ifj08-frogatto-unstable-2023-02-27/bin/.frogatto-wrapped : KRE::DisplayDeviceOpenGL::init(int, int)+0xefb
CRITICAL:   /nix/store/3vn3h29p4rsl3ryxzl6d3f9q132ifj08-frogatto-unstable-2023-02-27/bin/.frogatto-wrapped : KRE::SDLWindow::createWindow()+0x138a
CRITICAL:   /nix/store/3vn3h29p4rsl3ryxzl6d3f9q132ifj08-frogatto-unstable-2023-02-27/bin/.frogatto-wrapped : KRE::WindowManager::createWindow(std::shared_ptr<KRE::Window>)+0x1a
CRITICAL:   /nix/store/3vn3h29p4rsl3ryxzl6d3f9q132ifj08-frogatto-unstable-2023-02-27/bin/.frogatto-wrapped : main()+0x1e10
CRITICAL:   /nix/store/76l4v99sk83ylfwkz8wmwrm4s8h73rhd-glibc-2.35-224/lib/libc.so.6 : ()+0x2924e
CRITICAL:   /nix/store/76l4v99sk83ylfwkz8wmwrm4s8h73rhd-glibc-2.35-224/lib/libc.so.6 : __libc_start_main()+0x89
CRITICAL:   /nix/store/3vn3h29p4rsl3ryxzl6d3f9q132ifj08-frogatto-unstable-2023-02-27/bin/.frogatto-wrapped : _start()+0x25
```

Does it work for anyone on X11?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
