### PR TITLE
nixos: remove allowSubstitutes = false from core modules

### DIFF
--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -19,7 +19,6 @@ in rec {
     if unit.enable then
       pkgs.runCommand "unit-${mkPathSafeName name}"
         { preferLocalBuild = true;
-          allowSubstitutes = false;
           inherit (unit) text;
         }
         ''
@@ -29,9 +28,7 @@ in rec {
         ''
     else
       pkgs.runCommand "unit-${mkPathSafeName name}-disabled"
-        { preferLocalBuild = true;
-          allowSubstitutes = false;
-        }
+        { preferLocalBuild = true; }
         ''
           name=${shellEscape name}
           mkdir -p "$out/$(dirname "$name")"
@@ -131,9 +128,7 @@ in rec {
         nspawn = "nspawn";
       }).${type};
     in pkgs.runCommand "${type}-units"
-      { preferLocalBuild = true;
-        allowSubstitutes = false;
-      } ''
+      { preferLocalBuild = true; } ''
       mkdir -p $out
 
       # Copy the upstream systemd units we're interested in.

--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -6,7 +6,6 @@ let
 
   gtk2_cache = pkgs.runCommand "gtk2-immodule.cache"
     { preferLocalBuild = true;
-      allowSubstitutes = false;
       buildInputs = [ pkgs.gtk2 cfg.package ];
     }
     ''
@@ -16,7 +15,6 @@ let
 
   gtk3_cache = pkgs.runCommand "gtk3-immodule.cache"
     { preferLocalBuild = true;
-      allowSubstitutes = false;
       buildInputs = [ pkgs.gtk3 cfg.package ];
     }
     ''

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -256,7 +256,6 @@ in
               cp * $out/
             '';
             preferLocalBuild = true;
-            allowSubstitutes = false;
           };
           generateCompletions = package: pkgs.runCommand
             "${package.name}_fish-completions"
@@ -264,7 +263,6 @@ in
               {
                 inherit package;
                 preferLocalBuild = true;
-                allowSubstitutes = false;
               }
               // optionalAttrs (package ? meta.priority) { meta.priority = package.meta.priority; }
             )

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -54,7 +54,6 @@ let
   # Perform substitutions in all udev rules files.
   udevRulesFor = { name, udevPackages, udevPath, udev, systemd, binPackages, initrdBin ? null }: pkgs.runCommand name
     { preferLocalBuild = true;
-      allowSubstitutes = false;
       packages = unique (map toString udevPackages);
     }
     ''
@@ -156,7 +155,6 @@ let
 
   hwdbBin = pkgs.runCommand "hwdb.bin"
     { preferLocalBuild = true;
-      allowSubstitutes = false;
       packages = unique (map toString ([udev] ++ cfg.packages));
     }
     ''

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -111,7 +111,6 @@ let
   installedSessions = pkgs.runCommand "desktops"
     { # trivial derivation
       preferLocalBuild = true;
-      allowSubstitutes = false;
     }
     ''
       mkdir -p "$out/share/"{xsessions,wayland-sessions}

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -96,7 +96,6 @@ let
   baseSystem = pkgs.stdenvNoCC.mkDerivation ({
     name = "nixos-system-${config.system.name}-${config.system.nixos.label}";
     preferLocalBuild = true;
-    allowSubstitutes = false;
     buildCommand = systemBuilder;
 
     inherit (pkgs) coreutils;


### PR DESCRIPTION
###### Description of changes

These are used almost anywhere, and make building only uncached parts of
a NixOS system extremely annoying. They all already have `preferLocal =
true` set, which should be enough to prevent them from being built
remotely, where the largest perf hit would be seen.

Alternatively, we could introduce a top-level config option to NixOS like
`substituteTrivialDerivations` to let users toggle this behavior.

IMO, these derivations produce tiny files, and fetching them from a substituter
is probably not significantly worse than building them locally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
