### PR TITLE
linuxPackages.nvidia_x11_vulkan_beta: 525.47.11 -> 525.47.18

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -51,11 +51,11 @@ rec {
   # Vulkan developer beta driver
   # See here for more information: https://developer.nvidia.com/vulkan-driver
   vulkan_beta = generic rec {
-    version = "525.47.11";
+    version = "525.47.18";
     persistencedVersion = "525.85.05";
     settingsVersion = "525.85.05";
-    sha256_64bit = "sha256-R3W0Nn9HDluzF316kWDlBnmCgS/O3Atic4poJnjAdPU=";
-    openSha256 = "sha256-tZXzYQBx/3PzmHYrxmUD6iwxqwbi5/uVlN/7DU82oig=";
+    sha256_64bit = "sha256-L0H7o7zkN1pHHadaIC8nH+JMGt1IzuubEH6KgViU2Ic=";
+    openSha256 = "sha256-xlRTE+QdAxSomIdvLb5dxklSeu/JVjI8IeYDzSloOo4=";
     settingsSha256 = "sha256-ck6ra8y8nn5kA3L9/VcRR2W2RaWvfVbgBiOh2dRJr/8=";
     persistencedSha256 = "sha256-dt/Tqxp7ZfnbLel9BavjWDoEdLJvdJRwFjTFOBYYKLI=";
     url = "https://developer.nvidia.com/downloads/vulkan-beta-${lib.concatStrings (lib.splitString "." version)}-linux";


### PR DESCRIPTION
###### Description of changes

- March 31st, 2023 - Windows 531.54, Linux 525.47.18
  - New:
    - [VK_EXT_shader_object](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_shader_object.html)
      - [Khronos Blog](https://www.khronos.org/blog/you-can-use-vulkan-without-pipelines-today)
    - Provisional Vulkan video extension updates:
      - VK_KHR_video_encode_queue: 7 -> 8
      - VK_EXT_video_encode_h264: 9 -> 10
      - Note: these changes are not backwards compatible with the old revisions so applications using the old revisions will need to be updated to continue working
  - Fixes:
    - Vulkan video: Allow top and bottom field flags both being zero to mean progressive
- March 22nd, 2023 - Windows 531.46, Linux 525.47.15
  - Fixes:
    - Update VK_NV_displacement_micromap to work better on pre-Ada RTX GPUs
- March 21st, 2023 - Windows 531.44, Linux 525.47.14
  - New:
    - [VK_KHR_map_memory2](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_map_memory2.html)
    - VK_NV_displacement_micromap
      - [NVIDIA Displacement Micro-Map Toolkit](https://github.com/NVIDIAGameWorks/Displacement-MicroMap-Toolkit)
- March 11th, 2023 - Windows 531.32, Linux 525.47.13
  - Fixes:
    - Fixed Vulkan Video not working on NVIDIA Ada family of GPUs
    - Fixed the disk cache to handle UTF-8 paths
    - Improved robustness of vkCreatePipelineCache with invalid data
    - Fixed corruption that may occur when rendering with a previously resolved depth image
    - Fixed rare SPIR-V control flow bug that may result in infinite loop
    - Fixed the coherency order not being consistent between atomic loads and atomic stores

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
