### PR TITLE
python3Packages.ndeflib: init at 0.3.3

### DIFF
--- a/pkgs/development/python-modules/ndeflib/default.nix
+++ b/pkgs/development/python-modules/ndeflib/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage
+, fetchPypi
+, fetchpatch
+, lib
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ndeflib";
+  version = "0.3.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-HVaChVi5sW8oIqQFGCQ0Y0e2at9TIOqGBwdItvJFSog";
+  };
+
+  patches = [
+    # test reliability fix made after version 0.3.3, but 0.3.3 is the last one in pypi
+    (fetchpatch {
+      name = "struct.unpack_from-exception-message-has-changed";
+      url = "https://github.com/nfcpy/ndeflib/commit/f9e40f436ef0543148ae227c9e8a46b17e2ffc98.patch";
+      hash = "sha256-3uHy/1KsQJ0ERaKmLNbUhM1K+oMawwLTjfsihoSIIFI=";
+    })
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "NFC Data Exchange Format decoder and encoder";
+    homepage = "https://github.com/nfcpy/ndeflib";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [
+      snicket2100
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6314,6 +6314,8 @@ self: super: with self; {
 
   nclib = callPackage ../development/python-modules/nclib { };
 
+  ndeflib = callPackage ../development/python-modules/ndeflib { };
+
   ndg-httpsclient = callPackage ../development/python-modules/ndg-httpsclient { };
 
   ndjson = callPackage ../development/python-modules/ndjson { };


### PR DESCRIPTION
###### Description of changes

https://ndeflib.readthedocs.io/en/latest/

https://pypi.org/project/ndeflib/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
