### PR TITLE
lib/trivial: add `on`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -67,7 +67,7 @@ let
       hasAttr head isAttrs isBool isInt isList isPath isString length
       lessThan listToAttrs pathExists readFile replaceStrings seq
       stringLength sub substring tail trace;
-    inherit (self.trivial) id const pipe concat or and bitAnd bitOr bitXor
+    inherit (self.trivial) id const on pipe concat or and bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
       info showWarnings nixpkgsVersion version isInOldestRelease

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -34,6 +34,11 @@ runTests {
     expected = 2;
   };
 
+  testOn = {
+    expr = on (x: y: x + y) toString 4 2;
+    expected = "42";
+  };
+
   testPipe = {
     expr = pipe 2 [
       (x: x + 2) # 2 + 2 = 4

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -29,6 +29,21 @@ rec {
     # Value to ignore
     y: x;
 
+  /* Apply a binary function to the results of applying a unary function to two arguments
+
+     Type: on :: (b -> b -> c) -> (a -> b) -> a -> a -> c
+     Example:
+       on (x: y: x + y) toString 4 2
+       => "42"
+  */
+  on =
+    # The binary function
+    f:
+    # The unary function
+    g:
+      # The two arguments
+      x: y: f (g x) (g y);
+
   /* Pipes a value through a list of functions, left to right.
 
      Type: pipe :: a -> [<functions>] -> <return type of last function>

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -56,9 +56,9 @@ let
         declarations =
           map
             (decl:
-              if hasPrefix (toString ../../..) (toString decl)
+              if lib.on hasPrefix toString ../../.. decl
               then
-                let subpath = removePrefix "/" (removePrefix (toString ../../..) (toString decl));
+                let subpath = removePrefix "/" (lib.on removePrefix toString ../../.. decl);
                 in { url = "https://github.com/NixOS/nixpkgs/blob/master/${subpath}"; name = subpath; }
               else decl)
             opt.declarations;


### PR DESCRIPTION
###### Description of changes

Inspired by `on` from haskell: https://hackage.haskell.org/package/base-4.18.0.0/docs/Data-Function.html#v:on

`on` applies a binary function to the results of applying a unary function to two arguments

Type: `on` :: `(b -> b -> c) -> (a -> b) -> a -> a -> c`

Example:
```
  on (x: y: x + y) toString 4 2
  => "42"
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
