### PR TITLE
nixos: public evalSystemConfiguration interface

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -4,9 +4,11 @@
 
 let
 
-  eval = import ./lib/eval-config.nix {
-    inherit system;
-    modules = [ configuration ];
+  eval = (import ./lib {}).evalSystemConfiguration {
+    modules = [
+      { nixpkgs = {inherit system;}; }
+      configuration
+    ];
   };
 
 in

--- a/nixos/doc/manual/development/lib-modules-eval.section.md
+++ b/nixos/doc/manual/development/lib-modules-eval.section.md
@@ -1,0 +1,33 @@
+# Modules Evalutation {#sec-modules-evaluation}
+
+To evaluate a user's configuration on top of all of NixOS' `baseModules`,
+the [`nixos/lib/default.nix`][nixos-lib-default] file exposes the public
+`evalSystemConfiguration` function.
+
+`evalSystemConfiguration` is implemented in [`nixos/lib/eval-config-system.nix`]
+and it is the official entrypoint for evaluating a standard NixOS system configuration.
+
+All user configuration or additional module implementations is passed as modules
+to its `modules` parameter or is imported via `imports` inside these modules.
+
+Things that should be made available for `imports` can't be, themselves, provisioned
+via modules. Inside the module evaluation, resolving `imports` is a preprocessing
+step that happens prior to the evaluation. That means at the time of `imports`
+resolution, module system values are not yet available.
+
+To solve this chicken-and-egg problem, a special parameter, `specialArgs` can
+be passed to `evalSystemConfiguration` exclusively to pass items to modules
+that should be made available for `imports`.
+
+These `specialArgs` can be destructured in the same way as `config._module.args`.
+However, unless the ability to `imports` is explicitly desired,
+`config._module.args`, which can be defined in any regular module, should be
+always preferred.
+
+`evalSystemConfiguration` returns an attribute set that represents the final
+system configuration. Thanks to the system configuration contained in `baseModules`,
+the package that represents the final system's root filesystem can be found at
+`config.system.build.toplevel`.
+
+[nixos-lib-default]: https://github.com/NixOS/nixpkgs/tree/master/nixos/lib/default.nix
+[nixos-lib-eval-config-system]: https://github.com/NixOS/nixpkgs/tree/master/nixos/lib/eval-config-system.nix

--- a/nixos/doc/manual/development/lib-tests-eval.section.md
+++ b/nixos/doc/manual/development/lib-tests-eval.section.md
@@ -1,0 +1,1 @@
+# Tests Evalutation {#sec-tests-evaluation}

--- a/nixos/doc/manual/development/source-layout.chapter.md
+++ b/nixos/doc/manual/development/source-layout.chapter.md
@@ -1,0 +1,33 @@
+# Source Layout {#sec-source-layout}
+
+NixOS has a modular system for declarative configuration. This system
+evluates multiple *modules* to produce the full system configuration.
+
+A standard set of modules in the [`nixos/modules`][nixos-modules-dir]
+subdirectory of the Nixpkgs tree implements the default NixOS distribution.
+
+These modules are called `baseModules` and the entire set is specified
+in the [`nixos/modules/modules-list.nix`][modules-list-file] file.
+
+Their tests, in turn, live in the [`nixos/tests`][nixos-tests-dir] subdirectory
+of the Nixpkgs tree.
+
+Furthermore, a library implements shared functionality for the use with NixOS.
+This NixOS-specific library of Nix code lives in the [`nixos/lib`][nixos-lib-dir]
+of the Nixpkgs tree.
+
+Its two main domains are module and test evaluation. These are described in
+further detail in the below sections. In addition, the library implements a
+series of helper functions that can be used in modules or tests throughout
+the [`nixos`][nixos-dir] subdirectory of the Nixpkgs tree, but they aren't a
+public interface of the library.
+
+[nixos-dir]: https://github.com/NixOS/nixpkgs/tree/master/nixos
+[nixos-modules-dir]: https://github.com/NixOS/nixpkgs/tree/master/nixos/modules
+[modules-list-file]: https://github.com/NixOS/nixpkgs/tree/master/nixos/modules/modules-list.nix
+[nixos-lib-dir]: https://github.com/NixOS/nixpkgs/tree/master/nixos/lib
+[nixos-tests-dir]: https://github.com/NixOS/nixpkgs/tree/master/nixos/tests
+
+```{=include=} sections
+lib-modules-eval.section.md
+```

--- a/nixos/doc/manual/development/source-layout.chapter.md
+++ b/nixos/doc/manual/development/source-layout.chapter.md
@@ -30,4 +30,5 @@ public interface of the library.
 
 ```{=include=} sections
 lib-modules-eval.section.md
+lib-tests-eval.section.md
 ```

--- a/nixos/doc/manual/development/writing-modules.chapter.md
+++ b/nixos/doc/manual/development/writing-modules.chapter.md
@@ -1,11 +1,7 @@
 # Writing NixOS Modules {#sec-writing-modules}
 
-NixOS has a modular system for declarative configuration. This system
-combines multiple *modules* to produce the full system configuration.
 One of the modules that constitute the configuration is
-`/etc/nixos/configuration.nix`. Most of the others live in the
-[`nixos/modules`](https://github.com/NixOS/nixpkgs/tree/master/nixos/modules)
-subdirectory of the Nixpkgs tree.
+`/etc/nixos/configuration.nix`.
 
 Each NixOS module is a file that handles one logical aspect of the
 configuration, such as a specific kind of hardware, a service, or

--- a/nixos/lib/default.nix
+++ b/nixos/lib/default.nix
@@ -21,6 +21,7 @@ let
   seqAttrsIf = cond: a: lib.mapAttrs (_: v: seqIf cond a v);
 
   eval-config-minimal = import ./eval-config-minimal.nix { inherit lib; };
+  eval-config-system = import ./eval-config-system.nix { inherit lib; };
 
   testing-lib = import ./testing/default.nix { inherit lib; };
 in
@@ -29,8 +30,18 @@ in
   using a binding like `nixosLib = import (nixpkgs + "/nixos/lib") { }`.
 */
 {
+
+  # experimental
+
   inherit (seqAttrsIf (!featureFlags?minimalModules) minimalModulesWarning eval-config-minimal)
     evalModules
+    ;
+
+  # not experimental
+
+  inherit (eval-config-system)
+    evalSystemConfiguration
+    baseModules
     ;
 
   inherit (testing-lib)

--- a/nixos/lib/eval-config-system.nix
+++ b/nixos/lib/eval-config-system.nix
@@ -1,0 +1,56 @@
+# DO NOT IMPORT. Use nixpkgsFlake.lib.nixos, or import (nixpkgs + "/nixos/lib")
+{ lib }: # read -^
+
+let
+
+  # Base: Use the miminal module evaluation
+  evalModulesMinimal = (import ./default.nix {
+    inherit lib;
+    # Implicit use of feature is noted in implementation.
+    featureFlags.minimalModules = { };
+  }).evalModules;
+
+  baseModules = import ../modules/module-list.nix;
+
+  # See nixos/doc/manual/development/lib-modules-eval.section.md
+  # or https://nixos.org/manual/nixos/unstable/index.html#sec-modules-evaluation
+  # NOTE: We keep this interface simple, because almost everything can and should be done through `modules`!
+  evalSystemConfiguration = args@{ prefix ? [], modules ? [], specialArgs ? {} }: let
+
+    # Locate Modules: Ensure custom modules are located to guarantee a better user experience.
+    #                 Non-located modules are inline modules and ones imported from value instead
+    #                 of a file reference from which the importer could infer the location.
+    #                 For example when idiomatically consuming a public interface via
+    #                 `flake.nixosModules.my-module` instead of a private one via - say -
+    #                 `(flake + /modules/my-module.nix)`.
+    # Note: `setDefaultModuleLocation` only sets a location, if not set. So if you want to configure
+    #       this yourself, just ensure that all modules in the `modules` list already have one set.
+    modulesLocation = (builtins.unsafeGetAttrPos "modules" args).file or null;
+    locatedModules = if modulesLocation == null then modules
+      else map (lib.setDefaultModuleLocation modulesLocation) modules;
+
+    # `noUserModules` is a contract consumed by
+    # modules/system/activation/specialisation.nix
+    # TODO (during review): critically revise & discuss! (and then remove this line :-)
+    noUserModules = standardModules;
+
+    # Standard Modules: Gather standard modules that are always part of a standard
+    #                   configuration and place them into extra arguments so that
+    #                   a configuration can reproduce a variant of itself inside
+    #                   the module system.
+    standardModules = let
+      # Extra arguments that are useful for constructing a similar configuration.
+      modulesModule = {
+        config._module.args = { modules = locatedModules; inherit baseModules noUserModules; };
+      };
+    in evalModulesMinimal {
+      inherit prefix specialArgs;
+      modules = baseModules ++ [modulesModule];
+    };
+
+  in standardModules.extendModules { modules = locatedModules; };
+
+in
+{
+  inherit evalSystemConfiguration baseModules;
+}

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -19,7 +19,7 @@ evalConfigArgs@
 , # !!! what do we gain by making this configurable?
   #     we can add modules that are included in specialisations, regardless
   #     of inheritParentConfig.
-  baseModules ? import ../modules/module-list.nix
+  baseModules ? (import ./default.nix { inherit lib; }).baseModules
 , # !!! See comment about args in lib/modules.nix
   extraArgs ? {}
 , # !!! See comment about args in lib/modules.nix

--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -2,14 +2,14 @@
 
    Minimal example:
 
-    { pkgs,  }:
+    { pkgs, lib }:
 
     let
-      eval = import (pkgs.path + "/nixos/lib/eval-config.nix") {
-        baseModules = [
-          ../module.nix
+      # TODO (during review): shouldn't this be the minimal eval?!?
+      eval = (import (pkgs.path + "/nixos/lib") {}).evalSystemConfiguration {
+        modules = [
+          { _modules.args.baseModules = lib.mkForce [ ../module.nix ];
         ];
-        modules = [];
       };
     in pkgs.nixosOptionsDoc {
       options = eval.options;

--- a/nixos/maintainers/option-usages.nix
+++ b/nixos/maintainers/option-usages.nix
@@ -43,12 +43,13 @@
 # tested option result.
 
 with import ../../lib;
+with import ../lib {};
 
 let
 
   evalFun = {
     specialArgs ? {}
-  }: import ../lib/eval-config.nix {
+  }: evalSystemConfiguration {
        modules = [ configuration ];
        inherit specialArgs;
      };

--- a/nixos/maintainers/scripts/azure-new/examples/basic/image.nix
+++ b/nixos/maintainers/scripts/azure-new/examples/basic/image.nix
@@ -1,8 +1,8 @@
 let
   pkgs = (import ../../../../../../default.nix {});
-  machine = import (pkgs.path + "/nixos/lib/eval-config.nix") {
-    system = "x86_64-linux";
+  machine = (import (pkgs.path + "/nixos/lib") {}).evalSystemConfiguration {
     modules = [
+      { nixpkgs.system = "x86_64-linux"; }
       ({config, ...}: { imports = [ ./system.nix ]; })
     ];
   };

--- a/nixos/maintainers/scripts/gce/create-gce.sh
+++ b/nixos/maintainers/scripts/gce/create-gce.sh
@@ -7,9 +7,9 @@ BUCKET_NAME="${BUCKET_NAME:-nixos-cloud-images}"
 TIMESTAMP="$(date +%Y%m%d%H%M)"
 export TIMESTAMP
 
-nix-build '<nixpkgs/nixos/lib/eval-config.nix>' \
+nix-build '<nixpkgs/nixos>' \
    -A config.system.build.googleComputeImage \
-   --arg modules "[ <nixpkgs/nixos/modules/virtualisation/google-compute-image.nix> ]" \
+   --arg configuration "<nixpkgs/nixos/modules/virtualisation/google-compute-image.nix>" \
    --argstr system x86_64-linux \
    -o gce \
    -j 10

--- a/nixos/modules/misc/documentation/test.nix
+++ b/nixos/modules/misc/documentation/test.nix
@@ -1,7 +1,7 @@
-{ nixosLib, pkgsModule, runCommand }:
+{ evalModules, pkgsModule, runCommand }:
 
 let
-  sys = nixosLib.evalModules rec {
+  sys = evalModules rec {
     modules = [
       pkgsModule
       ../documentation.nix

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -482,7 +482,6 @@ in
               '';
               type = lib.mkOptionType {
                 name = "Toplevel NixOS config";
-                # TODO (during review): clarify whether `lib` be extended with nixos-lib - remove this comment
                 merge = loc: defs: ((import "${toString config.nixpkgs}/nixos/lib" {}).evalSystemConfiguration {
                   modules =
                     let

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -482,7 +482,8 @@ in
               '';
               type = lib.mkOptionType {
                 name = "Toplevel NixOS config";
-                merge = loc: defs: (import "${toString config.nixpkgs}/nixos/lib/eval-config.nix" {
+                # TODO (during review): clarify whether `lib` be extended with nixos-lib - remove this comment
+                merge = loc: defs: ((import "${toString config.nixpkgs}/nixos/lib" {}).evalSystemConfiguration {
                   modules =
                     let
                       extraConfig = { options, ... }: {

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -287,9 +287,7 @@ in rec {
     with import ./.. { inherit system; };
 
     hydraJob ((evalSystemConfiguration {
-      modules = makeModules system ./maintainers/scripts/ec2/amazon-image.nix {
-          ({ ... }: { amazonImage.sizeMB = "auto"; })
-      };
+      modules = makeModules system ./maintainers/scripts/ec2/amazon-image.nix ({ ... }: { amazonImage.sizeMB = "auto"; });
     }).config.system.build.amazonImage)
 
   );
@@ -319,11 +317,11 @@ in rec {
   # Ensure that all packages used by the minimal NixOS config end up in the channel.
   dummy = forAllSystems (system: pkgs.runCommand "dummy"
     { toplevel = (evalSystemConfiguration {
-        inherit system;
         modules = singleton ({ ... }:
           { fileSystems."/".device  = mkDefault "/dev/sda1";
             boot.loader.grub.device = mkDefault "/dev/sda";
             system.stateVersion = mkDefault "18.03";
+            nixpkgs = { inherit system; };
           });
       }).config.system.build.toplevel;
       preferLocalBuild = true;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -44,13 +44,10 @@ let
   nixosLib = import ../lib {};
 
   inherit
-    (nixosLibExperimental)
-    evalModules;
-  inherit
     (nixosLib)
     evalSystemConfiguration;
 
-  evalMinimalConfig = module: evalModules { modules = [ module ]; };
+  evalMinimalConfig = module: nixosLibExperimental.evalModules { modules = [ module ]; };
 
   inherit
     (rec {
@@ -192,7 +189,7 @@ in {
   docker-tools-cross = handleTestOn ["x86_64-linux" "aarch64-linux"] ./docker-tools-cross.nix {};
   docker-tools-overlay = handleTestOn ["x86_64-linux"] ./docker-tools-overlay.nix {};
   documize = handleTest ./documize.nix {};
-  documentation = pkgs.callPackage ../modules/misc/documentation/test.nix { inherit evalModules; };
+  documentation = pkgs.callPackage ../modules/misc/documentation/test.nix { inherit (nixosLibExperimental) evalModules; };
   doh-proxy-rust = handleTest ./doh-proxy-rust.nix {};
   dokuwiki = handleTest ./dokuwiki.nix {};
   dolibarr = handleTest ./dolibarr.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -36,12 +36,21 @@ let
     if elem system systems then handleTest path args
     else {};
 
-  nixosLib = import ../lib {
+  nixosLibExperimental = import ../lib {
     # Experimental features need testing too, but there's no point in warning
     # about it, so we enable the feature flag.
     featureFlags.minimalModules = {};
   };
-  evalMinimalConfig = module: nixosLib.evalModules { modules = [ module ]; };
+  nixosLib = import ../lib {};
+
+  inherit
+    (nixosLibExperimental)
+    evalModules;
+  inherit
+    (nixosLib)
+    evalSystemConfiguration;
+
+  evalMinimalConfig = module: evalModules { modules = [ module ]; };
 
   inherit
     (rec {
@@ -99,7 +108,7 @@ in {
   bittorrent = handleTest ./bittorrent.nix {};
   blockbook-frontend = handleTest ./blockbook-frontend.nix {};
   blocky = handleTest ./blocky.nix {};
-  boot = handleTestOn ["x86_64-linux" "aarch64-linux"] ./boot.nix {};
+  boot = handleTestOn ["x86_64-linux" "aarch64-linux"] ./boot.nix { inherit evalSystemConfiguration; };
   bootspec = handleTestOn ["x86_64-linux"] ./bootspec.nix {};
   boot-stage1 = handleTest ./boot-stage1.nix {};
   borgbackup = handleTest ./borgbackup.nix {};
@@ -147,7 +156,7 @@ in {
   containers-ephemeral = handleTest ./containers-ephemeral.nix {};
   containers-extra_veth = handleTest ./containers-extra_veth.nix {};
   containers-hosts = handleTest ./containers-hosts.nix {};
-  containers-imperative = handleTest ./containers-imperative.nix {};
+  containers-imperative = handleTest ./containers-imperative.nix { inherit evalSystemConfiguration; };
   containers-ip = handleTest ./containers-ip.nix {};
   containers-macvlans = handleTest ./containers-macvlans.nix {};
   containers-names = handleTest ./containers-names.nix {};
@@ -183,7 +192,7 @@ in {
   docker-tools-cross = handleTestOn ["x86_64-linux" "aarch64-linux"] ./docker-tools-cross.nix {};
   docker-tools-overlay = handleTestOn ["x86_64-linux"] ./docker-tools-overlay.nix {};
   documize = handleTest ./documize.nix {};
-  documentation = pkgs.callPackage ../modules/misc/documentation/test.nix { inherit nixosLib; };
+  documentation = pkgs.callPackage ../modules/misc/documentation/test.nix { inherit evalModules; };
   doh-proxy-rust = handleTest ./doh-proxy-rust.nix {};
   dokuwiki = handleTest ./dokuwiki.nix {};
   dolibarr = handleTest ./dolibarr.nix {};
@@ -191,8 +200,8 @@ in {
   dovecot = handleTest ./dovecot.nix {};
   drbd = handleTest ./drbd.nix {};
   earlyoom = handleTestOn ["x86_64-linux"] ./earlyoom.nix {};
-  ec2-config = (handleTestOn ["x86_64-linux"] ./ec2.nix {}).boot-ec2-config or {};
-  ec2-nixops = (handleTestOn ["x86_64-linux"] ./ec2.nix {}).boot-ec2-nixops or {};
+  ec2-config = (handleTestOn ["x86_64-linux"] ./ec2.nix { inherit evalSystemConfiguration; }).boot-ec2-config or {};
+  ec2-nixops = (handleTestOn ["x86_64-linux"] ./ec2.nix { inherit evalSystemConfiguration; }).boot-ec2-nixops or {};
   ecryptfs = handleTest ./ecryptfs.nix {};
   fscrypt = handleTest ./fscrypt.nix {};
   ejabberd = handleTest ./xmpp/ejabberd.nix {};
@@ -290,8 +299,8 @@ in {
   # 9pnet_virtio used to mount /nix partition doesn't support
   # hibernation. This test happens to work on x86_64-linux but
   # not on other platforms.
-  hibernate = handleTestOn ["x86_64-linux"] ./hibernate.nix {};
-  hibernate-systemd-stage-1 = handleTestOn ["x86_64-linux"] ./hibernate.nix { systemdStage1 = true; };
+  hibernate = handleTestOn ["x86_64-linux"] ./hibernate.nix { inherit evalSystemConfiguration; };
+  hibernate-systemd-stage-1 = handleTestOn ["x86_64-linux"] ./hibernate.nix { systemdStage1 = true; inherit evalSystemConfiguration; };
   hitch = handleTest ./hitch {};
   hledger-web = handleTest ./hledger-web.nix {};
   hocker-fetchdocker = handleTest ./hocker-fetchdocker {};
@@ -500,11 +509,11 @@ in {
   opensmtpd-rspamd = handleTest ./opensmtpd-rspamd.nix {};
   openssh = handleTest ./openssh.nix {};
   octoprint = handleTest ./octoprint.nix {};
-  openstack-image-metadata = (handleTestOn ["x86_64-linux"] ./openstack-image.nix {}).metadata or {};
-  openstack-image-userdata = (handleTestOn ["x86_64-linux"] ./openstack-image.nix {}).userdata or {};
+  openstack-image-metadata = (handleTestOn ["x86_64-linux"] ./openstack-image.nix {inherit evalSystemConfiguration;}).metadata or {};
+  openstack-image-userdata = (handleTestOn ["x86_64-linux"] ./openstack-image.nix {inherit evalSystemConfiguration;}).userdata or {};
   opentabletdriver = handleTest ./opentabletdriver.nix {};
   owncast = handleTest ./owncast.nix {};
-  image-contents = handleTest ./image-contents.nix {};
+  image-contents = handleTest ./image-contents.nix { inherit evalSystemConfiguration; };
   orangefs = handleTest ./orangefs.nix {};
   os-prober = handleTestOn ["x86_64-linux"] ./os-prober.nix {};
   osrm-backend = handleTest ./osrm-backend.nix {};
@@ -621,7 +630,7 @@ in {
   solanum = handleTest ./solanum.nix {};
   solr = handleTest ./solr.nix {};
   sonarr = handleTest ./sonarr.nix {};
-  sourcehut = handleTest ./sourcehut.nix {};
+  sourcehut = handleTest ./sourcehut.nix { inherit evalSystemConfiguration; };
   spacecookie = handleTest ./spacecookie.nix {};
   spark = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./spark {};
   sqlite3-to-mysql = handleTest ./sqlite3-to-mysql.nix {};
@@ -663,7 +672,7 @@ in {
   systemd-initrd-swraid = handleTest ./systemd-initrd-swraid.nix {};
   systemd-initrd-vconsole = handleTest ./systemd-initrd-vconsole.nix {};
   systemd-journal = handleTest ./systemd-journal.nix {};
-  systemd-machinectl = handleTest ./systemd-machinectl.nix {};
+  systemd-machinectl = handleTest ./systemd-machinectl.nix { inherit evalSystemConfiguration; };
   systemd-networkd = handleTest ./systemd-networkd.nix {};
   systemd-networkd-dhcpserver = handleTest ./systemd-networkd-dhcpserver.nix {};
   systemd-networkd-dhcpserver-static-leases = handleTest ./systemd-networkd-dhcpserver-static-leases.nix {};
@@ -735,7 +744,7 @@ in {
   vengi-tools = handleTest ./vengi-tools.nix {};
   victoriametrics = handleTest ./victoriametrics.nix {};
   vikunja = handleTest ./vikunja.nix {};
-  virtualbox = handleTestOn ["x86_64-linux"] ./virtualbox.nix {};
+  virtualbox = handleTestOn ["x86_64-linux"] ./virtualbox.nix { inherit evalSystemConfiguration; };
   vscodium = discoverTests (import ./vscodium.nix);
   vsftpd = handleTest ./vsftpd.nix {};
   warzone2100 = handleTest ./warzone2100.nix {};

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ pkgs, lib, ... }: {
+import ./make-test-python.nix ({ pkgs, lib, evalSystemConfiguration, ... }: {
   name = "containers-imperative";
   meta = {
     maintainers = with lib.maintainers; [ aristid aszlig eelco kampfschlaefer ];
@@ -17,7 +17,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
       # Make sure we always have all the required dependencies for creating a
       # container available within the VM, because we don't have network access.
       virtualisation.additionalPaths = let
-        emptyContainer = import ../lib/eval-config.nix {
+        emptyContainer = evalSystemConfiguration {
           modules = lib.singleton {
             nixpkgs = { inherit (config.nixpkgs) localSystem; };
 

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  pkgs ? import ../.. { inherit system config; },
+  evalSystemConfiguration ? (import ../lib {}).evalSystemConfiguration
 }:
 
 with import ../lib/testing-python.nix { inherit system pkgs; };
@@ -9,9 +10,9 @@ with pkgs.lib;
 with import common/ec2.nix { inherit makeTest pkgs; };
 
 let
-  imageCfg = (import ../lib/eval-config.nix {
-    inherit system;
+  imageCfg = (evalSystemConfiguration {
     modules = [
+      { nixpkgs = { inherit system; }; }
       ../maintainers/scripts/ec2/amazon-image.nix
       ../modules/testing/test-instrumentation.nix
       ../modules/profiles/qemu-guest.nix

--- a/nixos/tests/hibernate.nix
+++ b/nixos/tests/hibernate.nix
@@ -3,6 +3,7 @@
 { system ? builtins.currentSystem
 , config ? {}
 , pkgs ? import ../.. { inherit system config; }
+, evalSystemConfiguration ? (import ../lib {}).evalSystemConfiguration
 , systemdStage1 ? false
 }:
 
@@ -37,9 +38,11 @@ let
       emergencyAccess = true;
     };
   };
-  installedSystem = (import ../lib/eval-config.nix {
-    inherit system;
-    modules = [ installedConfig ];
+  installedSystem = (evalSystemConfiguration {
+    modules = [
+      { nixpkgs = { inherit system; }; }
+      installedConfig
+    ];
   }).config.system.build.toplevel;
 in makeTest {
   name = "hibernate";

--- a/nixos/tests/image-contents.nix
+++ b/nixos/tests/image-contents.nix
@@ -2,6 +2,7 @@
 # including its user, group, and mode attributes.
 { system ? builtins.currentSystem,
   config ? {},
+  evalSystemConfiguration ? (import ../lib {}).evalSystemConfiguration,
   pkgs ? import ../.. { inherit system config; }
 }:
 
@@ -11,9 +12,9 @@ with pkgs.lib;
 with import common/ec2.nix { inherit makeTest pkgs; };
 
 let
-  config = (import ../lib/eval-config.nix {
-    inherit system;
+  config = (evalSystemConfiguration {
     modules = [
+      { nixpkgs = { inherit system; }; }
       ../modules/testing/test-instrumentation.nix
       ../modules/profiles/qemu-guest.nix
       {

--- a/nixos/tests/openstack-image.nix
+++ b/nixos/tests/openstack-image.nix
@@ -1,6 +1,7 @@
 { system ? builtins.currentSystem,
   config ? {},
-  pkgs ? import ../.. { inherit system config; }
+  pkgs ? import ../.. { inherit system config; },
+  evalSystemConfiguration ? (import ../lib {}).evalSystemConfiguration
 }:
 
 with import ../lib/testing-python.nix { inherit system pkgs; };
@@ -9,12 +10,12 @@ with pkgs.lib;
 with import common/ec2.nix { inherit makeTest pkgs; };
 
 let
-  image = (import ../lib/eval-config.nix {
-    inherit system;
+  image = (evalSystemConfiguration {
     modules = [
       ../maintainers/scripts/openstack/openstack-image.nix
       ../modules/testing/test-instrumentation.nix
       ../modules/profiles/qemu-guest.nix
+      { nixpkgs = { inherit system; }; }
       {
         # Needed by nixos-rebuild due to lack of network access.
         system.extraDependencies = with pkgs; [

--- a/nixos/tests/sourcehut.nix
+++ b/nixos/tests/sourcehut.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ pkgs, lib, ... }:
+import ./make-test-python.nix ({ pkgs, lib, evalSystemConfiguration, ... }:
 let
   domain = "sourcehut.localdomain";
 
@@ -91,9 +91,14 @@ let
             timeout = 0;
           };
         };
-        config = (import (pkgs.path + "/nixos/lib/eval-config.nix") {
-          inherit pkgs; modules = [ qemuConfig ];
-          system = "x86_64-linux";
+        config = (evalSystemConfiguration {
+          modules = [
+            {
+              _module.args = { inherit pkgs; };
+              nixpkgs.system = "x86_64-linux";
+            }
+            qemuConfig
+          ];
         }).config;
       in
       import (pkgs.path + "/nixos/lib/make-disk-image.nix") {

--- a/nixos/tests/systemd-machinectl.nix
+++ b/nixos/tests/systemd-machinectl.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ pkgs, ... }:
+import ./make-test-python.nix ({ pkgs, evalSystemConfiguration, ... }:
   let
 
     container = {
@@ -17,9 +17,11 @@ import ./make-test-python.nix ({ pkgs, ... }:
       imports = [ ../modules/profiles/minimal.nix ];
     };
 
-    containerSystem = (import ../lib/eval-config.nix {
-      inherit (pkgs) system;
-      modules = [ container ];
+    containerSystem = (evalSystemConfiguration {
+      modules = [
+        { nixpkgs = { inherit (pkgs) system; }; }
+        container
+      ];
     }).config.system.build.toplevel;
 
     containerName = "container";

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -3,7 +3,8 @@
   pkgs ? import ../.. { inherit system config; },
   debug ? false,
   enableUnfree ? false,
-  use64bitGuest ? true
+  use64bitGuest ? true,
+  evalSystemConfiguration ? (import ../lib {}).evalSystemConfiguration
 }:
 
 with import ../lib/testing-python.nix { inherit system pkgs; };
@@ -94,9 +95,9 @@ let
   in if debug then "machine.execute(ru('${logcmd} & disown'))" else "pass";
 
   testVM = vmName: vmScript: let
-    cfg = (import ../lib/eval-config.nix {
-      system = if use64bitGuest then "x86_64-linux" else "i686-linux";
+    cfg = (evalSystemConfiguration {
       modules = [
+        { nixpkgs = if use64bitGuest then "x86_64-linux" else "i686-linux"; }
         ../modules/profiles/minimal.nix
         (testVMConfig vmName vmScript)
       ];


### PR DESCRIPTION
###### Description of changes

Problem: NixOS has no public-and-documented entrypoint for Nix expressions to evaluate a NixOS configuration.

Many a user has been confused by the eval-config.nix implementation.

To give just one example among many: What happens if I set pkgs  there? I also can set it self-contained in the module system. What's the difference?

This PR creates a documented & public `lib.nixos.evalSystemConfiguration` interface.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
