### PR TITLE
python3Packages.scikit-rf: init at 0.25.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8687,6 +8687,12 @@
     githubId = 542154;
     name = "Lorenz Leutgeb";
   };
+  lugarun = {
+    email = "lfschmidt.me@gmail.com";
+    github = "lugarun";
+    githubId = 5767106;
+    name = "Lukas Schmidt";
+  };
   luis = {
     email = "luis.nixos@gmail.com";
     github = "Luis-Hebendanz";

--- a/pkgs/development/python-modules/scikit-rf/default.nix
+++ b/pkgs/development/python-modules/scikit-rf/default.nix
@@ -1,0 +1,113 @@
+{ stdenv
+, lib
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, scipy
+, pandas
+, matplotlib
+, tox
+, coverage
+, flake8
+, nbval
+, pyvisa
+, networkx
+, ipython
+, ipykernel
+, ipywidgets
+, jupyter-client
+, sphinx-rtd-theme
+, sphinx
+, nbsphinx
+, openpyxl
+, qtpy
+, pyqtgraph
+, pyqt5
+, setuptools
+, pytestCheckHook
+, pytest-cov
+}:
+
+buildPythonPackage rec {
+  pname = "scikit-rf";
+  version = "0.25.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "scikit-rf";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-drH1N1rKFu/zdLmLsD1jH5xUkzK37V/+nJqGQ38vsTI=";
+  };
+
+  buildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    pandas
+  ];
+
+  passthru.optional-dependencies = {
+    plot = [
+      matplotlib
+    ];
+    xlsx = [
+      openpyxl
+    ];
+    netw = [
+      networkx
+    ];
+    visa = [
+      pyvisa
+    ];
+    docs = [
+      ipython
+      ipykernel
+      ipywidgets
+      jupyter-client
+      sphinx-rtd-theme
+      sphinx
+      nbsphinx
+      openpyxl
+    ];
+    qtapps = [
+      qtpy
+      pyqtgraph
+      pyqt5
+    ];
+  };
+
+  nativeCheckInputs = [
+    tox
+    coverage
+    flake8
+    pytest-cov
+    nbval
+    matplotlib
+    pyvisa
+    openpyxl
+    networkx
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "skrf"
+  ];
+
+  meta = with lib; {
+    description = "A Python library for RF/Microwave engineering";
+    homepage = "https://scikit-rf.org/";
+    changelog = "https://github.com/scikit-rf/scikit-rf/releases/tag/v${version}";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ lugarun ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10463,6 +10463,8 @@ self: super: with self; {
 
   scikit-optimize = callPackage ../development/python-modules/scikit-optimize { };
 
+  scikit-rf = callPackage ../development/python-modules/scikit-rf { };
+
   scikits-odes = callPackage ../development/python-modules/scikits-odes { };
 
   scikit-tda = callPackage ../development/python-modules/scikit-tda { };


### PR DESCRIPTION
###### Description of changes

A Python library for RF/Microwave engineering: https://scikit-rf.org/

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).