### PR TITLE
fzf: Install shell completion files

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -32,7 +32,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [Cloudlog](https://www.magicbug.co.uk/cloudlog/), a web-based Amateur Radio logging application. Available as [services.cloudlog](#opt-services.cloudlog.enable).
 
-- [fzf](https://github.com/junegunn/fzf), a command line fuzzyfinder. Available as [programs.fzf](#opt-programs.fzf.fuzzyCompletion).
+- [fzf](https://github.com/junegunn/fzf), a command line fuzzyfinder. Keybindings for Bash and Fish are available as [programs.fzf.key.keybindings](#opt-programs.fzf.keybindings).
 
 - [gmediarender](https://github.com/hzeller/gmrender-resurrect), a simple, headless UPnP/DLNA renderer.  Available as [services.gmediarender](options.html#opt-services.gmediarender.enable).
 

--- a/nixos/modules/programs/fzf.nix
+++ b/nixos/modules/programs/fzf.nix
@@ -3,24 +3,25 @@ with lib;
 let
   cfg = config.programs.fzf;
 in {
+  imports = [
+    (mkRemovedOptionModule [ "programs" "fzf" "fuzzyCompletion" ] "programs.fzf.fuzzyCompletion is now always enabled")
+  ];
   options = {
     programs.fzf = {
-      fuzzyCompletion = mkEnableOption (mdDoc "fuzzy completion with fzf");
       keybindings = mkEnableOption (mdDoc "fzf keybindings");
     };
   };
   config = {
-    environment.systemPackages = optional (cfg.keybindings || cfg.fuzzyCompletion) pkgs.fzf;
-    programs.bash.interactiveShellInit = optionalString cfg.fuzzyCompletion ''
-      source ${pkgs.fzf}/share/fzf/completion.bash
-    '' + optionalString cfg.keybindings ''
+    environment.systemPackages = optional (cfg.keybindings) pkgs.fzf;
+    programs.bash.interactiveShellInit = optionalString cfg.keybindings ''
       source ${pkgs.fzf}/share/fzf/key-bindings.bash
     '';
 
-    programs.zsh.interactiveShellInit = optionalString cfg.fuzzyCompletion ''
-      source ${pkgs.fzf}/share/fzf/completion.zsh
-    '' + optionalString cfg.keybindings ''
+    programs.zsh.interactiveShellInit = optionalString cfg.keybindings ''
       source ${pkgs.fzf}/share/fzf/key-bindings.zsh
+      # From some reason here only a function is defined, and we have to run it
+      # in order to actually set the bindings.
+      fzf_key_bindings
     '';
   };
   meta.maintainers = with maintainers; [ laalsaas ];

--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -67,11 +67,12 @@ buildGoModule rec {
 
     install -D plugin/* -t $out/share/vim-plugins/${pname}/plugin
 
-    # Install shell integrations
-    install -D shell/* -t $out/share/fzf/
-    install -D shell/key-bindings.fish $out/share/fish/vendor_functions.d/fzf_key_bindings.fish
-    mkdir -p $out/share/fish/vendor_conf.d
-    echo fzf_key_bindings > $out/share/fish/vendor_conf.d/load-fzf-key-bindings.fish
+    # Install optional shell files that enable keybinds
+    install -D shell/key-bindings.* -t $out/share/fzf/
+
+    # Install shell completion files
+    installShellCompletion --bash --name fzf.bash shell/completion.bash
+    installShellCompletion --zsh --name _fzf shell/completion.zsh
 
     cat <<SCRIPT > $out/bin/fzf-share
     #!${runtimeShell}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
