### PR TITLE
kicad(-unstable): bump to latest version, cleanup and fixes

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -22,7 +22,6 @@
 , libXdmcp
 , lndir
 , unixODBC
-, fetchpatch
 
 , util-linux
 , libselinux
@@ -72,19 +71,6 @@ stdenv.mkDerivation rec {
   patches = [
     # upstream issue 12941 (attempted to upstream, but appreciably unacceptable)
     ./writable.patch
-  ]
-  ++ optionals (stable) # the 2 wxGTK ones should in the next stable point release
-  [
-    (fetchpatch { # for wxGTK 3.2.2.1's .1 field
-      name = "support wxWidgets subrelease field";
-      url = "https://gitlab.com/kicad/code/kicad/-/commit/b536580119c59fde78e38d8d6388f2540ecb6cf9.diff";
-      hash = "sha256-F+J5oZO0BsT1VWKpx0KGA7ecn5/PBgCw8uiScihM+54=";
-    })
-    (fetchpatch { # for wxGTK 3.2.2.1's .1 field, but for wxPython
-      name = "relax wxPython check to just major.minor";
-      url = "https://gitlab.com/kicad/code/kicad/-/commit/1e8cc6855d6a8fc1f9dfc933224c3a10fb759f9c.diff";
-      hash = "sha256-CGNgxZ7QiVLkaauNl7Pmcl152lwyDZqA/HSyFdOswwU=";
-    })
   ];
 
   # tagged releases don't have "unknown"

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -86,6 +86,9 @@ stdenv.mkDerivation rec {
     "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;qa_eeschema'"  # upstream issue 12491
     "-DOCC_INCLUDE_DIR=${opencascade-occt}/include/opencascade"
   ]
+  ++ optionals (!stable) [ # workaround for https://gitlab.com/kicad/code/kicad/-/issues/14346
+    "-DPYTHON_SITE_PACKAGE_PATH=${placeholder "out"}/lib/python${lib.versions.majorMinor python.version}/site-packages"
+  ]
   ++ optionals (!withScripting) [
     "-DKICAD_SCRIPTING_WXPYTHON=OFF"
   ]

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -130,7 +130,7 @@ stdenv.mkDerivation rec {
   dontFixup = true;
 
   pythonPath = optionals (withScripting)
-    [ wxPython python.pkgs.six ];
+    [ wxPython python.pkgs.six python.pkgs.requests ];
 
   nativeBuildInputs = [ makeWrapper ]
     ++ optionals (withScripting)

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -14,7 +14,6 @@
 
 , pname ? "kicad"
 , stable ? true
-, withOCC ? true
 , withNgspice ? !stdenv.isDarwin
 , libngspice
 , withScripting ? true
@@ -117,7 +116,7 @@ stdenv.mkDerivation rec {
     inherit stable baseName;
     inherit kicadSrc kicadVersion;
     inherit wxGTK python wxPython;
-    inherit withOCC withNgspice withScripting withI18n;
+    inherit withNgspice withScripting withI18n;
     inherit debug sanitizeAddress sanitizeThreads;
   };
 

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,23 +3,23 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"7.0.0";
+      version =			"7.0.1";
       src = {
-        rev =			"da2b9df05c3ccd5ec104cf8cd8ded34f5dd25216";
-        sha256 =		"1zgpj1rvf97qv36hg4dja46pbzyixlh2g04wlh7cizcrs16b9mzw";
+        rev =			"3b83917a115be1ce2f33a73039f59f8784b5c2e7";
+        sha256 =		"021safxvyq9qzs08jy3jvpazmhvix4kyl05s9y9hwmyzdmdl2smn";
       };
     };
     libVersion = {
-      version =			"7.0.0";
+      version =			"7.0.1";
       libSources = {
-        symbols.rev =		"08a25991d07924b263cbf87c6e513feac2b2169f";
-        symbols.sha256 =	"1r87xr1453dpfglkg1m4p5d7kcv9gxls1anwk3vp2yppnwz24ydm";
+        symbols.rev =		"adfe3c06b5750d81580ed44e669b578f49c205eb";
+        symbols.sha256 =	"14c5gci13m30xv0cmic5jxsmfx9lq3fnd8hyq3mmgkrw7443zy30";
         templates.rev =		"66d76556d9e81f8a5be74457686d211c666ed200";
         templates.sha256 =	"02i279269mhq7wjhb1yqk90820ncssxl9n7b20qr2r4fmm7jpvxv";
-        footprints.rev =	"a0388d07e4a37e8db13a716efb3ad4750c839f9c";
-        footprints.sha256 =	"1akhifnjm8jvqsvscn2rr1wpzrls73bpdc6sk40355r1in2djmry";
-        packages3d.rev =	"bbee2295519bcf469d97f5e06bcf7175cddd2037";
-        packages3d.sha256 =	"1qw5xm0wbhv6gqvd8mn0jp4abjbizrkx79r6y8f6911mkzi47r6n";
+        footprints.rev =	"1cf5a1d979cffebd62464c1bb0d7b09c5ee3b8c3";
+        footprints.sha256 =	"0k0z40wmaq665hjxb6kp1yl3v7clxz49r6ki0chyphsxv1cnixmy";
+        packages3d.rev =	"e54b5b6368d03f396098448bcce37f2e432dac33";
+        packages3d.sha256 =	"0nzi7ijfb3rjm98kaa9va2mkh0nfzpq4vfhxkq8j18qhx24h5c8v";
       };
     };
   };

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -25,23 +25,23 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2023-02-14";
+      version =			"2023-03-29";
       src = {
-        rev =			"29c4482bc898f627cebcd5f64e063e8a813a5445";
-        sha256 =		"1hs1p79skmrn2k7qrpnkynzkk2g8ry20lqivzfqg87c56rd1522y";
+        rev =			"d5bc223ff2cd1fbf4e923e23b5bb442bb54faa95";
+        sha256 =		"0pbzmv9vh4bzhsxj46gjkgh7kk6a0v8gijvkmb56fy5i8xv2ixkn";
       };
     };
     libVersion = {
-      version =			"2023-02-14";
+      version =			"2023-03-29";
       libSources = {
-        symbols.rev =		"3ad8b98287ddf528ce8ff07bbe70aed85cb4410a";
-        symbols.sha256 =	"1p0wa3bhw2qgdvb5vzwvrbhkb6sqpc93d754rbcs2xh79d75l9nn";
+        symbols.rev =		"36fc1c88921bf32ebf667e027dfe63cca649fd95";
+        symbols.sha256 =	"177mqvjf3knldnl7pf1abv4pmlgi5cg02ggfwbc655jq4x6x8fkz";
         templates.rev =		"867eef383a0f61015cb69677d5c632d78a2ea01a";
         templates.sha256 =	"1qi20mrsfn4fxmr1fyphmil2i9p2nzmwk5rlfchc5aq2194nj3lq";
-        footprints.rev =	"a168dd18ea63c2df948c2de3026dc19730cb70cf";
-        footprints.sha256 =	"0y3cl9fcyi8z4yrn0kfgfy28gn9ngrdvnpgbpwykbbp8fpx401nk";
-        packages3d.rev =	"a0919e5e805157bccd65af313806de3833c1673e";
-        packages3d.sha256 =	"1yizw9g3skz7i9x9iwbnn3gk3lnh10krf6xg32plb2plxfynz3cw";
+        footprints.rev =	"dc4574eb65136d95a7775d09412d5159f8d7832c";
+        footprints.sha256 =	"1iz4wyiysdii378c3pjgkgwh1cssxbh5jkbhvj7rmi2vmgngl6nc";
+        packages3d.rev =	"e54b5b6368d03f396098448bcce37f2e432dac33";
+        packages3d.sha256 =	"0nzi7ijfb3rjm98kaa9va2mkh0nfzpq4vfhxkq8j18qhx24h5c8v";
       };
     };
   };


### PR DESCRIPTION
kicad: 7.0.0 -> 7.0.1
kicad-unstable: 2023-02-14 -> 2023-03-29

with a bunch of cleanup and fixes
(most notably, a kicad-unstable build and ngspice tests fixes)
the removal of the pointless package option `withOCC`
and the addition of `requests` as a runtime dependency of some vendored plugins

###### Description of changes

https://www.kicad.org/blog/2023/03/KiCad-7.0.1-Release/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).