### PR TITLE
hydrasect: init at unstable-2022-05-30

### DIFF
--- a/pkgs/by-name/hy/hydrasect/package.nix
+++ b/pkgs/by-name/hy/hydrasect/package.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, lib
+, fetchgit
+, meson
+, ninja
+, rustc
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation {
+  pname = "hydrasect";
+  version = "unstable-2022-05-30";
+
+  src = fetchgit {
+    url = "https://git.qyliss.net/hydrasect.git";
+    rev = "e8ac7c351122f1a8fc3dbf0cd4805cf2e83d14da";
+    hash = "sha256-A1FJGaFGm4Dw28gscOa5fY8Zumjg/0lUe0wul7bmpmw=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    rustc
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = with lib; {
+    description = "Bisect nix builds";
+    homepage = "https://git.qyliss.net/hydrasect/about/";
+    license = licenses.eupl12;
+    maintainers = with maintainers; [ ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

Just trying it out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
