### PR TITLE
texlive: fix kpathsea path expansion

### DIFF
--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -1,6 +1,26 @@
 { lib, runCommand, fetchurl, file, texlive, writeShellScript }:
 
 {
+
+  luaotfload-fonts = runCommand "texlive-test-lualatex" {
+    nativeBuildInputs = [
+      (with texlive; combine { inherit scheme-medium libertinus-fonts; })
+    ];
+    input = builtins.toFile "lualatex-testfile.tex" ''
+      \documentclass{article}
+      \usepackage{fontspec}
+      \setmainfont{Libertinus Serif}
+      \begin{document}
+        \LaTeX{} is great
+      \end{document}
+    '';
+  }
+  ''
+    export HOME="$(mktemp -d)"
+    lualatex -halt-on-error "$input"
+    echo success > $out
+  '';
+
   chktex = runCommand "texlive-test-chktex" {
     nativeBuildInputs = [
       (with texlive; combine { inherit scheme-infraonly chktex; })

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -30,6 +30,14 @@ let
       for i in texk/kpathsea/mktex*; do
         sed -i '/^mydir=/d' "$i"
       done
+
+      # ST_NLINK_TRICK causes kpathsea to treat folders with no real subfolders
+      # as leaves, even if they contain symlinks to other folders; must be
+      # disabled to work correctly with the nix store", see section 5.3.6
+      # “Subdirectory expansion” of the kpathsea manual
+      # http://mirrors.ctan.org/systems/doc/kpathsea/kpathsea.pdf for more
+      # details
+      sed -i '/^#define ST_NLINK_TRICK/d' texk/kpathsea/config.h
     '';
 
     configureFlags = [


### PR DESCRIPTION
###### Description of changes

When expanding path variables, kpathsea uses a trick to speed up identifying
leaf directories. The manual says

> The trick is that in every real Unix implementation (as opposed to the POSIX
> specification), a directory which contains no subdirectories will have
> exactly two links (namely, one for . and one for ..). That is to say, the
> st_nlink field in the ‘stat’ structure will be two. Thus, we don’t have to
> stat everything in the bottom-level (leaf) directories—we can just check
> st_nlink, notice it’s two, and do no more work.
>
> But if you have a directory that contains a single subdirectory and 500
> regular files, st_nlink will be 3, and Kpathsea has to stat every one of those
> 501 entries. Therein lies slowness.
>
> You can disable the trick by undefining ST_NLINK_TRICK in
> kpathsea/config.h. (It is undefined by default except under Unix.)

This does not work as expected with nixpkgs symlink trees and programs that rely
on kpathsea path expansion do not work properly.

One example is luaotfload's font database, which is populated by the font files
in the directories obtained by path-expanding the value of the `OPENTYPEFONTS`
configuration variable with kpathsea. The expanded value can be checked with
`kpsewhich --show-path="opentype fonts"`.  Before this change, the expanded
value does not include the various font directories symlinked into
`/texmf/fonts/opentype/public`, since kpathsea considers this a leaf
directory (every child is a symlink, not a directory). Hence luaotfload does
not find the fonts in the texlive installation.



This pull request disables this trick and adds a simple test which checks whether
luaotfload can find a custom font.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Maintainer highlights
@veprbl @lovek323 @7c6f434c @jwiegley  

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
