### PR TITLE
ruby_3_1,ruby_3_0,ruby_2_7: allow enabling dtrace support on linux

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -5,6 +5,7 @@
 , buildEnv, bundler, bundix
 , makeWrapper, buildRubyGem, defaultGemConfig, removeReferencesTo
 , openssl, openssl_1_1
+, linuxPackages, libsystemtap
 } @ args:
 
 let
@@ -34,6 +35,7 @@ let
       , libyaml, yamlSupport ? true
       , libffi, fiddleSupport ? true
       , jemalloc, jemallocSupport ? false
+      , linuxPackages, systemtap ? linuxPackages.systemtap, libsystemtap, dtraceSupport ? false
       # By default, ruby has 3 observed references to stdenv.cc:
       #
       # - If you run:
@@ -71,6 +73,7 @@ let
 
         nativeBuildInputs = [ autoreconfHook bison ]
           ++ (op docSupport groff)
+          ++ (ops (dtraceSupport && stdenv.isLinux) [ systemtap libsystemtap ])
           ++ op useBaseRuby baseRuby;
         buildInputs = [ autoconf ]
           ++ (op fiddleSupport libffi)
@@ -141,6 +144,7 @@ let
           (lib.enableFeature true "pthread")
           (lib.withFeatureAs true "soname" "ruby-${version}")
           (lib.withFeatureAs useBaseRuby "baseruby" "${baseRuby}/bin/ruby")
+          (lib.enableFeature dtraceSupport "dtrace")
           (lib.enableFeature jitSupport "jit-support")
           (lib.enableFeature docSupport "install-doc")
           (lib.withFeature jemallocSupport "jemalloc")


### PR DESCRIPTION
###### Description of changes

Allow enabling dtrace on linux.

Verified to work with `bpftrace -p (pid-of-ruby) -l`:
```
sudo bpftrace -p 320064 -l
uprobe:/proc/320064/root/nix/store/fryagbkvxwrmqg4lrdhk0h4sd8q3kkxk-ruby-3.1.2/bin/ruby:__do_global_dtors_aux
uprobe:/proc/320064/root/nix/store/fryagbkvxwrmqg4lrdhk0h4sd8q3kkxk-ruby-3.1.2/bin/ruby:_dl_relocate_static_pie
(...)
usdt:/proc/320064/root/nix/store/fryagbkvxwrmqg4lrdhk0h4sd8q3kkxk-ruby-3.1.2/lib/libruby-3.1.2.so.3.1.2:ruby:array__create
usdt:/proc/320064/root/nix/store/fryagbkvxwrmqg4lrdhk0h4sd8q3kkxk-ruby-3.1.2/lib/libruby-3.1.2.so.3.1.2:ruby:cmethod__entry
(...)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
