### PR TITLE
binutils: fix MinGW link failures with import libs

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -101,6 +101,9 @@ stdenv.mkDerivation (finalAttrs: {
      (if stdenv.targetPlatform.isMusl
       then substitute { src = ./mips64-default-n64.patch; replacements = [ "--replace" "gnuabi64" "muslabi64" ]; }
       else ./mips64-default-n64.patch)
+  # This patch fixes a bug in 2.40 on MinGW, which breaks DXVK when cross-building from Darwin.
+  # See https://sourceware.org/bugzilla/show_bug.cgi?id=30079
+  ++ lib.optional stdenv.targetPlatform.isMinGW ./mingw-abort-fix.patch
   ;
 
   outputs = [ "out" "info" "man" "dev" ]

--- a/pkgs/development/tools/misc/binutils/mingw-abort-fix.patch
+++ b/pkgs/development/tools/misc/binutils/mingw-abort-fix.patch
@@ -1,0 +1,30 @@
+From b7eab2a9d4f4e92692daf14b09fc95ca11b72e30 Mon Sep 17 00:00:00 2001
+From: Michael Matz <matz@suse.de>
+Date: Thu, 9 Feb 2023 15:29:00 +0100
+Subject: [PATCH 1/1] Fix PR30079: abort on mingw
+
+the early-out in wild_sort is not enough, it might still be
+that filenames are equal _and_ the wildcard list doesn't specify
+a sort order either.  Don't call compare_section then.
+
+Tested on all targets.
+---
+ ld/ldlang.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/ld/ldlang.c b/ld/ldlang.c
+index 84a2914fc26..b5e0d026ae4 100644
+--- a/ld/ldlang.c
++++ b/ld/ldlang.c
+@@ -649,7 +649,8 @@ wild_sort (lang_wild_statement_type *wild,
+ 	 looking at the sections for this file.  */
+ 
+       /* Find the correct node to append this section.  */
+-      if (compare_section (sec->spec.sorted, section, (*tree)->section) < 0)
++      if (sec && sec->spec.sorted != none && sec->spec.sorted != by_none
++	  && compare_section (sec->spec.sorted, section, (*tree)->section) < 0)
+ 	tree = &((*tree)->left);
+       else
+ 	tree = &((*tree)->right);
+-- 
+2.31.1


### PR DESCRIPTION
###### Description of changes

DXVK has been failing to build on Darwin since binutils was bumped to 2.40. It appears this is due to a bug in binutils when linking against a `.lib`. There is a patch upstream, which fixes the problem and allows DXVK to build again.

I’m targeting master instead of staging since this only affects MinGW and shouldn’t cause significant rebuilds on other platforms.

Upstream bug: https://sourceware.org/bugzilla/show_bug.cgi?id=30079

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
