### PR TITLE
hue-plus: init at 1.4.5

### DIFF
--- a/pkgs/applications/misc/hue-plus/default.nix
+++ b/pkgs/applications/misc/hue-plus/default.nix
@@ -1,0 +1,42 @@
+{ python3Packages
+, fetchFromGitHub
+, lib
+, wrapQtAppsHook
+, qtbase }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "hue-plus";
+  version = "1.4.5";
+
+  src = fetchFromGitHub {
+    owner = "kusti8";
+    repo = pname;
+    rev = "7ce7c4603c6d0ab1da29b0d4080aa05f57bd1760";
+    sha256 = "sha256-dDIJXhB3rmKnawOYJHE7WK38b0M5722zA+yLgpEjDyI=";
+  };
+
+  buildInputs = [ qtbase ];
+
+  nativeBuildInputs = [ wrapQtAppsHook ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pyserial pyqt5 pyaudio appdirs setuptools
+  ];
+
+  doCheck = false;
+  dontWrapQtApps = true;
+
+  makeWrapperArgs = [
+    "\${qtWrapperArgs[@]}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/kusti8/hue-plus";
+    description = "A Windows and Linux driver in Python for the NZXT Hue+";
+    longDescription = ''
+      A cross-platform driver in Python for the NZXT Hue+. Supports all functionality except FPS, CPU, and GPU lighting.
+    '';
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ garaiza-93 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8397,6 +8397,8 @@ with pkgs;
 
   httpx = callPackage ../tools/security/httpx { };
 
+  hue-plus = libsForQt5.callPackage ../applications/misc/hue-plus { };
+
   hurl = callPackage ../tools/networking/hurl { };
 
   hubicfuse = callPackage ../tools/filesystems/hubicfuse { };


### PR DESCRIPTION
###### Description of changes
https://github.com/kusti8/hue-plus

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
