### PR TITLE
elm-format: 0.8.5 -> 0.8.6

### DIFF
--- a/pkgs/development/compilers/elm/packages/avh4-lib.nix
+++ b/pkgs/development/compilers/elm/packages/avh4-lib.nix
@@ -1,26 +1,26 @@
 { mkDerivation, ansi-terminal, ansi-wl-pprint, array, base, bimap
 , binary, bytestring, containers, directory, fetchgit, filepath
-, lib, mtl, process, relude, tasty, tasty-discover, tasty-hspec
-, tasty-hunit, text
+, lib, mtl, pooled-io, process, relude, tasty, tasty-discover
+, tasty-hspec, tasty-hunit, text
 }:
 mkDerivation {
   pname = "avh4-lib";
   version = "0.0.0.1";
   src = fetchgit {
     url = "https://github.com/avh4/elm-format";
-    sha256 = "0bcjkcs1dy1csz0mpk7d4b5wf93fsj9p86x8fp42mb0pipdd0bh6";
-    rev = "80f15d85ee71e1663c9b53903f2b5b2aa444a3be";
+    sha256 = "1aiq3mv2ycv6bal5hnz6k33bzmnnidzxxs5b6z9y6lvmr0lbf3j4";
+    rev = "7e80dd48dd9b30994e43f4804b2ea7118664e8e0";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/avh4-lib; echo source root reset to $sourceRoot";
   libraryHaskellDepends = [
     ansi-terminal ansi-wl-pprint array base bimap binary bytestring
-    containers directory filepath mtl process relude text
+    containers directory filepath mtl pooled-io process relude text
   ];
   testHaskellDepends = [
     ansi-terminal ansi-wl-pprint array base bimap binary bytestring
-    containers directory filepath mtl process relude tasty tasty-hspec
-    tasty-hunit text
+    containers directory filepath mtl pooled-io process relude tasty
+    tasty-hspec tasty-hunit text
   ];
   testToolDepends = [ tasty-discover ];
   doHaddock = false;

--- a/pkgs/development/compilers/elm/packages/elm-format-lib.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format-lib.nix
@@ -1,30 +1,30 @@
-{ mkDerivation, ansi-terminal, ansi-wl-pprint, array, avh4-lib
-, base, bimap, binary, bytestring, containers, directory
+{ mkDerivation, aeson, ansi-terminal, ansi-wl-pprint, array
+, avh4-lib, base, bimap, binary, bytestring, containers, directory
 , elm-format-markdown, elm-format-test-lib, fetchgit, filepath
-, indents, json, lib, mtl, optparse-applicative, parsec, process
-, relude, split, tasty, tasty-discover, tasty-hspec, tasty-hunit
-, text
+, ghc-prim, hspec, lib, mtl, optparse-applicative, process, relude
+, split, tasty, tasty-discover, tasty-hspec, tasty-hunit, text
 }:
 mkDerivation {
   pname = "elm-format-lib";
   version = "0.0.0.1";
   src = fetchgit {
     url = "https://github.com/avh4/elm-format";
-    sha256 = "0bcjkcs1dy1csz0mpk7d4b5wf93fsj9p86x8fp42mb0pipdd0bh6";
-    rev = "80f15d85ee71e1663c9b53903f2b5b2aa444a3be";
+    sha256 = "1aiq3mv2ycv6bal5hnz6k33bzmnnidzxxs5b6z9y6lvmr0lbf3j4";
+    rev = "7e80dd48dd9b30994e43f4804b2ea7118664e8e0";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/elm-format-lib; echo source root reset to $sourceRoot";
   libraryHaskellDepends = [
-    ansi-terminal ansi-wl-pprint array avh4-lib base bimap binary
+    aeson ansi-terminal ansi-wl-pprint array avh4-lib base bimap binary
     bytestring containers directory elm-format-markdown filepath
-    indents json mtl optparse-applicative parsec process relude text
+    ghc-prim mtl optparse-applicative process relude text
   ];
   testHaskellDepends = [
-    ansi-terminal ansi-wl-pprint array avh4-lib base bimap binary
+    aeson ansi-terminal ansi-wl-pprint array avh4-lib base bimap binary
     bytestring containers directory elm-format-markdown
-    elm-format-test-lib filepath indents json mtl optparse-applicative
-    parsec process relude split tasty tasty-hspec tasty-hunit text
+    elm-format-test-lib filepath ghc-prim hspec mtl
+    optparse-applicative process relude split tasty tasty-hspec
+    tasty-hunit text
   ];
   testToolDepends = [ tasty-discover ];
   doHaddock = false;

--- a/pkgs/development/compilers/elm/packages/elm-format-markdown.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format-markdown.nix
@@ -4,8 +4,8 @@ mkDerivation {
   version = "0.0.0.1";
   src = fetchgit {
     url = "https://github.com/avh4/elm-format";
-    sha256 = "0bcjkcs1dy1csz0mpk7d4b5wf93fsj9p86x8fp42mb0pipdd0bh6";
-    rev = "80f15d85ee71e1663c9b53903f2b5b2aa444a3be";
+    sha256 = "1aiq3mv2ycv6bal5hnz6k33bzmnnidzxxs5b6z9y6lvmr0lbf3j4";
+    rev = "7e80dd48dd9b30994e43f4804b2ea7118664e8e0";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/elm-format-markdown; echo source root reset to $sourceRoot";

--- a/pkgs/development/compilers/elm/packages/elm-format-test-lib.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format-test-lib.nix
@@ -1,24 +1,24 @@
 { mkDerivation, avh4-lib, base, containers, fetchgit, filepath
-, hspec-core, hspec-golden, lib, mtl, split, tasty, tasty-discover
-, tasty-hspec, tasty-hunit, text
+, hspec, hspec-core, hspec-golden, lib, mtl, split, tasty
+, tasty-discover, tasty-hspec, tasty-hunit, text
 }:
 mkDerivation {
   pname = "elm-format-test-lib";
   version = "0.0.0.1";
   src = fetchgit {
     url = "https://github.com/avh4/elm-format";
-    sha256 = "0bcjkcs1dy1csz0mpk7d4b5wf93fsj9p86x8fp42mb0pipdd0bh6";
-    rev = "80f15d85ee71e1663c9b53903f2b5b2aa444a3be";
+    sha256 = "1aiq3mv2ycv6bal5hnz6k33bzmnnidzxxs5b6z9y6lvmr0lbf3j4";
+    rev = "7e80dd48dd9b30994e43f4804b2ea7118664e8e0";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/elm-format-test-lib; echo source root reset to $sourceRoot";
   libraryHaskellDepends = [
-    avh4-lib base containers filepath hspec-core hspec-golden mtl split
-    tasty tasty-hspec tasty-hunit text
+    avh4-lib base containers filepath hspec hspec-core hspec-golden mtl
+    split tasty tasty-hspec tasty-hunit text
   ];
   testHaskellDepends = [
-    avh4-lib base containers filepath hspec-core hspec-golden mtl split
-    tasty tasty-hspec tasty-hunit text
+    avh4-lib base containers filepath hspec hspec-core hspec-golden mtl
+    split tasty tasty-hspec tasty-hunit text
   ];
   testToolDepends = [ tasty-discover ];
   doHaddock = false;

--- a/pkgs/development/compilers/elm/packages/elm-format.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format.nix
@@ -1,33 +1,35 @@
-{ mkDerivation, ansi-wl-pprint, avh4-lib, base, bimap, cmark
-, containers, elm-format-lib, elm-format-test-lib, fetchgit, json
-, lib, mtl, optparse-applicative, parsec, QuickCheck, quickcheck-io
-, relude, tasty, tasty-hspec, tasty-hunit, tasty-quickcheck, text
+{ mkDerivation, aeson, ansi-wl-pprint, avh4-lib, base, bimap
+, bytestring, containers, elm-format-lib, elm-format-test-lib
+, fetchgit, hspec, lib, mtl, optparse-applicative, QuickCheck
+, quickcheck-io, relude, tasty, tasty-hspec, tasty-hunit
+, tasty-quickcheck, text
 }:
 mkDerivation rec {
   pname = "elm-format";
-  version = "0.8.5";
+  version = "0.8.6";
   src = fetchgit {
     url = "https://github.com/avh4/elm-format";
-    sha256 = "0bcjkcs1dy1csz0mpk7d4b5wf93fsj9p86x8fp42mb0pipdd0bh6";
-    rev = "80f15d85ee71e1663c9b53903f2b5b2aa444a3be";
+    sha256 = "1aiq3mv2ycv6bal5hnz6k33bzmnnidzxxs5b6z9y6lvmr0lbf3j4";
+    rev = "7e80dd48dd9b30994e43f4804b2ea7118664e8e0";
     fetchSubmodules = true;
   };
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [
-    ansi-wl-pprint avh4-lib base containers elm-format-lib json
-    optparse-applicative relude text
+    aeson ansi-wl-pprint avh4-lib base bytestring containers
+    elm-format-lib optparse-applicative relude text
   ];
   testHaskellDepends = [
-    ansi-wl-pprint avh4-lib base bimap cmark containers elm-format-lib
-    elm-format-test-lib json mtl optparse-applicative parsec QuickCheck
-    quickcheck-io relude tasty tasty-hspec tasty-hunit tasty-quickcheck
-    text
+    aeson ansi-wl-pprint avh4-lib base bimap bytestring containers
+    elm-format-lib elm-format-test-lib hspec mtl optparse-applicative
+    QuickCheck quickcheck-io relude tasty tasty-hspec tasty-hunit
+    tasty-quickcheck text
   ];
   doHaddock = false;
   homepage = "https://elm-lang.org";
   description = "A source code formatter for Elm";
   license = lib.licenses.bsd3;
+  mainProgram = "elm-format";
   postPatch = ''
     mkdir -p ./generated
     cat <<EOHS > ./generated/Build_elm_format.hs


### PR DESCRIPTION
###### Description of changes

Changelog: https://github.com/avh4/elm-format/releases/tag/0.8.6

###### Notes

@turboMaCk FYI, elm-format now depends on ghc 9.2, so I had to rework the top-level elmPackages nix file a little bit to make this work.  Lmk if you think we should handle this differently than what I did here.

Also tested:
- [x] `nix-build --option sandbox true -A elmPackages.elm-format`
- [x] `nix-build --option sandbox true -A elmPackages.elm`
- [x] `nix-build --option sandbox true -A elmPackages.elmi-to-json`
- [x] `nix-build --option sandbox true -A elmPackages.elm-instrument`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
