### PR TITLE
pythonPackages.kornia: init at 0.6.10

### DIFF
--- a/pkgs/development/python-modules/kornia/default.nix
+++ b/pkgs/development/python-modules/kornia/default.nix
@@ -1,0 +1,43 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, packaging
+, pytestCheckHook
+, pytorch
+}:
+
+buildPythonPackage rec {
+  pname = "kornia";
+  version = "0.6.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-f/V8kxVRoaFGWqrB+mhCoqrWUPUaD5v2zwsPfW5ftZw=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'pytest-runner'" ""
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  propagatedBuildInputs = [
+    packaging
+    pytorch
+  ];
+
+  # pytest.ini is not published to pypi
+  doCheck = false;
+
+  pythonImportsCheck = ["kornia"];
+
+  meta = with lib; {
+    description = "Differentiable computer vision library for PyTorch";
+    homepage = "https://kornia.readthedocs.io/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rehno-lindeque ];
+  };
+}

--- a/pkgs/development/python-modules/kornia/default.nix
+++ b/pkgs/development/python-modules/kornia/default.nix
@@ -1,18 +1,26 @@
 { buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , lib
+
+# propagated build inputs
 , packaging
-, pytestCheckHook
 , pytorch
+
+# check inputs
+, pytestCheckHook
+, opencv3
+, scipy
 }:
 
 buildPythonPackage rec {
   pname = "kornia";
   version = "0.6.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-f/V8kxVRoaFGWqrB+mhCoqrWUPUaD5v2zwsPfW5ftZw=";
+  src = fetchFromGitHub {
+    owner = "kornia";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-SWSVGwc6jet5p8Pm3Cz1DR70bhnZDMIwJzFAliOgjoA";
   };
 
   postPatch = ''
@@ -22,6 +30,8 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
+    opencv3
+    scipy
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/kornia/default.nix
+++ b/pkgs/development/python-modules/kornia/default.nix
@@ -14,13 +14,13 @@
 
 buildPythonPackage rec {
   pname = "kornia";
-  version = "0.6.7";
+  version = "0.6.10";
 
   src = fetchFromGitHub {
     owner = "kornia";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-SWSVGwc6jet5p8Pm3Cz1DR70bhnZDMIwJzFAliOgjoA";
+    sha256 = "sha256-4TE9GfcRMSpI18IEgAeuKjTroKGknc2dVlmXOdyiKuE";
   };
 
   postPatch = ''
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytorch
   ];
 
-  # pytest.ini is not published to pypi
+  # tests are extremely slow
   doCheck = false;
 
   pythonImportsCheck = ["kornia"];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5252,6 +5252,8 @@ self: super: with self; {
 
   korean-lunar-calendar = callPackage ../development/python-modules/korean-lunar-calendar { };
 
+  kornia = callPackage ../development/python-modules/kornia { };
+
   krakenex = callPackage ../development/python-modules/krakenex { };
 
   kubernetes = callPackage ../development/python-modules/kubernetes { };


### PR DESCRIPTION
###### Description of changes

Kornia is a differentiable library that allows classical computer vision to be integrated into machine learning models (via PyTorch).

Supersedes https://github.com/NixOS/nixpkgs/pull/193229

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
