### PR TITLE
microdude: init at 2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -920,6 +920,12 @@
     githubId = 1079173;
     name = "Andrew Dunham";
   };
+  andrewb = {
+    email = "me@andrewbruce.net";
+    github = "camelpunch";
+    githubId = 141733;
+    name = "Andrew Bruce";
+  };
   andrewchambers = {
     email = "ac@acha.ninja";
     github = "andrewchambers";

--- a/pkgs/applications/audio/microdude/default.nix
+++ b/pkgs/applications/audio/microdude/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, fetchgit
+, gnumake
+, gtk3
+, setproctitle
+, python-rtmidi
+, python3Packages
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "microdude";
+  version = "2.3";
+
+  src = fetchgit {
+    url = "https://github.com/dagargo/microdude";
+    rev = "2.3";
+    sha256 = "sha256-t3P6JMu//agRcLNtvcXki70kqlc4ed0P/oLYIL/2DcE=";
+  };
+
+  nativeBuildInputs = [
+    gtk3
+  ];
+
+  buildInputs = [
+    python-rtmidi
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    mido
+    pygobject3
+    setproctitle
+    setuptools
+  ];
+
+  postInstall = ''
+    substituteInPlace Makefile \
+      --replace "python3 setup.py install" "" \
+      --replace gtk-update-icon-cache "gtk-update-icon-cache --ignore-theme-index" \
+      --replace '/usr/share/$$locale' $out/share/locale
+    make \
+      ICON_THEME_DIR=$out/share/icons \
+      BINDIR=$out/bin \
+      DESKTOP_FILES_DIR=$out/share/applications \
+      install
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/dagargo/microdude";
+    description = "Editor for Arturia MicroBrute";
+    longDescription = ''
+      MicroDude is an editor for Arturia MicroBrute. It offers all the
+      functionality of Arturia MicroBrute Connection but the firmware upload
+      and the factory patterns reset.
+    '';
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ andrewb ];
+  };
+}

--- a/pkgs/applications/audio/microdude/default.nix
+++ b/pkgs/applications/audio/microdude/default.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchgit
+, fetchFromGitHub
 , gnumake
 , gtk3
 , setproctitle
@@ -11,8 +11,9 @@ python3Packages.buildPythonApplication rec {
   pname = "microdude";
   version = "2.3";
 
-  src = fetchgit {
-    url = "https://github.com/dagargo/microdude";
+  src = fetchFromGitHub {
+    owner = "dagargo";
+    repo = "microdude";
     rev = "2.3";
     sha256 = "sha256-t3P6JMu//agRcLNtvcXki70kqlc4ed0P/oLYIL/2DcE=";
   };
@@ -32,7 +33,7 @@ python3Packages.buildPythonApplication rec {
     setuptools
   ];
 
-  postInstall = ''
+  installPhase = ''
     substituteInPlace Makefile \
       --replace "python3 setup.py install" "" \
       --replace gtk-update-icon-cache "gtk-update-icon-cache --ignore-theme-index" \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30406,6 +30406,8 @@ with pkgs;
 
   meerk40t-camera = callPackage ../applications/misc/meerk40t/camera.nix { };
 
+  microdude = python3Packages.callPackage ../applications/audio/microdude { };
+
   musikcube = callPackage ../applications/audio/musikcube {
     inherit (darwin.apple_sdk.frameworks) Cocoa CoreAudio SystemConfiguration;
   };


### PR DESCRIPTION
###### Description of changes

Add the microdude application: a GTK Python program that interfaces with the Arturia Microbrute analogue synth.

I'm new to nix and nixos, and have [another open PR for a different audio program (shuriken)](https://github.com/NixOS/nixpkgs/pull/216837).

This one works fine and connects to my Microbrute when run with the following:

```
cd pkgs/applications/audio/microdude/
nix-build -E 'let pkgs = import <nixpkgs> { }; in pkgs.python3Packages.callPackage ./default.nix {}'
result/bin/microdude
```

But fails when run from the root of nixpkgs with the following:

```
$ nix-build -A microdude
# lots of happy-looking build output
$ result/bin/microdude 
Traceback (most recent call last):
  File "/nix/store/w03lfbrl2jasp75x16cqbbs1iz7j5nvy-microdude-2.3/bin/.microdude-wrapped", line 18, in <module>
    editor.main()
  File "/nix/store/w03lfbrl2jasp75x16cqbbs1iz7j5nvy-microdude-2.3/lib/python3.10/site-packages/microdude/editor.py", line 423, in main
    self.init_ui()
  File "/nix/store/w03lfbrl2jasp75x16cqbbs1iz7j5nvy-microdude-2.3/lib/python3.10/site-packages/microdude/editor.py", line 121, in init_ui
    self.main_window.connect(
TypeError: <Gtk.Window object at 0x7f7b882aef00 (GtkWindow at 0x1f66530)>: unknown signal name: delete-event
```

Have I done something weird with the GTK dependencies?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
