### PR TITLE
mpvScripts.acompressor: Init at 0.35.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10771,6 +10771,15 @@
     githubId = 8214542;
     name = "Nicolò Balzarotti";
   };
+  nicoo = {
+    email = "nicoo@debian.org";
+    github = "nbraud";
+    githubId = 1155801;
+    name = "nicoo";
+    keys = [{
+      fingerprint = "E44E 9EA5 4B8E 256A FB73 49D3 EC9D 3708 72BC 7A8C";
+    }];
+  };
   nidabdella = {
     name = "Mohamed Nidabdella";
     email = "nidabdella.mohamed@gmail.com";

--- a/pkgs/applications/video/mpv/scripts/acompressor.nix
+++ b/pkgs/applications/video/mpv/scripts/acompressor.nix
@@ -1,0 +1,27 @@
+{ stdenvNoCC
+, mpv-unwrapped
+, lib
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "mpv-acompressor";
+  version = mpv-unwrapped.version;
+
+  src = "${mpv-unwrapped.src.outPath}/TOOLS/lua/acompressor.lua";
+
+  dontBuild = true;
+  dontUnpack = true;
+
+  installPhase = ''
+    install -Dm644 ${src} $out/share/mpv/scripts/acompressor.lua
+  '';
+
+  passthru.scriptName = "acompressor.lua";
+
+  meta = with lib; {
+    description = "Script to toggle and control ffmpeg's dynamic range compression filter.";
+    homepage = "https://github.com/mpv-player/mpv/blob/master/TOOLS/lua/acompressor.lua";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ nicoo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31846,6 +31846,7 @@ with pkgs;
   mpvpaper = callPackage ../tools/wayland/mpvpaper { };
 
   mpvScripts = recurseIntoAttrs {
+    acompressor = callPackage ../applications/video/mpv/scripts/acompressor.nix {};
     autoload = callPackage ../applications/video/mpv/scripts/autoload.nix { };
     convert = callPackage ../applications/video/mpv/scripts/convert.nix { };
     inhibit-gnome = callPackage ../applications/video/mpv/scripts/inhibit-gnome.nix { };


### PR DESCRIPTION
###### Description of changes

- Add nicoo to `lib.maintainers`
- `mpvScripts.acompressor`: Init at 0.35.1

`acompressor` is a script that is part of `mpv`, but providing a separate
derivation makes it easier for users to enable that script in their
configuration (systemwide, through home-manager, or however else)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
