### PR TITLE
tesseract: fix missing utilities

### DIFF
--- a/pkgs/applications/graphics/tesseract/tesseract5.nix
+++ b/pkgs/applications/graphics/tesseract/tesseract5.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, autoconf-archive, pkg-config
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
 , leptonica, libpng, libtiff, icu, pango, opencl-headers, fetchpatch
 , Accelerate, CoreGraphics, CoreVideo
 }:
@@ -18,8 +18,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
-    autoreconfHook
-    autoconf-archive
+    cmake
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=1"
   ];
 
   buildInputs = [

--- a/pkgs/applications/graphics/tesseract/wrapper.nix
+++ b/pkgs/applications/graphics/tesseract/wrapper.nix
@@ -21,6 +21,8 @@ let
     buildCommand = ''
       makeWrapper {$tesseractBase,$out}/bin/tesseract --set-default TESSDATA_PREFIX $out/share/tessdata
 
+      cp -n $tesseractBase/bin/* $out/bin/
+
       # Recursively link include, share
       cp -rs --no-preserve=mode $tesseractBase/{include,share} $out
 


### PR DESCRIPTION
###### Description of changes

[The official packages of tesseract contain many utilities](https://notesalexp.org/tesseract-ocr/packages-dev/en/ubuntu/jammy/amd64/tesseract-ocr/filelist.html) while the package in nixpkgs contains only a single binary `tesseract`.

![image](https://user-images.githubusercontent.com/16915589/222961494-0c0d5683-4d93-497c-b6b4-0965027db877.png)
![image](https://user-images.githubusercontent.com/16915589/222961121-1398548e-2f12-4b92-a67b-290db6a54140.png)


* These utilities are enabled by default in [CMakeList.txt](https://github.com/tesseract-ocr/tesseract/blob/066fc2e11c889d87ae4833e97670454c3006ae6f/CMakeLists.txt#L92), so I changed the build tool from `autoconf` to `cmake`.
* The tesseract wrapper only exposes a single binary, so I added one more line to copy other binaries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
