### PR TITLE
gptfdisk: Backport upstream fix for popt 1.19

### DIFF
--- a/pkgs/tools/system/gptfdisk/default.nix
+++ b/pkgs/tools/system/gptfdisk/default.nix
@@ -13,7 +13,6 @@ stdenv.mkDerivation rec {
 
   patches = [
     # issues with popt 1.19 (from upstream but not yet released):
-    # https://sourceforge.net/p/gptfdisk/code/ci/5d5e76d369a412bfb3d2cebb5fc0a7509cef878d/
     # https://github.com/rpm-software-management/popt/issues/80
     ./popt-1-19.patch
 

--- a/pkgs/tools/system/gptfdisk/popt-1-19.patch
+++ b/pkgs/tools/system/gptfdisk/popt-1-19.patch
@@ -1,3 +1,25 @@
+commit 5d5e76d369a412bfb3d2cebb5fc0a7509cef878d
+Author: Rod Smith <rodsmith@rodsbooks.com>
+Date:   Fri Apr 15 18:10:14 2022 -0400
+
+    Fix failure & crash of sgdisk when compiled with latest popt (commit 740; presumably eventually release 1.19)
+
+diff --git a/NEWS b/NEWS
+index c7add56..9e153fd 100644
+--- a/NEWS
++++ b/NEWS
+@@ -1,3 +1,11 @@
++1.0.10 (?/??/2022):
++-------------------
++
++- Fixed problem that caused sgdisk to crash with errors about being unable
++  to read the disk's partition table when compiled with the latest popt
++  (commit 740, which is pre-release as I type; presumably version 1.19 and
++  later once released).
++
+ 1.0.9 (4/14/2022):
+ ------------------
+ 
 diff --git a/gptcl.cc b/gptcl.cc
 index 34c9421..0d578eb 100644
 --- a/gptcl.cc
@@ -11,3 +33,52 @@ index 34c9421..0d578eb 100644
     poptResetContext(poptCon);
  
     if (device != NULL) {
+diff --git a/support.h b/support.h
+index 8ba9ad1..f91f1bc 100644
+--- a/support.h
++++ b/support.h
+@@ -8,7 +8,7 @@
+ #include <stdlib.h>
+ #include <string>
+ 
+-#define GPTFDISK_VERSION "1.0.9"
++#define GPTFDISK_VERSION "1.0.9.1"
+ 
+ #if defined (__FreeBSD__) || defined (__FreeBSD_kernel__) || defined (__APPLE__)
+ // Darwin (Mac OS) & FreeBSD: disk IOCTLs are different, and there is no lseek64
+
+commit f5de3401b974ce103ffd93af8f9d43505a04aaf9
+Author: Damian Kurek <starfire24680@gmail.com>
+Date:   Thu Jul 7 03:39:16 2022 +0000
+
+    Fix NULL dereference when duplicating string argument
+    
+    poptGetArg can return NULL if there are no additional arguments, which
+    makes strdup dereference NULL on strlen
+
+diff --git a/gptcl.cc b/gptcl.cc
+index 0d578eb..ab95239 100644
+--- a/gptcl.cc
++++ b/gptcl.cc
+@@ -155,10 +155,11 @@ int GPTDataCL::DoOptions(int argc, char* argv[]) {
+    } // while
+ 
+    // Assume first non-option argument is the device filename....
+-   device = strdup((char*) poptGetArg(poptCon));
+-   poptResetContext(poptCon);
++   device = (char*) poptGetArg(poptCon);
+ 
+    if (device != NULL) {
++      device = strdup(device);
++      poptResetContext(poptCon);
+       JustLooking(); // reset as necessary
+       BeQuiet(); // Tell called functions to be less verbose & interactive
+       if (LoadPartitions((string) device)) {
+@@ -498,6 +499,7 @@ int GPTDataCL::DoOptions(int argc, char* argv[]) {
+          cerr << "Error encountered; not saving changes.\n";
+          retval = 4;
+       } // if
++      free(device);
+    } // if (device != NULL)
+    poptFreeContext(poptCon);
+    return retval;


### PR DESCRIPTION
###### Description of changes

Existing patch in nixpkgs causes segfault, see
https://github.com/NixOS/nixpkgs/issues/219775. This replaces that with cherry-picks from upstream.

###### Things done

- Tested basic behavior (`sgdisk --version ; sgdisk /dev/sda1`) and both seem to work okay.
- Tested that partitioning operations in gnome disks that previous failed now work.
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

nixpkgs-review output (note that gnomeExtensions.easyScreenCast is failing on base master):
```
121 packages updated:
adapta-gtk-theme almanah bubblemail calls cantata chatty cheese cinnamon-common cinnamon-control-center cinnamon-gsettings-overrides cinnamon-screensaver clementine-unstable cloud-init cloud-utils coreaction corearchiver corefm coregarage corehunt coreimage coreinfo corekeyboard corepad corepaint corepdf corepins corerenamer coreshot corestats corestuff coreterminal coretime coretoppings coreuniverse dde-device-formatter-unstable deepin-album deepin-compressor deepin-image-viewer deepin-music elementary-calendar elementary-greeter elementary-mail elementary-planner elementary-session-settings elementary-tasks endeavour enlightenment eos-installer evolution evolution-data-server evolution-data-server evolution-ews evolution-with-plugins exaile folks geary gfbgraph gnome-applets gnome-browser-connector gnome-browser-connector gnome-calendar gnome-contacts gnome-control-center gnome-disk-utility gnome-flashback gnome-gsettings-overrides gnome-initial-setup gnome-multi-writer gnome-music gnome-notes gnome-online-accounts gnome-online-miners gnome-panel gnome-photos gnome-recipes gnome-session gnome-shell gnome-shell-extension-EasyScreenCast gnome-shell-extension-gsconnect gnome-shell-extension-system-monitor-unstable gnome-terminal gnome-tweaks gptfdisk grilo-plugins gvfs gvfs libblockdev libcsys libgdata libzapojit mailnag mate-utils mojave-gtk-theme monitor nemo nemo-fileroller nemo-python nemo-with-extensions phosh phosh-mobile-settings psensor rabbitvcs rapid-photo-downloader spacefm switchboard-plug-about switchboard-plug-onlineaccounts switchboard-with-plugs totem udiskie udisks udisks2-qt5 usbimager usermount vifm-full vimix-gtk-themes whitesur-gtk-theme wingpanel-applications-menu wingpanel-indicator-datetime wingpanel-with-indicators xmonad-log-applet-gnomeflashback-unstable zpool-auto-expand-partitions

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/amarshall/.cache/nixpkgs-review/rev-90c0d8cf1eedb59247e2c0259832a2f332ebf6ae/build.nix
error: builder for '/nix/store/wq1l8gqv7w136kdg5jabq4z12k0gczyg-gnome-shell-extension-EasyScreenCast-1.7.0.drv' failed with exit code 2;
       last 10 log lines:
       > msgfmt -c locale/ja.po -o locale/ja.mo
       > msgfmt -c locale/pt_BR.po -o locale/pt_BR.mo
       > msgfmt -c locale/ru.po -o locale/ru.mo
       > msgfmt -c locale/uk.po -o locale/uk.mo
       > msgfmt -c locale/vi.po -o locale/vi.mo
       > mkdir -p locale
       > xgettext -k --keyword=_ --keyword=N_ --from-code=UTF-8 --add-comments='Translators:' -o locale/easyscreencast.pot --package-name "EasyScreenCast" prefs.js extension.js selection.js utilwebcam.js
       > intltool-extract --type=gettext/glade Options_UI.glade
       > /nix/store/5ynbf6wszmggr0abwifdagrixgnya5vy-bash-5.2-p15/bin/bash: line 1: intltool-extract: command not found
       > make: *** [Makefile:62: locale/easyscreencast.pot] Error 127
       For full logs, run 'nix log /nix/store/wq1l8gqv7w136kdg5jabq4z12k0gczyg-gnome-shell-extension-EasyScreenCast-1.7.0.drv'.
error: 1 dependencies of derivation '/nix/store/9zj0g8zh1j7kgb2xvjr9vdc2a7vfr14c-env.drv' failed to build
error: 1 dependencies of derivation '/nix/store/1rl97hxc2j66avhbqdimnynrgjfix35h-review-shell.drv' failed to build
6 packages marked as broken and skipped:
chrome-gnome-shell elementary-planner gnome2.gvfs mailnagWithPlugins pantheon.elementary-tasks xmonad_log_applet

1 package failed to build:
gnomeExtensions.easyScreenCast

114 packages built:
CuboCore.coreaction CuboCore.corearchiver CuboCore.corefm CuboCore.coregarage CuboCore.corehunt CuboCore.coreimage CuboCore.coreinfo CuboCore.corekeyboard CuboCore.corepad CuboCore.corepaint CuboCore.corepdf CuboCore.corepins CuboCore.corerenamer CuboCore.coreshot CuboCore.corestats CuboCore.corestuff CuboCore.coreterminal CuboCore.coretime CuboCore.coretoppings CuboCore.coreuniverse CuboCore.libcsys adapta-gtk-theme almanah bubblemail calls cantata chatty cinnamon.cinnamon-common cinnamon.cinnamon-control-center cinnamon.cinnamon-gsettings-overrides cinnamon.cinnamon-screensaver cinnamon.nemo cinnamon.nemo-fileroller cinnamon.nemo-python cinnamon.nemo-with-extensions clementine cloud-init cloud-utils deepin.dde-device-formatter deepin.deepin-album deepin.deepin-compressor deepin.deepin-image-viewer deepin.deepin-music deepin.udisks2-qt5 endeavour enlightenment.enlightenment eos-installer evolution evolution-data-server evolution-data-server-gtk4 evolution-ews evolutionWithPlugins exaile folks gfbgraph gnome-browser-connector gnome-multi-writer gnome-online-accounts gnome-photos gnome-recipes gnome.cheese gnome.geary gnome.gnome-applets gnome.gnome-calendar gnome.gnome-contacts gnome.gnome-control-center gnome.gnome-disk-utility gnome.gnome-flashback gnome.gnome-initial-setup gnome.gnome-music gnome.gnome-notes gnome.gnome-online-miners gnome.gnome-panel gnome.gnome-session gnome.gnome-shell gnome.gnome-terminal gnome.gnome-tweaks gnome.gvfs gnome.nixos-gsettings-overrides gnome.totem gnomeExtensions.gsconnect gnomeExtensions.system-monitor gptfdisk grilo-plugins libblockdev libgdata libzapojit mate.mate-utils mojave-gtk-theme monitor pantheon.elementary-calendar pantheon.elementary-greeter pantheon.elementary-mail pantheon.elementary-session-settings pantheon.switchboard-plug-about pantheon.switchboard-plug-onlineaccounts pantheon.switchboard-with-plugs pantheon.wingpanel-applications-menu pantheon.wingpanel-indicator-datetime pantheon.wingpanel-with-indicators phosh phosh-mobile-settings psensor rabbitvcs rapid-photo-downloader spaceFM udiskie udisks usbimager usermount vifm-full vimix-gtk-themes whitesur-gtk-theme zpool-auto-expand-partitions
```
