### PR TITLE
python3.pkgs.pint-pandas: 0.2 -> unstable-2022-11-24

### DIFF
--- a/pkgs/development/python-modules/pint-pandas/default.nix
+++ b/pkgs/development/python-modules/pint-pandas/default.nix
@@ -1,34 +1,29 @@
 { stdenv
 , lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , fetchpatch
-, setuptools-scm
+, setuptools
 , pint
 , pandas
 , pytestCheckHook
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pint-pandas";
-  version = "0.2";
+  # Latest release contains bugs and failing tests.
+  version = "unstable-2022-11-24";
+  format = "pyproject";
 
-  src = fetchPypi {
-    pname = "Pint-Pandas";
-    inherit version;
-    sha256 = "sha256-b2DS6ArBAuD5St25IG4PbMpe5C8Lf4kw2MeYAC5B+oc=";
+  src = fetchFromGitHub {
+    owner = "hgrecco";
+    repo = "pint-pandas";
+    rev = "c58a7fcf9123eb65f5e78845077b205e20279b9d";
+    hash = "sha256-gMZNJSJxtSZvgU4o71ws5ZA6tgD2M5c5oOrn62DRyMI=";
   };
 
-  patches = [
-    # Fixes a failing test, see: https://github.com/hgrecco/pint-pandas/issues/107
-    (fetchpatch{
-      url = "https://github.com/hgrecco/pint-pandas/commit/4c31e25609af968665ee60d019b9b5366f328680.patch";
-      sha256 = "vIT0LI4S73D4MBfGI8vtCZAM+Zb4PZ4E3xfpGKNyA4I=";
-    })
-  ];
-
   nativeBuildInputs = [
-    setuptools-scm
+    setuptools
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
