### PR TITLE
re-flex: init at 3.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12074,6 +12074,15 @@
     githubId = 4633847;
     name = "Ben Hamlin";
   };
+  prrlvr = {
+    email = "po@prrlvr.fr";
+    github = "prrlvr";
+    githubId = 33699501;
+    name = "Pierre-Olivier Rey";
+    keys = [{
+      fingerprint = "40A0 78FD 297B 0AC1 E6D8  A119 4D38 49D9 9555 1307";
+    }];
+  };
   prusnak = {
     email = "pavol@rusnak.io";
     github = "prusnak";

--- a/pkgs/development/tools/parsing/re-flex/default.nix
+++ b/pkgs/development/tools/parsing/re-flex/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, boost
+, autoconf
+, automake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "re-flex";
+  version = "3.3.1";
+
+  src = fetchFromGitHub {
+    owner = "Genivia";
+    repo = "RE-flex";
+    rev = "v${version}";
+    sha256 = "w3ecuUa7lBtRv071acBIZGcpjBZD4UvVQdUzT7qWiMo=";
+  };
+
+  nativeBuildInputs = [ boost autoconf automake ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Genivia/RE-flex";
+    description = "The regex-centric, fast lexical analyzer generator for C++ with full Unicode support";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with lib.maintainers; [ prrlvr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18002,6 +18002,8 @@ with pkgs;
   flex_2_5_35 = callPackage ../development/tools/parsing/flex/2.5.35.nix { };
   flex = callPackage ../development/tools/parsing/flex { };
 
+  re-flex = callPackage ../development/tools/parsing/re-flex { };
+
   flexibee = callPackage ../applications/office/flexibee { };
 
   flexcpp = callPackage ../development/tools/parsing/flexc++ { };


### PR DESCRIPTION
###### Description of changes

https://github.com/Genivia/RE-flex

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

