### PR TITLE
ch9344: init at 1.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9156,6 +9156,11 @@
     githubId = 115218;
     name = "Felix Richter";
   };
+  MakiseKurisu = {
+    github = "MakiseKurisu";
+    githubId = 2321672;
+    name = "Makise Kurisu";
+  };
   malbarbo = {
     email = "malbarbo@gmail.com";
     github = "malbarbo";

--- a/pkgs/os-specific/linux/ch9344/default.nix
+++ b/pkgs/os-specific/linux/ch9344/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, lib, fetchzip, kernel }:
+
+stdenv.mkDerivation rec {
+  pname = "ch9344";
+  version = "1.9";
+
+  src = fetchzip {
+    name = "CH9344SER_LINUX.zip";
+    url = "https://www.wch.cn/downloads/file/386.html#CH9344SER_LINUX.zip";
+    hash = "sha256-g55ftAfjKKlUFzGhI1a/O7Eqbz6rkGf1vWuEJjBZxBE=";
+  };
+
+  patches = lib.optionals (lib.versionAtLeast kernel.modDirVersion "6.1") [
+    # https://github.com/torvalds/linux/commit/a8c11c1520347be74b02312d10ef686b01b525f1
+    ./fix-incompatible-pointer-types.patch
+  ];
+
+  sourceRoot = "${src.name}/driver";
+  hardeningDisable = [ "pic" ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  preBuild = ''
+    substituteInPlace Makefile --replace "KERNELDIR :=" "KERNELDIR ?="
+  '';
+
+  makeFlags = [
+    "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D ch9344.ko $out/lib/modules/${kernel.modDirVersion}/usb/serial/ch9344.ko
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "http://www.wch-ic.com/";
+    downloadPage = "https://www.wch.cn/downloads/CH9344SER_LINUX_ZIP.html";
+    description = "WCH CH9344/CH348 UART driver";
+    longDescription = ''
+      A kernel module for WinChipHead CH9344/CH348 USB To Multi Serial Ports controller.
+    '';
+    # Archive contains no license.
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ MakiseKurisu ];
+  };
+}

--- a/pkgs/os-specific/linux/ch9344/fix-incompatible-pointer-types.patch
+++ b/pkgs/os-specific/linux/ch9344/fix-incompatible-pointer-types.patch
@@ -1,0 +1,22 @@
+diff --git a/ch9344.c b/ch9344.c
+index 1e37293..a16af82 100644
+--- a/ch9344.c
++++ b/ch9344.c
+@@ -79,7 +79,7 @@ static DEFINE_IDR(ch9344_minors);
+ static DEFINE_MUTEX(ch9344_minors_lock);
+ 
+ static void ch9344_tty_set_termios(struct tty_struct *tty,
+-                                   struct ktermios *termios_old);
++                                   const struct ktermios *termios_old);
+ 
+ static int ch9344_get_portnum(int index);
+ 
+@@ -1597,7 +1597,7 @@ u8 cal_recv_tmt(__le32 bd)
+ }
+ 
+ static void ch9344_tty_set_termios(struct tty_struct *tty,
+-                                   struct ktermios *termios_old)
++                                   const struct ktermios *termios_old)
+ {
+     struct ch9344 *ch9344 = tty->driver_data;
+     struct ktermios *termios = &tty->termios;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -308,6 +308,8 @@ in {
 
     bbswitch = callPackage ../os-specific/linux/bbswitch {};
 
+    ch9344 = callPackage ../os-specific/linux/ch9344 { };
+
     chipsec = callPackage ../tools/security/chipsec {
       inherit kernel;
       withDriver = true;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This package provides kernel module for WinChipHead CH9344/CH348 USB To Multi Serial Ports controller.

The driver source code, along with the chipset datasheets, can be found [here](https://www.wch.cn/downloads/CH9344SER_LINUX_ZIP.html) (language warning: Chinese).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

I'm new to NixOS so I don't know how to add out-of-tree modules from PR/local git repo to `configuration.nix`. I'm able to include the package to `environment.systemPackages`:

```
...
  nixpkgs.config = {
    # Allow unfree packages
    allowUnfree = true;
    packageOverrides = pkgs: {
      wip = import (fetchGit { url = "/home/user/nixpkgs"; shallow = true;}) { config = config.nixpkg>
    };
  };
...
  environment = {
    systemPackages = with pkgs; [
        wip.linuxKernel.packages.linux_5_15.ch9344
    ...
    ];
  };
```
<s>However, I don't know how to add `ch9344` to `boot.extraModulePackages`.</s> Figured it out and [Wiki updated](https://nixos.wiki/index.php?title=Linux_kernel#Loading_out-of-tree_kernel_modules).

ko generated according to [`Developing out-of-tree kernel modules`](https://nixos.wiki/wiki/Linux_kernel#Developing_out-of-tree_kernel_modules) is loadable and working with real hardware (I have a CH348 board). I also tested [patchPhase](https://nixos.wiki/wiki/Nixpkgs/Create_and_debug_packages#Using_nix-shell_for_package_development) to make sure patch is applied when building against 6.1 kernel.