### PR TITLE
nixos/wireguard add endpointFile option

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -223,7 +223,7 @@ let
         type = with types; nullOr str;
         description = lib.mdDoc ''
           Endpoint IP or hostname of the peer, followed by a colon,
-          and then a port number of the peer. Mutually excludive with
+          and then a port number of the peer. Mutually exclusive with
           "endpointFile".
 
           Warning for endpoints with changing IPs:
@@ -244,7 +244,7 @@ let
         example = "/run/secrets/peer.address";
         type = with types; nullOr str;
         description = lib.mdDoc ''
-          File Containing the endpoint IP or hostname of the peer,
+          File containing the endpoint IP or hostname of the peer,
           followed by a colon, and then a port number of the peer. Mutally exclusive
           with "endpoint".
 

--- a/nixos/tests/wireguard/default.nix
+++ b/nixos/tests/wireguard/default.nix
@@ -13,6 +13,7 @@ let
     wg-quick = callTest ./wg-quick.nix;
     wg-quick-nftables = args: callTest ./wg-quick.nix ({ nftables = true; } // args);
     generated = callTest ./generated.nix;
+    file-config = callTest ./file-config.nix;
   };
 in
 

--- a/nixos/tests/wireguard/file-config.nix
+++ b/nixos/tests/wireguard/file-config.nix
@@ -1,0 +1,81 @@
+import ../make-test-python.nix ({ pkgs, lib, kernelPackages ? null, ...} :
+  let
+    wg-snakeoil-keys = import ./snakeoil-keys.nix;
+    peer = (import ./make-peer.nix) { inherit lib; };
+  in
+  {
+    name = "wireguard";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ ma27 ];
+    };
+
+    nodes = {
+      peer0 = peer {
+        ip4 = "192.168.0.1";
+        ip6 = "fd00::1";
+        extraConfig = {
+          boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+          environment.etc."wireguard/private".text =
+            wg-snakeoil-keys.peer0.privateKey;
+          environment.etc."wireguard/endpoint".text =
+            "[fd00::2]:23542";
+
+          networking.firewall.allowedUDPPorts = [ 23542 ];
+          networking.wireguard.interfaces.wg0 = {
+            ips = [ "10.23.42.1/32" "fc00::1/128" ];
+            listenPort = 23542;
+            privateKeyFile = "/etc/wireguard/private";
+            peers = lib.singleton {
+              allowedIPs = [ "10.23.42.2/32" "fc00::2/128" ];
+              endpointFile = "/etc/wireguard/endpoint";
+              inherit (wg-snakeoil-keys.peer1) publicKey;
+            };
+          };
+        };
+      };
+
+      peer1 = peer {
+        ip4 = "192.168.0.2";
+        ip6 = "fd00::2";
+        extraConfig = {
+          boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+          environment.etc."wireguard/private".text =
+            wg-snakeoil-keys.peer1.privateKey;
+          environment.etc."wireguard/endpoint".text =
+            "192.168.0.1:23542";
+          networking.firewall.allowedUDPPorts = [ 23542 ];
+          networking.wireguard.interfaces.wg0 = {
+            ips = [ "10.23.42.2/32" "fc00::2/128" ];
+            listenPort = 23542;
+            allowedIPsAsRoutes = false;
+
+            privateKeyFile = "/etc/wireguard/private";
+
+            peers = lib.singleton {
+              allowedIPs = [ "0.0.0.0/0" "::/0" ];
+              endpointFile = "/etc/wireguard/endpoint";
+              persistentKeepalive = 25;
+
+              inherit (wg-snakeoil-keys.peer0) publicKey;
+            };
+
+            postSetup = let inherit (pkgs) iproute2; in ''
+              ${iproute2}/bin/ip route replace 10.23.42.1/32 dev wg0
+              ${iproute2}/bin/ip route replace fc00::1/128 dev wg0
+            '';
+          };
+        };
+      };
+    };
+
+    testScript = ''
+      start_all()
+
+      peer0.wait_for_unit("wireguard-wg0.service")
+      peer1.wait_for_unit("wireguard-wg0.service")
+
+      peer1.succeed("ping -c5 fc00::1")
+      peer1.succeed("ping -c5 10.23.42.1")
+    '';
+  }
+)


### PR DESCRIPTION
###### Description of changes

There are two motivating scenarios for this change:

1. In scenarios where the peer's endpoint might change over time, such as with a dynamic ip address, this provides a mechanism for communicating that change via updating a file and restarting wireguard, typically with a small systemd daemon.

2. This provides a way to interate with peers that may not want ip addresses or endpoints to be solicited in public configuration files.

I have been running this change on a server with no noticed issues, see here: https://github.com/mutantmell/dotfiles/blob/main/modules/overrides/wireguard.nix

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
