### PR TITLE
why3: 1.5.1 → 1.6.0; ocamlPackages.lambdapi: 2.2.1 → 2.3.1

### DIFF
--- a/pkgs/applications/science/logic/easycrypt/default.nix
+++ b/pkgs/applications/science/logic/easycrypt/default.nix
@@ -11,11 +11,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256:09rdwcj70lkamkhd895p284rfpz4bcnsf55mcimhiqncd2a21ml7";
   };
 
-  # Fix build with Why3 1.5
-  patches = fetchpatch {
-    url = "https://github.com/EasyCrypt/easycrypt/commit/d226387432deb7f22738e1d5579346a2cbc9be7a.patch";
-    sha256 = "sha256:1zvxij35fnr3h9b5wdl8ml17aqfx3a39rd4mgwmdvkapbg3pa4lm";
-  };
+  patches = lib.lists.map fetchpatch [
+    # Fix build with Why3 1.5
+    { url = "https://github.com/EasyCrypt/easycrypt/commit/d226387432deb7f22738e1d5579346a2cbc9be7a.patch";
+      hash = "sha256:1zvxij35fnr3h9b5wdl8ml17aqfx3a39rd4mgwmdvkapbg3pa4lm"; }
+    # Fix build with Why3 1.6
+    { url = "https://github.com/EasyCrypt/easycrypt/commit/876f2ed50a0434afdf2fb20e7c50b8a3e26bb06e.patch";
+      hash = "sha256-UycfLZWYHNsppb7qHSRaAF4Y0UnwoFueEG0wUcBUPYE="; }
+  ];
 
   nativeBuildInputs = with ocamlPackages; [
     dune_3

--- a/pkgs/applications/science/logic/why3/default.nix
+++ b/pkgs/applications/science/logic/why3/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   pname = "why3";
-  version = "1.5.1";
+  version = "1.6.0";
 
   src = fetchurl {
     url = "https://why3.gitlabpages.inria.fr/releases/${pname}-${version}.tar.gz";
-    sha256 = "sha256-vNR7WeiSvg+763GcovoZBFDfncekJMeqNegP4fVw06I=";
+    hash = "sha256-hFvM6kHScaCtcHCc6Vezl9CR7BFbiKPoTEh7kj0ZJxw=";
   };
 
   strictDeps = true;

--- a/pkgs/development/ocaml-modules/lambdapi/default.nix
+++ b/pkgs/development/ocaml-modules/lambdapi/default.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchFromGitHub
+, fetchurl
 , buildDunePackage
 , alcotest
 , dedukti
@@ -17,15 +17,14 @@
 
 buildDunePackage rec {
   pname = "lambdapi";
-  version = "2.2.1";
+  version = "2.3.1";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
-  src = fetchFromGitHub {
-    owner = "Deducteam";
-    repo = pname;
-    rev = version;
-    hash = "sha256-p2ZjSfiZwkf8X4fSNJx7bAVpTFl4UBHIEANIWF7NGCs=";
+  src = fetchurl {
+    url = "https://github.com/Deducteam/lambdapi/releases/download/${version}/lambdapi-${version}.tbz";
+    hash = "sha256-xWnKJtfTaLBNxpq4+LNLvVyqLg5wP7yD4FTvm0853XU=";
   };
 
   nativeBuildInputs = [ menhir ];

--- a/pkgs/development/ocaml-modules/lambdapi/default.nix
+++ b/pkgs/development/ocaml-modules/lambdapi/default.nix
@@ -24,7 +24,7 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/Deducteam/lambdapi/releases/download/${version}/lambdapi-${version}.tbz";
-    hash = "sha256-xWnKJtfTaLBNxpq4+LNLvVyqLg5wP7yD4FTvm0853XU=";
+    hash = "sha256-7ww2TjVcbEQyfmLnnEhLGAjW4US9a4mdOfDJw6NR1fI=";
   };
 
   nativeBuildInputs = [ menhir ];

--- a/pkgs/development/tools/analysis/frama-c/default.nix
+++ b/pkgs/development/tools/analysis/frama-c/default.nix
@@ -4,6 +4,15 @@
 , gdk-pixbuf, wrapGAppsHook
 }:
 
+let why3_1_5 = why3.overrideAttrs (o: rec {
+    version = "1.5.1";
+    src = fetchurl {
+      url = "https://why3.gitlabpages.inria.fr/releases/${o.pname}-${version}.tar.gz";
+      hash = "sha256-vNR7WeiSvg+763GcovoZBFDfncekJMeqNegP4fVw06I=";
+    };
+  }); in
+let why3 = why3_1_5; in
+
 let
   mkocamlpath = p: "${p}/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib";
   runtimeDeps = with ocamlPackages; [


### PR DESCRIPTION
###### Description of changes

https://gitlab.inria.fr/why3/why3/-/blob/1.6.0/CHANGES.md
https://github.com/Deducteam/lambdapi/blob/2.3.1/CHANGES.md

Note that Frama-C is not yet compatible with latest why3.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
