### PR TITLE
[Backport release-22.11] android-ndk: allow -no-pie

### DIFF
--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -132,7 +132,8 @@ rec {
       # Use -fPIC for compilation, and link with -pie if no -shared flag used in ldflags
       echo "-target ${targetInfo.triple} -fPIC" >> $out/nix-support/cc-cflags
       echo "-z,noexecstack -z,relro -z,now" >> $out/nix-support/cc-ldflags
-      echo 'if [[ ! " $@ " =~ " -shared " ]]; then NIX_LDFLAGS_${suffixSalt}+=" -pie"; fi' >> $out/nix-support/add-flags.sh
+      echo 'expandResponseParams "$@"' >> $out/nix-support/add-flags.sh
+      echo 'if [[ ! (" ''${params[@]} " =~ " -shared ") && ! (" ''${params[@]} " =~ " -no-pie ") ]]; then NIX_LDFLAGS_${suffixSalt}+=" -pie"; fi' >> $out/nix-support/add-flags.sh
       echo "-Xclang -mnoexecstack" >> $out/nix-support/cc-cxxflags
       if [ ${targetInfo.triple} == arm-linux-androideabi ]; then
         # https://android.googlesource.com/platform/external/android-cmake/+/refs/heads/cmake-master-dev/android.toolchain.cmake


### PR DESCRIPTION
We add -pie if we don't find -shared in the arguments. However this does not work in the presense of @response files.  We also do not respect -no-pie, and add -pie regardless. This improves the argument parsing, and allows to prevent the forced -pie flag.

(cherry picked from commit bd4cdf346c0e43f56b1055fc649b9e9987acd601)

See #216956 