### PR TITLE
funlisp: init at 1.2.0

### DIFF
--- a/pkgs/development/interpreters/funlisp/default.nix
+++ b/pkgs/development/interpreters/funlisp/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv
+, fetchurl
+, libedit
+}:
+
+stdenv.mkDerivation rec {
+  name = "funlisp";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/brenns10/funlisp/releases/download/v${version}/funlisp-${version}.tar.gz";
+    hash = "sha256-sO9XbGUZOCVfY0IsJLieLspPs+pVruveFNOxYNQJmf0=";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ libedit ];
+
+  installPhase = ''
+     # Install library
+     make PREFIX=$out install
+
+     # Default install only includes the library and manpage, so install
+     # useful repl binary manually.
+     install -d $out/bin
+     install bin/funlisp $out/bin
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    # Simple smoke test
+    test $(bin/funlisp <(echo "(print (* 2 21))")) -eq 42
+  '';
+
+  meta = with lib; {
+    description = "Simple, embeddable lisp interpreter";
+    homepage = "https://github.com/brenns10/funlisp";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16500,6 +16500,8 @@ with pkgs;
 
   inherit (beam.packages.erlangR21) lfe lfe_1_3;
 
+  funlisp = callPackage ../development/interpreters/funlisp { };
+
   gnudatalanguage = callPackage ../development/interpreters/gnudatalanguage {
     inherit (llvmPackages) openmp;
     inherit (darwin.apple_sdk.frameworks) Cocoa;


### PR DESCRIPTION
###### Description of changes

Add `funlisp`, a neat embeddable lisp interpreter.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - Ran `checkPhase`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
   - also added a simple smoke test in `checkPhase` to confirm.
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).