### PR TITLE
wine: fix build failure on Darwin

### DIFF
--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -108,9 +108,13 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
   ])));
 
   patches = [ ]
-    # Wine requires `MTLDevice.registryID` for `winemac.drv`, but that property is not available
-    # in the 10.12 SDK (current SDK on x86_64-darwin). Work around that by using selector syntax.
-    ++ lib.optional stdenv.isDarwin ./darwin-metal-compat.patch
+    ++ lib.optionals stdenv.isDarwin [
+      # Wine requires `MTLDevice.registryID` for `winemac.drv`, but that property is not available
+      # in the 10.12 SDK (current SDK on x86_64-darwin). Work around that by using selector syntax.
+      ./darwin-metal-compat.patch
+      # Wine requires `qos.h`, which is not included by default on the 10.12 SDK in nixpkgs.
+      ./darwin-qos.patch
+    ]
     ++ patches';
 
   configureFlags = prevConfigFlags

--- a/pkgs/applications/emulators/wine/darwin-qos.patch
+++ b/pkgs/applications/emulators/wine/darwin-qos.patch
@@ -1,0 +1,12 @@
+diff --git a/dlls/ntdll/unix/loader.c b/dlls/ntdll/unix/loader.c
+index cde37c48b0d..be237bc0ad3 100644
+--- a/dlls/ntdll/unix/loader.c
++++ b/dlls/ntdll/unix/loader.c
+@@ -65,6 +65,7 @@
+ # undef LoadResource
+ # undef GetCurrentThread
+ # include <pthread.h>
++# include <pthread/qos.h>
+ # include <mach/mach.h>
+ # include <mach/mach_error.h>
+ # include <mach-o/getsect.h>


### PR DESCRIPTION
###### Description of changes

It appears a change between Wine 7.20 and 8.0 upstream causes the build to fail the 10.12 SDK in nixpkgs, which requires `pthread/qos.h` to be included explicitly (while Apple’s does not). This patch fixes the failure and allows Wine 8.x to build on Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
