### PR TITLE
typeshare: 1.0.1 -> 1.1.0

### DIFF
--- a/pkgs/development/tools/rust/typeshare/default.nix
+++ b/pkgs/development/tools/rust/typeshare/default.nix
@@ -1,22 +1,37 @@
-{ lib, rustPlatform, fetchCrate }:
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, installShellFiles
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "typeshare";
-  version = "1.0.1";
+  version = "1.1.0";
 
-  src = fetchCrate {
-    inherit version;
-    pname = "typeshare-cli";
-    sha256 = "sha256-SbTI7170Oc1e09dv4TvUwByG3qkyAL5YXZ96NzI0FSI=";
+  src = fetchFromGitHub {
+    owner = "1password";
+    repo = "typeshare";
+    rev = "v${version}";
+    hash = "sha256-FQ9KL8X7zz3ew+H1lhh4bkZ01Te1TD+QXAMxS8dXAaI=";
   };
 
-  cargoSha256 = "sha256-5EhXw2WcRJqCbdMvOtich9EYQqi0uwCH1a1XXIo8aAo=";
+  cargoHash = "sha256-t6tGNHmPasmTRto2hobvJywrF/8tO79zkfWwa6lCPK8=";
+
+  nativeBuildInputs = [ installShellFiles ];
 
   buildFeatures = [ "go" ];
+
+  postInstall = ''
+    installShellCompletion --cmd typeshare \
+      --bash <($out/bin/typeshare completions bash) \
+      --fish <($out/bin/typeshare completions fish) \
+      --zsh <($out/bin/typeshare completions zsh)
+  '';
 
   meta = with lib; {
     description = "Command Line Tool for generating language files with typeshare";
     homepage = "https://github.com/1password/typeshare";
+    changelog = "https://github.com/1password/typeshare/blob/v${version}/CHANGELOG.md";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ figsoda ];
   };


### PR DESCRIPTION
Diff: https://github.com/1password/typeshare/compare/v1.0.1...v1.1.0

Changelog: https://github.com/1password/typeshare/blob/v1.1.0/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
