### PR TITLE
dxvk: fix DLL override setup

### DIFF
--- a/pkgs/misc/dxvk/setup_dxvk.sh
+++ b/pkgs/misc/dxvk/setup_dxvk.sh
@@ -2,11 +2,14 @@
 
 set -eu -o pipefail
 
-dxvk32_dir=@dxvk32@/bin
-dxvk64_dir=@dxvk64@/bin
+# shellcheck disable=SC2034
+{
+    dxvk32_dir=@dxvk32@/bin
+    dxvk64_dir=@dxvk64@/bin
 
-mcfgthreads32_dir=@mcfgthreads32@/bin
-mcfgthreads64_dir=@mcfgthreads64@/bin
+    mcfgthreads32_dir=@mcfgthreads32@/bin
+    mcfgthreads64_dir=@mcfgthreads64@/bin
+}
 
 ## Defaults
 
@@ -51,7 +54,7 @@ case "${1:-}" in
         usage
         ;;
     *)
-        if [ ! -z "${1:-}" ]; then
+        if [ -n "${1:-}" ]; then
             echo "Unrecognized command: $1"
         fi
         usage
@@ -62,19 +65,19 @@ esac
 do_symlink=false
 do_makeprefix=false
 
-while [ ! -z "${1:-}" ]; do
+while [ -n "${1:-}" ]; do
     case "$1" in
         --with-dxgi)
             targets[dxgi]=1
             ;;
         --without-dxgi)
-            unset targets[dxgi]
+            unset "targets[dxgi]"
             ;;
         --with-d3d10)
             targets[d3d10]=1
             ;;
         --without-d3d10)
-            unset targets[d3d10]
+            unset "targets[d3d10]"
             ;;
         -s|--symlink)
             do_symlink=true
@@ -90,7 +93,7 @@ while [ ! -z "${1:-}" ]; do
             ;;
         -p|--prefix)
             shift
-            if [ ! -z "${1:-}" ]; then
+            if [ -n "${1:-}" ]; then
                 WINEPREFIX=$1
             else
                 echo "Required PREFIX missing"
@@ -223,8 +226,7 @@ uninstall_file() {
 
 install_override() {
     dll=$(basename "$1")
-    $wine reg add 'HKEY_CURRENT_USER\Software\Wine\DllOverrides' /v "$dll" /d native /f >/dev/null 2>&1
-    if [ $? -ne 0 ]; then
+    if ! $wine reg add 'HKEY_CURRENT_USER\Software\Wine\DllOverrides' /v "$dll" /d native /f >/dev/null 2>&1; then
         echo -e "Failed to add override for $dll"
         exit 1
     fi
@@ -232,8 +234,7 @@ install_override() {
 
 uninstall_override() {
     dll=$(basename "$1")
-    $wine reg delete 'HKEY_CURRENT_USER\Software\Wine\DllOverrides' /v "$dll" /f > /dev/null 2>&1
-    if [ $? -ne 0 ]; then
+    if ! $wine reg delete 'HKEY_CURRENT_USER\Software\Wine\DllOverrides' /v "$dll" /f > /dev/null 2>&1; then
         echo "Failed to remove override for $dll"
     fi
 }
@@ -243,16 +244,16 @@ uninstall_override() {
 declare -A paths
 
 for target in "${!targets[@]}"; do
-    [ ${targets[$target]} -eq 1 ] || continue
+    [ "${targets[$target]}" -eq 1 ] || continue
     for dll in ${dlls[$target]}; do
         dllname=$(basename "$dll")
         basedir=$(dirname "$dll")
 
-        if [ ! -z "${win32_sys_path:-}" ]; then
+        if [ -n "${win32_sys_path:-}" ]; then
             basedir32=${basedir}32_dir
             paths["${!basedir32}/$dllname"]="$win32_sys_path/$dllname"
         fi
-        if [ ! -z "${win64_sys_path:-}" ]; then
+        if [ -n "${win64_sys_path:-}" ]; then
             basedir64=${basedir}64_dir
             paths["${!basedir64}/$dllname"]="$win64_sys_path/$dllname"
         fi
@@ -260,6 +261,6 @@ for target in "${!targets[@]}"; do
 done
 
 for srcpath in "${!paths[@]}"; do
-    ${action}_file "$srcpath" "${paths["$srcpath"]}"
-    ${action}_override "$(basename "$srcpath" .dll)"
+    "${action}_file" "$srcpath" "${paths["$srcpath"]}"
+    "${action}_override" "$(basename "$srcpath" .dll)"
 done

--- a/pkgs/misc/dxvk/setup_dxvk.sh
+++ b/pkgs/misc/dxvk/setup_dxvk.sh
@@ -42,7 +42,7 @@ usage() {
     exit 1
 }
 
-case "$1" in
+case "${1:-}" in
     uninstall|install)
         action=$1
         shift

--- a/pkgs/misc/dxvk/setup_dxvk.sh
+++ b/pkgs/misc/dxvk/setup_dxvk.sh
@@ -261,5 +261,5 @@ done
 
 for srcpath in "${!paths[@]}"; do
     ${action}_file "$srcpath" "${paths["$srcpath"]}"
-    ${action}_override "$(basename srcpath)"
+    ${action}_override "$(basename "$srcpath" .dll)"
 done


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`basename srcpath` simply prints "srcpath" which results in a single DLL override for srcpath.dll to be installed... clearly not what we want.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
