### PR TITLE
Fix the nixpkgs manual, build it on lib changes

### DIFF
--- a/.github/workflows/manual-nixpkgs.yml
+++ b/.github/workflows/manual-nixpkgs.yml
@@ -8,6 +8,7 @@ on:
       - master
     paths:
       - 'doc/**'
+      - 'lib/**'
 
 jobs:
   nixpkgs:

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -4,6 +4,8 @@ let
 
 inherit (builtins) length;
 
+asciiTable = import ./ascii-table.nix;
+
 in
 
 rec {
@@ -33,8 +35,6 @@ rec {
     typeOf
     unsafeDiscardStringContext
     ;
-
-  asciiTable = import ./ascii-table.nix;
 
   /* Concatenate a list of strings.
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/219235 broke the nixpkgs manual because it introduced `lib.strings.asciiTable`, an attribute set, and the code for generating lib function locations naively recurses into attribute sets to determine what subsets we have. See also https://github.com/NixOS/nixpkgs/issues/116472#issuecomment-1377236109

This wasn't detected because we don't build the nixpkgs manual when `lib` changes. This PR addresses that, and hides `asciiTable` for now (I don't think it should be exposed anyway).

The workflow change won't affect this PR but I can confirm it builds locally.