### PR TITLE
pcsc-safenet: 10.0.37 -> 10.8.28

### DIFF
--- a/pkgs/tools/security/pcsc-safenet/default.nix
+++ b/pkgs/tools/security/pcsc-safenet/default.nix
@@ -57,15 +57,17 @@ stdenv.mkDerivation rec {
     mkdir "$out"
     cp -r ./* "$out/"
 
+    # for each library like libfoo.so.1.2.3, create symlinks to it from libfoo.so, libfoo.so.1, libfoo.so.1.2
     (
       cd "$out/lib/" || exit
-      for f in *.so.*.*.*; do
-        ln -sf "$f" "''${f%.*}" || exit
-        ln -sf "$f" "''${f%.*.*}" || exit
-        ln -sf "$f" "''${f%.*.*.*}" || exit
+      for f in *.so.*.*.*; do                # find library names with three-layer suffixes
+        ln -sf "$f" "''${f%.*}" || exit      # strip only one suffix layer
+        ln -sf "$f" "''${f%.*.*}" || exit    # strip two suffix layers
+        ln -sf "$f" "''${f%.*.*.*}" || exit  # strip all three suffix layers
       done
     ) || exit
 
+    # when library links are missing in pcsc/drivers, create them
     (
       cd "$out/pcsc/drivers" || exit
       for f in *; do

--- a/pkgs/tools/security/pcsc-safenet/default.nix
+++ b/pkgs/tools/security/pcsc-safenet/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
 , runCommand
-, fetchurl
+, fetchzip
 , autoPatchelfHook
 , dpkg
 , gtk3
@@ -14,24 +14,22 @@ stdenv.mkDerivation rec {
   pname = "pcsc-safenet";
   version = "10.8.28";
 
+  debName = "Installation/Standard/Ubuntu-2004/safenetauthenticationclient_${version}_amd64.deb";
+
   # extract debian package from larger zip file
-  src = runCommand "sac.deb" {
-    zipSrc = let
+  src =
+    let
       versionWithUnderscores = builtins.replaceStrings ["."] ["_"] version;
-    in fetchurl {
+    in fetchzip {
       url = "https://www.digicert.com/StaticFiles/SAC_${versionWithUnderscores}_GA_Build.zip";
-      hash = "sha256-bh+TB7ZGDMh9G4lcPtv7mc0XeGhmCfMMqrlqtyGIIaA=";
+      hash = "sha256-7XWj3T9/KnmgQ05urOJV6dqgkAS/A2G7efnqjQO2ing=";
     };
-    debName = "SAC ${version} GA Build/Installation/Standard/Ubuntu-2004/safenetauthenticationclient_${version}_amd64.deb";
-  } ''
-    ${unzip}/bin/unzip -p "$zipSrc" "$debName" >"$out"
-  '';
 
   dontBuild = true;
   dontConfigure = true;
 
   unpackPhase = ''
-    dpkg-deb -x $src .
+    dpkg-deb -x "$src/$debName" .
   '';
 
   buildInputs = [


### PR DESCRIPTION
###### Description of changes

Update pcsc-safenet to a version with better hardware support, clearer licensing, less-unofficial download location. Also updates packaging to deal with `pkgs.openssl` no longer being a 1.x binary.

- Version 10.8 explicitly supports the 5110+ CC line of SafeNet tokens.

- Version 10.8 release notes explicitly document that "from SAC 10.8 release onwards, no license is required for SAC on Linux".

It's not clear to me whether this is sufficient to allow clearing the nonfree flag, but it's certainly an improvement.

Also, we're now getting our downloads from a company that distributes SafeNet hardware rather than a website under the control of an Arch contributor, and thus have a clearer chain-of-custody for these security-critical binaries.

@wldhx, your feedback would be greatly appreciated.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] ~~aarch64-linux~~
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
