### PR TITLE
Backport signal desktop to release 22.11

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,12 +1,12 @@
 { callPackage }: builtins.mapAttrs (pname: attrs: callPackage ./generic.nix (attrs // { inherit pname; })) {
   signal-desktop = {
     dir = "Signal";
-    version = "6.5.1";
-    hash = "sha256-At4ILl6nHltP1TMI5cjK7gE4NENAccS4MPMHXJoGveM=";
+    version = "6.7.0";
+    hash = "sha256-njiVPTkzYdt7QZcpohXUI3hj/o+fO4/O0ZlQrq2oP6Y=";
   };
   signal-desktop-beta = {
     dir = "Signal Beta";
-    version = "6.6.0-beta.1";
-    hash = "sha256-txSvMg7Q+r9UWJMC9Rj2XQ8y1WN3xphMruvOZok/VPk=";
+    version = "6.8.0-beta.1";
+    hash = "sha256-akQmGxDW6SBQCRLU6TgfODP8ZjEPsvaBvrkdd+6DqKs=";
   };
 }

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,8 +1,8 @@
 { callPackage }: builtins.mapAttrs (pname: attrs: callPackage ./generic.nix (attrs // { inherit pname; })) {
   signal-desktop = {
     dir = "Signal";
-    version = "6.4.1";
-    hash = "sha256-/Rrph74nVr64Z6blNNn3oMM25YK92MZY/vuF1d+r6Yc=";
+    version = "6.5.1";
+    hash = "sha256-At4ILl6nHltP1TMI5cjK7gE4NENAccS4MPMHXJoGveM=";
   };
   signal-desktop-beta = {
     dir = "Signal Beta";

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -6,7 +6,7 @@
   };
   signal-desktop-beta = {
     dir = "Signal Beta";
-    version = "6.5.0-beta.2";
-    hash = "sha256-cAX9oU3bJrTOH3RbbfUK+49OiRSLjEZLdpJNOMAa94I=";
+    version = "6.6.0-beta.1";
+    hash = "sha256-txSvMg7Q+r9UWJMC9Rj2XQ8y1WN3xphMruvOZok/VPk=";
   };
 }


### PR DESCRIPTION
###### Description of changes

Backporting changes up to March 12th to release 22.11, these are from #215638 and #217292
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
