### PR TITLE
qt5: make overrriding with separate debug info useful

### DIFF
--- a/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
@@ -22,6 +22,9 @@ qmakePrePhase() {
         qmakeFlags+=( "CONFIG+=release" )
     fi
 
+    # do the stripping ourselves (needed for separateDebugInfo)
+    qmakeFlags+=( "CONFIG+=nostrip" )
+
     qmakeFlags+=( "${qmakeFlags_orig[@]}" )
 }
 prePhases+=" qmakePrePhase"

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -213,7 +213,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-shared"
     "-accessibility"
     "-optimized-qmake"
-    "-strip"
+    # for separateDebugInfo
+    "-no-strip"
     "-system-proxies"
     "-pkg-config"
 


### PR DESCRIPTION
###### Description of changes

I'm currently investigating a segfault in nheko, and obtaining debug symbols for qt with enableDebugging does not work because qmake likes to strip itself.

I could build nheko and run gdb successfully on top of this.

EDIT: I consider qt6 out of scope for this PR, but may have a look at it in another PR later.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
