### PR TITLE
ocamlPackages.mezzo: fix build

### DIFF
--- a/pkgs/development/compilers/mezzo/default.nix
+++ b/pkgs/development/compilers/mezzo/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, menhir, menhirLib, yojson, ulex, pprint, fix, functory }:
+{ lib, stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, camlp4, menhir
+, menhirLib, yojson, ulex, pprint, fix, functory
+}:
 
 if lib.versionAtLeast ocaml.version "4.06"
 then throw "mezzo is not available for OCaml ${ocaml.version}"
@@ -24,8 +26,8 @@ stdenv.mkDerivation {
 
   strictDeps = true;
 
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  buildInputs = [ yojson menhir menhirLib ulex pprint fix functory ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild camlp4 menhir ];
+  buildInputs = [ yojson menhirLib ulex pprint fix functory ocamlbuild ];
 
   # Sets warning 3 as non-fatal
   prePatch = lib.optionalString (check-ocaml-version "4.02") ''


### PR DESCRIPTION
This had been broken by 376e9ceeadc4c4e06f34b33bf347a504a4b3bd65 (cc @ulrikstrid).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
