### PR TITLE
ocamlPackages.mirage-crypto: 0.10.7 -> 0.11.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jackline/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jackline/default.nix
@@ -4,7 +4,7 @@ with ocamlPackages;
 
 buildDunePackage rec {
   pname = "jackline";
-  version = "unstable-2022-05-27";
+  version = "unstable-2023-02-24";
 
   minimalOCamlVersion = "4.08";
 
@@ -13,8 +13,8 @@ buildDunePackage rec {
   src = fetchFromGitHub {
     owner  = "hannesm";
     repo   = "jackline";
-    rev    = "d8f7c504027a0dd51966b2b7304d6daad155a05b";
-    hash = "sha256-6SWYl2mB0g8JNVHBeTnZEbzOaTmVbsRMMEs+3j/ewwk=";
+    rev    = "846be4e7fcddf45e66e0ff5b29fb5a212d6ee8c3";
+    hash = "sha256-/j3VJRx/w9HQUnfoq/4gMWV5oVdRiPGddrgbCDk5y8c=";
   };
 
   nativeBuildInpts = [

--- a/pkgs/development/ocaml-modules/awa/default.nix
+++ b/pkgs/development/ocaml-modules/awa/default.nix
@@ -8,14 +8,14 @@
 
 buildDunePackage rec {
   pname = "awa";
-  version = "0.1.1";
+  version = "0.1.2";
 
   minimalOCamlVersion = "4.08";
   duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/awa-ssh/releases/download/v${version}/awa-${version}.tbz";
-    hash = "sha256-ae1gTx3Emmkof/2Gnhq0d5RyfkFx21hHkVEVgyPdXuo=";
+    hash = "sha256-HfIqvmvmdizPSfSHthj2syszVZXVhju7tI8yNEetc38=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -5,14 +5,14 @@
 
 buildDunePackage rec {
   pname = "conduit";
-  version = "6.1.0";
+  version = "6.2.0";
 
   minimalOCamlVersion = "4.08";
   duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-conduit/releases/download/v${version}/conduit-${version}.tbz";
-    sha256 = "sha256-ouKQiGMLvvksGpAhkqCVSKtKaz91p+7mciQm7KHvwF8=";
+    sha256 = "sha256-PtRAsO3aGyEt12K9skgx85TcoFmF3RtKxPlFgdFFI5Q=";
   };
 
   propagatedBuildInputs = [ astring ipaddr ipaddr-sexp sexplib uri ppx_sexp_conv ];

--- a/pkgs/development/ocaml-modules/conduit/mirage.nix
+++ b/pkgs/development/ocaml-modules/conduit/mirage.nix
@@ -1,7 +1,7 @@
 { buildDunePackage, conduit-lwt
 , ppx_sexp_conv, sexplib, uri, cstruct, mirage-flow
 , mirage-flow-combinators, mirage-random, mirage-time, mirage-clock
-, dns-client, vchan, xenstore, tls, tls-mirage, ipaddr, ipaddr-sexp
+, dns-client-mirage, vchan, xenstore, tls, tls-mirage, ipaddr, ipaddr-sexp
 , tcpip, ca-certs-nss
 }:
 
@@ -16,7 +16,7 @@ buildDunePackage {
   propagatedBuildInputs = [
     sexplib uri cstruct mirage-clock mirage-flow
     mirage-flow-combinators mirage-random mirage-time
-    dns-client conduit-lwt vchan xenstore tls tls-mirage
+    dns-client-mirage conduit-lwt vchan xenstore tls tls-mirage
     ipaddr ipaddr-sexp tcpip ca-certs-nss
   ];
 

--- a/pkgs/development/ocaml-modules/dns/cli.nix
+++ b/pkgs/development/ocaml-modules/dns/cli.nix
@@ -1,4 +1,4 @@
-{ buildDunePackage, dns, dns-tsig, dns-client, dns-server, dns-certify, dnssec
+{ buildDunePackage, dns, dns-tsig, dns-client-lwt, dns-server, dns-certify, dnssec
 , bos, cmdliner, fpath, x509, mirage-crypto, mirage-crypto-pk
 , mirage-crypto-rng, hex, ptime, mtime, logs, fmt, ipaddr, lwt
 , randomconv, alcotest
@@ -17,7 +17,7 @@ buildDunePackage {
   buildInputs = [
     dns
     dns-tsig
-    dns-client
+    dns-client-lwt
     dns-server
     dns-certify
     dnssec

--- a/pkgs/development/ocaml-modules/dns/client-lwt.nix
+++ b/pkgs/development/ocaml-modules/dns/client-lwt.nix
@@ -1,29 +1,30 @@
-{ lib, buildDunePackage, dns, lwt, mirage-clock, mirage-time
+{ lib, buildDunePackage, dns, dns-client, lwt, mirage-clock, mirage-time
 , mirage-random, mirage-crypto-rng, mtime, randomconv
 , cstruct, fmt, logs, rresult, domain-name, ipaddr, alcotest
 , ca-certs, ca-certs-nss
 , happy-eyeballs
 , tcpip
-, tls, tls-mirage
+, tls-lwt
 }:
 
 buildDunePackage {
-  pname = "dns-client";
+  pname = "dns-client-lwt";
   inherit (dns) src version;
   duneVersion = "3";
 
   propagatedBuildInputs = [
     dns
-    randomconv
-    domain-name
+    dns-client
+    ipaddr
+    lwt
+    ca-certs
+    happy-eyeballs
+    tls-lwt
     mtime
     mirage-crypto-rng
   ];
   checkInputs = [ alcotest ];
   doCheck = true;
 
-  meta = dns.meta // {
-    description = "Pure DNS resolver API";
-    mainProgram = "dns-client.unix";
-  };
+  meta = dns-client.meta;
 }

--- a/pkgs/development/ocaml-modules/dns/client-mirage.nix
+++ b/pkgs/development/ocaml-modules/dns/client-mirage.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, dns, lwt, mirage-clock, mirage-time
+{ lib, buildDunePackage, dns, dns-client, lwt, mirage-clock, mirage-time
 , mirage-random, mirage-crypto-rng, mtime, randomconv
 , cstruct, fmt, logs, rresult, domain-name, ipaddr, alcotest
 , ca-certs, ca-certs-nss
@@ -8,22 +8,25 @@
 }:
 
 buildDunePackage {
-  pname = "dns-client";
+  pname = "dns-client-mirage";
   inherit (dns) src version;
   duneVersion = "3";
 
   propagatedBuildInputs = [
-    dns
-    randomconv
+    dns-client
     domain-name
-    mtime
-    mirage-crypto-rng
+    ipaddr
+    lwt
+    mirage-random
+    mirage-time
+    mirage-clock
+    ca-certs-nss
+    happy-eyeballs
+    tcpip
+    tls
+    tls-mirage
   ];
-  checkInputs = [ alcotest ];
   doCheck = true;
 
-  meta = dns.meta // {
-    description = "Pure DNS resolver API";
-    mainProgram = "dns-client.unix";
-  };
+  meta = dns-client.meta;
 }

--- a/pkgs/development/ocaml-modules/dns/default.nix
+++ b/pkgs/development/ocaml-modules/dns/default.nix
@@ -17,14 +17,14 @@
 
 buildDunePackage rec {
   pname = "dns";
-  version = "6.4.1";
+  version = "7.0.1";
 
   minimalOCamlVersion = "4.08";
   duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-dns/releases/download/v${version}/dns-${version}.tbz";
-    hash = "sha256-omG0fKZAHGc+4ERC8cyK47jeEkiBZkB+1fz46j6SDno=";
+    hash = "sha256-vDe1U1NbbIPcD1AmMG265ke7651C64mds7KcFHUN4fU=";
   };
 
   propagatedBuildInputs = [ fmt logs ptime domain-name gmap cstruct ipaddr lru duration metrics base64 ];

--- a/pkgs/development/ocaml-modules/dns/stub.nix
+++ b/pkgs/development/ocaml-modules/dns/stub.nix
@@ -1,4 +1,4 @@
-{ buildDunePackage, dns, dns-client, dns-mirage, dns-resolver, dns-tsig
+{ buildDunePackage, dns, dns-client-mirage, dns-mirage, dns-resolver, dns-tsig
 , dns-server, duration, randomconv, lwt, mirage-time, mirage-clock
 , mirage-random, tcpip, metrics
 }:
@@ -11,7 +11,7 @@ buildDunePackage {
 
   propagatedBuildInputs = [
     dns
-    dns-client
+    dns-client-mirage
     dns-mirage
     dns-resolver
     dns-tsig

--- a/pkgs/development/ocaml-modules/git/unix.nix
+++ b/pkgs/development/ocaml-modules/git/unix.nix
@@ -1,4 +1,4 @@
-{ buildDunePackage, git
+{ buildDunePackage, fetchpatch, git
 , rresult, result, bigstringaf
 , fmt, bos, fpath, uri, digestif, logs, lwt
 , mirage-clock, mirage-clock-unix, astring, awa, cmdliner
@@ -13,6 +13,13 @@
 buildDunePackage {
   pname = "git-unix";
   inherit (git) version src;
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/mirage/ocaml-git/commit/b708db8319cc456a5640618210d740a1e00468e9.patch";
+      hash = "sha256-Fe+eDhU/beZT/8br8XmOhHYJowaVEha16eGqyuu2Zr4=";
+    })
+  ];
 
   minimalOCamlVersion = "4.08";
   duneVersion = "3";

--- a/pkgs/development/ocaml-modules/happy-eyeballs/default.nix
+++ b/pkgs/development/ocaml-modules/happy-eyeballs/default.nix
@@ -4,13 +4,13 @@
 
 buildDunePackage rec {
   pname = "happy-eyeballs";
-  version = "0.4.0";
+  version = "0.5.0";
 
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/roburio/happy-eyeballs/releases/download/v${version}/happy-eyeballs-${version}.tbz";
-    hash = "sha256-gR9q4J/DnYJz8oYmk/wy17h4F6wxbllba/gkor5i1nQ=";
+    hash = "sha256-T4BOFlSj3xfUFhP9v8UaCHgmhvGrMyeqNUQf79bdBh4=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/happy-eyeballs/lwt.nix
+++ b/pkgs/development/ocaml-modules/happy-eyeballs/lwt.nix
@@ -1,7 +1,7 @@
 { buildDunePackage
 , happy-eyeballs
 , cmdliner
-, dns-client
+, dns-client-lwt
 , duration
 , domain-name
 , ipaddr
@@ -29,7 +29,7 @@ buildDunePackage {
   ];
 
   propagatedBuildInputs = [
-    dns-client
+    dns-client-lwt
     happy-eyeballs
     logs
     lwt

--- a/pkgs/development/ocaml-modules/happy-eyeballs/mirage.nix
+++ b/pkgs/development/ocaml-modules/happy-eyeballs/mirage.nix
@@ -1,7 +1,7 @@
 { buildDunePackage
 , happy-eyeballs
 , duration
-, dns-client
+, dns-client-mirage
 , domain-name
 , ipaddr
 , fmt
@@ -32,7 +32,7 @@ buildDunePackage {
   ];
 
   propagatedBuildInputs = [
-    dns-client
+    dns-client-mirage
     happy-eyeballs
     logs
     lwt

--- a/pkgs/development/ocaml-modules/letsencrypt/default.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/default.nix
@@ -21,11 +21,11 @@
 
 buildDunePackage rec {
   pname = "letsencrypt";
-  version = "0.4.1";
+  version = "0.5.0";
 
   src = fetchurl {
-    url = "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v${version}/letsencrypt-v${version}.tbz";
-    hash = "sha256-+Qh19cm9yrTIvl7H6+nqdjAw+nCOAoVzAJlrsW58IHA=";
+    url = "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v${version}/letsencrypt-${version}.tbz";
+    hash = "sha256-XGroZiNyP0ItOMrXK07nrVqT4Yz9RKXYvZuRkDp089M=";
   };
 
   minimalOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -7,11 +7,11 @@ buildDunePackage rec {
   minimalOCamlVersion = "4.08";
 
   pname = "mirage-crypto";
-  version = "0.10.7";
+  version = "0.11.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-crypto/releases/download/v${version}/mirage-crypto-${version}.tbz";
-    sha256 = "sha256-PoGKdgwjXFtoTHtrQ7HN0qfdBOAQW2gNUk+DbrmIppw=";
+    sha256 = "sha256-A5SCuVmcIJo3dL0Tu//fQqEV0v3FuCxuANWnBo7hUeQ=";
   };
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-lwt.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-lwt.nix
@@ -1,0 +1,15 @@
+{ buildDunePackage, mirage-crypto, mirage-crypto-rng, dune-configurator
+, duration, logs, mtime, ocaml_lwt }:
+
+buildDunePackage rec {
+  pname = "mirage-crypto-rng-lwt";
+
+  inherit (mirage-crypto) version src;
+
+  doCheck = true;
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ mirage-crypto mirage-crypto-rng duration logs mtime ocaml_lwt ];
+
+  meta = mirage-crypto-rng.meta;
+}

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
@@ -10,7 +10,7 @@ buildDunePackage rec {
   checkInputs = [ ounit2 randomconv ];
 
   buildInputs = [ dune-configurator ];
-  propagatedBuildInputs = [ cstruct mirage-crypto duration logs mtime ocaml_lwt ];
+  propagatedBuildInputs = [ cstruct mirage-crypto duration logs mtime ];
 
   strictDeps = true;
 

--- a/pkgs/development/ocaml-modules/paf/cohttp.nix
+++ b/pkgs/development/ocaml-modules/paf/cohttp.nix
@@ -22,6 +22,7 @@ buildDunePackage {
   inherit (paf)
     version
     src
+    patches
     ;
 
   duneVersion = "3";

--- a/pkgs/development/ocaml-modules/paf/default.nix
+++ b/pkgs/development/ocaml-modules/paf/default.nix
@@ -32,6 +32,14 @@ buildDunePackage rec {
     hash = "sha256-ux8fk4XDdih4Ua9NGOJVSuPseJBPv6+6ND/esHrluQE=";
   };
 
+  patches = [
+    # Compatibility with mirage-crypto 0.11.0
+    (fetchpatch {
+      url = "https://github.com/dinosaure/paf-le-chien/commit/2f308c1c4d3ff49d42136f8ff86a4385661e4d1b.patch";
+      hash = "sha256-jmSeUpoRoUMPUNEH3Av2LxgRZs+eAectK+CpoH+SdpY=";
+    })
+  ];
+
   minimalOCamlVersion = "4.08";
   duneVersion = "3";
 

--- a/pkgs/development/ocaml-modules/paf/le.nix
+++ b/pkgs/development/ocaml-modules/paf/le.nix
@@ -1,7 +1,7 @@
 { lib
 , buildDunePackage
 , paf
-, dns-client
+, dns-client-mirage
 , duration
 , emile
 , httpaf
@@ -18,13 +18,14 @@ buildDunePackage {
   inherit (paf)
     version
     src
+    patches
   ;
 
   duneVersion = "3";
 
   propagatedBuildInputs = [
     paf
-    dns-client
+    dns-client-mirage
     duration
     emile
     httpaf

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -6,11 +6,11 @@
 
 buildDunePackage rec {
   pname = "tls";
-  version = "0.15.4";
+  version = "0.16.0";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-tls/releases/download/v${version}/tls-${version}.tbz";
-    sha256 = "sha256-X40dVrBvYGnv0dCj3gxFy0iNPRPrfxMshOx7o/DRw4I=";
+    sha256 = "sha256-uvIDZLNy6E/ce7YmzUUVaOeGRaHqPSUzuEPQDMu09tM=";
   };
 
   minimalOCamlVersion = "4.08";

--- a/pkgs/development/ocaml-modules/tls/lwt.nix
+++ b/pkgs/development/ocaml-modules/tls/lwt.nix
@@ -1,0 +1,19 @@
+{ lib, buildDunePackage, tls, lwt, mirage-crypto-rng-lwt, cmdliner, x509 }:
+
+buildDunePackage rec {
+  pname = "tls-lwt";
+
+  inherit (tls) src meta version;
+
+  minimalOCamlVersion = "4.11";
+  duneVersion = "3";
+
+  doCheck = true;
+
+  propagatedBuildInputs = [
+    lwt
+    mirage-crypto-rng-lwt
+    tls
+    x509
+  ];
+}

--- a/pkgs/development/ocaml-modules/x509/default.nix
+++ b/pkgs/development/ocaml-modules/x509/default.nix
@@ -8,13 +8,13 @@ buildDunePackage rec {
   minimalOCamlVersion = "4.08";
 
   pname = "x509";
-  version = "0.16.2";
+  version = "0.16.4";
 
   duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirleft/ocaml-x509/releases/download/v${version}/x509-${version}.tbz";
-    hash = "sha256-Zf/ZZjUAkeWe04XLmqMKgbxN/qe/Z1mpKM82veXVf2I=";
+    hash = "sha256-XegxhdASQK/I7Xd0gJSLumTGbCYFpWsjR7PlZSWqaVo=";
   };
 
   checkInputs = [ alcotest cstruct-unix ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -314,6 +314,10 @@ let
 
     dns-client =  callPackage ../development/ocaml-modules/dns/client.nix { };
 
+    dns-client-lwt = callPackage ../development/ocaml-modules/dns/client-lwt.nix { };
+
+    dns-client-mirage = callPackage ../development/ocaml-modules/dns/client-mirage.nix { };
+
     dns-mirage = callPackage ../development/ocaml-modules/dns/mirage.nix { };
 
     dns-resolver = callPackage ../development/ocaml-modules/dns/resolver.nix { };
@@ -908,6 +912,8 @@ let
 
     mirage-crypto-rng-async = callPackage ../development/ocaml-modules/mirage-crypto/rng-async.nix { };
 
+    mirage-crypto-rng-lwt = callPackage ../development/ocaml-modules/mirage-crypto/rng-lwt.nix { };
+
     mirage-crypto-rng-mirage = callPackage ../development/ocaml-modules/mirage-crypto/rng-mirage.nix { };
 
     mirage-device = callPackage ../development/ocaml-modules/mirage-device { };
@@ -1295,6 +1301,8 @@ let
     tls = callPackage ../development/ocaml-modules/tls { };
 
     tls-async = callPackage ../development/ocaml-modules/tls/async.nix { };
+
+    tls-lwt = callPackage ../development/ocaml-modules/tls/lwt.nix { };
 
     tls-mirage = callPackage ../development/ocaml-modules/tls/mirage.nix { };
 


### PR DESCRIPTION
###### Description of changes

Initially, the aim was just to update mirage-crypto to the latest version (which included a breakdown into a new package), but it turned out necessary to update many reverse dependencies and to package several new packages that were introduced during their last update. One package needed a patch that is not yet present in a release. One package (ocaml-git) is still not patched, so was marked as broken. I don't know what the process is in this case. It should not be too complicated to prepare a patch inspired by how the other packages were fixed (I have seen the same error in several other packages before updating them), but I have not investigated this, as I've already spent way longer than initially planned on this update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

```
4 packages added:
ocamlPackages.dns-client-lwt (init at 7.0.1) ocamlPackages.dns-client-mirage (init at 7.0.1) ocamlPackages.mirage-crypto-rng-lwt (init at 0.11.0) ocamlPackages.tls-lwt (init at 0.16.0)

81 packages updated:
eliom liquidsoap ocaml4.14.1-async_rpc_websocket ocamlPackages.awa (0.1.1 → 0.1.2) ocamlPackages.awa-lwt (0.1.1 → 0.1.2) ocamlPackages.awa-mirage (0.1.1 → 0.1.2) ocaml4.14.1-bonsai ocaml4.14.1-ca-certs ocaml4.14.1-ca-certs-nss ocaml4.14.1-chacha ocaml4.14.1-cohttp-async ocaml4.14.1-cohttp-lwt-unix ocaml4.14.1-cohttp-mirage ocaml4.14.1-cohttp_async_websocket ocaml4.14.1-comby ocamlPackages.conduit (6.1.0 → 6.2.0) ocamlPackages.conduit-async (6.1.0 → 6.2.0) ocamlPackages.conduit-lwt (6.1.0 → 6.2.0) ocamlPackages.conduit-lwt-unix (6.1.0 → 6.2.0) ocamlPackages.conduit-mirage (6.1.0 → 6.2.0) ocaml4.14.1-curly ocamlPackages.dns (6.4.1 → 7.0.1) ocamlPackages.dns-certify (6.4.1 → 7.0.1) ocamlPackages.dns-cli (6.4.1 → 7.0.1) ocamlPackages.dns-client (6.4.1 → 7.0.1) ocamlPackages.dns-mirage (6.4.1 → 7.0.1) ocamlPackages.dns-resolver (6.4.1 → 7.0.1) ocamlPackages.dns-server (6.4.1 → 7.0.1) ocamlPackages.dns-stub (6.4.1 → 7.0.1) ocamlPackages.dns-tsig (6.4.1 → 7.0.1) ocamlPackages.dnssec (6.4.1 → 7.0.1) ocaml4.14.1-dune-release ocaml4.14.1-erm_xmpp ocaml4.14.1-git ocaml4.14.1-git-mirage ocaml4.14.1-git-paf ocaml4.14.1-git-unix ocaml4.14.1-graphql-cohttp ocamlPackages.happy-eyeballs (0.4.0 → 0.5.0) ocamlPackages.happy-eyeballs-lwt (0.4.0 → 0.5.0) ocamlPackages.happy-eyeballs-mirage (0.4.0 → 0.5.0) ocaml4.14.1-hkdf ocaml4.14.1-irmin-git ocaml4.14.1-irmin-graphql ocaml4.14.1-irmin-http ocaml4.14.1-irmin-mirage-git ocaml4.14.1-irmin-mirage-graphql jackline (2022-05-27 → 2023-02-24) ocamlPackages.letsencrypt (0.4.1 → 0.5.0) ocamlPackages.letsencrypt-app (0.4.1 → 0.5.0) ocamlPackages.letsencrypt-dns (0.4.1 → 0.5.0) ocaml4.14.1-ligo ocaml4.14.1-mimic-happy-eyeballs ocamlPackages.mirage-crypto (0.10.7 → 0.11.0) ocamlPackages.mirage-crypto-ec (0.10.7 → 0.11.0) ocamlPackages.mirage-crypto-pk (0.10.7 → 0.11.0) ocamlPackages.mirage-crypto-rng (0.10.7 → 0.11.0) ocamlPackages.mirage-crypto-rng-async (0.10.7 → 0.11.0) ocamlPackages.mirage-crypto-rng-mirage (0.10.7 → 0.11.0) ocaml4.14.1-mrmime ocaml4.14.1-ocsigen-start ocaml4.14.1-ocsigen-toolkit ocaml4.14.1-ocsigenserver ocaml4.14.1-ocsipersist ocaml4.14.1-ocsipersist-pgsql ocaml4.14.1-ocsipersist-sqlite ocaml4.14.1-opium ocaml4.14.1-otr ocaml4.14.1-paf ocaml4.14.1-paf-cohttp ocaml4.14.1-paf-le ocaml4.14.1-pbkdf ocaml4.14.1-piaf ocaml4.14.1-plotkicadsch ocaml4.14.1-resto-cohttp-self-serving-client ocaml4.14.1-resto-cohttp-server ocaml4.14.1-telegraml-unstable ocamlPackages.tls (0.15.4 → 0.16.0) ocamlPackages.tls-async (0.15.4 → 0.16.0) ocamlPackages.tls-mirage (0.15.4 → 0.16.0) ocamlPackages.x509 (0.16.2 → 0.16.4)

$ nix --experimental-features nix-command build --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed -f /home/theo/.cache/nixpkgs-review/rev-f61f54ce3f0bf6f086a2586f3ba85923bbc83c8e/build.nix
10 packages marked as broken and skipped:
ocamlPackages.git ocamlPackages.git-mirage ocamlPackages.git-paf ocamlPackages.git-unix ocamlPackages.irmin-git ocamlPackages.irmin-graphql ocamlPackages.irmin-http ocamlPackages.irmin-mirage-git ocamlPackages.irmin-mirage-graphql ocamlPackages.plotkicadsch

75 packages built:
comby dune-release jackline ligo liquidsoap ocamlPackages.async_rpc_websocket ocamlPackages.awa ocamlPackages.awa-lwt ocamlPackages.awa-mirage ocamlPackages.bonsai ocamlPackages.ca-certs ocamlPackages.ca-certs-nss ocamlPackages.chacha ocamlPackages.cohttp-async ocamlPackages.cohttp-lwt-unix ocamlPackages.cohttp-mirage ocamlPackages.cohttp_async_websocket ocamlPackages.conduit ocamlPackages.conduit-async ocamlPackages.conduit-lwt ocamlPackages.conduit-lwt-unix ocamlPackages.conduit-mirage ocamlPackages.curly ocamlPackages.dns ocamlPackages.dns-certify ocamlPackages.dns-cli ocamlPackages.dns-client ocamlPackages.dns-client-lwt ocamlPackages.dns-client-mirage ocamlPackages.dns-mirage ocamlPackages.dns-resolver ocamlPackages.dns-server ocamlPackages.dns-stub ocamlPackages.dns-tsig ocamlPackages.dnssec ocamlPackages.eliom ocamlPackages.erm_xmpp ocamlPackages.graphql-cohttp ocamlPackages.happy-eyeballs ocamlPackages.happy-eyeballs-lwt ocamlPackages.happy-eyeballs-mirage ocamlPackages.hkdf ocamlPackages.letsencrypt ocamlPackages.letsencrypt-app ocamlPackages.letsencrypt-dns ocamlPackages.mimic-happy-eyeballs ocamlPackages.mirage-crypto ocamlPackages.mirage-crypto-ec ocamlPackages.mirage-crypto-pk ocamlPackages.mirage-crypto-rng ocamlPackages.mirage-crypto-rng-async ocamlPackages.mirage-crypto-rng-lwt ocamlPackages.mirage-crypto-rng-mirage ocamlPackages.mrmime ocamlPackages.ocsigen-start ocamlPackages.ocsigen-toolkit ocamlPackages.ocsigen_server ocamlPackages.ocsipersist ocamlPackages.ocsipersist-pgsql ocamlPackages.ocsipersist-sqlite ocamlPackages.opium ocamlPackages.otr ocamlPackages.paf ocamlPackages.paf-cohttp ocamlPackages.paf-le ocamlPackages.pbkdf ocamlPackages.piaf ocamlPackages.resto-cohttp-self-serving-client ocamlPackages.resto-cohttp-server ocamlPackages.telegraml ocamlPackages.tls ocamlPackages.tls-async ocamlPackages.tls-lwt ocamlPackages.tls-mirage ocamlPackages.x509
```