### PR TITLE
topiary: unstable-2023-01-10 -> 0.1.0

### DIFF
--- a/pkgs/development/tools/misc/topiary/default.nix
+++ b/pkgs/development/tools/misc/topiary/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "topiary";
-  version = "unstable-2023-01-10";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "tweag";
     repo = pname;
-    rev = "c36d4a2253f337e1a28d497826a84754b8d833f6";
-    sha256 = "sha256-0uqDuEpL9JCXzD7sQ3PDv4N1KtCSkoMoD5i402uIfas=";
+    rev = "v${version}";
+    sha256 = "sha256-Gm6AzzVLUXZi2jzJ1b/c4yjIvRRA2e5mC2CMVyly2X8=";
   };
 
-  cargoSha256 = "sha256-PvMjLC133rlsPrgyESuVHIf2TPCtgGQQULCQvBTIJ20=";
+  cargoSha256 = "sha256-2Ovwntg3aZyR73rg8ruA/U1wVS1BO+B7r37D6/LPa/g=";
 
   postInstall = ''
     install -Dm444 languages/* -t $out/share/languages


### PR DESCRIPTION
###### Description of changes

First official release of Topiary (apart from `v0.0.1-prototype` that really doesn't count).

- [Changes since `unstable-2023-01-10`](https://github.com/tweag/topiary/compare/c36d4a2253f337e1a28d497826a84754b8d833f6...c4fe76c)
- [Changelog from scratch](https://github.com/tweag/topiary/blob/6d86fa78b4b2e59b4db203b7db0dab6811e5b27f/CHANGELOG.md)
- [Blog post announcement](https://www.tweag.io/blog/2023-03-09-announcing-topiary/)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).