### PR TITLE
add linux kernel miniconfig support

### DIFF
--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -859,7 +859,17 @@ in
       version ? (builtins.parseDrvName src.name).version,
       makeTarget ? "defconfig",
       name ? "kernel.config",
+      miniconfig ? null, # ref https://docs.kernel.org/kbuild/kconfig.html
     }:
+    assert
+      (miniconfig != null)
+      -> builtins.elem makeTarget [
+        "allyesconfig"
+        "allmodconfig"
+        "allnoconfig"
+        "alldefconfig"
+        "randconfig"
+      ];
     stdenvNoCC.mkDerivation {
       inherit name src;
       depsBuildBuild =
@@ -877,6 +887,7 @@ in
         make \
           ARCH=${stdenv.hostPlatform.linuxArch} \
           HOSTCC=${buildPackages.stdenv.cc.targetPrefix}gcc \
+          ${lib.optionalString (miniconfig != null) "KCONFIG_ALLCONFIG=${miniconfig}"} \
           ${makeTarget}
       '';
       installPhase = ''


### PR DESCRIPTION
Add linux kernel "miniconfig" support as per https://docs.kernel.org/kbuild/kconfig.html and https://lwn.net/Articles/160497/

This feature is useful for building compact kernels for embedded systems and VMs.  I use it to build a non-modular kernel with a closure size of ~11MB.  Contrast this to the standard kernel build which is 100MB+.


Example, a complete "minikernel" builder using this PR:

```
  mkMinikernel = miniconfig: linuxKernel.manualConfig rec {
    version = "6.12.30";
    src = fetchurl {
      url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
      sha256 = "sha256-3wRqSJceQM4LLgA+flW2sefaKRISDrIW1dbIRQyc+C4=";
    };
    configfile = linuxKernel.linuxConfig { inherit src version miniconfig; makeTarget = "alldefconfig"; };
  };
```

... and then the miniconfig file would look something like...

```
CONFIG_MODE_SKAS=y
CONFIG_BINFMT_ELF=y
CONFIG_HOSTFS=y
CONFIG_SYSCTL=y
CONFIG_STDERR_CONSOLE=y
CONFIG_UNIX98_PTYS=y
CONFIG_BLK_DEV_LOOP=y
CONFIG_BLK_DEV_UBD=y
CONFIG_TMPFS=y
CONFIG_SWAP=y
CONFIG_LBD=y
CONFIG_EXT2_FS=y
CONFIG_PROC_FS=y
```

The change in this PR introduces an optional parameter that will have no impact on existing users of the `linuxConfig` function.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
