### PR TITLE
raspberrypi-wireless-firmware: fix broken firmware symlink

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
@@ -37,6 +37,10 @@ stdenvNoCC.mkDerivation {
     # Bluetooth firmware
     cp -rv "$NIX_BUILD_TOP/bluez-firmware/broadcom/." "$out/lib/firmware/brcm"
 
+    # brcmfmac43455-stdio.bin is a symlink to the non-existent path: ../cypress/cyfmac43455-stdio.bin.
+    # See https://github.com/RPi-Distro/firmware-nonfree/issues/26
+    ln -s "./cyfmac43455-sdio-standard.bin" "$out/lib/firmware/cypress/cyfmac43455-sdio.bin"
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Description of changes
Wireless firmware for the Raspberry Pi 4b is a broken symlink.

[`brcmfmac43455-sdio.bin`](https://github.com/RPi-Distro/firmware-nonfree/blob/541e5a05d152e7e6f0d9be45622e4a3741e51c02/debian/config/brcm80211/brcm/brcmfmac43455-sdio.bin) links to a non-existent file: `../cypress/cyfmac43455-sdio.bin`.  This is intentional; RaspberryPi OS creates `cyfmac43455-sdio.bin` with a script (see [this issue](https://github.com/RPi-Distro/firmware-nonfree/issues/26)). This PR follows suit and links `cyfmac43455-sdio.bin` to `cyfmac43455-sdio-standard.bin`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
