### PR TITLE
python311Packages.markdown2: 2.4.3 -> 2.4.8

### DIFF
--- a/pkgs/development/python-modules/markdown2/default.nix
+++ b/pkgs/development/python-modules/markdown2/default.nix
@@ -8,23 +8,15 @@
 
 buildPythonPackage rec {
   pname = "markdown2";
-  version = "2.4.3";
+  version = "2.4.8";
 
   # PyPI does not contain tests, so using GitHub instead.
   src = fetchFromGitHub {
     owner = "trentm";
     repo = "python-markdown2";
     rev = version;
-    sha256 = "sha256-zNZ7/dDZbPIwcxSLvf8u5oaAgHLrZ6kk4vXNPUuZs/4=";
+    sha256 = "sha256-0T3HcfjEApEEWtNZGZcta85dY9d/0mSyRBlrqBQEQwk=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "SNYK-PYTHON-MARKDOWN2-2606985-xss.patch";  # no CVE (yet?)
-      url = "https://github.com/trentm/python-markdown2/commit/5898fcc1090ef7cd7783fa1422cc0e53cbca9d1b.patch";
-      sha256 = "sha256-M6kKxjHVC3O0BvDeEF4swzfpFsDO/LU9IHvfjK4hznA=";
-    })
-  ];
 
   nativeCheckInputs = [ pygments ];
 


### PR DESCRIPTION
python311Packages.markdown2: 2.4.3 -> 2.4.8

Release: https://github.com/trentm/python-markdown2/releases/tag/2.4.8
Diff: https://github.com/trentm/python-markdown2/releases/tag/2.4.8

(Targets staging because it is only broken at staging.)


Maybe needs to include? Upstream has not approved/merged yet.
* https://github.com/trentm/python-markdown2/pull/494