### PR TITLE
zap: Fix configuration persistence

### DIFF
--- a/pkgs/tools/networking/zap/default.nix
+++ b/pkgs/tools/networking/zap/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     #!${runtimeShell}
     export PATH="${lib.makeBinPath [ jre ]}:\$PATH"
     export JAVA_HOME='${jre}'
-    if ! [ -f "~/.ZAP/config.xml" ];then
+    if ! [ -f "\$HOME/.ZAP/config.xml" ];then
       mkdir -p "\$HOME/.ZAP"
       head -n 2 $out/share/${pname}/xml/config.xml > "\$HOME/.ZAP/config.xml"
       echo "<version>${version_tag}</version>" >> "\$HOME/.ZAP/config.xml"
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://www.owasp.org/index.php/ZAP";
     description = "Java application for web penetration testing";
-    maintainers = with maintainers; [ mog ];
+    maintainers = with maintainers; [ mog rafael ];
     platforms = platforms.linux;
     license = licenses.asl20;
   };


### PR DESCRIPTION
Fixed the reference for the home direction on ZAP initialization script. Closes #219737.

###### Description of changes

Fixed the reference for the `$HOME` directory.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
