### PR TITLE
kube3d: 5.4.4 -> 5.4.8

### DIFF
--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -2,7 +2,7 @@
 , buildGoModule
 , fetchFromGitHub
 , installShellFiles
-, k3sVersion ? null
+, k3sVersion ? "1.25.6-k3s1"
 }:
 
 let
@@ -15,15 +15,20 @@ let
 in
 buildGoModule rec {
   pname = "kube3d";
-  version = "5.4.4";
+  version = "5.4.8";
 
   src = fetchFromGitHub {
     owner = "k3d-io";
     repo = "k3d";
     rev = "v${version}";
-    sha256 = "sha256-3J25Aj/otKDCWJ+YqAsoJogU2vckZMy7fsS8XR2EMgE=";
+    sha256 = "sha256-AweoDdw1ZktRofQZgBfzsvwuA8lVS8SDbctk5HrUAyg=";
   };
-  vendorSha256 = null;
+  # the committed vendor dir is out of sync
+  # https://github.com/k3d-io/k3d/issues/1237
+  deleteVendor = true;
+  vendorSha256 = "sha256-Dwh1VsxRiX5Mrz4FboNTfz+ql0BQIXekk+W5XNrmZsU=";
+  # needs go workspaces to successfully compile due to docker/cli dependency
+  proxyVendor = true;
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -33,7 +38,7 @@ buildGoModule rec {
     let t = "github.com/k3d-io/k3d/v5/version"; in
     [ "-s" "-w" "-X ${t}.Version=v${version}" ] ++ lib.optionals k3sVersionSet [ "-X ${t}.K3sVersion=v${k3sVersion}" ];
 
-   preCheck = ''
+  preCheck = ''
     # skip test that uses networking
     substituteInPlace version/version_test.go \
       --replace "TestGetK3sVersion" "SkipGetK3sVersion"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39266,7 +39266,7 @@ with pkgs;
   dapper = callPackage ../development/tools/dapper { };
 
   kube3d =  callPackage ../applications/networking/cluster/kube3d {
-    buildGoModule = buildGo118Module; # tests fail with 1.19
+    buildGoModule = buildGo120Module;
   };
 
   zfs-prune-snapshots = callPackage ../tools/backup/zfs-prune-snapshots {};


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updated k3d to 5.4.8

Have to jump through some hoops to get k3d to compile
https://github.com/k3d-io/k3d/issues/1237

Added back a k3sVersion since the fallback value is really old


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
