### PR TITLE
castget: 2.0.0 -> 2.0.1

### DIFF
--- a/pkgs/applications/networking/feedreaders/castget/default.nix
+++ b/pkgs/applications/networking/feedreaders/castget/default.nix
@@ -1,5 +1,6 @@
-{ lib, stdenv, fetchFromGitHub
-, autoreconfHook
+{ lib
+, stdenv
+, fetchurl
 , pkg-config
 , glib
 , ronn
@@ -11,14 +12,11 @@
 
 stdenv.mkDerivation rec {
   pname = "castget";
-  version = "2.0.0";
+  version = "2.0.1";
 
-  src = fetchFromGitHub {
-    owner = "mlj";
-    repo = pname;
-    # Upstream uses `_` instead of `.` for the version
-    rev = "rel_${lib.replaceStrings ["."] ["_"] version}";
-    sha256 = "1129x64rw587q3sdpa3lrgs0gni5f0siwbvmfz8ya4zkbhgi2ik7";
+  src = fetchurl {
+    url = "http://savannah.nongnu.org/download/castget/castget-${version}.tar.bz2";
+    hash = "sha256-Q4tffsfjGkXtN1ZjD+RH9CAVrNpT7AkgL0hihya16HU=";
   };
 
   # without this, the build fails because of an encoding issue with the manual page.
@@ -34,7 +32,6 @@ stdenv.mkDerivation rec {
     ronn
     # See comment on locale above
     glibcLocales
-    autoreconfHook
     pkg-config
   ];
 

--- a/pkgs/applications/networking/feedreaders/castget/default.nix
+++ b/pkgs/applications/networking/feedreaders/castget/default.nix
@@ -27,7 +27,12 @@ stdenv.mkDerivation rec {
     export LC_ALL="en_US.UTF-8";
   '';
 
-  buildInputs = [ glib curl id3lib libxml2 ];
+  buildInputs = [
+    glib
+    curl
+    id3lib
+    libxml2
+  ];
   nativeBuildInputs = [
     ronn
     # See comment on locale above


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
