### PR TITLE
fftw: enable optimizations unconditionally and build with mtune=generic

### DIFF
--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -5,10 +5,6 @@
 , perl
 , llvmPackages
 , precision ? "double"
-, enableAvx ? stdenv.hostPlatform.avxSupport
-, enableAvx2 ? stdenv.hostPlatform.avx2Support
-, enableAvx512 ? stdenv.hostPlatform.avx512Support
-, enableFma ? stdenv.hostPlatform.fmaSupport
 , enableMpi ? false
 , mpi
 , withDoc ? stdenv.cc.isGNU
@@ -40,22 +36,25 @@ stdenv.mkDerivation (finalAttrs: {
     llvmPackages.openmp
   ] ++ lib.optional enableMpi mpi;
 
-  configureFlags =
-    [ "--enable-shared"
-      "--enable-threads"
-    ]
-    ++ lib.optional (precision != "double") "--enable-${precision}"
-    # all x86_64 have sse2
-    # however, not all float sizes fit
-    ++ lib.optional (stdenv.isx86_64 && (precision == "single" || precision == "double") )  "--enable-sse2"
-    ++ lib.optional enableAvx "--enable-avx"
-    ++ lib.optional enableAvx2 "--enable-avx2"
-    ++ lib.optional enableAvx512 "--enable-avx512"
-    ++ lib.optional enableFma "--enable-fma"
-    ++ [ "--enable-openmp" ]
-    ++ lib.optional enableMpi "--enable-mpi"
-    # doc generation causes Fortran wrapper generation which hard-codes gcc
-    ++ lib.optional (!withDoc) "--disable-doc";
+  configureFlags = [
+    "--enable-shared"
+    "--enable-threads"
+    "--enable-openmp"
+  ]
+
+  ++ lib.optional (precision != "double") "--enable-${precision}"
+  # https://www.fftw.org/fftw3_doc/SIMD-alignment-and-fftw_005fmalloc.html
+  # FFTW will try to detect at runtime whether the CPU supports these extensions
+  ++ lib.optional (stdenv.isx86_64 && (precision == "single" || precision == "double"))
+    "--enable-sse2 --enable-avx --enable-avx2 --enable-avx512 --enable-avx128-fma"
+  ++ lib.optional enableMpi "--enable-mpi"
+  # doc generation causes Fortran wrapper generation which hard-codes gcc
+  ++ lib.optional (!withDoc) "--disable-doc";
+
+  # fftw builds with -mtune=native by default
+  postPatch = ''
+    substituteInPlace configure --replace "-mtune=native" "-mtune=generic"
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Description of changes

Fftw has the ability to detect if a CPU supports SIMD extensions at runtime:
```
Enable various SIMD instruction sets. You need compiler that supports the given SIMD extensions, but FFTW will try to detect at runtime whether the CPU supports these extensions. That is, you can compile with--enable-avx and the code will still run on a CPU without AVX support. 
```
https://www.fftw.org/fftw3_doc/Installation-on-Unix.html
So the SIMD extensions should be always enabled, [other distros](https://github.com/archlinux/svntogit-packages/blob/e54aec66f6e1131fb73f42f43bc41117b30242ec/trunk/PKGBUILD#L46) do the same.

Also, fftw builds everything with mtune=native, so setting it to mtune=generic instead.

I have also removed --enable-fma because it didn't enable fma, but it forced it:
```
enable if the machine architecture "naturally" prefers fused multiply-add instructions
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
