### PR TITLE
supercolliderPlugins.sc3-plugins: 3.11.1 → 3.13.0

### DIFF
--- a/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
+++ b/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "sc3-plugins";
-  version = "3.11.1";
+  version = "3.13.0";
 
   src = fetchurl {
     url = "https://github.com/supercollider/sc3-plugins/releases/download/Version-${version}/sc3-plugins-${version}-Source.tar.bz2";
-    sha256 = "sha256-JjUmu7PJ+x3yRibr+Av2gTREng51fPo7Rk+B4y2JvkQ=";
+    sha256 = "sha256-+N7rhh1ALipy21HUC0jEQ2kCYbWlOveJg9TPe6dnF6I=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
###### Description of changes

This is a very minor update that just has accumulated fixes from upstream for the last while (including docs and atk speed of sound fix)

Release notes: https://github.com/supercollider/sc3-plugins/releases/tag/Version-3.13.0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review pr 220766` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>sonic-pi</li>
    <li>supercollider-with-sc3-plugins</li>
    <li>supercolliderPlugins.sc3-plugins</li>
  </ul>
</details>