### PR TITLE
kubernetes-metrics-server: init at version 0.6.2

### DIFF
--- a/pkgs/applications/networking/cluster/kubernetes-metrics-server/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes-metrics-server/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kubernetes-metrics-server";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "kubernetes-sigs";
+    repo = "metrics-server";
+    rev = "v${version}";
+    sha256 = "sha256-TTI+dNBQ/jKt6Yhud3/OO+zOkeO46CmUz6J6ByX26JE=";
+  };
+
+  vendorSha256 = "sha256-lpSMvHYlPtlJQUqsdXJ6ewBEBiwLPvP/rsUgYzJhOxc=";
+
+  preCheck = ''
+    # the e2e test breaks the sandbox, so let's skip that
+    rm test/e2e_test.go
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/kubernetes-sigs/metrics-server";
+    description = "Kubernetes container resource metrics collector";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ eskytthe ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31094,6 +31094,8 @@ with pkgs;
   kubectl = callPackage ../applications/networking/cluster/kubernetes/kubectl.nix { };
   kubectl-convert = kubectl.convert;
 
+  kubernetes-metrics-server = callPackage ../applications/networking/cluster/kubernetes-metrics-server { };
+
   kubemqctl = callPackage ../applications/networking/cluster/kubemqctl { };
 
   kubent = callPackage ../applications/networking/cluster/kubent { };


### PR DESCRIPTION
###### Description of changes
Metrics Server is a scalable, efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.

We have used it for several years - time to upstream it. 

https://github.com/kubernetes-sigs/metrics-server
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

```
$ result/bin/metrics-server --help
Launch metrics-server

Usage:
   [flags]

Metrics server flags:

      --kubeconfig string                                                                                                                                                                                                             
                The path to the kubeconfig used to connect to the Kubernetes API server and the Kubelets (defaults to in-cluster config)
      --metric-resolution duration                                                                                                                                                                                                    
                The resolution at which metrics-server will retain metrics, must set value at least 10s. (default 1m0s)
      --version                                                                                                                                                                                                                       
                Show version
```