### PR TITLE
rhasspy: init at unstable-2023-03-08

### DIFF
--- a/pkgs/servers/rhasspy/default.nix
+++ b/pkgs/servers/rhasspy/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "rhasspy";
+  version = "unstable-2023-03-29";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "rhasspy";
+    repo = "rhasspy3";
+    rev = "f11b15fdfb29fb2f8274dae83db5909558012d1f";
+    hash = "sha256-BQ9efrFyjXEa8yxGaEal4+KnxbQRfwSZbdwogI1RPuw=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    hypercorn
+    quart
+    quart-cors
+  ];
+
+  pythonImportsCheck = [
+    "rhasspy3"
+    "rhasspy3_http_api"
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "An open source voice assistant toolkit for many human languages";
+    homepage = "https://github.com/rhasspy/rhasspy3";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25789,6 +25789,8 @@ with pkgs;
     libtool = darwin.cctools;
   };
 
+  rhasspy = callPackage ../servers/rhasspy { };
+
   # Fails to compile with boost <= 1.72
   rippled = callPackage ../servers/rippled {
     boost = boost172;


### PR DESCRIPTION
*Currently just a developer preview*

An open source voice assistant toolkit for many human languages

https://github.com/rhasspy/rhasspy3


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
