### PR TITLE
teams-for-linux: 1.0.45 -> 1.0.53

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -11,6 +11,7 @@
 , electron
 , libpulseaudio
 , pipewire
+, alsa-utils
 }:
 
 stdenv.mkDerivation rec {
@@ -67,8 +68,12 @@ stdenv.mkDerivation rec {
     done
     popd
 
+    # Linux needs 'aplay' for notification sounds, 'libpulse' for meeting sound, and 'libpipewire' for screen sharing
     makeWrapper '${electron}/bin/electron' "$out/bin/teams-for-linux" \
-      ${lib.optionalString stdenv.isLinux "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libpulseaudio pipewire ]}"} \
+      ${lib.optionalString stdenv.isLinux ''
+        --prefix PATH : ${lib.makeBinPath [ alsa-utils ]} \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libpulseaudio pipewire ]} \
+      ''} \
       --add-flags "$out/share/teams-for-linux/app.asar" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
 

--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -4,10 +4,10 @@
 , makeWrapper
 , makeDesktopItem
 , copyDesktopItems
-, fixup_yarn_lock
 , yarn
 , nodejs
 , fetchYarnDeps
+, fixup_yarn_lock
 , electron
 , libpulseaudio
 , pipewire
@@ -15,18 +15,18 @@
 
 stdenv.mkDerivation rec {
   pname = "teams-for-linux";
-  version = "1.0.45";
+  version = "1.0.53";
 
   src = fetchFromGitHub {
     owner = "IsmaelMartinez";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-Q6DFegFrLUW/YiRyYJI4ITVVyMC5IkazlzhdR8203cY=";
+    sha256 = "sha256-zigcOshtRQuQxJBXPWVmTjj5+4AorR5WW8lHVInUKFg=";
   };
 
   offlineCache = fetchYarnDeps {
-    yarnLock = src + "/yarn.lock";
-    sha256 = "sha256-jaAieO5q+tNfWN7Rp6ueasl45cfp9W1QxPdqIeCnVkE=";
+    yarnLock = "${src}/yarn.lock";
+    sha256 = "sha256-3zjmVIPQ+F2jPQ2xkAv5hQUjr8k5jIHTsa73J+IMayw=";
   };
 
   nativeBuildInputs = [ yarn fixup_yarn_lock nodejs copyDesktopItems makeWrapper ];
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     runHook preBuild
 
     yarn --offline electron-builder \
-      --dir --linux ${if stdenv.hostPlatform.isAarch64 then "--arm64" else "--x64"} \
+      --dir ${if stdenv.isDarwin then "--macos" else "--linux"} ${if stdenv.hostPlatform.isAarch64 then "--arm64" else "--x64"} \
       -c.electronDist=${electron}/lib/electron \
       -c.electronVersion=${electron.version}
 
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out/share/{applications,teams-for-linux}
-    cp dist/linux-${lib.optionalString stdenv.hostPlatform.isAarch64 "arm64-"}unpacked/resources/app.asar $out/share/teams-for-linux/
+    cp dist/${if stdenv.isDarwin then "darwin-" else "linux-"}${lib.optionalString stdenv.hostPlatform.isAarch64 "arm64-"}unpacked/resources/app.asar $out/share/teams-for-linux/
 
     pushd build/icons
     for image in *png; do
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
     popd
 
     makeWrapper '${electron}/bin/electron' "$out/bin/teams-for-linux" \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libpulseaudio pipewire ]} \
+      ${lib.optionalString stdenv.isLinux "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libpulseaudio pipewire ]}"} \
       --add-flags "$out/share/teams-for-linux/app.asar" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
 
@@ -88,7 +88,8 @@ stdenv.mkDerivation rec {
     description = "Unofficial Microsoft Teams client for Linux";
     homepage = "https://github.com/IsmaelMartinez/teams-for-linux";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ muscaln ];
-    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    maintainers = with maintainers; [ muscaln lilyinstarlight ];
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Description of changes

The biggest changes are having macOS support and having a multi-account command-line flag. Other release notes at https://github.com/ismaelmartinez/teams-for-linux/releases

I added myself as maintainer and am letting OfBorg test to see if it builds on macOS or not (and I'll mark it broken if not)

Versions in-between these were waiting on #214062 but this version works without it again (so some of the drive-by changes were originally related to getting it to work with that)

I also tossed in a fix for notification sounds

Fixes #215593

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).