### PR TITLE
dspdfviewer: init at 1.15.1

### DIFF
--- a/pkgs/applications/office/dspdfviewer/default.nix
+++ b/pkgs/applications/office/dspdfviewer/default.nix
@@ -1,0 +1,51 @@
+{ stdenv
+, fetchFromGitHub
+, boost
+, libsForQt5
+, qt5
+, cmake
+, pkg-config
+, lib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dspdfviewer";
+  version = "1.15.1";
+
+  src = fetchFromGitHub {
+    owner = "dannyedel";
+    repo = "dspdfviewer";
+    rev = "v${version}";
+    hash = "sha256-NDjbr7kWQP1OkikveLWlGCZzJUF0u1+dnzaeE32MK1g=";
+  };
+
+  cmakeFlags = [
+    "-DDCMAKE_BUILD_TYPE=Release"
+    "-DUsePrerenderedPDF=ON"
+    "-DCMAKE_CXX_FLAGS_INIT=\"-Wno-error=deprecated-declarations\" "
+  ];
+  makeWrapperArgs = [
+    "\${qtWrapperArgs[@]}"
+  ];
+
+  buildInputs = [
+    boost
+    libsForQt5.poppler
+    qt5.qtbase
+    qt5.qttools
+    qt5.wrapQtAppsHook
+  ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = " Dual-Screen PDF Viewer for latex-beamer";
+    homepage = "https://dspdfviewer.danny-edel.de/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ e1mo ];
+    changelog = "https://github.com/dannyedel/dspdfviewer/blob/v${version}/CHANGELOG.md";
+    platforms = [ "x86_64-linux" "aarch64-linux" ]; # Offborg builds fail on aarch64-darwin, x86_64-darwin. I'm unable to test/debug this
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6674,6 +6674,8 @@ with pkgs;
 
   dsp = callPackage ../tools/audio/dsp { };
 
+  dspdfviewer = callPackage ../applications/office/dspdfviewer { };
+
   dirdiff = callPackage ../tools/text/dirdiff {
     tcl = tcl-8_5;
     tk = tk-8_5;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
