### PR TITLE
cmake-language-server: unstable-2023-01-08 → 0.1.7

### DIFF
--- a/pkgs/development/tools/misc/cmake-language-server/default.nix
+++ b/pkgs/development/tools/misc/cmake-language-server/default.nix
@@ -11,17 +11,17 @@
 
 buildPythonApplication rec {
   pname = "cmake-language-server";
-  version = "unstable-2023-01-08";
+  version = "0.1.7";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "regen100";
-    repo = pname;
-    rev = "60c376a5fda29835060687569cb212350a292116";
-    hash = "sha256-vNG43sZy2wMetY5mbgxIoei5jCCj1f8vWiovWtwzbPc=";
+    repo = "cmake-language-server";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ExEAi47hxxEJeoT3FCwpRwJrf3URnI47/5FDL7fS5sY=";
   };
 
-  PDM_PEP517_SCM_VERSION = "2023.1";
+  PDM_PEP517_SCM_VERSION = version;
 
   patches = [
     # Test timeouts occasionally cause the build to fail

--- a/pkgs/development/tools/misc/cmake-language-server/disable-test-timeouts.patch
+++ b/pkgs/development/tools/misc/cmake-language-server/disable-test-timeouts.patch
@@ -1,10 +1,10 @@
 diff --git a/tests/test_server.py b/tests/test_server.py
-index 2d09bb2..59a122a 100644
+index f349329..d130a2e 100644
 --- a/tests/test_server.py
 +++ b/tests/test_server.py
-@@ -26,7 +26,7 @@ from pygls.lsp.types import (
- )
- from pygls.server import LanguageServer
+@@ -27,7 +27,7 @@ from pygls.server import LanguageServer
+ 
+ from cmake_language_server.server import CMakeLanguageServer
  
 -CALL_TIMEOUT = 2
 +CALL_TIMEOUT = None


### PR DESCRIPTION
###### Description of changes

Update to the latest version: https://github.com/regen100/cmake-language-server/releases/tag/v0.1.7

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
