### PR TITLE
servo: init at unstable-2023-03-11

### DIFF
--- a/pkgs/by-name/se/servo/package.nix
+++ b/pkgs/by-name/se/servo/package.nix
@@ -1,0 +1,93 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fontconfig
+, freetype
+, openssl
+, libunwind
+, xorg
+, gst_all_1
+, rustup
+, cmake
+, dbus
+, gcc
+, git
+, pkg-config
+, which
+, llvm
+, autoconf213
+, perl
+, yasm
+, m4
+, python3
+, darwin
+}:
+
+stdenv.mkDerivation {
+  pname = "servo";
+  version = "0-unstable-2024-05-22";
+
+  src = fetchFromGitHub {
+    owner = "servo";
+    repo = "servo";
+    rev = "9f32809671c8c8e79d59c95194dcc466452299fc";
+    hash = "";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [
+    # Native dependencies
+    fontconfig
+    freetype
+    openssl
+    libunwind
+    xorg.libxcb
+
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-bad
+
+    rustup
+
+    # Build utilities
+    cmake dbus gcc git pkg-config which llvm autoconf213 perl yasm m4
+    (python3.withPackages (ps: with ps; [virtualenv pip dbus]))
+
+  ] ++ (lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.AppKit
+  ]);
+
+  enableParallelBuilding = true;
+
+  configurePhase = ''
+    runHook preConfigure
+
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    ./mach build --release
+
+    runHook postBuild
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    ./mach run --release tests/html/about-mozilla.html
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://servo.org";
+    description = "Servo is a prototype web browser engine written in the Rust language.";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ GaetanLepage ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
###### Description of changes

This is a draft PR to package the servo browser.
I am not sure to have the necessary skills to package such an application: any help would be appreciated :)

Homepage: https://servo.org/
GitHub: https://github.com/servo/servo

Note: A nix shell has been made to provide a developer environment:
https://github.com/servo/servo/blob/master/etc/shell.nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
