### PR TITLE
mutagen-compose: 0.16.5 -> 0.17.0

### DIFF
--- a/pkgs/tools/misc/mutagen-compose/default.nix
+++ b/pkgs/tools/misc/mutagen-compose/default.nix
@@ -28,7 +28,6 @@ buildGoModule rec {
   tags = [ "mutagencompose" ] ++ lib.optional withSSPL "mutagensspl";
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "Compose with Mutagen integration";
     homepage = "https://mutagen.io/";
     changelog = "https://github.com/mutagen-io/mutagen-compose/releases/tag/v${version}";

--- a/pkgs/tools/misc/mutagen-compose/default.nix
+++ b/pkgs/tools/misc/mutagen-compose/default.nix
@@ -1,21 +1,31 @@
-{ stdenv, lib, buildGoModule, fetchFromGitHub, fetchzip }:
+{
+  stdenv,
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchzip,
+  # Used to enable SSPL licensed code.
+  withSSPL ? false,
+}:
 
 buildGoModule rec {
   pname = "mutagen-compose";
-  version = "0.16.5";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "mutagen-io";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-Rn3aXwez/WUGpuRvA6lkuECchpYek8KDMh6xzZOV9v0=";
+    sha256 = "sha256-kw+/HG6UfbocWeCoI2Bk/wjL+4lUl7B/OOg/ImYTOQQ=";
   };
 
-  vendorHash = "sha256-EkLeB2zUJkKCWsJxMiYHSDgr0/8X24MT0Jp0nuYebds=";
+  vendorHash = "sha256-A4nLRzgkg8xbODlKyNRg04Qpwd8tUyG44M7zYw1p96U=";
 
   doCheck = false;
 
   subPackages = [ "cmd/mutagen-compose" ];
+
+  tags = [ "mutagencompose" ] ++ lib.optional withSSPL "mutagensspl";
 
   meta = with lib; {
     broken = stdenv.isDarwin;
@@ -23,6 +33,6 @@ buildGoModule rec {
     homepage = "https://mutagen.io/";
     changelog = "https://github.com/mutagen-io/mutagen-compose/releases/tag/v${version}";
     maintainers = [ maintainers.matthewpi ];
-    license = licenses.mit;
+    license = if withSSPL then licenses.sspl else licenses.mit;
   };
 }


### PR DESCRIPTION
###### Description of changes

Replaces https://github.com/NixOS/nixpkgs/pull/218822

[mutagen-io/mutagen-compose@`v0.17.0`](https://github.com/mutagen-io/mutagen-compose/releases/tag/v0.17.0)
https://github.com/mutagen-io/mutagen-compose/compare/v0.16.5...v0.17.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
