### PR TITLE
various: (re-)disable introspection if no emulator

### DIFF
--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -5,6 +5,8 @@
 , ninja
 , pkg-config
 , gobject-introspection
+, buildPackages
+, withIntrospection ? stdenv.hostPlatform.emulatorAvailable buildPackages
 , gsettings-desktop-schemas
 , makeWrapper
 , dbus
@@ -30,11 +32,13 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    glib
     meson
     ninja
     pkg-config
-    gobject-introspection
     makeWrapper
+  ] ++ lib.optionals withIntrospection [
+    gobject-introspection
   ];
 
   buildInputs = [
@@ -58,7 +62,6 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   mesonFlags = [
-    "-Dintrospection=yes"
     # Provide dbus-daemon fallback when it is not already running when
     # at-spi2-bus-launcher is executed. This allows us to avoid
     # including the entire dbus closure in libraries linked with

--- a/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
+++ b/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
@@ -3,6 +3,8 @@
 , pkg-config
 , glib
 , gobject-introspection
+, buildPackages
+, withIntrospection ? stdenv.hostPlatform.emulatorAvailable buildPackages
 , meson
 , ninja
 , python3
@@ -27,7 +29,12 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
+  ] ++ lib.optionals withIntrospection [
     gobject-introspection
+  ];
+
+  mesonFlags = [
+    (lib.mesonBool "introspection" withIntrospection)
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -8,6 +8,7 @@
 , docbook_xml_dtd_43
 , gtk-doc
 , meson
+, mesonEmulatorHook
 , ninja
 , python3
 , makeWrapper
@@ -21,6 +22,8 @@
 , atk
 , at-spi2-atk
 , gobject-introspection
+, buildPackages
+, withIntrospection ? stdenv.hostPlatform.emulatorAvailable buildPackages
 , fribidi
 , xorg
 , libepoxy
@@ -39,7 +42,6 @@
 , wayland-protocols
 , xineramaSupport ? stdenv.isLinux
 , cupsSupport ? stdenv.isLinux
-, withGtkDoc ? stdenv.isLinux && (stdenv.buildPlatform == stdenv.hostPlatform)
 , cups
 , AppKit
 , Cocoa
@@ -63,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "gtk+3";
   version = "3.24.36";
 
-  outputs = [ "out" "dev" ] ++ lib.optional withGtkDoc "devdoc";
+  outputs = [ "out" "dev" ] ++ lib.optional withIntrospection "devdoc";
   outputBin = "dev";
 
   setupHooks = [
@@ -94,7 +96,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   nativeBuildInputs = [
     gettext
-    gobject-introspection
     makeWrapper
     meson
     ninja
@@ -102,12 +103,15 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     sassc
     gdk-pixbuf
-  ] ++ finalAttrs.setupHooks ++ lib.optionals withGtkDoc [
+  ] ++ finalAttrs.setupHooks ++ lib.optionals withIntrospection [
+    gobject-introspection
     docbook_xml_dtd_43
     docbook-xsl-nons
     gtk-doc
     # For xmllint
     libxml2
+  ] ++ lib.optionals (withIntrospection && !stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    mesonEmulatorHook
   ] ++ lib.optionals waylandSupport [
     wayland-scanner
   ];
@@ -157,12 +161,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    "-Dgtk_doc=${lib.boolToString withGtkDoc}"
+    "-Dgtk_doc=${lib.boolToString withIntrospection}"
     "-Dtests=false"
     "-Dtracker3=${lib.boolToString trackerSupport}"
     "-Dbroadway_backend=${lib.boolToString broadwaySupport}"
     "-Dx11_backend=${lib.boolToString x11Support}"
     "-Dquartz_backend=${lib.boolToString (stdenv.isDarwin && !x11Support)}"
+    "-Dintrospection=${lib.boolToString withIntrospection}"
   ];
 
   doCheck = false; # needs X11

--- a/pkgs/development/libraries/json-glib/default.nix
+++ b/pkgs/development/libraries/json-glib/default.nix
@@ -7,6 +7,8 @@
 , nixosTests
 , pkg-config
 , gettext
+, withIntrospection ? stdenv.hostPlatform.emulatorAvailable buildPackages
+, buildPackages
 , gobject-introspection
 , gi-docgen
 , libxslt
@@ -18,7 +20,8 @@ stdenv.mkDerivation rec {
   pname = "json-glib";
   version = "1.6.6";
 
-  outputs = [ "out" "dev" "devdoc" "installedTests" ];
+  outputs = [ "out" "dev" "installedTests" ]
+    ++ lib.optional withIntrospection "devdoc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -43,10 +46,11 @@ stdenv.mkDerivation rec {
     gettext
     glib
     libxslt
-    gobject-introspection
-    gi-docgen
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     fixDarwinDylibNames
+  ] ++ lib.optionals withIntrospection [
+    gobject-introspection
+    gi-docgen
   ];
 
   propagatedBuildInputs = [
@@ -55,6 +59,8 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dinstalled_test_prefix=${placeholder "installedTests"}"
+    (lib.mesonEnable "introspection" withIntrospection)
+    (lib.mesonEnable "gtk_doc" withIntrospection)
   ];
 
   # Run-time dependency gi-docgen found: NO (tried pkgconfig and cmake)

--- a/pkgs/development/libraries/libmanette/default.nix
+++ b/pkgs/development/libraries/libmanette/default.nix
@@ -6,6 +6,8 @@
 , pkg-config
 , vala
 , gobject-introspection
+, buildPackages
+, withIntrospection ? stdenv.hostPlatform.emulatorAvailable buildPackages
 , gtk-doc
 , docbook-xsl-nons
 , docbook_xml_dtd_43
@@ -19,7 +21,7 @@ stdenv.mkDerivation rec {
   pname = "libmanette";
   version = "0.2.6";
 
-  outputs = [ "out" "dev" "devdoc" ];
+  outputs = [ "out" "dev" ] ++ lib.optional withIntrospection "devdoc";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -30,23 +32,29 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
+    glib
+  ] ++ lib.optionals withIntrospection [
     vala
     gobject-introspection
     gtk-doc
     docbook-xsl-nons
     docbook_xml_dtd_43
-  ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+  ] ++ lib.optionals (withIntrospection && !stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     mesonEmulatorHook
   ];
 
   buildInputs = [
     glib
-    libgudev
     libevdev
+  ] ++ lib.optionals withIntrospection [
+    libgudev
   ];
 
   mesonFlags = [
-    "-Ddoc=true"
+    (lib.mesonBool "doc" withIntrospection)
+    (lib.mesonEnable "gudev" withIntrospection)
+    (lib.mesonBool "introspection" withIntrospection)
+    (lib.mesonBool "vapi" withIntrospection)
   ];
 
   doCheck = true;

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -15,6 +15,8 @@
 , gnomeSupport ? true
 , sqlite
 , glib-networking
+, buildPackages
+, withIntrospection ? stdenv.hostPlatform.emulatorAvailable buildPackages
 }:
 
 stdenv.mkDerivation rec {
@@ -37,6 +39,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     glib
+  ] ++ lib.optionals withIntrospection [
     gobject-introspection
     vala
   ];
@@ -58,6 +61,8 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dtls_check=false" # glib-networking is a runtime dependency, not a compile-time dependency
     "-Dgssapi=disabled"
+    "-Dvapi=${if withIntrospection then "enabled" else "disabled"}"
+    "-Dintrospection=${if withIntrospection then "enabled" else "disabled"}"
     "-Dgnome=${lib.boolToString gnomeSupport}"
     "-Dntlm=disabled"
   ] ++ lib.optionals (!stdenv.isLinux) [

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -24,6 +24,8 @@
 , useSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal
 , systemdMinimal
 , elogind
+, buildPackages
+, withIntrospection ? stdenv.hostPlatform.emulatorAvailable buildPackages
 # A few tests currently fail on musl (polkitunixusertest, polkitunixgrouptest, polkitidentitytest segfault).
 # Not yet investigated; it may be due to the "Make netgroup support optional"
 # patch not updating the tests correctly yet, or doing something wrong,
@@ -65,14 +67,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     glib
-    gtk-doc
     pkg-config
     gettext
     meson
     ninja
     perl
     rsync
-    gobject-introspection
     (python3.pythonForBuild.withPackages (pp: with pp; [
       dbus-python
       (python-dbusmock.overridePythonAttrs (attrs: {
@@ -85,7 +85,10 @@ stdenv.mkDerivation rec {
     libxslt
     docbook-xsl-nons
     docbook_xml_dtd_412
-  ] ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+  ] ++ lib.optionals withIntrospection [
+    gobject-introspection
+    gtk-doc
+  ] ++ lib.optionals (withIntrospection && !stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     mesonEmulatorHook
   ];
 
@@ -113,7 +116,9 @@ stdenv.mkDerivation rec {
     "-Dsystemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
     "-Dpolkitd_user=polkituser" #TODO? <nixos> config.ids.uids.polkituser
     "-Dos_type=redhat" # only affects PAM includes
+    "-Dintrospection=${lib.boolToString withIntrospection}"
     "-Dtests=${lib.boolToString doCheck}"
+    "-Dgtk_doc=${lib.boolToString withIntrospection}"
     "-Dman=true"
   ] ++ lib.optionals stdenv.isLinux [
     "-Dsession_tracking=${if useSystemd then "libsystemd-login" else "libelogind"}"

--- a/pkgs/development/libraries/tracker/default.nix
+++ b/pkgs/development/libraries/tracker/default.nix
@@ -7,6 +7,8 @@
 , pkg-config
 , asciidoc
 , gobject-introspection
+, buildPackages
+, withIntrospection ? stdenv.hostPlatform.emulatorAvailable buildPackages
 , python3
 , docbook-xsl-nons
 , docbook_xml_dtd_45
@@ -52,12 +54,14 @@ stdenv.mkDerivation rec {
     pkg-config
     asciidoc
     gettext
+    glib
     libxslt
     wrapGAppsNoGuiHook
-    gobject-introspection
     docbook-xsl-nons
     docbook_xml_dtd_45
     (python3.pythonForBuild.withPackages (p: [ p.pygobject3 ]))
+  ] ++ lib.optionals withIntrospection [
+    gobject-introspection
   ];
 
   buildInputs = [
@@ -77,6 +81,8 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Ddocs=true"
+    (lib.mesonEnable "introspection" withIntrospection)
+    (lib.mesonBool "test_utils" withIntrospection)
   ] ++ (
     let
       # https://gitlab.gnome.org/GNOME/tracker/-/blob/master/meson.build#L159


### PR DESCRIPTION
###### Description of changes

We can cross-compile with gobject-introspection in some cases, but not all, because it requires us to have an emulator for the host platform (which we don't for e.g. Linux → BSD).  Recent changes have changed gobject-introspection support in various packages from being native-only to unconditional, which was good for cross setups where we have the emulator as they got g-i support in the cross-compiled packages, but broke cross entirely for setups with no emulator.  So we need to partially go back on that, by restricting gobject-introspection to only be enabled for setups where we can actually support it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
