### PR TITLE
karton: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13295,6 +13295,7 @@
   schrottkatze = {
     email = "contact-nixpkgs@schrottkatze.de";
     github = "obsidianical";
+    githubId = 68819302;
     matrix = "@obsidianical:matrix.org";
     name = "Schrottkatze";
   };

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13292,6 +13292,12 @@
     githubId = 5104601;
     name = "schnusch";
   };
+  schrottkatze = {
+    email = "contact-nixpkgs@schrottkatze.de";
+    github = "obsidianical";
+    matrix = "@obsidianical:matrix.org";
+    name = "Schrottkatze";
+  };
   sciencentistguy = {
     email = "jamie@quigley.xyz";
     name = "Jamie Quigley";

--- a/pkgs/servers/karton/default.nix
+++ b/pkgs/servers/karton/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "sha256-MzRpLGHDtF1PumS0L1H26EH257PZnTPNw/8Fip3FTn4=";
 
   meta = with lib; {
-    description = "A lightweight pastebin application written in rust. Forked from MicroBin.";
+    description = "A lightweight pastebin application written in rust and a fork from microbin";
     homepage = "https://gitlab.com/obsidianical/microbin";
     license = licenses.bsd3;
     maintainers = with maintainers; [ schrottkatze ];

--- a/pkgs/servers/karton/default.nix
+++ b/pkgs/servers/karton/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, rustPlatform
+, fetchCrate
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "karton";
+  version = "2.0.0";
+
+  # GitHub sources do not have Cargo.lock
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-dBMRgIu1uMe+YNuKO21hziKKoWSF2ha/2pDedrX67W8=";
+  };
+
+  cargoSha256 = "sha256-MzRpLGHDtF1PumS0L1H26EH257PZnTPNw/8Fip3FTn4=";
+
+  meta = with lib; {
+    description = "A lightweight pastebin application written in rust. Forked from MicroBin.";
+    homepage = "https://gitlab.com/obsidianical/microbin";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ schrottkatze ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24788,6 +24788,8 @@ with pkgs;
 
   kapowbang = callPackage ../servers/kapowbang { };
 
+  karton = callPackage ../servers/karton { };
+
   keycloak = callPackage ../servers/keycloak { };
 
   knot-dns = callPackage ../servers/dns/knot-dns { };


### PR DESCRIPTION
###### Description of changes

Karton is my fork of MicroBin. [Here is a link to the gitlab repository.](https://gitlab.com/obsidianical/microbin)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

_Note: The second commit should've been an amendment to the first, but because I noticed my mistake just after pushing, apparently I'm unable to easily revert that now._

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md). 


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
