### PR TITLE
haskellPackages.glualint: init at 1.24.1

### DIFF
--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -38,4 +38,6 @@ self: super: {
   # Unofficial fork until PRs are merged https://github.com/pcapriotti/optparse-applicative/pulls/roberth
   # cabal2nix --maintainer roberth https://github.com/hercules-ci/optparse-applicative.git > pkgs/development/misc/haskell/hercules-ci-optparse-applicative.nix
   hercules-ci-optparse-applicative = self.callPackage ../misc/haskell/hercules-ci-optparse-applicative.nix {};
+
+  glualint = self.callPackage ../tools/glualint {};
 }

--- a/pkgs/development/tools/glualint/default.nix
+++ b/pkgs/development/tools/glualint/default.nix
@@ -1,0 +1,104 @@
+{ mkDerivation
+, aeson
+, array
+, base
+, bytestring
+, containers
+, directory
+, deepseq
+, filemanip
+, filepath
+, ListLike
+, MissingH
+, mtl
+, optparse-applicative
+, parsec
+, pretty
+, signal
+, lib
+, uu-parsinglib
+, uuagc
+, uuagc-cabal
+, vector
+, pkgs
+, fetchFromGitHub
+}:
+mkDerivation rec {
+  # Clean up the source of the derivation to prevent rebuilds
+  src = lib.cleanSourceWith {
+    src = fetchFromGitHub {
+      owner = "FPtje";
+      repo = "GLuaFixer";
+      rev = "1.24.1";
+      hash = "sha256-zL0GcrNihSOaw5JkDi04ipOmBq8idj2m0VCKU2J1ZbA=";
+    };
+    filter = path: type:
+      let
+        suffixAllowlist = [
+          ".ag"
+          ".cabal"
+          ".hs"
+          "AGGenerator.sh"
+          "LICENSE"
+        ];
+        suffixDenylist = [
+          "release-linux.sh"
+        ];
+      in
+      ((type == "directory") ||
+      (builtins.any (suffix: lib.hasSuffix suffix path) suffixAllowlist)
+      ) &&
+      !(builtins.any (suffix: lib.hasSuffix suffix path) suffixDenylist) &&
+      # Simple library function to remove git related files.
+      lib.cleanSourceFilter path type
+    ;
+  };
+
+  pname = "glualint-lib";
+  version = "0.1.0.0";
+  isLibrary = true;
+  isExecutable = true;
+  buildDepends = [ uuagc uuagc-cabal ];
+  libraryHaskellDepends = [
+    aeson
+    array
+    base
+    bytestring
+    containers
+    directory
+    filemanip
+    filepath
+    ListLike
+    MissingH
+    mtl
+    optparse-applicative
+    parsec
+    pretty
+    signal
+    uu-parsinglib
+    uuagc
+    uuagc-cabal
+    deepseq
+
+    # Require haskellPackages' uuagc and uuagc-cabal specifically
+    # Otherwise compilation with ghcjs will fuck up.
+    pkgs.haskellPackages.uuagc
+    pkgs.haskellPackages.uuagc-cabal
+    vector
+  ];
+  executableHaskellDepends = [ base directory ];
+
+  preBuild = ''
+    printf "Generating attribute grammar haskell files"
+    ${uuagc}/bin/uuagc --haskellsyntax --data src/GLua/AG/AST.ag
+    ${uuagc}/bin/uuagc --haskellsyntax --data --strictdata src/GLua/AG/Token.ag
+    ${uuagc}/bin/uuagc --catas --haskellsyntax --semfuns --wrappers --signatures src/GLua/AG/PrettyPrint.ag
+    ${uuagc}/bin/uuagc --catas --haskellsyntax --semfuns --wrappers --signatures --optimize src/GLuaFixer/AG/LexLint.ag
+    ${uuagc}/bin/uuagc --catas --haskellsyntax --semfuns --wrappers --signatures --optimize src/GLuaFixer/AG/ASTLint.ag
+  '';
+
+  homepage = "https://github.com/FPtje/GLuaFixer";
+  description = "Linter for Garry's mod Lua";
+  license = lib.licenses.lgpl21;
+  # maintainers = with lib.maintainers; [ ruby0b ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17103,6 +17103,8 @@ with pkgs;
 
   global = callPackage ../development/tools/misc/global { };
 
+  glualint = haskell.lib.compose.justStaticExecutables haskellPackages.glualint;
+
   gnatcoll-db2ada = callPackage ../development/libraries/ada/gnatcoll/db.nix {
     component = "gnatcoll_db2ada";
   };


### PR DESCRIPTION
###### Description of changes
[glualint](https://github.com/FPtje/GLuaFixer) is a linter and pretty printer for Garry's Mod's variant of Lua.
The derivation pretty much just uses the project's own [default.nix](https://github.com/FPtje/GLuaFixer/blob/1.24.1/default.nix).

The package is not available on hackage and the version stated in its cabal file is a constant 0.1.0.0 (even though the github release is at version 1.24.1).
I wasn't sure which version I should for mkDerivation so I didn't modify the 0.1.0.0 which means that the version attribute is effectively meaningless.

Note: Currently based on nixos-22.11 because uuagc-cabal is broken on master.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
