### PR TITLE
pcsx2: 1.7.3331 -> 1.7.4554

### DIFF
--- a/pkgs/applications/emulators/pcsx2/default.nix
+++ b/pkgs/applications/emulators/pcsx2/default.nix
@@ -1,89 +1,109 @@
-{ alsa-lib
-, cmake
+{ cmake
 , fetchFromGitHub
+, lib
+, stdenv
+, curl
+, ffmpeg
 , fmt
 , gettext
-, glib
-, gtk3
 , harfbuzz
-, lib
 , libaio
+, libbacktrace
 , libpcap
-, libpng
 , libpulseaudio
 , libsamplerate
-, libXdmcp
-, openssl
-, pcre
-, perl
+, libXrandr
+, libzip
 , pkg-config
-, portaudio
+, qtbase
+, qtsvg
+, qttools
+, qttranslations
+, qtwayland
+, rapidyaml
 , SDL2
 , soundtouch
-, stdenv
-, udev
 , vulkan-headers
 , vulkan-loader
-, wrapGAppsHook
-, wxGTK
-, zlib
 , wayland
+, wrapQtAppsHook
+, xz
+, zip
 }:
 
+let
+  # The pre-zipped files in releases don't have a versioned link, we need to zip them ourselves
+  pcsx2_patches = fetchFromGitHub {
+    owner = "PCSX2";
+    repo = "pcsx2_patches";
+    rev = "8db5ae467a35cc00dc50a65061aa78dc5115e6d1";
+    sha256 = "sha256-68kD7IAhBMASFmkGwvyQ7ppO/3B1csAKik+rU792JI4=";
+  };
+in
 stdenv.mkDerivation rec {
   pname = "pcsx2";
-  version = "1.7.3331";
-  # nixpkgs-update: no auto update
+  version = "1.7.4554";
 
   src = fetchFromGitHub {
     owner = "PCSX2";
     repo = "pcsx2";
     fetchSubmodules = true;
     rev = "v${version}";
-    hash = "sha256-0RcmBMxKj/gnkNEjn2AUSSO1DzyNSf1lOZWPSUq6764=";
+    sha256 = "sha256-9MRbpm7JdVmZwv8zD4lErzVTm7A4tYM0FgXE9KpX+/8=";
   };
 
   cmakeFlags = [
     "-DDISABLE_ADVANCE_SIMD=TRUE"
-    "-DDISABLE_PCSX2_WRAPPER=TRUE"
-    "-DPACKAGE_MODE=TRUE"
-    "-DWAYLAND_API=TRUE"
-    "-DXDG_STD=TRUE"
-    "-DUSE_VULKAN=TRUE"
+    "-DUSE_SYSTEM_LIBS=ON"
+    "-DDISABLE_BUILD_DATE=TRUE"
   ];
 
-  nativeBuildInputs = [ cmake perl pkg-config vulkan-headers wrapGAppsHook ];
+  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook zip ];
 
   buildInputs = [
-    alsa-lib
+    curl
+    ffmpeg
     fmt
     gettext
-    glib
-    gtk3
     harfbuzz
     libaio
+    libbacktrace
     libpcap
-    libpng
     libpulseaudio
     libsamplerate
-    libXdmcp
-    openssl
-    pcre
-    portaudio
+    libXrandr
+    libzip
+    qtbase
+    qtsvg
+    qttools
+    qttranslations
+    qtwayland
+    rapidyaml
     SDL2
     soundtouch
-    udev
+    vulkan-headers
     vulkan-loader
     wayland
-    wxGTK
-    zlib
+    xz
   ];
 
-  preFixup = ''
-    gappsWrapperArgs+=(
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
-    )
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a bin/pcsx2-qt bin/resources $out/bin/
+
+    install -Dm644 $src/pcsx2/Resources/AppIcon64.png $out/share/pixmaps/PCSX2.png
+    install -Dm644 $src/.github/workflows/scripts/linux/pcsx2-qt.desktop $out/share/applications/PCSX2.desktop
+
+    zip -jq $out/bin/resources/patches.zip ${pcsx2_patches}/patches/*
   '';
+
+  qtWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
+      ffmpeg # It's loaded with dlopen. They plan to change it https://github.com/PCSX2/pcsx2/issues/8624
+      libpulseaudio
+      vulkan-loader
+    ]}"
+  ];
 
   meta = with lib; {
     description = "Playstation 2 emulator";
@@ -95,13 +115,9 @@ stdenv.mkDerivation rec {
       PC, with many additional features and benefits.
     '';
     homepage = "https://pcsx2.net";
+    license = with licenses; [ gpl3 lgpl3 ];
     maintainers = with maintainers; [ hrdinka govanify ];
-
-    # PCSX2's source code is released under LGPLv3+. It However ships
-    # additional data files and code that are licensed differently.
-    # This might be solved in future, for now we should stick with
-    # license.free
-    license = licenses.free;
+    mainProgram = "pcsx2-qt";
     platforms = platforms.x86_64;
   };
 }

--- a/pkgs/development/libraries/rapidyaml/default.nix
+++ b/pkgs/development/libraries/rapidyaml/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, stdenv
+, cmake
+, fetchFromGitHub
+, git
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rapidyaml";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "biojppm";
+    repo = pname;
+    fetchSubmodules = true;
+    rev = "v${version}";
+    sha256 = "sha256-1/P6Szgng94UU8cPFAtOKMS+EmiwfW/IJl2UTolDU5s=";
+  };
+
+  nativeBuildInputs = [ cmake git ];
+
+  meta = with lib; {
+    description = "A library to parse and emit YAML, and do it fast.";
+    homepage = "https://github.com/biojppm/rapidyaml";
+    license = licenses.mit;
+    maintainers = with maintainers; [ martfont ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23811,6 +23811,8 @@ with pkgs;
 
   rapidxml = callPackage ../development/libraries/rapidxml { };
 
+  rapidyaml = callPackage ../development/libraries/rapidyaml {};
+
   raul = callPackage ../development/libraries/audio/raul { };
 
   raylib = callPackage ../development/libraries/raylib { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2399,9 +2399,7 @@ with pkgs;
 
   pcem = callPackage ../applications/emulators/pcem { };
 
-  pcsx2 = callPackage ../applications/emulators/pcsx2 {
-    wxGTK = wxGTK32;
-  };
+  pcsx2 = qt6Packages.callPackage ../applications/emulators/pcsx2 { };
 
   pcsxr = callPackage ../applications/emulators/pcsxr { };
 


### PR DESCRIPTION
###### Description of changes

Brings PCSX2 to the latest version, which moves to Qt among many other things.

~This is a draft because there is an issue not present in the AppImage: if you press the "Shut Down Virtual Machine" hotkey while the game is fullscreen, the window asking you to confirm shutting down the game doesn't appear, and you are forced to force-close PCSX2.~ EDIT: The issue has been solved upstream.

Also, I guess closes #104850.
Closes #233498.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
