### PR TITLE
python3Packages.python-djvulibre: init at 0.9.0

### DIFF
--- a/pkgs/development/python-modules/python-djvulibre/default.nix
+++ b/pkgs/development/python-modules/python-djvulibre/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cython
+, djvulibre
+, ghostscript_headless
+, packaging
+, pkg-config
+, requests
+, setuptools
+, unittestCheckHook
+, wheel
+}:
+
+buildPythonPackage rec {
+  pname = "python-djvulibre";
+  version = "0.9.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "FriedrichFroebel";
+    repo = "python-djvulibre";
+    rev = version;
+    hash = "sha256-OrOZFvzDEBwBmIc+i3LjNTh6K2vhe6NWtSJrFTSkrgA=";
+  };
+
+  nativeBuildInputs = [
+    cython
+    packaging
+    pkg-config
+    setuptools
+    wheel
+  ];
+
+  buildInputs = [
+    djvulibre
+    ghostscript_headless
+  ];
+
+  preCheck = ''
+    rm -rf djvu
+  '';
+
+  nativeCheckInputs = [ unittestCheckHook ];
+
+  unittestFlagsArray = [ "tests" "-v" ];
+
+  meta = with lib; {
+    description = "Python support for the DjVu image format";
+    homepage = "https://github.com/FriedrichFroebel/python-djvulibre";
+    license = licenses.gpl2Only;
+    changelog = "https://github.com/FriedrichFroebel/python-djvulibre/releases/tag/${version}";
+    maintainers = with maintainers; [ dansbandit ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9487,6 +9487,8 @@ self: super: with self; {
 
   python-csxcad = callPackage ../development/python-modules/python-csxcad { };
 
+  python-djvulibre = callPackage ../development/python-modules/python-djvulibre { };
+
   python-ecobee-api = callPackage ../development/python-modules/python-ecobee-api { };
 
   python-flirt = callPackage ../development/python-modules/python-flirt { };


### PR DESCRIPTION
###### Description of changes
###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).