### PR TITLE
coreboot-utils: 4.14 -> 4.19

### DIFF
--- a/pkgs/tools/misc/coreboot-utils/default.nix
+++ b/pkgs/tools/misc/coreboot-utils/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchurl, zlib, pciutils, coreutils, acpica-tools, makeWrapper, gnugrep, gnused, file, buildEnv }:
+{ lib, stdenv, fetchurl, pkg-config, zlib, pciutils, openssl, coreutils, acpica-tools, makeWrapper, gnugrep, gnused, file, buildEnv }:
 
 let
-  version = "4.14";
+  version = "4.19";
 
   commonMeta = with lib; {
     description = "Various coreboot-related tools";
@@ -16,7 +16,7 @@ let
 
     src = fetchurl {
       url = "https://coreboot.org/releases/coreboot-${version}.tar.xz";
-      sha256 = "0viw2x4ckjwiylb92w85k06b0g9pmamjy2yqs7fxfqbmfadkf1yr";
+      sha256 = "sha256-Zcyy9GU1uZbgBmobdvgcjPH/PiffhLP5fYrXs+fPCkM=";
     };
 
     enableParallelBuilding = true;
@@ -32,7 +32,7 @@ let
     ];
 
     meta = commonMeta // args.meta;
-  } // (removeAttrs args ["meta"]));
+  } // (removeAttrs args [ "meta" ]));
 
   utils = {
     msrtool = generic {
@@ -84,6 +84,8 @@ let
     amdfwtool = generic {
       pname = "amdfwtool";
       meta.description = "Create AMD firmware combination";
+      buildInputs = [ openssl ];
+      nativeBuildInputs = [ pkg-config ];
       installPhase = ''
         runHook preInstall
 
@@ -105,13 +107,15 @@ let
 
         runHook postInstall
       '';
-      postFixup = let
-        binPath = [ coreutils acpica-tools gnugrep gnused file ];
-      in "wrapProgram $out/bin/acpidump-all --set PATH ${lib.makeBinPath binPath}";
+      postFixup = ''
+        wrapProgram $out/bin/acpidump-all \
+          --set PATH ${lib.makeBinPath [ coreutils acpica-tools gnugrep gnused file ]}
+      '';
     };
   };
 
-in utils // {
+in
+utils // {
   coreboot-utils = (buildEnv {
     name = "coreboot-utils-${version}";
     paths = lib.attrValues utils;


### PR DESCRIPTION
###### Description of changes

Utils changes:
- https://review.coreboot.org/plugins/gitiles/coreboot/+/4d661eebe95b06acae7d99777ed36ba56a560112/Documentation/releases/coreboot-4.19-relnotes.md#additional-coreboot-changes
- https://review.coreboot.org/plugins/gitiles/coreboot/+/4d661eebe95b06acae7d99777ed36ba56a560112/Documentation/releases/coreboot-4.17-relnotes.md#util_cbmem_add-flamegraph_compatible-timestamps-output
- https://review.coreboot.org/plugins/gitiles/coreboot/+/4d661eebe95b06acae7d99777ed36ba56a560112/Documentation/releases/coreboot-4.17-relnotes.md#util_cbmem_add-an-option-to-append-timestamp


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
