### PR TITLE
nixos: clean up the eval-config interface

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,11 +26,6 @@
                   ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";
                 system.nixos.revision = final.mkIf (self ? rev) self.rev;
               }];
-            } // lib.optionalAttrs (! args?system) {
-              # Allow system to be set modularly in nixpkgs.system.
-              # We set it to null, to remove the "legacy" entrypoint's
-              # non-hermetic default.
-              system = null;
             }
           );
       });

--- a/nixos/lib/eval-config-legacy.nix
+++ b/nixos/lib/eval-config-legacy.nix
@@ -1,0 +1,39 @@
+# This module encapsulates the legacy nixos eval entrypoint
+# in order to clean up the main entrypoint and make
+# a small step towards actual deprecation
+{ lib, evalConfigArgs }: let
+  _file = ./eval-config-legacy.nix;
+  key = _file;
+in {
+
+  legacyModules =
+    lib.optional (evalConfigArgs?extraArgs) {
+      config._module.args = evalConfigArgs.extraArgs;
+      inherit key _file;
+    }
+    ++ lib.optional (evalConfigArgs?check) {
+      config._module.check = lib.mkDefault evalConfigArgs.check;
+      inherit key _file;
+    };
+
+  legacyPkgsModules = let
+    # Explicit `nixpkgs.system` or `nixpkgs.localSystem` should override
+    # this.  Since the latter defaults to the former, the former should
+    # default to the argument. That way this new default could propagate all
+    # they way through, but has the last priority behind everything else.
+    mkDefaultSystem = lib.mkDefault;
+  in
+    lib.optional (evalConfigArgs?system) {
+      config.nixpkgs.system = mkDefaultSystem evalConfigArgs.system;
+      inherit key _file;
+    }
+    # legacy impure entrypoint shim
+    ++ lib.optional (!evalConfigArgs?system && builtins?currentSystem) {
+      config.nixpkgs.system = mkDefaultSystem builtins.currentSystem;
+      inherit key _file;
+    }
+    ++ lib.optional (evalConfigArgs?pkgs) {
+      _module.args.pkgs = lib.mkForce evalConfigArgs.pkgs;
+      inherit key _file;
+    };
+}


### PR DESCRIPTION
Problem: the NixOS eval-config has been undergoing a long-lasting
transformation from away from specifying function inputs towards
having all possible setting self-contained within the module system.
As a result, the interface of eval-config has confused a many nixos
users. "Should I set lib here? What's the impact if I do?" - "What
happens if I set pkgs here? I also can set it self-contained in the
module system. What's the difference?"

Solution: In order to dial back on this confusion, mark the excess
interfaces as clearly deprecated for another very long time.
This gives clarity to users how the module system is supposed to be
configured and in 5-10 years, we'll eventually be able to pay off
this techincal debt and remove the interface and more closely
align with lib.evalModules.
