### PR TITLE
colima: patch `sw_vers` on darwin

### DIFF
--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -32,7 +32,8 @@ buildGoModule rec {
     '';
   };
 
-  nativeBuildInputs = [ installShellFiles makeWrapper ];
+  nativeBuildInputs = [ installShellFiles makeWrapper ]
+    ++ lib.optionals stdenv.isDarwin [ darwin.DarwinTools ];
 
   vendorSha256 = "sha256-Iz1LYL25NpkztTM86zrLwehub8FzO1IlwZqCPW7wDN4=";
 
@@ -41,11 +42,6 @@ buildGoModule rec {
   preConfigure = ''
     ldflags="-s -w -X github.com/abiosoft/colima/config.appVersion=${version} \
     -X github.com/abiosoft/colima/config.revision=$(cat .git-revision)"
-  '';
-
-  postPatch = lib.optionalString stdenv.isDarwin ''
-    substituteInPlace util/util.go \
-      --replace 'sw_vers' "${darwin.DarwinTools}/bin/sw_vers"
   '';
 
   postInstall = ''

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -43,8 +43,6 @@ buildGoModule rec {
     -X github.com/abiosoft/colima/config.revision=$(cat .git-revision)"
   '';
 
-  subPackages = [ "cmd/colima" ];
-
   postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace util/util.go \
       --replace 'sw_vers' "${darwin.DarwinTools}/bin/sw_vers"

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, darwin
 , buildGoModule
 , fetchFromGitHub
 , installShellFiles
@@ -43,6 +44,11 @@ buildGoModule rec {
   '';
 
   subPackages = [ "cmd/colima" ];
+
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace util/util.go \
+      --replace 'sw_vers' "${darwin.DarwinTools}/bin/sw_vers"
+  '';
 
   postInstall = ''
     wrapProgram $out/bin/colima \


### PR DESCRIPTION
###### Description of changes

- Colima uses `sw_vers` [in util/util.go](https://github.com/abiosoft/colima/blob/feef4176f56a7dea487d43689317a9d7fe9de27e/util/util.go#L141)  to determine the MacOS version and conditionally adds [default start start arguments](https://github.com/abiosoft/colima/blob/feef4176f56a7dea487d43689317a9d7fe9de27e/cmd/start.go#L153). This is also used to check for the new rosetta emulation which is only available on macOS >= 13. We therefore better ~~replace `sw_vers` with the binary from `${darwin.DarwinTools}/bin/sw_vers`~~ add `${darwin.DarwinTools}` to `nativeBuildInputs` so that this logic does not break.
- Build and test all packages instead of only `cmd/colima`. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
