### PR TITLE
cataclysm-dda: enable tests; misc fixes

### DIFF
--- a/pkgs/games/cataclysm-dda/common.nix
+++ b/pkgs/games/cataclysm-dda/common.nix
@@ -56,6 +56,12 @@ stdenv.mkDerivation {
     "OSX_MIN=${stdenv.targetPlatform.darwinMinVersion}"
   ];
 
+  doCheck = true;
+  # tests all use the same user profile dir
+  enableParallelChecking = false;
+  # tests fail with default locale
+  LC_ALL = "C.UTF-8";
+
   postInstall = optionalString tiles
   ( if !stdenv.isDarwin
     then patchDesktopFile

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -2,9 +2,9 @@
 , tiles ? true, Cocoa
 , debug ? false
 , useXdgDir ? false
-, version ? "2022-08-20"
-, rev ? "f65b2bc4c6dea24bd9a993b8df146e5698e7e36f"
-, sha256 ? "sha256-00Tp9OmsM39PYwAJXKKRS9zmn7KsGQ9s1eVmEqghkpw="
+, version ? "2023-03-02"
+, rev ? "fd6c68cc908666a4ca47e8809309f49bd4bc74c6"
+, sha256 ? "sha256-hYd5AXrsN5Y5ZqCEUAuI0Bq/Kh64CCfuZDNahxAcerA="
 }:
 
 let

--- a/pkgs/games/cataclysm-dda/stable.nix
+++ b/pkgs/games/cataclysm-dda/stable.nix
@@ -37,11 +37,6 @@ let
       "VERSION=${version}"
     ];
 
-    env.NIX_CFLAGS_COMPILE = toString [
-      # Needed with GCC 12
-      "-Wno-error=array-bounds"
-    ];
-
     meta = common.meta // {
       maintainers = with lib.maintainers;
         common.meta.maintainers ++ [ skeidel ];


### PR DESCRIPTION
###### Description of changes
While CDDA has the make flag `RUNTESTS=1` by default, that doesn't actually *run* the tests, just builds them, so we've been building the test binaries and discarding them without running.

I've also bumped cataclysm-dda-git to be ahead of 0.G, and dropped a compiler flag that is no longer needed after 0.G

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
