### PR TITLE
marst,libidn2,mdk: remove duplicate /gnu in the url

### DIFF
--- a/pkgs/development/compilers/marst/default.nix
+++ b/pkgs/development/compilers/marst/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   version = "2.7";
 
   src = fetchurl {
-    url = "mirror://gnu/gnu/${pname}/${pname}-${version}.tar.gz";
+    url = "mirror://gnu/${pname}/${pname}-${version}.tar.gz";
     hash = "sha256-Pue50cvjzZ+19iJxfae7VQbxpto7MPgS4jhLh7zk2lA=";
   };
 

--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   version = "2.3.2";
 
   src = fetchurl {
-    url = "mirror://gnu/gnu/libidn/${pname}-${version}.tar.gz";
+    url = "mirror://gnu/libidn/${pname}-${version}.tar.gz";
     sha256 = "sha256-dpQM1Od46Ak1eanRlbJf/16Tbp3GJCBoUotDenZ2T5E=";
   };
 

--- a/pkgs/development/tools/mdk/default.nix
+++ b/pkgs/development/tools/mdk/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   pname = "gnu-mdk";
   version = "1.3.0";
   src = fetchurl {
-    url = "mirror://gnu/gnu/mdk/v${version}/mdk-${version}.tar.gz";
+    url = "mirror://gnu/mdk/v${version}/mdk-${version}.tar.gz";
     sha256 = "0bhk3c82kyp8167h71vdpbcr852h5blpnwggcswqqwvvykbms7lb";
   };
   nativeBuildInputs = [ pkg-config intltool ];


### PR DESCRIPTION
there mirrors only worked with "https://ftpmirror.gnu.org/" because it ignored the extra /gnu

while with the other gnu mirrors "https://ftp.nluug.nl/pub/gnu/" it failed because the url would be pub/gnu/gnu.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
