### PR TITLE
sdrangel: fix darwin build

### DIFF
--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -1,4 +1,6 @@
-{ airspy
+{ lib
+, stdenv
+, airspy
 , airspyhf
 , aptdec
 , boost
@@ -13,7 +15,6 @@
 , glew
 , hackrf
 , hidapi
-, lib
 , ffmpeg
 , libiio
 , libopus
@@ -95,7 +96,7 @@ mkDerivation rec {
     "-DDAB_LIB=${dab_lib}"
     "-DLIBSERIALDV_INCLUDE_DIR:PATH=${serialdv}/include/serialdv"
     "-DLIMESUITE_INCLUDE_DIR:PATH=${limesuite}/include"
-    "-DLIMESUITE_LIBRARY:FILEPATH=${limesuite}/lib/libLimeSuite.so"
+    "-DLIMESUITE_LIBRARY:FILEPATH=${limesuite}/lib/libLimeSuite${stdenv.hostPlatform.extensions.sharedLibrary}"
     "-DSGP4_DIR=${sgp4}"
     "-DSOAPYSDR_DIR=${soapysdr-with-plugins}"
   ];
@@ -110,6 +111,6 @@ mkDerivation rec {
     homepage = "https://github.com/f4exb/sdrangel";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ alkeryn ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/aptdec/default.nix
+++ b/pkgs/development/libraries/aptdec/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/Xerbo/aptdec";
     license = licenses.gpl2;
     maintainers = with maintainers; [ alexwinter ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/cm256cc/default.nix
+++ b/pkgs/development/libraries/cm256cc/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Fast GF(256) Cauchy MDS Block Erasure Codec in C++";
     homepage = "https://github.com/f4exb/cm256cc";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ alkeryn ];
     license = licenses.gpl3;
   };

--- a/pkgs/development/libraries/dab_lib/default.nix
+++ b/pkgs/development/libraries/dab_lib/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/JvanKatwijk/dab-cmdline";
     license = licenses.gpl2;
     maintainers = with maintainers; [ alexwinter ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/dsdcc/default.nix
+++ b/pkgs/development/libraries/dsdcc/default.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/f4exb/dsdcc";
     license = licenses.gpl3;
     maintainers = with maintainers; [ alexwinter ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -32,7 +32,7 @@
 , enableDC1394    ? false, libdc1394
 , enableDocs      ? false, doxygen, graphviz-nox
 
-, AVFoundation, Cocoa, VideoDecodeAcceleration, bzip2
+, AVFoundation, Cocoa, VideoDecodeAcceleration, bzip2, CoreMedia, MediaToolbox
 }:
 
 assert blas.implementation == "openblas" && lapack.implementation == "openblas";
@@ -211,7 +211,7 @@ stdenv.mkDerivation {
     # tesseract & leptonica.
     ++ lib.optionals enableTesseract [ tesseract leptonica ]
     ++ lib.optional enableTbb tbb
-    ++ lib.optionals stdenv.isDarwin [ bzip2 AVFoundation Cocoa VideoDecodeAcceleration ]
+    ++ lib.optionals stdenv.isDarwin [ bzip2 AVFoundation Cocoa VideoDecodeAcceleration CoreMedia MediaToolbox ]
     ++ lib.optionals enableDocs [ doxygen graphviz-nox ];
 
   propagatedBuildInputs = lib.optional enablePython pythonPackages.numpy
@@ -250,7 +250,6 @@ stdenv.mkDerivation {
   ] ++ lib.optionals stdenv.isDarwin [
     "-DWITH_OPENCL=OFF"
     "-DWITH_LAPACK=OFF"
-    "-DBUILD_opencv_videoio=OFF"
   ] ++ lib.optionals enablePython [
     "-DOPENCV_SKIP_PYTHON_LOADER=ON"
   ] ++ lib.optionals enableEigen [

--- a/pkgs/development/libraries/qt-5/modules/qtspeech.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtspeech.nix
@@ -1,9 +1,9 @@
-{ qtModule, speechd, pkg-config }:
+{ lib, qtModule, stdenv, speechd, pkg-config }:
 
 qtModule {
   pname = "qtspeech";
   qtInputs = [ ];
-  buildInputs = [ speechd ];
+  buildInputs = lib.optionals stdenv.isLinux [ speechd ];
   nativeBuildInputs = [ pkg-config ];
   outputs = [ "out" "dev" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -221,6 +221,7 @@ qtModule {
     Prefix = ..
     EOF
 
+  '' + ''
     # Fix for out-of-sync QtWebEngine and Qt releases (since 5.15.3)
     sed 's/${lib.head (lib.splitString "-" version)} /${qtCompatVersion} /' -i "$out"/lib/cmake/*/*Config.cmake
   '';

--- a/pkgs/development/libraries/serialdv/default.nix
+++ b/pkgs/development/libraries/serialdv/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "C++ Minimal interface to encode and decode audio with AMBE3000 based devices in packet mode over a serial link";
     homepage = "https://github.com/f4exb/serialdv";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ alkeryn ];
     license = licenses.gpl3;
   };

--- a/pkgs/development/libraries/sgp4/default.nix
+++ b/pkgs/development/libraries/sgp4/default.nix
@@ -18,6 +18,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/dnwrnr/sgp4";
     license = licenses.asl20;
     maintainers = with maintainers; [ alexwinter ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22743,7 +22743,7 @@ with pkgs;
   };
 
   opencv3 = callPackage ../development/libraries/opencv/3.x.nix {
-    inherit (darwin.apple_sdk.frameworks) AVFoundation Cocoa VideoDecodeAcceleration;
+    inherit (darwin.apple_sdk.frameworks) AVFoundation Cocoa VideoDecodeAcceleration CoreMedia MediaToolbox;
     ffmpeg = ffmpeg_4;
   };
 


### PR DESCRIPTION
###### Description of changes
This makes a few fixes in order to get sdrangel to build and run correction on aarch64-darwin.

1. QtWebEngine has had a fix in #118084 in order to fix version mismatches in Qt, but this fix was introduced inside a conditional block only applying it on linux. This makes the fix available to other platforms as well, while not causing any rebuilds for linux platforms (by preserving the whitespace content of the linux derivation inputs)
2. OpenCV3 was building without Video IO on darwin. OpenCV4 had the right configuration, but not v3. I added the right dependencies and it now builds correctly.
3. A few dependencies were marked as `platforms = platforms.linux`, since they build correctly on darwin, I upgraded their platform metadata to `platforms.unix`

I have tested applying #220746 as well (another sdrangel fix PR), and it builds correctly in both platforms.

- Built on platform(s)
  - [x] x86_64-linux (no changes, same derivation)
  - [x] aarch64-linux (no changes, same derivation) 
  - [ ] x86_64-darwin (qtwebengine is marked as broken, and doesn't build)
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? No
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
