### PR TITLE
geeqie: 1.7.3 -> 2.0.1 (take 2)

### DIFF
--- a/pkgs/applications/graphics/geeqie/default.nix
+++ b/pkgs/applications/graphics/geeqie/default.nix
@@ -1,5 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, autoconf, automake, gettext, intltool
+{ lib, stdenv, fetchFromGitHub, pkg-config, meson, ninja, xxd, gettext, intltool
 , gtk3, lcms2, exiv2, libchamplain, clutter-gtk, ffmpegthumbnailer, fbida
+, libarchive, djvulibre, libheif, openjpeg, libjxl, libraw, lua5_3, poppler
+, gspell, libtiff, libwebp
 , wrapGAppsHook, fetchpatch, doxygen
 , nix-update-script
 }:
@@ -12,31 +14,26 @@ stdenv.mkDerivation rec {
     owner = "BestImageViewer";
     repo = "geeqie";
     rev = "v${version}";
-    sha256 = "sha256-O+yz/uNxueR+naEJG8EZ+k/JutRjJ5wwbB9DYb8YNLw=";
+    sha256 = "sha256-0GOX77vZ4KZkvwnR1vlv52tlbR+ciwl3ycxbOIcDOqU=";
   };
-
-  patches = [
-    # Do not build the changelog as this requires markdown.
-    (fetchpatch {
-      name = "geeqie-1.4-goodbye-changelog.patch";
-      url = "https://src.fedoraproject.org/rpms/geeqie/raw/132fb04a1a5e74ddb333d2474f7edb9a39dc8d27/f/geeqie-1.4-goodbye-changelog.patch";
-      sha256 = "00a35dds44kjjdqsbbfk0x9y82jspvsbpm2makcm1ivzlhjjgszn";
-    })
-  ];
 
   postPatch = ''
     patchShebangs .
+    # libtiff detection is broken and looks for liblibtiff...
+    # fixed upstream, to remove for 2.1
+    substituteInPlace meson.build --replace 'libtiff' 'tiff'
   '';
 
-  preConfigure = "./autogen.sh";
-
   nativeBuildInputs =
-    [ pkg-config autoconf automake gettext intltool
+    [ pkg-config gettext intltool
       wrapGAppsHook doxygen
+      meson ninja xxd
     ];
 
   buildInputs = [
     gtk3 lcms2 exiv2 libchamplain clutter-gtk ffmpegthumbnailer fbida
+    libarchive djvulibre libheif openjpeg libjxl libraw lua5_3 poppler
+    gspell libtiff libwebp
   ];
 
   postInstall = ''


### PR DESCRIPTION
the version number was updated without the hash previously, so geeqie has not actually been updated since 1.7.2

Build system changed from configure to meson in 2.0, and our meson flags have auto_features=enable so we enable here a lot of features that were previously automatically disabled by configure.
It might make sense to disable some back, or provide options like other packages do.

###### Description of changes

Follow up of https://github.com/NixOS/nixpkgs/pull/186698

I didn't actually run any binary, @ju1m or someone else if you have time to test that'd be great!