### PR TITLE
openocd: rework configuration flags

### DIFF
--- a/pkgs/development/embedded/openocd/default.nix
+++ b/pkgs/development/embedded/openocd/default.nix
@@ -3,9 +3,13 @@
 , fetchurl
 , pkg-config
 , hidapi
-, libftdi1
 , libusb1
 , libgpiod
+
+, enableFtdi ? true, libftdi1
+
+# Allow selection the hardware targets (SBCs, JTAG Programmers, JTAG Adapters)
+, extraHardwareSupport ? []
 }:
 
 stdenv.mkDerivation rec {
@@ -24,17 +28,14 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--disable-werror"
     "--enable-jtag_vpi"
-    "--enable-usb_blaster_libftdi"
-    (lib.enableFeature (! stdenv.isDarwin) "amtjtagaccel")
-    (lib.enableFeature (! stdenv.isDarwin) "gw16012")
-    "--enable-presto_libftdi"
-    "--enable-openjtag_ftdi"
-    (lib.enableFeature (! stdenv.isDarwin) "oocd_trace")
     "--enable-buspirate"
-    (lib.enableFeature stdenv.isLinux "sysfsgpio")
-    (lib.enableFeature stdenv.isLinux "linuxgpiod")
     "--enable-remote-bitbang"
-  ];
+    (lib.enableFeature enableFtdi "ftdi")
+    (lib.enableFeature stdenv.isLinux "linuxgpiod")
+    (lib.enableFeature stdenv.isLinux "sysfsgpio")
+  ] ++
+    map (hardware: "--enable-${hardware}") extraHardwareSupport
+  ;
 
   env.NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.cc.isGNU [
     "-Wno-error=cpp"


### PR DESCRIPTION
###### Description of changes
I noticed that some of the configure flags passed to openocd were no longer supported by version 0.12. These were removed. Additionally, I felt it was inappropriate for nixpkgs to select 2 hardware platforms to enable without having any support for others. To avoid having to mess with overrideAttrs, I added an optional list of strings with the names of the hardware configure flags that can be passed to openocd with override.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
