### PR TITLE
[22.11] element-{web,desktop}: hack to make ofborg maintainer pings work again

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/pin.json
+++ b/pkgs/applications/networking/instant-messengers/element/pin.json
@@ -1,7 +1,0 @@
-{
-  "version": "1.11.24",
-  "desktopSrcHash": "eAcJwoifIg0yCcYyeueVOL6CeGVMwmHpbr58MOUpK9I=",
-  "desktopYarnHash": "175ln40xp4djzc9wrx2vfg6did4rxy7nyxm6vs95pcbpv1i84g97",
-  "webSrcHash": "45xyfflTGA9LQxKi2WghYdDN0+R4ntjIPONnm+CJ5Dk=",
-  "webYarnHash": "1rwlx73chgq7x4zki9w4y3br8ypvk37vi6agqhk2dvq6y4znr93y"
-}

--- a/pkgs/applications/networking/instant-messengers/element/pin.nix
+++ b/pkgs/applications/networking/instant-messengers/element/pin.nix
@@ -1,0 +1,9 @@
+{
+  "version" = "1.11.24";
+  "hashes" = {
+    "desktopSrcHash" = "eAcJwoifIg0yCcYyeueVOL6CeGVMwmHpbr58MOUpK9I=";
+    "desktopYarnHash" = "175ln40xp4djzc9wrx2vfg6did4rxy7nyxm6vs95pcbpv1i84g97";
+    "webSrcHash" = "45xyfflTGA9LQxKi2WghYdDN0+R4ntjIPONnm+CJ5Dk=";
+    "webYarnHash" = "1rwlx73chgq7x4zki9w4y3br8ypvk37vi6agqhk2dvq6y4znr93y";
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/element/update.sh
+++ b/pkgs/applications/networking/instant-messengers/element/update.sh
@@ -42,12 +42,14 @@ wget "$desktop_src/yarn.lock"
 desktop_yarn_hash=$(prefetch-yarn-deps yarn.lock)
 popd
 
-cat > pin.json << EOF
+cat > pin.nix << EOF
 {
-  "version": "$version",
-  "desktopSrcHash": "$desktop_src_hash",
-  "desktopYarnHash": "$desktop_yarn_hash",
-  "webSrcHash": "$web_src_hash",
-  "webYarnHash": "$web_yarn_hash"
+  "version" = "$version";
+  "hashes" = {
+    "desktopSrcHash" = "$desktop_src_hash";
+    "desktopYarnHash" = "$desktop_yarn_hash";
+    "webSrcHash" = "$web_src_hash";
+    "webYarnHash" = "$web_yarn_hash";
+  };
 }
 EOF


### PR DESCRIPTION
###### Description of changes

Backport of #219821. Doesn't change the final derivation and keeps the diff in sync, so we don't have to manually backport element changes.

Until now we had the problem that the matrix team wasn't pinged on element changes because the version data is in a JSON and the position of the `version`-attribute wrongly pointed to
`element-{web,desktop}.nix`:

    nix-instantiate -E 'with import ./. {}; builtins.unsafeGetAttrPos "version" element-web' --eval
    { column = 22; file = "/home/ma27/Projects/nixpkgs/pkgs/applications/networking/instant-messengers/element/element-web.nix"; line = 24; }

This is a problem because ofborg checks if modified file is part of a derivation that got changed in a PR. I.e. only pings for element's maintainers would be added to an element update PR if `pin.json` (which gets modified in that case) would be recognized as file being a part of the changed derivations (element-web/element-desktop)[1]

However, JSON imports don't propagate attribute positions (I don't know how one would that sanely implement btw), so I decided to change `pin.json` to a `pin.nix` and merge the relevant contents into element-web/element-desktop.

This is kinda hacky, but as a maintainer I'd like to get modified if somebody touches element so I can review & merge that.

With this change the position detection works fine now:

    { column = 3; file = "/home/ma27/Projects/nixpkgs/pkgs/applications/networking/instant-messengers/element/pin.nix"; line = 2; }

[1] https://github.com/NixOS/ofborg/blob/released/ofborg/src/maintainers.nix

(cherry picked from commit ad9206529272709d983822f7661bcc8b2ab343c8)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
