### PR TITLE
yuzu-early-access: fix build error due to warning as errors

### DIFF
--- a/pkgs/applications/emulators/yuzu/generic.nix
+++ b/pkgs/applications/emulators/yuzu/generic.nix
@@ -87,6 +87,11 @@ stdenv.mkDerivation rec {
   # making the build fail, as that path does not exist
   dontFixCmake = true;
 
+  # -Werror causes build failures for deprecation warnings introduced by transitive dependency updates
+  postPatch = ''
+    sed -i '/-Werror/d' src/common/CMakeLists.txt
+  '';
+
   cmakeFlags = [
     "-DYUZU_USE_BUNDLED_QT=OFF"
     "-DYUZU_USE_BUNDLED_FFMPEG=OFF"


### PR DESCRIPTION
###### Description of changes

yuzu-early-access uses a blanket -Werror which causes the build to fail due to library functions marked as deprecated

###### Things done

Added a patch that removes -Werror

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux (not supported)
  - [ ] x86_64-darwin (not supported)
  - [ ] aarch64-darwin (not supported)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
