### PR TITLE
alttab: Remove sgraf as maintainer

### DIFF
--- a/pkgs/tools/X11/alttab/default.nix
+++ b/pkgs/tools/X11/alttab/default.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation rec {
     description = "X11 window switcher designed for minimalistic window managers or standalone X11 session";
     license = licenses.gpl3Plus;
     platforms = platforms.all;
-    maintainers = [ maintainers.sgraf ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
###### Description of changes

I'm no longer using `alttab` and have no way to test it, thus I removed myself as maintainer. That said, maintenance overhead is quite manageable, for anyone interested in picking up.
