### PR TITLE
factorio: various updates (1.1.76 stable, 1.1.77 experimental)

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -28,12 +28,12 @@
         "version": "1.1.76"
       },
       "stable": {
-        "name": "factorio_demo_x64-1.1.69.tar.xz",
+        "name": "factorio_demo_x64-1.1.76.tar.xz",
         "needsAuth": false,
-        "sha256": "08nakf6f31dra3rzv2l57pnww04i4ppil6c3vvvhjcv8j35b5k29",
+        "sha256": "0f3m0p5baakc6cv9fr3rwyq39bydraji9wh3ivblg1mj6dwpqnlj",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.69/demo/linux64",
-        "version": "1.1.69"
+        "url": "https://factorio.com/get-download/1.1.76/demo/linux64",
+        "version": "1.1.76"
       }
     },
     "headless": {

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,12 +2,12 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.76.tar.xz",
+        "name": "factorio_alpha_x64-1.1.77.tar.xz",
         "needsAuth": true,
-        "sha256": "1kz93imyddivpp8zslggldm8zyb9j0zdj67pgkxazn8fd9avrq1p",
+        "sha256": "1qcjp51sykq0ygq4j4zih3yp1x517b2j54xfyi8g4minfk57zwk9",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.76/alpha/linux64",
-        "version": "1.1.76"
+        "url": "https://factorio.com/get-download/1.1.77/alpha/linux64",
+        "version": "1.1.77"
       },
       "stable": {
         "name": "factorio_alpha_x64-1.1.76.tar.xz",

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -10,12 +10,12 @@
         "version": "1.1.76"
       },
       "stable": {
-        "name": "factorio_alpha_x64-1.1.74.tar.xz",
+        "name": "factorio_alpha_x64-1.1.76.tar.xz",
         "needsAuth": true,
-        "sha256": "0ygnqlw92gz2s2c4pdhb11lvh86d7byhw5l3qw1fjsx0xv3qnxrs",
+        "sha256": "1kz93imyddivpp8zslggldm8zyb9j0zdj67pgkxazn8fd9avrq1p",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.74/alpha/linux64",
-        "version": "1.1.74"
+        "url": "https://factorio.com/get-download/1.1.76/alpha/linux64",
+        "version": "1.1.76"
       }
     },
     "demo": {

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -46,12 +46,12 @@
         "version": "1.1.77"
       },
       "stable": {
-        "name": "factorio_headless_x64-1.1.74.tar.xz",
+        "name": "factorio_headless_x64-1.1.76.tar.xz",
         "needsAuth": false,
-        "sha256": "1lqxprmai3vrm3hf9zdj9c9c6w05086nzn0vy88zy7xm2dgw7ylv",
+        "sha256": "19xx6sv382ijwv8nbqw3c3izckvqkpsf949bn4g09qmg7b663g94",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.74/headless/linux64",
-        "version": "1.1.74"
+        "url": "https://factorio.com/get-download/1.1.76/headless/linux64",
+        "version": "1.1.76"
       }
     }
   }

--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -38,12 +38,12 @@
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.76.tar.xz",
+        "name": "factorio_headless_x64-1.1.77.tar.xz",
         "needsAuth": false,
-        "sha256": "19xx6sv382ijwv8nbqw3c3izckvqkpsf949bn4g09qmg7b663g94",
+        "sha256": "1ygzlr26bp7l9znbjyqj7il6yq9faxjfr6cvfqbs8ls66qiv0ls6",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.76/headless/linux64",
-        "version": "1.1.76"
+        "url": "https://factorio.com/get-download/1.1.77/headless/linux64",
+        "version": "1.1.77"
       },
       "stable": {
         "name": "factorio_headless_x64-1.1.74.tar.xz",


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* stable: 1.1.74 -> 1.1.76 (factorio, factorio-headless)
  * https://wiki.factorio.com/Version_history/1.1.0#1.1.75
  * https://wiki.factorio.com/Version_history/1.1.0#1.1.76
* experimental: 1.1.76 -> 1.1.77 (factorio-experimental, factorio-headless-experimental)
  * https://wiki.factorio.com/Version_history/1.1.0#1.1.77
  * *adds support for Wayland*: `SDL_VIDEODRIVER=wayland`
* demo: 1.1.69 -> 1.1.76 (factorio-demo)
  * https://wiki.factorio.com/Version_history/1.1.0#1.1.70
  * https://wiki.factorio.com/Version_history/1.1.0#1.1.71
  * https://wiki.factorio.com/Version_history/1.1.0#1.1.72
  * https://wiki.factorio.com/Version_history/1.1.0#1.1.73
  * https://wiki.factorio.com/Version_history/1.1.0#1.1.74
  * https://wiki.factorio.com/Version_history/1.1.0#1.1.75
  * https://wiki.factorio.com/Version_history/1.1.0#1.1.76

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
