### PR TITLE
ponyc: 0.50.0 -> 0.54.0

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -1,24 +1,39 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, makeWrapper, pcre2, coreutils, which, openssl, libxml2, cmake, z3, substituteAll, python3,
-  cc ? stdenv.cc, lto ? !stdenv.isDarwin }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, callPackage
+, cc ? stdenv.cc
+, cmake
+, coreutils
+, libxml2
+, lto ? !stdenv.isDarwin
+, makeWrapper
+, openssl
+, pcre2
+, pony-corral
+, python3
+, substituteAll
+, which
+, z3
+}:
 
 stdenv.mkDerivation (rec {
   pname = "ponyc";
-  version = "0.50.0";
+  version = "0.54.0";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = pname;
     rev = version;
-    sha256 = "sha256-FnzlFTiJrqoUfnys+q9is6OH9yit5ExDiRszQ679QbY=";
-
+    hash = "sha256-qFPubqGfK0WCun6QA1OveyDJj7Wf6SQpky7pEb7qsf4=";
     fetchSubmodules = true;
   };
 
   ponygbenchmark = fetchFromGitHub {
     owner = "google";
     repo = "benchmark";
-    rev = "v1.5.4";
-    sha256 = "1dbjdjzkpbsq3jl9ksyg8mw759vkac8qzq1557m73ldnavbhz48x";
+    rev = "v1.7.1";
+    hash = "sha256-gg3g/0Ki29FnGqKv9lDTs5oA9NjH23qQ+hTdVtSU+zo=";
   };
 
   nativeBuildInputs = [ cmake makeWrapper which python3 ];
@@ -32,14 +47,10 @@ stdenv.mkDerivation (rec {
       googletest = fetchFromGitHub {
         owner = "google";
         repo = "googletest";
-        rev = "release-1.10.0";
-        sha256 = "1zbmab9295scgg4z2vclgfgjchfjailjnvzc6f5x9jvlsdi3dpwz";
+        # GoogleTest follows Abseil Live at Head philosophy, use latest commit from main branch as often as possible.
+        rev = "1a727c27aa36c602b24bf170a301aec8686b88e8"; # unstable-2023-03-07
+        hash = "sha256-/FWBSxZESwj/QvdNK5BI2EfonT64DP1eGBZR4O8uJww=";
       };
-    })
-    (fetchpatch {
-      name = "remove-decnet-header.patch";
-      url = "https://github.com/ponylang/ponyc/commit/e5b9b5daec5b19415d519b09954cbd3cf5f34220.patch";
-      hash = "sha256-60cOhBBwQxWLwEx+svtFtJ7POQkHzJo2LDPRJ5L/bNk=";
     })
   ];
 
@@ -52,9 +63,6 @@ stdenv.mkDerivation (rec {
   dontConfigure = true;
 
   postPatch = ''
-    # Patching Vendor LLVM
-    patchShebangs --host build/build_libs/gbenchmark-prefix/src/benchmark/tools/*.py
-    patch -d lib/llvm/src/ -p1 < lib/llvm/patches/2020-07-28-01-c-exports.diff
     substituteInPlace packages/process/_test.pony \
         --replace '"/bin/' '"${coreutils}/bin/' \
         --replace '=/bin' "${coreutils}/bin"
@@ -62,7 +70,6 @@ stdenv.mkDerivation (rec {
         --replace "/usr/local/lib" "" \
         --replace "/opt/local/lib" ""
   '';
-
 
   preBuild = ''
     make libs build_flags=-j$NIX_BUILD_CORES
@@ -72,17 +79,14 @@ stdenv.mkDerivation (rec {
   makeFlags = [
     "PONYC_VERSION=${version}"
     "prefix=${placeholder "out"}"
-  ]
-    ++ lib.optionals stdenv.isDarwin [ "bits=64" ]
-    ++ lib.optionals (stdenv.isDarwin && (!lto)) [ "lto=no" ];
-
-  doCheck = true;
+  ] ++ lib.optionals stdenv.isDarwin ([ "bits=64" ] ++ lib.optional (!lto) "lto=no");
 
   env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=redundant-move" "-Wno-error=implicit-fallthrough" ];
 
+  doCheck = true;
+
   installPhase = "make config=release prefix=$out "
-    + lib.optionalString stdenv.isDarwin "bits=64 "
-    + lib.optionalString (stdenv.isDarwin && (!lto)) "lto=no "
+    + lib.optionalString stdenv.isDarwin ("bits=64 " + (lib.optionalString (!lto) "lto=no "))
     + '' install
     wrapProgram $out/bin/ponyc \
       --prefix PATH ":" "${stdenv.cc}/bin" \
@@ -93,11 +97,13 @@ stdenv.mkDerivation (rec {
   # Stripping breaks linking for ponyc
   dontStrip = true;
 
+  passthru.tests.pony-corral = pony-corral;
+
   meta = with lib; {
     description = "Pony is an Object-oriented, actor-model, capabilities-secure, high performance programming language";
     homepage = "https://www.ponylang.org";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ kamilchm patternspandemic redvers ];
+    maintainers = with maintainers; [ kamilchm patternspandemic redvers superherointj ];
     platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
   };
 })

--- a/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
+++ b/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
@@ -1,18 +1,26 @@
+From e26ae067644ea780f050fb900bd850027bb86456 Mon Sep 17 00:00:00 2001
+From: superherointj <5861043+superherointj@users.noreply.github.com>
+Date: Tue, 7 Mar 2023 14:59:31 -0300
+Subject: [PATCH] make-safe-for-sandbox.patch
+
+---
+ lib/CMakeLists.txt | 80 ++--------------------------------------------
+ 1 file changed, 2 insertions(+), 78 deletions(-)
+
 diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index dab2aaef..26b587b1 100644
+index 129e26e6..d25bdf9d 100644
 --- a/lib/CMakeLists.txt
 +++ b/lib/CMakeLists.txt
-@@ -36,7 +36,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
- endif()
+@@ -32,14 +32,14 @@ endif()
  
+ set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.7.1.tar.gz)
  ExternalProject_Add(gbenchmark
 -    URL ${PONYC_GBENCHMARK_URL}
 +    SOURCE_DIR gbenchmark-prefix/src/benchmark
-     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} --no-warn-unused-cli
+     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DBENCHMARK_ENABLE_WERROR=OFF -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} --no-warn-unused-cli
  )
  
-@@ -46,7 +46,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
- endif()
+ set(PONYC_GOOGLETEST_URL https://github.com/google/googletest/archive/release-1.12.1.tar.gz)
  
  ExternalProject_Add(googletest
 -    URL ${PONYC_GOOGLETEST_URL}
@@ -20,14 +28,14 @@ index dab2aaef..26b587b1 100644
      CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} -Dgtest_force_shared_crt=ON --no-warn-unused-cli
  )
  
-@@ -59,82 +59,6 @@ install(TARGETS blake2
+@@ -52,82 +52,6 @@ install(TARGETS blake2
      COMPONENT library
  )
  
 -find_package(Git)
 -
--set(LLVM_DESIRED_HASH "75e33f71c2dae584b13a7d1186ae0a038ba98838")
--set(PATCHES_DESIRED_HASH "a16f299fbfced16a2bbc628746db341f2a5af9ae8cc9c9ef4b1e9ca26de3c292")
+-set(LLVM_DESIRED_HASH "1f9140064dfbfb0bbda8e51306ea51080b2f7aac")
+-set(PATCHES_DESIRED_HASH "3e16c097794cb669a8f6a0bd7600b440205ac5c29a6135750c2e83263eb16a95")
 -
 -if(GIT_FOUND)
 -    if(EXISTS "${PROJECT_SOURCE_DIR}/../.git")
@@ -102,4 +110,7 @@ index dab2aaef..26b587b1 100644
 -
  message("Building targets: ${LLVM_TARGETS_TO_BUILD}")
  
- set(LLVM_ENABLE_BINDINGS OFF)
+ set(LLVM_ENABLE_BINDINGS OFF CACHE BOOL "ponyc specific override of LLVM cache entry")
+-- 
+2.39.2
+

--- a/pkgs/development/compilers/ponyc/pony-corral.nix
+++ b/pkgs/development/compilers/ponyc/pony-corral.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation ( rec {
   pname = "corral";
-  version = "0.6.1";
+  version = "unstable-2023-02-11";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = pname;
-    rev = "refs/tags/${version}";
-    hash = "sha256-Rv1K6kFRylWodm1uACBs8KqqEqQZh86NqAG50heNteE=";
+    rev = "f31353a9ec9cd7eab6ee89079ae6a782192fd4b5";
+    hash = "sha256-jTx/7iFvmwOdjGVf/6NUy+FTkv6Mkv8DeotJ67pvmtc=";
   };
 
   buildInputs = [ ponyc ];
@@ -24,7 +24,7 @@ stdenv.mkDerivation ( rec {
     homepage = "https://www.ponylang.io";
     changelog = "https://github.com/ponylang/corral/blob/${version}/CHANGELOG.md";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ redvers ];
+    maintainers = with maintainers; [ redvers superherointj ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15606,8 +15606,8 @@ with pkgs;
   picat = callPackage ../development/compilers/picat { };
 
   ponyc = callPackage ../development/compilers/ponyc {
-    # Upstream pony has dropped support for versions compiled with gcc.
-    stdenv = llvmPackages_9.stdenv;
+    # Upstream pony no longer supports GCC
+    stdenv = llvmPackages.stdenv;
   };
 
   blaze = callPackage ../development/libraries/blaze { };


### PR DESCRIPTION
ponyc: 0.50.0 -> 0.54.0
* Release: https://github.com/ponylang/ponyc/releases/tag/0.54.0

pony-corral: 0.6.1 -> unstable-2023-02-11
* upgrade to `unstable-2023-02-11` is required because pony `0.54.0` breaks it.

CC: @redvers 