### PR TITLE
{ibus,fcitx5}-rime: support user provided RIME data packages

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -103,6 +103,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The [services.unifi-video.openFirewall](#opt-services.unifi-video.openFirewall) module option default value has been changed from `true` to `false`. You will need to explicitly set this option to `true`, or configure your firewall.
 
+- The option `i18n.inputMethod.fcitx5.enableRimeData` has been renamed to `i18n.inputMethod.rime.enableDefaultRimeData`, the new option is set to `true` by default.
+
 - Kime has been updated from 2.5.6 to 3.0.2 and the `i18n.inputMethod.kime.config` option has been removed. Users should use `daemonModules`, `iconColor`, and `extraConfig` options under `i18n.inputMethod.kime` instead.
 
 - `tut` has been updated from 1.0.34 to 2.0.0, and now uses the TOML format for the configuration file instead of INI. Additional information can be found [here](https://github.com/RasmusLindroth/tut/releases/tag/2.0.0).
@@ -234,6 +236,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The `root` package is now built with the `"-Dgnuinstall=ON"` CMake flag, making the output conform the `bin` `lib` `share` layout. In this layout, `tutorials` is under `share/doc/ROOT/`; `cmake`, `font`, `icons`, `js` and `macro` under `share/root`; `Makefile.comp` and `Makefile.config` under `etc/root`.
 
 - Enabling global redirect in `services.nginx.virtualHosts` now allows one to add exceptions with the `locations` option.
+
+- A new option `i18n.inputMethod.rime.packages` has been added to control the RIME data packages used by `ibus-engines.rime` and `fcitx5-rime`. Add new option `i18n.inputMethod.rime.enableDefaultRimeData` has been added to control whether the `rime-data` package should be added to to `i18n.inputMethod.rime.packages`. The option `enableDefaultRimeData` is set to `true` by default.
 
 - A new option `recommendedBrotliSettings` has been added to `services.nginx`. Learn more about compression in Brotli format [here](https://github.com/google/ngx_brotli/blob/master/README.md).
 

--- a/nixos/modules/i18n/input-method/ibus.nix
+++ b/nixos/modules/i18n/input-method/ibus.nix
@@ -3,8 +3,11 @@
 with lib;
 
 let
-  cfg = config.i18n.inputMethod.ibus;
-  ibusPackage = pkgs.ibus-with-plugins.override { plugins = cfg.engines; };
+  im = config.i18n.inputMethod;
+  cfg = im.ibus;
+  rimeEnabled = any (p: p.pname == "ibus-rime") cfg.engines;
+  plugins = cfg.engines ++ (if rimeEnabled then im.rime.packages else []);
+  ibusPackage = pkgs.ibus-with-plugins.override { inherit plugins; };
   ibusEngine = types.package // {
     name  = "ibus-engine";
     check = x: (lib.types.package.check x) && (attrByPath ["meta" "isIbusEngine"] false x);
@@ -80,6 +83,10 @@ in
 
     xdg.portal.extraPortals = mkIf config.xdg.portal.enable [
       ibusPackage
+    ];
+
+    i18n.inputMethod.rime.packages = lib.mkIf rimeEnabled [
+      pkgs.ibus-engines.rime # ibus-rime contains rime data ibus_rime.yaml
     ];
   };
 

--- a/nixos/modules/i18n/input-method/rime.nix
+++ b/nixos/modules/i18n/input-method/rime.nix
@@ -1,0 +1,43 @@
+{ config, pkgs, lib, ... }:
+
+let
+  cfg = config.i18n.inputMethod.rime;
+in
+{
+  imports = [
+    (lib.mkRenamedOptionModule [ "i18n" "inputMethod" "fcitx5" "enableRimeData" ]
+                               [ "i18n" "inputMethod" "rime" "enableDefaultRimeData" ])
+  ];
+
+  options = {
+    i18n.inputMethod.rime = {
+      # cfg.packages is used by different rime input method in different way,
+      # currently including ibus-rime and fcitx5-rime
+      packages = lib.mkOption {
+        type = with lib.types; listOf package;
+        default = [ ];
+        description = lib.mdDoc ''
+          List of RIME packages to install.
+        '';
+      };
+
+      enableDefaultRimeData = lib.mkOption {
+        type = with lib.types; bool;
+        # default is true so that default RIME schames works out-of-box
+        # expirenced users can disable it
+        default = true;
+        description = lib.mdDoc ''
+          Whether to enable the default rime-data package.
+          Default RIME schemas including luna pinyin are included in the package.
+        '';
+      };
+    };
+  };
+
+  config = {
+    # cfg.enableDefaultRimeData simply add the default rime-data package to cfg.packages
+    i18n.inputMethod.rime.packages = lib.mkIf cfg.enableDefaultRimeData [
+      pkgs.rime-data
+    ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -111,6 +111,7 @@
   ./i18n/input-method/kime.nix
   ./i18n/input-method/nabi.nix
   ./i18n/input-method/uim.nix
+  ./i18n/input-method/rime.nix
   ./installer/tools/tools.nix
   ./misc/assertions.nix
   ./misc/crashdump.nix

--- a/pkgs/tools/inputmethods/fcitx5/with-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/with-addons.nix
@@ -11,6 +11,7 @@ symlinkJoin {
     wrapProgram $out/bin/fcitx5 \
       --prefix FCITX_ADDON_DIRS : "$out/lib/fcitx5" \
       --suffix XDG_DATA_DIRS : "$out/share" \
+      --suffix NIX_RIME_DATA_DIR : "$out/share/rime-data" \
       --suffix PATH : "$out/bin" \
       --suffix LD_LIBRARY_PATH : ${lib.makeLibraryPath (lib.flatten (map (x: x.extraLdLibraries or []) addons))}
 

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-rime/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-rime/default.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation rec {
     sha256 = "0gdxg6ia0i31jn3cvh1nrsjga1j31hf8a2zfgg8rzn25chrfr319";
   };
 
+  patches = [
+    ./ibus-rime-with-nix-env-variable.patch
+  ];
+
   buildInputs = [ gdk-pixbuf glib ibus libnotify librime rime-data ];
   nativeBuildInputs = [ cmake pkg-config ];
 

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-rime/ibus-rime-with-nix-env-variable.patch
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-rime/ibus-rime-with-nix-env-variable.patch
@@ -1,0 +1,18 @@
+diff --git a/rime_main.c b/rime_main.c
+index c0e9229..c7cca93 100644
+--- a/rime_main.c
++++ b/rime_main.c
+@@ -56,7 +56,12 @@ static void notification_handler(void* context_object,
+ }
+ 
+ static void fill_traits(RimeTraits *traits) {
+-  traits->shared_data_dir = IBUS_RIME_SHARED_DATA_DIR;
++  const char* nix_rime_data_dir = getenv("NIX_RIME_DATA_DIR");
++  if (nix_rime_data_dir != NULL) {
++    traits->shared_data_dir = nix_rime_data_dir;
++  } else {
++    traits->shared_data_dir = IBUS_RIME_SHARED_DATA_DIR;
++  }
+   traits->distribution_name = DISTRIBUTION_NAME;
+   traits->distribution_code_name = DISTRIBUTION_CODE_NAME;
+   traits->distribution_version = DISTRIBUTION_VERSION;

--- a/pkgs/tools/inputmethods/ibus/wrapper.nix
+++ b/pkgs/tools/inputmethods/ibus/wrapper.nix
@@ -66,6 +66,7 @@ buildEnv {
           --set IBUS_TABLE_DATA_DIR "$out/share" \
           --set IBUS_TABLE_LIB_LOCATION "$out/libexec" \
           --set IBUS_TABLE_LOCATION "$out/share/ibus-table" \
+          --set NIX_RIME_DATA_DIR "$out/share/rime-data" \
           --prefix PYTHONPATH : "$PYTHONPATH" \
           --prefix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH" \
           --suffix XDG_DATA_DIRS : "${hicolor-icon-theme}/share" \


### PR DESCRIPTION
###### Description of changes

Provide a generic option `i18n.inputMethod.rime.packages` to specify rime data packages used by fcitx5-rime and ibus-rime.

With this PR, third-party rime data packages like [iDvel/rime-ice](https://github.com/iDvel/rime-ice) can be easily packaged and used with ibus-rime and fcitx5-rime.
Also, the `rime-data` package can be refactored to be fine-grained. Currently, nixpkgs only provide a single rime data package called `rime-data`, which contains all official rime data (maintained by the [RIME GitHub organization](https://github.com/rime)). While the Arch Linux community repository provides fine-grained packages like `rime-luna-pinyin`, `rime-double-pinyin`, and `rime-cangjie` etc.

Changes:

1. Add a new option `i18n.inputMethod.rime.packages`. The option itself does not do anything. But It will be used by the fctix5 module and the ibus module to install rime data.
3. Add a new option `i18n.inputMethod.rime.enableDefaultRimeData` for compatibility and out-of-box experience. This option replaces `i18n.inputMethod.fcitx5.enableRimeData`.
4. Update the fcitx5 module to use the new option. Provide `NIX_RIME_DATA_DIR` environment variable in the wrapper instead of adding it to `environment.variables`. The new method should be more robust.
5. Patch ibus-rime to support the `NIX_RIME_DATA_DIR` environment variable (like #167032). And update the ibus module as the fcitx5 module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).