### PR TITLE
ldc: 1.30.0 -> 1.31.0, bump bootstrap ldc to 1.30.0, bump LLVM to 14

### DIFF
--- a/pkgs/development/compilers/ldc/bootstrap.nix
+++ b/pkgs/development/compilers/ldc/bootstrap.nix
@@ -1,11 +1,11 @@
 { callPackage }:
 callPackage ./binary.nix {
-  version = "1.25.0";
+  version = "1.30.0";
   hashes = {
-    # Get these from `nix-prefetch-url https://github.com/ldc-developers/ldc/releases/download/v1.19.0/ldc2-1.19.0-osx-x86_64.tar.xz` etc..
-    osx-x86_64 = "sha256-6iKnbS+oalLKmyS8qYD/wS21b7+O+VgsWG2iT4PrWPU=";
-    linux-x86_64 = "sha256-sfg47RdlsIpryc3iZvE17OtLweh3Zw6DeuNJYgpuH+o=";
-    linux-aarch64  = "sha256-UDZ43x4flSo+SfsPeE8juZO2Wtk2ZzwySk0ADHnvJBI=";
-    osx-arm64  = "sha256-O/x0vy0wwQFaDc4uWSeMhx+chJKqbQb6e5QNYf+7DCw=";
+    # Get these from `nix store prefetch-file https://github.com/ldc-developers/ldc/releases/download/v1.19.0/ldc2-1.19.0-osx-x86_64.tar.xz` etc..
+    osx-x86_64 = "sha256-AAWZvxuZC82xvrW6fpYm783TY+H8k3DvqE94ZF1yjmk=";
+    linux-x86_64 = "sha256-V4TUzEfQhFrwiX07dHOgjdAoGkzausCkhnQIQNAU/eE=";
+    linux-aarch64  = "sha256-kTeglub75iv/jWWNPCn15aCGAbmck0RQl6L7bFOUu7Y=";
+    osx-arm64  = "sha256-Nb/owBdIeroB9jLMDvwjo8bvsTC9vFyJPLMTOMsSAd4=";
   };
 }

--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "1.30.0";
-  sha256 = "sha256-/bs3bwgkLZF5IqaiKnc5gCF/r6MQBG/F1kWUkK8j2s0=";
+  version = "1.31.0";
+  sha256 = "sha256-8cjs6eHjWAbDRBvyT75mbN3Y7vN1WSwZzY/uRwHNVFg=";
 }

--- a/pkgs/development/compilers/ldc/generic.nix
+++ b/pkgs/development/compilers/ldc/generic.nix
@@ -1,5 +1,5 @@
 { version, sha256 }:
-{ lib, stdenv, fetchurl, cmake, ninja, llvm_11, curl, tzdata
+{ lib, stdenv, fetchurl, cmake, ninja, llvm_14, curl, tzdata
 , libconfig, lit, gdb, unzip, darwin, bash
 , callPackage, makeWrapper, runCommand, targetPackages
 , ldcBootstrap ? callPackage ./bootstrap.nix { }
@@ -30,12 +30,12 @@ stdenv.mkDerivation rec {
     patchShebangs .
   ''
   + ''
-      rm ldc-${version}-src/tests/d2/dmd-testsuite/fail_compilation/mixin_gc.d
-      rm ldc-${version}-src/tests/d2/dmd-testsuite/runnable/xtest46_gc.d
-      rm ldc-${version}-src/tests/d2/dmd-testsuite/runnable/testptrref_gc.d
+      rm ldc-${version}-src/tests/dmd/fail_compilation/mixin_gc.d
+      rm ldc-${version}-src/tests/dmd/runnable/xtest46_gc.d
+      rm ldc-${version}-src/tests/dmd/runnable/testptrref_gc.d
 
       # test depends on current year
-      rm ldc-${version}-src/tests/d2/dmd-testsuite/compilable/ddocYear.d
+      rm ldc-${version}-src/tests/dmd/compilable/ddocYear.d
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
       # https://github.com/NixOS/nixpkgs/issues/34817
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     # Setting SHELL=$SHELL when dmd testsuite is run doesn't work on Linux somehow
-    substituteInPlace tests/d2/dmd-testsuite/Makefile --replace "SHELL=/bin/bash" "SHELL=${bash}/bin/bash"
+    substituteInPlace tests/dmd/Makefile --replace "SHELL=/bin/bash" "SHELL=${bash}/bin/bash"
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
       substituteInPlace runtime/phobos/std/socket.d --replace "assert(ih.addrList[0] == 0x7F_00_00_01);" ""
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    cmake ldcBootstrap lit lit.python llvm_11.dev makeWrapper ninja unzip
+    cmake ldcBootstrap lit lit.python llvm_14.dev makeWrapper ninja unzip
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.apple_sdk.frameworks.Foundation


### PR DESCRIPTION
###### Description of changes

- ldc: 1.30.0 -> 1.31.0, changelog available [here](https://github.com/ldc-developers/ldc/releases/tag/v1.31.0). Also update the bootstrap LDC's version to 1.30.0 and build against LLVM 14 instead of LLVM 11.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
