### PR TITLE
duden: init at 0.18.0

### DIFF
--- a/pkgs/applications/misc/duden/default.nix
+++ b/pkgs/applications/misc/duden/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "duden";
+  version = "0.18.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "radomirbosak";
+    repo = "duden";
+    rev = version;
+    hash = "sha256-ZrarN09Znw4m6YiZxD7q7dTJ49WjmHDobLnOt8JCwvc=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    beautifulsoup4
+    crayons
+    pyxdg
+    pyyaml
+    requests
+    setuptools
+  ];
+
+  pythonImportsCheck = [ "duden" ];
+
+  meta = with lib; {
+    description = "CLI for http://duden.de dictionary written in Python";
+    homepage = "https://github.com/radomirbosak/duden";
+    changelog = "https://github.com/radomirbosak/duden/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39463,4 +39463,6 @@ with pkgs;
   ali = callPackage ../tools/networking/ali { };
 
   udict = callPackage ../applications/misc/udict { };
+
+  duden = callPackage ../applications/misc/duden { };
 }


### PR DESCRIPTION
###### Description of changes

duden is a CLI-based program and python module, which can provide various information about given german word. The provided data are parsed from german dictionary [duden.de](https://duden.de/).  
from https://github.com/radomirbosak/duden

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

