### PR TITLE
geekbench: 5.4.6 -> 6.0.1

### DIFF
--- a/pkgs/tools/misc/geekbench/5.nix
+++ b/pkgs/tools/misc/geekbench/5.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "geekbench";
-  version = "5.4.6";
+  version = "5.5.1";
 
   src = fetchurl {
     url = "https://cdn.geekbench.com/Geekbench-${version}-Linux.tar.gz";
-    sha256 = "sha256-fCS6cSD3w2EbLL1yNfH+NKxswRUY4zyCR07gKGXW4Yc=";
+    sha256 = "sha256-MgN+VcPcjzYP4Wt/uxiNMTh+p1mA5I2M8CgzDjI5xAQ=";
   };
 
   dontConfigure = true;

--- a/pkgs/tools/misc/geekbench/6.nix
+++ b/pkgs/tools/misc/geekbench/6.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, linuxPackages
+, ocl-icd
+, vulkan-loader
+}:
+
+stdenv.mkDerivation rec {
+  pname = "geekbench";
+  version = "6.0.1";
+
+  src = fetchurl {
+    url = "https://cdn.geekbench.com/Geekbench-${version}-Linux.tar.gz";
+    hash = "sha256-RrfyB7RvYWkVCbjblLIPOFcZjUR/fJHk1Em1HP74kmY=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    linuxPackages.nvidia_x11
+    ocl-icd
+    vulkan-loader
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r geekbench.plar geekbench-workload.plar geekbench6 geekbench_x86_64 geekbench_avx2 $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Cross-platform benchmark";
+    homepage = "https://geekbench.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = [ maintainers.michalrus ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "geekbench6";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4840,7 +4840,7 @@ with pkgs;
   };
 
   geekbench4 = callPackage ../tools/misc/geekbench/4.nix { };
-  geekbench5 = callPackage ../tools/misc/geekbench { };
+  geekbench5 = callPackage ../tools/misc/geekbench/5.nix { };
   geekbench = geekbench5;
 
   gencfsm = callPackage ../tools/security/gencfsm { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4841,7 +4841,8 @@ with pkgs;
 
   geekbench4 = callPackage ../tools/misc/geekbench/4.nix { };
   geekbench5 = callPackage ../tools/misc/geekbench/5.nix { };
-  geekbench = geekbench5;
+  geekbench_6 = callPackage ../tools/misc/geekbench/6.nix { };
+  geekbench = geekbench_6;
 
   gencfsm = callPackage ../tools/security/gencfsm { };
 


### PR DESCRIPTION
* geekbench: 5.4.6 -> 6.0.1
* geekbench5: 5.4.6 -> 5.5.1

* Note: At top-level, package name and version should be split by an underscore `_`. I'm not changing previous packages because I don't want to affect any use legacy usage. This will naturally be sorted out when these legacy packages are removed. So no need to bother about this.

* As this is a proprietary application, and user buys access to a specific version, I didn't want to make version 5 unavailable for someone only owns that version. Also benchmark might vary between versions. Anyway, didn't want to call the shot on this.

Reference packages at AUR: (for comparison)
* https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=geekbench
* https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=geekbench5