### PR TITLE
pkgs/top-level/config: add alwaysAllowSubstitutes

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -288,7 +288,8 @@ else let
        "nativeCheckInputs" "nativeInstallCheckInputs"
        "__darwinAllowLocalNetworking"
        "__impureHostDeps" "__propagatedImpureHostDeps"
-       "sandboxProfile" "propagatedSandboxProfile"]
+       "sandboxProfile" "propagatedSandboxProfile"
+       "allowSubstitutes"]
        ++ lib.optional (__structuredAttrs || envIsExportable) "env"))
     // (lib.optionalAttrs (attrs ? name || (attrs ? pname && attrs ? version)) {
       name =
@@ -486,6 +487,9 @@ else let
     lib.optionalAttrs (attrs ? allowedRequisites) {
       allowedRequisites =
         lib.mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
+    } //
+    lib.optionalAttrs (attrs ? allowSubstitutes) {
+      allowSubstitutes = if config.alwaysAllowSubstitutes then true else attrs.allowSubstitutes;
     };
 
   validity = checkMeta { inherit meta attrs; };

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -63,6 +63,10 @@ let
       feature = "set `__contentAddressed` to true by default";
     };
 
+    alwaysAllowSubstitutes = mkMassRebuild {
+      feature = "set `allowSubstitutes` to true always";
+    };
+
     allowAliases = mkOption {
       type = types.bool;
       default = true;


### PR DESCRIPTION
###### Description of changes

This introduces a new nixpkgs config option, `alwaysAllowSubstitutes`
which causes `allowSubstitutes` to always be `true`.

This is extremely useful for users with fast connections to their cache,
and who prefer to _always_ fetch something from cache. In particular,
those using `nix-build-uncached` could benefit from this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
