### PR TITLE
osu-lazer: 2023.301.0 -> 2023.305.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14120,6 +14120,16 @@
     githubId = 22163194;
     name = "Stel Abrego";
   };
+  stepbrobd = {
+    name = "StepBroBD";
+    github = "StepBroBD";
+    githubId = 81826728;
+    email = "Hi@StepBroBD.com";
+    matrix = "@stepbrobd:matrix.org";
+    keys = [{
+      fingerprint = "5D8B FA8B 286A C2EF 6EE4  8598 F742 B72C 8926 1A51";
+    }];
+  };
   stephank = {
     email = "nix@stephank.nl";
     matrix = "@skochen:matrix.org";

--- a/pkgs/games/osu-lazer/bin.nix
+++ b/pkgs/games/osu-lazer/bin.nix
@@ -1,28 +1,74 @@
-{ appimageTools, lib, fetchurl }:
+{ lib
+, stdenv
+, fetchurl
+, fetchzip
+, appimageTools
+}:
 
-appimageTools.wrapType2 rec {
+let
   pname = "osu-lazer-bin";
   version = "2023.301.0";
+  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/ppy/osu/releases/download/${version}/osu.AppImage";
-    sha256 = "sha256-0c74bGOY9f2K52xE7CZy/i3OfyCC+a6XGI30c6hI7jM=";
+  file = {
+    aarch64-darwin = "osu.app.Apple.Silicon.zip";
+    x86_64-darwin = "osu.app.Intel.zip";
+    aarch64-linux = "osu.AppImage";
+    x86_64-linux = "osu.AppImage";
+  }.${stdenv.system} or (throw "${pname}-${version}: ${stdenv.system} is unsupported.");
+
+  fileHash = {
+    aarch64-darwin = "sha256-INZEL78JusTjTHaK0LugfQlA+HRfkpLE/LhJUU++Hsc=";
+    x86_64-darwin = "sha256-eM0aIxbxKgbNiWfKwP70UeFJHi1GN6uu58NoL57p6hU";
+    aarch64-linux = "sha256-0c74bGOY9f2K52xE7CZy/i3OfyCC+a6XGI30c6hI7jM=";
+    x86_64-linux = "sha256-0c74bGOY9f2K52xE7CZy/i3OfyCC+a6XGI30c6hI7jM=";
+  }.${stdenv.system};
+
+  linux = appimageTools.wrapType2 rec {
+    inherit name pname version meta;
+
+    src = fetchurl {
+      url = "https://github.com/ppy/osu/releases/download/${version}/${file}";
+      sha256 = fileHash;
+    };
+
+    extraPkgs = pkgs: with pkgs; [ icu ];
+
+    extraInstallCommands =
+      let contents = appimageTools.extract { inherit pname version src; };
+      in
+      ''
+        mv -v $out/bin/${pname}-${version} $out/bin/osu\!
+        install -m 444 -D ${contents}/osu\!.desktop -t $out/share/applications
+        for i in 16 32 48 64 96 128 256 512 1024; do
+          install -D ${contents}/osu\!.png $out/share/icons/hicolor/''${i}x$i/apps/osu\!.png
+        done
+      '';
   };
 
-  extraPkgs = pkgs: with pkgs; [ icu ];
+  darwin = stdenv.mkDerivation rec {
+    inherit name pname version meta;
 
-  extraInstallCommands =
-    let contents = appimageTools.extract { inherit pname version src; };
-    in ''
-      mv -v $out/bin/${pname}-${version} $out/bin/osu\!
-      install -m 444 -D ${contents}/osu\!.desktop -t $out/share/applications
-      for i in 16 32 48 64 96 128 256 512 1024; do
-        install -D ${contents}/osu\!.png $out/share/icons/hicolor/''${i}x$i/apps/osu\!.png
-      done
+    src = fetchzip {
+      url = "https://github.com/ppy/osu/releases/download/${version}/${file}";
+      sha256 = fileHash;
+      stripRoot = false;
+    };
+
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+      APP_DIR="$out/Applications"
+      mkdir -p "$APP_DIR"
+      cp -r . "$APP_DIR"
+      runHook postInstall
     '';
+  };
 
   meta = with lib; {
-    description = "Rhythm is just a *click* away (AppImage version for score submission and multiplayer)";
+    description = "Rhythm is just a *click* away (AppImage version for score submission and multiplayer, and binary distribution for Darwin systems)";
     homepage = "https://osu.ppy.sh";
     license = with licenses; [
       mit
@@ -30,8 +76,11 @@ appimageTools.wrapType2 rec {
       unfreeRedistributable # osu-framework contains libbass.so in repository
     ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = [ maintainers.delan ];
+    maintainers = with maintainers; [ delan stepbrobd ];
     mainProgram = "osu!";
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
   };
-}
+in
+if stdenv.isDarwin
+then darwin
+else linux

--- a/pkgs/games/osu-lazer/bin.nix
+++ b/pkgs/games/osu-lazer/bin.nix
@@ -7,21 +7,19 @@
 
 let
   pname = "osu-lazer-bin";
-  version = "2023.301.0";
+  version = "2023.305.0";
   name = "${pname}-${version}";
 
   file = {
     aarch64-darwin = "osu.app.Apple.Silicon.zip";
     x86_64-darwin = "osu.app.Intel.zip";
-    aarch64-linux = "osu.AppImage";
     x86_64-linux = "osu.AppImage";
   }.${stdenv.system} or (throw "${pname}-${version}: ${stdenv.system} is unsupported.");
 
   fileHash = {
-    aarch64-darwin = "sha256-INZEL78JusTjTHaK0LugfQlA+HRfkpLE/LhJUU++Hsc=";
-    x86_64-darwin = "sha256-eM0aIxbxKgbNiWfKwP70UeFJHi1GN6uu58NoL57p6hU";
-    aarch64-linux = "sha256-0c74bGOY9f2K52xE7CZy/i3OfyCC+a6XGI30c6hI7jM=";
-    x86_64-linux = "sha256-0c74bGOY9f2K52xE7CZy/i3OfyCC+a6XGI30c6hI7jM=";
+    aarch64-darwin = "sha256-vfDEEU+InD5uIc1QKceM2SN1GlWV93DySn3ik1MSYf4=";
+    x86_64-darwin = "sha256-dK+qqwBzuPXHqQk8U3TpWQBWEz+8S9GHShVwTTq2BBQ=";
+    x86_64-linux = "sha256-W3XJ7HtJM5iFI8OOTTu8IBHMerZSCETHMemkoTislK8=";
   }.${stdenv.system};
 
   linux = appimageTools.wrapType2 rec {
@@ -78,7 +76,7 @@ let
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [ delan stepbrobd ];
     mainProgram = "osu!";
-    platforms = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
+    platforms = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ];
   };
 in
 if stdenv.isDarwin

--- a/pkgs/games/osu-lazer/default.nix
+++ b/pkgs/games/osu-lazer/default.nix
@@ -17,13 +17,13 @@
 
 buildDotnetModule rec {
   pname = "osu-lazer";
-  version = "2023.301.0";
+  version = "2023.305.0";
 
   src = fetchFromGitHub {
     owner = "ppy";
     repo = "osu";
     rev = version;
-    sha256 = "sha256-SUVxe3PdUch8NYR7X4fatbmSpyYewI69usBDICcSq3s=";
+    sha256 = "sha256-gkAHAiTwCYXTSIHrM3WWLBLbC7S9x1cAaEhSYvtNsvQ=";
   };
 
   projectFile = "osu.Desktop/osu.Desktop.csproj";

--- a/pkgs/games/osu-lazer/update.sh
+++ b/pkgs/games/osu-lazer/update.sh
@@ -3,7 +3,8 @@
 set -eo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-deps_file="$(realpath "./deps.nix")"
+deps_file="$(realpath ./deps.nix)"
+bin_file="$(realpath ./bin.nix)"
 
 new_version="$(curl -s "https://api.github.com/repos/ppy/osu/releases?per_page=1" | jq -r '.[0].name')"
 old_version="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
@@ -15,7 +16,22 @@ fi
 cd ../../..
 
 if [[ "$1" != "--deps-only" ]]; then
-    update-source-version osu-lazer "$new_version"
+  update-source-version osu-lazer "$new_version"
+  sed -Ei.bak '/ *version = "/s/".+"/"'"$new_version"'"/' "$bin_file"
+  rm "$bin_file.bak"
+  for pair in \
+    'aarch64-darwin osu.app.Apple.Silicon.zip' \
+    'x86_64-darwin osu.app.Intel.zip' \
+    'x86_64-linux osu.AppImage' \
+  ; do
+    set -- $pair
+    nix-prefetch-url "https://github.com/ppy/osu/releases/download/$new_version/$2" | while read -r hash; do
+      nix --extra-experimental-features nix-command hash to-sri --type sha256 "$hash" | while read -r hash; do
+        sed -Ei.bak '/ *'"$1"' = "sha256-/s@".+"@"'"$hash"'"@' "$bin_file"
+        rm "$bin_file.bak"
+      done
+    done
+  done
 fi
 
 $(nix-build . -A osu-lazer.fetch-deps --no-out-link) "$deps_file"


### PR DESCRIPTION
###### Description of changes

This patch updates osu-lazer and osu-lazer-bin from 2023.301.0 to [2023.305.0](https://github.com/ppy/osu/releases/tag/2023.305.0), and includes @StepBroBD’s changes adding darwin support to osu-lazer-bin (delan/nixpkgs#2).

I’ve extended update.sh to also update the bin package. I couldn’t figure out how to do it with update-source-version though, since trying to update other platforms gives me an error:

```
$ update-source-version osu-lazer-bin "$new_version" --system=aarch64-darwin
error: a 'aarch64-darwin' with features {} is required to build '/nix/store/...', but I am a 'x86-64_linux' with features {benchmark, big-parallel, kvm, nixos-test}
```

I’ve tested both on NixOS 22.05 (still no time to upgrade sorry) with the following additional patch:

```diff
diff --git a/pkgs/games/osu-lazer/default.nix b/pkgs/games/osu-lazer/default.nix
index 3a56c35fe88..ff37f988ccf 100644
--- a/pkgs/games/osu-lazer/default.nix
+++ b/pkgs/games/osu-lazer/default.nix
@@ -29,6 +29,10 @@ buildDotnetModule rec {
   projectFile = "osu.Desktop/osu.Desktop.csproj";
   nugetDeps = ./deps.nix;
 
+  # TODO remove in NixOS 22.11
+  dotnet-sdk = dotnetCorePackages.sdk_6_0;
+  dotnet-runtime = dotnetCorePackages.runtime_6_0;
+
   nativeBuildInputs = [ copyDesktopItems ];
 
   runtimeDeps = [
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] ~~aarch64-linux~~
  - [ ] x86_64-darwin (untested!)
  - [ ] aarch64-darwin (untested!)
- [ ] ~~For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~~
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).