### PR TITLE
pjsip: add darwin support

### DIFF
--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
   dontPatchELF = true;
 
   passthru.tests.python-pjsua2 = runCommand "python-pjsua2" { } ''
-    ${python3.withPackages (pkgs: [ pkgs.pjsua2 ])}/bin/python -c "import pjsua2" > $out
+    ${(python3.withPackages (pkgs: [ pkgs.pjsua2 ])).interpreter} -c "import pjsua2" > $out
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -84,8 +84,7 @@ stdenv.mkDerivation rec {
     # First, find all libraries (and their symlinks) in our outputs to define
     # the install_name_tool -change arguments we should pass.
     readarray -t libraries < <(
-      for outputName in $(getAllOutputNames)
-      do
+      for outputName in $(getAllOutputNames); do
         find "''${!outputName}" \( -name '*.dylib*' -o -name '*.so*' \)
       done
     )
@@ -93,18 +92,15 @@ stdenv.mkDerivation rec {
     # Determine the install_name_tool -change arguments that are going to be
     # applied to all libraries.
     change_args=()
-    for lib in "''${libraries[@]}"
-    do
+    for lib in "''${libraries[@]}"; do
       lib_name="$(basename $lib)"
       change_args+=(-change ../lib/$lib_name $lib)
       change_args+=(-change ../../lib/$lib_name $lib)
     done
 
     # Rewrite id and library refences for all non-symlinked libraries.
-    for lib in "''${libraries[@]}"
-    do
-      if [ -f "$lib" ]
-      then
+    for lib in "''${libraries[@]}"; do
+      if [ -f "$lib" ]; then
         install_name_tool -id $lib "''${change_args[@]}" $lib
       fi
     done

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -14,7 +14,6 @@
 , pjsip
 , runCommand
 }:
-
 stdenv.mkDerivation rec {
   pname = "pjsip";
   version = "2.13";

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -55,10 +55,6 @@ stdenv.mkDerivation rec {
     make -C pjsip-apps/src/swig/python
   '';
 
-  preConfigure = ''
-    export LD=$CC
-  '';
-
   configureFlags = [ "--enable-shared" ]
     # darwin-ssl is a deprecated SSL library that requires
     # a more recent version of Apple SDK 10 which is not in nixpkgs.

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -47,6 +47,9 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.isLinux alsa-lib
     ++ lib.optionals stdenv.isDarwin [ AppKit CoreFoundation Security ];
 
+  preConfigure = ''
+    export LD=$CC
+  '';
 
   NIX_CFLAGS_LINK = lib.optionalString stdenv.isDarwin "-headerpad_max_install_names";
 

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -12,6 +12,8 @@
 , Security
 , python3
 , pythonSupport ? true
+, pjsip
+, runCommand
 }:
 
 stdenv.mkDerivation rec {
@@ -80,6 +82,10 @@ stdenv.mkDerivation rec {
 
   # We need the libgcc_s.so.1 loadable (for pthread_cancel to work)
   dontPatchELF = true;
+
+  passthru.tests.python-pjsua2 = runCommand "python-pjsua2" { } ''
+    ${python3.withPackages (pkgs: [ pkgs.pjsua2 ])}/bin/python -c "import pjsua2" > $out
+  '';
 
   meta = with lib; {
     description = "A multimedia communication library written in C, implementing standard based protocols such as SIP, SDP, RTP, STUN, TURN, and ICE";

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -49,21 +49,21 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.isLinux alsa-lib
     ++ lib.optionals stdenv.isDarwin [ AppKit CoreFoundation Security ];
 
-  preConfigure = ''
-    export LD=$CC
-  '';
-
   postBuild = lib.optionalString pythonSupport ''
     make -C pjsip-apps/src/swig/python
   '';
 
-  outputs = [ "out" ]
-    ++ lib.optional pythonSupport "py";
+  preConfigure = ''
+    export LD=$CC
+  '';
 
   configureFlags = [ "--enable-shared" ]
     # darwin-ssl is a deprecated SSL library that requires
     # a more recent version of Apple SDK 10 which is not in nixpkgs.
     ++ lib.optional stdenv.isDarwin "--disable-darwin-ssl";
+
+  outputs = [ "out" ]
+    ++ lib.optional pythonSupport "py";
 
   postInstall = ''
     mkdir -p $out/bin

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.isLinux alsa-lib
     ++ lib.optionals stdenv.isDarwin [ AppKit CoreFoundation Security ];
 
-
   NIX_CFLAGS_LINK = lib.optionalString stdenv.isDarwin "-headerpad_max_install_names";
 
   postBuild = lib.optionalString pythonSupport ''

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -54,10 +54,7 @@ stdenv.mkDerivation rec {
     make -C pjsip-apps/src/swig/python
   '';
 
-  configureFlags = [ "--enable-shared" ]
-    # darwin-ssl is a deprecated SSL library that requires
-    # a more recent version of Apple SDK 10 which is not in nixpkgs.
-    ++ lib.optional stdenv.isDarwin "--disable-darwin-ssl";
+  configureFlags = [ "--enable-shared" ];
 
   outputs = [ "out" ]
     ++ lib.optional pythonSupport "py";

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -48,8 +48,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals stdenv.isDarwin [ AppKit CoreFoundation Security ];
 
 
-  NIX_CFLAGS_LINK = lib.optionalString stdenv.isDarwin
-                      "-headerpad_max_install_names";
+  NIX_CFLAGS_LINK = lib.optionalString stdenv.isDarwin "-headerpad_max_install_names";
 
   postBuild = lib.optionalString pythonSupport ''
     make -C pjsip-apps/src/swig/python

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38517,7 +38517,7 @@ with pkgs;
   physlock = callPackage ../misc/screensavers/physlock { };
 
   pjsip = callPackage ../applications/networking/pjsip {
-    inherit (darwin.apple_sdk.frameworks) AppKit;
+    inherit (darwin.apple_sdk.frameworks) AppKit CoreFoundation Security;
   };
 
   pounce = callPackage ../servers/pounce { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38516,7 +38516,9 @@ with pkgs;
 
   physlock = callPackage ../misc/screensavers/physlock { };
 
-  pjsip = darwin.apple_sdk_11_0.callPackage ../applications/networking/pjsip { };
+  pjsip = darwin.apple_sdk_11_0.callPackage ../applications/networking/pjsip {
+    inherit (darwin.apple_sdk_11_0.frameworks) AppKit CoreFoundation Security;
+  };
 
   pounce = callPackage ../servers/pounce { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38516,9 +38516,7 @@ with pkgs;
 
   physlock = callPackage ../misc/screensavers/physlock { };
 
-  pjsip = callPackage ../applications/networking/pjsip {
-    inherit (darwin.apple_sdk.frameworks) AppKit CoreFoundation Security;
-  };
+  pjsip = darwin.apple_sdk_11_0.callPackage ../applications/networking/pjsip { };
 
   pounce = callPackage ../servers/pounce { };
 


### PR DESCRIPTION
###### Description of changes

Currently the pjsip package is marked as broken for darwin because it is not able to build correctly.

This PR attempts to fix this for both aarch64-darwin and x86_64-darwin.

There are 2 workarounds in this PR:

* `fixDarwinDylibNames` wasn't able to rewrite the relative paths, because they contained `../` and `../../`. A similar method to `fixDarwinDylibNames` was used to rewrite them, but with support for `../` and `../`.
* On x86_64-darwin the library was automatically configured to use a deprecated `darwin-ssl` library, instead of openssl. This wasn't the case on aarch64, probably because `darwin-ssl` wasn't supported for aarch64 anymore. The configure flag `--disable-darwin-ssl` was needed to force using openssl on both architectures.

Lastly, because the linking issues were a bit finicky, I also added a package test to check whether the python library can be loaded correctly.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
