### PR TITLE
cudaPackages: fix #220357; use -Xfatbin=-compress-all; prune default cudaCapabilities

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/common.nix
+++ b/pkgs/development/compilers/cudatoolkit/common.nix
@@ -151,6 +151,10 @@ backendStdenv.mkDerivation rec {
   # Refer to comments in the overrides for cuda_nvcc for explanation
   # CUDA_TOOLKIT_ROOT_DIR is legacy,
   # Cf. https://cmake.org/cmake/help/latest/module/FindCUDA.html#input-variables
+  # NOTE: We unconditionally set -Xfatbin=-compress-all, which reduces the size of the compiled
+  #   binaries. If binaries grow over 2GB, they will fail to link. This is a problem for us, as
+  #   the default set of CUDA capabilities we build can regularly cause this to occur (for
+  #   example, with Magma).
   ''
     mkdir -p $out/nix-support
     cat <<EOF >> $out/nix-support/setup-hook
@@ -160,7 +164,7 @@ backendStdenv.mkDerivation rec {
     if [ -z "\''${CUDAHOSTCXX-}" ]; then
       export CUDAHOSTCXX=${backendStdenv.cc}/bin;
     fi
-    export NVCC_PREPEND_FLAGS+=' --compiler-bindir=${backendStdenv.cc}/bin'
+    export NVCC_PREPEND_FLAGS+=' --compiler-bindir=${backendStdenv.cc}/bin -Xfatbin=-compress-all'
     EOF
 
     # Move some libraries to the lib output so that programs that

--- a/pkgs/development/compilers/cudatoolkit/gpus.nix
+++ b/pkgs/development/compilers/cudatoolkit/gpus.nix
@@ -1,110 +1,148 @@
 [
+  # Type alias
+  # Gpu = {
+  #   archName: String
+  #     - The name of the microarchitecture.
+  #   computeCapability: String
+  #     - The compute capability of the GPU.
+  #   minCudaVersion: String
+  #     - The minimum (inclusive) CUDA version that supports this GPU.
+  #   dontDefaultAfter: null | String
+  #     - The CUDA version after which to exclude this GPU from the list of default capabilities
+  #       we build. null means we always include this GPU in the default capabilities if it is
+  #       supported.
+  #   maxCudaVersion: null | String
+  #     - The maximum (exclusive) CUDA version that supports this GPU. null means there is no
+  #       maximum.
+  # }
   {
     archName = "Kepler";
     computeCapability = "3.0";
     minCudaVersion = "10.0";
+    dontDefaultAfter = "10.2";
     maxCudaVersion = "10.2";
   }
   {
     archName = "Kepler";
     computeCapability = "3.2";
     minCudaVersion = "10.0";
+    dontDefaultAfter = "10.2";
     maxCudaVersion = "10.2";
   }
   {
     archName = "Kepler";
     computeCapability = "3.5";
     minCudaVersion = "10.0";
+    dontDefaultAfter = "11.0";
     maxCudaVersion = "11.8";
   }
   {
     archName = "Kepler";
     computeCapability = "3.7";
     minCudaVersion = "10.0";
+    dontDefaultAfter = "11.0";
     maxCudaVersion = "11.8";
   }
   {
     archName = "Maxwell";
     computeCapability = "5.0";
     minCudaVersion = "10.0";
-    maxCudaVersion = "12.0";
+    dontDefaultAfter = "11.0";
+    maxCudaVersion = null;
   }
   {
     archName = "Maxwell";
     computeCapability = "5.2";
     minCudaVersion = "10.0";
-    maxCudaVersion = "12.0";
+    dontDefaultAfter = "11.0";
+    maxCudaVersion = null;
   }
   {
     archName = "Maxwell";
     computeCapability = "5.3";
     minCudaVersion = "10.0";
-    maxCudaVersion = "12.0";
+    dontDefaultAfter = "11.0";
+    maxCudaVersion = null;
   }
   {
     archName = "Pascal";
     computeCapability = "6.0";
     minCudaVersion = "10.0";
-    maxCudaVersion = "12.0";
+    dontDefaultAfter = null;
+    maxCudaVersion = null;
   }
   {
     archName = "Pascal";
     computeCapability = "6.1";
     minCudaVersion = "10.0";
-    maxCudaVersion = "12.0";
+    dontDefaultAfter = null;
+    maxCudaVersion = null;
   }
   {
     archName = "Pascal";
     computeCapability = "6.2";
     minCudaVersion = "10.0";
-    maxCudaVersion = "12.0";
+    dontDefaultAfter = null;
+    maxCudaVersion = null;
   }
   {
     archName = "Volta";
     computeCapability = "7.0";
     minCudaVersion = "10.0";
-    maxCudaVersion = "12.0";
+    dontDefaultAfter = null;
+    maxCudaVersion = null;
   }
   {
     archName = "Volta";
     computeCapability = "7.2";
     minCudaVersion = "10.0";
-    maxCudaVersion = "12.0";
+    dontDefaultAfter = null;
+    maxCudaVersion = null;
   }
   {
     archName = "Turing";
     computeCapability = "7.5";
     minCudaVersion = "10.0";
-    maxCudaVersion = "12.0";
+    dontDefaultAfter = null;
+    maxCudaVersion = null;
   }
   {
     archName = "Ampere";
     computeCapability = "8.0";
     minCudaVersion = "11.2";
-    maxCudaVersion = "12.0";
+    dontDefaultAfter = null;
+    maxCudaVersion = null;
   }
   {
     archName = "Ampere";
     computeCapability = "8.6";
     minCudaVersion = "11.2";
-    maxCudaVersion = "12.0";
+    dontDefaultAfter = null;
+    maxCudaVersion = null;
   }
   {
     archName = "Ampere";
     computeCapability = "8.7";
     minCudaVersion = "11.5";
-    maxCudaVersion = "12.0";
+    # NOTE: This is purposefully before 11.5 to ensure it is never a capability we target by
+    #   default. 8.7 is the Jetson Orin series of devices which are a very specific platform.
+    #   We keep this entry here in case we ever want to target it explicitly, but we don't
+    #   want to target it by default.
+    dontDefaultAfter = "11.4";
+    maxCudaVersion = null;
   }
   {
     archName = "Ada";
     computeCapability = "8.9";
     minCudaVersion = "11.8";
-    maxCudaVersion = "12.0";
+    dontDefaultAfter = null;
+    maxCudaVersion = null;
   }
   {
     archName = "Hopper";
     computeCapability = "9.0";
     minCudaVersion = "11.8";
-    maxCudaVersion = "12.0";
+    dontDefaultAfter = null;
+    maxCudaVersion = null;
   }
 ]

--- a/pkgs/development/compilers/cudatoolkit/redist/overrides.nix
+++ b/pkgs/development/compilers/cudatoolkit/redist/overrides.nix
@@ -41,6 +41,10 @@ in
       # uses the last --compiler-bindir it gets on the command line.
       # FIXME: this results in "incompatible redefinition" warnings.
       # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#compiler-bindir-directory-ccbin
+      # NOTE: We unconditionally set -Xfatbin=-compress-all, which reduces the size of the
+      #   compiled binaries. If binaries grow over 2GB, they will fail to link. This is a problem
+      #   for us, as the default set of CUDA capabilities we build can regularly cause this to
+      #   occur (for example, with Magma).
       postInstall = (oldAttrs.postInstall or "") + ''
         mkdir -p $out/nix-support
         cat <<EOF >> $out/nix-support/setup-hook
@@ -49,7 +53,7 @@ in
         if [ -z "\''${CUDAHOSTCXX-}" ]; then
           export CUDAHOSTCXX=${cc}/bin;
         fi
-        export NVCC_PREPEND_FLAGS+=' --compiler-bindir=${cc}/bin'
+        export NVCC_PREPEND_FLAGS+=' --compiler-bindir=${cc}/bin -Xfatbin=-compress-all'
         EOF
       '';
     });


### PR DESCRIPTION
###### Description of changes

- adds `-Xfatbin=-compress-all` to `NVCC_PREPEND_FLAGS` to help ensure the generated libraries aren't so large that they fail to link
  - has the added benefit of making the NARs *much* smaller, and reducing closure size as well
- prunes the default cudaCapabilities without removing any of the existing capabilities by introducing a `dontDefaultAfter` attribute to `gpus.nix`
  - this way, users can specifically target supported capabilities we don't build for by default
- excludes 8.7 from the default capabilities because it is the Orin series of devices, which are very different
- Minor cleanup of `gpus.nix` by making `maxCudaVersion` a string or `null`, indicating there is no maximum supported version
  - This change allows us to add new versions of CUDA without having to manually bump a bunch of `maxCudaVersion` attributes in `gpus.nix` every time
- Fixes #220357

We're experiencing the same problems Apache MXNet did due to the the number of capabilities we build for currently: https://github.com/apache/mxnet/pull/19123. Unfortunately, just using `-Xfatbin=-compress-all` isn't enough --  the number of CUDA capabilities we support is still so large that, without some pruning, Magma will fail to build.

I think it'd be fair to remove support for Kepler and Maxwell since they're 11 and 9 years old, respectively. Kepler has been deprecated for most of CUDA 11 and is fully removed as of CUDA 12. Maxwell is still supported in CUDA 12, but they are increasingly old and rare.

Before:

```console
nix-repl> legacyPackages.x86_64-linux.cudaPackages.cudaFlags.cudaCapabilities
[ "3.5" "3.7" "5.0" "5.2" "5.3" "6.0" "6.1" "6.2" "7.0" "7.2" "7.5" "8.0" "8.6" "8.7" ]
```

After:

```console
nix-repl> legacyPackages.x86_64-linux.cudaPackages.cudaFlags.cudaCapabilities
[ "6.0" "6.1" "6.2" "7.0" "7.2" "7.5" "8.0" "8.6" ]
```

An added benefit of this PR: the closure and NAR serializations of CUDA-binaries and libraries are smaller. 

**Closure size with cudaCapabilities = [ "8.6" ];**

From

```console
/nix/store/ib9ckb796i7nqj0fy6iankvhyfc6az70-magma-2.7.1 429.4M 2.6G
```

to

```console
/nix/store/r9dc4yf6nq17dl8bdav4hy7q0vd80s64-magma-2.7.1 233.6M 2.4G
```

<details>

With the following example (which, admittedly is just targeting a single capability), the size of the Magma NAR is nearly _halved_, from 429.4M to 233.6M.

With

```nix
# ~/.config/nixpkgs/config.nix 
{
  allowUnfree = true;
  cudaSupport = true;
  cudaCapabilities = [ "8.6" ];
  cudaForwardCompat = false;
}
```

the before closure:

```console
/nix/store/qmnr18aqd08zdkhka695ici96k6nzirv-libunistring-1.0         	   1.7M	   1.7M
/nix/store/vv6rlzln7vhxk519rdsrzmhhlpyb5q2m-libidn2-2.3.2            	 254.1K	   2.0M
/nix/store/76l4v99sk83ylfwkz8wmwrm4s8h73rhd-glibc-2.35-224           	  28.9M	  30.8M
/nix/store/205vsmbfhq1q2vhgskpqyymqvba4mscp-gcc-11.3.0-lib           	   7.5M	  38.3M
/nix/store/2w4k8nvdyiggz717ygbbxchpnxrqc6y9-gcc-12.2.0-lib           	   7.8M	  38.6M
/nix/store/x6nnam5hk44mljbk782rcbd92jlnz8r6-pcre-8.45                	 514.4K	  31.3M
/nix/store/4vkv3rzky44hp2b8r13d8hr4ykvqhvwh-gnugrep-3.7              	 773.2K	  32.1M
/nix/store/5ynbf6wszmggr0abwifdagrixgnya5vy-bash-5.2-p15             	   1.6M	  32.4M
/nix/store/mg9l7phyhvi16p9g8g3g8fbyj4mr79gq-zlib-1.2.13              	 125.6K	  31.0M
/nix/store/6g6d4la7xsizvr8qg91f56jiqx149iqq-binutils-2.40-lib        	   2.7M	  33.7M
/nix/store/izdfacm4wfmfjbgl1k3qlfjslkkrb2kg-gfortran-12.2.0-lib      	  10.7M	  41.6M
/nix/store/yzbam1rxs24z2apzpdpgqwi5fcwbid6z-openblas-0.3.21          	  26.1M	  67.7M
/nix/store/azvwwb4994qm7b1fcz8gc3gnlf8zwzi4-blas-3                   	  53.3M	 121.0M
/nix/store/ia34rbsa6d2dalzk5f7hy5jp9zazpv24-gmp-with-cxx-6.2.1       	 729.2K	  39.3M
/nix/store/b8wwwcng8c0snvmcawvhiny4b2gr6yhh-mpfr-4.2.0               	 774.0K	  40.1M
/nix/store/jn9kg98dsaajx4mh95rb9r5rf2idglqh-attr-2.5.1               	  78.8K	  30.9M
/nix/store/bw9s084fzmb5h40x98mfry25blj4cr9r-acl-2.3.1                	 108.9K	  31.0M
/nix/store/jvl8dr21nrwhqywwxcl8di4j55765gvy-gmp-with-cxx-stage4-6.2.1	 730.4K	  39.3M
/nix/store/bg8f47vihykgqcgblxkfk9sbvc4dnksa-coreutils-9.1            	   1.4M	  40.9M
/nix/store/lp8qrhb6hs42jwbapzq20l05jf4kyicq-glibc-2.35-224-bin       	   3.0M	  33.8M
/nix/store/wyzaa007anaxxhmrcbffm597v14n2mxs-linux-headers-6.1        	   6.0M	   6.0M
/nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev       	   2.2M	  42.0M
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40            	  28.2M	  69.6M
/nix/store/xnrwkaidhxjsb70c2bnrl6j0mmr0y3qg-expand-response-params   	  16.4K	  30.9M
/nix/store/qkshx57xqsr4g4v8ga0jn8jrgnyaam3f-binutils-wrapper-2.40    	  48.5K	  84.8M
/nix/store/f6172g5agk13134pdx5hl1qjmw8a4sdw-libmpc-1.3.1             	 273.4K	  40.4M
/nix/store/fdfcva0q4zgnm1gpc7wmz4cgq7c3hxx1-isl-0.20                 	   2.5M	  41.8M
/nix/store/vns64fmwpqz8himgfdy8h7i29h9gbryc-gcc-11.3.0               	 180.6M	 242.2M
/nix/store/ds6ivg31k3l0pjhhf3s769bkpmafa54g-gcc-wrapper-11.3.0       	  55.2K	 278.4M
/nix/store/l0d6c6wa5sk4wx70x77k3d5clmny7sw6-cuda_cudart-11.7.60      	   6.2M	   6.2M
/nix/store/mxcbimi0gs021wwyfik63km6v26pzhp8-libcublas-11.10.1.25     	   1.1G	   1.2G
/nix/store/ss8jw175bhs3cmlzmmhsbpqihy457ids-libcusparse-11.7.3.50    	 488.1M	 488.1M
/nix/store/rbm214ji7jqk58g8shhkmhvl6xflblz0-cuda_cupti-11.7.50       	  88.4M	  88.4M
/nix/store/virnlrgvysrn1nl6bra798fy6x731nj0-cuda_nvprof-11.7.50      	   9.9M	 129.1M
/nix/store/zrpivbb39kiyij6dns4pz4wh8nik6m3y-cuda_nvcc-11.7.64        	 114.8M	 393.2M
/nix/store/mpj8ij172g466nncmnfqpz694pa746dr-cuda-redist-11.7         	  63.0K	   2.1G
/nix/store/ib9ckb796i7nqj0fy6iankvhyfc6az70-magma-2.7.1              	 429.4M	   2.6G
```

and afterwards:

```console
/nix/store/qmnr18aqd08zdkhka695ici96k6nzirv-libunistring-1.0         	   1.7M	   1.7M
/nix/store/vv6rlzln7vhxk519rdsrzmhhlpyb5q2m-libidn2-2.3.2            	 254.1K	   2.0M
/nix/store/76l4v99sk83ylfwkz8wmwrm4s8h73rhd-glibc-2.35-224           	  28.9M	  30.8M
/nix/store/205vsmbfhq1q2vhgskpqyymqvba4mscp-gcc-11.3.0-lib           	   7.5M	  38.3M
/nix/store/2w4k8nvdyiggz717ygbbxchpnxrqc6y9-gcc-12.2.0-lib           	   7.8M	  38.6M
/nix/store/x6nnam5hk44mljbk782rcbd92jlnz8r6-pcre-8.45                	 514.4K	  31.3M
/nix/store/4vkv3rzky44hp2b8r13d8hr4ykvqhvwh-gnugrep-3.7              	 773.2K	  32.1M
/nix/store/5ynbf6wszmggr0abwifdagrixgnya5vy-bash-5.2-p15             	   1.6M	  32.4M
/nix/store/mg9l7phyhvi16p9g8g3g8fbyj4mr79gq-zlib-1.2.13              	 125.6K	  31.0M
/nix/store/6g6d4la7xsizvr8qg91f56jiqx149iqq-binutils-2.40-lib        	   2.7M	  33.7M
/nix/store/izdfacm4wfmfjbgl1k3qlfjslkkrb2kg-gfortran-12.2.0-lib      	  10.7M	  41.6M
/nix/store/yzbam1rxs24z2apzpdpgqwi5fcwbid6z-openblas-0.3.21          	  26.1M	  67.7M
/nix/store/azvwwb4994qm7b1fcz8gc3gnlf8zwzi4-blas-3                   	  53.3M	 121.0M
/nix/store/ia34rbsa6d2dalzk5f7hy5jp9zazpv24-gmp-with-cxx-6.2.1       	 729.2K	  39.3M
/nix/store/b8wwwcng8c0snvmcawvhiny4b2gr6yhh-mpfr-4.2.0               	 774.0K	  40.1M
/nix/store/jn9kg98dsaajx4mh95rb9r5rf2idglqh-attr-2.5.1               	  78.8K	  30.9M
/nix/store/bw9s084fzmb5h40x98mfry25blj4cr9r-acl-2.3.1                	 108.9K	  31.0M
/nix/store/jvl8dr21nrwhqywwxcl8di4j55765gvy-gmp-with-cxx-stage4-6.2.1	 730.4K	  39.3M
/nix/store/bg8f47vihykgqcgblxkfk9sbvc4dnksa-coreutils-9.1            	   1.4M	  40.9M
/nix/store/lp8qrhb6hs42jwbapzq20l05jf4kyicq-glibc-2.35-224-bin       	   3.0M	  33.8M
/nix/store/wyzaa007anaxxhmrcbffm597v14n2mxs-linux-headers-6.1        	   6.0M	   6.0M
/nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev       	   2.2M	  42.0M
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40            	  28.2M	  69.6M
/nix/store/xnrwkaidhxjsb70c2bnrl6j0mmr0y3qg-expand-response-params   	  16.4K	  30.9M
/nix/store/qkshx57xqsr4g4v8ga0jn8jrgnyaam3f-binutils-wrapper-2.40    	  48.5K	  84.8M
/nix/store/f6172g5agk13134pdx5hl1qjmw8a4sdw-libmpc-1.3.1             	 273.4K	  40.4M
/nix/store/fdfcva0q4zgnm1gpc7wmz4cgq7c3hxx1-isl-0.20                 	   2.5M	  41.8M
/nix/store/vns64fmwpqz8himgfdy8h7i29h9gbryc-gcc-11.3.0               	 180.6M	 242.2M
/nix/store/ds6ivg31k3l0pjhhf3s769bkpmafa54g-gcc-wrapper-11.3.0       	  55.2K	 278.4M
/nix/store/l0d6c6wa5sk4wx70x77k3d5clmny7sw6-cuda_cudart-11.7.60      	   6.2M	   6.2M
/nix/store/mxcbimi0gs021wwyfik63km6v26pzhp8-libcublas-11.10.1.25     	   1.1G	   1.2G
/nix/store/q8dcnsj9nh10z4vzfpdsmqgxr2q3ppkj-cuda_nvcc-11.7.64        	 114.8M	 393.2M
/nix/store/ss8jw175bhs3cmlzmmhsbpqihy457ids-libcusparse-11.7.3.50    	 488.1M	 488.1M
/nix/store/rbm214ji7jqk58g8shhkmhvl6xflblz0-cuda_cupti-11.7.50       	  88.4M	  88.4M
/nix/store/virnlrgvysrn1nl6bra798fy6x731nj0-cuda_nvprof-11.7.50      	   9.9M	 129.1M
/nix/store/val7mwg8inz92ijwylcb6pm3mwr5qidx-cuda-redist-11.7         	  63.0K	   2.1G
/nix/store/r9dc4yf6nq17dl8bdav4hy7q0vd80s64-magma-2.7.1              	 233.6M	   2.4G
```

</details>

**Closure size with cudaCapabilities = [ "6.0" "6.1" "6.2" "7.0" "7.2" "7.5" "8.0" "8.6" ];**

NOTE: Even with the reduced number of capabilities this PR introduces, without `-Xfatbin=-compress-all` Magma still fails to build.

Master failed to build so there's only an after for this example:

```console
/nix/store/dhqykhps4khbzr8aks84qlyxnhqxi066-magma-2.7.1 1.7G 3.9G
```

<details>

With a config to mimic the `cudaCapabilities` this PR would generate

```nix
# ~/.config/nixpkgs/config.nix 
{
  allowUnfree = true;
  cudaSupport = true;
  cudaCapabilities = [ "6.0" "6.1" "6.2" "7.0" "7.2" "7.5" "8.0" "8.6" ];
}
```

the build of Magma against master failed with the linking error again! The build against this PR however, succeeded:

```console
/nix/store/qmnr18aqd08zdkhka695ici96k6nzirv-libunistring-1.0         	   1.7M	   1.7M
/nix/store/vv6rlzln7vhxk519rdsrzmhhlpyb5q2m-libidn2-2.3.2            	 254.1K	   2.0M
/nix/store/76l4v99sk83ylfwkz8wmwrm4s8h73rhd-glibc-2.35-224           	  28.9M	  30.8M
/nix/store/205vsmbfhq1q2vhgskpqyymqvba4mscp-gcc-11.3.0-lib           	   7.5M	  38.3M
/nix/store/2w4k8nvdyiggz717ygbbxchpnxrqc6y9-gcc-12.2.0-lib           	   7.8M	  38.6M
/nix/store/x6nnam5hk44mljbk782rcbd92jlnz8r6-pcre-8.45                	 514.4K	  31.3M
/nix/store/4vkv3rzky44hp2b8r13d8hr4ykvqhvwh-gnugrep-3.7              	 773.2K	  32.1M
/nix/store/5ynbf6wszmggr0abwifdagrixgnya5vy-bash-5.2-p15             	   1.6M	  32.4M
/nix/store/mg9l7phyhvi16p9g8g3g8fbyj4mr79gq-zlib-1.2.13              	 125.6K	  31.0M
/nix/store/6g6d4la7xsizvr8qg91f56jiqx149iqq-binutils-2.40-lib        	   2.7M	  33.7M
/nix/store/izdfacm4wfmfjbgl1k3qlfjslkkrb2kg-gfortran-12.2.0-lib      	  10.7M	  41.6M
/nix/store/yzbam1rxs24z2apzpdpgqwi5fcwbid6z-openblas-0.3.21          	  26.1M	  67.7M
/nix/store/azvwwb4994qm7b1fcz8gc3gnlf8zwzi4-blas-3                   	  53.3M	 121.0M
/nix/store/ia34rbsa6d2dalzk5f7hy5jp9zazpv24-gmp-with-cxx-6.2.1       	 729.2K	  39.3M
/nix/store/b8wwwcng8c0snvmcawvhiny4b2gr6yhh-mpfr-4.2.0               	 774.0K	  40.1M
/nix/store/jn9kg98dsaajx4mh95rb9r5rf2idglqh-attr-2.5.1               	  78.8K	  30.9M
/nix/store/bw9s084fzmb5h40x98mfry25blj4cr9r-acl-2.3.1                	 108.9K	  31.0M
/nix/store/jvl8dr21nrwhqywwxcl8di4j55765gvy-gmp-with-cxx-stage4-6.2.1	 730.4K	  39.3M
/nix/store/bg8f47vihykgqcgblxkfk9sbvc4dnksa-coreutils-9.1            	   1.4M	  40.9M
/nix/store/l0d6c6wa5sk4wx70x77k3d5clmny7sw6-cuda_cudart-11.7.60      	   6.2M	   6.2M
/nix/store/mxcbimi0gs021wwyfik63km6v26pzhp8-libcublas-11.10.1.25     	   1.1G	   1.2G
/nix/store/lp8qrhb6hs42jwbapzq20l05jf4kyicq-glibc-2.35-224-bin       	   3.0M	  33.8M
/nix/store/wyzaa007anaxxhmrcbffm597v14n2mxs-linux-headers-6.1        	   6.0M	   6.0M
/nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev       	   2.2M	  42.0M
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40            	  28.2M	  69.6M
/nix/store/xnrwkaidhxjsb70c2bnrl6j0mmr0y3qg-expand-response-params   	  16.4K	  30.9M
/nix/store/qkshx57xqsr4g4v8ga0jn8jrgnyaam3f-binutils-wrapper-2.40    	  48.5K	  84.8M
/nix/store/f6172g5agk13134pdx5hl1qjmw8a4sdw-libmpc-1.3.1             	 273.4K	  40.4M
/nix/store/fdfcva0q4zgnm1gpc7wmz4cgq7c3hxx1-isl-0.20                 	   2.5M	  41.8M
/nix/store/vns64fmwpqz8himgfdy8h7i29h9gbryc-gcc-11.3.0               	 180.6M	 242.2M
/nix/store/ds6ivg31k3l0pjhhf3s769bkpmafa54g-gcc-wrapper-11.3.0       	  55.2K	 278.4M
/nix/store/q8dcnsj9nh10z4vzfpdsmqgxr2q3ppkj-cuda_nvcc-11.7.64        	 114.8M	 393.2M
/nix/store/ss8jw175bhs3cmlzmmhsbpqihy457ids-libcusparse-11.7.3.50    	 488.1M	 488.1M
/nix/store/rbm214ji7jqk58g8shhkmhvl6xflblz0-cuda_cupti-11.7.50       	  88.4M	  88.4M
/nix/store/virnlrgvysrn1nl6bra798fy6x731nj0-cuda_nvprof-11.7.50      	   9.9M	 129.1M
/nix/store/val7mwg8inz92ijwylcb6pm3mwr5qidx-cuda-redist-11.7         	  63.0K	   2.1G
/nix/store/dhqykhps4khbzr8aks84qlyxnhqxi066-magma-2.7.1              	   1.7G	   3.9G
```

</details>

**Closure size with cudaCapabilities = [ "7.5" "8.0" "8.6" ];**

From

```console
/nix/store/8q090bm2r3n4b58ygsbsnlj68rxb92vx-magma-2.7.1 1.2G 3.4G
```

to

```console
/nix/store/1f78c0ihfrxdfbmc56jp4s9ql4kdd3bw-magma-2.7.1 659.9M 2.8G
```

<details>

And one last comparison, this time building against only three capabilities so `master` can succeed as well. With this configuration:

```nix
# ~/.config/nixpkgs/config.nix 
{
  allowUnfree = true;
  cudaSupport = true;
  cudaCapabilities = [ "7.5" "8.0" "8.6" ];
}
```

Before closure:

```console
/nix/store/qmnr18aqd08zdkhka695ici96k6nzirv-libunistring-1.0         	   1.7M	   1.7M
/nix/store/vv6rlzln7vhxk519rdsrzmhhlpyb5q2m-libidn2-2.3.2            	 254.1K	   2.0M
/nix/store/76l4v99sk83ylfwkz8wmwrm4s8h73rhd-glibc-2.35-224           	  28.9M	  30.8M
/nix/store/205vsmbfhq1q2vhgskpqyymqvba4mscp-gcc-11.3.0-lib           	   7.5M	  38.3M
/nix/store/2w4k8nvdyiggz717ygbbxchpnxrqc6y9-gcc-12.2.0-lib           	   7.8M	  38.6M
/nix/store/x6nnam5hk44mljbk782rcbd92jlnz8r6-pcre-8.45                	 514.4K	  31.3M
/nix/store/4vkv3rzky44hp2b8r13d8hr4ykvqhvwh-gnugrep-3.7              	 773.2K	  32.1M
/nix/store/5ynbf6wszmggr0abwifdagrixgnya5vy-bash-5.2-p15             	   1.6M	  32.4M
/nix/store/mg9l7phyhvi16p9g8g3g8fbyj4mr79gq-zlib-1.2.13              	 125.6K	  31.0M
/nix/store/6g6d4la7xsizvr8qg91f56jiqx149iqq-binutils-2.40-lib        	   2.7M	  33.7M
/nix/store/izdfacm4wfmfjbgl1k3qlfjslkkrb2kg-gfortran-12.2.0-lib      	  10.7M	  41.6M
/nix/store/yzbam1rxs24z2apzpdpgqwi5fcwbid6z-openblas-0.3.21          	  26.1M	  67.7M
/nix/store/azvwwb4994qm7b1fcz8gc3gnlf8zwzi4-blas-3                   	  53.3M	 121.0M
/nix/store/l0d6c6wa5sk4wx70x77k3d5clmny7sw6-cuda_cudart-11.7.60      	   6.2M	   6.2M
/nix/store/mxcbimi0gs021wwyfik63km6v26pzhp8-libcublas-11.10.1.25     	   1.1G	   1.2G
/nix/store/ss8jw175bhs3cmlzmmhsbpqihy457ids-libcusparse-11.7.3.50    	 488.1M	 488.1M
/nix/store/rbm214ji7jqk58g8shhkmhvl6xflblz0-cuda_cupti-11.7.50       	  88.4M	  88.4M
/nix/store/virnlrgvysrn1nl6bra798fy6x731nj0-cuda_nvprof-11.7.50      	   9.9M	 129.1M
/nix/store/jn9kg98dsaajx4mh95rb9r5rf2idglqh-attr-2.5.1               	  78.8K	  30.9M
/nix/store/bw9s084fzmb5h40x98mfry25blj4cr9r-acl-2.3.1                	 108.9K	  31.0M
/nix/store/jvl8dr21nrwhqywwxcl8di4j55765gvy-gmp-with-cxx-stage4-6.2.1	 730.4K	  39.3M
/nix/store/bg8f47vihykgqcgblxkfk9sbvc4dnksa-coreutils-9.1            	   1.4M	  40.9M
/nix/store/lp8qrhb6hs42jwbapzq20l05jf4kyicq-glibc-2.35-224-bin       	   3.0M	  33.8M
/nix/store/wyzaa007anaxxhmrcbffm597v14n2mxs-linux-headers-6.1        	   6.0M	   6.0M
/nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev       	   2.2M	  42.0M
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40            	  28.2M	  69.6M
/nix/store/xnrwkaidhxjsb70c2bnrl6j0mmr0y3qg-expand-response-params   	  16.4K	  30.9M
/nix/store/qkshx57xqsr4g4v8ga0jn8jrgnyaam3f-binutils-wrapper-2.40    	  48.5K	  84.8M
/nix/store/ia34rbsa6d2dalzk5f7hy5jp9zazpv24-gmp-with-cxx-6.2.1       	 729.2K	  39.3M
/nix/store/b8wwwcng8c0snvmcawvhiny4b2gr6yhh-mpfr-4.2.0               	 774.0K	  40.1M
/nix/store/f6172g5agk13134pdx5hl1qjmw8a4sdw-libmpc-1.3.1             	 273.4K	  40.4M
/nix/store/fdfcva0q4zgnm1gpc7wmz4cgq7c3hxx1-isl-0.20                 	   2.5M	  41.8M
/nix/store/vns64fmwpqz8himgfdy8h7i29h9gbryc-gcc-11.3.0               	 180.6M	 242.2M
/nix/store/ds6ivg31k3l0pjhhf3s769bkpmafa54g-gcc-wrapper-11.3.0       	  55.2K	 278.4M
/nix/store/zrpivbb39kiyij6dns4pz4wh8nik6m3y-cuda_nvcc-11.7.64        	 114.8M	 393.2M
/nix/store/mpj8ij172g466nncmnfqpz694pa746dr-cuda-redist-11.7         	  63.0K	   2.1G
/nix/store/8q090bm2r3n4b58ygsbsnlj68rxb92vx-magma-2.7.1              	   1.2G	   3.4G
```

After closure:

```console
/nix/store/qmnr18aqd08zdkhka695ici96k6nzirv-libunistring-1.0         	   1.7M	   1.7M
/nix/store/vv6rlzln7vhxk519rdsrzmhhlpyb5q2m-libidn2-2.3.2            	 254.1K	   2.0M
/nix/store/76l4v99sk83ylfwkz8wmwrm4s8h73rhd-glibc-2.35-224           	  28.9M	  30.8M
/nix/store/205vsmbfhq1q2vhgskpqyymqvba4mscp-gcc-11.3.0-lib           	   7.5M	  38.3M
/nix/store/izdfacm4wfmfjbgl1k3qlfjslkkrb2kg-gfortran-12.2.0-lib      	  10.7M	  41.6M
/nix/store/yzbam1rxs24z2apzpdpgqwi5fcwbid6z-openblas-0.3.21          	  26.1M	  67.7M
/nix/store/azvwwb4994qm7b1fcz8gc3gnlf8zwzi4-blas-3                   	  53.3M	 121.0M
/nix/store/l0d6c6wa5sk4wx70x77k3d5clmny7sw6-cuda_cudart-11.7.60      	   6.2M	   6.2M
/nix/store/mxcbimi0gs021wwyfik63km6v26pzhp8-libcublas-11.10.1.25     	   1.1G	   1.2G
/nix/store/5ynbf6wszmggr0abwifdagrixgnya5vy-bash-5.2-p15             	   1.6M	  32.4M
/nix/store/x6nnam5hk44mljbk782rcbd92jlnz8r6-pcre-8.45                	 514.4K	  31.3M
/nix/store/4vkv3rzky44hp2b8r13d8hr4ykvqhvwh-gnugrep-3.7              	 773.2K	  32.1M
/nix/store/jn9kg98dsaajx4mh95rb9r5rf2idglqh-attr-2.5.1               	  78.8K	  30.9M
/nix/store/bw9s084fzmb5h40x98mfry25blj4cr9r-acl-2.3.1                	 108.9K	  31.0M
/nix/store/2w4k8nvdyiggz717ygbbxchpnxrqc6y9-gcc-12.2.0-lib           	   7.8M	  38.6M
/nix/store/jvl8dr21nrwhqywwxcl8di4j55765gvy-gmp-with-cxx-stage4-6.2.1	 730.4K	  39.3M
/nix/store/bg8f47vihykgqcgblxkfk9sbvc4dnksa-coreutils-9.1            	   1.4M	  40.9M
/nix/store/lp8qrhb6hs42jwbapzq20l05jf4kyicq-glibc-2.35-224-bin       	   3.0M	  33.8M
/nix/store/wyzaa007anaxxhmrcbffm597v14n2mxs-linux-headers-6.1        	   6.0M	   6.0M
/nix/store/pqnd39aq2sksad2zvswjcpkqdc7ig3f9-glibc-2.35-224-dev       	   2.2M	  42.0M
/nix/store/mg9l7phyhvi16p9g8g3g8fbyj4mr79gq-zlib-1.2.13              	 125.6K	  31.0M
/nix/store/6g6d4la7xsizvr8qg91f56jiqx149iqq-binutils-2.40-lib        	   2.7M	  33.7M
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40            	  28.2M	  69.6M
/nix/store/xnrwkaidhxjsb70c2bnrl6j0mmr0y3qg-expand-response-params   	  16.4K	  30.9M
/nix/store/qkshx57xqsr4g4v8ga0jn8jrgnyaam3f-binutils-wrapper-2.40    	  48.5K	  84.8M
/nix/store/ia34rbsa6d2dalzk5f7hy5jp9zazpv24-gmp-with-cxx-6.2.1       	 729.2K	  39.3M
/nix/store/b8wwwcng8c0snvmcawvhiny4b2gr6yhh-mpfr-4.2.0               	 774.0K	  40.1M
/nix/store/f6172g5agk13134pdx5hl1qjmw8a4sdw-libmpc-1.3.1             	 273.4K	  40.4M
/nix/store/fdfcva0q4zgnm1gpc7wmz4cgq7c3hxx1-isl-0.20                 	   2.5M	  41.8M
/nix/store/vns64fmwpqz8himgfdy8h7i29h9gbryc-gcc-11.3.0               	 180.6M	 242.2M
/nix/store/ds6ivg31k3l0pjhhf3s769bkpmafa54g-gcc-wrapper-11.3.0       	  55.2K	 278.4M
/nix/store/q8dcnsj9nh10z4vzfpdsmqgxr2q3ppkj-cuda_nvcc-11.7.64        	 114.8M	 393.2M
/nix/store/ss8jw175bhs3cmlzmmhsbpqihy457ids-libcusparse-11.7.3.50    	 488.1M	 488.1M
/nix/store/rbm214ji7jqk58g8shhkmhvl6xflblz0-cuda_cupti-11.7.50       	  88.4M	  88.4M
/nix/store/virnlrgvysrn1nl6bra798fy6x731nj0-cuda_nvprof-11.7.50      	   9.9M	 129.1M
/nix/store/val7mwg8inz92ijwylcb6pm3mwr5qidx-cuda-redist-11.7         	  63.0K	   2.1G
/nix/store/1f78c0ihfrxdfbmc56jp4s9ql4kdd3bw-magma-2.7.1              	 659.9M	   2.8G
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
