### PR TITLE
monero-{cli,gui}: 0.18.1.2 -> 0.18.2.0

### DIFF
--- a/pkgs/applications/blockchains/monero-cli/default.nix
+++ b/pkgs/applications/blockchains/monero-cli/default.nix
@@ -25,13 +25,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "monero-cli";
-  version = "0.18.1.2";
+  version = "0.18.2.0";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero";
     rev = "v${version}";
-    sha256 = "sha256-yV1ysoesEcjL+JX6hkmcrBDmazOWBvYK6EjshxJzcAw=";
+    sha256 = "n2e5U3p0eG2atPYV86H2UAURwsIkeSOBm8iwYsDVAoc=";
   };
 
   patches = [

--- a/pkgs/applications/blockchains/monero-cli/default.nix
+++ b/pkgs/applications/blockchains/monero-cli/default.nix
@@ -6,6 +6,23 @@
 , trezorSupport ? true, libusb1, protobuf, python3
 }:
 
+let
+  # submodules
+  supercop = fetchFromGitHub {
+    owner = "monero-project";
+    repo = "supercop";
+    rev = "633500ad8c8759995049ccd022107d1fa8a1bbc9";
+    sha256 = "26UmESotSWnQ21VbAYEappLpkEMyl0jiuCaezRYd/sE=";
+  };
+  trezor-common = fetchFromGitHub {
+    owner = "trezor";
+    repo = "trezor-common";
+    rev = "bff7fdfe436c727982cc553bdfb29a9021b423b0";
+    sha256 = "VNypeEz9AV0ts8X3vINwYMOgO8VpNmyUPC4iY3OOuZI=";
+  };
+
+in
+
 stdenv.mkDerivation rec {
   pname = "monero-cli";
   version = "0.18.1.2";
@@ -15,7 +32,6 @@ stdenv.mkDerivation rec {
     repo = "monero";
     rev = "v${version}";
     sha256 = "sha256-yV1ysoesEcjL+JX6hkmcrBDmazOWBvYK6EjshxJzcAw=";
-    fetchSubmodules = true;
   };
 
   patches = [
@@ -23,8 +39,10 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    # remove vendored libraries
-    rm -r external/{miniupnp,randomx,rapidjson}
+    # manually install submodules
+    rmdir external/{supercop,trezor-common}
+    ln -sf ${supercop} external/supercop
+    ln -sf ${trezor-common} external/trezor-common
     # export patched source for monero-gui
     cp -r . $source
   '';

--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "monero-gui";
-  version = "0.18.1.2";
+  version = "0.18.2.0";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero-gui";
     rev = "v${version}";
-    sha256 = "sha256-GBILqNkYQUkil1qvYnJTkHwgK3dzKR9I9GVbbLy/0UU=";
+    sha256 = "Bm6OpK1jjdWVqdp6HpirqP6+3GcMSZfZ/e70wcu+rQc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Version bump

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change (`monero-cli`, `monero-gui`)
- [x] Tested basic functionality of all binary files (just `--help` and missing `.so`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

As usual, I tested connecting monero-gui to a remote node, creating a wallet and syncing the blockchain.

cc: [dani0854](https://github.com/dani0854)