### PR TITLE
grub2: Pull upstream patches for flicker-free boot

### DIFF
--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -81,6 +81,30 @@ stdenv.mkDerivation rec {
       url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=000b5cd04fd228f9741f5dca0491636bc0b89eb8";
       sha256 = "sha256-Mex3qQ0lW7ZCv7ZI7MSSqbylJXZ5RTbR4Pv1+CJ0ciM=";
     })
+
+    # Upstreamed patches for flicker-free boot
+    # Remove these patches once a new release is cut
+    (fetchpatch {
+      # term/efi/console: Do not set colorstate until the first text output
+      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=9381dbe045b39bd9395c9ab4276d95b4041ec9fb";
+      sha256 = "sha256-ZFq/PdCYo6aRySZRAfZARO8BmXwGgqeXz+9uNgNJEO8=";
+    })
+    (fetchpatch {
+      # term/efi/console: Do not set cursor until the first text output
+      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=7c316e18301e101e4dcd8abe88c0bed0b1b78857";
+      sha256 = "sha256-WJiK7MqmdStzq77vIDsO60Fu7i9LE/jDYzF4E9FXb7c=";
+    })
+    (fetchpatch {
+      # normal/menu: Don't show "Booting `%s'" msg when auto-booting with TIMEOUT_STYLE_HIDDEN
+      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=5bb4f2b7d665c84bde402d1a528b652a61753380";
+      sha256 = "sha256-lwJPPyq6yj7X1C2RuHfxnwKKstFkWGxcMXuSQqd9Z4I=";
+    })
+    (fetchpatch {
+      # kern/main: Suppress the "Welcome to GRUB!" message in EFI builds
+      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=3e4cbbeca0ef35097301a1086f85fd0d119e64aa";
+      sha256 = "sha256-cQX4x9V5Y7SU9WACn5FzDjukL2/StAUMMoHY/DRHq+g=";
+    })
+
     (fetchpatch {
       name = "CVE-2021-3981.patch";
       url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=0adec29674561034771c13e446069b41ef41e4d4";


### PR DESCRIPTION
###### Description of changes

This imports the patches already accepted by upstream necessary for flicker-free boot.

###### What I tested

 - GRUB EFI on x86_64

With [another PR](https://github.com/NixOS/nixpkgs/pull/220263), which can be reviewed independently, this was verified to not introduce any "flicker" during boot on hardware. In other words, when GRUB was configured not to show itself, the display was left unchanged with the vendor logo (BGRT) as it was, until early when Linux takes over (or if configured properly, until later during the Linux boot).

Soon I'll be validating properly on AArch64, it's currently building.

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
