### PR TITLE
rustc: 1.67.1 -> 1.68.1

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
+++ b/pkgs/build-support/rust/fetch-cargo-tarball/default.nix
@@ -62,6 +62,10 @@ in stdenv.mkDerivation ({
     export CARGO_HOME=$(mktemp -d cargo-home.XXX)
     CARGO_CONFIG=$(mktemp cargo-config.XXXX)
 
+    # https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol
+    # planned to become the default in 1.70
+    export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
     if [[ -n "$NIX_CRATES_INDEX" ]]; then
     cat >$CARGO_HOME/config.toml <<EOF
     [source.crates-io]

--- a/pkgs/development/compilers/rust/1_68.nix
+++ b/pkgs/development/compilers/rust/1_68.nix
@@ -21,8 +21,8 @@
 } @ args:
 
 import ./default.nix {
-  rustcVersion = "1.67.1";
-  rustcSha256 = "sha256-Rkg9Pl3oWjvUb456OuGDdJY5EGfb5xOiXTzwUbPZ/24=";
+  rustcVersion = "1.68.0";
+  rustcSha256 = "sha256-6vTYsZ8jojKkdw+1OrXnrN7ewR2h0CsOXUkcqSypbWI=";
 
   llvmSharedForBuild = pkgsBuildBuild.llvmPackages_15.libllvm.override { enableSharedLibraries = true; };
   llvmSharedForHost = pkgsBuildHost.llvmPackages_15.libllvm.override { enableSharedLibraries = true; };
@@ -38,36 +38,27 @@ import ./default.nix {
 
   # Note: the version MUST be one version prior to the version we're
   # building
-  bootstrapVersion = "1.66.1";
+  bootstrapVersion = "1.67.1";
 
   # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
   bootstrapHashes = {
-    i686-unknown-linux-gnu = "823128f64e902ee8aff61488c552c983e17ccca10c3f46dd93fde924d5100eb3";
-    x86_64-unknown-linux-gnu = "7ecf79e9ea23d05917b0172f9f81fb1e47011d261a719998f8d5620a1e835023";
-    x86_64-unknown-linux-musl = "70b660148238b8a137c6f165b0bc7bdcb50204c22a314bed6174ecd672f02e57";
-    arm-unknown-linux-gnueabihf = "12c93efe71f3334ef6e718786f6a60b9566f097d23a7f1e8f38ed9add209126f";
-    armv7-unknown-linux-gnueabihf = "f43c8cd3fd7d1c1e08bd6317220b2ec9b25891f464604f80bb17985b09bbf62a";
-    aarch64-unknown-linux-gnu = "84b8a79803c1b91386460fe6a7d04c54002344452ff8e5c5631d5fa275ed0c9c";
-    aarch64-unknown-linux-musl = "b2665da33efd328cff192a67ad026ea84f9deab8d1971892f4bbc22647606163";
-    x86_64-apple-darwin = "0fcf341db2579aa6eb61a3430cd1dbc79b042dfe89686b93cc887d818d086c30";
-    aarch64-apple-darwin = "03469fcaa0d8c505e6db03c18ded73cfbb6a2ce159292f8cf06c042bfc9f7cf9";
-    powerpc64le-unknown-linux-gnu = "ccf915a0137bb83a9d9b133a234ae53cc099f2ba26e3cb09d209b47bbee2ade7";
-    riscv64gc-unknown-linux-gnu = "525cb05edaf3ed0560753b413c72dd1b06492df28bf3c427a66fda683fdca3fc";
-    mips64el-unknown-linux-gnuabi64 = "3c241cc80410fe389e8b04beda62c42496c225fe8776db9d55a498c53244f7a6";
+    i686-unknown-linux-gnu = "4fe2128cfc32687e4717da4c6cb21aa563c36802c8e695cd3537a45efc5b8729";
+    x86_64-unknown-linux-gnu = "652a8966436c4e97b127721d9130810e1cdc8dfdf526fad68c9c1f6281bd02a3";
+    x86_64-unknown-linux-musl = "6fdc9379f662f8e9edd2d23e0a3ebcda502cc9f9a381b7c7d5fa38c326a82ad1";
+    arm-unknown-linux-gnueabihf = "eb919ef62a084797c148574abe39f2fb1e52d20b004041090811a6d479eb6503";
+    armv7-unknown-linux-gnueabihf = "09614988feb6310f64eaadf609c92dba5da5ebdbb5531b43a2b18d5336296b67";
+    aarch64-unknown-linux-gnu = "8edee248eed4b17c09b3d7b0096944b7e5992dd1119a28429c0b6b4d39a9613c";
+    aarch64-unknown-linux-musl = "05d03936493c19483eec4dc63d03f9e7a13f356d1147d1b8d7fc5dbfe508b4ed";
+    x86_64-apple-darwin = "020702c9564f53e18ac880db77c2f6b660a24ea372e4fda3f0c1ef2f8b9c74b9";
+    aarch64-apple-darwin = "8b07560267ec85703a5a9397a1746170fd7013e29fcfb9ffb8daa9bbf1e3211a";
+    powerpc64le-unknown-linux-gnu = "1d4d8b75c72362bb6e02bf56b53af9287806c4ef08187b8d166af0557a7c0096";
+    riscv64gc-unknown-linux-gnu = "a1a33154aeb5498c0c24a2ba77ec63e31a40df5e0861c0afda8d5867289c5984";
+    mips64el-unknown-linux-gnuabi64 = "6d70fe81e4f52ce5d87bcf95b60587f43f68e6730d2def7872646a9c561017ca";
   };
 
-  selectRustPackage = pkgs: pkgs.rust_1_67;
+  selectRustPackage = pkgs: pkgs.rust_1_68;
 
-  rustcPatches = [
-    # Fixes ICE.
-    # https://github.com/rust-lang/rust/pull/107688
-    (fetchpatch {
-      name = "re-erased-regions-are-local.patch";
-      url = "https://github.com/rust-lang/rust/commit/9d110847ab7f6aef56a8cd20cb6cea4fbcc51cd9.patch";
-      excludes = [ "*tests/*" ];
-      hash = "sha256-EZH5K1BEOOfi97xZr1xEHFP4jjvJ1+xqtRMvxBoL8pU=";
-    })
-  ];
+  rustcPatches = [ ];
 }
 
 (builtins.removeAttrs args [ "fetchpatch" "pkgsBuildHost" "llvmPackages_11" "llvmPackages_15" "llvm_15"])

--- a/pkgs/development/compilers/rust/1_68.nix
+++ b/pkgs/development/compilers/rust/1_68.nix
@@ -21,8 +21,8 @@
 } @ args:
 
 import ./default.nix {
-  rustcVersion = "1.68.0";
-  rustcSha256 = "sha256-6vTYsZ8jojKkdw+1OrXnrN7ewR2h0CsOXUkcqSypbWI=";
+  rustcVersion = "1.68.1";
+  rustcSha256 = "sha256-zLBR31cB1MWI49BVj4PnPn7qCpsWXas+Od0tuKaiXQM=";
 
   llvmSharedForBuild = pkgsBuildBuild.llvmPackages_15.libllvm.override { enableSharedLibraries = true; };
   llvmSharedForHost = pkgsBuildHost.llvmPackages_15.libllvm.override { enableSharedLibraries = true; };

--- a/pkgs/development/compilers/rust/rustfmt.nix
+++ b/pkgs/development/compilers/rust/rustfmt.nix
@@ -11,7 +11,9 @@ rustPlatform.buildRustPackage rec {
   # changes hash of vendor directory otherwise
   dontUpdateAutotoolsGnuConfigScripts = true;
 
-  buildInputs = lib.optional stdenv.isDarwin Security;
+  buildInputs = [
+    rustPlatform.rust.rustc.llvm
+  ] ++ lib.optional stdenv.isDarwin Security;
 
   # As of 1.0.0 and rustc 1.30 rustfmt requires a nightly compiler
   RUSTC_BOOTSTRAP = 1;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15851,11 +15851,11 @@ with pkgs;
     inherit (darwin) apple_sdk;
   };
 
-  rust_1_67 = callPackage ../development/compilers/rust/1_67.nix {
+  rust_1_68 = callPackage ../development/compilers/rust/1_68.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_15 = llvmPackages_15.libllvm;
   };
-  rust = rust_1_67;
+  rust = rust_1_68;
 
   mrustc = callPackage ../development/compilers/mrustc { };
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
@@ -15864,8 +15864,8 @@ with pkgs;
     openssl = openssl_1_1;
   };
 
-  rustPackages_1_67 = rust_1_67.packages.stable;
-  rustPackages = rustPackages_1_67;
+  rustPackages_1_68 = rust_1_68.packages.stable;
+  rustPackages = rustPackages_1_68;
 
   inherit (rustPackages) cargo cargo-auditable cargo-auditable-cargo-wrapper clippy rustc rustPlatform;
 


### PR DESCRIPTION
###### Description of changes

https://github.com/rust-lang/rust/blob/master/RELEASES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).