### PR TITLE
lua-rocks-move-data: fix missing doc tags on luaPackages neovim plugins

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -157,6 +157,28 @@ rec {
     '';
   });
 
+  # check that the vim-doc hook correctly generates the tag
+  # for neovim packages from luaPackages
+  # we know for a fact gitsigns-nvim has a doc folder and comes from luaPackages
+  checkForTagsLuaPackages = vimPlugins.gitsigns-nvim.overrideAttrs(oldAttrs: {
+    doInstallCheck = true;
+    installCheckPhase = ''
+      [ -f $out/doc/tags ]
+    '';
+  });
+
+  nvim_with_gitsigns_plugin = neovim.override {
+    extraName = "-with-gitsigns-plugin";
+    configure.packages.plugins = {
+      start = [
+        vimPlugins.gitsigns-nvim
+      ];
+    };
+  };
+  checkHelpLuaPackages = runTest nvim_with_gitsigns_plugin ''
+    export HOME=$TMPDIR
+    ${nvim_with_gitsigns_plugin}/bin/nvim -i NONE -c 'help gitsigns' +quitall! -e
+  '';
 
   # nixpkgs should detect that no wrapping is necessary
   nvimShouldntWrap = wrapNeovim2 "-should-not-wrap" nvimAutoDisableWrap;

--- a/pkgs/development/interpreters/lua-5/hooks/luarocks-move-data.sh
+++ b/pkgs/development/interpreters/lua-5/hooks/luarocks-move-data.sh
@@ -12,4 +12,4 @@ luarocksMoveDataHook () {
 }
 
 echo "Using luarocksMoveDataHook"
-preDistPhases+=" luarocksMoveDataHook"
+preFixupHooks+=(luarocksMoveDataHook)


### PR DESCRIPTION
fix #220199

###### Description of changes

Makes `luarocksMoveDataHook` run before `vimPluginGenTags` since it is added first to `preFixupHooks`.

I have tested it with `pkgs.vimPlugins.gitsigns-nvim` and it generates the documentation tags properly.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
