### PR TITLE
crosvm: 107.1 -> 111.1

### DIFF
--- a/pkgs/applications/virtualization/crosvm/default.nix
+++ b/pkgs/applications/virtualization/crosvm/default.nix
@@ -1,35 +1,25 @@
-{ stdenv, lib, rust, rustPlatform, fetchgit, fetchpatch
-, clang, pkg-config, protobuf, python3, wayland-scanner
+{ lib, rustPlatform, fetchgit, pkg-config, protobuf, python3, wayland-scanner
 , libcap, libdrm, libepoxy, minijail, virglrenderer, wayland, wayland-protocols
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "crosvm";
-  version = "107.1";
+  version = "111.1";
 
   src = fetchgit {
     url = "https://chromium.googlesource.com/chromiumos/platform/crosvm";
-    rev = "5a49a836e63aa6e9ae38b80daa09a013a57bfb7f";
-    sha256 = "F+5i3R7Tbd9xF63Olnyavzg/hD+8HId1duWm8bvAmLA=";
+    rev = "9ad89972330f70fca5a29967f226cf905977bf7f";
+    sha256 = "hvP3V7kzfPXOIe+6GBWupfhW5SM3ifoqmx7dyTgSTeU=";
     fetchSubmodules = true;
   };
 
   separateDebugInfo = true;
 
-  patches = [
-    # Backport seccomp sandbox update for recent Glibc.
-    # fetchpatch is not currently gerrit/gitiles-compatible, so we
-    # have to use the mirror.
-    # https://github.com/NixOS/nixpkgs/pull/133604
-    (fetchpatch {
-      url = "https://github.com/google/crosvm/commit/aae01416807e7c15270b3d44162610bcd73952ff.patch";
-      sha256 = "nQuOMOwBu8QvfwDSuTz64SQhr2dF9qXt2NarbIU55tU=";
-    })
+  cargoSha256 = "S8zeOB+S5ZTuHqWNjxDIa4ev24ose/fByYwPrhR9OY8=";
+
+  nativeBuildInputs = [
+    pkg-config protobuf python3 rustPlatform.bindgenHook wayland-scanner
   ];
-
-  cargoSha256 = "1jg9x5adz1lbqdwnzld4xg4igzmh90nd9xm287cgkvh5fbmsjfjv";
-
-  nativeBuildInputs = [ clang pkg-config protobuf python3 wayland-scanner ];
 
   buildInputs = [
     libcap libdrm libepoxy minijail virglrenderer wayland wayland-protocols
@@ -37,11 +27,7 @@ rustPlatform.buildRustPackage rec {
 
   preConfigure = ''
     patchShebangs third_party/minijail/tools/*.py
-    substituteInPlace build.rs --replace '"clang"' '"${stdenv.cc.targetPrefix}clang"'
   '';
-
-  "CARGO_TARGET_${lib.toUpper (builtins.replaceStrings ["-"] ["_"] (rust.toRustTarget stdenv.hostPlatform))}_LINKER" =
-    "${stdenv.cc.targetPrefix}cc";
 
   # crosvm mistakenly expects the stable protocols to be in the root
   # of the pkgdatadir path, rather than under the "stable"


### PR DESCRIPTION
###### Description of changes

I'm aware of a [nasty bug][1] in this crosvm version, which didn't affect me on earlier versions (although from the code it looks like the bug was already present).  But it only affects vhost-user-gpu, which is probably a fairly obscure feature, so I guess it shouldn't hold us back?

[1]: https://groups.google.com/a/chromium.org/g/crosvm-dev/c/v_7Gie37NCI

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
