### PR TITLE
pioneer: 20220203 -> 20230203

### DIFF
--- a/pkgs/games/pioneer/5526.patch
+++ b/pkgs/games/pioneer/5526.patch
@@ -1,0 +1,23 @@
+From 058bb753ccddee110ed2fb76908cb25b5a656635 Mon Sep 17 00:00:00 2001
+From: Dmitry Marakasov <amdmi3@amdmi3.ru>
+Date: Fri, 3 Feb 2023 16:26:46 +0300
+Subject: [PATCH] Fix path to lua.h
+
+Fixes build with USE_SYSTEM_LIBLUA. Fixes #5525.
+---
+ src/lua/LuaShip.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/lua/LuaShip.cpp b/src/lua/LuaShip.cpp
+index 1cf96d9cc4..102140a327 100644
+--- a/src/lua/LuaShip.cpp
++++ b/src/lua/LuaShip.cpp
+@@ -19,7 +19,7 @@
+ #include "SpaceStation.h"
+ #include "ship/PlayerShipController.h"
+ #include "ship/PrecalcPath.h"
+-#include "src/lua.h"
++#include "lua.h"
+ 
+ /*
+  * Class: Ship

--- a/pkgs/games/pioneer/default.nix
+++ b/pkgs/games/pioneer/default.nix
@@ -7,11 +7,14 @@
 , curl
 , freetype
 #, glew
+, libdeflate
 , libGL
 , libGLU
 , libpng
 , libsigcxx
+, libtiff
 , libvorbis
+, libwebp
 , lua5_2
 , mesa
 , SDL2
@@ -20,14 +23,16 @@
 
 stdenv.mkDerivation rec {
   pname = "pioneer";
-  version = "20220203";
+  version = "20230203";
 
   src = fetchFromGitHub{
     owner = "pioneerspacesim";
     repo = "pioneer";
     rev = version;
-    hash = "sha256-HNVg8Lq6k6gQDmgOdpnBwJ57WSEnn5XwtqzmkDU1WGI=";
+    hash = "sha256-AUz+rcbuxw6RgFbugxhWFCBdHdbYNPgIKsx933STqok=";
   };
+
+  patches = [ ./5526.patch ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
@@ -40,11 +45,14 @@ stdenv.mkDerivation rec {
     assimp
     curl
     freetype
+    libdeflate
     libGL
     libGLU
     libpng
     libsigcxx
+    libtiff
     libvorbis
+    libwebp
     lua5_2
     mesa
     SDL2


### PR DESCRIPTION
###### Description of changes

Update pioneer to 20230203

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
