### PR TITLE
aaaaxy: init at 1.3.372

### DIFF
--- a/pkgs/games/aaaaxy/default.nix
+++ b/pkgs/games/aaaaxy/default.nix
@@ -1,0 +1,89 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+, alsa-lib
+, libglvnd
+, libX11
+, libXcursor
+, libXext
+, libXi
+, libXinerama
+, libXrandr
+, libXxf86vm
+, go-licenses
+, pkg-config
+}:
+
+buildGoModule rec {
+  pname = "aaaaxy";
+  version = "1.3.372";
+
+  src = fetchFromGitHub {
+    owner = "divVerent";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-vm3wA8lzoaJ5iGwf2nZ0EvoSATHGftQ77lwdEjGe2RU=";
+    fetchSubmodules = true;
+  };
+
+  vendorHash = "sha256-WEK7j7FMiue0Fl1R+To5GKwvM03pjc1nKig/wePEAAY=";
+
+  buildInputs = [
+    alsa-lib
+    libglvnd
+    libX11 libXcursor libXext libXi libXinerama libXrandr
+    libXxf86vm
+  ];
+
+  nativeBuildInputs = [
+    go-licenses
+    pkg-config
+  ];
+
+  postPatch = ''
+    # Without patching, "go run" fails with the error message:
+    # package github.com/google/go-licenses: no Go files in /build/source/vendor/github.com/google/go-licenses
+    substituteInPlace scripts/build-licenses.sh --replace \
+      '$GO run ''${GO_FLAGS} github.com/google/go-licenses' 'go-licenses'
+  '';
+
+  makeFlags = [
+    "BUILDTYPE=release"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    AAAAXY_BUILD_USE_VERSION_FILE=true make $makeFlags
+    runHook postBuild
+  '';
+
+  postInstall = ''
+    install -Dm755 'aaaaxy' -t "$out/bin/"
+    install -Dm444 'aaaaxy.svg' -t "$out/share/icons/hicolor/scalable/apps/"
+    install -Dm644 'aaaaxy.png' -t "$out/share/icons/hicolor/128x128/apps/"
+    install -Dm644 'aaaaxy.desktop' -t "$out/share/applications/"
+    install -Dm644 'io.github.divverent.aaaaxy.metainfo.xml' -t "$out/share/metainfo/"
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    # Can't get GLX to work even though it seems to work in their CI system:
+    # [FATAL] RunGame exited abnormally: APIUnavailable: GLX: GLX extension not found
+    # xvfb-run sh scripts/regression-test-demo.sh aaaaxy \
+    #   "on track for Any%, All Paths and No Teleports" \
+    #   ./aaaaxy assets/demos/benchmark.dem
+
+    runHook postCheck
+  '';
+
+  strictDeps = true;
+
+  meta = with lib; {
+    description = "A nonlinear 2D puzzle platformer taking place in impossible spaces";
+    homepage = "https://divverent.github.io/aaaaxy/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ Luflosi ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35146,6 +35146,8 @@ with pkgs;
 
   _90secondportraits = callPackage ../games/90secondportraits { love = love_0_10; };
 
+  aaaaxy = callPackage ../games/aaaaxy { };
+
   ace-of-penguins = callPackage ../games/ace-of-penguins { };
 
   among-sus = callPackage ../games/among-sus { };


### PR DESCRIPTION
###### Description of changes
Adds a game called aaaaxy, see https://divverent.github.io/aaaaxy/.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).