### PR TITLE
python3Packages.cairo-lang: 0.10.0 -> 0.10.1

### DIFF
--- a/pkgs/development/python-modules/cairo-lang/default.nix
+++ b/pkgs/development/python-modules/cairo-lang/default.nix
@@ -31,27 +31,15 @@
 
 buildPythonPackage rec {
   pname = "cairo-lang";
-  version = "0.10.0";
+  version = "0.10.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchzip {
     url = "https://github.com/starkware-libs/cairo-lang/releases/download/v${version}/cairo-lang-${version}.zip";
-    hash = "sha256-+PE7RSKEGADbue63FoT6UBOwURJs7lBNkL7aNlpSxP8=";
+    hash = "sha256-MNbzDqqNhij9JizozLp9hhQjbRGzWxECOErS3TOPlAA=";
   };
-
-  # TODO: remove a substantial part when https://github.com/starkware-libs/cairo-lang/pull/88/files is merged.
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "lark-parser" "lark"
-
-    substituteInPlace starkware/cairo/lang/compiler/parser_transformer.py \
-      --replace 'value, meta' 'meta, value' \
-      --replace 'value: Tuple[CommaSeparatedWithNotes], meta' 'meta, value: Tuple[CommaSeparatedWithNotes]'
-    substituteInPlace starkware/cairo/lang/compiler/parser.py \
-      --replace 'standard' 'basic'
-  '';
 
   nativeBuildInputs = [
     pythonRelaxDepsHook
@@ -98,6 +86,10 @@ buildPythonPackage rec {
     "pytest"
     "pytest-asyncio"
   ];
+
+  postFixup = ''
+    chmod +x $out/bin/*
+  '';
 
   # There seems to be no test included in the ZIP release…
   # Cloning from GitHub is harder because they use a custom CMake setup


### PR DESCRIPTION
###### Description of changes

This enables usage of https://github.com/starkware-libs/formal-proofs to automate formal verification of Cairo contracts.

It's uncertain to me this should be upgraded to 0.10.2 or 0.10.3 as the verification framework seems to indicate it's only compatible with 0.10.1. I will test and report back.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
