### PR TITLE
llvmPackages_*.clang: bind linker on compiling clang

### DIFF
--- a/pkgs/development/compilers/llvm/10/clang/default.nix
+++ b/pkgs/development/compilers/llvm/10/clang/default.nix
@@ -2,6 +2,7 @@
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
+, targetPackages
 }:
 
 let
@@ -37,6 +38,8 @@ let
     ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
       "-DCLANG_TABLEGEN=${buildLlvmTools.libclang.dev}/bin/clang-tblgen"
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform) [
+      "-DCLANG_DEFAULT_LINKER=${targetPackages.stdenv.cc.bintools}/bin/${stdenv.targetPlatform.config}-ld"
     ];
 
     patches = [

--- a/pkgs/development/compilers/llvm/10/default.nix
+++ b/pkgs/development/compilers/llvm/10/default.nix
@@ -195,7 +195,9 @@ let
     };
 
     clangNoLibc = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [
@@ -208,7 +210,9 @@ let
     };
 
     clangNoCompilerRt = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [ ];

--- a/pkgs/development/compilers/llvm/11/clang/default.nix
+++ b/pkgs/development/compilers/llvm/11/clang/default.nix
@@ -3,6 +3,7 @@
 , fixDarwinDylibNames
 , enableManpages ? false
 , enablePolly ? false
+, targetPackages
 }:
 
 let
@@ -42,6 +43,8 @@ let
     ] ++ lib.optionals enablePolly [
       "-DWITH_POLLY=ON"
       "-DLINK_POLLY_INTO_TOOLS=ON"
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform) [
+      "-DCLANG_DEFAULT_LINKER=${targetPackages.stdenv.cc.bintools}/bin/${stdenv.targetPlatform.config}-ld"
     ];
 
 

--- a/pkgs/development/compilers/llvm/11/default.nix
+++ b/pkgs/development/compilers/llvm/11/default.nix
@@ -210,7 +210,9 @@ let
     };
 
     clangNoLibc = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [
@@ -223,7 +225,9 @@ let
     };
 
     clangNoCompilerRt = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [ ];

--- a/pkgs/development/compilers/llvm/12/clang/default.nix
+++ b/pkgs/development/compilers/llvm/12/clang/default.nix
@@ -2,6 +2,7 @@
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
+, targetPackages
 }:
 
 let
@@ -40,6 +41,8 @@ let
     ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
       "-DCLANG_TABLEGEN=${buildLlvmTools.libclang.dev}/bin/clang-tblgen"
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform) [
+      "-DCLANG_DEFAULT_LINKER=${targetPackages.stdenv.cc.bintools}/bin/${stdenv.targetPlatform.config}-ld"
     ];
 
     patches = [

--- a/pkgs/development/compilers/llvm/12/default.nix
+++ b/pkgs/development/compilers/llvm/12/default.nix
@@ -210,7 +210,9 @@ let
     };
 
     clangNoLibc = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [
@@ -223,7 +225,9 @@ let
     };
 
     clangNoCompilerRt = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [ ];

--- a/pkgs/development/compilers/llvm/13/clang/default.nix
+++ b/pkgs/development/compilers/llvm/13/clang/default.nix
@@ -2,6 +2,7 @@
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
+, targetPackages
 }:
 
 let
@@ -30,6 +31,8 @@ let
     ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
       "-DCLANG_TABLEGEN=${buildLlvmTools.libclang.dev}/bin/clang-tblgen"
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform) [
+      "-DCLANG_DEFAULT_LINKER=${targetPackages.stdenv.cc.bintools}/bin/${stdenv.targetPlatform.config}-ld"
     ];
 
     patches = [

--- a/pkgs/development/compilers/llvm/13/default.nix
+++ b/pkgs/development/compilers/llvm/13/default.nix
@@ -223,7 +223,9 @@ let
     };
 
     clangNoLibc = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [
@@ -236,7 +238,9 @@ let
     };
 
     clangNoCompilerRt = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [ ];

--- a/pkgs/development/compilers/llvm/14/clang/default.nix
+++ b/pkgs/development/compilers/llvm/14/clang/default.nix
@@ -4,6 +4,7 @@
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
+, targetPackages
 }:
 
 let
@@ -38,6 +39,8 @@ let
     ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
       "-DCLANG_TABLEGEN=${buildLlvmTools.libclang.dev}/bin/clang-tblgen"
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform) [
+      "-DCLANG_DEFAULT_LINKER=${targetPackages.stdenv.cc.bintools}/bin/${stdenv.targetPlatform.config}-ld"
     ];
 
     patches = [

--- a/pkgs/development/compilers/llvm/14/default.nix
+++ b/pkgs/development/compilers/llvm/14/default.nix
@@ -226,7 +226,9 @@ let
     };
 
     clangNoLibc = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [
@@ -240,7 +242,9 @@ let
     };
 
     clangNoCompilerRt = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [ ];

--- a/pkgs/development/compilers/llvm/15/clang/default.nix
+++ b/pkgs/development/compilers/llvm/15/clang/default.nix
@@ -4,6 +4,7 @@
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
+, targetPackages
 }:
 
 let
@@ -44,6 +45,8 @@ let
       # `clang-pseudo-gen`: https://github.com/llvm/llvm-project/commit/cd2292ef824591cc34cc299910a3098545c840c7
       "-DCLANG_TIDY_CONFUSABLE_CHARS_GEN=${buildLlvmTools.libclang.dev}/bin/clang-tidy-confusable-chars-gen"
       "-DCLANG_PSEUDO_GEN=${buildLlvmTools.libclang.dev}/bin/clang-pseudo-gen"
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform) [
+      "-DCLANG_DEFAULT_LINKER=${targetPackages.stdenv.cc.bintools}/bin/${stdenv.targetPlatform.config}-ld"
     ];
 
     patches = [

--- a/pkgs/development/compilers/llvm/15/default.nix
+++ b/pkgs/development/compilers/llvm/15/default.nix
@@ -274,7 +274,9 @@ in let
     };
 
     clangNoLibc = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [
@@ -288,7 +290,9 @@ in let
     };
 
     clangNoCompilerRt = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [ ];

--- a/pkgs/development/compilers/llvm/16/clang/default.nix
+++ b/pkgs/development/compilers/llvm/16/clang/default.nix
@@ -4,6 +4,7 @@
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
+, targetPackages
 }:
 
 let
@@ -44,6 +45,8 @@ let
       # `clang-pseudo-gen`: https://github.com/llvm/llvm-project/commit/cd2292ef824591cc34cc299910a3098545c840c7
       "-DCLANG_TIDY_CONFUSABLE_CHARS_GEN=${buildLlvmTools.libclang.dev}/bin/clang-tidy-confusable-chars-gen"
       "-DCLANG_PSEUDO_GEN=${buildLlvmTools.libclang.dev}/bin/clang-pseudo-gen"
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform) [
+      "-DCLANG_DEFAULT_LINKER=${targetPackages.stdenv.cc.bintools}/bin/${stdenv.targetPlatform.config}-ld"
     ];
 
     patches = [

--- a/pkgs/development/compilers/llvm/16/default.nix
+++ b/pkgs/development/compilers/llvm/16/default.nix
@@ -279,7 +279,9 @@ in let
     };
 
     clangNoLibc = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [
@@ -293,7 +295,9 @@ in let
     };
 
     clangNoCompilerRt = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [ ];

--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -2,6 +2,7 @@
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
+, targetPackages
 }:
 
 let
@@ -38,6 +39,8 @@ let
     ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
       "-DCLANG_TABLEGEN=${buildLlvmTools.libclang.dev}/bin/clang-tblgen"
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform) [
+      "-DCLANG_DEFAULT_LINKER=${targetPackages.stdenv.cc.bintools}/bin/${stdenv.targetPlatform.config}-ld"
     ];
 
     patches = [

--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -2,6 +2,7 @@
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
+, targetPackages
 }:
 
 let
@@ -38,6 +39,8 @@ let
     ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.llvm}/bin/llvm-tblgen"
       "-DCLANG_TABLEGEN=${buildLlvmTools.libclang.dev}/bin/clang-tblgen"
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform) [
+      "-DCLANG_DEFAULT_LINKER=${targetPackages.stdenv.cc.bintools}/bin/${stdenv.targetPlatform.config}-ld"
     ];
 
     patches = [

--- a/pkgs/development/compilers/llvm/7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/7/clang/default.nix
@@ -3,6 +3,7 @@
 , fixDarwinDylibNames
 , enableManpages ? false
 , enablePolly ? false # TODO: get this info from llvm (passthru?)
+, targetPackages
 }:
 
 let
@@ -42,6 +43,8 @@ let
     ] ++ lib.optionals enablePolly [
       "-DWITH_POLLY=ON"
       "-DLINK_POLLY_INTO_TOOLS=ON"
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform) [
+      "-DCLANG_DEFAULT_LINKER=${targetPackages.stdenv.cc.bintools}/bin/${stdenv.targetPlatform.config}-ld"
     ];
 
     patches = [

--- a/pkgs/development/compilers/llvm/7/default.nix
+++ b/pkgs/development/compilers/llvm/7/default.nix
@@ -197,7 +197,9 @@ let
     };
 
     clangNoLibc = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [
@@ -210,7 +212,9 @@ let
     };
 
     clangNoCompilerRt = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [ ];

--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -3,6 +3,7 @@
 , fixDarwinDylibNames
 , enableManpages ? false
 , enablePolly ? false # TODO: get this info from llvm (passthru?)
+, targetPackages
 }:
 
 let
@@ -42,6 +43,8 @@ let
     ] ++ lib.optionals enablePolly [
       "-DWITH_POLLY=ON"
       "-DLINK_POLLY_INTO_TOOLS=ON"
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform) [
+      "-DCLANG_DEFAULT_LINKER=${targetPackages.stdenv.cc.bintools}/bin/${stdenv.targetPlatform.config}-ld"
     ];
 
     patches = [

--- a/pkgs/development/compilers/llvm/8/default.nix
+++ b/pkgs/development/compilers/llvm/8/default.nix
@@ -198,7 +198,9 @@ let
     };
 
     clangNoLibc = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [
@@ -211,7 +213,9 @@ let
     };
 
     clangNoCompilerRt = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [ ];

--- a/pkgs/development/compilers/llvm/9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/9/clang/default.nix
@@ -3,6 +3,7 @@
 , fixDarwinDylibNames
 , enableManpages ? false
 , enablePolly ? false # TODO: get this info from llvm (passthru?)
+, targetPackages
 }:
 
 let
@@ -42,6 +43,8 @@ let
     ] ++ lib.optionals enablePolly [
       "-DWITH_POLLY=ON"
       "-DLINK_POLLY_INTO_TOOLS=ON"
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform) [
+      "-DCLANG_DEFAULT_LINKER=${targetPackages.stdenv.cc.bintools}/bin/${stdenv.targetPlatform.config}-ld"
     ];
 
     patches = [

--- a/pkgs/development/compilers/llvm/9/default.nix
+++ b/pkgs/development/compilers/llvm/9/default.nix
@@ -198,7 +198,9 @@ let
     };
 
     clangNoLibc = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [
@@ -211,7 +213,9 @@ let
     };
 
     clangNoCompilerRt = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [ ];

--- a/pkgs/development/compilers/llvm/git/clang/default.nix
+++ b/pkgs/development/compilers/llvm/git/clang/default.nix
@@ -4,6 +4,7 @@
 , buildLlvmTools
 , fixDarwinDylibNames
 , enableManpages ? false
+, targetPackages
 }:
 
 let
@@ -44,6 +45,8 @@ let
       # `clang-pseudo-gen`: https://github.com/llvm/llvm-project/commit/cd2292ef824591cc34cc299910a3098545c840c7
       "-DCLANG_TIDY_CONFUSABLE_CHARS_GEN=${buildLlvmTools.libclang.dev}/bin/clang-tidy-confusable-chars-gen"
       "-DCLANG_PSEUDO_GEN=${buildLlvmTools.libclang.dev}/bin/clang-pseudo-gen"
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform) [
+      "-DCLANG_DEFAULT_LINKER=${targetPackages.stdenv.cc.bintools}/bin/${stdenv.targetPlatform.config}-ld"
     ];
 
     patches = [

--- a/pkgs/development/compilers/llvm/git/default.nix
+++ b/pkgs/development/compilers/llvm/git/default.nix
@@ -265,7 +265,9 @@ in let
     };
 
     clangNoLibc = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [
@@ -279,7 +281,9 @@ in let
     };
 
     clangNoCompilerRt = wrapCCWith rec {
-      cc = tools.clang-unwrapped;
+      cc = tools.clang-unwrapped.override {
+        targetPackages.stdenv.cc.bintools = bintoolsNoLibc';
+      };
       libcxx = null;
       bintools = bintoolsNoLibc';
       extraPackages = [ ];

--- a/pkgs/os-specific/darwin/cctools/llvm.nix
+++ b/pkgs/os-specific/darwin/cctools/llvm.nix
@@ -1,7 +1,7 @@
 # Create a cctools-compatible bintools that uses equivalent tools from LLVM in place of the ones
 # from cctools when possible.
 
-{ lib, stdenv, makeWrapper, cctools-port, llvmPackages, enableManpages ? stdenv.targetPlatform == stdenv.hostPlatform }:
+{ lib, stdenv, makeWrapper, cctools-port, llvmPackages, clang-unwrapped, enableManpages ? stdenv.targetPlatform == stdenv.hostPlatform }:
 
 let
   inherit (stdenv) targetPlatform hostPlatform;
@@ -86,7 +86,7 @@ stdenv.mkDerivation {
 
   '' + lib.optionalString useClangAssembler ''
     # Use the clang-integrated assembler instead of using `as` from cctools.
-    makeWrapper "${lib.getBin llvmPackages.clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
+    makeWrapper "${lib.getBin clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
       --add-flags "-x assembler -integrated-as -c"
 
   '' + ''


### PR DESCRIPTION
When using clang for cross compilation, clang cannot find the linker. 

Example (works for clang 12 and later):
```
$ nix build nixpkgs#pkgsCross.aarch64-multiplatform.buildPackages.llvmPackages_14.clang
$ ./result/bin/aarch64-unknown-linux-gnu-cc foo.c
clang-14: error: unable to execute command: Executable "ld" doesn't exist!
clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
```

Let me explain why this happens. For consistency with gcc, given a linker name (`ld`), clang finds the linker in the following order:

1. in prefix dirs, which is specified with COMPILER_PATH environment or `-B` command line args.
2. in ProgramPaths, which is toolchain specific.
3. in PATH environment.

The step 2 and 3 considers all possible target triple prefixes, but the step 1 does not. In nixpkgs, all binaries in cross toolchains are prefixed by the target triple, thus clang cannot find them.

Related LLVM source: https://github.com/llvm/llvm-project/blob/8dfdcc7b7bf66834a761bd8de445840ef68e4d1a/clang/lib/Driver/Driver.cpp#L5857-L5897

Related LLVM commit: https://github.com/llvm/llvm-project/commit/3452a0d8c17f7166f479706b293caf6ac76ffd90

Related gcc doc: https://gcc.gnu.org/onlinedocs/gccint/Collect2.html

For gcc in nixpkgs, the linker path is hardcoded in configuration phase (as is shown below). This commit copies this behavior to clang.

https://github.com/NixOS/nixpkgs/blob/5c5ca018c8f2d819ef94429a5358af96533ff6b9/pkgs/development/compilers/gcc/common/configure-flags.nix#L38

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
