### PR TITLE
pianotrans: Use torch-bin on darwin

### DIFF
--- a/pkgs/applications/audio/pianotrans/default.nix
+++ b/pkgs/applications/audio/pianotrans/default.nix
@@ -1,10 +1,17 @@
 { lib
+, stdenv
 , fetchFromGitHub
 , python3
 , ffmpeg
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
+  python = python3.override (lib.optionalAttrs stdenv.isDarwin {
+    packageOverrides = self: super: {
+      torch = super.torch-bin;
+    };
+  });
+in python.pkgs.buildPythonApplication rec {
   pname = "pianotrans";
   version = "1.0.1";
   format = "setuptools";
@@ -16,7 +23,7 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-gRbyUQmPtGvx5QKAyrmeJl0stp7hwLBWwjSbJajihdE=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python.pkgs; [
     piano-transcription-inference
     torch
     tkinter


### PR DESCRIPTION
###### Description of changes

torch on darwin is very slow, switch to torch-bin make it 10 times faster.

Before this commit:

```
$ ./result/bin/pianotrans ~/src/pianotrans/test/cut_liszt.opus
Queue: /Users/azuwis/src/pianotrans/test/cut_liszt.opus
--------------------------------------------------------------------------------
Checkpoint path: /nix/store/x5s23cxikav9j6b7qjc8h8dj3939awsr-python3.10-piano-transcription-inference-0.0.5/share/checkpoint.pth
Using cpu for inference.
Using CPU.
--------------------------------------------------------------------------------
Transcribe: /Users/azuwis/src/pianotrans/test/cut_liszt.opus
Segment 0 / 3
Segment 1 / 3
Segment 2 / 3
Segment 3 / 3
Write out to /Users/azuwis/src/pianotrans/test/cut_liszt.opus.mid
Transcribe time: 86.738 s
--------------------------------------------------------------------------------
Queue finished.
--------------------------------------------------------------------------------
```

After this commit:
```
$ ./result/bin/pianotrans ~/src/pianotrans/test/cut_liszt.opus
Queue: /Users/azuwis/src/pianotrans/test/cut_liszt.opus
--------------------------------------------------------------------------------
Checkpoint path: /nix/store/zcfbs3p3j27rg73rs1pfqn75n1icmiyd-python3.10-piano-transcription-inference-0.0.5/share/checkpoint.pth
Using cpu for inference.
Using CPU.
--------------------------------------------------------------------------------
Transcribe: /Users/azuwis/src/pianotrans/test/cut_liszt.opus
Segment 0 / 3
Segment 1 / 3
Segment 2 / 3
Segment 3 / 3
Write out to /Users/azuwis/src/pianotrans/test/cut_liszt.opus.mid
Transcribe time: 8.796 s
--------------------------------------------------------------------------------
Queue finished.
--------------------------------------------------------------------------------
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
