### PR TITLE
nixos/lib/testing: allow overriding `virtualisation.test.nodeNumber`

### DIFF
--- a/nixos/lib/testing/network.nix
+++ b/nixos/lib/testing/network.nix
@@ -82,7 +82,12 @@ let
       virtualisation.test.nodeNumber = mkOption {
         internal = true;
         type = types.int;
-        readOnly = true;
+        # Allow overriding the nodeNumber. Useful when having e.g.
+        # two nodes in a test, but only one is booted. After that,
+        # the first node does a switch-to-configuration to the config of the second
+        # node (e.g. `<nixpkgs/nixos/tests/switch-test.nix>`), but you want to have
+        # stable IPs between the switch.
+        # readOnly = true;
         default = nodeNumbers.${config.virtualisation.test.nodeName};
         description = mdDoc ''
           A unique number assigned for each node in `nodes`.


### PR DESCRIPTION
###### Description of changes

Say you have a VM test with two nodes, but only one node is started and eventually switched to the config of the other, i.e.

    nixosTest {
      name = "foobar";
      nodes = {
        node1 = {};
        node2 = {};
      };
      testScript = { nodes, ... }: ''
        node1.start()
        node1.succeed("${nodes.node2.config.system.build.toplevel}/bin/switch-to-configuration test")
      '';
    }

then you'll end up with another IP (i.e. `192.168.1.2` instead of `192.168.1.1` on `node1` in the example above). This can be a problem when writing a test where a node's configuration must be changed while running and the IP must remain stable.

The workaround I ended up with was

    virtualisation.test.nodeNumber = lib.mkForce 1;

However this option is read-only, so currently this breaks with an evaluation error.

Since I haven't found a trivial way to override
`virtualisation.test.nodeNumber` (another module
redefining the option isn't accepted[1]), I figured it's OK to drop the immutability here.

[1] I tried to work around like this:

        let
          hackhack.options.virtualisation.test.nodeNumber = lib.mkOption {
            type = lib.types.int;
            default = 23;
          };
        in nixosTest {
          # ...
          nodes.node1.imports = [ hackhack ];
        }

    But it broke with the following error:

        error: The option `nodes.cfssl.virtualisation.test.nodeNumber' in `makeTest parameters' is already declared in `/home/ma27/Projects/mf-admin/nixpkgs/nixos/lib/testing/network.nix, via option extraBaseModules'.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
