### PR TITLE
pgadmin: fix python dependencies, uvloop: skip test

### DIFF
--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -66,14 +66,14 @@ buildPythonPackage rec {
     # Tries to run "env", but fails to find it
     "--deselect=tests/test_process.py::Test_UV_Process::test_process_env_2"
     "--deselect=tests/test_process.py::Test_AIO_Process::test_process_env_2"
+    # AssertionError: b'' != b'out\n'
+    "--deselect=tests/test_process.py::Test_UV_Process::test_process_streams_redirect"
+    "--deselect=tests/test_process.py::Test_AIO_Process::test_process_streams_redirect"
   ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
     # Broken: https://github.com/NixOS/nixpkgs/issues/160904
     "--deselect=tests/test_context.py::Test_UV_Context::test_create_ssl_server_manual_connection_lost"
     # Segmentation fault
     "--deselect=tests/test_fs_event.py::Test_UV_FS_EVENT_RENAME::test_fs_event_rename"
-    # AssertionError: b'' != b'out\n'
-    "--deselect=tests/test_process.py::Test_UV_Process::test_process_streams_redirect"
-    "--deselect=tests/test_process.py::Test_AIO_Process::test_process_streams_redirect"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
###### Description of changes

**python3Packages.uvloop**
the skipped test for darwin also fails on linux, so skip it there, too.

**pgadmin4**
due to upstreams fix on old versions of flask and flask-security-too, we'll need to pin other older versions, too.
Also fix extra_require bug with requirements.txt

targeted at staging-next, since the python upgrades are merged there #219444 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
