### PR TITLE
gcc: do not install sys-include headers for cross-compilers.

### DIFF
--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -250,6 +250,17 @@ postInstall() {
         done
     fi
 
+    # Cross-compiler specific:
+    # --with-headers=$dir option triggers gcc to make a private copy
+    # of $dir headers and use it later as `-isysroot`. This prevents
+    # cc-wrapper from overriding libc headers with `-idirafter`.
+    # It should be safe to drop it and rely solely on the cc-wrapper.
+    local sysinc_dir=$out/${targetConfig+$targetConfig/}sys-include
+    if [ -d "$sysinc_dir" ]; then
+        chmod -R u+w "$out/${targetConfig+$targetConfig/}sys-include"
+        rm -rfv "$out/${targetConfig+$targetConfig/}sys-include"
+    fi
+
     # Get rid of some "fixed" header files
     rm -rfv $out/lib/gcc/*/*/include-fixed/{root,linux}
 


### PR DESCRIPTION
Before the change include headers for cross-compilers like `pkgsStatic` looked like this:

    $ nix build -L --impure --expr 'with import ./. {}; pkgsStatic.stdenv.mkDerivation { name = "probe"; buildCommand = "echo | $CXX -x c++ -E -v - |& fgrep -B10 search; exit 1"; }' |& unnix

    #include "..." search starts here:
    #include <...> search starts here:
     /<<NIX>>/x86_64-unknown-linux-musl-stage-final-gcc-13.0.0/lib/gcc/x86_64-unknown-linux-musl/13.0.1/../../../../x86_64-unknown-linux-musl/include/c++/13.0.1
     /<<NIX>>/x86_64-unknown-linux-musl-stage-final-gcc-13.0.0/lib/gcc/x86_64-unknown-linux-musl/13.0.1/../../../../x86_64-unknown-linux-musl/include/c++/13.0.1/x86_64-unknown-linux-musl
     /<<NIX>>/x86_64-unknown-linux-musl-stage-final-gcc-13.0.0/lib/gcc/x86_64-unknown-linux-musl/13.0.1/../../../../x86_64-unknown-linux-musl/include/c++/13.0.1/backward
     /<<NIX>>/x86_64-unknown-linux-musl-stage-final-gcc-13.0.0/lib/gcc/x86_64-unknown-linux-musl/13.0.1/../../../../x86_64-unknown-linux-musl/sys-include
     /<<NIX>>/x86_64-unknown-linux-musl-stage-final-gcc-13.0.0/lib/gcc/x86_64-unknown-linux-musl/13.0.1/../../../../x86_64-unknown-linux-musl/include
     /<<NIX>>/x86_64-unknown-linux-musl-stage-final-gcc-13.0.0/lib/gcc/x86_64-unknown-linux-musl/13.0.1/include
     /<<NIX>>/musl-static-x86_64-unknown-linux-musl-1.2.3-dev/include
     /<<NIX>>/x86_64-unknown-linux-musl-stage-final-gcc-13.0.0/lib/gcc/x86_64-unknown-linux-musl/13.0.1/include-fixed
    End of search list.

Note that `.../sys-include` inhibits the effect of `musl-static-x86_64-unknown-linux-musl-1.2.3-dev/include`.

After the change the paths look as expected:

    $ nix build -L --impure --expr 'with import ./. {}; pkgsStatic.stdenv.mkDerivation { name = "probe"; buildCommand = "echo | $CXX -x c++ -E -v - |& fgrep -B10 search; exit 1"; }' |& unnix

    #include "..." search starts here:
    #include <...> search starts here:
     /<<NIX>>/x86_64-unknown-linux-musl-stage-final-gcc-13.0.0/lib/gcc/x86_64-unknown-linux-musl/13.0.1/../../../../x86_64-unknown-linux-musl/include/c++/13.0.1
     /<<NIX>>/x86_64-unknown-linux-musl-stage-final-gcc-13.0.0/lib/gcc/x86_64-unknown-linux-musl/13.0.1/../../../../x86_64-unknown-linux-musl/include/c++/13.0.1/x86_64-unknown-linux-musl
     /<<NIX>>/x86_64-unknown-linux-musl-stage-final-gcc-13.0.0/lib/gcc/x86_64-unknown-linux-musl/13.0.1/../../../../x86_64-unknown-linux-musl/include/c++/13.0.1/backward
     /<<NIX>>/x86_64-unknown-linux-musl-stage-final-gcc-13.0.0/lib/gcc/x86_64-unknown-linux-musl/13.0.1/../../../../x86_64-unknown-linux-musl/include
     /<<NIX>>/x86_64-unknown-linux-musl-stage-final-gcc-13.0.0/lib/gcc/x86_64-unknown-linux-musl/13.0.1/include
     /<<NIX>>/musl-static-x86_64-unknown-linux-musl-1.2.3-dev/include
     /<<NIX>>/x86_64-unknown-linux-musl-stage-final-gcc-13.0.0/lib/gcc/x86_64-unknown-linux-musl/13.0.1/include-fixed
    End of search list.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
