### PR TITLE
sage: fix build by downgrading maxima to 5.45

### DIFF
--- a/pkgs/applications/science/math/maxima/5.45.nix
+++ b/pkgs/applications/science/math/maxima/5.45.nix
@@ -1,0 +1,126 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, texinfo
+, perl
+, python3
+, makeWrapper
+, autoreconfHook
+, rlwrap ? null
+, tk ? null
+, gnuplot ? null
+, lisp-compiler
+}:
+
+let
+  # Allow to remove some executables from the $PATH of the wrapped binary
+  searchPath = lib.makeBinPath
+    (lib.filter (x: x != null) [ lisp-compiler rlwrap tk gnuplot ]);
+in
+stdenv.mkDerivation rec {
+  pname = "maxima";
+  # old version temporarily kept for sage due to
+  # https://github.com/sagemath/sage/issues/33718
+  version = "5.45.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "sha256-/pAWJ2lwvvIUoaJENIVYZEUU1/36pPyLnQ6Hr8u059w=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    lisp-compiler
+    makeWrapper
+    python3
+    texinfo
+  ];
+
+  strictDeps = true;
+
+  nativeCheckInputs = [
+    gnuplot
+  ];
+
+  postPatch = ''
+    substituteInPlace doc/info/Makefile.am --replace "/usr/bin/env perl" "${perl}/bin/perl"
+  '';
+
+  postInstall = ''
+    # Make sure that maxima can find its runtime dependencies.
+    for prog in "$out/bin/"*; do
+      wrapProgram "$prog" --prefix PATH ":" "$out/bin:${searchPath}"
+    done
+    # Move emacs modules and documentation into the right place.
+    mkdir -p $out/share/emacs $out/share/doc
+    ln -s ../maxima/${version}/emacs $out/share/emacs/site-lisp
+    ln -s ../maxima/${version}/doc $out/share/doc/maxima
+  ''
+   + (lib.optionalString (lisp-compiler.pname == "ecl") ''
+     cp src/binary-ecl/maxima.fas* "$out/lib/maxima/${version}/binary-ecl/"
+   '')
+  ;
+
+  patches = [
+    # fix path to info dir (see https://trac.sagemath.org/ticket/11348)
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/infodir.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "09v64n60f7i6frzryrj0zd056lvdpms3ajky4f9p6kankhbiv21x";
+    })
+
+    # fix https://sourceforge.net/p/maxima/bugs/2596/
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/matrixexp.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "06961hn66rhjijfvyym21h39wk98sfxhp051da6gz0n9byhwc6zg";
+    })
+
+    # undo https://sourceforge.net/p/maxima/code/ci/f5e9b0f7eb122c4e48ea9df144dd57221e5ea0ca
+    # see https://trac.sagemath.org/ticket/13364#comment:93
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/undoing_true_false_printing_patch.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "0fvi3rcjv6743sqsbgdzazy9jb6r1p1yq63zyj9fx42wd1hgf7yx";
+    })
+  ] ++ lib.optionals (lisp-compiler.pname == "ecl") [
+    # build fasl, needed for ECL support
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/maxima.system.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "18zafig8vflhkr80jq2ivk46k92dkszqlyq8cfmj0b2vcfjwwbar";
+    })
+  ];
+
+  # The test suite is disabled since 5.42.2 because of the following issues:
+  #
+  #   Error(s) found:
+  #   /build/maxima-5.44.0/share/linearalgebra/rtest_matrixexp.mac problems:
+  #   (20 21 22)
+  #   Tests that were expected to fail but passed:
+  #   /build/maxima-5.44.0/share/vector/rtest_vect.mac problem:
+  #   (19)
+  #   3 tests failed out of 16,184 total tests.
+  #
+  # These failures don't look serious. It would be nice to fix them, but I
+  # don't know how and probably won't have the time to find out.
+  doCheck = false;    # try to re-enable after next version update
+
+  enableParallelBuilding = true;
+
+  passthru = {
+    inherit lisp-compiler;
+  };
+
+  meta = with lib; {
+    description = "Computer algebra system";
+    homepage = "http://maxima.sourceforge.net";
+    license = licenses.gpl2Plus;
+
+    longDescription = ''
+      Maxima is a fairly complete computer algebra system written in
+      lisp with an emphasis on symbolic computation. It is based on
+      DOE-MACSYMA and licensed under the GPL. Its abilities include
+      symbolic integration, 3D plotting, and an ODE solver.
+    '';
+    maintainers = with maintainers; [ doronbehar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -128,7 +128,7 @@ let
 
   singular = pkgs.singular.override { inherit flint; };
 
-  maxima = pkgs.maxima.override {
+  maxima = pkgs.maxima-ecl-5_45.override {
     lisp-compiler = pkgs.ecl.override {
       # "echo syntax error | ecl > /dev/full 2>&1" segfaults in
       # ECL. We apply a patch to fix it (write_error.patch), but it

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37461,6 +37461,10 @@ with pkgs;
   maxima-ecl = maxima.override {
     lisp-compiler = ecl;
   };
+  # old version temporarily kept for sage
+  maxima-ecl-5_45 = callPackage ../applications/science/math/maxima/5.45.nix {
+    lisp-compiler = ecl;
+  };
 
   mxnet = callPackage ../applications/science/math/mxnet {
     inherit (linuxPackages) nvidia_x11;


### PR DESCRIPTION
###### Description of changes

The upgrade of maxima to 5.46 in #219171 broke the sage doctests, see https://github.com/sagemath/sage/issues/33718 for the upstream ticket. Hence, we downgrade maxima for sage, see #57126 as a precursor.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
