### PR TITLE
sticky: init at 0.1.1

### DIFF
--- a/pkgs/applications/misc/sticky-vixalien/default.nix
+++ b/pkgs/applications/misc/sticky-vixalien/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchYarnDeps
+, writeText
+, appstream-glib
+, desktop-file-utils
+, fixup_yarn_lock
+, gjs
+, glib
+, gtk4
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook4
+, yarn
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sticky";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "vixalien";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-qyCXlU6aKjBr8tTo/es1WqVaz/B5O/O4clsmuHznJss=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    fixup_yarn_lock
+    gjs
+    glib
+    gtk4
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+    yarn
+  ];
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = src + "/yarn.lock";
+    hash = "sha256-HQC13KiLTP0akkH9hHyV/ephSwzPmnys1AavSNZ+8Oo=";
+  };
+
+  yarnrc = writeText ".yarnrc" "yarn-offline-mirror \"${offlineCache}\"";
+
+  mesonFlags = [ "-Dyarnrc=${yarnrc}" ];
+
+  preBuild = ''
+    # meson's setup hook cd into build
+    fixup_yarn_lock ../yarn.lock
+  '';
+
+  postFixup = ''
+    # gjs uses the invocation name to add gresource files
+    # - https://gitlab.gnome.org/GNOME/gjs/-/blob/6aca7b50785fa1638f144b17060870d721e3f65a/modules/script/package.js#L159
+    # - https://gitlab.gnome.org/GNOME/gjs/-/blob/6aca7b50785fa1638f144b17060870d721e3f65a/modules/script/package.js#L37
+    # To work around this, we manually set the the name as done in foliate
+    # - https://github.com/NixOS/nixpkgs/blob/3bacde6273b09a21a8ccfba15586fb165078fb62/pkgs/applications/office/foliate/default.nix#L23
+    sed -i "1 a imports.package._findEffectiveEntryPointName = () => 'com.vixalien.sticky';" $out/bin/.com.vixalien.sticky-wrapped
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/vixalien/sticky";
+    description = "A simple sticky notes app";
+    maintainers = with maintainers; [ linsui ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38336,6 +38336,8 @@ with pkgs;
 
   sticky = callPackage ../applications/misc/sticky { };
 
+  sticky-vixalien = callPackage ../applications/misc/sticky-vixalien { };
+
   stork = darwin.apple_sdk_11_0.callPackage ../applications/misc/stork {
     inherit (darwin.apple_sdk_11_0.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

https://github.com/vixalien/sticky Yet another sticky notes app.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
