### PR TITLE
teleport: 12.0.2 -> 12.1.0

### DIFF
--- a/pkgs/servers/teleport/12.nix
+++ b/pkgs/servers/teleport/12.nix
@@ -1,8 +1,8 @@
 { callPackage, ... }@args:
 callPackage ./generic.nix ({
-  version = "12.0.2";
-  hash = "sha256-9RD4ETQEXnj3d5YID3f3BghwitdqfcDgNhsk8ixWTW4=";
-  vendorHash = "sha256-2sOELuMyg7w/rhnWvnwDiUOsjUfb56JdAbrTGKvGnjs=";
-  cargoHash = "sha256-1ScU5ywq8vz1sWHW2idBsWcB1Xs+aylukBm96dKrwL4=";
-  yarnHash = "sha256-ItRi5EkYrwNB1MIf9l3yyK1BX6vNpL2+H1BlN3Evibg=";
+  version = "12.1.0";
+  hash = "sha256-rM8ehf4Bb+IvbLLeZEfQZnq6ViAp4d3RiYv1lGYbrOc=";
+  vendorHash = "sha256-euzu6GROCZnmawLnh549ETlfLDqKFuUG9YM6klXO3z0=";
+  cargoHash = "sha256-p8N07EITd+EAMJxMqBtg+1kOuqa94e5c3NtT3Z4VL6g=";
+  yarnHash = "sha256-zwKjuP85VCCghpRdwGtaul9VtMF5ByMJ45QU7wgrteg=";
 } // builtins.removeAttrs args [ "callPackage" ])

--- a/pkgs/servers/teleport/generic.nix
+++ b/pkgs/servers/teleport/generic.nix
@@ -159,7 +159,7 @@ buildGoModule rec {
     description = "Certificate authority and access plane for SSH, Kubernetes, web applications, and databases";
     homepage = "https://goteleport.com/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ sigma tomberek freezeboy ];
+    maintainers = with maintainers; [ justinas sigma tomberek freezeboy ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/teleport/generic.nix
+++ b/pkgs/servers/teleport/generic.nix
@@ -159,7 +159,7 @@ buildGoModule rec {
     description = "Certificate authority and access plane for SSH, Kubernetes, web applications, and databases";
     homepage = "https://goteleport.com/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ justinas sigma tomberek freezeboy ];
+    maintainers = with maintainers; [ arianvp justinas sigma tomberek freezeboy ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

New minor upstream version. Also fixes the unintended breakage in Darwin reported in https://github.com/NixOS/nixpkgs/pull/217852#issuecomment-1457600821

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).