### PR TITLE
eigenmath: init at unstable-2023-03-05

### DIFF
--- a/pkgs/applications/science/math/eigenmath/default.nix
+++ b/pkgs/applications/science/math/eigenmath/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+}:
+
+stdenv.mkDerivation rec {
+  pname = "eigenmath";
+  version = "unstable-2023-03-05";
+
+  src = fetchFromGitHub {
+    owner = "georgeweigt";
+    repo = pname;
+    rev = "633d5b0b2f2b87b6377bc4f715604f79b17aab66";
+    hash = "sha256-5LOSyfeGavWesAR7jqd37Z845iyNstr/cJdQiWHlIPg=";
+  };
+
+  patches = [
+    # treewide: use $(CC) instead of hardcoding gcc
+    # https://github.com/georgeweigt/eigenmath/pull/18
+    (fetchpatch {
+      url = "https://github.com/georgeweigt/eigenmath/commit/70551b3624ea25911f6de608c9ee9833885ab0b8.patch";
+      hash = "sha256-g2crXOlC5SM1vAq87Vg/2zWMvx9DPFWEPaTrrPbcDZ0=";
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 eigenmath "$out/bin/eigenmath"
+    runHook postInstall
+  '';
+
+  meta = with lib;{
+    description = "Computer algebra system written in C";
+    homepage = "https://georgeweigt.github.io";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ nickcao ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19673,6 +19673,8 @@ with pkgs;
 
   eigen2 = callPackage ../development/libraries/eigen/2.0.nix {};
 
+  eigenmath = callPackage ../applications/science/math/eigenmath { };
+
   vapoursynth = callPackage ../development/libraries/vapoursynth {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] riscv64-linux (cross)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
