### PR TITLE
coder: resolve hash mismatch in fixed-output derivation

### DIFF
--- a/pkgs/development/tools/coder/default.nix
+++ b/pkgs/development/tools/coder/default.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
 
   offlineCache = fetchYarnDeps {
     yarnLock = src + "/site/yarn.lock";
-    hash = "sha256-4GbM7GNZ3wHIZJIJuHw1v/SwjUNc1vi8IHRGaGwPGZQ=";
+    hash = "sha256-nRmEXR9fjDxvpbnT+qpGeM0Cc/qW/kN53sKOXwZiBXY=";
   };
 
   subPackages = [ "cmd/..." ];


### PR DESCRIPTION
Resolves

```
buildPhase completed in 1 minutes 35 seconds
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/3gvpsbxyrckxnganwrqlav3h14h78zvp-offline
checking for references to /build/ in /nix/store/3gvpsbxyrckxnganwrqlav3h14h78zvp-offline...
patching script interpreter paths in /nix/store/3gvpsbxyrckxnganwrqlav3h14h78zvp-offline
error: hash mismatch in fixed-output derivation '/nix/store/wmdb63p17g1r7gs2v1kq94qg1vn01i6w-offline.drv':
         specified: sha256-4GbM7GNZ3wHIZJIJuHw1v/SwjUNc1vi8IHRGaGwPGZQ=
            got:    sha256-nRmEXR9fjDxvpbnT+qpGeM0Cc/qW/kN53sKOXwZiBXY=
error: 1 dependencies of derivation '/nix/store/wm8hs8p8laf0q8afjra59hp43nd6plwk-coder-0.17.1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/n3m9zj42n97w30va4lm0sawzw4cl4vv9-unit-coder.service.drv' failed to build
error: 1 dependencies of derivation '/nix/store/adrn82iinyrw35ri7viji02y10zv6a7x-system-units.drv' failed to build
error: 1 dependencies of derivation '/nix/store/lwc0vyr7c9l1r2qr68cq4a4hs16dawn1-etc.drv' failed to build
error: 1 dependencies of derivation '/nix/store/mgq0scqh5wm055l9gcybahd012yzglfn-nixos-system-ghuntley-net-23.05pre461993.0c4800d579a.drv' failed to build
```