### PR TITLE
someblocks: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14219,6 +14219,12 @@
     githubId = 1694705;
     name = "Sam Stites";
   };
+  stonks3141 = {
+    email = "sam@samnystrom.dev";
+    github = "Stonks3141";
+    githubId = 82178396;
+    name = "Sam Nystrom";
+  };
   strager = {
     email = "strager.nds@gmail.com";
     github = "strager";

--- a/pkgs/applications/misc/someblocks/default.nix
+++ b/pkgs/applications/misc/someblocks/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenv, fetchFromSourcehut, writeText, patches ? [ ], conf ? null }:
+stdenv.mkDerivation rec {
+  pname = "someblocks";
+  version = "1.0.1";
+
+  src = fetchFromSourcehut {
+    owner = "~raphi";
+    repo = "someblocks";
+    rev = version;
+    sha256 = "sha256-pUdiEyhqLx3aMjN0D0y0ykeXF3qjJO0mM8j1gLIf+ww=";
+  };
+
+  inherit patches;
+  postPatch =
+    let
+      configFile =
+        if lib.isDerivation conf || builtins.isPath conf
+        then conf else writeText "blocks.def.h" conf;
+    in
+    lib.optionalString (conf != null) "cp ${configFile} blocks.def.h";
+
+  dontConfigure = true;
+
+  NIX_CFLAGS_COMPILE = [ "-Wno-unused-result" ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "Modular status bar for somebar, based on dwmblocks";
+    homepage = "https://sr.ht/~raphi/someblocks";
+    license = licenses.isc;
+    maintainers = with maintainers; [ stonks3141 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12289,6 +12289,8 @@ with pkgs;
 
   somebar = callPackage ../applications/misc/somebar { };
 
+  someblocks = callPackage ../applications/misc/someblocks { };
+
   spacebar = callPackage ../os-specific/darwin/spacebar {
     inherit (darwin.apple_sdk.frameworks)
       Carbon Cocoa ScriptingBridge SkyLight;


### PR DESCRIPTION
###### Description of changes

[someblocks](https://sr.ht/~raphi/someblocks) is a modular status bar for somebar, based on dwmblocks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Closes #219537
