### PR TITLE
pleroma: 2.5.0 -> 2.5.1

### DIFF
--- a/nixos/tests/pleroma.nix
+++ b/nixos/tests/pleroma.nix
@@ -170,8 +170,8 @@ import ./make-test-python.nix ({ pkgs, ... }:
   '';
 
   hosts = nodes: ''
-    ${nodes.pleroma.config.networking.primaryIPAddress} pleroma.nixos.test
-    ${nodes.client.config.networking.primaryIPAddress} client.nixos.test
+    ${nodes.pleroma.networking.primaryIPAddress} pleroma.nixos.test
+    ${nodes.client.networking.primaryIPAddress} client.nixos.test
   '';
   in {
   name = "pleroma";

--- a/pkgs/servers/pleroma/default.nix
+++ b/pkgs/servers/pleroma/default.nix
@@ -8,14 +8,14 @@
 
 beamPackages.mixRelease rec {
   pname = "pleroma";
-  version = "2.5.0";
+  version = "2.5.1";
 
   src = fetchFromGitLab {
     domain = "git.pleroma.social";
     owner = "pleroma";
     repo = "pleroma";
     rev = "v${version}";
-    sha256 = "sha256-Pry3eEUvrGUXK+x4et7DMbSxz9Mh/o5L0/Mh728mv1U=";
+    sha256 = "sha256-3iG2s7jVEnhq1kLLgtaHnFmLYBO2Xr5M5jjZfSNA9z4=";
   };
   stripDebug = false;
 
@@ -97,24 +97,6 @@ beamPackages.mixRelease rec {
       majic = prev.majic.override {
         buildInputs = [ file ];
       };
-      crypt = beamPackages.buildRebar3 rec {
-        name = "crypt";
-        version = "1.0.0";
-
-        src = fetchFromGitHub {
-          owner = "msantos";
-          repo = "crypt";
-          rev = "f75cd55325e33cbea198fb41fe41871392f8fb76";
-          sha256 = "sha256-ZYhZTe7cTITkl8DZ4z2IOlxTX5gnbJImu/lVJ2ZjR1o=";
-        };
-
-        postInstall = "mv $out/lib/erlang/lib/crypt-${version}/priv/{source,crypt}.so";
-
-        beamDeps = with final; [ elixir_make ];
-
-        buildInputs = [ libxcrypt ];
-      };
-
       # Some additional build inputs and build fixes
       http_signatures = prev.http_signatures.override {
         patchPhase = ''
@@ -178,6 +160,13 @@ beamPackages.mixRelease rec {
           mkdir config
           cp ${cfgFile} config/config.exs
         '';
+      };
+
+      crypt = let
+        version = prev.crypt.version;
+      in prev.crypt.override {
+        buildInputs = [ libxcrypt ];
+        postInstall = "mv $out/lib/erlang/lib/crypt-${version}/priv/{hex-source-crypt-${version},crypt}.so";
       };
     });
   };

--- a/pkgs/servers/pleroma/mix.nix
+++ b/pkgs/servers/pleroma/mix.nix
@@ -281,6 +281,19 @@ let
       beamDeps = [ ecto ];
     };
 
+    crypt = buildRebar3 rec {
+      name = "crypt";
+      version = "1.0.1";
+
+      src = fetchHex {
+        pkg = "${name}";
+        version = "${version}";
+        sha256 = "10ir7nsa0dkn5jr0w9x2m38jc73aym7llz2pnkwxk9f747izz3cn";
+      };
+
+      beamDeps = [];
+    };
+
     custom_base = buildMix rec {
       name = "custom_base";
       version = "0.2.1";
@@ -335,12 +348,12 @@ let
 
     earmark = buildMix rec {
       name = "earmark";
-      version = "1.4.18";
+      version = "1.4.22";
 
       src = fetchHex {
         pkg = "${name}";
         version = "${version}";
-        sha256 = "0q15ypgdr94z425dxb3blp6wqzrphsg1b6wscsfd13lmldnkpb2p";
+        sha256 = "1yzx2j48cxny7l8ap1jgq2qiz1kiq6q8cwiismvgshjscr2m3bqw";
       };
 
       beamDeps = [ earmark_parser ];
@@ -348,12 +361,12 @@ let
 
     earmark_parser = buildMix rec {
       name = "earmark_parser";
-      version = "1.4.17";
+      version = "1.4.29";
 
       src = fetchHex {
         pkg = "${name}";
         version = "${version}";
-        sha256 = "08r06hp1wwfbfpalqqxwpq9lsd42pwvmhjr6bcb1r9pckyfchfpr";
+        sha256 = "00rmqvf3hkxfvkijqd624n0hn1xqims8h211xmm02fdi7qdsy0j9";
       };
 
       beamDeps = [];
@@ -816,12 +829,12 @@ let
 
     linkify = buildMix rec {
       name = "linkify";
-      version = "0.5.2";
+      version = "0.5.3";
 
       src = fetchHex {
         pkg = "${name}";
         version = "${version}";
-        sha256 = "11mbbqm7yi6rhza5d2hd4fxkhdy3ik5n7sybj0n9bn0q09lsqwcd";
+        sha256 = "0xw14ls480jzha9fx4lxd40dff4xx82w1h87dr82az6lfw9mmwry";
       };
 
       beamDeps = [];


### PR DESCRIPTION
Bumping pleroma. Crypt landed in hex, we can remove the custom git
override.

The manually added git deps were manually double-checked.

Upstream changelog: https://git.pleroma.social/pleroma/pleroma/-/releases/v2.5.1###### Description of changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
