### PR TITLE
pkgsi686Linux.python3Packages.rdflib: disable test failing on 32-bit …

### DIFF
--- a/pkgs/development/python-modules/rdflib/default.nix
+++ b/pkgs/development/python-modules/rdflib/default.nix
@@ -64,6 +64,9 @@ buildPythonPackage rec {
     # requires network access
     "--deselect=rdflib/__init__.py::rdflib"
     "--deselect=test/jsonld/test_onedotone.py::test_suite"
+    # assumes 64-bit hash length, fails on pkgsi686Linux.python3Packages.rdflib:
+    #   https://github.com/RDFLib/rdflib/issues/2275
+    "--deselect=test/test_extras/test_infixowl/test_restriction.py::test_restriction_str_and_hash"
   ];
 
   disabledTests = [


### PR DESCRIPTION
…systems

Without the change test fails due to too short hash length as:

    =========================== short test summary info ============================
    FAILED test/test_extras/test_infixowl/test_restriction.py::test_restriction_str_and_hash - AssertionError: assert 9 > 17
    = 1 failed, 6343 passed, 72 skipped, 304 deselected, 373 xfailed, 2 xpassed, 130 warnings in 54.86s =

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
