### PR TITLE
gamescope: 3.11.49 -> 3.11.52-beta6

### DIFF
--- a/pkgs/applications/window-managers/gamescope/default.nix
+++ b/pkgs/applications/window-managers/gamescope/default.nix
@@ -1,11 +1,13 @@
 { stdenv
 , fetchFromGitHub
+, fetchpatch
 , meson
 , pkg-config
 , ninja
 , xorg
 , libdrm
 , vulkan-loader
+, vulkan-headers
 , wayland
 , wayland-protocols
 , libxkbcommon
@@ -18,15 +20,25 @@
 , seatd
 , xwayland
 , glslang
+, hwdata
+, openvr
 , stb
 , wlroots
 , libliftoff
+, libdisplay-info
 , lib
 , makeBinaryWrapper
 }:
 let
   pname = "gamescope";
-  version = "3.11.49";
+  version = "3.11.52-beta6";
+
+  vkroots = fetchFromGitHub {
+    owner = "Joshua-Ashton";
+    repo = "vkroots";
+    rev = "26757103dde8133bab432d172b8841df6bb48155";
+    sha256 = "sha256-eet+FMRO2aBQJcCPOKNKGuQv5oDIrgdVPRO00c5gkL0=";
+  };
 in
 stdenv.mkDerivation {
   inherit pname version;
@@ -35,10 +47,37 @@ stdenv.mkDerivation {
     owner = "Plagman";
     repo = "gamescope";
     rev = "refs/tags/${version}";
-    hash = "sha256-GRq/b013wFRHzFz2YCulJRtcwzX/dhJKd8dkATSLug0=";
+    hash = "sha256-2gn6VQfmwwl86mmnRh+J1uxSIpA5x/Papq578seJ3n8=";
   };
 
-  patches = [ ./use-pkgconfig.patch ];
+  patches = [
+    ./use-pkgconfig.patch
+
+    # https://github.com/Plagman/gamescope/pull/811
+    (fetchpatch {
+      name = "fix-openvr-dependency-name.patch";
+      url = "https://github.com/Plagman/gamescope/commit/557e56badec7d4c56263d3463ca9cdb195e368d7.patch";
+      sha256 = "sha256-9Y1tJ24EsdtZEOCEA30+FJBrdzXX+Nj3nTb5kgcPfBE=";
+    })
+    # https://github.com/Plagman/gamescope/pull/813
+    (fetchpatch {
+      name = "fix-openvr-include.patch";
+      url = "https://github.com/Plagman/gamescope/commit/1331b9f81ea4b3ae692a832ed85a464c3fd4c5e9.patch";
+      sha256 = "sha256-wDtFpM/nMcqSbIpR7K5Tyf0845r3l4kQHfwll1VL4Mc=";
+    })
+    # https://github.com/Plagman/gamescope/pull/812
+    (fetchpatch {
+      name = "bump-libdisplay-info-maximum-version.patch";
+      url = "https://github.com/Plagman/gamescope/commit/b430c5b9a05951755051fd4e41ce20496705fbbc.patch";
+      sha256 = "sha256-YHtwudMUHiE8i3ZbiC9gkSjrlS0/7ydjmJsY1a8ZI2E=";
+    })
+    # https://github.com/Plagman/gamescope/pull/824
+    (fetchpatch {
+      name = "update-libdisplay-info-pkgconfig-filename.patch";
+      url = "https://github.com/Plagman/gamescope/commit/5a672f09aa07c7c5d674789f3c685c8173e7a2cf.patch";
+      sha256 = "sha256-7NX54WIsJDvZT3C58N2FQasV9PJyKkJrLGYS1r4f+kc=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson
@@ -56,9 +95,11 @@ stdenv.mkDerivation {
     xorg.libXtst
     xorg.libXres
     xorg.libXi
+    xorg.libXmu
     libdrm
     libliftoff
     vulkan-loader
+    vulkan-headers
     glslang
     SDL2
     wayland
@@ -73,7 +114,16 @@ stdenv.mkDerivation {
     pipewire
     libcap
     stb
+    hwdata
+    openvr
+    vkroots
+    libdisplay-info
   ];
+
+  postUnpack = ''
+    rm -rf source/subprojects/vkroots
+    ln -s ${vkroots} source/subprojects/vkroots
+  '';
 
   # --debug-layers flag expects these in the path
   postInstall = ''
@@ -85,7 +135,7 @@ stdenv.mkDerivation {
     description = "SteamOS session compositing window manager";
     homepage = "https://github.com/Plagman/gamescope";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ nrdxp zhaofengli ];
+    maintainers = with maintainers; [ nrdxp pedrohlc Scrumplex zhaofengli ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libliftoff/default.nix
+++ b/pkgs/development/libraries/libliftoff/default.nix
@@ -5,14 +5,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libliftoff";
-  version = "0.3.0";
+  version = "0.4.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "emersion";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-MbXDUkAA9gY6Qb6Ok33MNuqIfb4bPIEHd1IVH/UmH10=";
+    sha256 = "sha256-NPwhsd6IOQ0XxNQQNdaaM4kmwoLftokV86WYhoa5csY=";
   };
 
   nativeBuildInputs = [ meson pkg-config ninja ];
@@ -30,6 +30,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/emersion/libliftoff/releases/tag/v${version}";
     license     = licenses.mit;
     platforms   = platforms.linux;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ pedrohlc primeos Scrumplex ];
   };
 }

--- a/pkgs/development/libraries/openvr/default.nix
+++ b/pkgs/development/libraries/openvr/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, cmake
+, libGL
+, jsoncpp
+, fetchFromGitHub
+, fetchpatch2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openvr";
+  version = "1.23.8";
+
+  src = fetchFromGitHub {
+    owner = "ValveSoftware";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-ZdL1HDRSpPykbV3M0CjCZkOt7XlF7Z7OAhOey2ALeHg=";
+  };
+
+  patches = [
+    # https://github.com/ValveSoftware/openvr/pull/594
+    (fetchpatch2 {
+      name = "use-correct-CPP11-definition-for-vsprintf_s.patch";
+      url = "https://github.com/ValveSoftware/openvr/commit/0fa21ba17748efcca1816536e27bdca70141b074.patch";
+      sha256 = "sha256-0sPNDx5qKqCzN35FfArbgJ0cTztQp+SMLsXICxneLx4=";
+    })
+    # https://github.com/ValveSoftware/openvr/pull/1716
+    (fetchpatch2 {
+      name = "add-ability-to-build-with-system-installed-jsoncpp.patch";
+      url = "https://github.com/ValveSoftware/openvr/commit/54a58e479f4d63e62e9118637cd92a2013a4fb95.patch";
+      sha256 = "sha256-aMojjbNjLvsGev0JaBx5sWuMv01sy2tG/S++I1NUi7U=";
+    })
+  ];
+
+  postUnpack = ''
+    # Move in-tree jsoncpp out to complement the patch above
+    # fetchpatch2 is not able to handle these renames
+    mkdir source/thirdparty
+    mv source/src/json source/thirdparty/jsoncpp
+  '';
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ jsoncpp libGL ];
+
+  cmakeFlags = [ "-DUSE_SYSTEM_JSONCPP=ON" "-DBUILD_SHARED=1" ];
+
+  meta = with lib;{
+    homepage = "https://github.com/ValveSoftware/openvr";
+    description = "An API and runtime that allows access to VR hardware from multiple vendors without requiring that applications have specific knowledge of the hardware they are targeting";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ pedrohlc Scrumplex ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22810,6 +22810,8 @@ with pkgs;
 
   openvdb = callPackage ../development/libraries/openvdb {};
 
+  openvr = callPackage ../development/libraries/openvr { };
+
   inherit (callPackages ../development/libraries/libressl { })
     libressl_3_4
     libressl_3_5

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1455,7 +1455,9 @@ with pkgs;
     libgamemode32 = pkgsi686Linux.gamemode.lib;
   };
 
-  gamescope = callPackage ../applications/window-managers/gamescope { };
+  gamescope = callPackage ../applications/window-managers/gamescope {
+    wlroots = wlroots_0_16;
+  };
 
   gay = callPackage ../tools/misc/gay {  };
 


### PR DESCRIPTION
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

NOTE: This PR will probably be updated a few times until the eventual release of gamescope 3.11.52

- openvr: init at 1.23.8:
  - SDK for interacting with SteamVR, [Project page](https://github.com/ValveSoftware/openvr)
  - Patches are the same [as used by Arch Linux](https://github.com/archlinux/svntogit-community/blob/b7924c88fae0fe2026b6cf91f47db4d542a35564/trunk/PKGBUILD)
  - Required by gamescope for running as an OpenVR overlay
- libliftoff: 0.3.0 -> 0.4.0
  - [Changelog](https://gitlab.freedesktop.org/emersion/libliftoff/-/tags/v0.4.0), [Project page](https://gitlab.freedesktop.org/emersion/libliftoff)
  - Bump required by gamescope
- gamescope: 3.11.49 -> 3.11.52-beta6
  - [Project page](https://github.com/Plagman/gamescope)
  - Patches are here to fix the build in its current state. They are probably going to be unneeded for the stable release of 3.11.52

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
