### PR TITLE
trustymail: init at 0.8.1

### DIFF
--- a/pkgs/development/python-modules/publicsuffixlist/default.nix
+++ b/pkgs/development/python-modules/publicsuffixlist/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pandoc
+, pytestCheckHook
+, pythonOlder
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "publicsuffixlist";
+  version = "0.9.3";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-9iQZb9v8aV7hg6UqLfxWGByPWb8mn+14vktIvCRX4hg=";
+  };
+
+  passthru.optional-dependencies = {
+    update = [
+      requests
+    ];
+    readme = [
+      pandoc
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "publicsuffixlist"
+  ];
+
+  pytestFlagsArray = [
+    "publicsuffixlist/test.py"
+  ];
+
+  meta = with lib; {
+    description = "Public Suffix List parser implementation";
+    homepage = "https://github.com/ko-zu/psl";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/trustymail/default.nix
+++ b/pkgs/tools/security/trustymail/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "trustymail";
+  version = "0.8.1";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "cisagov";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-hKiQWAOzUjmoCcEH9OTgkgU7s1V+Vv3+93OLkqDRDoU=";
+  };
+
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace " --cov" ""
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    dnspython
+    docopt
+    publicsuffixlist
+    pydns
+    pyspf
+    requests
+  ] ++ publicsuffixlist.optional-dependencies.update;
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "trustymail"
+  ];
+
+  meta = with lib; {
+    description = "Tool to scan domains and return data based on trustworthy email best practices";
+    homepage = "https://github.com/cisagov/trustymail";
+    changelog = "https://github.com/cisagov/trustymail/releases/tag/v${version}";
+    license = with licenses; [ cc0 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26917,6 +26917,8 @@ with pkgs;
 
   trust-dns = callPackage ../servers/dns/trust-dns { };
 
+  trustymail = callPackage ../tools/security/trustymail { };
+
   tunctl = callPackage ../os-specific/linux/tunctl { };
 
   twa = callPackage ../tools/networking/twa { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7685,6 +7685,8 @@ self: super: with self; {
 
   publicsuffix = callPackage ../development/python-modules/publicsuffix { };
 
+  publicsuffixlist = callPackage ../development/python-modules/publicsuffixlist { };
+
   pubnub = callPackage ../development/python-modules/pubnub { };
 
   pubnubsub-handler = callPackage ../development/python-modules/pubnubsub-handler { };


### PR DESCRIPTION
###### Description of changes
Tool to scan domains and return data based on trustworthy email best practices

https://github.com/cisagov/trustymail

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
