### PR TITLE
python310Packages.tables: Fix build (probably, hopefully)

### DIFF
--- a/pkgs/development/python-modules/blosc2/default.nix
+++ b/pkgs/development/python-modules/blosc2/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# build-system
+, setuptools
+, scikit-build
+, cython
+, cmake
+, ninja
+
+# propagates
+, msgpack
+, ndindex
+, numpy
+, py-cpuinfo
+, rich
+
+# tests
+, psutil
+, pytestCheckHook
+, torch
+}:
+
+buildPythonPackage rec {
+  pname = "blosc2";
+  version = "2.1.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "Blosc";
+    repo = "python-blosc2";
+    rev = "refs/tags/v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-nbPMLkTye0/Q05ubE35LssN677sUIQErPTxjAtSuGgI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    cython
+    ninja
+    numpy
+    scikit-build
+    setuptools
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  propagatedBuildInputs = [
+    msgpack
+    ndindex
+    numpy
+    py-cpuinfo
+    rich
+  ];
+
+  nativeCheckInputs = [
+    psutil
+    pytestCheckHook
+    torch
+  ];
+
+  meta = with lib; {
+    description = "Python wrapper for the extremely fast Blosc2 compression library";
+    homepage = "https://github.com/Blosc/python-blosc2";
+    changelog = "https://github.com/Blosc/python-blosc2/releases/tag/v${version}";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/ndindex/default.nix
+++ b/pkgs/development/python-modules/ndindex/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# build-system
+, cython
+
+# optional
+, numpy
+
+# tests
+, hypothesis
+, pytest-cov
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ndindex";
+  version = "1.6";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "Quansight-Labs";
+    repo = "ndindex";
+    rev = "refs/tags/${version}";
+    hash = "sha256-QLWGgbF5nNTa1SsSkupo+fAs9K7eTexTK9n9yDLVgrQ=";
+  };
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace "--cov=ndindex/ --cov-report=term-missing --flakes" ""
+  '';
+
+  passthru.optional-dependencies.arrays = [
+    numpy
+  ];
+
+  pythonImportsCheck = [
+    "ndindex"
+  ];
+
+  nativeCheckInputs = [
+    hypothesis
+    pytest-cov # uses cov markers
+    pytestCheckHook
+  ] ++ passthru.optional-dependencies.arrays;
+
+  pytestFlagsArray = [
+    # pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
+    "--deselect=ndindex/tests/test_ndindex.py::test_ndindex_invalid"
+  ];
+
+  meta = with lib; {
+    description = "";
+    homepage = "https://github.com/Quansight-Labs/ndindex";
+    changelog = "https://github.com/Quansight-Labs/ndindex/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/tables/default.nix
+++ b/pkgs/development/python-modules/tables/default.nix
@@ -3,6 +3,7 @@
 , fetchpatch
 , buildPythonPackage
 , pythonOlder
+, blosc2
 , bzip2
 , c-blosc
 , cython
@@ -11,8 +12,10 @@
 , numpy
 , numexpr
 , packaging
+, sphinx
   # Test inputs
-, pytestCheckHook
+, python
+, pytest
 }:
 
 buildPythonPackage rec {
@@ -25,7 +28,11 @@ buildPythonPackage rec {
     hash = "sha256-NPP6I2bOILGPHfVzp3wdJzBs4fKkHZ+e/2IbUZLqh4g=";
   };
 
-  nativeBuildInputs = [ cython ];
+  nativeBuildInputs = [
+    blosc2
+    cython
+    sphinx
+  ];
 
   buildInputs = [
     bzip2
@@ -34,6 +41,7 @@ buildPythonPackage rec {
     lzo
   ];
   propagatedBuildInputs = [
+    blosc2
     numpy
     numexpr
     packaging  # uses packaging.version at runtime
@@ -46,6 +54,8 @@ buildPythonPackage rec {
     substituteInPlace tables/tests/test_suite.py \
       --replace "return 0" "assert result.wasSuccessful(); return 0" \
       --replace "return 1" "assert result.wasSuccessful(); return 1"
+    substituteInPlace requirements.txt \
+      --replace "blosc2~=2.0.0" "blosc2"
   '';
 
   # Regenerate C code with Cython
@@ -60,15 +70,21 @@ buildPythonPackage rec {
     "--blosc=${lib.getDev c-blosc}"
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytest
+  ];
+
   preCheck = ''
     cd ..
   '';
-  # Runs the test suite as one single test via unittest. The whole "heavy" test suite supposedly takes ~5 hours to run.
-  pytestFlagsArray = [
-    "--pyargs"
-    "tables.tests.test_suite"
-  ];
+
+  # Runs the light (yet comprehensive) subset of the test suite.
+  # The whole "heavy" test suite supposedly takes ~4 hours to run.
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m tables.tests.test_all
+    runHook postCheck
+  '';
 
   pythonImportsCheck = [ "tables" ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1354,6 +1354,8 @@ self: super: with self; {
 
   blocksat-cli = callPackage ../development/python-modules/blocksat-cli { };
 
+  blosc2 = callPackage ../development/python-modules/blosc2 { };
+
   blspy = callPackage ../development/python-modules/blspy { };
 
   bluemaestro-ble = callPackage ../development/python-modules/bluemaestro-ble { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6347,6 +6347,8 @@ self: super: with self; {
 
   ndg-httpsclient = callPackage ../development/python-modules/ndg-httpsclient { };
 
+  ndindex = callPackage ../development/python-modules/ndindex { };
+
   ndjson = callPackage ../development/python-modules/ndjson { };
 
   ndms2-client = callPackage ../development/python-modules/ndms2-client { };


### PR DESCRIPTION
Packages ndindex as a dependency for blosc2.
Packages blosc2 as a dependency for tables.

Adds missing dependency to tables and update the check phase.

Tests take a while, not going to wait for them to finish. :zzz: 

```
tables> running install tests
tables> -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
tables> PyTables version:    3.8.0
tables> HDF5 version:        1.14.0
tables> NumPy version:       1.24.2
tables> Numexpr version:     2.8.4 (not using Intel's VML/MKL)
tables> Zlib version:        1.2.13 (in Python interpreter)
tables> LZO version:         2.10 (Mar 01 2017)
tables> BZIP2 version:       1.0.8 (13-Jul-2019)
tables> Blosc version:       1.21.1 (2021-10-06)
tables> Blosc compressors:   blosclz (2.5.1), lz4 (1.9.3), lz4hc (1.9.3), zlib (1.2.11), zstd (1.5.0)
tables> Blosc filters:       shuffle, bitshuffle
tables> Blosc2 version:      2.7.1 (2023-02-22)
tables> Blosc2 compressors:  blosclz (2.5.1), lz4 (1.9.4), lz4hc (1.9.4), zlib (1.2.11.zlib-ng), zstd (1.5.4)
tables> Blosc2 filters:      shuffle, bitshuffle
tables> Cython version:      0.29.33
tables> Python version:      3.10.10 (main, Feb  7 2023, 12:19:31) [GCC 12.2.0]
tables> Platform:            Linux-6.1.15-x86_64-with-glibc2.35
tables> Byte-ordering:       little
tables> Detected cores:      64
tables> Default encoding:    utf-8
tables> Default FS encoding: utf-8
tables> Default locale:      (en_US, UTF-8)
tables> -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
tables> Performing only a light (yet comprehensive) subset of the test suite.
tables> If you want a more complete test, try passing the --heavy flag to this script
tables> (or set the 'heavy' parameter in case you are using tables.test() call).
tables> The whole suite will take more than 4 hours to complete on a relatively
tables> modern CPU and around 512 MB of main memory.
tables> -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
```

15 minutes in...

#219444 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
