### PR TITLE
ocamlPackages.mirage-kv: 3.0.1 → 4.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-fs/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-fs/default.nix
@@ -1,19 +1,19 @@
 { lib, fetchurl, buildDunePackage
-, cstruct, fmt, lwt, mirage-device, mirage-kv
+, cstruct, fmt, lwt, mirage-kv
 }:
 
 buildDunePackage rec {
   pname = "mirage-fs";
   version = "4.0.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-fs/releases/download/v${version}/mirage-fs-v${version}.tbz";
-    sha256 = "sha256-PYZ2HCPuxOv4FU7EHymsa1oIZU7q8TSzzRvlngYdZ3s=";
+    hash = "sha256-PYZ2HCPuxOv4FU7EHymsa1oIZU7q8TSzzRvlngYdZ3s=";
   };
 
-  propagatedBuildInputs = [ cstruct fmt lwt mirage-device mirage-kv ];
+  propagatedBuildInputs = [ cstruct fmt lwt mirage-kv ];
 
   meta = {
     description = "MirageOS signatures for filesystem devices";

--- a/pkgs/development/ocaml-modules/mirage-kv/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-kv/default.nix
@@ -1,20 +1,22 @@
 { lib, fetchurl, buildDunePackage
-, fmt, mirage-device
+, fmt
+, lwt
 , alcotest
 }:
 
 buildDunePackage rec {
   pname = "mirage-kv";
-  version = "3.0.1";
+  version = "4.0.1";
 
-  useDune2 = true;
+  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
-    url = "https://github.com/mirage/mirage-kv/releases/download/v${version}/mirage-kv-v${version}.tbz";
-    sha256 = "1n736sjvdd8rkbc2b5jm9sn0w6hvhjycma5328r0l03v24vk5cki";
+    url = "https://github.com/mirage/mirage-kv/releases/download/v${version}/mirage-kv-${version}.tbz";
+    hash = "sha256-p6i4zUVgxtTnUiBIjb8W6u9xRTczVl4WwfFcl5tVqnE=";
   };
 
-  propagatedBuildInputs = [ fmt mirage-device ];
+  propagatedBuildInputs = [ fmt lwt ];
 
   doCheck = true;
   checkInputs = [ alcotest ];


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/mirage-kv/blob/v4.0.1/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
