### PR TITLE
ospd-openvas: init at 22.4.6 

### DIFF
--- a/pkgs/development/python-modules/ospd/default.nix
+++ b/pkgs/development/python-modules/ospd/default.nix
@@ -21,8 +21,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "greenbone";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-dZgs+G2vJQIKnN9xHcNeNViG7mOIdKb+Ms2AKE+FC4M=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-dZgs+G2vJQIKnN9xHcNeNViG7mOIdKb+Ms2AKE+FC4M=";
   };
 
   propagatedBuildInputs = [
@@ -44,6 +44,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Framework for vulnerability scanners which support OSP";
     homepage = "https://github.com/greenbone/ospd";
+    changelog = "https://github.com/greenbone/ospd/releases/tag/v${version}";
     license = with licenses; [ agpl3Plus ];
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/tools/security/ospd-openvas/default.nix
+++ b/pkgs/tools/security/ospd-openvas/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "ospd-openvas";
+  version = "22.4.6";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "greenbone";
+    repo = "ospd-openvas";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-tgLOO4L/P6USiPf72uZse36r8HhXJnUUT8PfZH4E/jg=";
+  };
+
+  pythonRelaxDeps = [
+    "packaging"
+    "python-gnupg"
+  ];
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    defusedxml
+    deprecated
+    lxml
+    packaging
+    paho-mqtt
+    psutil
+    python-gnupg
+    redis
+    sentry-sdk
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "ospd_openvas"
+  ];
+
+  meta = with lib; {
+    description = "OSP server implementation to allow GVM to remotely control an OpenVAS Scanner";
+    homepage = "https://github.com/greenbone/ospd-openvas";
+    changelog = "https://github.com/greenbone/ospd-openvas/blob/${version}/CHANGELOG.md";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5405,6 +5405,8 @@ with pkgs;
 
   ossutil = callPackage ../tools/admin/ossutil {};
 
+  ospd-openvas = callPackage ../tools/security/ospd-openvas {};
+
   osv-detector = callPackage ../tools/security/osv-detector {};
 
   osv-scanner = callPackage ../tools/security/osv-scanner {};


### PR DESCRIPTION
###### Description of changes
OSP server implementation to allow GVM to remotely control an OpenVAS Scanner

https://github.com/greenbone/ospd-openvas

Related to 81418

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
