### PR TITLE
python3Packages.sphinxext-opengraph: 0.7.5 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/sphinxext-opengraph/default.nix
+++ b/pkgs/development/python-modules/sphinxext-opengraph/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , sphinx
+, matplotlib
 , pytestCheckHook
 , beautifulsoup4
 , setuptools-scm
@@ -9,13 +10,13 @@
 
 buildPythonPackage rec {
   pname = "sphinxext-opengraph";
-  version = "0.7.5";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "wpilibsuite";
     repo = "sphinxext-opengraph";
     rev = "refs/tags/v${version}";
-    hash = "sha256-fNtXj7iYX7rSaGO6JcxC+PvR8WzTFl8gYwHyRExYdfI=";
+    hash = "sha256-3q/OKkLtyA1Dw2PfTT4Fmzyn5qPbjprekpE7ItnFNUo=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -26,6 +27,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     sphinx
+    matplotlib
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/sphinxext-opengraph/default.nix
+++ b/pkgs/development/python-modules/sphinxext-opengraph/default.nix
@@ -40,6 +40,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Sphinx extension to generate unique OpenGraph metadata";
     homepage = "https://github.com/wpilibsuite/sphinxext-opengraph";
+    changelog = "https://github.com/wpilibsuite/sphinxext-opengraph/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ Luflosi ];
   };

--- a/pkgs/development/python-modules/sphinxext-opengraph/default.nix
+++ b/pkgs/development/python-modules/sphinxext-opengraph/default.nix
@@ -4,6 +4,7 @@
 , sphinx
 , matplotlib
 , pytestCheckHook
+, pythonOlder
 , beautifulsoup4
 , setuptools-scm
 }:
@@ -11,6 +12,9 @@
 buildPythonPackage rec {
   pname = "sphinxext-opengraph";
   version = "0.8.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "wpilibsuite";


### PR DESCRIPTION
###### Description of changes
https://github.com/wpilibsuite/sphinxext-opengraph/releases/tag/V0.8.0
https://github.com/wpilibsuite/sphinxext-opengraph/releases/tag/v0.8.1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).