### PR TITLE
Resolved conflict of reserved delimiter ':' in device names when booting

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -90,6 +90,15 @@ waitDevice() {
     # uses this for multi-device filesystems, i.e. /dev/sda1:/dev/sda2:/dev/sda3
     local IFS=':'
 
+    # Check whether the delimiter is really used for bcachefs (i.e. it's
+    # elements are device nodes). In other cases the delimiter might occur in
+    # valid device filenames (e.g. /dev/disk/by-id/...)
+    for dev in $device; do
+        if ! [ "${dev:0:5}" = "/dev/" ]; then
+            IFS=
+        fi
+    done
+
     # USB storage devices tend to appear with some delay.  It would be
     # great if we had a way to synchronously wait for them, but
     # alas...  So just wait for a few seconds for the device to


### PR DESCRIPTION
###### Description of changes

bcachefs uses `:` in device paths to separate multiple devices, but it might occur in valid device paths too. If for example a device path in `/dev/disk/by-id` is used that contains a `:`, the stage-1 init script will split that path and wait for two devices that will never exist. This additional check for bcachefs tests, whether the splitted paths are absolute and in `/dev`, which very likely would not happen with normal device paths.

Here an example for a configuration that NixOS can't boot without the fix, but is desireable, because of the unique device path:
```nix
{...}:
{
  fileSystems."/" = {
    device = "/dev/disk/by-id/md-uuid-87f8d026:9d4e4aa1:b8ac6c73:7cf43cb2";
    fsType = "ext4";
  };
}
```

I've tested the change with the following code snipped that emulates the `waitDevice` function:
```sh
test() {
    local device="$1"
    local IFS=:
    for dev in $device; do
        if ! [ "${dev:0:5}" = "/dev/" ]; then
            IFS=
        fi
    done
    for dev in $device; do
        echo "$dev"
    done
}

echo ":: Test 1"
test "/dev/disk/by-id/md-uuid-87f8d026:9d4e4aa1:b8ac6c73:7cf43cb2"
echo ":: Test 2"
test "/dev/sda:/dev/sdb:/dev/sdc"
```
which outputs
```
:: Test 1
/dev/disk/by-id/md-uuid-87f8d026:9d4e4aa1:b8ac6c73:7cf43cb2
:: Test 2
/dev/sda
/dev/sdb
/dev/sdc
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
