### PR TITLE
ocamlPackages.letsencrypt-mirage: init at 0.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/chacha/default.nix
+++ b/pkgs/development/ocaml-modules/chacha/default.nix
@@ -17,7 +17,7 @@ buildDunePackage rec {
     owner = "abeaumont";
     repo = "ocaml-chacha";
     rev = version;
-    sha256 = "sha256-PmeiFloU0k3SqOK1VjaliiCEzDzrzyMSasgnO5fJS1k=";
+    hash = "sha256-PmeiFloU0k3SqOK1VjaliiCEzDzrzyMSasgnO5fJS1k=";
   };
 
   # Ensure compatibility with cstruct ≥ 6.1.0
@@ -27,6 +27,7 @@ buildDunePackage rec {
   })];
 
   minimalOCamlVersion = "4.02";
+  duneVersion = "3";
 
   propagatedBuildInputs = [ cstruct mirage-crypto ];
 

--- a/pkgs/development/ocaml-modules/http-mirage-client/default.nix
+++ b/pkgs/development/ocaml-modules/http-mirage-client/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, fetchurl
+, fetchpatch
+, buildDunePackage
+, h2
+, httpaf
+, mimic-happy-eyeballs
+, mirage-clock
+, paf
+, tcpip
+, x509
+, alcotest-lwt
+, mirage-clock-unix
+, mirage-crypto-rng
+, mirage-time-unix
+}:
+
+buildDunePackage rec {
+  pname = "http-mirage-client";
+  version = "0.0.2";
+
+  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
+
+  src = fetchurl {
+    url = "https://github.com/roburio/http-mirage-client/releases/download/v${version}/http-mirage-client-${version}.tbz";
+    hash = "sha256-stom13t3Kn1ehkeURem39mxhd3Lmlz8z9m3tHGcp5vY=";
+  };
+
+  # Make tests use mirage-crypto
+  patches = lib.lists.map fetchpatch [
+    { url = "https://github.com/roburio/http-mirage-client/commit/c6cd38db9c23ac23e7c3e4cf2d41420f58034e8d.patch";
+      hash = "sha256-b3rurqF0DxLpVQEhVfROwc7qyul0Fjfl3zhD8AkzemU="; }
+    { url = "https://github.com/roburio/http-mirage-client/commit/0a5367e7c6d9b7f45c88493f7a596f7a83e8c7d5.patch";
+      hash = "sha256-Q6YlfuiAfsyhty9EvoBetvekuU25KjrH5wwGwYTAAiA="; }
+    ];
+
+  propagatedBuildInputs = [
+    h2
+    httpaf
+    mimic-happy-eyeballs
+    mirage-clock
+    paf
+    tcpip
+    x509
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    alcotest-lwt
+    mirage-clock-unix
+    mirage-crypto-rng
+    mirage-time-unix
+  ];
+
+  meta = {
+    description = "HTTP client for MirageOS";
+    homepage = "https://github.com/roburio/http-mirage-client";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/letsencrypt/mirage.nix
+++ b/pkgs/development/ocaml-modules/letsencrypt/mirage.nix
@@ -1,0 +1,20 @@
+{ buildDunePackage
+, letsencrypt
+, emile
+, http-mirage-client
+, paf
+}:
+
+buildDunePackage {
+  pname = "letsencrypt-mirage";
+
+  inherit (letsencrypt) version src;
+
+  duneVersion = "3";
+
+  propagatedBuildInputs = [ emile http-mirage-client letsencrypt paf ];
+
+  meta = letsencrypt.meta // {
+    description = "ACME implementation in OCaml for MirageOS";
+  };
+}

--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -5,6 +5,7 @@
 
 buildDunePackage rec {
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   pname = "mirage-crypto";
   version = "0.11.0";

--- a/pkgs/development/ocaml-modules/mirage-crypto/ec.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/ec.nix
@@ -24,6 +24,8 @@ buildDunePackage rec {
     src
     version;
 
+  duneVersion = "3";
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     dune-configurator

--- a/pkgs/development/ocaml-modules/mirage-crypto/pk.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/pk.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
 
   inherit (mirage-crypto) version src;
 
+  duneVersion = "3";
+
   buildInputs = [ gmp ];
   propagatedBuildInputs = [ cstruct mirage-crypto mirage-crypto-rng
                             zarith eqaf sexplib0 ];

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-async.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-async.nix
@@ -8,6 +8,8 @@ buildDunePackage {
 
   inherit (mirage-crypto) version src;
 
+  duneVersion = "3";
+
   buildInputs = [
     dune-configurator
   ];

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-lwt.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-lwt.nix
@@ -1,15 +1,17 @@
 { buildDunePackage, mirage-crypto, mirage-crypto-rng, dune-configurator
-, duration, logs, mtime, ocaml_lwt }:
+, duration, logs, mtime, lwt }:
 
 buildDunePackage rec {
   pname = "mirage-crypto-rng-lwt";
 
   inherit (mirage-crypto) version src;
 
+  duneVersion = "3";
+
   doCheck = true;
 
   buildInputs = [ dune-configurator ];
-  propagatedBuildInputs = [ mirage-crypto mirage-crypto-rng duration logs mtime ocaml_lwt ];
+  propagatedBuildInputs = [ mirage-crypto mirage-crypto-rng duration logs mtime lwt ];
 
   meta = mirage-crypto-rng.meta;
 }

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
@@ -7,6 +7,7 @@ buildDunePackage rec {
   pname = "mirage-crypto-rng-mirage";
 
   inherit (mirage-crypto-rng) version src;
+  duneVersion = "3";
 
   doCheck = true;
   checkInputs = [ mirage-unix mirage-clock-unix mirage-time-unix ];

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
@@ -5,6 +5,7 @@ buildDunePackage rec {
   pname = "mirage-crypto-rng";
 
   inherit (mirage-crypto) version src;
+  duneVersion = "3";
 
   doCheck = true;
   checkInputs = [ ounit2 randomconv ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -569,6 +569,8 @@ let
 
     hpack = callPackage ../development/ocaml-modules/hpack { };
 
+    http-mirage-client = callPackage ../development/ocaml-modules/http-mirage-client { };
+
     hxd = callPackage ../development/ocaml-modules/hxd { };
 
     imagelib = callPackage ../development/ocaml-modules/imagelib { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -757,6 +757,8 @@ let
 
     letsencrypt-dns = callPackage ../development/ocaml-modules/letsencrypt/dns.nix { };
 
+    letsencrypt-mirage = callPackage ../development/ocaml-modules/letsencrypt/mirage.nix { };
+
     lilv = callPackage ../development/ocaml-modules/lilv {
       inherit (pkgs) lilv;
     };


### PR DESCRIPTION
###### Description of changes



###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
