### PR TITLE
SDL2: 2.26.3 -> 2.26.4

### DIFF
--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -57,11 +57,11 @@
 
 stdenv.mkDerivation rec {
   pname = "SDL2";
-  version = "2.26.3";
+  version = "2.26.4";
 
   src = fetchurl {
     url = "https://www.libsdl.org/release/${pname}-${version}.tar.gz";
-    sha256 = "sha256-xmEgWlU7fSUkJfS3Uf8TIJ5eAguHa7+hWYSUr2F5AFc=";
+    sha256 = "sha256-Gg9oZJj7dorZ8/gLOQN6fQBurAk6rTnLTrzIMqiIcjE=";
   };
   dontDisableStatic = if withStatic then 1 else 0;
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -173,6 +173,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.libsdl.org/";
     license = licenses.zlib;
     platforms = platforms.all;
-    maintainers = with maintainers; [ cpages ];
+    maintainers = with maintainers; [ cpages superherointj ];
   };
 }


### PR DESCRIPTION
SDL2: 2.26.3 -> 2.26.4
* add superherointj as maintainer

Release: https://github.com/libsdl-org/SDL/releases/tag/release-2.26.4
  - Fixes using older game controller mappings on Linux

Tested building: Steam.