### PR TITLE
libreoffice: improve out/share looping in wrapper

### DIFF
--- a/pkgs/applications/office/libreoffice/wrapper.nix
+++ b/pkgs/applications/office/libreoffice/wrapper.nix
@@ -89,12 +89,16 @@ in runCommand "${unwrapped.name}-wrapped" {
 } (''
   mkdir -p "$out/bin"
   mkdir -p "$out/share"
+  for dir in ${unwrapped}/share/*; do
+    dirname="''${dir##*/}"
+    if [[ $dirname == "applications" ]]; then
+      cp -r $dir/ $out/share/
+    else
+      ln -s $dir $out/share/
+    fi
+  done
 
-  ln -s ${unwrapped}/share/icons $out/share/icons
-  ln -s ${unwrapped}/share/templates $out/share/templates
   ln -s ${unwrapped}/lib $out/lib
-
-  cp -r ${unwrapped}/share/applications/ $out/share/
   for f in $out/share/applications/*.desktop; do
     substituteInPlace "$f" \
       --replace "Exec=libreoffice${major}.${minor}" "Exec=soffice"


### PR DESCRIPTION
The copying/linking implemented in #220694 resulted in a higher maintenance burden (need to manually add all new folders in $out/share). The introduced loop will continue linking everything but the .desktop files.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
