### PR TITLE
mbrola: split derivation for bin and data files

### DIFF
--- a/pkgs/applications/audio/mbrola/default.nix
+++ b/pkgs/applications/audio/mbrola/default.nix
@@ -1,42 +1,72 @@
-{ stdenv, lib, fetchFromGitHub }:
+{ stdenv, stdenvNoCC, lib, symlinkJoin, fetchFromGitHub }:
 
 let
-  voices = fetchFromGitHub {
-    owner = "numediart";
-    repo = "MBROLA-voices";
-    rev = "fe05a0ccef6a941207fd6aaad0b31294a1f93a51";  # using latest commit
-    sha256 = "1w0y2xjp9rndwdjagp2wxh656mdm3d6w9cs411g27rjyfy1205a0";
-  };
-in
-stdenv.mkDerivation rec {
   pname = "mbrola";
   version = "3.3";
 
-  src = fetchFromGitHub {
-    owner = "numediart";
-    repo = "MBROLA";
-    rev = version;
-    sha256 = "1w86gv6zs2cbr0731n49z8v6xxw0g8b0hzyv2iqb9mqcfh38l8zy";
-  };
-
-  # required for cross compilation
-  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
-
-  installPhase = ''
-    runHook preInstall
-    install -D Bin/mbrola $out/bin/mbrola
-
-    # TODO: package separately because it's very big
-    install -d $out/share/mbrola/voices
-    cp -R ${voices}/data/* $out/share/mbrola/voices/
-    runHook postInstall
-  '';
-
   meta = with lib; {
-    description = "Speech synthesizer based on the concatenation of diphones";
-    homepage = "https://github.com/numediart/MBROLA";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ davidak ];
     platforms = platforms.linux;
+    description = "Speech synthesizer based on the concatenation of diphones";
+    homepage = "https://github.com/numediart/MBROLA";
   };
+
+  voices = stdenvNoCC.mkDerivation {
+    pname = "${pname}-voices";
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "numediart";
+      repo = "MBROLA-voices";
+      rev = "fe05a0ccef6a941207fd6aaad0b31294a1f93a51";  # using latest commit
+      sha256 = "1w0y2xjp9rndwdjagp2wxh656mdm3d6w9cs411g27rjyfy1205a0";
+    };
+
+    dontBuild = true;
+    installPhase = ''
+      runHook preInstall
+      install -d $out/share/mbrola/voices
+      cp -R $src/data/* $out/share/mbrola/voices/
+      runHook postInstall
+    '';
+    dontFixup = true;
+
+    meta = meta // {
+      description = "Speech synthesizer based on the concatenation of diphones (voice files)";
+      homepage = "https://github.com/numediart/MBROLA-voices";
+    };
+  };
+
+  bin = stdenv.mkDerivation {
+    pname = "${pname}-bin";
+    inherit version;
+
+    src = fetchFromGitHub {
+      owner = "numediart";
+      repo = "MBROLA";
+      rev = version;
+      sha256 = "1w86gv6zs2cbr0731n49z8v6xxw0g8b0hzyv2iqb9mqcfh38l8zy";
+    };
+
+    # required for cross compilation
+    makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+
+    installPhase = ''
+      runHook preInstall
+      install -D Bin/mbrola $out/bin/mbrola
+      rm -rf $out/share/mbrola/voices/*
+      runHook postInstall
+    '';
+
+    meta = meta // {
+      description = "Speech synthesizer based on the concatenation of diphones (binary only)";
+    };
+  };
+
+in
+symlinkJoin {
+  inherit pname version meta;
+  name = "${pname}-${version}";
+  paths = [ bin voices ];
 }


### PR DESCRIPTION
###### Description of changes

Splitting the derivation avoids downloading hundreds of megabytes of voice data files in case only the executable has been rebuilt.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
