### PR TITLE
tvbrowser: clean up derivation file

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -269,8 +269,6 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [Xastir](https://xastir.org/index.php/Main_Page) can now access AX.25 interfaces via the `libax25` package.
 
-- `tvbrowser-bin` was removed, and now `tvbrowser` is built from source.
-
 - `nixos-version` now accepts `--configuration-revision` to display more information about the current generation revision
 
 - The option `services.nomad.extraSettingsPlugins` has been fixed to allow more than one plugin in the path.

--- a/pkgs/applications/misc/tvbrowser/default.nix
+++ b/pkgs/applications/misc/tvbrowser/default.nix
@@ -16,7 +16,6 @@ let
     hash = "sha256-5XoypuMd2AFBE2SJ6EdECuvq6D81HLLuu9UoA9kcKAM=";
   };
 in
-assert lib.versionAtLeast jdk.version minimalJavaVersion;
 stdenv.mkDerivation rec {
   pname = "tvbrowser";
   version = "4.2.7";

--- a/pkgs/applications/misc/tvbrowser/default.nix
+++ b/pkgs/applications/misc/tvbrowser/default.nix
@@ -74,7 +74,6 @@ stdenv.mkDerivation rec {
     changelog = "https://www.tvbrowser.org/index.php?id=news";
     sourceProvenance = with sourceTypes; [ binaryBytecode fromSource ];
     license = licenses.gpl3Plus;
-    mainProgram = pname;
     platforms = platforms.linux;
     maintainers = with maintainers; [ jfrankenau yarny ];
     longDescription = ''

--- a/pkgs/applications/misc/tvbrowser/default.nix
+++ b/pkgs/applications/misc/tvbrowser/default.nix
@@ -40,27 +40,28 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/${pname}
-    cp -R runtime/tvbrowser_linux/* $out/share/${pname}
+    mkdir -p $out/share/tvbrowser
+    cp -R runtime/tvbrowser_linux/* $out/share/tvbrowser
 
     mkdir -p $out/share/applications
-    mv -t $out/share/applications $out/share/${pname}/${pname}.desktop
-    sed -e 's|=imgs/|='$out'/share/${pname}/imgs/|'  \
-        -e 's|=${pname}.sh|='$out'/bin/${pname}|'  \
-        -i $out/share/applications/${pname}.desktop
+    mv -t $out/share/applications $out/share/tvbrowser/tvbrowser.desktop
+    sed -e 's|=imgs/|='$out'/share/tvbrowser/imgs/|'  \
+        -e 's|=tvbrowser.sh|='$out'/bin/tvbrowser|'  \
+        -i $out/share/applications/tvbrowser.desktop
 
     for i in 16 32 48 128; do
       mkdir -p $out/share/icons/hicolor/''${i}x''${i}/apps
-      ln -s $out/share/${pname}/imgs/${pname}$i.png $out/share/icons/hicolor/''${i}x''${i}/apps/${pname}.png
+      ln -s $out/share/tvbrowser/imgs/tvbrowser$i.png  \
+          $out/share/icons/hicolor/''${i}x''${i}/apps/tvbrowser.png
     done
 
     mkdir -p $out/bin
     makeWrapper  \
-        $out/share/${pname}/${pname}.sh  \
-        $out/bin/${pname}  \
+        $out/share/tvbrowser/tvbrowser.sh  \
+        $out/bin/tvbrowser  \
         --prefix PATH : ${jdk}/bin  \
         --prefix XDG_DATA_DIRS : $out/share  \
-        --set PROGRAM_DIR $out/share/${pname}
+        --set PROGRAM_DIR $out/share/tvbrowser
 
     runHook postInstall
   '';

--- a/pkgs/applications/misc/tvbrowser/test.nix
+++ b/pkgs/applications/misc/tvbrowser/test.nix
@@ -12,20 +12,20 @@ let
     runtimeInputs = [ xorg.xwininfo tvbrowser ];
     text = ''
       function find_tvbrowser_windows {
-          for window_name in java tvbrowser-TVBrowser 'Setup assistant' ; do
-              grep -q "$window_name" "$1"  ||  return 1
-          done
+        for window_name in java tvbrowser-TVBrowser 'Setup assistant' ; do
+          grep -q "$window_name" "$1"  ||  return 1
+        done
       }
       tvbrowser &
       for _ in {0..900} ; do
-          xwininfo -root -tree  \
-              | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d'  \
-              | tee window-names
-          echo
-          if find_tvbrowser_windows window-names ; then
-              break
-          fi
-          sleep 1
+        xwininfo -root -tree  \
+            | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d'  \
+            | tee window-names
+        echo
+        if find_tvbrowser_windows window-names ; then
+          break
+        fi
+        sleep 1
       done
       find_tvbrowser_windows window-names
     '';

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1571,7 +1571,7 @@ mapAliases ({
   truecrypt = throw "'truecrypt' has been renamed to/replaced by 'veracrypt'"; # Converted to throw 2022-02-22
   tuijam = throw "tuijam has been removed because Google Play Music was discontinued"; # Added 2021-03-07
   turbo-geth = throw "turbo-geth has been renamed to erigon"; # Added 2021-08-08
-  tvbrowser-bin = throw "tvbrowser-bin was removed because it is now built from sources; use 'tvbrowser' instead"; # Added 2023-02-04
+  tvbrowser-bin = tvbrowser; # Added 2023-03-02
   twister = throw "twister has been removed: abandoned by upstream and python2-only"; # Added 2022-04-26
   tychus = throw "tychus has been dropped due to the lack of maintenance from upstream since 2018"; # Added 2022-06-03
   typora = throw "Newer versions of typora use anti-user encryption and refuse to start. As such it has been removed"; # Added 2021-09-11


### PR DESCRIPTION
###### Description of changes

This pull introduces several tiny improvements to `tvbrowser`, based on a post-merge review https://github.com/NixOS/nixpkgs/pull/210902#pullrequestreview-1286075436 by @SuperSandro2000 :

* use a proper alias for the old package name,
* use correct indentation for inline shell script in nix file,
* remove definition of `mainProgram` as it was identical to the default value,
* remove `pname` substitutions from inline shell scripts,
* remove the jdk version check.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Note that `nixpkgs-review` was skipped due to https://github.com/NixOS/nixpkgs/pull/219385 .