### PR TITLE
qrupdate: 1.1.2 -> 1.1.5

### DIFF
--- a/pkgs/development/libraries/qrupdate/default.nix
+++ b/pkgs/development/libraries/qrupdate/default.nix
@@ -1,54 +1,50 @@
 { stdenv
 , lib
-, fetchurl
+, fetchFromGitHub
 , gfortran
 , blas
+, cmake
 , lapack
 , which
 }:
 
 stdenv.mkDerivation rec {
   pname = "qrupdate";
-  version = "1.1.2";
-  src = fetchurl {
-    url = "mirror://sourceforge/qrupdate/${pname}-${version}.tar.gz";
-    sha256 = "024f601685phcm1pg8lhif3lpy5j9j0k6n0r46743g4fvh8wg8g2";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = "mpimd-csc";
+    repo = "qrupdate-ng";
+    rev = "v${version}";
+    hash = "sha256-dHxLPrN00wwozagY2JyfZkD3sKUD2+BcnbjNgZepzFg=";
   };
 
-  preBuild =
-    # Check that blas and lapack are compatible
-    assert (blas.isILP64 == lapack.isILP64);
-  # We don't have structuredAttrs yet implemented, and we need to use space
-  # seprated values in makeFlags, so only this works.
-  ''
-    makeFlagsArray+=(
-      "LAPACK=-L${lapack}/lib -llapack"
-      "BLAS=-L${blas}/lib -lblas"
-      "PREFIX=${placeholder "out"}"
-      "FFLAGS=${toString ([
-        "-std=legacy"
-      ] ++ lib.optionals blas.isILP64 [
-        # If another application intends to use qrupdate compiled with blas with
-        # 64 bit support, it should add this to it's FFLAGS as well. See (e.g):
-        # https://savannah.gnu.org/bugs/?50339
-        "-fdefault-integer-8"
-      ])}"
-    )
-  '';
+  cmakeFlags = assert (blas.isILP64 == lapack.isILP64); [
+    "-DCMAKE_Fortran_FLAGS=${toString ([
+      "-std=legacy"
+    ] ++ lib.optionals blas.isILP64 [
+      # If another application intends to use qrupdate compiled with blas with
+      # 64 bit support, it should add this to it's FFLAGS as well. See (e.g):
+      # https://savannah.gnu.org/bugs/?50339
+      "-fdefault-integer-8"
+    ])}"
+  ];
 
   doCheck = true;
 
-  checkTarget = "test";
-
-  buildFlags = [ "lib" "solib" ];
-
-  installTargets = lib.optionals stdenv.isDarwin [ "install-staticlib" "install-shlib" ];
-
-  nativeBuildInputs = [ which gfortran ];
+  nativeBuildInputs = [
+    cmake
+    which
+    gfortran
+  ];
+  buildInputs = [
+    blas
+    lapack
+  ];
 
   meta = with lib; {
     description = "Library for fast updating of qr and cholesky decompositions";
-    homepage = "https://sourceforge.net/projects/qrupdate/";
+    homepage = "https://github.com/mpimd-csc/qrupdate-ng";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ doronbehar ];
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
