### PR TITLE
isolate: init at 1.10

### DIFF
--- a/pkgs/tools/security/isolate/default.nix
+++ b/pkgs/tools/security/isolate/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, asciidoc
+, libcap
+, installShellFiles
+}:
+
+stdenv.mkDerivation rec {
+  pname = "isolate";
+  version = "1.10";
+
+  src = fetchFromGitHub {
+    owner = "ioi";
+    repo = "isolate";
+    rev = "v${version}";
+    hash = "sha256-fuv9HOw0XkRBRjwAp4b6LpoB5p7a+yo66AcT3B0yQUw=";
+  };
+
+  nativeBuildInputs = [
+    asciidoc
+    installShellFiles
+  ];
+
+  buildInputs = [
+    libcap.dev
+  ];
+
+  buildFlags = [
+    "isolate"
+    "isolate.1"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ./isolate $out/bin/isolate
+    installManPage isolate.1
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Sandbox for securely executing untrusted programs";
+    homepage = "https://github.com/ioi/isolate";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ virchau13 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39695,4 +39695,6 @@ with pkgs;
   duden = callPackage ../applications/misc/duden { };
 
   zf = callPackage ../tools/misc/zf { };
+
+  isolate = callPackage ../tools/security/isolate { };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds `isolate`, a sandbox for securely executing untrusted programs (especially in a competitive programming environment.)
https://github.com/ioi/isolate

This package just contains a binary `bin/isolate` and a man page `share/man/man1/isolate.1`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
