### PR TITLE
wpa_supplicant: better compatibility with entreprise WiFi networks

### DIFF
--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, openssl, pkg-config, libnl
+{ lib, stdenv, fetchurl, fetchpatch, openssl, pkg-config, libnl
 , nixosTests, wpa_supplicant_gui
 , dbusSupport ? !stdenv.hostPlatform.isStatic, dbus
 , withReadline ? true, readline
@@ -20,6 +20,11 @@ stdenv.mkDerivation rec {
   patches = [
     # Fix a bug when using two config files
     ./Use-unique-IDs-for-networks-and-credentials.patch
+    # Drop security level to 0 with OpenSSL 3.0 when using TLS 1.0/1.1
+    (fetchpatch {
+            url = "https://w1.fi/cgit/hostap/patch/?id=bc99366f9b960150aa2e369048bbc2218c1d414e";
+            sha256 = "sha256-ESL7OZhVZz+YhDqZSQzRyh8ZX9RmZi2EO8o7aLRODHY=";
+          })
   ] ++ lib.optionals readOnlyModeSSIDs [
     # Allow read-only networks
     ./0001-Implement-read-only-mode-for-ssids.patch


### PR DESCRIPTION
OpenSSL: Drop security level to 0 with OpenSSL 3.0 when using TLS 1.0/1.1

###### Description of changes

Added patch, cherry-picked upstream commit, also used in debian and ubuntu packages to allow me and potentially other users to connect to entreprise/university (old) Wi-Fi networks similar to the one I use. Source: https://w1.fi/cgit/hostap/commit/?id=bc99366f9b960150aa2e369048bbc2218c1d414e (upstream main branch)

The default settings are allowing TLS 1.0 and 1.1 to be negotiated
just to see them fail immediately when using OpenSSL 3.0. This is not
exactly helpful especially when the OpenSSL error message for this
particular case is "internal error" which does not really say anything
about the reason for the error.

It is is a bit inconvenient to update the security policy for this
particular issue based on the negotiated TLS version since that happens
in the middle of processing for the first message from the server.
However, this can be done by using the debug callback for printing out
the received TLS messages during processing.

Drop the OpenSSL security level to 0 if that is the only option to
continue the TLS negotiation, i.e., when TLS 1.0/1.1 are still allowed
in wpa_supplicant default configuration and OpenSSL 3.0 with the
constraint on MD5-SHA1 use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
