### PR TITLE
buildFHSUserEnv: add version arg

### DIFF
--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -2,6 +2,7 @@
 
 args @ {
   name
+, version ? null
 , runScript ? "bash"
 , extraInstallCommands ? ""
 , meta ? {}
@@ -24,6 +25,7 @@ let
   env = buildFHSEnv (removeAttrs args [
     "runScript" "extraInstallCommands" "meta" "passthru" "extraBwrapArgs" "dieWithParent"
     "unshareUser" "unshareCgroup" "unshareUts" "unshareNet" "unsharePid" "unshareIpc"
+    "version"
   ]);
 
   etcBindFlags = let
@@ -192,7 +194,11 @@ let
 
   bin = writeShellScriptBin name (bwrapCmd { initArgs = ''"$@"''; });
 
-in runCommandLocal name {
+  versionStr = lib.optionalString (! isNull version) ("-" + version);
+
+  nameAndVersion = name + versionStr;
+
+in runCommandLocal nameAndVersion {
   inherit meta;
 
   passthru = passthru // {

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -194,7 +194,7 @@ let
 
   bin = writeShellScriptBin name (bwrapCmd { initArgs = ''"$@"''; });
 
-  versionStr = lib.optionalString (! isNull version) ("-" + version);
+  versionStr = lib.optionalString (version != null) ("-" + version);
 
   nameAndVersion = name + versionStr;
 

--- a/pkgs/build-support/build-fhs-userenv/default.nix
+++ b/pkgs/build-support/build-fhs-userenv/default.nix
@@ -1,11 +1,11 @@
-{ callPackage, runCommandLocal, writeScript, stdenv, coreutils }:
+{ lib, callPackage, runCommandLocal, writeScript, stdenv, coreutils }:
 
 let buildFHSEnv = callPackage ./env.nix { }; in
 
-args@{ name, runScript ? "bash", extraInstallCommands ? "", meta ? {}, passthru ? {}, ... }:
+args@{ name, version ? null, runScript ? "bash", extraInstallCommands ? "", meta ? {}, passthru ? {}, ... }:
 
 let
-  env = buildFHSEnv (removeAttrs args [ "runScript" "extraInstallCommands" "meta" "passthru" ]);
+  env = buildFHSEnv (removeAttrs args [ "version" "runScript" "extraInstallCommands" "meta" "passthru" ]);
 
   chrootenv = callPackage ./chrootenv {};
 
@@ -23,7 +23,11 @@ let
     exec ${run} "$@"
   '';
 
-in runCommandLocal name {
+  versionStr = lib.optionalString (! isNull version) ("-" + version);
+
+  nameAndVersion = name + versionStr;
+
+in runCommandLocal nameAndVersion {
   inherit meta;
 
   passthru = passthru // {

--- a/pkgs/build-support/build-fhs-userenv/default.nix
+++ b/pkgs/build-support/build-fhs-userenv/default.nix
@@ -23,7 +23,7 @@ let
     exec ${run} "$@"
   '';
 
-  versionStr = lib.optionalString (! isNull version) ("-" + version);
+  versionStr = lib.optionalString (version != null) ("-" + version);
 
   nameAndVersion = name + versionStr;
 


### PR DESCRIPTION
###### Description of changes

This PR adds an optional `version` argument to `buildFHSUserEnvChroot` and `buildFHSUserEnvBubblewrap`.  This makes it so that derivations produced by these functions can have their versions set.  This can help end-users more clearly see the version of the packages they are using.

For instance, on current `master`:

```console
$ nix-build -E 'with import ./. {}; buildFHSUserEnvChroot { name = "hello"; }'
/nix/store/1wxqalaknmjsdhd576377wxjl7rn9zkh-hello
$ nix-build -E 'with import ./. {}; buildFHSUserEnvBubblewrap { name = "hello"; }'
/nix/store/nn6gvq4gvz64nhcrs8si08cbqny1n2pq-hello
```

With this PR, using the new `version` argument:

```console
$ nix-build -E 'with import ./. {}; buildFHSUserEnvChroot { name = "hello"; version = "1.2.3"; }'
/nix/store/vzg1rdkqdxk00dx3li03f3h3l04qwaab-hello-1.2.3
$ nix-build -E 'with import ./. {}; buildFHSUserEnvBubblewrap { name = "hello"; version = "1.2.3"; }'
/nix/store/vs0z3cbwbmw11wqz6ykrah1sc2vna68g-hello-1.2.3
```

This was suggested in https://github.com/NixOS/nixpkgs/pull/218162#issuecomment-1445037235.

Derivations created from `buildFHSUserEnv` not having versions by default has confused at least two end users (myself included):

https://discourse.nixos.org/t/how-to-run-latest-anki-download/25406/5?u=cdepillabout

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
