### PR TITLE
nixos/druid: init module and package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20595,6 +20595,12 @@
     githubId = 70410;
     name = "Rahul Gopinath";
   };
+  vsharathchandra = {
+    email = "chandrasharath.v@gmail.com";
+    github = "vsharathchandra";
+    githubId = 12689380;
+    name = "sharath chandra";
+  };
   vskilet = {
     email = "victor@sene.ovh";
     github = "Vskilet";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -389,6 +389,7 @@
   ./services/blockchain/ethereum/geth.nix
   ./services/blockchain/ethereum/lighthouse.nix
   ./services/cluster/corosync/default.nix
+  ./services/cluster/druid/default.nix
   ./services/cluster/hadoop/default.nix
   ./services/cluster/k3s/default.nix
   ./services/cluster/kubernetes/addon-manager.nix

--- a/nixos/modules/services/cluster/druid/default.nix
+++ b/nixos/modules/services/cluster/druid/default.nix
@@ -1,0 +1,296 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.druid;
+  inherit (lib)
+    concatStrings
+    concatStringsSep
+    mapAttrsToList
+    concatMap
+    attrByPath
+    mkIf
+    mkMerge
+    mkEnableOption
+    mkOption
+    types
+    mkPackageOption
+    ;
+
+  druidServiceOption = serviceName: {
+    enable = mkEnableOption serviceName;
+
+    restartIfChanged = mkOption {
+      type = types.bool;
+      description = ''
+        Automatically restart the service on config change.
+        This can be set to false to defer restarts on clusters running critical applications.
+        Please consider the security implications of inadvertently running an older version,
+        and the possibility of unexpected behavior caused by inconsistent versions across a cluster when disabling this option.
+      '';
+      default = false;
+    };
+
+    config = mkOption {
+      default = { };
+      type = types.attrsOf types.anything;
+      description = ''
+        (key=value) Configuration to be written to runtime.properties of the druid ${serviceName}
+        <https://druid.apache.org/docs/latest/configuration/index.html>
+      '';
+      example = {
+        "druid.plainTextPort" = "8082";
+        "druid.service" = "servicename";
+      };
+    };
+
+    jdk = mkPackageOption pkgs "JDK" { default = [ "jdk17_headless" ]; };
+
+    jvmArgs = mkOption {
+      type = types.str;
+      default = "";
+      description = "Arguments to pass to the JVM";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Open firewall ports for ${serviceName}.";
+    };
+
+    internalConfig = mkOption {
+      default = { };
+      type = types.attrsOf types.anything;
+      internal = true;
+      description = "Internal Option to add to runtime.properties for ${serviceName}.";
+    };
+  };
+
+  druidServiceConfig =
+    {
+      name,
+      serviceOptions ? cfg."${name}",
+      allowedTCPPorts ? [ ],
+      tmpDirs ? [ ],
+      extraConfig ? { },
+    }:
+    (mkIf serviceOptions.enable (mkMerge [
+      {
+        systemd = {
+          services."druid-${name}" = {
+            after = [ "network.target" ];
+
+            description = "Druid ${name}";
+
+            wantedBy = [ "multi-user.target" ];
+
+            inherit (serviceOptions) restartIfChanged;
+
+            path = [
+              cfg.package
+              serviceOptions.jdk
+            ];
+
+            script =
+              let
+                cfgFile =
+                  fileName: properties:
+                  pkgs.writeTextDir fileName (
+                    concatStringsSep "\n" (mapAttrsToList (n: v: "${n}=${toString v}") properties)
+                  );
+
+                commonConfigFile = cfgFile "common.runtime.properties" cfg.commonConfig;
+
+                configFile = cfgFile "runtime.properties" (serviceOptions.config // serviceOptions.internalConfig);
+
+                extraClassPath = concatStrings (map (path: ":" + path) cfg.extraClassPaths);
+
+                extraConfDir = concatStrings (map (dir: ":" + dir + "/*") cfg.extraConfDirs);
+              in
+              ''
+                run-java -Dlog4j.configurationFile=file:${cfg.log4j} \
+                  -Ddruid.extensions.directory=${cfg.package}/extensions \
+                  -Ddruid.extensions.hadoopDependenciesDir=${cfg.package}/hadoop-dependencies \
+                  -classpath  ${commonConfigFile}:${configFile}:${cfg.package}/lib/\*${extraClassPath}${extraConfDir} \
+                  ${serviceOptions.jvmArgs} \
+                  org.apache.druid.cli.Main server ${name}
+              '';
+
+            serviceConfig = {
+              User = "druid";
+              SyslogIdentifier = "druid-${name}";
+              Restart = "always";
+            };
+          };
+
+          tmpfiles.rules = concatMap (x: [ "d ${x} 0755 druid druid" ]) (cfg.commonTmpDirs ++ tmpDirs);
+        };
+        networking.firewall.allowedTCPPorts = mkIf (attrByPath [
+          "openFirewall"
+        ] false serviceOptions) allowedTCPPorts;
+
+        users = {
+          users.druid = {
+            description = "Druid user";
+            group = "druid";
+            isNormalUser = true;
+          };
+          groups.druid = { };
+        };
+      }
+      extraConfig
+    ]));
+in
+{
+  options.services.druid = {
+    package = mkPackageOption pkgs "apache-druid" { default = [ "druid" ]; };
+
+    commonConfig = mkOption {
+      default = { };
+
+      type = types.attrsOf types.anything;
+
+      description = "(key=value) Configuration to be written to common.runtime.properties";
+
+      example = {
+        "druid.zk.service.host" = "localhost:2181";
+        "druid.metadata.storage.type" = "mysql";
+        "druid.metadata.storage.connector.connectURI" = "jdbc:mysql://localhost:3306/druid";
+        "druid.extensions.loadList" = ''[ "mysql-metadata-storage" ]'';
+      };
+    };
+
+    commonTmpDirs = mkOption {
+      default = [ "/var/log/druid/requests" ];
+      type = types.listOf types.str;
+      description = "Common List of directories used by druid processes";
+    };
+
+    log4j = mkOption {
+      type = types.path;
+      description = "Log4j Configuration for the druid process";
+    };
+
+    extraClassPaths = mkOption {
+      default = [ ];
+      type = types.listOf types.str;
+      description = "Extra classpath to include in the jvm";
+    };
+
+    extraConfDirs = mkOption {
+      default = [ ];
+      type = types.listOf types.path;
+      description = "Extra Conf Dirs to include in the jvm";
+    };
+
+    overlord = druidServiceOption "Druid Overlord";
+
+    coordinator = druidServiceOption "Druid Coordinator";
+
+    broker = druidServiceOption "Druid Broker";
+
+    historical = (druidServiceOption "Druid Historical") // {
+      segmentLocations = mkOption {
+
+        default = null;
+
+        description = "Locations where the historical will store its data.";
+
+        type =
+          with types;
+          nullOr (
+            listOf (submodule {
+              options = {
+                path = mkOption {
+                  type = path;
+                  description = "the path to store the segments";
+                };
+
+                maxSize = mkOption {
+                  type = str;
+                  description = "Max size the druid historical can occupy";
+                };
+
+                freeSpacePercent = mkOption {
+                  type = float;
+                  default = 1.0;
+                  description = "Druid Historical will fail to write if it exceeds this value";
+                };
+              };
+            })
+          );
+
+      };
+    };
+
+    middleManager = druidServiceOption "Druid middleManager";
+    router = druidServiceOption "Druid Router";
+  };
+  config = mkMerge [
+    (druidServiceConfig rec {
+      name = "overlord";
+      allowedTCPPorts = [ (attrByPath [ "druid.plaintextPort" ] 8090 cfg."${name}".config) ];
+    })
+
+    (druidServiceConfig rec {
+      name = "coordinator";
+      allowedTCPPorts = [ (attrByPath [ "druid.plaintextPort" ] 8081 cfg."${name}".config) ];
+    })
+
+    (druidServiceConfig rec {
+      name = "broker";
+
+      tmpDirs = [ (attrByPath [ "druid.lookup.snapshotWorkingDir" ] "" cfg."${name}".config) ];
+
+      allowedTCPPorts = [ (attrByPath [ "druid.plaintextPort" ] 8082 cfg."${name}".config) ];
+    })
+
+    (druidServiceConfig rec {
+      name = "historical";
+
+      tmpDirs = [
+        (attrByPath [ "druid.lookup.snapshotWorkingDir" ] "" cfg."${name}".config)
+      ] ++ (map (x: x.path) cfg."${name}".segmentLocations);
+
+      allowedTCPPorts = [ (attrByPath [ "druid.plaintextPort" ] 8083 cfg."${name}".config) ];
+
+      extraConfig.services.druid.historical.internalConfig."druid.segmentCache.locations" = builtins.toJSON cfg.historical.segmentLocations;
+    })
+
+    (druidServiceConfig rec {
+      name = "middleManager";
+
+      tmpDirs = [
+        "/var/log/druid/indexer"
+      ] ++ [ (attrByPath [ "druid.indexer.task.baseTaskDir" ] "" cfg."${name}".config) ];
+
+      allowedTCPPorts = [ (attrByPath [ "druid.plaintextPort" ] 8091 cfg."${name}".config) ];
+
+      extraConfig = {
+        services.druid.middleManager.internalConfig = {
+          "druid.indexer.runner.javaCommand" = "${cfg.middleManager.jdk}/bin/java";
+          "druid.indexer.runner.javaOpts" =
+            (attrByPath [ "druid.indexer.runner.javaOpts" ] "" cfg.middleManager.config)
+            + " -Dlog4j.configurationFile=file:${cfg.log4j}";
+        };
+
+        networking.firewall.allowedTCPPortRanges = mkIf cfg.middleManager.openFirewall [
+          {
+            from = attrByPath [ "druid.indexer.runner.startPort" ] 8100 cfg.middleManager.config;
+            to = attrByPath [ "druid.indexer.runner.endPort" ] 65535 cfg.middleManager.config;
+          }
+        ];
+      };
+    })
+
+    (druidServiceConfig rec {
+      name = "router";
+
+      allowedTCPPorts = [ (attrByPath [ "druid.plaintextPort" ] 8888 cfg."${name}".config) ];
+    })
+  ];
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -261,6 +261,7 @@ in {
   dovecot = handleTest ./dovecot.nix {};
   drawterm = discoverTests (import ./drawterm.nix);
   drbd = handleTest ./drbd.nix {};
+  druid = handleTestOn [ "x86_64-linux" ] ./druid {};
   dublin-traceroute = handleTest ./dublin-traceroute.nix {};
   earlyoom = handleTestOn ["x86_64-linux"] ./earlyoom.nix {};
   early-mount-options = handleTest ./early-mount-options.nix {};

--- a/nixos/tests/druid/default.nix
+++ b/nixos/tests/druid/default.nix
@@ -1,0 +1,289 @@
+{ pkgs, ... }:
+let
+  inherit (pkgs) lib;
+  commonConfig = {
+    "druid.zk.service.host" = "zk1:2181";
+    "druid.extensions.loadList" = ''[ "druid-histogram", "druid-datasketches",  "mysql-metadata-storage", "druid-avro-extensions", "druid-parquet-extensions", "druid-lookups-cached-global", "druid-hdfs-storage","druid-kafka-indexing-service","druid-basic-security","druid-kinesis-indexing-service"]'';
+    "druid.startup.logging.logProperties" = "true";
+    "druid.metadata.storage.connector.connectURI" = "jdbc:mysql://mysql:3306/druid";
+    "druid.metadata.storage.connector.user" = "druid";
+    "druid.metadata.storage.connector.password" = "druid";
+    "druid.request.logging.type" = "file";
+    "druid.request.logging.dir" = "/var/log/druid/requests";
+    "druid.javascript.enabled" = "true";
+    "druid.sql.enable" = "true";
+    "druid.metadata.storage.type" = "mysql";
+    "druid.storage.type" = "hdfs";
+    "druid.storage.storageDirectory" = "/druid-deepstore";
+  };
+  log4jConfig = ''
+    <?xml version="1.0" encoding="UTF-8" ?>
+    <Configuration status="WARN">
+     <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+          <PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/>
+        </Console>
+      </Appenders>
+      <Loggers>
+        <Root level="error">
+          <AppenderRef ref="Console"/>
+        </Root>
+      </Loggers>
+    </Configuration>
+  '';
+  log4j = pkgs.writeText "log4j2.xml" log4jConfig;
+  coreSite = {
+    "fs.defaultFS" = "hdfs://namenode:8020";
+  };
+  tests = {
+    default = testsForPackage {
+      druidPackage = pkgs.druid;
+      hadoopPackage = pkgs.hadoop_3_2;
+    };
+  };
+  testsForPackage =
+    args:
+    lib.recurseIntoAttrs {
+      druidCluster = testDruidCluster args;
+      passthru.override = args': testsForPackage (args // args');
+    };
+  testDruidCluster =
+    { druidPackage, hadoopPackage, ... }:
+    pkgs.testers.nixosTest {
+      name = "druid-hdfs";
+      nodes = {
+        zk1 =
+          { ... }:
+          {
+            services.zookeeper.enable = true;
+            networking.firewall.allowedTCPPorts = [ 2181 ];
+          };
+        namenode =
+          { ... }:
+          {
+            services.hadoop = {
+              package = hadoopPackage;
+              hdfs = {
+                namenode = {
+                  enable = true;
+                  openFirewall = true;
+                  formatOnInit = true;
+                };
+              };
+              inherit coreSite;
+            };
+          };
+        datanode =
+          { ... }:
+          {
+            services.hadoop = {
+              package = hadoopPackage;
+              hdfs.datanode = {
+                enable = true;
+                openFirewall = true;
+              };
+              inherit coreSite;
+            };
+          };
+        mm =
+          { ... }:
+          {
+            virtualisation.memorySize = 1024;
+            services.druid = {
+              inherit commonConfig log4j;
+              package = druidPackage;
+              extraClassPaths = [ "/etc/hadoop-conf" ];
+              middleManager = {
+                config = {
+                  "druid.indexer.task.baseTaskDir" = "/tmp/druid/persistent/task";
+                  "druid.worker.capacity" = 1;
+                  "druid.indexer.logs.type" = "file";
+                  "druid.indexer.logs.directory" = "/var/log/druid/indexer";
+                  "druid.indexer.runner.startPort" = 8100;
+                  "druid.indexer.runner.endPort" = 8101;
+                };
+                enable = true;
+                openFirewall = true;
+              };
+            };
+            services.hadoop = {
+              gatewayRole.enable = true;
+              package = hadoopPackage;
+              inherit coreSite;
+            };
+          };
+        overlord =
+          { ... }:
+          {
+            services.druid = {
+              inherit commonConfig log4j;
+              package = druidPackage;
+              extraClassPaths = [ "/etc/hadoop-conf" ];
+              overlord = {
+                config = {
+                  "druid.indexer.runner.type" = "remote";
+                  "druid.indexer.storage.type" = "metadata";
+                };
+                enable = true;
+                openFirewall = true;
+              };
+            };
+            services.hadoop = {
+              gatewayRole.enable = true;
+              package = hadoopPackage;
+              inherit coreSite;
+            };
+          };
+        broker =
+          { ... }:
+          {
+            services.druid = {
+              package = druidPackage;
+              inherit commonConfig log4j;
+              extraClassPaths = [ "/etc/hadoop-conf" ];
+              broker = {
+                config = {
+                  "druid.plaintextPort" = 8082;
+                  "druid.broker.http.numConnections" = "2";
+                  "druid.server.http.numThreads" = "2";
+                  "druid.processing.buffer.sizeBytes" = "100";
+                  "druid.processing.numThreads" = "1";
+                  "druid.processing.numMergeBuffers" = "1";
+                  "druid.broker.cache.unCacheable" = ''["groupBy"]'';
+                  "druid.lookup.snapshotWorkingDir" = "/opt/broker/lookups";
+                };
+                enable = true;
+                openFirewall = true;
+              };
+            };
+            services.hadoop = {
+              gatewayRole.enable = true;
+              package = hadoopPackage;
+              inherit coreSite;
+            };
+
+          };
+        historical =
+          { ... }:
+          {
+            services.druid = {
+              package = druidPackage;
+              inherit commonConfig log4j;
+              extraClassPaths = [ "/etc/hadoop-conf" ];
+              historical = {
+                config = {
+                  "maxSize" = 200000000;
+                  "druid.lookup.snapshotWorkingDir" = "/opt/historical/lookups";
+                };
+                segmentLocations = [
+                  {
+                    "path" = "/tmp/1";
+                    "maxSize" = "100000000";
+                  }
+                  {
+                    "path" = "/tmp/2";
+                    "maxSize" = "100000000";
+                  }
+                ];
+                enable = true;
+                openFirewall = true;
+              };
+            };
+            services.hadoop = {
+              gatewayRole.enable = true;
+              package = hadoopPackage;
+              inherit coreSite;
+            };
+
+          };
+        coordinator =
+          { ... }:
+          {
+            services.druid = {
+              package = druidPackage;
+              inherit commonConfig log4j;
+              extraClassPaths = [ "/etc/hadoop-conf" ];
+              coordinator = {
+                config = {
+                  "druid.plaintextPort" = 9091;
+                  "druid.service" = "coordinator";
+                  "druid.coordinator.startDelay" = "PT10S";
+                  "druid.coordinator.period" = "PT10S";
+                  "druid.manager.config.pollDuration" = "PT10S";
+                  "druid.manager.segments.pollDuration" = "PT10S";
+                  "druid.manager.rules.pollDuration" = "PT10S";
+                };
+                enable = true;
+                openFirewall = true;
+              };
+            };
+            services.hadoop = {
+              gatewayRole.enable = true;
+              package = hadoopPackage;
+              inherit coreSite;
+            };
+
+          };
+
+        mysql =
+          { ... }:
+          {
+            services.mysql = {
+              enable = true;
+              package = pkgs.mariadb;
+              initialDatabases = [ { name = "druid"; } ];
+              initialScript = pkgs.writeText "mysql-init.sql" ''
+                CREATE USER 'druid'@'%' IDENTIFIED BY 'druid';
+                GRANT ALL PRIVILEGES ON druid.* TO 'druid'@'%';
+              '';
+            };
+            networking.firewall.allowedTCPPorts = [ 3306 ];
+          };
+
+      };
+      testScript = ''
+        start_all()
+        namenode.wait_for_unit("hdfs-namenode")
+        namenode.wait_for_unit("network.target")
+        namenode.wait_for_open_port(8020)
+        namenode.succeed("ss -tulpne | systemd-cat")
+        namenode.succeed("cat /etc/hadoop*/hdfs-site.xml | systemd-cat")
+        namenode.wait_for_open_port(9870)
+        datanode.wait_for_unit("hdfs-datanode")
+        datanode.wait_for_unit("network.target")
+
+        mm.succeed("mkdir -p /quickstart/")
+        mm.succeed("cp -r ${pkgs.druid}/quickstart/* /quickstart/")
+        mm.succeed("touch /quickstart/tutorial/wikiticker-2015-09-12-sampled.json")
+        mm.succeed("zcat /quickstart/tutorial/wikiticker-2015-09-12-sampled.json.gz | head -n 10 > /quickstart/tutorial/wikiticker-2015-09-12-sampled.json || true")
+        mm.succeed("rm /quickstart/tutorial/wikiticker-2015-09-12-sampled.json.gz && gzip /quickstart/tutorial/wikiticker-2015-09-12-sampled.json")
+
+        namenode.succeed("sudo -u hdfs hdfs dfs -mkdir /druid-deepstore")
+        namenode.succeed("HADOOP_USER_NAME=druid sudo -u hdfs hdfs dfs -chown druid:hadoop /druid-deepstore")
+
+
+        ### Druid tests
+        coordinator.wait_for_unit("druid-coordinator")
+        overlord.wait_for_unit("druid-overlord")
+        historical.wait_for_unit("druid-historical")
+        mm.wait_for_unit("druid-middleManager")
+
+        coordinator.wait_for_open_port(9091)
+        overlord.wait_for_open_port(8090)
+        historical.wait_for_open_port(8083)
+        mm.wait_for_open_port(8091)
+
+        broker.wait_for_unit("network.target")
+        broker.wait_for_open_port(8082)
+
+        broker.succeed("curl -X 'POST' -H 'Content-Type:application/json' -d @${pkgs.druid}/quickstart/tutorial/wikipedia-index.json http://coordinator:9091/druid/indexer/v1/task")
+        broker.wait_until_succeeds("curl http://coordinator:9091/druid/coordinator/v1/metadata/datasources | grep  'wikipedia'")
+
+        broker.wait_until_succeeds("curl http://localhost:8082/druid/v2/datasources/ | grep wikipedia")
+        broker.succeed("curl -X 'POST' -H 'Content-Type:application/json' -d @${pkgs.druid}/quickstart/tutorial/wikipedia-top-pages.json http://localhost:8082/druid/v2/")
+
+      '';
+
+    };
+in
+tests

--- a/pkgs/by-name/dr/druid/package.nix
+++ b/pkgs/by-name/dr/druid/package.nix
@@ -67,6 +67,10 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  passthru = {
+    tests = nixosTests.druid.default.passthru.override { druidPackage = finalAttrs.finalPackage; };
+  };
+
   meta = {
     description = "Apache Druid: a high performance real-time analytics database";
     homepage = "https://github.com/apache/druid";

--- a/pkgs/by-name/dr/druid/package.nix
+++ b/pkgs/by-name/dr/druid/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  extensions ? { },
+  libJars ? [ ],
+  nixosTests,
+  mysqlSupport ? true,
+}:
+let
+  inherit (lib)
+    concatStringsSep
+    licenses
+    maintainers
+    mapAttrsToList
+    optionalString
+    forEach
+    ;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "apache-druid";
+  version = "30.0.0";
+
+  src = fetchurl {
+    url = "mirror://apache/druid/${finalAttrs.version}/apache-druid-${finalAttrs.version}-bin.tar.gz";
+    hash = "sha256-mRYorVkNzM94LP53G78eW20N5UsvMP7Lv4rAysmPwXw=";
+  };
+
+  mysqlConnector = fetchurl {
+    url = "https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.48/mysql-connector-java-5.1.48.jar";
+    hash = "sha256-VuJsqqOCH1rkr0T5x09mz4uE6gFRatOAPLsOkEm27Kg=";
+  };
+
+  dontBuild = true;
+
+  loadExtensions = (
+    concatStringsSep "\n" (
+      mapAttrsToList (
+        dir: files:
+        ''
+          if ! test -d $out/extensions/${dir}; then
+               mkdir $out/extensions/${dir};
+           fi
+        ''
+        + concatStringsSep "\n" (
+          forEach files (file: ''
+            if test -d ${file} ; then
+              cp  ${file}/* $out/extensions/${dir}/
+            else
+              cp ${file} $out/extensions/${dir}/
+            fi
+          '')
+        )
+      ) extensions
+    )
+  );
+
+  loadJars = concatStringsSep "\n" (forEach libJars (jar: "cp ${jar} $out/lib/"));
+
+  installPhase = ''
+    runHook preInstall
+    mkdir $out
+    mv * $out
+    ${optionalString mysqlSupport "cp ${finalAttrs.mysqlConnector} $out/extensions/mysql-metadata-storage"}
+    ${finalAttrs.loadExtensions}
+    ${finalAttrs.loadJars}
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Apache Druid: a high performance real-time analytics database";
+    homepage = "https://github.com/apache/druid";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ vsharathchandra ];
+    mainProgram = "druid";
+  };
+
+})


### PR DESCRIPTION
###### Description of changes

- init apache druid at 29.0.0
- init druid module
- init druid nixos tests

Druid is a high performance, real-time analytics database that delivers sub-second queries on streaming and batch data at scale and under load.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
