### PR TITLE
signal-desktop: 6.7.0 → 6.9.0, signal-desktop-beta: 6.8.0-beta.1 → 6.…

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,12 +1,12 @@
 { callPackage }: builtins.mapAttrs (pname: attrs: callPackage ./generic.nix (attrs // { inherit pname; })) {
   signal-desktop = {
     dir = "Signal";
-    version = "6.7.0";
-    hash = "sha256-njiVPTkzYdt7QZcpohXUI3hj/o+fO4/O0ZlQrq2oP6Y=";
+    version = "6.9.0";
+    hash = "sha256-VgEGFt8LvVpIWiqFyYiTXUavYY0YmnJ+CxrNhPP0hCg=";
   };
   signal-desktop-beta = {
     dir = "Signal Beta";
-    version = "6.8.0-beta.1";
-    hash = "sha256-akQmGxDW6SBQCRLU6TgfODP8ZjEPsvaBvrkdd+6DqKs=";
+    version = "6.10.0-beta.1";
+    hash = "sha256-A8jpYDWiCCBadRDzmNVxzucKPomgXlqdyeGiYp+1Byo=";
   };
 }


### PR DESCRIPTION
…10.0-beta.1

###### Description of changes
Updates released:
- signal-desktop:
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.8.0
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.9.0
- signal-desktop-beta:
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.9.0-beta.1
  - https://github.com/signalapp/Signal-Desktop/releases/tag/v6.10.0-beta.1

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
