### PR TITLE
Revert "logseq: Fix publishing graph"

### DIFF
--- a/pkgs/applications/misc/logseq/default.nix
+++ b/pkgs/applications/misc/logseq/default.nix
@@ -2,8 +2,8 @@
 , stdenv
 , fetchurl
 , appimageTools
-, appimage-run
 , makeWrapper
+, electron
 , git
 }:
 
@@ -30,21 +30,28 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin $out/share/${pname} $out/share/applications $out/share/${pname}/resources/app/icons
-    cp -a ${appimageContents}/resources/app/icons/logseq.png $out/share/${pname}/resources/app/icons/logseq.png
+    mkdir -p $out/bin $out/share/${pname} $out/share/applications
+    cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
     cp -a ${appimageContents}/Logseq.desktop $out/share/applications/${pname}.desktop
 
-    # set the env "LOCAL_GIT_DIRECTORY" for dugite so that we can use the git in nixpkgs
-    makeWrapper ${appimage-run}/bin/appimage-run $out/bin/logseq \
-      --set "LOCAL_GIT_DIRECTORY" ${git} \
-      --add-flags ${src}
+    # remove the `git` in `dugite` because we want the `git` in `nixpkgs`
+    chmod +w -R $out/share/${pname}/resources/app/node_modules/dugite/git
+    chmod +w $out/share/${pname}/resources/app/node_modules/dugite
+    rm -rf $out/share/${pname}/resources/app/node_modules/dugite/git
+    chmod -w $out/share/${pname}/resources/app/node_modules/dugite
 
-    # Make the desktop entry run the app using appimage-run
     substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace Exec=Logseq "Exec=$out/bin/logseq" \
+      --replace Exec=Logseq Exec=${pname} \
       --replace Icon=Logseq Icon=$out/share/${pname}/resources/app/icons/logseq.png
 
     runHook postInstall
+  '';
+
+  postFixup = ''
+    # set the env "LOCAL_GIT_DIRECTORY" for dugite so that we can use the git in nixpkgs
+    makeWrapper ${electron}/bin/electron $out/bin/${pname} \
+      --set "LOCAL_GIT_DIRECTORY" ${git} \
+      --add-flags $out/share/${pname}/resources/app
   '';
 
   passthru.updateScript = ./update.sh;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2588,7 +2588,9 @@ with pkgs;
 
   lilo = callPackage ../tools/misc/lilo { };
 
-  logseq = callPackage ../applications/misc/logseq { };
+  logseq = callPackage ../applications/misc/logseq {
+    electron = electron_20;
+  };
 
   natls = callPackage ../tools/misc/natls { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2588,9 +2588,7 @@ with pkgs;
 
   lilo = callPackage ../tools/misc/lilo { };
 
-  logseq = callPackage ../applications/misc/logseq {
-    electron = electron_20;
-  };
+  logseq = callPackage ../applications/misc/logseq { };
 
   natls = callPackage ../tools/misc/natls { };
 


### PR DESCRIPTION
###### Description of changes
This reverts commit 7db6808335f5307f94f0f49d73669e565f526f46.

Revert the changes introduced in #205057 (as requested in https://github.com/NixOS/nixpkgs/issues/218471#issuecomment-1447688562) because they caused some issues (#218471, #217320).

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).