### PR TITLE
libsForQt5.mauiPackages: 2.2.1 -> 2.2.2

### DIFF
--- a/pkgs/applications/maui/mauikit-imagetools.nix
+++ b/pkgs/applications/maui/mauikit-imagetools.nix
@@ -4,10 +4,13 @@
 , extra-cmake-modules
 , kconfig
 , kio
+, leptonica
 , mauikit
+, opencv
 , qtlocation
 , exiv2
 , kquickimageedit
+, tesseract
 }:
 
 mkDerivation {
@@ -21,10 +24,13 @@ mkDerivation {
   buildInputs = [
     kconfig
     kio
+    leptonica
     mauikit
+    opencv
     qtlocation
     exiv2
     kquickimageedit
+    tesseract
   ];
 
   meta = with lib; {

--- a/pkgs/applications/maui/mauiman.nix
+++ b/pkgs/applications/maui/mauiman.nix
@@ -2,13 +2,7 @@
 , mkDerivation
 , cmake
 , extra-cmake-modules
-, kconfig
-, kcoreaddons
-, ki18n
-, knotifications
-, qtbase
-, qtquickcontrols2
-, qtx11extras
+, qtsystems
 }:
 
 mkDerivation {
@@ -17,6 +11,10 @@ mkDerivation {
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
+  ];
+
+  buildInputs = [
+    qtsystems
   ];
 
   meta = with lib; {

--- a/pkgs/applications/maui/srcs.nix
+++ b/pkgs/applications/maui/srcs.nix
@@ -3,6 +3,22 @@
 { fetchurl, mirror }:
 
 {
+  agenda = {
+    version = "0.1.1";
+    src = fetchurl {
+      url = "${mirror}/stable/maui/agenda/0.1.1/agenda-0.1.1.tar.xz";
+      sha256 = "0czpsybvvvnfg0n1ri94a2agwhdnmy124ggxqb5kjnsw35ivz35a";
+      name = "agenda-0.1.1.tar.xz";
+    };
+  };
+  arca = {
+    version = "0.1.1";
+    src = fetchurl {
+      url = "${mirror}/stable/maui/arca/0.1.1/arca-0.1.1.tar.xz";
+      sha256 = "0d4mdv1israljn9mhpb3nx8442g7kiqg87gmsb74z08v02yywmc0";
+      name = "arca-0.1.1.tar.xz";
+    };
+  };
   bonsai = {
     version = "2.2.0";
     src = fetchurl {
@@ -12,43 +28,59 @@
     };
   };
   booth = {
-    version = "1.0.1";
+    version = "1.0.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/booth/1.0.1/booth-1.0.1.tar.xz";
-      sha256 = "02p3xxfk1fsqd8z55gmkhj68j8sjbgjyrj2anpq8qsmblznsvmdn";
-      name = "booth-1.0.1.tar.xz";
+      url = "${mirror}/stable/maui/booth/1.0.2/booth-1.0.2.tar.xz";
+      sha256 = "1b9akwwi1cmvk87zna0yrw1a6mwjd8qg0k3lnivwqfm5zi1xlpb6";
+      name = "booth-1.0.2.tar.xz";
     };
   };
   buho = {
-    version = "2.2.1";
+    version = "2.2.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/buho/2.2.1/buho-2.2.1.tar.xz";
-      sha256 = "1iv30avnfdh78zq7kxigxlkzdp2jfzx0sl88vssjcisniabyd1ri";
-      name = "buho-2.2.1.tar.xz";
+      url = "${mirror}/stable/maui/buho/2.2.2/buho-2.2.2.tar.xz";
+      sha256 = "0kvg34dmk46aawa8vnl70m8gi6qjr709czgmzb8a7pa77clyyyg8";
+      name = "buho-2.2.2.tar.xz";
     };
   };
   clip = {
-    version = "2.2.1";
+    version = "2.2.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/clip/2.2.1/clip-2.2.1.tar.xz";
-      sha256 = "00w9kgqw4dxb9b9rq11jzdb9pj48qdkdj23wdjwdk52nyfkw7sbh";
-      name = "clip-2.2.1.tar.xz";
+      url = "${mirror}/stable/maui/clip/2.2.2/clip-2.2.2.tar.xz";
+      sha256 = "1dk9x5lrp197g2qgi10p536dshaaxacgrkwr3pqywqcqqyrvjiyf";
+      name = "clip-2.2.2.tar.xz";
     };
   };
   communicator = {
-    version = "2.2.1";
+    version = "2.2.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/communicator/2.2.1/communicator-2.2.1.tar.xz";
-      sha256 = "1h689dr9iy07r7ypyfgrb3n0ljigz847m6vq1jaia6phgix07hn6";
-      name = "communicator-2.2.1.tar.xz";
+      url = "${mirror}/stable/maui/communicator/2.2.2/communicator-2.2.2.tar.xz";
+      sha256 = "02c7w6km6a5plf56g4wwdw8k8kif3pmwd1agvhvfpq84yq73naz4";
+      name = "communicator-2.2.2.tar.xz";
+    };
+  };
+  era = {
+    version = "0.1.0";
+    src = fetchurl {
+      url = "${mirror}/stable/maui/era/0.1.0/era-0.1.0.tar.xz";
+      sha256 = "0qllnpibkhrr52gsngrkzrxcaj68hngsaavdwkds3rbaq4a5by9g";
+      name = "era-0.1.0.tar.xz";
+    };
+  };
+  fiery = {
+    version = "1.0.2";
+    src = fetchurl {
+      url = "${mirror}/stable/maui/fiery/1.0.2/fiery-1.0.2.tar.xz";
+      sha256 = "0xw3p0dna3p05k8mv8sw8aw3clgb3kx72405826k0ldva8mh5q55";
+      name = "fiery-1.0.2.tar.xz";
     };
   };
   index-fm = {
-    version = "2.2.1";
+    version = "2.2.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/index/2.2.1/index-fm-2.2.1.tar.xz";
-      sha256 = "1gin3may65f8nafbgyv90k31z69xwx1awnnxmciqn5zz7cdh9slm";
-      name = "index-fm-2.2.1.tar.xz";
+      url = "${mirror}/stable/maui/index/2.2.2/index-fm-2.2.2.tar.xz";
+      sha256 = "156fb5kx9hkdg4q4c2r0822s49w86kixvn3m7m1gfxbc6hr5h291";
+      name = "index-fm-2.2.2.tar.xz";
     };
   };
   mauikit = {
@@ -60,91 +92,99 @@
     };
   };
   mauikit-accounts = {
-    version = "2.2.1";
+    version = "2.2.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-accounts/2.2.1/mauikit-accounts-2.2.1.tar.xz";
-      sha256 = "13k9y7z9mw17rdn1z9ixgi1bf6q2hf0afp53nb8d9gz5mqkaf6qh";
-      name = "mauikit-accounts-2.2.1.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-accounts/2.2.2/mauikit-accounts-2.2.2.tar.xz";
+      sha256 = "10rvzy5m5bmf98q5akvq87q00nz9mxmnp9ywnswl65gnmihiwis8";
+      name = "mauikit-accounts-2.2.2.tar.xz";
     };
   };
   mauikit-calendar = {
-    version = "1.0.0";
+    version = "1.0.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-calendar/1.0.0/mauikit-calendar-1.0.0.tar.xz";
-      sha256 = "1zqaf0nddb220w14ar9gg6p695p0my8whn8p8wgxm7mwjfb6hlil";
-      name = "mauikit-calendar-1.0.0.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-calendar/1.0.1/mauikit-calendar-1.0.1.tar.xz";
+      sha256 = "0l3195zy2qzcc1in9m0k8lpzbqbhdjvlr40n23plr6ldwc61q34b";
+      name = "mauikit-calendar-1.0.1.tar.xz";
     };
   };
   mauikit-documents = {
-    version = "1.0.0";
+    version = "1.0.1";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-documents/1.0.0/mauikit-documents-1.0.0.tar.xz";
-      sha256 = "1dniab7f113vbxng9b1nwmh6wviv1m1gb842k98vxgnhmsljq24a";
-      name = "mauikit-documents-1.0.0.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-documents/1.0.1/mauikit-documents-1.0.1.tar.xz";
+      sha256 = "0rfznsdlfhf0bjk4fkybbvv56c55w0krjaa8by26fzkqannd7smd";
+      name = "mauikit-documents-1.0.1.tar.xz";
     };
   };
   mauikit-filebrowsing = {
-    version = "2.2.1";
+    version = "2.2.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-filebrowsing/2.2.1/mauikit-filebrowsing-2.2.1.tar.xz";
-      sha256 = "1szghmp1p9pvsfqx8sk345j7riqxv2kib41l277rm14pwbs6zx1c";
-      name = "mauikit-filebrowsing-2.2.1.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-filebrowsing/2.2.2/mauikit-filebrowsing-2.2.2.tar.xz";
+      sha256 = "0dj06qak410gf4xykhigxrswbchfkicgihzksgv63z9ggfg64jbr";
+      name = "mauikit-filebrowsing-2.2.2.tar.xz";
     };
   };
   mauikit-imagetools = {
-    version = "2.2.1";
+    version = "2.2.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-imagetools/2.2.1/mauikit-imagetools-2.2.1.tar.xz";
-      sha256 = "1wfhzkw4bs3518gylfxyp1arg2w204f73wg1l2s4pygbdh5ylav2";
-      name = "mauikit-imagetools-2.2.1.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-imagetools/2.2.2/mauikit-imagetools-2.2.2.tar.xz";
+      sha256 = "1jf60725v887dfl3l9sbknkwns15bz7a7b9v0p6llhw00hiq83b4";
+      name = "mauikit-imagetools-2.2.2.tar.xz";
+    };
+  };
+  mauikit-terminal = {
+    version = "1.0.0";
+    src = fetchurl {
+      url = "${mirror}/stable/maui/mauikit-terminal/1.0.0/mauikit-terminal-1.0.0.tar.xz";
+      sha256 = "1r6dcna2fyglj4q33i5qnzv763y3y65fcqb4ralyydlb8x2nb248";
+      name = "mauikit-terminal-1.0.0.tar.xz";
     };
   };
   mauikit-texteditor = {
-    version = "2.2.1";
+    version = "2.2.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-texteditor/2.2.1/mauikit-texteditor-2.2.1.tar.xz";
-      sha256 = "0dzzlmdpl0y843lywfjc4za152r87kncafkmmbp8bdwc9j5fdzzv";
-      name = "mauikit-texteditor-2.2.1.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-texteditor/2.2.2/mauikit-texteditor-2.2.2.tar.xz";
+      sha256 = "0g8n0xzn9iiq122hb23rhn3c9vkq6hm7kgv5mv8dx2kv17gdyzcg";
+      name = "mauikit-texteditor-2.2.2.tar.xz";
     };
   };
   mauiman = {
-    version = "1.0.1";
+    version = "1.0.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauiman/1.0.1/mauiman-1.0.1.tar.xz";
-      sha256 = "0awqb8kygacirlhha58bzgrd47zsxmfm3h5k68g8liymqn00fh30";
-      name = "mauiman-1.0.1.tar.xz";
+      url = "${mirror}/stable/maui/mauiman/1.0.2/mauiman-1.0.2.tar.xz";
+      sha256 = "0v3jhy3j04aq5935pr6mzgdjwj6mgj1rwscmmg3b9vsi9f6s17n4";
+      name = "mauiman-1.0.2.tar.xz";
     };
   };
   nota = {
-    version = "2.2.1";
+    version = "2.2.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/nota/2.2.1/nota-2.2.1.tar.xz";
-      sha256 = "1fl4w0l3l6rdgxw5w479nzbcff7rmdcxil7y6jdr8z2q50lkazj8";
-      name = "nota-2.2.1.tar.xz";
+      url = "${mirror}/stable/maui/nota/2.2.2/nota-2.2.2.tar.xz";
+      sha256 = "1c72s4ra5gl9gpq8amwhaw9wkgrgd0fiaknxhn528gzpmq52i8rn";
+      name = "nota-2.2.2.tar.xz";
     };
   };
   pix = {
-    version = "2.2.1";
+    version = "2.2.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/pix/2.2.1/pix-2.2.1.tar.xz";
-      sha256 = "0j2kpcxgdz21phdl0mx84ynalzf6bf3qalq524j7p297pdkrq3d6";
-      name = "pix-2.2.1.tar.xz";
+      url = "${mirror}/stable/maui/pix/2.2.2/pix-2.2.2.tar.xz";
+      sha256 = "0j315n1aka0pikqyq2hy15k3indr7g8vkcyxsikdd3kj968386pv";
+      name = "pix-2.2.2.tar.xz";
     };
   };
   shelf = {
-    version = "2.2.1";
+    version = "2.2.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/shelf/2.2.1/shelf-2.2.1.tar.xz";
-      sha256 = "1h24mrzq5p63b11caml51az99gjipdlyrbx3na2jsxy4rvzryddm";
-      name = "shelf-2.2.1.tar.xz";
+      url = "${mirror}/stable/maui/shelf/2.2.2/shelf-2.2.2.tar.xz";
+      sha256 = "1aw6k7z7w0qslya20h0gv3k8h526jrz8a6vb10ack3i5gw6csp1k";
+      name = "shelf-2.2.2.tar.xz";
     };
   };
   station = {
-    version = "2.2.1";
+    version = "2.2.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/station/2.2.1/station-2.2.1.tar.xz";
-      sha256 = "1ch5c4728hahh90nlpqwnlaljpingvwrjwxajan1j2kgwb5lynwz";
-      name = "station-2.2.1.tar.xz";
+      url = "${mirror}/stable/maui/station/2.2.2/station-2.2.2.tar.xz";
+      sha256 = "1svs6kjbk09l3sprq64bdm01y73vcb10y4ifh5y2a1fwa99c59sb";
+      name = "station-2.2.2.tar.xz";
     };
   };
   strike = {
@@ -156,11 +196,11 @@
     };
   };
   vvave = {
-    version = "2.2.1";
+    version = "2.2.2";
     src = fetchurl {
-      url = "${mirror}/stable/maui/vvave/2.2.1/vvave-2.2.1.tar.xz";
-      sha256 = "0mg4p44da16xkcra1akvh6f2fixd682clmd6wqgc34j7n1a9y773";
-      name = "vvave-2.2.1.tar.xz";
+      url = "${mirror}/stable/maui/vvave/2.2.2/vvave-2.2.2.tar.xz";
+      sha256 = "0m8jg79gz3dljbkrgjqlfmbmpgwawzaz37avx5nj1rlpm36b195f";
+      name = "vvave-2.2.2.tar.xz";
     };
   };
 }

--- a/pkgs/applications/maui/station.nix
+++ b/pkgs/applications/maui/station.nix
@@ -2,6 +2,7 @@
 , mkDerivation
 , cmake
 , extra-cmake-modules
+, kconfig
 , kcoreaddons
 , ki18n
 , kirigami2
@@ -19,6 +20,7 @@ mkDerivation {
   ];
 
   buildInputs = [
+    kconfig
     kcoreaddons
     ki18n
     kirigami2


### PR DESCRIPTION
`libsForQt5.mauikit-imagetools` fails to build with
```
/build/mauikit-imagetools-2.2.2/src/code/modules/image2text/src/ocs.cpp: In function 'PIX* qImage2PIX(const QImage&)':
/build/mauikit-imagetools-2.2.2/src/code/modules/image2text/src/ocs.cpp:156:27: error: invalid use of incomplete type 'PIX' {aka 'struct Pix'}
  156 |     l_uint32 *datas = pixs->data;
      |                           ^~
In file included from /nix/store/92jahpf5bhniny3dbq9p0j4k95b70c1r-tesseract-3.05.02/include/tesseract/baseapi.h:34,
                 from /build/mauikit-imagetools-2.2.2/src/code/modules/image2text/src/ocs.cpp:5:
/nix/store/92jahpf5bhniny3dbq9p0j4k95b70c1r-tesseract-3.05.02/include/tesseract/thresholder.h:26:8: note: forward declaration of 'PIX' {aka 'struct Pix'}
   26 | struct Pix;
      |        ^~~
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @milahu 

closes https://github.com/NixOS/nixpkgs/pull/214179