### PR TITLE
geekbench{4,5}: use autoPatchelfHook and do not hardcode CUDA lib,  geekbench6: init at 6.0.1

### DIFF
--- a/pkgs/tools/misc/geekbench/4.nix
+++ b/pkgs/tools/misc/geekbench/4.nix
@@ -48,5 +48,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     maintainers = [ maintainers.michalrus ];
     platforms = [ "x86_64-linux" ];
+    mainProgram = "geekbench4";
   };
 }

--- a/pkgs/tools/misc/geekbench/4.nix
+++ b/pkgs/tools/misc/geekbench/4.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchurl, makeWrapper, ocl-icd, vulkan-loader, linuxPackages }:
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, addOpenGLRunpath
+, makeWrapper
+, ocl-icd
+, vulkan-loader
+}:
 
 stdenv.mkDerivation rec {
   pname = "geekbench";
@@ -12,23 +20,25 @@ stdenv.mkDerivation rec {
   dontConfigure = true;
   dontBuild = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+  buildInputs = [ stdenv.cc.cc ];
 
   installPhase = ''
-    mkdir -p $out/bin $out/lib
+    runHook preInstall
+
+    mkdir -p $out/bin
     cp -r geekbench.plar geekbench4 geekbench_x86_64 $out/bin
 
-    # needed for compute benchmark
-    ln -s ${linuxPackages.nvidia_x11}/lib/libcuda.so $out/lib/
-    ln -s ${ocl-icd}/lib/libOpenCL.so $out/lib/
-    ln -s ${ocl-icd}/lib/libOpenCL.so.1 $out/lib/
-    ln -s ${vulkan-loader}/lib/libvulkan.so $out/lib/
-    ln -s ${vulkan-loader}/lib/libvulkan.so.1 $out/lib/
-
     for f in geekbench4 geekbench_x86_64 ; do
-      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) $out/bin/$f
-      wrapProgram $out/bin/$f --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}:$out/lib/"
+      wrapProgram $out/bin/$f \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [
+          addOpenGLRunpath.driverLink
+          ocl-icd
+          vulkan-loader
+       ]}"
     done
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/tools/misc/geekbench/5.nix
+++ b/pkgs/tools/misc/geekbench/5.nix
@@ -47,5 +47,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     maintainers = [ maintainers.michalrus ];
     platforms = [ "x86_64-linux" ];
+    mainProgram = "geekbench5";
   };
 }

--- a/pkgs/tools/misc/geekbench/5.nix
+++ b/pkgs/tools/misc/geekbench/5.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchurl, makeWrapper, ocl-icd, vulkan-loader, linuxPackages }:
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, addOpenGLRunpath
+, makeWrapper
+, ocl-icd
+, vulkan-loader
+}:
 
 stdenv.mkDerivation rec {
   pname = "geekbench";
@@ -12,23 +20,24 @@ stdenv.mkDerivation rec {
   dontConfigure = true;
   dontBuild = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
 
   installPhase = ''
-    mkdir -p $out/bin $out/lib
+    runHook preInstall
+
+    mkdir -p $out/bin
     cp -r geekbench.plar geekbench5 geekbench_x86_64 $out/bin
 
-    # needed for compute benchmark
-    ln -s ${linuxPackages.nvidia_x11}/lib/libcuda.so $out/lib/
-    ln -s ${ocl-icd}/lib/libOpenCL.so $out/lib/
-    ln -s ${ocl-icd}/lib/libOpenCL.so.1 $out/lib/
-    ln -s ${vulkan-loader}/lib/libvulkan.so $out/lib/
-    ln -s ${vulkan-loader}/lib/libvulkan.so.1 $out/lib/
-
     for f in geekbench5 geekbench_x86_64 ; do
-      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) $out/bin/$f
-      wrapProgram $out/bin/$f --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}:$out/lib/"
+      wrapProgram $out/bin/$f \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [
+          addOpenGLRunpath.driverLink
+          ocl-icd
+          vulkan-loader
+       ]}"
     done
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/tools/misc/geekbench/5.nix
+++ b/pkgs/tools/misc/geekbench/5.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "geekbench";
-  version = "5.4.6";
+  version = "5.5.1";
 
   src = fetchurl {
     url = "https://cdn.geekbench.com/Geekbench-${version}-Linux.tar.gz";
-    sha256 = "sha256-fCS6cSD3w2EbLL1yNfH+NKxswRUY4zyCR07gKGXW4Yc=";
+    sha256 = "sha256-MgN+VcPcjzYP4Wt/uxiNMTh+p1mA5I2M8CgzDjI5xAQ=";
   };
 
   dontConfigure = true;

--- a/pkgs/tools/misc/geekbench/6.nix
+++ b/pkgs/tools/misc/geekbench/6.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, addOpenGLRunpath
+, makeWrapper
+, ocl-icd
+, vulkan-loader
+}:
+
+stdenv.mkDerivation rec {
+  pname = "geekbench";
+  version = "6.0.1";
+
+  src = fetchurl {
+    url = "https://cdn.geekbench.com/Geekbench-${version}-Linux.tar.gz";
+    hash = "sha256-RrfyB7RvYWkVCbjblLIPOFcZjUR/fJHk1Em1HP74kmY=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r geekbench.plar geekbench-workload.plar geekbench6 geekbench_x86_64 geekbench_avx2 $out/bin
+
+    for f in geekbench6 geekbench_x86_64 geekbench_avx2 ; do
+      wrapProgram $out/bin/$f \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [
+          addOpenGLRunpath.driverLink
+          ocl-icd
+          vulkan-loader
+        ]}"
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Cross-platform benchmark";
+    homepage = "https://geekbench.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = [ maintainers.michalrus ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "geekbench6";
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -511,6 +511,8 @@ mapAliases ({
   gdal_1_11 = throw "gdal_1_11 was removed. Use gdal instead"; # Added 2021-04-03
   gdb-multitarget = throw "'gdb-multitarget' has been renamed to/replaced by 'gdb'"; # Converted to throw 2022-02-22
   gdk_pixbuf = throw "'gdk_pixbuf' has been renamed to/replaced by 'gdk-pixbuf'"; # Converted to throw 2022-02-22
+  geekbench4 = throw "'geekbench4' has been renamed to 'geekbench_4'"; # Added 2023-03-10
+  geekbench5 = throw "'geekbench5' has been renamed to 'geekbench_5'"; # Added 2023-03-10
   getmail = throw "getmail has been removed from nixpkgs, migrate to getmail6"; # Added 2022-01-12
   gettextWithExpat = throw "'gettextWithExpat' has been renamed to/replaced by 'gettext'"; # Converted to throw 2022-02-22
   gfm = throw "gfm has been removed"; # Added 2021-01-15

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4839,9 +4839,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  geekbench4 = callPackage ../tools/misc/geekbench/4.nix { };
-  geekbench5 = callPackage ../tools/misc/geekbench/5.nix { };
-  geekbench = geekbench5;
+  geekbench_4 = callPackage ../tools/misc/geekbench/4.nix { };
+  geekbench_5 = callPackage ../tools/misc/geekbench/5.nix { };
+  geekbench_6 = callPackage ../tools/misc/geekbench/6.nix { };
+  geekbench = geekbench_6;
 
   gencfsm = callPackage ../tools/security/gencfsm { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4840,7 +4840,7 @@ with pkgs;
   };
 
   geekbench4 = callPackage ../tools/misc/geekbench/4.nix { };
-  geekbench5 = callPackage ../tools/misc/geekbench { };
+  geekbench5 = callPackage ../tools/misc/geekbench/5.nix { };
   geekbench = geekbench5;
 
   gencfsm = callPackage ../tools/security/gencfsm { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Substitute PR for https://github.com/NixOS/nixpkgs/pull/220517.

Use `autoPatchelfHook` to avoid patching manually, and also remove NVIDIA drivers and instead add `/run/opengl-driver/lib` to the `LD_LIBRARY_PATH`.

Should make the whole derivation smaller in general, and also means you don't need to build the NVIDIA driver even if you don't have a NVIDIA GPU.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
