### PR TITLE
hase: init at unstable-2020-10-06

### DIFF
--- a/pkgs/development/libraries/sparrow3d/default.nix
+++ b/pkgs/development/libraries/sparrow3d/default.nix
@@ -1,0 +1,98 @@
+{ lib
+, stdenv
+, copyPkgconfigItems
+, fetchFromGitHub
+, makePkgconfigItem
+, pkg-config
+, SDL
+, SDL_image
+, SDL_mixer
+, SDL_net
+, SDL_ttf
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sparrow3d";
+  version = "unstable-2020-10-06";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "theZiz";
+    repo = "sparrow3d";
+    rev = "2033349d7adeba34bda2c442e1fec22377471134";
+    hash = "sha256-28j5nbTYBrMN8BQ6XrTlO1D8Viw+RiT3MAl99BAbhR4=";
+  };
+
+  pkgconfigItems = [
+    (makePkgconfigItem rec {
+      name = "sparrow3d";
+      inherit (finalAttrs) version;
+      inherit (finalAttrs.meta) description;
+
+      cflags = [ "-isystem${variables.includedir}" ];
+      libs = [
+        "-L${variables.libdir}"
+        "-lsparrow3d"
+        "-lsparrowNet"
+        "-lsparrowSound"
+      ];
+      variables = rec {
+        prefix = "@dev@";
+        exec_prefix = "@out@";
+        includedir = "${prefix}/include";
+        libdir = "${exec_prefix}/lib";
+      };
+    })
+  ];
+
+  nativeBuildInputs = [
+    copyPkgconfigItems
+    pkg-config
+  ];
+
+  propagatedBuildInputs = [
+    SDL.dev
+    SDL_image
+    SDL_ttf
+    SDL_mixer
+    SDL_net
+  ];
+
+  postConfigure = ''
+    NIX_CFLAGS_COMPILE=$(pkg-config --cflags SDL_image SDL_ttf SDL_mixer SDL_net)
+  '';
+
+  buildFlags = [ "dynamic" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp libsparrow{3d,Net,Sound}.so $out/lib
+
+    mkdir -p $dev/include
+    cp sparrow*.h $dev/include
+
+    runHook postInstall
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+
+    make all_no_static
+    ./testfile.sh
+
+    runHook postCheck
+  '';
+
+  meta = {
+    homepage = "https://github.com/theZiz/sparrow3d";
+    description = "A software renderer for different open handhelds like the gp2x, wiz, caanoo and pandora";
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ colinsane ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/development/libraries/sparrow3d/sparrow3d.pc.in
+++ b/pkgs/development/libraries/sparrow3d/sparrow3d.pc.in
@@ -1,0 +1,16 @@
+prefix=@out@
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: sparrow3d
+Description: a software renderer for different open handhelds like the gp2x, wiz, caanoo and pandora
+URL: https://github.com/theZiz/sparrow3d
+Version: @version@
+Requires: \
+  sdl \
+  SDL_image \
+  SDL_ttf \
+  SDL_mixer \
+  SDL_net
+Cflags: -isystem${includedir}
+Libs: -L${libdir} -lsparrow3d -lsparrowNet -lsparrowSound

--- a/pkgs/games/hase/default.nix
+++ b/pkgs/games/hase/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, sparrow3d
+, zlib
+}:
+
+stdenv.mkDerivation {
+  pname = "hase";
+  version = "unstable-2020-10-06";
+
+  src = fetchFromGitHub {
+    owner = "theZiz";
+    repo = "hase";
+    rev = "31d6840cdf0c72fc459f10402dae7726096b2974";
+    hash = "sha256-d9So3E8nCQJ1/BdlwMkGbaFPT9mkX1VzlDGKp71ptEE=";
+  };
+
+  patches = [ ./prefer-dynamic.patch ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    sparrow3d
+    zlib
+  ];
+
+  buildPhase = ''
+    NIX_CFLAGS_COMPILE=$(pkg-config --cflags sparrow3d zlib)
+
+    # build and install are one step, and inseparable without patching
+    mkdir -p $out/{bin,share/applications,share/pixmaps}
+    ./install.sh $out
+  '';
+
+  postFixup = ''
+    substituteInPlace "$out/share/applications/hase.desktop" \
+      --replace "Exec=hase" "Exec=$out/bin/hase"
+  '';
+
+  meta = {
+    description = "An open-source artillery shooter";
+    longDescription = ''
+      Hase is an open source gravity based artillery shooter. It is similar to
+      Worms, Hedgewars or artillery, but the gravity force and direction
+      depends on the mass nearby. It is optimized for mobile game consoles like
+      the GP2X, Open Pandora or GCW Zero.
+    '';
+    homepage = "http://ziz.gp2x.de/hase/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ colinsane ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/games/hase/prefer-dynamic.patch
+++ b/pkgs/games/hase/prefer-dynamic.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 95d894e..3c561c1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -35,7 +35,7 @@ endif
+ LIB += -L$(SPARROW_LIB)
+ INCLUDE += -I$(SPARROW_FOLDER)
+ 
+-HASE_STATIC = $(SPARROW_LIB)/$(SPARROW3D_STATIC_LIB) $(SPARROW_LIB)/$(SPARROWSOUND_STATIC_LIB) $(SPARROW_LIB)/$(SPARROWNET_STATIC_LIB) $(STATIC)
++DYNAMIC += -lsparrow3d -lsparrowSound -lsparrowNet
+ 
+ ifneq ($(TARGET),win32)
+ DYNAMIC += -lz

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35929,6 +35929,8 @@ with pkgs;
 
   harmonist = callPackage ../games/harmonist { };
 
+  hase = callPackage ../games/hase { };
+
   hedgewars = libsForQt5.callPackage ../games/hedgewars {
     inherit (haskellPackages) ghcWithPackages;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23663,6 +23663,8 @@ with pkgs;
 
   spaceship-prompt = callPackage ../shells/zsh/spaceship-prompt { };
 
+  sparrow3d = callPackage ../development/libraries/sparrow3d {};
+
   spdk = callPackage ../development/libraries/spdk { };
 
   speechd = callPackage ../development/libraries/speechd { };


### PR DESCRIPTION
project page: <http://ziz.gp2x.de/hase/index.htm>

"Hase is an open source (GPL) gravity based artillery shooter. It is similar to Worms, Hedgewars or artillery, but the gravity force and direction depends on the mass nearby."

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
