### PR TITLE
wine{Unstable,Staging}: 8.1 -> 8.3

### DIFF
--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, pkgArches, callPackage, makeSetupHook,
   pname, version, src, mingwGccs, monos, geckos, platforms,
   bison, flex, fontforge, makeWrapper, pkg-config,
-  autoconf, hexdump, perl, nixosTests,
+  nixosTests,
   supportFlags,
   patches,
   moltenvk,
@@ -54,11 +54,6 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
     fontforge
     makeWrapper
     pkg-config
-
-    # Required by staging
-    autoconf
-    hexdump
-    perl
   ]
   ++ lib.optionals supportFlags.mingwSupport (mingwGccs
     ++ lib.optional stdenv.isDarwin setupHookDarwin);

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -73,9 +73,9 @@ in rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the hash for staging as well.
-    version = "8.1";
+    version = "8.3";
     url = "https://dl.winehq.org/wine/source/8.x/wine-${version}.tar.xz";
-    hash = "sha256-QSDuaz8pTZeq8scwNM8cLL8ToZXJTFx0pkaoH5JBJZg=";
+    hash = "sha256-QQJpAAKSw7+t0lYf3eBtm8sryVi0mwPpY/FBd6J2MfA=";
     inherit (stable) gecko32 gecko64 patches;
 
     mono = fetchurl rec {
@@ -105,7 +105,7 @@ in rec {
   staging = fetchFromGitHub rec {
     # https://github.com/wine-staging/wine-staging/releases
     inherit (unstable) version;
-    hash = "sha256-5AzXXaRGyvfYxd3yXtAlZREv1wp6UqWdDRdnwmKVaUg=";
+    hash = "sha256-b49WFyiEbkJFUp1n9rz+A1c6iseSfV+5DrpA6AwKa+4=";
     owner = "wine-staging";
     repo = "wine-staging";
     rev = "v${version}";
@@ -113,7 +113,7 @@ in rec {
     disabledPatchsets = [ ];
   };
 
-  wayland = fetchFromGitLab rec {
+  wayland = fetchFromGitLab {
     # https://gitlab.collabora.com/alf/wine/-/tree/wayland
     version = "8.0";
     hash = "sha256-whRnm21UyKZ4AQufNmctzivISVobnCeidmpYz65vlyk=";

--- a/pkgs/applications/emulators/wine/staging.nix
+++ b/pkgs/applications/emulators/wine/staging.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, wineUnstable }:
+{ lib, callPackage, autoconf, hexdump, perl, python3, wineUnstable }:
 
 with callPackage ./util.nix {};
 
@@ -9,17 +9,16 @@ in assert lib.getVersion wineUnstable == patch.version;
 
 (lib.overrideDerivation wineUnstable (self: {
   buildInputs = build-inputs [ "perl" "util-linux" "autoconf" "gitMinimal" ] self.buildInputs;
+  nativeBuildInputs = [ autoconf hexdump perl python3 ] ++ self.nativeBuildInputs;
 
   name = "${self.name}-staging";
 
   prePatch = self.prePatch or "" + ''
     patchShebangs tools
-    cp -r ${patch}/patches .
+    cp -r ${patch}/patches ${patch}/staging .
     chmod +w patches
-    cd patches
-    patchShebangs gitapply.sh
-    ./patchinstall.sh DESTDIR="$PWD/.." --all ${lib.concatMapStringsSep " " (ps: "-W ${ps}") patch.disabledPatchsets}
-    cd ..
+    patchShebangs ./patches/gitapply.sh
+    python3 ./staging/patchinstall.py DESTDIR="$PWD" --all ${lib.concatMapStringsSep " " (ps: "-W ${ps}") patch.disabledPatchsets}
   '';
 })) // {
   meta = wineUnstable.meta // {


### PR DESCRIPTION
###### Description of changes
https://www.winehq.org/announce/8.2
https://www.winehq.org/announce/8.3

Briefly tested `winePackages.unstableFull`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
