### PR TITLE
viber: fix build with openssl

### DIFF
--- a/pkgs/applications/networking/instant-messengers/viber/default.nix
+++ b/pkgs/applications/networking/instant-messengers/viber/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
       libxslt
       nspr
       nss
-      openssl
+      openssl_1_1
       stdenv.cc.cc
       systemd
       wayland


### PR DESCRIPTION
###### Description of changes

https://github.com/NixOS/nixpkgs/pull/219384 broke evaluation of `viber` as it references `openssl` which is no longer included in package argument list.

Note that I am not a user of `viber`, but I noticed the problem as it breaks nixpkgs-review:

> error: undefined variable 'openssl'
>
>        at /home/wolfi/.cache/nixpkgs-review/rev-2ac465b2302d82274d83918ca49ecec1b15fb345/nixpkgs/pkgs/applications/networking/instant-messengers/viber/default.nix:42:7:
>
>            41|       nss
>            42|       openssl
>              |       ^
>            43|       stdenv.cc.cc
>
>        … while evaluating 'functionArgs'

Notifying pull request author @prtzl and maintainer @jagajaga .


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).