### PR TITLE
mpvScripts.uosc: init at 4.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1096,6 +1096,12 @@
     githubId = 1078530;
     name = "Alexandre Peyroux";
   };
+  apfelkuchen6 = {
+    email = "apfelkuchen6@hrnz.li";
+    github = "apfelkuchen6";
+    githubId = 73002165;
+    name = "apfelkuchen6";
+  };
   applePrincess = {
     email = "appleprincess@appleprincess.io";
     github = "applePrincess";

--- a/pkgs/applications/video/mpv/scripts/uosc.nix
+++ b/pkgs/applications/video/mpv/scripts/uosc.nix
@@ -1,0 +1,48 @@
+{ stdenvNoCC, lib, fetchFromGitHub, makeFontsConf }:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "uosc";
+  version = "4.6.0";
+
+  src = fetchFromGitHub {
+    owner = "tomasklaen";
+    repo = "uosc";
+    rev = finalAttrs.version;
+    hash = "sha256-AxApKlSaRLPl6VsXsARfaT3kWDK6AB2AAEmIHYiuFaM=";
+  };
+
+  postPatch = ''
+    substituteInPlace scripts/uosc.lua \
+      --replace "mp.find_config_file('scripts')" "\"$out/share/mpv/scripts\""
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/mpv/
+    cp -r scripts $out/share/mpv
+    cp -r fonts $out/share
+
+    runHook postInstall
+  '';
+
+  passthru.scriptName = "uosc.lua";
+  # the script uses custom "texture" fonts as the background for ui elements.
+  # In order for mpv to find them, we need to adjust the fontconfig search path.
+  passthru.extraWrapperArgs = [
+    "--set"
+    "FONTCONFIG_FILE"
+    (toString (makeFontsConf {
+      fontDirectories = [ "${finalAttrs.finalPackage}/share/fonts" ];
+    }))
+  ];
+
+  meta = with lib; {
+    description = "Feature-rich minimalist proximity-based UI for MPV player";
+    homepage = "https://github.com/tomasklaen/uosc";
+    license = licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ apfelkuchen6 ];
+  };
+})

--- a/pkgs/applications/video/mpv/wrapper.nix
+++ b/pkgs/applications/video/mpv/wrapper.nix
@@ -18,6 +18,7 @@ let
     # expected to have a `scriptName` passthru attribute that points to the
     # name of the script that would reside in the script's derivation's
     # `$out/share/mpv/scripts/`.
+    # A script can optionally also provide an `extraWrapperArgs` passthru attribute.
     scripts ? [],
     extraUmpvWrapperArgs ? []
   }:
@@ -49,6 +50,8 @@ let
           # attribute of the script derivation from the `scripts`
           "--script=${script}/share/mpv/scripts/${script.scriptName}"
         ]
+        # scripts can also set the `extraWrapperArgs` passthru
+        ++ (script.extraWrapperArgs or [])
       ) scripts
     )) ++ extraMakeWrapperArgs)
     ;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31765,6 +31765,7 @@ with pkgs;
     simple-mpv-webui = callPackage ../applications/video/mpv/scripts/simple-mpv-webui.nix {};
     sponsorblock = callPackage ../applications/video/mpv/scripts/sponsorblock.nix {};
     thumbnail = callPackage ../applications/video/mpv/scripts/thumbnail.nix { };
+    uosc = callPackage ../applications/video/mpv/scripts/uosc.nix { };
     vr-reversal = callPackage ../applications/video/mpv/scripts/vr-reversal.nix {};
     webtorrent-mpv-hook = callPackage ../applications/video/mpv/scripts/webtorrent-mpv-hook.nix { };
     youtube-quality = callPackage ../applications/video/mpv/scripts/youtube-quality.nix { };


### PR DESCRIPTION
###### Project description

Feature-rich minimalist proximity-based UI for [MPV player](https://mpv.io/).

requested in #218653.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Pinging mpv maintainers @AndersonTorres @fpletz @globin @ma27 @tadeokondrak since this changes the wrapper.

Also @lunik1 as they opened  #218653.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Can be tested with
```
nix build -I nixpkgs=flake:github:apfelkuchen6/nixpkgs/mpv-uosc --impure --expr \
'with import <nixpkgs> {}; pkgs.wrapMpv pkgs.mpv-unwrapped { scripts = [ pkgs.mpvScripts.uosc ]; }'
./result/bin/mpv /path/to/test/file.mkv
```
