### PR TITLE
unzrip: init at unstable-2023-03-13

### DIFF
--- a/pkgs/tools/compression/unzrip/default.nix
+++ b/pkgs/tools/compression/unzrip/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, zstd
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "unzrip";
+  version = "unstable-2023-03-13";
+
+  src = fetchFromGitHub {
+    owner = "quininer";
+    repo = "unzrip";
+    rev = "bd2dffd43c3235857500190571602f3ce58c5f70";
+    hash = "sha256-Ih47xF4JYQf10RuTnfJJGUAJwyxDxCAdTTCdwGf4i/U=";
+  };
+
+  cargoHash = "sha256-11UESSKvTcr6Wa0cASRSQ55kBbRL5AelI6thv3oi0sI=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    zstd
+  ];
+
+  meta = with lib; {
+    description = "Unzip implementation, support for parallel decompression, automatic detection encoding";
+    homepage = "https://github.com/quininer/unzrip";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13074,6 +13074,8 @@ with pkgs;
 
   untrunc-anthwlock = callPackage ../tools/video/untrunc-anthwlock { };
 
+  unzrip = callPackage ../tools/compression/unzrip { };
+
   up = callPackage ../tools/misc/up { };
 
   upbound = callPackage ../development/tools/upbound { };


### PR DESCRIPTION
###### Description of changes

https://github.com/quininer/unzrip

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
