### PR TITLE
nixos/bind: Support defining the zone file using nix expressions

### DIFF
--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -12,6 +12,68 @@ let
 
   bindZoneCoerce = list: builtins.listToAttrs (lib.forEach list (zone: { name = zone.name; value = zone; }));
 
+  makeSOARecord = soa: ''
+@ ${toString soa.ttl} SOA  ${soa.nameserver} (
+                      ${soa.admin}
+                      ${toString soa.serial}
+                      ${toString soa.refresh}
+                      ${toString soa.retry}
+                      ${toString soa.expire}
+                      ${toString soa.ttl})'';
+
+  identity = _: value: value;
+
+  makeGenericRecord = name: value: "${name} ${toString value.ttl} ${value.type} ${value.value}";
+  makeGenericRecords = transformation: records:
+      concatStringsSep "\n" (mapAttrsToList makeGenericRecord (mapAttrs transformation records));
+
+  makeNSRecords = records:
+    let
+      transformNS = _: value: value // { type = "NS"; };
+    in
+      makeGenericRecords transformNS records;
+  makeMXRecords = records:
+    let
+      transformMX = _: record: record // {
+        type = "MX";
+        value = "${toString record.priority} ${record.value}";
+      };
+    in
+      makeGenericRecords transformMX records;
+
+
+  makeZoneFile = name: records: pkgs.writeTextFile {
+    name = "${name}.zone";
+    text = ''$ORIGIN ${name}.
+${makeSOARecord records.SOA}
+${makeNSRecords records.NS}
+${makeGenericRecords identity records.A}
+${makeGenericRecords identity records.AAAA}
+${makeGenericRecords identity records.CNAME}
+${makeGenericRecords identity records.TXT}
+${makeMXRecords records.MX}
+      '';
+  };
+
+  defaultDNSRecord = type: ttl: types.submodule {
+    options = {
+      type = mkOption {
+        type = types.str;
+        default = type;
+        description = lib.mdDoc "Type of this DNS record";
+      };
+      ttl = mkOption {
+        type = types.int;
+        default = ttl;
+        description = lib.mdDoc "TTL for this record";
+      };
+      value = mkOption {
+        type = types.str;
+        description = lib.mdDoc "value of this record";
+      };
+    };
+  };
+
   bindZoneOptions = { name, config, ... }: {
     options = {
       name = mkOption {
@@ -25,7 +87,142 @@ let
       };
       file = mkOption {
         type = types.either types.str types.path;
+        default = makeZoneFile name config.records;
+        defaultText = "Generated from records";
         description = lib.mdDoc "Zone file resource records contain columns of data, separated by whitespace, that define the record.";
+      };
+      records = mkOption {
+        description = lib.mdDoc "Record entries for this zone";
+        default = {};
+        type = types.submodule {
+          options = {
+            ttl = mkOption {
+              type = types.int;
+              default = 60;
+              description = lib.mdDoc "Default TTL for records in this zone";
+            };
+            SOA = mkOption {
+              description = lib.mdDoc "SOA record entry";
+              type = types.submodule {
+                options = {
+                  nameserver = mkOption {
+                    type = types.str;
+                    description = lib.mdDoc "Default nameserver for this SOA record";
+                  };
+                  admin = mkOption {
+                    type = types.str;
+                    description = lib.mdDoc "Admin address for the zone";
+                  };
+                  serial = mkOption {
+                    type = types.int;
+                    description = lib.mdDoc "Serial number for the zone";
+                  };
+                  refresh = mkOption {
+                    type = types.int;
+                    description = lib.mdDoc "Length of time before secondary servers should pull new SOA record";
+                  };
+                  retry = mkOption {
+                    type = types.int;
+                    description = lib.mdDoc "Length of time before asking for an update if server is unresponsive";
+                  };
+                  expire = mkOption {
+                    type = types.int;
+                    description = lib.mdDoc "Length of time before secondary servers should stop polling an unresponsive server";
+                  };
+                  ttl = mkOption {
+                    type = types.int;
+                    default = config.records.ttl;
+                    description = lib.mdDoc "TTL for the SOA record";
+                  };
+                };
+              };
+            };
+            NS = mkOption {
+              description = lib.mdDoc "NS record entries";
+              default = {};
+              example = {
+                "foo" = {
+                  ttl = 60;
+                  value  = "ns1.example.com.";
+                };
+              };
+              type = types.attrsOf (defaultDNSRecord "NS" config.records.ttl);
+            };
+            A = mkOption {
+              description = lib.mdDoc "A record entries";
+              default = {};
+              example = {
+                "foo" = {
+                  ttl = 60;
+                  value  = "192.0.1.2";
+                };
+              };
+              type = types.attrsOf (defaultDNSRecord "A" config.records.ttl);
+            };
+            AAAA = mkOption {
+              description = lib.mdDoc "AAAA record entries";
+              default = {};
+              example = {
+                "foo" = {
+                  ttl = 60;
+                  value  = "2001:420::2617:de4::d87f:2092";
+                };
+              };
+              type = types.attrsOf (defaultDNSRecord "AAAA" config.records.ttl);
+            };
+            CNAME = mkOption {
+              description = lib.mdDoc "CNAME record entries";
+              default = {};
+              example = {
+                "foo" = {
+                  ttl = 60;
+                  value  = "bar.zone.org";
+                };
+              };
+              type = types.attrsOf (defaultDNSRecord "CNAME" config.records.ttl);
+            };
+            TXT = mkOption {
+              description = lib.mdDoc "TXT record entries";
+              default = {};
+              example = {
+                "foo" = {
+                  ttl = 60;
+                  value  = "Wohooo, a TXT entry in my DNS entries";
+                };
+              };
+              type = types.attrsOf (defaultDNSRecord "TXT" config.records.ttl);
+            };
+            MX = mkOption {
+              description = lib.mdDoc "MX record entries";
+              default = {};
+              example = {
+                "foo" = {
+                  ttl = 60;
+                  value  = "mailhost1.example.com";
+                  priority = 10;
+                };
+              };
+              type = types.attrsOf (types.submodule {
+                options = {
+                  ttl = mkOption {
+                    type = types.int;
+                    default = config.records.ttl;
+                    description = lib.mdDoc "TTL for this DNS entry";
+                  };
+                  value = mkOption {
+                    type = types.str;
+                    description = lib.mdDoc "Value for this MX record";
+                  };
+                  priority = mkOption {
+                    type = types.int;
+                    description = lib.mdDoc "Priority for this MX record";
+                  };
+                };
+              });
+            };
+
+          };
+        };
       };
       masters = mkOption {
         type = types.listOf types.str;
@@ -69,7 +266,7 @@ let
       ${cfg.extraConfig}
 
       ${ concatMapStrings
-          ({ name, file, master ? true, slaves ? [], masters ? [], extraConfig ? "" }:
+          ({ name, file, records, master ? true, slaves ? [], masters ? [], extraConfig ? "" }:
             ''
               zone "${name}" {
                 type ${if master then "master" else "slave"};


### PR DESCRIPTION
This removes the need to manually write a zone file for bind, and it can instead be defined in nix expressions.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
