### PR TITLE
magma: fix #220343 and separate CUDA build/run-time dependencies

### DIFF
--- a/pkgs/development/libraries/science/math/magma/generic.nix
+++ b/pkgs/development/libraries/science/math/magma/generic.nix
@@ -35,7 +35,7 @@
 
 let
   inherit (lib) lists strings trivial;
-  inherit (cudaPackages) cudatoolkit cudaFlags cudaVersion;
+  inherit (cudaPackages) backendStdenv cudaFlags cudaVersion;
   inherit (magmaRelease) version hash supportedGpuTargets;
 
   # NOTE: The lists.subtractLists function is perhaps a bit unintuitive. It subtracts the elements
@@ -148,8 +148,8 @@ stdenv.mkDerivation {
   ] ++ lists.optionals cudaSupport [
     "-DCMAKE_CUDA_ARCHITECTURES=${cudaArchitecturesString}"
     "-DMIN_ARCH=${minArch}" # Disarms magma's asserts
-    "-DCMAKE_C_COMPILER=${cudatoolkit.cc}/bin/cc"
-    "-DCMAKE_CXX_COMPILER=${cudatoolkit.cc}/bin/c++"
+    "-DCMAKE_C_COMPILER=${backendStdenv.cc}/bin/cc"
+    "-DCMAKE_CXX_COMPILER=${backendStdenv.cc}/bin/c++"
     "-DMAGMA_ENABLE_CUDA=ON"
   ] ++ lists.optionals rocmSupport [
     "-DCMAKE_C_COMPILER=${hip}/bin/hipcc"

--- a/pkgs/development/libraries/science/math/magma/generic.nix
+++ b/pkgs/development/libraries/science/math/magma/generic.nix
@@ -173,7 +173,7 @@ stdenv.mkDerivation {
     license = licenses.bsd3;
     homepage = "http://icl.cs.utk.edu/magma/index.html";
     platforms = platforms.unix;
-    maintainers = with maintainers; [ tbenst ];
+    maintainers = with maintainers; [ connorbaker ];
     # CUDA and ROCm are mutually exclusive
     broken = cudaSupport && rocmSupport || cudaSupport && strings.versionOlder cudaVersion "9";
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Goal is to shrink the size of the closure, or modularize the components which are downloaded.

Also fixes #220343.

My hope is that, for packages which do not fully support CUDA redistributables, by creating separate symlinked copies of what cudatoolkit would provide we can improve the user experience.

Closure before:

```console
/nix/store/qmnr18aqd08zdkhka695ici96k6nzirv-libunistring-1.0         	   1.7M	   1.7M
/nix/store/vv6rlzln7vhxk519rdsrzmhhlpyb5q2m-libidn2-2.3.2            	 254.1K	   2.0M
/nix/store/76l4v99sk83ylfwkz8wmwrm4s8h73rhd-glibc-2.35-224           	  28.9M	  30.8M
/nix/store/205vsmbfhq1q2vhgskpqyymqvba4mscp-gcc-11.3.0-lib           	   7.5M	  38.3M
/nix/store/2w4k8nvdyiggz717ygbbxchpnxrqc6y9-gcc-12.2.0-lib           	   7.8M	  38.6M
/nix/store/x6nnam5hk44mljbk782rcbd92jlnz8r6-pcre-8.45                	 514.4K	  31.3M
/nix/store/4vkv3rzky44hp2b8r13d8hr4ykvqhvwh-gnugrep-3.7              	 773.2K	  32.1M
/nix/store/5ynbf6wszmggr0abwifdagrixgnya5vy-bash-5.2-p15             	   1.6M	  32.4M
/nix/store/mg9l7phyhvi16p9g8g3g8fbyj4mr79gq-zlib-1.2.13              	 125.6K	  31.0M
/nix/store/6g6d4la7xsizvr8qg91f56jiqx149iqq-binutils-2.40-lib        	   2.7M	  33.7M
/nix/store/izdfacm4wfmfjbgl1k3qlfjslkkrb2kg-gfortran-12.2.0-lib      	  10.7M	  41.6M
/nix/store/yzbam1rxs24z2apzpdpgqwi5fcwbid6z-openblas-0.3.21          	  26.1M	  67.7M
/nix/store/azvwwb4994qm7b1fcz8gc3gnlf8zwzi4-blas-3                   	  53.3M	 121.0M
/nix/store/ia34rbsa6d2dalzk5f7hy5jp9zazpv24-gmp-with-cxx-6.2.1       	 729.2K	  39.3M
/nix/store/b8wwwcng8c0snvmcawvhiny4b2gr6yhh-mpfr-4.2.0               	 774.0K	  40.1M
/nix/store/jn9kg98dsaajx4mh95rb9r5rf2idglqh-attr-2.5.1               	  78.8K	  30.9M
/nix/store/bw9s084fzmb5h40x98mfry25blj4cr9r-acl-2.3.1                	 108.9K	  31.0M
/nix/store/jvl8dr21nrwhqywwxcl8di4j55765gvy-gmp-with-cxx-stage4-6.2.1	 730.4K	  39.3M
/nix/store/bg8f47vihykgqcgblxkfk9sbvc4dnksa-coreutils-9.1            	   1.4M	  40.9M
/nix/store/lp8qrhb6hs42jwbapzq20l05jf4kyicq-glibc-2.35-224-bin       	   3.0M	  33.8M
/nix/store/wyzaa007anaxxhmrcbffm597v14n2mxs-linux-headers-6.1        	   6.0M	   6.0M
/nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev       	   2.2M	  42.0M
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40            	  28.2M	  69.6M
/nix/store/xnrwkaidhxjsb70c2bnrl6j0mmr0y3qg-expand-response-params   	  16.4K	  30.9M
/nix/store/qkshx57xqsr4g4v8ga0jn8jrgnyaam3f-binutils-wrapper-2.40    	  48.5K	  84.8M
/nix/store/f6172g5agk13134pdx5hl1qjmw8a4sdw-libmpc-1.3.1             	 273.4K	  40.4M
/nix/store/fdfcva0q4zgnm1gpc7wmz4cgq7c3hxx1-isl-0.20                 	   2.5M	  41.8M
/nix/store/vns64fmwpqz8himgfdy8h7i29h9gbryc-gcc-11.3.0               	 180.6M	 242.2M
/nix/store/ds6ivg31k3l0pjhhf3s769bkpmafa54g-gcc-wrapper-11.3.0       	  55.2K	 278.4M
/nix/store/l0d6c6wa5sk4wx70x77k3d5clmny7sw6-cuda_cudart-11.7.60      	   6.2M	   6.2M
/nix/store/mxcbimi0gs021wwyfik63km6v26pzhp8-libcublas-11.10.1.25     	   1.1G	   1.2G
/nix/store/ss8jw175bhs3cmlzmmhsbpqihy457ids-libcusparse-11.7.3.50    	 488.1M	 488.1M
/nix/store/rbm214ji7jqk58g8shhkmhvl6xflblz0-cuda_cupti-11.7.50       	  88.4M	  88.4M
/nix/store/virnlrgvysrn1nl6bra798fy6x731nj0-cuda_nvprof-11.7.50      	   9.9M	 129.1M
/nix/store/zrpivbb39kiyij6dns4pz4wh8nik6m3y-cuda_nvcc-11.7.64        	 114.8M	 393.2M
/nix/store/mpj8ij172g466nncmnfqpz694pa746dr-cuda-redist-11.7         	  63.0K	   2.1G
/nix/store/ib9ckb796i7nqj0fy6iankvhyfc6az70-magma-2.7.1              	 429.4M	   2.6G
```

Closure after:

```console
/nix/store/qmnr18aqd08zdkhka695ici96k6nzirv-libunistring-1.0         	   1.7M	   1.7M
/nix/store/vv6rlzln7vhxk519rdsrzmhhlpyb5q2m-libidn2-2.3.2            	 254.1K	   2.0M
/nix/store/76l4v99sk83ylfwkz8wmwrm4s8h73rhd-glibc-2.35-224           	  28.9M	  30.8M
/nix/store/205vsmbfhq1q2vhgskpqyymqvba4mscp-gcc-11.3.0-lib           	   7.5M	  38.3M
/nix/store/mxcbimi0gs021wwyfik63km6v26pzhp8-libcublas-11.10.1.25     	   1.1G	   1.2G
/nix/store/ss8jw175bhs3cmlzmmhsbpqihy457ids-libcusparse-11.7.3.50    	 488.1M	 488.1M
/nix/store/23ygxbxapna1d80v447mnpfa2n78ay0x-cuda-redist-11.7         	  10.5K	   1.6G
/nix/store/2w4k8nvdyiggz717ygbbxchpnxrqc6y9-gcc-12.2.0-lib           	   7.8M	  38.6M
/nix/store/x6nnam5hk44mljbk782rcbd92jlnz8r6-pcre-8.45                	 514.4K	  31.3M
/nix/store/4vkv3rzky44hp2b8r13d8hr4ykvqhvwh-gnugrep-3.7              	 773.2K	  32.1M
/nix/store/5ynbf6wszmggr0abwifdagrixgnya5vy-bash-5.2-p15             	   1.6M	  32.4M
/nix/store/mg9l7phyhvi16p9g8g3g8fbyj4mr79gq-zlib-1.2.13              	 125.6K	  31.0M
/nix/store/6g6d4la7xsizvr8qg91f56jiqx149iqq-binutils-2.40-lib        	   2.7M	  33.7M
/nix/store/izdfacm4wfmfjbgl1k3qlfjslkkrb2kg-gfortran-12.2.0-lib      	  10.7M	  41.6M
/nix/store/yzbam1rxs24z2apzpdpgqwi5fcwbid6z-openblas-0.3.21          	  26.1M	  67.7M
/nix/store/azvwwb4994qm7b1fcz8gc3gnlf8zwzi4-blas-3                   	  53.3M	 121.0M
/nix/store/ia34rbsa6d2dalzk5f7hy5jp9zazpv24-gmp-with-cxx-6.2.1       	 729.2K	  39.3M
/nix/store/b8wwwcng8c0snvmcawvhiny4b2gr6yhh-mpfr-4.2.0               	 774.0K	  40.1M
/nix/store/jn9kg98dsaajx4mh95rb9r5rf2idglqh-attr-2.5.1               	  78.8K	  30.9M
/nix/store/bw9s084fzmb5h40x98mfry25blj4cr9r-acl-2.3.1                	 108.9K	  31.0M
/nix/store/jvl8dr21nrwhqywwxcl8di4j55765gvy-gmp-with-cxx-stage4-6.2.1	 730.4K	  39.3M
/nix/store/bg8f47vihykgqcgblxkfk9sbvc4dnksa-coreutils-9.1            	   1.4M	  40.9M
/nix/store/lp8qrhb6hs42jwbapzq20l05jf4kyicq-glibc-2.35-224-bin       	   3.0M	  33.8M
/nix/store/wyzaa007anaxxhmrcbffm597v14n2mxs-linux-headers-6.1        	   6.0M	   6.0M
/nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev       	   2.2M	  42.0M
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40            	  28.2M	  69.6M
/nix/store/xnrwkaidhxjsb70c2bnrl6j0mmr0y3qg-expand-response-params   	  16.4K	  30.9M
/nix/store/qkshx57xqsr4g4v8ga0jn8jrgnyaam3f-binutils-wrapper-2.40    	  48.5K	  84.8M
/nix/store/f6172g5agk13134pdx5hl1qjmw8a4sdw-libmpc-1.3.1             	 273.4K	  40.4M
/nix/store/fdfcva0q4zgnm1gpc7wmz4cgq7c3hxx1-isl-0.20                 	   2.5M	  41.8M
/nix/store/vns64fmwpqz8himgfdy8h7i29h9gbryc-gcc-11.3.0               	 180.6M	 242.2M
/nix/store/ds6ivg31k3l0pjhhf3s769bkpmafa54g-gcc-wrapper-11.3.0       	  55.2K	 278.4M
/nix/store/l0d6c6wa5sk4wx70x77k3d5clmny7sw6-cuda_cudart-11.7.60      	   6.2M	   6.2M
/nix/store/rbm214ji7jqk58g8shhkmhvl6xflblz0-cuda_cupti-11.7.50       	  88.4M	  88.4M
/nix/store/virnlrgvysrn1nl6bra798fy6x731nj0-cuda_nvprof-11.7.50      	   9.9M	 129.1M
/nix/store/zrpivbb39kiyij6dns4pz4wh8nik6m3y-cuda_nvcc-11.7.64        	 114.8M	 393.2M
/nix/store/fmv2m75gvby3jg106ibs4k956yl59b66-cuda-native-redist-11.7  	  53.3K	 497.8M
/nix/store/zwjfybn9vah5vkxmxl9qlawxmx7zmagp-magma-2.7.1              	 429.4M	   2.6G
```

<details>

Common derivations:

```console
/nix/store/qmnr18aqd08zdkhka695ici96k6nzirv-libunistring-1.0         	   1.7M	   1.7M
/nix/store/vv6rlzln7vhxk519rdsrzmhhlpyb5q2m-libidn2-2.3.2            	 254.1K	   2.0M
/nix/store/76l4v99sk83ylfwkz8wmwrm4s8h73rhd-glibc-2.35-224           	  28.9M	  30.8M
/nix/store/205vsmbfhq1q2vhgskpqyymqvba4mscp-gcc-11.3.0-lib           	   7.5M	  38.3M
/nix/store/2w4k8nvdyiggz717ygbbxchpnxrqc6y9-gcc-12.2.0-lib           	   7.8M	  38.6M
/nix/store/x6nnam5hk44mljbk782rcbd92jlnz8r6-pcre-8.45                	 514.4K	  31.3M
/nix/store/4vkv3rzky44hp2b8r13d8hr4ykvqhvwh-gnugrep-3.7              	 773.2K	  32.1M
/nix/store/5ynbf6wszmggr0abwifdagrixgnya5vy-bash-5.2-p15             	   1.6M	  32.4M
/nix/store/mg9l7phyhvi16p9g8g3g8fbyj4mr79gq-zlib-1.2.13              	 125.6K	  31.0M
/nix/store/6g6d4la7xsizvr8qg91f56jiqx149iqq-binutils-2.40-lib        	   2.7M	  33.7M
/nix/store/izdfacm4wfmfjbgl1k3qlfjslkkrb2kg-gfortran-12.2.0-lib      	  10.7M	  41.6M
/nix/store/yzbam1rxs24z2apzpdpgqwi5fcwbid6z-openblas-0.3.21          	  26.1M	  67.7M
/nix/store/azvwwb4994qm7b1fcz8gc3gnlf8zwzi4-blas-3                   	  53.3M	 121.0M
/nix/store/ia34rbsa6d2dalzk5f7hy5jp9zazpv24-gmp-with-cxx-6.2.1       	 729.2K	  39.3M
/nix/store/b8wwwcng8c0snvmcawvhiny4b2gr6yhh-mpfr-4.2.0               	 774.0K	  40.1M
/nix/store/jn9kg98dsaajx4mh95rb9r5rf2idglqh-attr-2.5.1               	  78.8K	  30.9M
/nix/store/bw9s084fzmb5h40x98mfry25blj4cr9r-acl-2.3.1                	 108.9K	  31.0M
/nix/store/jvl8dr21nrwhqywwxcl8di4j55765gvy-gmp-with-cxx-stage4-6.2.1	 730.4K	  39.3M
/nix/store/bg8f47vihykgqcgblxkfk9sbvc4dnksa-coreutils-9.1            	   1.4M	  40.9M
/nix/store/lp8qrhb6hs42jwbapzq20l05jf4kyicq-glibc-2.35-224-bin       	   3.0M	  33.8M
/nix/store/wyzaa007anaxxhmrcbffm597v14n2mxs-linux-headers-6.1        	   6.0M	   6.0M
/nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev       	   2.2M	  42.0M
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40            	  28.2M	  69.6M
/nix/store/xnrwkaidhxjsb70c2bnrl6j0mmr0y3qg-expand-response-params   	  16.4K	  30.9M
/nix/store/qkshx57xqsr4g4v8ga0jn8jrgnyaam3f-binutils-wrapper-2.40    	  48.5K	  84.8M
/nix/store/f6172g5agk13134pdx5hl1qjmw8a4sdw-libmpc-1.3.1             	 273.4K	  40.4M
/nix/store/fdfcva0q4zgnm1gpc7wmz4cgq7c3hxx1-isl-0.20                 	   2.5M	  41.8M
/nix/store/vns64fmwpqz8himgfdy8h7i29h9gbryc-gcc-11.3.0               	 180.6M	 242.2M
/nix/store/ds6ivg31k3l0pjhhf3s769bkpmafa54g-gcc-wrapper-11.3.0       	  55.2K	 278.4M
/nix/store/l0d6c6wa5sk4wx70x77k3d5clmny7sw6-cuda_cudart-11.7.60      	   6.2M	   6.2M
/nix/store/mxcbimi0gs021wwyfik63km6v26pzhp8-libcublas-11.10.1.25     	   1.1G	   1.2G
/nix/store/ss8jw175bhs3cmlzmmhsbpqihy457ids-libcusparse-11.7.3.50    	 488.1M	 488.1M
/nix/store/rbm214ji7jqk58g8shhkmhvl6xflblz0-cuda_cupti-11.7.50       	  88.4M	  88.4M
/nix/store/virnlrgvysrn1nl6bra798fy6x731nj0-cuda_nvprof-11.7.50      	   9.9M	 129.1M
/nix/store/zrpivbb39kiyij6dns4pz4wh8nik6m3y-cuda_nvcc-11.7.64        	 114.8M	 393.2M
```

Derivations unique to before:

```console
/nix/store/mpj8ij172g466nncmnfqpz694pa746dr-cuda-redist-11.7         	  63.0K	   2.1G
/nix/store/ib9ckb796i7nqj0fy6iankvhyfc6az70-magma-2.7.1              	 429.4M	   2.6G
```

Derivations unique to after:

```console
/nix/store/23ygxbxapna1d80v447mnpfa2n78ay0x-cuda-redist-11.7         	  10.5K	   1.6G
/nix/store/fmv2m75gvby3jg106ibs4k956yl59b66-cuda-native-redist-11.7  	  53.3K	 497.8M
/nix/store/zwjfybn9vah5vkxmxl9qlawxmx7zmagp-magma-2.7.1              	 429.4M	   2.6G
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
