### PR TITLE
rz-ghidra, jsdec: init at 0.6.0; rizin-sigdb: init at unstable-2023-02-13

### DIFF
--- a/pkgs/development/tools/analysis/rizin/cutter.nix
+++ b/pkgs/development/tools/analysis/rizin/cutter.nix
@@ -1,4 +1,6 @@
 { fetchFromGitHub, lib, mkDerivation
+# for passthru.plugins
+, pkgs
 # nativeBuildInputs
 , qmake, pkg-config, cmake
 # Qt
@@ -10,7 +12,7 @@
 , wrapQtAppsHook
 }:
 
-mkDerivation rec {
+let cutter = mkDerivation rec {
   pname = "cutter";
   version = "2.3.0";
 
@@ -37,10 +39,19 @@ mkDerivation rec {
     qtWrapperArgs+=(--prefix PYTHONPATH : "$PYTHONPATH")
   '';
 
+  passthru = rec {
+    inherit (rizin) plugins;
+    withPlugins = filter: pkgs.callPackage ./wrapper.nix {
+      unwrapped = cutter;
+      inherit rizin;
+      plugins = filter plugins;
+    };
+  };
+
   meta = with lib; {
     description = "Free and Open Source Reverse Engineering Platform powered by rizin";
     homepage = src.meta.homepage;
     license = licenses.gpl3;
     maintainers = with maintainers; [ mic92 dtzWill ];
   };
-}
+}; in cutter

--- a/pkgs/development/tools/analysis/rizin/cutter.nix
+++ b/pkgs/development/tools/analysis/rizin/cutter.nix
@@ -40,7 +40,12 @@ let cutter = mkDerivation rec {
   '';
 
   passthru = rec {
-    inherit (rizin) plugins;
+    plugins = rizin.plugins // {
+      rz-ghidra = rizin.plugins.rz-ghidra.override {
+        inherit cutter qtbase qtsvg;
+        enableCutterPlugin = true;
+      };
+    };
     withPlugins = filter: pkgs.callPackage ./wrapper.nix {
       unwrapped = cutter;
       inherit rizin;

--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -106,6 +106,9 @@ let rizin = stdenv.mkDerivation rec {
 
   passthru = rec {
     plugins = {
+      jsdec = pkgs.callPackage ./jsdec.nix {
+        inherit rizin openssl;
+      };
       # sigdb isn't a real plugin, but it's separated from the main rizin
       # derivation so that only those who need it will download it
       sigdb = pkgs.callPackage ./sigdb.nix { };

--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -1,4 +1,5 @@
 { lib
+, pkgs # for passthru.plugins
 , stdenv
 , fetchurl
 , pkg-config
@@ -22,7 +23,7 @@
 , tree-sitter
 }:
 
-stdenv.mkDerivation rec {
+let rizin = stdenv.mkDerivation rec {
   pname = "rizin";
   version = "0.6.0";
 
@@ -42,7 +43,16 @@ stdenv.mkDerivation rec {
     "-Duse_sys_openssl=enabled"
     "-Duse_sys_libmspack=enabled"
     "-Duse_sys_tree_sitter=enabled"
+    # this is needed for wrapping (adding plugins) to work
+    "-Dportable=true"
   ];
+
+  # Normally, Rizin only looks for files in the install prefix. With
+  # portable=true, it instead looks for files in relation to the parent
+  # of the directory of the binary file specified in /proc/self/exe,
+  # caching it. This patch replaces the entire logic to only look at
+  # the env var NIX_RZ_PREFIX
+  patches = [ ./librz-wrapper-support.patch ];
 
   nativeBuildInputs = [
     pkg-config
@@ -94,6 +104,18 @@ stdenv.mkDerivation rec {
       --replace "import('python').find_installation()" "find_program('python3')"
   '';
 
+  passthru = rec {
+    plugins = {
+      # sigdb isn't a real plugin, but it's separated from the main rizin
+      # derivation so that only those who need it will download it
+      sigdb = pkgs.callPackage ./sigdb.nix { };
+    };
+    withPlugins = filter: pkgs.callPackage ./wrapper.nix {
+      unwrapped = rizin;
+      plugins = filter plugins;
+    };
+  };
+
   meta = {
     description = "UNIX-like reverse engineering framework and command-line toolset.";
     homepage = "https://rizin.re/";
@@ -101,4 +123,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ raskin makefu mic92 ];
     platforms = with lib.platforms; unix;
   };
-}
+}; in rizin

--- a/pkgs/development/tools/analysis/rizin/default.nix
+++ b/pkgs/development/tools/analysis/rizin/default.nix
@@ -109,6 +109,10 @@ let rizin = stdenv.mkDerivation rec {
       jsdec = pkgs.callPackage ./jsdec.nix {
         inherit rizin openssl;
       };
+      rz-ghidra = pkgs.libsForQt5.callPackage ./rz-ghidra.nix {
+        inherit rizin openssl;
+        enableCutterPlugin = false;
+      };
       # sigdb isn't a real plugin, but it's separated from the main rizin
       # derivation so that only those who need it will download it
       sigdb = pkgs.callPackage ./sigdb.nix { };

--- a/pkgs/development/tools/analysis/rizin/jsdec.nix
+++ b/pkgs/development/tools/analysis/rizin/jsdec.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, pkg-config
+, ninja
+, rizin
+, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "jsdec";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "rizinorg";
+    repo = "jsdec";
+    rev = "v${version}";
+    hash = "sha256-iVaxxPBIJRhZrmejAOL/Fb4k66mGsZOBs7UikgMj5WA=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  preConfigure = ''
+    cd p
+  '';
+  mesonFlags = [ "-Djsc_folder=.." ];
+  buildInputs = [ openssl rizin ];
+
+  meta = with lib; {
+    description = "Simple decompiler for Rizin";
+    homepage = src.meta.homepage;
+    license = with licenses; [ asl20 bsd3 mit ];
+    maintainers = with maintainers; [ chayleaf ];
+  };
+}

--- a/pkgs/development/tools/analysis/rizin/librz-wrapper-support.patch
+++ b/pkgs/development/tools/analysis/rizin/librz-wrapper-support.patch
@@ -1,0 +1,13 @@
+diff --git a/librz/util/path.c b/librz/util/path.c
+index 8ea3d67..f4a8918 100644
+--- a/librz/util/path.c
++++ b/librz/util/path.c
+@@ -35,6 +35,8 @@ static void fini_portable_prefix(void) {
+ }
+ 
+ static char *set_portable_prefix(void) {
++	return rz_sys_getenv("NIX_RZ_PREFIX");
++
+ 	char *pid_to_path = rz_sys_pid_to_path(rz_sys_getpid());
+ 	if (!pid_to_path) {
+ 		return NULL;

--- a/pkgs/development/tools/analysis/rizin/rz-ghidra.nix
+++ b/pkgs/development/tools/analysis/rizin/rz-ghidra.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+# buildInputs
+, rizin
+, openssl
+, pugixml
+# optional buildInputs
+, enableCutterPlugin ? true
+, cutter
+, qtbase
+, qtsvg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rz-ghidra";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "rizinorg";
+    repo = "rz-ghidra";
+    rev = "v${version}";
+    hash = "sha256-tQAurouRr6fP1tbIkfd0a9UfeYcwiU1BpjOTcooXkT0=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/rizinorg/rz-ghidra/pull/327/commits/eba20e2c743ed3dfc5d1be090a5018f7267baa49.patch";
+      hash = "sha256-aoXFClXZBcOnHl+6lLYrnui7sRb3cRJQhQfNDLxHtcs=";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    openssl
+    pugixml
+    rizin
+  ] ++ lib.optionals enableCutterPlugin [
+    cutter
+    qtbase
+    qtsvg
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    "-DUSE_SYSTEM_PUGIXML=ON"
+  ] ++ lib.optionals enableCutterPlugin [
+    "-DBUILD_CUTTER_PLUGIN=ON"
+    "-DCUTTER_INSTALL_PLUGDIR=share/rizin/cutter/plugins/native"
+  ];
+
+  meta = with lib; {
+    description = "Deep ghidra decompiler and sleigh disassembler integration for rizin";
+    homepage = src.meta.homepage;
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ chayleaf ];
+  };
+}

--- a/pkgs/development/tools/analysis/rizin/sigdb.nix
+++ b/pkgs/development/tools/analysis/rizin/sigdb.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchFromGitHub
+, stdenvNoCC
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "rizin-sigdb";
+  version = "unstable-2023-02-13";
+
+  src = fetchFromGitHub {
+    owner = "rizinorg";
+    # sigdb-source: source files (.pat and etc), around 2.5gb total
+    # sigdb: built and deflated .sig files, around 50mb total
+    repo = "sigdb";
+    rev = "829baf835e3515923266898fd597f7f75046ebd2";
+    hash = "sha256-zvGna2CEsDctc9P7hWTaz7kdtxAtPsXHNWOrRQ9ocdc=";
+  };
+
+  buildPhase = ''
+    mkdir installdir
+    cp -r elf pe installdir
+    .scripts/verify-sigs-install.sh
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/rizin
+    mv installdir $out/share/rizin/sigdb
+  '';
+
+  meta = with lib; {
+    description = "Rizin FLIRT Signature Database";
+    homepage = src.meta.homepage;
+    license = licenses.lgpl3;
+    maintainers = with lib.maintainers; [ chayleaf ];
+  };
+}

--- a/pkgs/development/tools/analysis/rizin/wrapper.nix
+++ b/pkgs/development/tools/analysis/rizin/wrapper.nix
@@ -1,0 +1,46 @@
+{ lib
+, makeWrapper
+, symlinkJoin
+, unwrapped
+, plugins
+# NIX_RZ_PREFIX only changes where *Rizin* locates files (plugins,
+# themes, etc). But we must change it even for wrapping Cutter, because
+# Cutter plugins often have associated Rizin plugins. This means that
+# NIX_RZ_PREFIX must always contain Rizin files, even if we only wrap
+# Cutter - so for Cutter, include Rizin to symlinkJoin paths.
+, rizin ? null
+}:
+
+symlinkJoin {
+  name = "${unwrapped.pname}-with-plugins-${unwrapped.version}";
+
+  paths = [ unwrapped ] ++ lib.optional (rizin != null) rizin ++ plugins;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  passthru = {
+    inherit unwrapped;
+  };
+
+  postBuild = ''
+    rm $out/bin/*
+    wrapperArgs=(--set NIX_RZ_PREFIX $out)
+    if [ -d $out/share/rizin/cutter ]; then
+      wrapperArgs+=(--prefix XDG_DATA_DIRS : $out/share)
+    fi
+    for binary in $(ls ${unwrapped}/bin); do
+      makeWrapper ${unwrapped}/bin/$binary $out/bin/$binary "''${wrapperArgs[@]}"
+    done
+    ${lib.optionalString (rizin != null) ''
+      for binary in $(ls ${rizin}/bin); do
+        makeWrapper ${rizin}/bin/$binary $out/bin/$binary "''${wrapperArgs[@]}"
+      done
+    ''}
+  '';
+
+  meta = unwrapped.meta // {
+    # prefer wrapped over unwrapped, prefer cutter wrapper over rizin wrapper
+    # (because cutter versions of plugins also contain rizin plugins)
+    priority = (unwrapped.meta.priority or 0) - (if rizin != null then 2 else 1);
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19760,7 +19760,11 @@ with pkgs;
 
   rizin = pkgs.callPackage ../development/tools/analysis/rizin { };
 
+  rizinPlugins = recurseIntoAttrs rizin.plugins;
+
   cutter = libsForQt5.callPackage ../development/tools/analysis/rizin/cutter.nix { };
+
+  cutterPlugins = recurseIntoAttrs rizin.plugins;
 
   ragel = ragelStable;
 


### PR DESCRIPTION
###### Description of changes

Related to #86448 (which is about Radare2, which Rizin forks from)

Inits https://github.com/rizinorg/rz-ghidra/ and https://github.com/rizinorg/jsdec/

This adds the ability to do the following:

```nix
rizin.withPlugins (ps: with ps; [ jsdec rz-ghidra sigdb ])
cutter.withPlugins (ps: with ps; [ jsdec rz-ghidra sigdb ])
```

It does this by creating a "portable" Rizin build (which looks for files relative to `/proc/self/exe`), but overrides the logic to use `NIX_RZ_PREFIX` env var instead.

Also, since Cutter looks for plugins in `XDG_DATA_DIRS` , the wrapper has to extend `XDG_DATA_DIRS` as well.

Sigdb isn't a real plugin, it's a signature database for Rizin that allows restoring some symbols. It's supposed to be downloaded during Rizin build, but that makes no sense to do in general as it's quite huge (50MB) and making it toggleable using a derivation flag would cause a Rizin rebuild.

TODO: rz-retdec (currently retdec package is outdated by 2 major versions and is missing e.g. cmake config, so rz-retdec can't be built reproducibly)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
