### PR TITLE
monkeysAudio: 3.99 -> 9.20

### DIFF
--- a/pkgs/applications/audio/monkeys-audio/default.nix
+++ b/pkgs/applications/audio/monkeys-audio/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     # it's not standard, see a quote of it:
     # https://github.com/NixOS/nixpkgs/pull/171682#issuecomment-1120260551
     license = licenses.free;
-    maintainers = [ ];
+    maintainers = with maintainers; [ doronbehar ];
   };
 }

--- a/pkgs/applications/audio/monkeys-audio/default.nix
+++ b/pkgs/applications/audio/monkeys-audio/default.nix
@@ -1,28 +1,25 @@
-{lib, gcc10Stdenv, fetchurl}:
+{ lib
+, stdenv
+, fetchzip
+, cmake
+}:
 
-gcc10Stdenv.mkDerivation rec {
-  version = "3.99-u4-b5";
-  pname = "monkeys-audio-old";
+stdenv.mkDerivation rec {
+  version = "9.20";
+  pname = "monkeys-audio";
 
-  patches = [ ./buildfix.diff ];
-
-  src = fetchurl {
-    /*
-    The real homepage is <https://monkeysaudio.com/>, but in fact we are
-    getting an old, ported to Linux version of the sources, made by (quoting
-    from the AUTHORS file found in the source):
-
-    Frank Klemm : First port to linux (with makefile)
-
-    SuperMMX <SuperMMX AT GMail DOT com> : Package the source, include the frontend and shared lib,
-         porting to Big Endian platform and adding other non-win32 enhancement.
-    */
-    url = "https://deb-multimedia.org/pool/main/m/${pname}/${pname}_${version}.orig.tar.gz";
-    sha256 = "0kjfwzfxfx7f958b2b1kf8yj655lp0ppmn0sh57gbkjvj8lml7nz";
+  src = fetchzip {
+    url = "https://monkeysaudio.com/files/MAC_${
+      builtins.concatStringsSep "" (lib.strings.splitString "." version)}_SDK.zip";
+    sha256 = "sha256-8cJ88plR9jrrLdzRHzRotGBrn6qIqOWvl+oOTXxY/TE=";
+    stripRoot = false;
   };
+  nativeBuildInputs = [
+    cmake
+  ];
 
   meta = with lib; {
-    description = "Lossless audio codec";
+    description = "APE codec and decompressor";
     platforms = platforms.linux;
     # This is not considered a GPL license, but it seems rather free although
     # it's not standard, see a quote of it:


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
