### PR TITLE
python310Packages.evaluate: fix `evaluate-cli` and add as mainProgram

### DIFF
--- a/pkgs/development/python-modules/evaluate/default.nix
+++ b/pkgs/development/python-modules/evaluate/default.nix
@@ -4,6 +4,7 @@
 , pythonOlder
 , pythonRelaxDepsHook
 , pytestCheckHook
+, cookiecutter
 , datasets
 , dill
 , fsspec
@@ -13,6 +14,7 @@
 , numpy
 , packaging
 , pandas
+, pyarrow
 , requests
 , responses
 , tqdm
@@ -37,6 +39,7 @@ buildPythonPackage rec {
   pythonRelaxDeps = [ "responses" ];
 
   propagatedBuildInputs = [
+    cookiecutter
     datasets
     numpy
     dill
@@ -48,6 +51,7 @@ buildPythonPackage rec {
     fsspec
     huggingface-hub
     packaging
+    pyarrow
     responses
   ] ++ lib.optionals (pythonOlder "3.8") [
     importlib-metadata
@@ -66,5 +70,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/huggingface/evaluate/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ bcdarwin ];
+    mainProgram = "evaluate-cli";
   };
 }


### PR DESCRIPTION
###### Description of changes

Add semi-documented (part of `evaluate["template"]`, but required for `evaluate-cli` to run) runtime dependency.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
