### PR TITLE
nix-serve: 0.2-e4675e3 -> 0.2-7089565

### DIFF
--- a/pkgs/tools/package-management/nix-serve/default.nix
+++ b/pkgs/tools/package-management/nix-serve/default.nix
@@ -9,8 +9,8 @@
 }:
 
 let
-  rev = "e4675e38ab54942e351c7686e40fabec822120b9";
-  sha256 = "1wm24p6pkxl1d7hrvf4ph6mwzawvqi22c60z9xzndn5xfyr4v0yr";
+  rev = "7089565e260267c9c234a81292c841958737cef6";
+  sha256 = "/nf09eM2vey9GrAXoqagccJrBo/fGyVKP7oNSxPqwdo=";
 in
 
 stdenv.mkDerivation {


### PR DESCRIPTION
Old version doesn't serve packages anymore

###### Description of changes
Previous version didn't serve packages from cache. Below error message
`
GET /vvzprcfsdnpccw7w90l5cz73vnxny2yj.narinfo
The program must call nix::initNix() before calling any libstore library functions.
`
Installed new version according to instructions found on [nix-serve](https://github.com/edolstra/nix-serve),
verifying works fine, cached packages are served.

Made change so I can install it from nix channel
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

