### PR TITLE
treewide: link `$out/share/vim-plugin/${pname}` to `nvim/site`

### DIFF
--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -34,9 +34,10 @@ stdenv.mkDerivation rec {
     rm -r $out/share/doc/task/scripts/bash
     rm -r $out/share/doc/task/scripts/fish
     # Install vim and neovim plugin
-    mkdir -p $out/share/vim-plugins $out/share/nvim/site
+    mkdir -p $out/share/vim-plugins
     mv $out/share/doc/task/scripts/vim $out/share/vim-plugins/task
-    ln -s $out/share/vim-plugins/task $out/share/nvim/site/task
+    mkdir -p $out/share/nvim
+    ln -s $out/share/vim-plugins/task $out/share/nvim/site
   '';
 
   meta = with lib; {

--- a/pkgs/applications/science/logic/tamarin-prover/default.nix
+++ b/pkgs/applications/science/logic/tamarin-prover/default.nix
@@ -80,6 +80,8 @@ mkDerivation (common "tamarin-prover" src // {
     # so that the package can be used as a vim plugin to install syntax coloration
     install -Dt $out/share/vim-plugins/tamarin-prover/syntax/ etc/syntax/spthy.vim
     install etc/filetype.vim -D $out/share/vim-plugins/tamarin-prover/ftdetect/tamarin.vim
+    mkdir -p $out/share/nvim
+    ln -s $out/share/vim-plugins/tamarin-prover $out/share/nvim/site
     # Emacs SPTHY major mode
     install -Dt $out/share/emacs/site-lisp etc/spthy-mode.el
   '';

--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -66,6 +66,8 @@ buildGoModule rec {
     installManPage man/man1/fzf.1 man/man1/fzf-tmux.1
 
     install -D plugin/* -t $out/share/vim-plugins/${pname}/plugin
+    mkdir -p $out/share/nvim
+    ln -s $out/share/vim-plugins/${pname} $out/share/nvim/site
 
     # Install shell integrations
     install -D shell/* -t $out/share/fzf/

--- a/pkgs/tools/text/txr/default.nix
+++ b/pkgs/tools/text/txr/default.nix
@@ -49,6 +49,8 @@ stdenv.mkDerivation (finalAttrs: {
       au BufRead,BufNewFile *.txr set filetype=txr | set lisp
       au BufRead,BufNewFile *.tl,*.tlo set filetype=tl | set lisp
     EOF
+    mkdir -p $out/share/nvim
+    ln -s $out/share/vim-plugins/txr $out/share/nvim/site
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -148,6 +148,8 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
         install -Dt $vimdir/syntax/ Util/vim/syntax/boogie.vim
         mkdir $vimdir/ftdetect
         echo 'au BufRead,BufNewFile *.bpl set filetype=boogie' > $vimdir/ftdetect/bpl.vim
+        mkdir -p $out/share/nvim
+        ln -s $out/share/vim-plugins/boogie $out/share/nvim/site
     '';
 
     postFixup = ''


### PR DESCRIPTION
###### Motivation for this change

All 5 packages in NixOS that install a Vim plugin into `$out/share/vim-plugins/${pname}`, can also make neovim read those files, if one links that directory to `$out/share/nvim/site`. This PR does that for all of these packages. For `taskwarrior` - this is a fixup to https://github.com/NixOS/nixpkgs/pull/219544 .

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
