### PR TITLE
udict: init at 0.1.2

### DIFF
--- a/pkgs/applications/misc/udict/0001-update-version-in-lock-file.patch
+++ b/pkgs/applications/misc/udict/0001-update-version-in-lock-file.patch
@@ -1,0 +1,25 @@
+From 4952ceece60ff2e7eabec45411b8824da6673bff Mon Sep 17 00:00:00 2001
+From: m <m@linuxistsuper.de>
+Date: Sun, 5 Mar 2023 11:25:40 +0100
+Subject: [PATCH] update version in lock file
+
+---
+ Cargo.lock | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index d571155..ca28bef 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1554,7 +1554,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+ 
+ [[package]]
+ name = "udict"
+-version = "0.1.1"
++version = "0.1.2"
+ dependencies = [
+  "reqwest",
+  "scraper",
+-- 
+2.38.4
+

--- a/pkgs/applications/misc/udict/default.nix
+++ b/pkgs/applications/misc/udict/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, openssl
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "udict";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "lsmb";
+    repo = "udict";
+    rev = "v${version}";
+    hash = "sha256-vcyzMw2tWil4MULEkf25S6kXzqMG6JXIx6GibxxspkY=";
+  };
+
+  cargoHash = "sha256-WI+dz7FKa3kot3gWr/JK/v6Ua/u2ioZ04Jwk8t9r1ls=";
+
+  cargoPatches = [
+    ./0001-update-version-in-lock-file.patch
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.CoreFoundation
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  meta = with lib; {
+    description = "Urban Dictionary CLI - written in Rust";
+    homepage = "https://github.com/lsmb/udict";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39436,4 +39436,6 @@ with pkgs;
   gnss-share = callPackage ../servers/gnss-share { };
 
   ali = callPackage ../tools/networking/ali { };
+
+  udict = callPackage ../applications/misc/udict { };
 }


### PR DESCRIPTION
###### Description of changes

udict is a small cli tool to look up entries from https://www.urbandictionary.com/  
https://github.com/lsmb/udict

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md). (I hope)

