### PR TITLE
ocamlPackages.uring: init at 0.5

### DIFF
--- a/pkgs/development/ocaml-modules/uring/default.nix
+++ b/pkgs/development/ocaml-modules/uring/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildDunePackage
+, cstruct
+, dune-configurator
+, fetchurl
+, fmt
+, optint
+, mdx
+}:
+
+buildDunePackage rec {
+  pname = "uring";
+  version = "0.5";
+
+  minimalOCamlVersion = "4.12";
+  duneVersion = "3";
+
+  src = fetchurl {
+    url = "https://github.com/ocaml-multicore/ocaml-uring/releases/download/v${version}/${pname}-${version}.tbz";
+    sha256 = "106w7mabqihdhj4csk9jfqag220rwhqdp5lapn0xmw2035scvxvk";
+  };
+
+  propagatedBuildInputs = [
+    cstruct
+    fmt
+    optint
+  ];
+
+  buildInputs = [
+    dune-configurator
+  ];
+
+  checkInputs = [
+    mdx
+  ];
+
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+
+  doCheck = true;
+
+  dontStrip = true;
+
+  meta = {
+    homepage = "https://github.com/ocaml-multicore/ocaml-${pname}";
+    changelog = "https://github.com/ocaml-multicore/ocaml-${pname}/raw/v${version}/CHANGES.md";
+    description = "Bindings to io_uring for OCaml";
+    license = with lib.licenses; [ isc mit ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1624,6 +1624,8 @@ let
 
     uri-sexp = callPackage ../development/ocaml-modules/uri/sexp.nix { };
 
+    uring = callPackage ../development/ocaml-modules/uring { };
+
     utop = callPackage ../development/tools/ocaml/utop { };
 
     uucd = callPackage ../development/ocaml-modules/uucd { };


### PR DESCRIPTION
###### Description of changes

https://github.com/ocaml-multicore/ocaml-uring/releases/tag/v0.5

Unsure why I needed `mdx` in the `buildInputs` + `nativeCheckInputs` but it wouldn't otherwise.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
