### PR TITLE
teip: 2.0.0 -> 2.3.0

### DIFF
--- a/pkgs/tools/text/teip/default.nix
+++ b/pkgs/tools/text/teip/default.nix
@@ -1,28 +1,50 @@
-{ lib, rustPlatform, fetchCrate, installShellFiles, perl }:
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, installShellFiles
+, perl
+, stdenv
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "teip";
-  version = "2.0.0";
+  version = "2.3.0";
 
-  src = fetchCrate {
-    inherit pname version;
-    sha256 = "sha256-fME+tS8wcC6mk5FjuDJpFWWhIsiXV4kuybSqj9awFUM=";
+  src = fetchFromGitHub {
+    owner = "greymd";
+    repo = "teip";
+    rev = "v${version}";
+    hash = "sha256-09IKAM1ha40CvF5hdQIlUab7EBBFourC70LAagrs5+4=";
   };
 
-  cargoSha256 = "sha256-wrfS+OEYF60nOhtrnmk7HKqVuAJQFaiT0GM+3OoZ3Wk=";
+  cargoHash = "sha256-cBFczgvLja6upuPnXphG2d9Rf1ZpNAVh16NHAHfXxHg=";
 
   nativeBuildInputs = [ installShellFiles ];
 
   nativeCheckInputs = [ perl ];
 
+  # Cargo.lock is outdated
+  preConfigure = ''
+    cargo update --offline
+  '';
+
+  # tests are locale sensitive
+  preCheck = ''
+    export LANG=${if stdenv.isDarwin then "en_US.UTF-8" else "C.UTF-8"}
+  '';
+
   postInstall = ''
     installManPage man/teip.1
-    installShellCompletion --zsh completion/zsh/_teip
+    installShellCompletion \
+      --bash completion/bash/teip \
+      --fish completion/fish/teip.fish \
+      --zsh completion/zsh/_teip
   '';
 
   meta = with lib; {
     description = "A tool to bypass a partial range of standard input to any command";
     homepage = "https://github.com/greymd/teip";
+    changelog = "https://github.com/greymd/teip/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ figsoda ];
   };


### PR DESCRIPTION
Diff: https://github.com/greymd/teip/compare/v2.0.0...v2.3.0

Changelog: https://github.com/greymd/teip/releases/tag/v2.3.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
