### PR TITLE
pantheon.elementary-files: 6.2.2 -> 6.3.0 + nixosTests.pantheon: ensure the password box is focused when login

### DIFF
--- a/nixos/tests/pantheon.nix
+++ b/nixos/tests/pantheon.nix
@@ -15,6 +15,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...} :
     services.xserver.enable = true;
     services.xserver.desktopManager.pantheon.enable = true;
 
+    environment.systemPackages = [ pkgs.xdotool ];
   };
 
   enableOCR = true;
@@ -29,6 +30,10 @@ import ./make-test-python.nix ({ pkgs, lib, ...} :
         machine.wait_for_text("${user.description}")
         # OCR was struggling with this one.
         # machine.wait_for_text("${bob.description}")
+        # Ensure the password box is focused by clicking it.
+        # Workaround for https://github.com/NixOS/nixpkgs/issues/211366.
+        machine.succeed("XAUTHORITY=/var/lib/lightdm/.Xauthority DISPLAY=:0 xdotool mousemove 512 505 click 1")
+        machine.sleep(2)
         machine.screenshot("elementary_greeter_lightdm")
 
     with subtest("Login with elementary-greeter"):

--- a/pkgs/desktops/pantheon/apps/elementary-files/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-files/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -28,7 +29,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-files";
-  version = "6.2.2";
+  version = "6.3.0";
 
   outputs = [ "out" "dev" ];
 
@@ -36,8 +37,17 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = "files";
     rev = version;
-    sha256 = "sha256-YV7fcRaLaDwa0m6zbdhayCAqeON5nqEdQ1IUtDKu5AY=";
+    sha256 = "sha256-DS39jCeN+FFiEqJqxa5F2XRKF7SJsm2qi5KKb79guKo=";
   };
+
+  patches = [
+    # Avoid crash due to ref counting issues in Directory cache
+    # https://github.com/elementary/files/pull/2149
+    (fetchpatch {
+      url = "https://github.com/elementary/files/commit/6a0d16e819dea2d0cd2d622414257da9433afe2f.patch";
+      sha256 = "sha256-ijuSMZzVbSwWMWsK24A/24NfxjxgK/BU2qZlq6xLBEU=";
+    })
+  ];
 
   nativeBuildInputs = [
     desktop-file-utils


### PR DESCRIPTION
###### Description of changes

~~Draft because I want to pick up~~ Picked [elementary/files#2149](//github.com/elementary/files/pull/2149).

- [<code>Fix click above and below text in listview (#2121)</code>](https://github.com/elementary/files/commit/29d28c30e92c02717d80bca142cdbb1a4722e0be)
- [<code>Add AppMenu button to headerbar (#2132)</code>](https://github.com/elementary/files/commit/917aa874875938e9400ebe8ae5dbd9c8aae36e66)
- [<code>Update io.elementary.files.appdata.xml.in.in</code>](https://github.com/elementary/files/commit/4e5ea69e58c48f2f0651ec9a1efc42d2c496ae1f)
- [<code>Update Undo/Redo button tooltips with operation type (#2137)</code>](https://github.com/elementary/files/commit/e721ffefeff3c1befec008d766fe6652c52bef52)
- [<code>HeaderBar: Remove defunct translator comments (#2139)</code>](https://github.com/elementary/files/commit/a844e311afb9c9af28f9d877ee298713ea466186)
- [<code>Fix case sensitivity when providing completions for paths (#2059)</code>](https://github.com/elementary/files/commit/9ec58ab57227832223b95e0cceaa5df51f2524ca)
- [<code>Rewrite overwrite prompt for link case (#2050)</code>](https://github.com/elementary/files/commit/a10e4e8bf8a6da638d91bbb643e7b8b4bf1d2f6e)
- [<code>Fix browsing mtp/ptp devices with a colon in the device name (#1977)</code>](https://github.com/elementary/files/commit/6e8ea6e56a187ecaaeccda9bd3619294e4df9e15)
- [<code>Focus FileChooser name entry when saving (#2125)</code>](https://github.com/elementary/files/commit/a1b9a28fe8c658f2ffb2994fcbdc8175796df04b)
- [<code>Update appdata 6.3.0 (#2147)</code>](https://github.com/elementary/files/commit/7281dbac328f1f651312cd4033a7b9520caf4431)
  - <sub>Keywords: <code>dependency</code></sub>
- [<code>Release 6.3.0 (#2140)</code>](https://github.com/elementary/files/commit/aa42466c9ee69bd874e2fca81ba9b89ef9baa104)
  - <sub>Tags: <code>6.3.0</code></sub>
  - <sub>Files: <code>meson.build</code></sub>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
