### PR TITLE
qt6ct: init at 0.8

### DIFF
--- a/nixos/modules/config/qt.nix
+++ b/nixos/modules/config/qt.nix
@@ -20,7 +20,7 @@ let
       pkgs.adwaita-qt6
     ]
     else if isQtStyle then [ pkgs.libsForQt5.qtstyleplugins ]
-    else if isQt5ct then [ pkgs.libsForQt5.qt5ct ]
+    else if isQt5ct then [ pkgs.libsForQt5.qt5ct pkgs.qt6Packages.qt6ct ]
     else if isLxqt then [ pkgs.lxqt.lxqt-qtplugin pkgs.lxqt.lxqt-config ]
     else if isKde then [ pkgs.libsForQt5.plasma-integration pkgs.libsForQt5.systemsettings ]
     else throw "`qt.platformTheme` ${cfg.platformTheme} and `qt.style` ${cfg.style} are not compatible.";

--- a/pkgs/tools/misc/qt6ct/default.nix
+++ b/pkgs/tools/misc/qt6ct/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qtbase
+, qtsvg
+, qtwayland
+, qmake
+, qttools
+, wrapQtAppsHook
+}:
+let
+  inherit (lib) getDev;
+in
+stdenv.mkDerivation rec {
+  pname = "qt6ct";
+  version = "0.8";
+
+  src = fetchFromGitHub {
+    owner = "trialuser02";
+    repo = "qt6ct";
+    rev = version;
+    sha256 = "BFE5aUgn3uFJWTgd4sUwP2L9RZwwwr5jVtAapA9vYbA=";
+  };
+
+  nativeBuildInputs = [ qmake qttools wrapQtAppsHook ];
+
+  buildInputs = [ qtbase qtsvg qtwayland ];
+
+  qmakeFlags = [
+    "LRELEASE_EXECUTABLE=${getDev qttools}/bin/lrelease"
+    "PLUGINDIR=${placeholder "out"}/${qtbase.qtPluginPrefix}"
+    "LIBDIR=${placeholder "out"}/lib"
+  ];
+
+  meta = with lib; {
+    description = "Qt6 Configuration Tool";
+    homepage = "https://github.com/trialuser02/qt6ct";
+    platforms = platforms.linux;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ Flakebi Scrumplex ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1410,6 +1410,7 @@ mapAliases ({
   qt514 = throw "Qt 5 versions prior to 5.15 are no longer supported upstream and have been removed";  # Added 2022-11-24
   qt515 = qt5;  # Added 2022-11-24
   qt5ct = libsForQt5.qt5ct; # Added 2021-12-27
+  qt6ct = qt6Packages.qt6ct; # Added 2023-03-07
   qtcurve = libsForQt5.qtcurve; # Added 2020-11-07
   qtkeychain = throw "the qtkeychain attribute (qt4 version) has been removes, use the qt5 version: libsForQt5.qtkeychain"; # Added 2021-08-04
   qtscriptgenerator = throw "'qtscriptgenerator' (Qt4) is unmaintained upstream and not used in nixpkgs"; # Added 2022-06-14

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -31,6 +31,8 @@ in
 
   inherit (kdeFrameworks) kcoreaddons;
 
+  qt6ct = callPackage ../tools/misc/qt6ct { };
+
   qtkeychain = callPackage ../development/libraries/qtkeychain {
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation Security;
   };


### PR DESCRIPTION
###### Description of changes

Add [qt6ct](https://github.com/trialuser02/qt6ct)

Install it in addition to qt5ct, when using `qt5ct` platform theme on NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
