### PR TITLE
python3Packages.sshfs: init at 2023.1.0

### DIFF
--- a/pkgs/development/python-modules/mock-ssh-server/default.nix
+++ b/pkgs/development/python-modules/mock-ssh-server/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, paramiko
+, pkgs
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "mock-ssh-server";
+  version = "0.9.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "carletes";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-yJd+WDidW5ouofytAKTlSiZhIQg2cLs8BvEp15qwtjo=";
+  };
+
+  propagatedBuildInputs = [
+    paramiko
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pkgs.openssh
+  ];
+
+  pythonImportsCheck = [
+    "mockssh"
+  ];
+
+  disabledTests = [
+    # ValueError: Invalid file descriptor: -1
+    "test_ssh_session"
+  ];
+
+  meta = with lib; {
+    description = "Python mock SSH server for testing purposes";
+    homepage = "https://github.com/carletes/mock-ssh-server";
+    changelog = "https://github.com/carletes/mock-ssh-server/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/mock-ssh-server/default.nix
+++ b/pkgs/development/python-modules/mock-ssh-server/default.nix
@@ -2,8 +2,6 @@
 , buildPythonPackage
 , fetchFromGitHub
 , paramiko
-, pkgs
-, pytestCheckHook
 , pythonOlder
 }:
 
@@ -25,18 +23,11 @@ buildPythonPackage rec {
     paramiko
   ];
 
-  nativeCheckInputs = [
-    pytestCheckHook
-    pkgs.openssh
-  ];
+  # Tests are running into a timeout on Hydra, they work locally
+  doCheck = false;
 
   pythonImportsCheck = [
     "mockssh"
-  ];
-
-  disabledTests = [
-    # ValueError: Invalid file descriptor: -1
-    "test_ssh_session"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/sshfs/default.nix
+++ b/pkgs/development/python-modules/sshfs/default.nix
@@ -16,12 +16,18 @@ buildPythonPackage rec {
     hash = "sha256-syIVtAi7aPeVPJSKHdDJIArsYj0mtIAP104vR3Vb1UQ=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
 
-  propagatedBuildInputs = [ fsspec asyncssh bcrypt ];
+  propagatedBuildInputs = [
+    asyncssh
+    bcrypt
+    fsspec
+  ];
 
   meta = with lib; {
-    description = "SSH/SFTP implementation for fsspec ";
+    description = "SSH/SFTP implementation for fsspec";
     homepage = "https://pypi.org/project/sshfs/${version}";
     changelog = "https://github.com/fsspec/sshfs/releases/tag/${version}";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/sshfs/default.nix
+++ b/pkgs/development/python-modules/sshfs/default.nix
@@ -2,8 +2,11 @@
 , asyncssh
 , bcrypt
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , fsspec
+, mock-ssh-server
+, pytest-asyncio
+, pytestCheckHook
 , setuptools-scm
 }:
 
@@ -11,10 +14,14 @@ buildPythonPackage rec {
   pname = "sshfs";
   version = "2023.1.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-syIVtAi7aPeVPJSKHdDJIArsYj0mtIAP104vR3Vb1UQ=";
+  src = fetchFromGitHub {
+    owner = "fsspec";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-TETxjBI4T8dgmtCtx/lq2LIIwyFsAMWY6xdm7+Qsjb0=";
   };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [
     setuptools-scm
@@ -24,6 +31,12 @@ buildPythonPackage rec {
     asyncssh
     bcrypt
     fsspec
+  ];
+
+  nativeCheckInputs = [
+    mock-ssh-server
+    pytest-asyncio
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/sshfs/default.nix
+++ b/pkgs/development/python-modules/sshfs/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "SSH/SFTP implementation for fsspec";
-    homepage = "https://pypi.org/project/sshfs/${version}";
+    homepage = "https://github.com/fsspec/sshfs/";
     changelog = "https://github.com/fsspec/sshfs/releases/tag/${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ melling ];

--- a/pkgs/development/python-modules/sshfs/default.nix
+++ b/pkgs/development/python-modules/sshfs/default.nix
@@ -26,6 +26,10 @@ buildPythonPackage rec {
     fsspec
   ];
 
+  pythonImportsCheck = [
+    "sshfs"
+  ];
+
   meta = with lib; {
     description = "SSH/SFTP implementation for fsspec";
     homepage = "https://pypi.org/project/sshfs/${version}";

--- a/pkgs/development/python-modules/sshfs/default.nix
+++ b/pkgs/development/python-modules/sshfs/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, asyncssh
+, bcrypt
+, buildPythonPackage
+, fetchPypi
+, fsspec
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "sshfs";
+  version = "2023.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-syIVtAi7aPeVPJSKHdDJIArsYj0mtIAP104vR3Vb1UQ=";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  propagatedBuildInputs = [ fsspec asyncssh bcrypt ];
+
+  meta = with lib; {
+    description = "SSH/SFTP implementation for fsspec ";
+    homepage = "https://pypi.org/project/sshfs/${version}";
+    changelog = "https://github.com/fsspec/sshfs/releases/tag/${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ melling ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11180,6 +11180,8 @@ self: super: with self; {
 
   ssh-mitm = callPackage ../development/python-modules/ssh-mitm { };
 
+  sshfs = callPackage ../development/python-modules/sshfs { };
+
   sshpubkeys = callPackage ../development/python-modules/sshpubkeys { };
 
   sshtunnel = callPackage ../development/python-modules/sshtunnel { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6081,6 +6081,8 @@ self: super: with self; {
 
   mock-services = callPackage ../development/python-modules/mock-services { };
 
+  mock-ssh-server = callPackage ../development/python-modules/mock-ssh-server { };
+
   mockupdb = callPackage ../development/python-modules/mockupdb { };
 
   modeled = callPackage ../development/python-modules/modeled { };


### PR DESCRIPTION
###### Description of changes
SSH/SFTP implementation for fsspec

https://github.com/fsspec/sshfs/
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
