### PR TITLE
python311Packages.zigpy: skip test_periodic_scan_priority

### DIFF
--- a/pkgs/development/python-modules/zigpy-cc/default.nix
+++ b/pkgs/development/python-modules/zigpy-cc/default.nix
@@ -46,6 +46,9 @@ buildPythonPackage rec {
     "tests/test_application.py "
   ];
 
+  # AttributeError: module 'asyncio' has no attribute 'coroutine'
+  doCheck = pythonOlder "3.10";
+
   pythonImportsCheck = [
     "zigpy_cc"
   ];

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -48,6 +48,10 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTests = [
+    "test_periodic_scan_priority"
+  ];
+
   pythonImportsCheck = [
     "zigpy.application"
     "zigpy.config"


### PR DESCRIPTION
python311Packages.zigpy: skip (failing) test_periodic_scan_priority

* Fail happens at `staging`:
  - > FAILED tests/test_topology.py::test_periodic_scan_priority - AssertionError: assert 4 == 3

    Error logs: https://termbin.com/qfu0l

Opened upstream issue at: https://github.com/zigpy/zigpy/issues/1171

Downstream failures:
* `python3.11-zigpy-cc`
  > AttributeError: module 'asyncio' has no attribute 'coroutine'

  - python311Packages.zigpy-cc: disable tests for Python >3.11