### PR TITLE
faustPhhysicalModeling 2.20.2 -> faustPhysicalModeling 2.50.6

### DIFF
--- a/pkgs/applications/audio/faustStk/default.nix
+++ b/pkgs/applications/audio/faustStk/default.nix
@@ -1,14 +1,14 @@
 { stdenv, lib, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 
 stdenv.mkDerivation rec {
-  pname = "faustPhhysicalModeling";
-  version = "2.20.2";
+  pname = "faustPhysicalModeling";
+  version = "2.50.6";
 
   src = fetchFromGitHub {
     owner = "grame-cncm";
     repo = "faust";
     rev = version;
-    sha256 = "1mm93ba26b7q69hvabzalg30dh8pl858nj4m2bb57pznnp09lq9a";
+    sha256 = "sha256-Q/vrm3WPsjkE3Xf/XEirsJPFXHNSW/Ve3Jbi/5nIrx8=";
   };
 
   buildInputs = [ faust2jaqt faust2lv2 ];


### PR DESCRIPTION
###### Description of changes

Updated version from 2.20.2 to 2.50.6 and fixed typo in name

Reopened https://github.com/NixOS/nixpkgs/pull/203264

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).