### PR TITLE
cargo-auditable: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/development/compilers/rust/cargo-auditable.nix
+++ b/pkgs/development/compilers/rust/cargo-auditable.nix
@@ -1,18 +1,23 @@
-{ lib, fetchFromGitHub, makeRustPlatform, rustc, cargo }:
+{ lib, fetchFromGitHub, makeRustPlatform, rustc, cargo, installShellFiles }:
 
 let
   args = rec {
     pname = "cargo-auditable";
-    version = "0.6.0";
+    version = "0.6.1";
 
     src = fetchFromGitHub {
       owner = "rust-secure-code";
       repo = pname;
       rev = "v${version}";
-      sha256 = "sha256-mSiEC+9QtRjWmywJnGgUqp+q8fhY0qUYrgjrAVaY114=";
+      sha256 = "sha256-MKMPLv8jeST0l4tq+MMPC18qfZMmBixdj6Ng19YKepU=";
     };
 
-    cargoSha256 = "sha256-Wz5My/QxPpZVsPBUe3KHT3ttD6CTU8NCY8rhFEC+UlA=";
+    cargoSha256 = "sha256-6/f7pNaTL+U6bI6jMakU/lfwYYxN/EM3WkKZcydsyLk=";
+
+    # Cargo.lock is outdated
+    preConfigure = ''
+      cargo update --offline
+    '';
 
     meta = with lib; {
       description = "A tool to make production Rust binaries auditable";
@@ -37,4 +42,12 @@ in
 
 rustPlatform.buildRustPackage.override { cargo-auditable = bootstrap; } (args // {
   auditable = true; # TODO: remove when this is the default
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = ''
+    installManPage cargo-auditable/cargo-auditable.1
+  '';
 })


### PR DESCRIPTION
Diff: https://github.com/rust-secure-code/cargo-auditable/compare/v0.6.0...v0.6.1

Changelog: https://github.com/rust-secure-code/cargo-auditable/blob/v0.6.1/cargo-auditable/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s) (`cargo-auditable` and `fd` on master)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
