### PR TITLE
lib/options: fix mkPackageOption docs

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -110,10 +110,6 @@ rec {
   /* Creates an Option attribute set for an option that specifies the
      package a module should use for some purpose.
 
-     Type: mkPackageOption :: pkgs -> (string|[string]) ->
-      { default? :: [string], example? :: null|string|[string], extraDescription? :: string } ->
-      option
-
      The package is specified in the third argument under `default` as a list of strings
      representing its attribute path in nixpkgs (or another package set).
      Because of this, you need to pass nixpkgs itself (or a subset) as the first argument.
@@ -132,6 +128,8 @@ rec {
      valid attribute path in pkgs (if name is a list).
 
      If you wish to explicitly provide no default, pass `null` as `default`.
+
+     Type: mkPackageOption :: pkgs -> (string|[string]) -> { default? :: [string], example? :: null|string|[string], extraDescription? :: string } -> option
 
      Example:
        mkPackageOption pkgs "hello" { }
@@ -157,11 +155,11 @@ rec {
       # Name for the package, shown in option description
       name:
       {
-        # The attribute path where the default package is located
+        # The attribute path where the default package is located (may be omitted)
         default ? name,
-        # A string or an attribute path to use as an example
+        # A string or an attribute path to use as an example (may be omitted)
         example ? null,
-        # Additional text to include in the option description
+        # Additional text to include in the option description (may be omitted)
         extraDescription ? "",
       }:
       let


### PR DESCRIPTION
###### Description of changes

nixdoc takes everything from Type: to Example: as the type, which misrendered a large part of the docs. it also drops sorely needed spaces where the type had line breaks, so all has to be on one line (or use non-standard literal spaces, which is probably worse).

also clarify what the `?` for arguments mean while we're here.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
