### PR TITLE
ocamlPackages.duration: 0.2.0 → 0.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/alcotest/mirage.nix
+++ b/pkgs/development/ocaml-modules/alcotest/mirage.nix
@@ -5,6 +5,8 @@ buildDunePackage {
 
   inherit (alcotest) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ alcotest lwt logs mirage-clock duration ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/duration/default.nix
+++ b/pkgs/development/ocaml-modules/duration/default.nix
@@ -2,13 +2,13 @@
 
 buildDunePackage rec {
   pname = "duration";
-  version = "0.2.0";
+  version = "0.2.1";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
-    url = "https://github.com/hannesm/duration/releases/download/${version}/duration-${version}.tbz";
-    sha256 = "sha256-rRT7daWm9z//fvFyEXiSXuVVzw8jsj46sykYS8DBzmk=";
+    url = "https://github.com/hannesm/duration/releases/download/v${version}/duration-${version}.tbz";
+    hash = "sha256-xzjB84z7mYIMEhzT3fgZ3ksiKPDVDqy9HMPOmefHHis=";
   };
 
   doCheck = lib.versionAtLeast ocaml.version "4.08";

--- a/pkgs/development/ocaml-modules/happy-eyeballs/default.nix
+++ b/pkgs/development/ocaml-modules/happy-eyeballs/default.nix
@@ -7,6 +7,7 @@ buildDunePackage rec {
   version = "0.5.0";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/roburio/happy-eyeballs/releases/download/v${version}/happy-eyeballs-${version}.tbz";

--- a/pkgs/development/ocaml-modules/metrics/default.nix
+++ b/pkgs/development/ocaml-modules/metrics/default.nix
@@ -5,6 +5,7 @@ buildDunePackage rec {
   version = "0.4.0";
 
   minimalOCamlVersion = "4.04";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/metrics/releases/download/v${version}/metrics-${version}.tbz";

--- a/pkgs/development/ocaml-modules/metrics/influx.nix
+++ b/pkgs/development/ocaml-modules/metrics/influx.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
   pname = "metrics-influx";
   inherit (metrics) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ duration fmt lwt metrics ];
 
   meta = metrics.meta // {

--- a/pkgs/development/ocaml-modules/metrics/lwt.nix
+++ b/pkgs/development/ocaml-modules/metrics/lwt.nix
@@ -5,6 +5,8 @@ buildDunePackage {
 
   inherit (metrics) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ logs lwt metrics ];
 
   meta = metrics.meta // {

--- a/pkgs/development/ocaml-modules/metrics/rusage.nix
+++ b/pkgs/development/ocaml-modules/metrics/rusage.nix
@@ -7,6 +7,7 @@ buildDunePackage {
   inherit (metrics) src version;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [ fmt logs metrics ];
 

--- a/pkgs/development/ocaml-modules/metrics/unix.nix
+++ b/pkgs/development/ocaml-modules/metrics/unix.nix
@@ -6,6 +6,8 @@ buildDunePackage rec {
 
   inherit (metrics) version src;
 
+  duneVersion = "3";
+
   # Fixes https://github.com/mirage/metrics/issues/57
   postPatch = ''
     substituteInPlace src/unix/dune --replace "mtime mtime.clock" "mtime"

--- a/pkgs/development/ocaml-modules/mirage-time/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-time/default.nix
@@ -1,19 +1,19 @@
-{ lib, buildDunePackage, fetchurl, ocaml_lwt }:
+{ lib, buildDunePackage, fetchurl, lwt }:
 
 buildDunePackage rec {
-  minimumOCamlVersion = "4.06";
+  minimalOCamlVersion = "4.08";
 
   pname = "mirage-time";
   version = "3.0.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-time/releases/download/v${version}/mirage-time-v${version}.tbz";
-    sha256 = "sha256-DUCUm1jix+i3YszIzgZjRQRiM8jJXQ49F6JC/yicvXw=";
+    hash = "sha256-DUCUm1jix+i3YszIzgZjRQRiM8jJXQ49F6JC/yicvXw=";
   };
 
-  propagatedBuildInputs = [ ocaml_lwt ];
+  propagatedBuildInputs = [ lwt ];
 
   meta = with lib; {
     homepage = "https://github.com/mirage/mirage-time";

--- a/pkgs/development/ocaml-modules/mirage-time/unix.nix
+++ b/pkgs/development/ocaml-modules/mirage-time/unix.nix
@@ -1,11 +1,12 @@
-{ buildDunePackage, fetchurl, mirage-time, ocaml_lwt, duration }:
+{ buildDunePackage, fetchurl, mirage-time, lwt, duration }:
 
 buildDunePackage {
   pname = "mirage-time-unix";
 
-  inherit (mirage-time) src useDune2 version minimumOCamlVersion;
+  inherit (mirage-time) src version;
+  duneVersion = "3";
 
-  propagatedBuildInputs = [ mirage-time ocaml_lwt duration ];
+  propagatedBuildInputs = [ mirage-time lwt duration ];
 
   meta = mirage-time.meta // {
     description = "Time operations for MirageOS on Unix";

--- a/pkgs/development/ocaml-modules/mirage-unix/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-unix/default.nix
@@ -4,9 +4,11 @@ buildDunePackage rec {
   pname = "mirage-unix";
   version = "5.0.1";
 
+  duneVersion = "3";
+
   src = fetchurl {
     url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-${version}.tbz";
-    sha256 = "sha256-U1oLznUDBcJLcVygfSiyl5qRLDM27cm/WrjT0vSGhPg=";
+    hash = "sha256-U1oLznUDBcJLcVygfSiyl5qRLDM27cm/WrjT0vSGhPg=";
   };
 
   propagatedBuildInputs = [ lwt duration mirage-runtime ];

--- a/pkgs/development/ocaml-modules/mirage-vnetif/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-vnetif/default.nix
@@ -9,10 +9,11 @@ buildDunePackage rec {
   version = "0.6.0";
 
   minimalOCamlVersion = "4.06";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/${pname}/releases/download/v${version}/${pname}-${version}.tbz";
-    sha256 = "sha256-fzRoNFqdnj4Ke+eNdo5crvbnKDx6/+dQyu+K3rD5dYw=";
+    hash = "sha256-fzRoNFqdnj4Ke+eNdo5crvbnKDx6/+dQyu+K3rD5dYw=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Minor fix: https://github.com/hannesm/duration/blob/v0.2.1/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
