### PR TITLE
tilemaker: 2.2.0 → 2.3.0

### DIFF
--- a/pkgs/applications/misc/tilemaker/default.nix
+++ b/pkgs/applications/misc/tilemaker/default.nix
@@ -3,22 +3,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tilemaker";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "systemed";
     repo = "tilemaker";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-st6WDCk1RZ2lbfrudtcD+zenntyTMRHrIXw3nX5FHOU=";
+    hash = "sha256-O1zoRYNUeReIH2ZpL05SiwCZrZrM2IAkwhsP30k/hHc=";
   };
-
-  patches = [
-    # Fix build with Boost >= 1.79, remove on next upstream release
-    (fetchpatch {
-      url = "https://github.com/systemed/tilemaker/commit/252e7f2ad8938e38d51783d1596307dcd27ed269.patch";
-      hash = "sha256-YSkhmpzEYk/mxVPSDYdwZclooB3zKRjDPzqamv6Nvyc=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace src/tilemaker.cpp \
@@ -48,6 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "Make OpenStreetMap vector tiles without the stack";
     homepage = "https://tilemaker.org/";
+    changelog = "https://github.com/systemed/tilemaker/blob/v${version}/CHANGELOG.md";
     license = licenses.free; # FTWPL
     maintainers = with maintainers; [ sikmir ];
     platforms = platforms.unix;


### PR DESCRIPTION
###### Description of changes
[Changelog](https://github.com/systemed/tilemaker/blob/v2.3.0/CHANGELOG.md)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
