### PR TITLE
kcov: 38 -> 41

### DIFF
--- a/pkgs/development/tools/analysis/kcov/default.nix
+++ b/pkgs/development/tools/analysis/kcov/default.nix
@@ -19,24 +19,14 @@ let
   self =
     stdenv.mkDerivation rec {
       pname = "kcov";
-      version = "38";
+      version = "41";
 
       src = fetchFromGitHub {
         owner = "SimonKagstrom";
         repo = "kcov";
         rev = "v${version}";
-        sha256 = "sha256-6LoIo2/yMUz8qIpwJVcA3qZjjF+8KEM1MyHuyHsQD38=";
+        sha256 = "sha256-Kit4Yn5Qeg3uAc6+RxwlVEhDKN6at+Uc7V38yhDPrAY=";
       };
-
-      patches = [
-        # Pull upstream patch for binutils-2/39 support:
-        #   https://github.com/SimonKagstrom/kcov/pull/383
-        (fetchpatch {
-          name = "binutils-2.39.patch";
-          url = "https://github.com/SimonKagstrom/kcov/commit/fd1a4fd2f02cee49afd74e427e38c61b89154582.patch";
-          hash = "sha256-licQkC8qDg2i6No3j0yKEU6i+Owi4lhrnfGvETkzz7w=";
-        })
-      ];
 
       preConfigure = "patchShebangs src/bin-to-c-source.py";
       nativeBuildInputs = [ cmake pkg-config python3 ];

--- a/pkgs/development/tools/analysis/kcov/default.nix
+++ b/pkgs/development/tools/analysis/kcov/default.nix
@@ -10,8 +10,7 @@
 , python3
 , libiberty
 , libopcodes
-, runCommand
-, gcc
+, runCommandCC
 , rustc
 }:
 
@@ -36,25 +35,25 @@ let
       strictDeps = true;
 
       passthru.tests = {
-        works-on-c = runCommand "works-on-c" {} ''
+        works-on-c = runCommandCC "works-on-c" { } ''
           set -ex
           cat - > a.c <<EOF
           int main() {}
           EOF
-          ${gcc}/bin/gcc a.c -o a.out
+          $CC a.c -o a.out
           ${self}/bin/kcov /tmp/kcov ./a.out
           test -e /tmp/kcov/index.html
           touch $out
           set +x
         '';
 
-        works-on-rust = runCommand "works-on-rust" {} ''
+        works-on-rust = runCommandCC "works-on-rust" { } ''
           set -ex
           cat - > a.rs <<EOF
           fn main() {}
           EOF
           # Put gcc in the path so that `cc` is found
-          PATH=${gcc}/bin:$PATH ${rustc}/bin/rustc a.rs -o a.out
+          ${rustc}/bin/rustc a.rs -o a.out
           ${self}/bin/kcov /tmp/kcov ./a.out
           test -e /tmp/kcov/index.html
           touch $out

--- a/pkgs/development/tools/analysis/kcov/default.nix
+++ b/pkgs/development/tools/analysis/kcov/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , pkg-config
 , zlib
@@ -47,13 +46,13 @@ let
           set +x
         '';
 
-        works-on-rust = runCommandCC "works-on-rust" { } ''
+        works-on-rust = runCommandCC "works-on-rust" { nativeBuildInputs = [ rustc ]; } ''
           set -ex
           cat - > a.rs <<EOF
           fn main() {}
           EOF
           # Put gcc in the path so that `cc` is found
-          ${rustc}/bin/rustc a.rs -o a.out
+          rustc a.rs -o a.out
           ${self}/bin/kcov /tmp/kcov ./a.out
           test -e /tmp/kcov/index.html
           touch $out


### PR DESCRIPTION
###### Description of changes

Update kcov to v41.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
