### PR TITLE
nixos-bgrt-plymouth: init at unstable-2023-03-10

### DIFF
--- a/pkgs/data/themes/nixos-bgrt-plymouth/default.nix
+++ b/pkgs/data/themes/nixos-bgrt-plymouth/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation {
+  name = "nixos-bgrt-plymouth";
+  version = "unstable-2023-03-10";
+
+  src = fetchFromGitHub {
+    repo = "plymouth-theme-nixos-bgrt";
+    owner = "helsinki-systems";
+    rev = "0771e04f13b6b908d815b506472afb1c9a2c81ae";
+    hash = "sha256-aF4Ro5z4G6LS40ENwFDH8CgV7ldfhzqekuSph/DMQoo=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/plymouth/themes/nixos-bgrt
+    cp -r $src/{*.plymouth,images} $out/share/plymouth/themes/nixos-bgrt/
+    substituteInPlace $out/share/plymouth/themes/nixos-bgrt/*.plymouth --replace '@IMAGES@' "$out/share/plymouth/themes/nixos-bgrt/images"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = with lib; {
+    description = "BGRT theme with a spinning NixOS logo";
+    homepage = "https://github.com/helsinki-systems/plymouth-theme-nixos-bgrt";
+    license = licenses.mit;
+    maintainers = with maintainers; [ lilyinstarlight ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38329,6 +38329,8 @@ with pkgs;
   nixos-icons = callPackage ../data/misc/nixos-artwork/icons.nix { };
   nixos-grub2-theme = callPackage ../data/misc/nixos-artwork/grub2-theme.nix { };
 
+  nixos-bgrt-plymouth = callPackage ../data/themes/nixos-bgrt-plymouth { };
+
   nixos-container = callPackage ../tools/virtualization/nixos-container { };
 
   nixos-generators = callPackage ../tools/nix/nixos-generators { };


### PR DESCRIPTION
###### Description of changes

Add new package for https://github.com/helsinki-systems/plymouth-theme-nixos-bgrt

It can be used in NixOS via setting the plymouth options:

```nix
{
  boot.plymouth = {
    enable = true;
    theme = "nixos-bgrt";
    themePackages = [ pkgs.nixos-bgrt-plymouth ];
  };
}
```

cc: @dasJ

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).