### PR TITLE
ttop: init at 0.8.6

### DIFF
--- a/pkgs/development/nim-packages/asciigraph/default.nix
+++ b/pkgs/development/nim-packages/asciigraph/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildNimPackage, fetchFromGitHub }:
+
+buildNimPackage rec {
+  pname = "asciigraph";
+  version = "unstable-2021-03-02";
+
+  src = fetchFromGitHub {
+    owner = "Yardanico";
+    repo = "asciigraph";
+    rev = "9f51fc4e94d0960ab63fa6ea274518159720aa69";
+    hash = "sha256-JMBAW8hkE2wuXkRt4aHqFPoz1HX1J4SslvcaQXfpDNk";
+  };
+
+  doCheck = true;
+
+  meta = with lib;
+    src.meta // {
+      description = "Console ascii line graphs in pure Nim";
+      license = [ licenses.mit ];
+      maintainers = with maintainers; [ sikmir ];
+    };
+}

--- a/pkgs/development/nim-packages/illwill/default.nix
+++ b/pkgs/development/nim-packages/illwill/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildNimPackage, fetchFromGitHub }:
+
+buildNimPackage rec {
+  pname = "illwill";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "johnnovak";
+    repo = "illwill";
+    rev = "v${version}";
+    hash = "sha256-9YBkad5iUKRb375caAuoYkfp5G6KQDhX/yXQ7vLu/CA=";
+  };
+
+  meta = with lib;
+    src.meta // {
+      description = "A curses inspired simple cross-platform console library for Nim";
+      license = [ licenses.wtfpl ];
+      maintainers = with maintainers; [ sikmir ];
+    };
+}

--- a/pkgs/development/nim-packages/parsetoml/default.nix
+++ b/pkgs/development/nim-packages/parsetoml/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildNimPackage, fetchFromGitHub }:
+
+buildNimPackage rec {
+  pname = "parsetoml";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "NimParsers";
+    repo = "parsetoml";
+    rev = "v${version}";
+    hash = "sha256-jtqn59x2ZRRgrPir6u/frsDHnl4kvTJWpbejxti8aHY=";
+  };
+
+  doCheck = true;
+
+  meta = with lib;
+    src.meta // {
+      description = "A Nim library to parse TOML files";
+      license = [ licenses.mit ];
+      maintainers = with maintainers; [ sikmir ];
+    };
+}

--- a/pkgs/tools/system/ttop/default.nix
+++ b/pkgs/tools/system/ttop/default.nix
@@ -1,0 +1,24 @@
+{ lib, nimPackages, fetchFromGitHub }:
+
+nimPackages.buildNimPackage rec {
+  pname = "ttop";
+  version = "0.8.6";
+  nimBinOnly = true;
+
+  src = fetchFromGitHub {
+    owner = "inv2004";
+    repo = "ttop";
+    rev = "v${version}";
+    hash = "sha256-2TuDaStWRsO02l8WhYLWX7vqsC0ne2adxrzqrFF9BfQ=";
+  };
+
+  buildInputs = with nimPackages; [ asciigraph illwill parsetoml zippy ];
+
+  meta = with lib;
+    src.meta // {
+      description = "Top-like system monitoring tool";
+      license = licenses.mit;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ sikmir ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12900,6 +12900,8 @@ with pkgs;
   };
   ttfautohint-nox = ttfautohint.override { enableGUI = false; };
 
+  ttop = callPackage ../tools/system/ttop { };
+
   tty-clock = callPackage ../tools/misc/tty-clock { };
 
   tty-share = callPackage ../applications/misc/tty-share { };

--- a/pkgs/top-level/nim-packages.nix
+++ b/pkgs/top-level/nim-packages.nix
@@ -39,6 +39,8 @@ lib.makeScope newScope (self:
 
     hts-nim = callPackage ../development/nim-packages/hts-nim { };
 
+    illwill = callPackage ../development/nim-packages/illwill { };
+
     jester = callPackage ../development/nim-packages/jester { };
 
     jsonschema = callPackage ../development/nim-packages/jsonschema { };

--- a/pkgs/top-level/nim-packages.nix
+++ b/pkgs/top-level/nim-packages.nix
@@ -11,6 +11,8 @@ lib.makeScope newScope (self:
       };
     fetchNimble = callPackage ../development/nim-packages/fetch-nimble { };
 
+    asciigraph = callPackage ../development/nim-packages/asciigraph { };
+
     astpatternmatching =
       callPackage ../development/nim-packages/astpatternmatching { };
 

--- a/pkgs/top-level/nim-packages.nix
+++ b/pkgs/top-level/nim-packages.nix
@@ -69,6 +69,8 @@ lib.makeScope newScope (self:
 
     packedjson = callPackage ../development/nim-packages/packedjson { };
 
+    parsetoml = callPackage ../development/nim-packages/parsetoml { };
+
     pixie = callPackage ../development/nim-packages/pixie { };
 
     redis = callPackage ../development/nim-packages/redis { };


### PR DESCRIPTION
###### Description of changes
[ttop](https://github.com/inv2004/ttop) - top-like system monitoring tool with TUI, historical data service and triggers.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
