### PR TITLE
libagent: hardcode the path to gpgconf/gpg-connect-agent

### DIFF
--- a/pkgs/development/python-modules/libagent/default.nix
+++ b/pkgs/development/python-modules/libagent/default.nix
@@ -5,6 +5,7 @@
 , cryptography
 , ed25519
 , ecdsa
+, gnupg
 , semver
 , mnemonic
 , unidecode
@@ -29,6 +30,12 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "sha256-RISAy0efdatr9u4CWNRGnlffkC8ksw1NyRpJWKwqz+s=";
   };
+
+  # hardcode the path to gpgconf in the libagent library
+  postPatch = ''
+    substituteInPlace libagent/gpg/keyring.py \
+      --replace "util.which('gpgconf')" "'${gnupg}/bin/gpgconf'"
+  '';
 
   propagatedBuildInputs = [
     unidecode

--- a/pkgs/development/python-modules/libagent/default.nix
+++ b/pkgs/development/python-modules/libagent/default.nix
@@ -34,7 +34,8 @@ buildPythonPackage rec {
   # hardcode the path to gpgconf in the libagent library
   postPatch = ''
     substituteInPlace libagent/gpg/keyring.py \
-      --replace "util.which('gpgconf')" "'${gnupg}/bin/gpgconf'"
+      --replace "util.which('gpgconf')" "'${gnupg}/bin/gpgconf'" \
+      --replace "'gpg-connect-agent'" "'${gnupg}/bin/gpg-connect-agent'"
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Since I updated my system to 22.11, onlykey-agent has been failing to start. In the logs I see this:

```
2023-03-02 09:28:41,123 ERROR        gpg-agent failed: Cannot find 'gpgconf' in $PATH                                                     [__init__.py:321]
Traceback (most recent call last):
  File "/nix/store/7cynwy5rym5dvski2ik45kz9rlbrngbg-python3.10-libagent-1.0.4/lib/python3.10/site-packages/libagent/gpg/__init__.py", line 296, in run_agent_internal
    pubkey_bytes = keyring.export_public_keys(env=env)
  File "/nix/store/7cynwy5rym5dvski2ik45kz9rlbrngbg-python3.10-libagent-1.0.4/lib/python3.10/site-packages/libagent/gpg/keyring.py", line 246, in export_public_keys
    args = gpg_command(['--export'])
  File "/nix/store/7cynwy5rym5dvski2ik45kz9rlbrngbg-python3.10-libagent-1.0.4/lib/python3.10/site-packages/libagent/gpg/keyring.py", line 213, in gpg_command
    cmd = get_gnupg_binary(neopg_binary=env.get('NEOPG_BINARY'))
  File "/nix/store/7cynwy5rym5dvski2ik45kz9rlbrngbg-python3.10-libagent-1.0.4/lib/python3.10/site-packages/libagent/util.py", line 212, in wrapper
    result = func(*args, **kwargs)
  File "/nix/store/7cynwy5rym5dvski2ik45kz9rlbrngbg-python3.10-libagent-1.0.4/lib/python3.10/site-packages/libagent/gpg/keyring.py", line 206, in get_gnupg_binary
    return get_gnupg_components(sp=sp)['gpg']
  File "/nix/store/7cynwy5rym5dvski2ik45kz9rlbrngbg-python3.10-libagent-1.0.4/lib/python3.10/site-packages/libagent/gpg/keyring.py", line 194, in get_gnupg_components
    args = [util.which('gpgconf'), '--list-components']
  File "/nix/store/7cynwy5rym5dvski2ik45kz9rlbrngbg-python3.10-libagent-1.0.4/lib/python3.10/site-packages/libagent/util.py", line 212, in wrapper
    result = func(*args, **kwargs)
  File "/nix/store/7cynwy5rym5dvski2ik45kz9rlbrngbg-python3.10-libagent-1.0.4/lib/python3.10/site-packages/libagent/util.py", line 248, in which
    raise OSError('Cannot find {!r} in $PATH'.format(cmd))
OSError: Cannot find 'gpgconf' in $PATH
```

It seems libagent depends on gpgconf binary but uses `which` to find it [here](https://github.com/romanz/trezor-agent/blob/58bbb24fb4d30b73c237e95c547ec3f9b194d6bf/libagent/gpg/keyring.py#L30). I've used `substituteInPlace` to fix this in the postPatch phase.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
