### PR TITLE
vengi-tools: 0.0.23 -> 0.0.24

### DIFF
--- a/pkgs/applications/graphics/vengi-tools/default.nix
+++ b/pkgs/applications/graphics/vengi-tools/default.nix
@@ -29,13 +29,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vengi-tools";
-  version = "0.0.23";
+  version = "0.0.24";
 
   src = fetchFromGitHub {
     owner = "mgerhardy";
     repo = "vengi";
     rev = "v${version}";
-    sha256 = "sha256-wRqQ7x6eQTrzFU++Qgq/7NXXo5F1onlZBdQ9ttNvvEw=";
+    sha256 = "sha256-ZkO2CLSuuJcFJFBO4XS8Qec0CxxAJdzOGfFa2zy+4uI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/vengi-tools/test-voxconvert-all-formats.nix
+++ b/pkgs/applications/graphics/vengi-tools/test-voxconvert-all-formats.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     mkdir $out
     for format in vox qef qbt qb vxm vxr binvox gox cub vxl csv; do
       echo Testing $format export
-      ${vengi-tools}/bin/vengi-voxconvert --input ${vengi-tools}/share/vengi-voxedit/chr_knight.qb --output $out/chr_knight.$format
+      ${vengi-tools}/bin/vengi-voxconvert --input ${vengi-tools.src}/data/voxedit/chr_knight.qb --output $out/chr_knight.$format
     done
   '';
 }

--- a/pkgs/applications/graphics/vengi-tools/test-voxconvert-roundtrip.nix
+++ b/pkgs/applications/graphics/vengi-tools/test-voxconvert-roundtrip.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
   name = "vengi-tools-test-voxconvert-roundtrip";
   meta.timeout = 10;
   buildCommand = ''
-    ${vengi-tools}/bin/vengi-voxconvert --input ${vengi-tools}/share/vengi-voxedit/chr_knight.qb --output chr_knight.vox
+    ${vengi-tools}/bin/vengi-voxconvert --input ${vengi-tools.src}/data/voxedit/chr_knight.qb --output chr_knight.vox
     ${vengi-tools}/bin/vengi-voxconvert --input chr_knight.vox --output chr_knight.qb
     ${vengi-tools}/bin/vengi-voxconvert --input chr_knight.qb --output chr_knight1.vox
     diff chr_knight.vox chr_knight1.vox


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/mgerhardy/vengi/releases/tag/v0.0.24

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
