### PR TITLE
r-modules: Replace MRAN with Posit

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -68,9 +68,9 @@ let
     hydraPlatforms = [];
   };
   deriveCran = mkDerive {
-    mkHomepage = {name, snapshot, ...}: "http://mran.revolutionanalytics.com/snapshot/${snapshot}/web/packages/${name}/";
+    mkHomepage = {name, snapshot, ...}: "https://cran.r-project.org/${snapshot}/web/packages/${name}/";
     mkUrls = {name, version, snapshot}: [
-      "http://mran.revolutionanalytics.com/snapshot/${snapshot}/src/contrib/${name}_${version}.tar.gz"
+      "https://packagemanager.rstudio.com/cran/${snapshot}/src/contrib/${name}_${version}.tar.gz"
     ];
   };
 

--- a/pkgs/development/r-modules/generate-r-packages.R
+++ b/pkgs/development/r-modules/generate-r-packages.R
@@ -1,5 +1,6 @@
 #!/usr/bin/env Rscript
 library(data.table)
+library(jsonlite)
 library(parallel)
 library(BiocManager)
 cl <- makeCluster(10)
@@ -11,12 +12,13 @@ if ("release" %in% biocVersion$BiocStatus) {
 } else {
   biocVersion <-  max(as.numeric(as.character(biocVersion$Bioc)))
 }
-snapshotDate <- Sys.Date()-1
+dates <- stream_in(url("https://packagemanager.rstudio.com/__api__/repos/2/transaction-dates"), verbose = FALSE)
+snapshotDate <- as.Date(dates[nrow(dates), "alias"])
 
 mirrorUrls <- list( bioc=paste0("http://bioconductor.statistik.tu-dortmund.de/packages/", biocVersion, "/bioc/src/contrib/")
                   , "bioc-annotation"=paste0("http://bioconductor.statistik.tu-dortmund.de/packages/", biocVersion, "/data/annotation/src/contrib/")
                   , "bioc-experiment"=paste0("http://bioconductor.statistik.tu-dortmund.de/packages/", biocVersion, "/data/experiment/src/contrib/")
-                  , cran=paste0("http://mran.revolutionanalytics.com/snapshot/", snapshotDate, "/src/contrib/")
+                  , cran=paste0("https://packagemanager.rstudio.com/cran/", snapshotDate, "/src/contrib/")
                   )
 
 mirrorType <- commandArgs(trailingOnly=TRUE)[1]

--- a/pkgs/development/r-modules/generate-shell.nix
+++ b/pkgs/development/r-modules/generate-shell.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation {
     (rWrapper.override {
       packages = with rPackages; [
         data_table
+        jsonlite
         parallel
         BiocManager
       ];


### PR DESCRIPTION
###### Description of changes

This PR switches to the [Posit mirror](https://packagemanager.rstudio.com/client/#/repos/2/overview) for CRAN, since [MRAN is retiring](https://techcommunity.microsoft.com/t5/azure-sql-blog/microsoft-r-application-network-retirement/ba-p/3707161). I have not configured for [private mirrors](https://discourse.nixos.org/t/mran-microsoft-r-application-network-being-shutdown-will-this-affect-how-r-packages-get-into-nixpkgs/24671), yet. Resolves #209871.

@alexvorobiev @jbedo @Kupac

###### Things done

- Generated cran-packages.nix and built dplyr on aarch64-darwin.
