### PR TITLE
taskwarrior: cleanup postInstall

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -39,6 +39,7 @@
 , statix
 , stylish-haskell
 , tabnine
+, taskwarrior
 , tmux
 , tup
 , vim
@@ -894,6 +895,10 @@ self: super: {
       };
     });
 
+  taskwarrior = buildVimPluginFrom2Nix {
+    inherit (taskwarrior) version pname;
+    src = "${taskwarrior.src}/scripts/vim";
+  };
   telescope-cheat-nvim = super.telescope-cheat-nvim.overrideAttrs (old: {
     dependencies = with self; [ sqlite-lua telescope-nvim ];
   });

--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -33,6 +33,10 @@ stdenv.mkDerivation rec {
       --fish $out/share/doc/task/scripts/fish/task.fish
     rm -r $out/share/doc/task/scripts/bash
     rm -r $out/share/doc/task/scripts/fish
+    # Install vim and neovim plugin
+    mkdir -p $out/share/vim-plugins $out/share/nvim/site
+    mv $out/share/doc/task/scripts/vim $out/share/vim-plugins/task
+    ln -s $out/share/vim-plugins/task $out/share/nvim/site/task
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libuuid, gnutls, python3, xdg-utils }:
+{ lib, stdenv, fetchFromGitHub, cmake, libuuid, gnutls, python3, xdg-utils, installShellFiles }:
 
 stdenv.mkDerivation rec {
   pname = "taskwarrior";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
       --replace "xdg-open" "${lib.getBin xdg-utils}/bin/xdg-open"
   '';
 
-  nativeBuildInputs = [ cmake libuuid gnutls python3 ];
+  nativeBuildInputs = [ cmake libuuid gnutls python3 installShellFiles ];
 
   doCheck = true;
   preCheck = ''
@@ -26,10 +26,13 @@ stdenv.mkDerivation rec {
   checkTarget = "test";
 
   postInstall = ''
-    mkdir -p "$out/share/bash-completion/completions"
-    ln -s "../../doc/task/scripts/bash/task.sh" "$out/share/bash-completion/completions/task.bash"
-    mkdir -p "$out/share/fish/vendor_completions.d"
-    ln -s "../../../share/doc/task/scripts/fish/task.fish" "$out/share/fish/vendor_completions.d/"
+    # ZSH is installed automatically from some reason, only bash and fish need
+    # manual installation
+    installShellCompletion --cmd task \
+      --bash $out/share/doc/task/scripts/bash/task.sh \
+      --fish $out/share/doc/task/scripts/fish/task.fish
+    rm -r $out/share/doc/task/scripts/bash
+    rm -r $out/share/doc/task/scripts/fish
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Install vim plugins to a predictable and more standard location.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
