### PR TITLE
wine-nine-standalone: init at 0.9

### DIFF
--- a/pkgs/applications/emulators/wine-nine-standalone/default.nix
+++ b/pkgs/applications/emulators/wine-nine-standalone/default.nix
@@ -1,0 +1,22 @@
+{ lib, symlinkJoin, makeWrapper, bash, wine, nine32, nine64 }:
+
+symlinkJoin {
+  inherit (nine64) name pname version meta;
+
+  nativeBuildInputs = [ makeWrapper ];
+  paths = [ wine ];
+
+  postBuild = ''
+    [[ -x "$out"/bin/wine ]] && wrapProgram "$out"/bin/wine \
+      --prefix WINEDLLPATH ':' ${lib.escapeShellArg "${nine32}/lib/wine"} \
+      --prefix WINEDLLPATH ':' ${lib.escapeShellArg "${nine64}/lib/wine"}
+
+    [[ -x "$out"/bin/wine64 ]] && wrapProgram "$out"/bin/wine64 \
+      --prefix WINEDLLPATH ':' ${lib.escapeShellArg "${nine32}/lib/wine"} \
+      --prefix WINEDLLPATH ':' ${lib.escapeShellArg "${nine64}/lib/wine"}
+
+    # Convenience symlink for ninewinecfg
+    # Many wine commands like wineboot resolve to `wine $0.exe "$@"`
+    ln -s wineboot "$out"/bin/ninewinecfg
+  '';
+}

--- a/pkgs/applications/emulators/wine-nine-standalone/nine.nix
+++ b/pkgs/applications/emulators/wine-nine-standalone/nine.nix
@@ -1,0 +1,56 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, meson
+, ninja
+, libGL
+, libdrm
+, mesa
+, xorg
+, wine
+, wine64
+}:
+
+let
+  arch = if stdenv.is32bit then "32" else "64";
+in
+stdenv.mkDerivation rec {
+  pname = "wine-nine-standalone";
+  version = "0.10-unstable";
+
+  src = fetchFromGitHub {
+    owner = "iXit";
+    repo = pname;
+    #rev = "v${version}"
+    rev = "5ba57d60a351d87d3b2ef18acd8e43a15e2ece6b";
+    hash = "sha256-3b0irtj5aDEXkpOZNJgw2Ba5RXnYA90mcmncNILIszM=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    (if stdenv.is32bit then wine else wine64)
+  ];
+  buildInputs = [ libGL libdrm mesa.driversdev xorg.libX11 ];
+
+  preConfigure = ''
+    ./bootstrap.sh --distro nixos
+  '';
+
+  mesonFlags = [
+    "--buildtype" "release"
+    "--prefix" "${placeholder "out"}"
+    "--cross-file" "tools/cross-wine${arch}"
+  ];
+
+  meta = {
+    description = "Standalone Gallium Nine library for Wine";
+    homepage = "https://github.com/iXit/wine-nine-standalone";
+    changelog = "https://github.com/iXit/wine-nine-standalone/releases";
+    maintainers = [ lib.maintainers.novenary ];
+    license = lib.licenses.lgpl21Plus;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38924,6 +38924,12 @@ with pkgs;
 
   wineasio = callPackage ../applications/emulators/wineasio { };
 
+  wine-nine = callPackage ../applications/emulators/wine-nine-standalone {
+    nine32 = pkgsi686Linux.wine-nine-standalone-unwrapped;
+    nine64 = wine-nine-standalone-unwrapped;
+  };
+  wine-nine-standalone-unwrapped = callPackage ../applications/emulators/wine-nine-standalone/nine.nix { };
+
   wishbone-tool = callPackage ../development/tools/misc/wishbone-tool { };
 
   with-shell = callPackage ../applications/misc/with-shell { };


### PR DESCRIPTION
###### Description of changes

wine-nine-standalone provides the plumbing for Wine to use Gallium Nine, the D3D9 implementation in Mesa that is already shipped by NixOS. Upstream provides binary releases that are unlikely to work in a regular NixOS environment, so here it is nicely packaged.

Wine interfaces should be stable enough for a single build to be usable with all Wine variants and versions shipped by nixpkgs: upstream binary releases claim to work on a wide range of Wine versions.

Fixes #58701.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
