### PR TITLE
krabby: init at 0.1.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13000,6 +13000,11 @@
     githubId = 61306;
     name = "Rene Treffer";
   };
+  ruby0b = {
+    github = "ruby0b";
+    githubId = 106119328;
+    name = "ruby0b";
+  };
   rubyowo = {
     name = "Rei Star";
     email = "perhaps-you-know@what-is.ml";

--- a/pkgs/applications/misc/krabby/default.nix
+++ b/pkgs/applications/misc/krabby/default.nix
@@ -1,0 +1,23 @@
+{ lib
+, rustPlatform
+, fetchCrate
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "krabby";
+  version = "0.1.6";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-BUX3D/UXJt9OxajUYaUDxI0u4t4ntSxqI1PMtk5IZNQ=";
+  };
+
+  cargoHash = "sha256-XynD19mlCmhHUCfbr+pmWkpb+D4+vt3bsgV+bpbUoaY=";
+
+  meta = with lib; {
+    description = "Print pokemon sprites in your terminal";
+    homepage = "https://github.com/yannjor/krabby";
+    changelog = "https://github.com/yannjor/krabby/releases/tag/v${version}";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ruby0b ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31030,6 +31030,8 @@ with pkgs;
 
   kpt = callPackage ../applications/networking/cluster/kpt { };
 
+  krabby = callPackage ../applications/misc/krabby { };
+
   krane = callPackage ../applications/networking/cluster/krane { };
 
   krita = libsForQt5.callPackage ../applications/graphics/krita { };


### PR DESCRIPTION
###### Description of changes
Adds [krabby](https://github.com/yannjor/krabby), a simple rust program that prints pokemon sprites in your terminal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
