### PR TITLE
vscode-extensions.ms-vsliveshare.vsliveshare: 1.0.5043 -> 1.0.5834

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-vsliveshare-vsliveshare/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vsliveshare-vsliveshare/default.nix
@@ -2,20 +2,14 @@
 #  -  <https://github.com/msteen/nixos-vsliveshare/blob/master/pkgs/vsliveshare/default.nix>
 #  -  <https://github.com/NixOS/nixpkgs/issues/41189>
 { lib, gccStdenv, vscode-utils
-, jq, autoPatchelfHook, bash, makeWrapper
-, dotnet-sdk_3, curl, gcc, icu, libkrb5, libsecret, libunwind, libX11, lttng-ust, openssl, util-linux, zlib
-, desktop-file-utils, xprop, xsel
+, autoPatchelfHook, bash, makeWrapper
+, curl, gcc, libsecret, libunwind, libX11, lttng-ust, util-linux
+, desktop-file-utils, xsel
 }:
 
 let
   # https://docs.microsoft.com/en-us/visualstudio/liveshare/reference/linux#install-prerequisites-manually
   libs = [
-    # .NET Core
-    openssl
-    libkrb5
-    zlib
-    icu
-
     # Credential Storage
     libsecret
 
@@ -36,89 +30,18 @@ in ((vscode-utils.override { stdenv = gccStdenv; }).buildVscodeMarketplaceExtens
   mktplcRef = {
     name = "vsliveshare";
     publisher = "ms-vsliveshare";
-    version = "1.0.5043";
-    sha256 = "OdFOFvidUV/trySHvF8iELPNVP2kq8+vZQ4q4Nf7SiQ=";
+    version = "1.0.5834";
+    sha256 = "sha256-+KfivY8W1VtUxhdXuUKI5e1elo6Ert1Tsf4xVXsKB3Y=";
   };
-}).overrideAttrs({ nativeBuildInputs ? [], buildInputs ? [], ... }: {
-  nativeBuildInputs = nativeBuildInputs ++ [
-    jq
-    autoPatchelfHook
-    makeWrapper
-  ];
+}).overrideAttrs({ buildInputs ? [], ... }: {
   buildInputs = buildInputs ++ libs;
 
   # Using a patch file won't work, because the file changes too often, causing the patch to fail on most updates.
   # Rather than patching the calls to functions, we modify the functions to return what we want,
   # which is less likely to break in the future.
   postPatch = ''
-    sed -i \
-      -e 's/updateExecutablePermissionsAsync() {/& return;/' \
-      -e 's/isInstallCorrupt(traceSource, manifest) {/& return false;/' \
-      out/prod/extension-prod.js
-
-    declare ext_unique_id
-    ext_unique_id="$(basename "$out")"
-
-    # Fix extension attempting to write to 'modifiedInternalSettings.json'.
-    # Move this write to the tmp directory indexed by the nix store basename.
-    substituteInPlace out/prod/extension-prod.js \
-      --replace "path.resolve(constants_1.EXTENSION_ROOT_PATH, './modifiedInternalSettings.json')" \
-                "path.join(os.tmpdir(), '$ext_unique_id-modifiedInternalSettings.json')"
-
-    # Fix extension attempting to write to 'vsls-agent.lock'.
-    # Move this write to the tmp directory indexed by the nix store basename.
-    substituteInPlace out/prod/extension-prod.js \
-      --replace "path + '.lock'" \
-                "__webpack_require__('path').join(__webpack_require__('os').tmpdir(), '$ext_unique_id-vsls-agent.lock')"
-
-    # Hardcode executable paths
-    echo '#!/bin/sh' >node_modules/@vsliveshare/vscode-launcher-linux/check-reqs.sh
-    substituteInPlace node_modules/@vsliveshare/vscode-launcher-linux/install.sh \
-      --replace desktop-file-install ${desktop-file-utils}/bin/desktop-file-install
-    substituteInPlace node_modules/@vsliveshare/vscode-launcher-linux/uninstall.sh \
-      --replace update-desktop-database ${desktop-file-utils}/bin/update-desktop-database
-    substituteInPlace node_modules/@vsliveshare/vscode-launcher-linux/vsls-launcher \
-      --replace /bin/bash ${bash}/bin/bash
-    substituteInPlace out/prod/extension-prod.js \
-      --replace xprop ${xprop}/bin/xprop \
+    substituteInPlace extension.js \
       --replace "'xsel'" "'${xsel}/bin/xsel'"
-  '';
-
-  postInstall = ''
-    cd $out/share/vscode/extensions/ms-vsliveshare.vsliveshare
-
-    bash -s <<ENDSUBSHELL
-    shopt -s extglob
-
-    # A workaround to prevent the journal filling up due to diagnostic logging.
-    # See: https://github.com/MicrosoftDocs/live-share/issues/1272
-    # See: https://unix.stackexchange.com/questions/481799/how-to-prevent-a-process-from-writing-to-the-systemd-journal
-    gcc -fPIC -shared -ldl -o dotnet_modules/noop-syslog.so ${./noop-syslog.c}
-
-    # Normally the copying of the right executables is done externally at a later time,
-    # but we want it done at installation time.
-    cp dotnet_modules/exes/linux-x64/* dotnet_modules
-
-    # The required executables are already copied over,
-    # and the other runtimes won't be used and thus are just a waste of space.
-    rm -r dotnet_modules/exes dotnet_modules/runtimes/!(linux-x64|unix)
-
-    # Not all executables and libraries are executable, so make sure that they are.
-    jq <package.json '.executables.linux[]' -r | xargs chmod +x
-
-    # Lock the extension downloader.
-    touch install-linux.Lock externalDeps-linux.Lock
-    ENDSUBSHELL
-  '';
-
-  postFixup = ''
-    # We cannot use `wrapProgram`, because it will generate a relative path,
-    # which will break when copying over the files.
-    mv dotnet_modules/vsls-agent{,-wrapped}
-    makeWrapper $PWD/dotnet_modules/vsls-agent{-wrapped,} \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath libs}" \
-      --set LD_PRELOAD $PWD/dotnet_modules/noop-syslog.so \
-      --set DOTNET_ROOT ${dotnet-sdk_3}
   '';
 
   meta = with lib; {

--- a/pkgs/applications/editors/vscode/extensions/ms-vsliveshare-vsliveshare/noop-syslog.c
+++ b/pkgs/applications/editors/vscode/extensions/ms-vsliveshare-vsliveshare/noop-syslog.c
@@ -1,1 +1,0 @@
-void syslog(int priority, const char *format, ...) { }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update to the latest version.

Since the underlying extension logic changed significantly, a lot of the previous patches no longer apply and were removed. From what I tested, the extension works fine.

Since this removes the extensions' dependency on native agents (https://github.com/MicrosoftDocs/live-share/issues/1272#issuecomment-1312570760), it removes the dependency on .NET Core 3.1 - and helps with https://github.com/NixOS/nixpkgs/issues/202572
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
