### PR TITLE
ioc-scan: init at 1.5.0

### DIFF
--- a/pkgs/tools/security/ioc-scan/default.nix
+++ b/pkgs/tools/security/ioc-scan/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "ioc-scan";
+  version = "1.5.0";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "cisagov";
+    repo = "ioc-scanner";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-dRrLd41HVVHJse7nkem8Cy+ltfJRnJiWrX/WShMfcOw=";
+  };
+
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace " --cov" ""
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    docopt
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pyfakefs
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "ioc_scan"
+  ];
+
+  meta = with lib; {
+    description = "Tool to search a filesystem for indicators of compromise (IoC)";
+    homepage = "https://github.com/cisagov/ioc-scanner";
+    changelog = "https://github.com/cisagov/ioc-scanner/releases/tag/v${version}";
+    license = with licenses; [ cc0 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8545,6 +8545,8 @@ with pkgs;
 
   iodine = callPackage ../tools/networking/iodine { };
 
+  ioc-scan = callPackage ../tools/security/ioc-scan { };
+
   ioccheck = callPackage ../tools/security/ioccheck { };
 
   ioping = callPackage ../tools/system/ioping { };


### PR DESCRIPTION
###### Description of changes
Tool to search a filesystem for indicators of compromise (IoC)

https://github.com/cisagov/ioc-scanner

Related to https://github.com/NixOS/nixpkgs/issues/81418

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
