### PR TITLE
pufferpanel: 2.2.0 -> 2.6.6

### DIFF
--- a/pkgs/servers/pufferpanel/default.nix
+++ b/pkgs/servers/pufferpanel/default.nix
@@ -2,23 +2,53 @@
 , buildGoModule
 , fetchFromGitHub
 , makeWrapper
-, pkgs
-, stdenv
 , fetchzip
-, jdk
-, nodejs
+, fetchpatch
 , pathDeps ? [ ]
 }:
 
 buildGoModule rec {
   pname = "pufferpanel";
-  version = "2.2.0";
+  version = "2.6.6";
+
+  patches = [
+    # Bump go-sqlite3 version to avoid a GNU C compiler error.
+    # See https://github.com/PufferPanel/PufferPanel/pull/1240
+    (fetchpatch {
+      url = "https://github.com/PufferPanel/PufferPanel/pull/1240/commits/3065dca2d9b05a56789971ccf0f43a7079a390b8.patch";
+      hash = "sha256-ygMrhJoba8swoRBBii7BEiLihqOebLUtSH7os7W3s+k=";
+    })
+
+    # Fix errors in tests.
+    # See https://github.com/PufferPanel/PufferPanel/pull/1241
+    (fetchpatch {
+      url = "https://github.com/PufferPanel/PufferPanel/pull/1241/commits/ffd21bce4bff3040c8e3e783e5b4779222e7a3a5.patch";
+      hash = "sha256-BzGfcWhzRrCHKkAhWf0uvXiiiutWqthn/ed7bN2hR8U=";
+    })
+
+    # Seems to be an anti-feature. Startup is the only place where user/group is
+    # hardcoded and checked.
+    #
+    # There is no technical reason PufferPanel cannot run as a different user,
+    # especially for simple commands like `pufferpanel version`.
+    ./disable-group-checks.patch
+
+    # Some tests do not have network requests stubbed :(
+    ./skip-network-tests.patch
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/pufferpanel/pufferpanel/v2.Hash=none"
+    "-X=github.com/pufferpanel/pufferpanel/v2.Version=${version}-nixpkgs"
+  ];
 
   src = fetchFromGitHub {
     owner = "pufferpanel";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1ifig8ckjlg47wj0lfk4q941dan7llb1i5l76akcpjq726b2j8lh";
+    hash = "sha256-0Vyi47Rkpe3oODHfsl/7tCerENpiEa3EWBHhfTO/uu4=";
   };
 
   # PufferPanel is split into two parts: the backend daemon and the
@@ -28,25 +58,35 @@ buildGoModule rec {
   # we just download the built frontend and package that.
   frontend = fetchzip {
     url = "https://github.com/PufferPanel/PufferPanel/releases/download/v${version}/pufferpanel_${version}_linux_arm64.zip";
-    sha256 = "0phbf4asr0dns7if84crx05kfgr44yaxrbsbihdywbhh2mb16052";
+    hash = "sha256-z7HWhiEBma37OMGEkTGaEbnF++Nat8wAZE2UeOoaO/U=";
     stripRoot = false;
-  } + "/www";
+    postFetch = ''
+      mv $out $TMPDIR/subdir
+      mv $TMPDIR/subdir/www $out
+    '';
+  };
 
   nativeBuildInputs = [ makeWrapper ];
 
-  vendorSha256 = "061l1sy0z3kd7rc2blqh333gy66nbadfxy9hyxgq07dszds4byys";
+  vendorHash = "sha256-fB8MxSl9E2W+BdO6i+drbCe9Z3bPHPi0MvpJEomU9co=";
+  proxyVendor = true;
 
   postFixup = ''
     mkdir -p $out/share/pufferpanel
     cp -r ${src}/assets/email $out/share/pufferpanel/templates
     cp -r ${frontend} $out/share/pufferpanel/www
 
-    # Wrap the binary with the path to the external files.
-    mv $out/bin/cmd $out/bin/pufferpanel
-    wrapProgram "$out/bin/pufferpanel" \
-      --set PUFFER_PANEL_EMAIL_TEMPLATES $out/share/pufferpanel/templates/emails.json \
-      --set GIN_MODE release \
-      --set PUFFER_PANEL_WEB_FILES $out/share/pufferpanel/www \
+    # Rename cmd to pufferpanel and remove other binaries.
+    mv $out/bin $TMPDIR/bin
+    mkdir $out/bin
+    mv $TMPDIR/bin/cmd $out/bin/pufferpanel
+
+    # Wrap the binary with the path to the external files, but allow setting
+    # custom paths if needed.
+    wrapProgram $out/bin/pufferpanel \
+      --set-default GIN_MODE release \
+      --set-default PUFFER_PANEL_EMAIL_TEMPLATES $out/share/pufferpanel/templates/emails.json \
+      --set-default PUFFER_PANEL_WEB_FILES $out/share/pufferpanel/www \
       --prefix PATH : ${lib.escapeShellArg (lib.makeBinPath pathDeps)}
   '';
 
@@ -55,6 +95,5 @@ buildGoModule rec {
     homepage = "https://www.pufferpanel.com/";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ ckie ];
-    broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/pufferpanel.x86_64-darwin
   };
 }

--- a/pkgs/servers/pufferpanel/disable-group-checks.patch
+++ b/pkgs/servers/pufferpanel/disable-group-checks.patch
@@ -1,0 +1,34 @@
+diff --git a/cmd/main.go b/cmd/main.go
+index f9af7038..099ff2e2 100644
+--- a/cmd/main.go
++++ b/cmd/main.go
+@@ -24,11 +24,6 @@ import (
+ )
+ 
+ func main() {
+-	if !pufferpanel.UserInGroup("pufferpanel") {
+-		fmt.Println("You do not have permission to use this command")
+-		return
+-	}
+-
+ 	defer logging.Close()
+ 
+ 	defer func() {
+diff --git a/cmd/user.go b/cmd/user.go
+index d4a27aaf..9bf21910 100644
+--- a/cmd/user.go
++++ b/cmd/user.go
+@@ -218,10 +218,9 @@ type userCreate struct {
+ }
+ 
+ func editUser(cmd *cobra.Command, args []string) {
+-	if !pufferpanel.UserInGroup() {
+-		fmt.Printf("You do not have permission to use this command")
+-		return
+-	}
++	// Keeping import to avoid merge conflicts with future updates in case
++	// PufferPanel starts using this import elsewhere in this file.
++	_ = pufferpanel.UserInGroup
+ 
+ 	db, err := database.GetConnection()
+ 	if err != nil {

--- a/pkgs/servers/pufferpanel/skip-network-tests.patch
+++ b/pkgs/servers/pufferpanel/skip-network-tests.patch
@@ -1,0 +1,61 @@
+diff --git a/operations/javadl/javadl_test.go b/operations/javadl/javadl_test.go
+index 3938a58c..a51e2f4a 100644
+--- a/operations/javadl/javadl_test.go
++++ b/operations/javadl/javadl_test.go
+@@ -22,6 +22,8 @@ import (
+ )
+ 
+ func Test_downloadJava(t *testing.T) {
++	t.Skip("requires network access")
++
+ 	tests := []struct {
+ 		name    string
+ 		wantErr bool
+diff --git a/operations/spongedl/spongedl_test.go b/operations/spongedl/spongedl_test.go
+index efb1665c..1b93be8c 100644
+--- a/operations/spongedl/spongedl_test.go
++++ b/operations/spongedl/spongedl_test.go
+@@ -5,6 +5,8 @@ import (
+ )
+ 
+ func TestSpongeDl_Run(t *testing.T) {
++	t.Skip("requires network access")
++
+ 	type fields struct {
+ 		Recommended      bool
+ 		SpongeType       string
+diff --git a/operations/steamgamedl/dl_test.go b/operations/steamgamedl/dl_test.go
+index f4df4bf3..f7cd9681 100644
+--- a/operations/steamgamedl/dl_test.go
++++ b/operations/steamgamedl/dl_test.go
+@@ -19,6 +19,8 @@ import (
+ )
+ 
+ func Test_downloadSteamcmd(t *testing.T) {
++	t.Skip("requires network access")
++
+ 	tests := []struct {
+ 		name    string
+ 		wantErr bool
+diff --git a/services/templates_test.go b/services/templates_test.go
+index 5305dbc0..127efc54 100644
+--- a/services/templates_test.go
++++ b/services/templates_test.go
+@@ -9,6 +9,8 @@ import (
+ )
+ 
+ func TestTemplate_GetImportableTemplates(t1 *testing.T) {
++	t1.Skip("requires network access")
++
+ 	t1.Run("GetImportableTemplates", func(t1 *testing.T) {
+ 		t := &Template{}
+ 
+@@ -26,6 +28,8 @@ func TestTemplate_GetImportableTemplates(t1 *testing.T) {
+ }
+ 
+ func TestTemplate_ImportTemplates(t1 *testing.T) {
++	t1.Skip("requires network access")
++
+ 	t1.Run("GetImportableTemplates", func(t1 *testing.T) {
+ 		db := prepareDatabase(t1)
+ 		if t1.Failed() {


### PR DESCRIPTION
###### Description of changes

Reopening #220407 since changing the target branch accidentally added a lot of folks as reviewers 😅 cc @ckiee

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
