### PR TITLE
openjfx11: fix build

### DIFF
--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchFromGitHub, writeText, gradle_7, pkg-config, perl, cmake
 , gperf, gtk3, libXtst, libXxf86vm, glib, alsa-lib, ffmpeg_4-headless, python3, ruby, icu68
+, gtk2
 , openjdk11-bootstrap
 , withMedia ? true
 , withWebKit ? false
@@ -24,7 +25,16 @@ let
       sha256 = "sha256-46DjIzcBHkmp5vnhYnLu78CG72bIBRM4A6mgk2OLOko=";
     };
 
-    buildInputs = [ gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless icu68 ];
+    buildInputs = [
+      alsa-lib
+      ffmpeg_4-headless
+      glib
+      gtk2
+      gtk3
+      icu68
+      libXtst
+      libXxf86vm
+    ];
     nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python3 ruby ];
 
     dontUseCmakeConfigure = true;


### PR DESCRIPTION
openjfx11: fix build

> Configure project :
> Package gtk+-2.0 was not found in the pkg-config search path.
> Perhaps you should add the directory containing `gtk+-2.0.pc'
> to the PKG_CONFIG_PATH environment variable
> No package 'gtk+-2.0' found

Error logs: https://termbin.com/1xhep

Adding gtk2 fixed it.