### PR TITLE
sparrow: 1.7.1 -> 1.7.3

### DIFF
--- a/pkgs/applications/blockchains/sparrow/default.nix
+++ b/pkgs/applications/blockchains/sparrow/default.nix
@@ -20,11 +20,11 @@
 
 let
   pname = "sparrow";
-  version = "1.7.1";
+  version = "1.7.3";
 
   src = fetchurl {
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}-x86_64.tar.gz";
-    sha256 = "0q31b4ncvbhr9gb47wplphg43pwlg5vpd1b12qiidqlrkgm2vjy8";
+    sha256 = "sha256-/tKct73v0zWAjY4kTllnb/+SB/8ENgVl8Yh/LErKTxY=";
   };
 
   launcher = writeScript "sparrow" ''
@@ -156,24 +156,6 @@ let
       ln -s ${hwi}/bin/hwi $out/modules/com.sparrowwallet.sparrow/native/linux/x64/hwi
     '';
   };
-
-  # To use the udev rules for connected hardware wallets,
-  # add "pkgs.sparrow" to "services.udev.packages" and add user accounts to the user group "plugdev".
-  udev-rules = stdenv.mkDerivation {
-    name = "sparrow-udev";
-
-    src = let version = "2.0.2"; in
-      fetchurl {
-        url = "https://github.com/bitcoin-core/HWI/releases/download/${version}/hwi-${version}.tar.gz";
-        sha256 = "sha256-di1fRsMbwpHcBFNTCVivfxpwhUoUKLA3YTnJxKq/jHM=";
-      };
-
-    installPhase = ''
-      mkdir -p $out/etc/udev/rules.d
-      cp -a hwilib/udev/* $out/etc/udev/rules.d
-      rm $out/etc/udev/rules.d/README.md
-    '';
-  };
 in
 stdenv.mkDerivation rec {
   inherit pname version src;
@@ -186,8 +168,9 @@ stdenv.mkDerivation rec {
       icon = pname;
       desktopName = "Sparrow Bitcoin Wallet";
       genericName = "Bitcoin Wallet";
-      categories = [ "Finance" ];
+      categories = [ "Finance" "Network" ];
       mimeTypes = [ "application/psbt" "application/bitcoin-transaction" "x-scheme-handler/bitcoin" "x-scheme-handler/auth47" "x-scheme-handler/lightning" ];
+      startupWMClass = "Sparrow";
     })
   ];
 
@@ -217,8 +200,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/icons
     ln -s ${sparrow-icons}/hicolor $out/share/icons
 
-    mkdir -p $out/etc/udev
-    ln -s ${udev-rules}/etc/udev/rules.d $out/etc/udev/rules.d
+    mkdir -p $out/etc/udev/rules.d
+    cp ${hwi}/lib/python*/site-packages/hwilib/udev/*.rules $out/etc/udev/rules.d
 
     runHook postInstall
   '';

--- a/pkgs/applications/blockchains/sparrow/fhsenv.nix
+++ b/pkgs/applications/blockchains/sparrow/fhsenv.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildFHSUserEnv
+, sparrow-unwrapped
+}:
+
+buildFHSUserEnv {
+  name = "sparrow";
+
+  runScript = "${sparrow-unwrapped}/bin/sparrow";
+
+  targetPkgs = pkgs: with pkgs; [
+    sparrow-unwrapped
+    pcsclite
+  ];
+
+  multiPkgs = pkgs: with pkgs; [
+    pcsclite
+  ];
+
+  extraInstallCommands = ''
+    mkdir -p $out/share
+    ln -s ${sparrow-unwrapped}/share/applications $out/share
+    ln -s ${sparrow-unwrapped}/share/icons $out/share
+
+    mkdir -p $out/etc/udev
+    ln -s ${sparrow-unwrapped}/etc/udev/rules.d $out/etc/udev/rules.d
+  '';
+
+  meta = sparrow-unwrapped.meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12267,8 +12267,12 @@ with pkgs;
 
   sozu = callPackage ../servers/sozu { };
 
-  sparrow = callPackage ../applications/blockchains/sparrow {
-    openimajgrabber = callPackage ../applications/blockchains/sparrow/openimajgrabber.nix { };
+  sparrow-unwrapped = callPackage ../applications/blockchains/sparrow {
+    openimajgrabber = callPackage ../applications/blockchains/sparrow/openimajgrabber.nix {};
+  };
+
+  sparrow = callPackage ../applications/blockchains/sparrow/fhsenv.nix {
+    buildFHSUserEnv = buildFHSUserEnvBubblewrap;
   };
 
   sparsehash = callPackage ../development/libraries/sparsehash { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12269,6 +12269,7 @@ with pkgs;
 
   sparrow-unwrapped = callPackage ../applications/blockchains/sparrow {
     openimajgrabber = callPackage ../applications/blockchains/sparrow/openimajgrabber.nix {};
+    openjdk = openjdk.override { enableJavaFX = true; };
   };
 
   sparrow = callPackage ../applications/blockchains/sparrow/fhsenv.nix {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- This PR updates sparrow from 1.7.1 to 1.7.3 and obsoletes PR #216478 which was generated with the auto-update script. and PR #216893. See https://github.com/sparrowwallet/sparrow/releases/tag/1.7.3 for the release details.
- sparrow 1.7.3 adds code to dynamically load a library, and said code uses a hard-coded path. Since the package doesn't build from source, I'm using `buildFHSUserEnv` to provide the library at the expected path, which I manually confirmed. But note however that I don't have the hardware to test that particular code path.
- I also incorporated changes in the upstream .desktop file.
- I enabled JavaFX. See #206643
- Sparrow 1.7.3 bundles hwi 2.2.1, which they said was updated to fix some issues with specific hardware wallets. We don't use the bundled version and instead use the one from Nixpkgs. The Nixpkgs version upon which this commit is built contains the expected hwi 2.2.1.

---

Closes #222691.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
