### PR TITLE
cc-wrapper: include fortify-headers before libc includes for musl

### DIFF
--- a/pkgs/development/libraries/fortify-headers/default.nix
+++ b/pkgs/development/libraries/fortify-headers/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation {
+  pname = "fortify-headers";
+  version = "1.1alpine1";
+
+  # upstream only accessible via git - unusable during bootstrap, hence
+  # extract from the alpine package
+  src = fetchurl {
+    url = "https://dl-cdn.alpinelinux.org/alpine/v3.17/main/x86_64/fortify-headers-1.1-r1.apk";
+    name = "fortify-headers.tar.gz";  # ensure it's extracted as a .tar.gz
+    hash = "sha256-A67NzUv+dldARY+MTaoVnezTg+Es8ZK/b7XOxA6KzpI=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r include/fortify $out/include
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Standalone header-based fortify-source implementation";
+    homepage = "https://git.2f30.org/fortify-headers";
+    license = lib.licenses.bsd0;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ ris ];
+  };
+}

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -194,6 +194,7 @@ let
           inherit lib;
           inherit (prevStage) coreutils gnugrep;
           stdenvNoCC = prevStage.ccWrapperStdenv;
+          fortify-headers = prevStage.fortify-headers;
         }).overrideAttrs(a: lib.optionalAttrs (prevStage.gcc-unwrapped.passthru.isXgcc or false) {
           # This affects only `xgcc` (the compiler which compiles the final compiler).
           postFixup = (a.postFixup or "") + ''
@@ -568,6 +569,7 @@ in
         inherit lib;
         inherit (self) stdenvNoCC coreutils gnugrep;
         shell = self.bash + "/bin/bash";
+        fortify-headers = self.fortify-headers;
       };
     };
     extraNativeBuildInputs = [
@@ -645,6 +647,7 @@ in
         ++  [ linuxHeaders # propagated from .dev
             binutils gcc gcc.cc gcc.cc.lib gcc.expand-response-params gcc.cc.libgcc glibc.passthru.libgcc
           ]
+        ++ lib.optionals (localSystem.libc == "musl") [ fortify-headers ]
         ++ [ prevStage.updateAutotoolsGnuConfigScriptsHook prevStage.gnu-config ]
         ++ (with gcc-unwrapped.passthru; [
           gmp libmpc mpfr isl

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21096,6 +21096,8 @@ with pkgs;
 
   folks = callPackage ../development/libraries/folks { };
 
+  fortify-headers = callPackage ../development/libraries/fortify-headers { };
+
   makeFontsConf = let fontconfig_ = fontconfig; in {fontconfig ? fontconfig_, fontDirectories}:
     callPackage ../development/libraries/fontconfig/make-fonts-conf.nix {
       inherit fontconfig fontDirectories;


### PR DESCRIPTION
###### Description of changes

Musl itself doesn't have support for `FORTIFY_SOURCE`. Distributions like alpine use the fortify-headers project (https://git.2f30.org/fortify-headers/file/README.html) to provide some basic fortify support using a header `#include_next` wrapper/passthru mechanism.

This PR does the same, firstly by packaging `fortify-headers` (in fact this extracts them from the alpine package because upstream only has a bare git repository and we don't want to depend on git in the bootstrap phases), then by applying them from the cc-wrapper on musl systems (or if `includeFortifyHeaders` is set manually).

This can be tested using the tests in #217390 (cherry-pick on top of this). I added `tests.hardeningFlags.fortify1ExplicitEnabledExecTest` to that specifically for testing this PR - the `hardening-check` method won't be able to detect `fortify-headers`' entirely-inlined approach and `fortify-headers` really only implements `FORTIFY_SOURCE=1` mode. This passes for me for `pkgsMusl` and `pkgsStatic` on nixos x86_64.

(Side note: I don't think it would be particularly hard to add `FORTIFY_SOURCE=2` or even `FORTIFY_SOURCE=3` mode to `fortify-headers`, but it feels like the author is opposed to this. Yell if you'd be interested for me to try this...)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
