### PR TITLE
obex-data-server: enable strictDeps

### DIFF
--- a/pkgs/tools/bluetooth/obex-data-server/default.nix
+++ b/pkgs/tools/bluetooth/obex-data-server/default.nix
@@ -9,7 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "0kq940wqs9j8qjnl58d6l3zhx0jaszci356xprx23l6nvdfld6dk";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  strictDeps = true;
+  nativeBuildInputs = [
+    pkg-config
+    dbus-glib # required for dbus-binding-tool
+  ];
   buildInputs = [ libusb-compat-0_1 glib dbus-glib bluez openobex dbus ];
 
   patches = [ ./obex-data-server-0.4.6-build-fixes-1.patch ];


### PR DESCRIPTION
###### Description of changes

Motivation: https://github.com/NixOS/nixpkgs/issues/178468

Fixes the following error when using strictDepsByDefault:
```
[...]
checking for BLUEZ... yes
checking for sdp_extract_seqtype_safe in -lbluetooth... no
checking for OPENOBEX... yes
configure: creating ./config.status
config.status: creating Makefile
config.status: creating config.h
config.status: executing depfiles commands

                    obex-data-server 0.4.6
                  =============================

        prefix:                    /nix/store/dq0cps7xz5hjfcjnzkksj9nwryzr3g0s-obex-data-server-0.4.6
        compiler:                  gcc
        cflags:                    -Wall -O2 -D_FORTIFY_SOURCE=2
        BIP imaging support:       disabled
        USB support:               yes

building
build flags: SHELL=/nix/store/5ynbf6wszmggr0abwifdagrixgnya5vy-bash-5.2-p15/bin/bash
  GEN    src/ods-manager-dbus-glue.h
/nix/store/5ynbf6wszmggr0abwifdagrixgnya5vy-bash-5.2-p15/bin/bash: line 2: --prefix=ods_manager: command not found
make: *** [Makefile:953: src/ods-manager-dbus-glue.h] Error 127
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
