### PR TITLE
jetbrains-toolbox: init at 1.27.3.14493

### DIFF
--- a/pkgs/applications/misc/jetbrains-toolbox/default.nix
+++ b/pkgs/applications/misc/jetbrains-toolbox/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, fetchzip
+, copyDesktopItems
+, makeDesktopItem
+, makeWrapper
+, runCommand
+, appimageTools
+, patchelf
+}:
+let
+  pname = "jetbrains-toolbox";
+  version = "1.27.3.14493";
+
+  src = fetchzip {
+    url = "https://download.jetbrains.com/toolbox/jetbrains-toolbox-${version}.tar.gz";
+    sha256 = "sha256-aK5T95Yg8Us8vkznWlDHnPiPAKiUtlU0Eswl9rD01VY=";
+    stripRoot = false;
+  };
+
+  appimageContents = runCommand "${pname}-extracted"
+    {
+      nativeBuildInputs = [ appimageTools.appimage-exec ];
+    }
+    ''
+      appimage-exec.sh -x $out ${src}/${pname}-${version}/${pname}
+    '';
+
+  appimage = appimageTools.wrapAppImage {
+    inherit pname version;
+    src = appimageContents;
+    extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.targetPkgs pkgs);
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "JetBrains Toolbox";
+    exec = "jetbrains-toolbox";
+    comment = "JetBrains Toolbox";
+    desktopName = "JetBrains Toolbox";
+    type = "Application";
+    icon = "jetbrains-toolbox";
+    terminal = false;
+    categories = [ "Development" ];
+    startupWMClass = "jetbrains-toolbox";
+    startupNotify = false;
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version src appimage;
+
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 ${appimageContents}/.DirIcon $out/share/icons/hicolor/scalable/apps/jetbrains-toolbox.svg
+    makeWrapper ${appimage}/bin/${pname}-${version} $out/bin/${pname} --append-flags "--update-failed"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [ desktopItem ];
+
+  # Disabling the tests, this seems to be very difficult to test this app.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Jetbrains Toolbox";
+    homepage = "https://jetbrains.com/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ AnatolyPopov ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17081,6 +17081,8 @@ with pkgs;
 
   infracost = callPackage ../tools/misc/infracost { };
 
+  jetbrains-toolbox = callPackage ../applications/misc/jetbrains-toolbox { };
+
   msp430GccSupport = callPackage ../development/misc/msp430/gcc-support.nix { };
 
   msp430Newlib      = callPackage ../development/misc/msp430/newlib.nix { };


### PR DESCRIPTION
Derivation for [Jetbrains Toolbox](https://www.jetbrains.com/toolbox-app/).

This PR
- Fix the commit log message
- Fix the PR title
- Adds `doCheck=false;`
- Remove a couple of things that were not needed

If you want to test this thing quickly:

```shell
NIXPKGS_ALLOW_UNFREE=1 nix run "github:drupol/nixpkgs/init/jetbrains-toolbox-init#jetbrains-toolbox" --impure
```

This PR has been created due to the lack of feedback from the original author in #206288

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
