### PR TITLE
linux_testing_bcachefs: 6.1.3-unstable-2023-02-01 -> 6.3.1-unstable-2023-05-02

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -2,9 +2,12 @@
 , stdenv
 , fetchpatch
 , kernel
-, commitDate ? "2023-02-01"
-, currentCommit ? "65960c284ad149cc4bfbd64f21e6889c1e3d1c5f"
-, diffHash ? "sha256-4wpY3aYZ93OXSU4wmQs9K62nPyIzjKu4RBQTwksmyyk="
+, commitDate ? "2023-05-02"
+# bcachefs-tools stores the expected-revision in:
+#   https://evilpiepirate.org/git/bcachefs-tools.git/tree/.bcachefs_revision
+# but this does not means that it'll be the latest-compatible revision
+, currentCommit ? "6a20aede294f72f3920146a352aa102a9fd3d0aa"
+, diffHash ? "sha256-IGOsZm3SdWUf6DNVQiDMRGoyKNIPvwSwN0jgktRTVbk="
 
 , kernelPatches # must always be defined in bcachefs' all-packages.nix entry because it's also a top-level attribute supplied by callPackage
 , argsOverride ? {}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -211,16 +211,8 @@ in {
 
     linux_testing_bcachefs = callPackage ../os-specific/linux/kernel/linux-testing-bcachefs.nix {
       # Pinned on the last version which Kent's commits can be cleany rebased up.
-      kernel = buildLinux rec {
-        version = "6.1.3";
-        modDirVersion = lib.versions.pad 3 version;
-        extraMeta.branch = lib.versions.majorMinor version;
-        src = fetchurl {
-          url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
-          hash = "sha256-bcia56dRPkM8WXxzRu1/9L/RFepDo7XiemvbOMVYAxc=";
-        };
-      };
-      kernelPatches = linux_6_1.kernelPatches;
+      kernel = linux_6_3;
+      kernelPatches = linux_6_3.kernelPatches;
    };
 
     linux_hardkernel_4_14 = callPackage ../os-specific/linux/kernel/linux-hardkernel-4.14.nix {


### PR DESCRIPTION
**Why Draft?**: Right now `nixosTests.bcachefs` don't pass. According to Kent the `bcachefs unlock` and the mount helper are not talking through the same keyring.

###### Description of changes

- The new kernel commit which the bcachefs-tools are based cleanly merges with ~6.1.15~ ~6.2.2~  6.3.1;
- The new bcachefs-tools now has a rust portion;

Important to note that the crates depend on `https://evilpiepirate.org/git/rust-bindgen.git`, which is very very very slow to fetch.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

**NOTE**: I DID NOT TEST IT IN A RUNNING SYSTEM YET!