### PR TITLE
dockfmt: 0.3.3 -> unstable-2020-09-18

### DIFF
--- a/pkgs/development/tools/dockfmt/default.nix
+++ b/pkgs/development/tools/dockfmt/default.nix
@@ -5,13 +5,14 @@
 
 buildGoModule rec {
   pname = "dockfmt";
-  version = "0.3.3";
+  version = "unstable-2020-09-18";
 
+  # The latest released version doesn't support reading from stdin.
   src = fetchFromGitHub {
     owner = "jessfraz";
     repo = "dockfmt";
-    rev = "v${version}";
-    sha256 = "0m56ydmf7zbcsa5yym7j5fgr75v677h9s40zyzwrqccyq01myp06";
+    rev = "1455059b8bb53ab4723ef41946c43160583a8333";
+    hash = "sha256-wEC9kENcE3u+Mb7uLbx/VBUup6PBnCY5cxTYvkJcavg=";
   };
 
   vendorSha256 = null;
@@ -25,7 +26,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "Dockerfile format";
     homepage = "https://github.com/jessfraz/dockfmt";
-    license = [ licenses.mit ];
-    maintainers = [ maintainers.cpcloud ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ cpcloud ];
   };
 }


### PR DESCRIPTION
###### Description of changes

0.3.3 doesn't support reading from stdin, which makes it unusable from emacs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
