### PR TITLE
erlang-ls: fix build

### DIFF
--- a/pkgs/development/beam-modules/erlang-ls/default.nix
+++ b/pkgs/development/beam-modules/erlang-ls/default.nix
@@ -30,10 +30,9 @@ rebar3Relx {
   releaseType = "escript";
   beamDeps = builtins.attrValues deps;
 
-  # Skip "els_hover_SUITE" test for Erlang/OTP 25+ while upstream hasn't fixed it
-  # https://github.com/erlang-ls/erlang_ls/pull/1402
-  postPatch = lib.optionalString (lib.versionOlder "25" erlang.version) ''
-    rm apps/els_lsp/test/els_hover_SUITE.erl
+  # https://github.com/erlang-ls/erlang_ls/issues/1429
+  postPatch =  ''
+    rm apps/els_lsp/test/els_diagnostics_SUITE.erl
   '';
 
   buildPlugins = [ rebar3-proper ];


### PR DESCRIPTION
This fix addressses breakage of devenv erlang integration: https://github.com/cachix/devenv/actions/runs/4403922559/jobs/7712892859

Opened the report upstream: https://github.com/erlang-ls/erlang_ls/issues/1429