### PR TITLE
in-formant: 2021-06-30 -> unstable-2022-09-15; unbreak

### DIFF
--- a/pkgs/applications/audio/in-formant/0001-Avoid-using-vendored-dependencies-we-have-in-nixpkgs.patch
+++ b/pkgs/applications/audio/in-formant/0001-Avoid-using-vendored-dependencies-we-have-in-nixpkgs.patch
@@ -1,0 +1,47 @@
+From 42eda1afc1cfb0506b02baae894fb32f7e21755d Mon Sep 17 00:00:00 2001
+From: ckie <git-525ff67@ckie.dev>
+Date: Fri, 10 Mar 2023 04:39:38 +0200
+Subject: [PATCH] Avoid using vendored dependencies we have in nixpkgs
+
+---
+ CMakeLists.txt | 12 ++++--------
+ 1 file changed, 4 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 136e7b0..5416da1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -246,8 +246,6 @@ qt6_add_resources(RESOURCES_OBJ resources/qml.qrc)
+ qt6_add_big_resources(RESOURCES_OBJ resources/other.qrc)
+ set_property(SOURCE "${RESOURCES_OBJ}" PROPERTY SKIP_AUTOMOC ON)
+ 
+-set(ARMADILLO_INCLUDE_DIR external/armadillo/include)
+-set(TOMLPP_INCLUDE_DIR external/tomlplusplus/include)
+ 
+ ### SEARCH AUDIO MODULES 
+ 
+@@ -334,17 +332,15 @@ target_include_directories(in-formant SYSTEM PRIVATE ${ARMADILLO_INCLUDE_DIR} ${
+ target_link_libraries(in-formant PRIVATE Eigen3::Eigen ${FFTW_LIBRARIES} Qt6::Charts Qt6::Quick Qt6::QuickControls2 Qt6::QuickTemplates2 Qt6::Qml Qt6::Widgets Qt6::OpenGL Qt6::Gui Qt6::Core)
+ target_link_directories(in-formant PRIVATE ${FFTW_LIBRARY_DIRS})
+ 
+-set(BUILD_SHARED_LIBS TRUE)
+-add_subdirectory(external/freetype EXCLUDE_FROM_ALL)
++find_package(Freetype)
+ target_link_libraries(in-formant PRIVATE freetype)
+-set(BUILD_SHARED_LIBS)
+ 
+ add_subdirectory(external/rpmalloc EXCLUDE_FROM_ALL)
+ target_link_libraries(in-formant PRIVATE rpcxx_only)
+ 
+-add_subdirectory(external/libsamplerate)
+-target_link_libraries(in-formant PRIVATE lsr)
+-target_include_directories(in-formant PRIVATE external/libsamplerate/src)
++
++find_library(LIBSAMPLERATE_LIBRARY NAMES samplerate libsamplerate-0 samplerate-0)
++target_link_libraries(in-formant PRIVATE ${LIBSAMPLERATE_LIBRARY})
+ 
+ target_compile_definitions(in-formant PRIVATE
+     -DINFORMANT_VERSION=${CUR_VERSION} -DARMA_DONT_USE_WRAPPER
+-- 
+2.39.0
+

--- a/pkgs/applications/audio/in-formant/default.nix
+++ b/pkgs/applications/audio/in-formant/default.nix
@@ -1,33 +1,56 @@
-{ stdenv, cmake, lib, fetchFromGitHub, qt5, fftw, libtorch-bin, portaudio, eigen
-, xorg, pkg-config, autoPatchelfHook, soxr
+{ stdenv
+, cmake
+, lib
+, fetchFromGitHub
+, wrapQtAppsHook
+, qtbase
+, qtcharts
+, fftw
+, libtorch-bin
+, portaudio
+, eigen
+, xorg
+, pkg-config
+, autoPatchelfHook
+, soxr
+, freetype
+, libsamplerate
+, armadillo
+, tomlplusplus
 }:
 
 stdenv.mkDerivation rec {
   pname = "in-formant";
-  version = "2021-06-30";
+  version = "unstable-2022-09-15";
 
-  # no Qt6 yet, so we're stuck in the last Qt5-supporting commit: https://github.com/NixOS/nixpkgs/issues/108008
   src = fetchFromGitHub {
     owner = "in-formant";
     repo = "in-formant";
-    rev = "e28e628cf5ff0949a7b046d220cc884f6035f31a";
-    sha256 = "sha256-YvtV0wGUNmI/+GGxrIfTk/l8tqUsWgc/LAI17X+AWGI=";
+    rev = "e0606feecff70f0fd4226ff8f116e46817dd7462";
+    hash = "sha256-/4eKny9M2e8Lb9LOiKBj9QLE00CAaD+2ZAwn48lnvKQ=";
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ cmake pkg-config qt5.wrapQtAppsHook autoPatchelfHook ];
+  patches = [
+    # Ignore the freetype sources bundled as a submodule:
+    # /nix/store/…-harfbuzz-7.0.0/lib/libharfbuzz.so.0: undefined reference to `FT_Get_Transform'
+    ./0001-Avoid-using-vendored-dependencies-we-have-in-nixpkgs.patch
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook autoPatchelfHook ];
 
   buildInputs = [
-    qt5.qtbase
-    qt5.qtquickcontrols
-    qt5.qtquickcontrols2
-    qt5.qtcharts
+    qtbase
+    qtcharts
     fftw
     libtorch-bin
     portaudio
     eigen
     xorg.libxcb
     soxr
+    libsamplerate
+    armadillo
+    tomlplusplus
   ];
 
   installPhase = ''
@@ -35,14 +58,12 @@ stdenv.mkDerivation rec {
     cp in-formant $out/bin
   '';
 
-  # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
-  cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=ON" ];
-
   meta = with lib; {
     description = "A real-time pitch and formant tracking software";
     homepage = "https://github.com/in-formant/in-formant";
     license = licenses.asl20;
-    platforms = platforms.linux;
+    # currently broken on i686-linux and aarch64-linux due to other nixpkgs dependencies
+    platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ ckie ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8626,7 +8626,7 @@ with pkgs;
 
   imgurbash2 = callPackage ../tools/graphics/imgurbash2 { };
 
-  in-formant = callPackage ../applications/audio/in-formant { };
+  in-formant = qt6Packages.callPackage ../applications/audio/in-formant { };
 
   inadyn = callPackage ../tools/networking/inadyn { };
 


### PR DESCRIPTION
###### Description of changes

This fixes the build failure we've had around for a while now.

It now runs, but segfaults on exit and won't render a few icons, but is still usable once you figure out where the buttons are supposed to be.

The Qt6 transition was delightfully simple, and the actual unbreaking is probably unrelated to it, as not much has changed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
