### PR TITLE
lv2: 1.18.2 -> 1.18.10

### DIFF
--- a/pkgs/development/libraries/audio/lv2/default.nix
+++ b/pkgs/development/libraries/audio/lv2/default.nix
@@ -1,45 +1,59 @@
 { stdenv
 , lib
 , fetchurl
-, libsndfile
-, pkg-config
-, python3
-, wafHook
+, meson
+, ninja
+
 , pipewire
+, gitUpdater
 }:
 
 stdenv.mkDerivation rec {
   pname = "lv2";
-  version = "1.18.2";
+  version = "1.18.10";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
-    url = "https://lv2plug.in/spec/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-TokfvHRMBYVb6136gugisUkX3Wbpj4K4Iw29HHqy4F4=";
+    url = "https://lv2plug.in/spec/${pname}-${version}.tar.xz";
+    hash = "sha256-eMUbzyG1Tli7Yymsy7Ta4Dsu15tSD5oB5zS9neUwlT8=";
   };
 
+  strictDeps = true;
+
   nativeBuildInputs = [
-    pkg-config
-    wafHook
-    python3
+    meson
+    ninja
   ];
 
-  buildInputs = [
-    libsndfile
-    python3
-  ];
+  buildInputs = [ ];
 
-  wafConfigureFlags = [
-    "--includedir=${placeholder "dev"}/include"
+  mesonFlags = [
+    # install validators to $dev
     "--bindir=${placeholder "dev"}/bin"
-  ] ++ lib.optionals stdenv.isDarwin [
-    "--lv2dir=${placeholder "out"}/lib/lv2"
-  ];
-  dontAddWafCrossFlags = true;
 
-  passthru.tests = {
-    inherit pipewire;
+    # These are just example plugins. They pull in outdated gtk-2
+    # dependency and many other things. Upstream would like to
+    # eventually move them of the project:
+    #   https://gitlab.com/lv2/lv2/-/issues/57#note_1096060029
+    "-Dplugins=disabled"
+    # Pulls in spell checkers among other things.
+    "-Dtests=disabled"
+    # Avoid heavyweight python dependencies.
+    "-Ddocs=disabled"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-Dlv2dir=${placeholder "out"}/lib/lv2"
+  ];
+
+  passthru = {
+    tests = {
+      inherit pipewire;
+    };
+    updateScript = gitUpdater {
+      # No nicer place to find latest release.
+      url = "https://gitlab.com/lv2/lv2.git";
+      rev-prefix = "v";
+    };
   };
 
   meta = with lib; {


### PR DESCRIPTION
The major change is the switch from waf to meson.

Changes: https://gitlab.com/lv2/lv2/-/blob/master/NEWS

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
