### PR TITLE
tracee: 0.11.0 -> 0.13.0

### DIFF
--- a/pkgs/tools/security/tracee/default.nix
+++ b/pkgs/tools/security/tracee/default.nix
@@ -2,7 +2,7 @@
 , buildGoModule
 , fetchFromGitHub
 
-, llvmPackages_13
+, clang
 , pkg-config
 
 , zlib
@@ -14,20 +14,17 @@
 , tracee
 }:
 
-let
-  inherit (llvmPackages_13) clang;
-in
 buildGoModule rec {
   pname = "tracee";
-  version = "0.11.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "aquasecurity";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-fAbii/DEXx9WJpolc7amqF9TQj4oE5x0TCiNOtVasGo=";
+    hash = "sha256-55+eyulFbzR2ZzKbTN5sHIickpwXY8eJDDzf6Gzwhsk=";
   };
-  vendorSha256 = "sha256-eenhIsiJhPLgwJo2spIGURPkcsec3kO4L5UJ0FWniQc=";
+  vendorHash = "sha256-qEubjzYGdiBntPOJw8dR/THcvK2Bml97SXHImIWbDm0=";
 
   patches = [
     ./use-our-libbpf.patch
@@ -59,15 +56,16 @@ buildGoModule rec {
   # see passthru.tests.integration
   doCheck = false;
 
+  outputs = [ "out" "lib" "share" ];
+
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/{bin,share/tracee}
+    mkdir -p $out/bin $lib/lib/tracee $share/share/tracee
 
-    mv ./dist/tracee-{ebpf,rules} $out/bin/
-
-    mv ./dist/rules $out/share/tracee/
-    mv ./cmd/tracee-rules/templates $out/share/tracee/
+    mv ./dist/tracee $out/bin/
+    mv ./dist/tracee.bpf.core.o $lib/lib/tracee/
+    mv ./cmd/tracee-rules/templates $share/share/tracee/
 
     runHook postInstall
   '';
@@ -76,10 +74,8 @@ buildGoModule rec {
   installCheckPhase = ''
     runHook preInstallCheck
 
-    $out/bin/tracee-ebpf --help
-    $out/bin/tracee-ebpf --version | grep "v${version}"
-
-    $out/bin/tracee-rules --help
+    $out/bin/tracee --help
+    $out/bin/tracee --version | grep "v${version}"
 
     runHook postInstallCheck
   '';
@@ -89,7 +85,7 @@ buildGoModule rec {
     version = testers.testVersion {
       package = tracee;
       version = "v${version}";
-      command = "tracee-ebpf --version";
+      command = "tracee --version";
     };
   };
 
@@ -111,6 +107,7 @@ buildGoModule rec {
       gpl2Plus
     ];
     maintainers = with maintainers; [ jk ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    outputsToInstall = [ "out" "share" ];
   };
 }

--- a/pkgs/tools/security/tracee/use-our-libbpf.patch
+++ b/pkgs/tools/security/tracee/use-our-libbpf.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index c72cf63d..e96b7eed 100644
+index d7596a1a..dd7b97b6 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -50,6 +50,7 @@ CMD_STATICCHECK ?= staticcheck
@@ -10,18 +10,7 @@ index c72cf63d..e96b7eed 100644
  LIB_ELF ?= libelf
  LIB_ZLIB ?= zlib
  
-@@ -172,10 +173,6 @@ env:
- 	@echo "KERN_BUILD_PATH          $(KERN_BUILD_PATH)"
- 	@echo "KERN_SRC_PATH            $(KERN_SRC_PATH)"
- 	@echo ---------------------------------------
--	@echo "LIBBPF_CFLAGS            $(LIBBPF_CFLAGS)"
--	@echo "LIBBPF_LDLAGS            $(LIBBPF_LDFLAGS)"
--	@echo "LIBBPF_SRC               $(LIBBPF_SRC)"
--	@echo ---------------------------------------
- 	@echo "STATIC                   $(STATIC)"
- 	@echo ---------------------------------------
- 	@echo "BPF_VCPU                 $(BPF_VCPU)"
-@@ -274,8 +271,6 @@ OUTPUT_DIR = ./dist
+@@ -279,8 +280,6 @@ OUTPUT_DIR = ./dist
  $(OUTPUT_DIR):
  #
  	@$(CMD_MKDIR) -p $@
@@ -30,61 +19,7 @@ index c72cf63d..e96b7eed 100644
  
  #
  # embedded btfhub
-@@ -286,37 +281,6 @@ $(OUTPUT_DIR)/btfhub:
- 	@$(CMD_MKDIR) -p $@
- 	@$(CMD_TOUCH) $@/.place-holder # needed for embed.FS
- 
--#
--# libbpf
--#
--
--LIBBPF_CFLAGS = "-fPIC"
--LIBBPF_LDLAGS =
--LIBBPF_SRC = ./3rdparty/libbpf/src
--
--$(OUTPUT_DIR)/libbpf/libbpf.a: \
--	$(LIBBPF_SRC) \
--	$(wildcard $(LIBBPF_SRC)/*.[ch]) \
--	| .checkver_$(CMD_CLANG) $(OUTPUT_DIR)
--#
--	CC="$(CMD_CLANG)" \
--		CFLAGS="$(LIBBPF_CFLAGS)" \
--		LD_FLAGS="$(LIBBPF_LDFLAGS)" \
--		$(MAKE) \
--		-C $(LIBBPF_SRC) \
--		BUILD_STATIC_ONLY=1 \
--		DESTDIR=$(abspath ./$(OUTPUT_DIR)/libbpf/) \
--		OBJDIR=$(abspath ./$(OUTPUT_DIR)/libbpf/obj) \
--		INCLUDEDIR= LIBDIR= UAPIDIR= prefix= libdir= \
--		install install_uapi_headers
--
--$(LIBBPF_SRC): \
--	| .check_$(CMD_GIT)
--#
--ifeq ($(wildcard $@), )
--	@$(CMD_GIT) submodule update --init --recursive
--endif
--
- #
- # non co-re ebpf
- #
-@@ -333,7 +297,6 @@ BPF_NOCORE_TAG = $(subst .,_,$(KERN_RELEASE)).$(subst .,_,$(VERSION))
- bpf-nocore: $(OUTPUT_DIR)/tracee.bpf.$(BPF_NOCORE_TAG).o
- 
- $(OUTPUT_DIR)/tracee.bpf.$(BPF_NOCORE_TAG).o: \
--	$(OUTPUT_DIR)/libbpf/libbpf.a \
- 	$(TRACEE_EBPF_OBJ_SRC)
- #
- 	MAKEFLAGS="--no-print-directory"
-@@ -351,7 +314,6 @@ $(OUTPUT_DIR)/tracee.bpf.$(BPF_NOCORE_TAG).o: \
- 		-I $(KERN_SRC_PATH)/include/uapi \
- 		-I $(KERN_BUILD_PATH)/include/generated \
- 		-I $(KERN_BUILD_PATH)/include/generated/uapi \
--		-I $(OUTPUT_DIR)/libbpf \
- 		-I ./3rdparty/include \
- 		-Wunused \
- 		-Wall \
-@@ -412,7 +374,6 @@ TRACEE_EBPF_OBJ_CORE_HEADERS = $(shell find pkg/ebpf/c -name *.h)
+@@ -418,7 +417,6 @@ TRACEE_EBPF_OBJ_CORE_HEADERS = $(shell find pkg/ebpf/c -name *.h)
  bpf-core: $(OUTPUT_DIR)/tracee.bpf.core.o
  
  $(OUTPUT_DIR)/tracee.bpf.core.o: \
@@ -92,15 +27,7 @@ index c72cf63d..e96b7eed 100644
  	$(TRACEE_EBPF_OBJ_SRC) \
  	$(TRACEE_EBPF_OBJ_CORE_HEADERS)
  #
-@@ -421,7 +382,6 @@ $(OUTPUT_DIR)/tracee.bpf.core.o: \
- 		-D__BPF_TRACING__ \
- 		-DCORE \
- 		-I./pkg/ebpf/c/ \
--		-I$(OUTPUT_DIR)/libbpf/ \
- 		-I ./3rdparty/include \
- 		-target bpf \
- 		-O2 -g \
-@@ -447,8 +407,8 @@ ifeq ($(STATIC), 1)
+@@ -453,8 +451,8 @@ ifeq ($(STATIC), 1)
      GO_TAGS_EBPF := $(GO_TAGS_EBPF),netgo
  endif
  
@@ -111,7 +38,7 @@ index c72cf63d..e96b7eed 100644
  
  GO_ENV_EBPF =
  GO_ENV_EBPF += GOOS=linux
-@@ -468,6 +428,7 @@ $(OUTPUT_DIR)/tracee-ebpf: \
+@@ -474,6 +472,7 @@ $(OUTPUT_DIR)/tracee-ebpf: \
  	$(TRACEE_EBPF_SRC) \
  	./embedded-ebpf.go \
  	| .checkver_$(CMD_GO) \
@@ -119,11 +46,3 @@ index c72cf63d..e96b7eed 100644
  	.checklib_$(LIB_ELF) \
  	.checklib_$(LIB_ZLIB) \
  	btfhub
-@@ -658,7 +619,6 @@ test-rules: \
- .PHONY: test-upstream-libbpfgo
- test-upstream-libbpfgo: \
- 	.checkver_$(CMD_GO) \
--	$(OUTPUT_DIR)/libbpf/libbpf.a
- #
- 	./tests/libbpfgo.sh $(GO_ENV_EBPF)
- 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12971,7 +12971,9 @@ with pkgs;
 
   tracebox = callPackage ../tools/networking/tracebox { stdenv = gcc10StdenvCompat; };
 
-  tracee = callPackage ../tools/security/tracee { };
+  tracee = callPackage ../tools/security/tracee {
+    clang = clang_14;
+  };
 
   tracefilegen = callPackage ../development/tools/analysis/garcosim/tracefilegen { };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated tracee to 0.13.0

Also split out into separate outputs and dropped tracee-*
binaries due to the new single tracee binary

![image](https://user-images.githubusercontent.com/9866621/230032356-8c91a09c-0b5e-4258-b27e-7ce3047404ba.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
