### PR TITLE
onlykey: 5.3.4 -> 5.3.6

### DIFF
--- a/pkgs/tools/security/onlykey/node-packages.nix
+++ b/pkgs/tools/security/onlykey/node-packages.nix
@@ -5956,14 +5956,14 @@ let
   };
 in
 {
-  "onlykey-git+https://github.com/trustcrypto/OnlyKey-App.git#v5.3.4" = nodeEnv.buildNodePackage {
+  "onlykey-git+https://github.com/trustcrypto/OnlyKey-App.git#v5.3.6" = nodeEnv.buildNodePackage {
     name = "OnlyKey";
     packageName = "OnlyKey";
-    version = "5.3.4";
+    version = "5.3.6";
     src = fetchgit {
       url = "https://github.com/trustcrypto/OnlyKey-App.git";
-      rev = "da67e5088514c919a3a0a885ed68ca19a904da13";
-      sha256 = "9e3f434932483a8709227ce6b51a746f38a647b53ef6b1ee5b85b68855c412a7";
+      rev = "14bb83ff780608adc8e4f9a5b4867378e1d66a84";
+      sha256 = "sha256-aq7IrqT73L9uUdEqA7kUEby5fxHr8Mcwe29skE2M/GQ=";
     };
     dependencies = [
       sources."@babel/code-frame-7.16.7"

--- a/pkgs/tools/security/onlykey/package.json
+++ b/pkgs/tools/security/onlykey/package.json
@@ -1,3 +1,3 @@
 [
-  {"onlykey": "git+https://github.com/trustcrypto/OnlyKey-App.git#v5.3.4"}
+  {"onlykey": "git+https://github.com/trustcrypto/OnlyKey-App.git#v5.3.6"}
 ]


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changelogs:
[https://github.com/trustcrypto/OnlyKey-App/releases/tag/v5.3.5](https://github.com/trustcrypto/OnlyKey-App/releases/tag/v5.3.5) 
[https://github.com/trustcrypto/OnlyKey-App/releases/tag/v5.3.6](https://github.com/trustcrypto/OnlyKey-App/releases/tag/v5.3.6)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
