### PR TITLE
gpu-viewer: init at 2.26

### DIFF
--- a/pkgs/applications/misc/gpu-viewer/default.nix
+++ b/pkgs/applications/misc/gpu-viewer/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, fetchFromGitHub
+, pkg-config
+, meson
+, ninja
+, gtk4
+, libadwaita
+, python3Packages
+, gobject-introspection
+, vulkan-tools
+, python3
+, wrapGAppsHook
+, gdk-pixbuf
+, lsb-release
+, glxinfo
+, vdpauinfo
+, clinfo
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "gpu-viewer";
+  version = "2.26";
+
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "arunsivaramanneo";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-3GYJq76g/pU8dt+OMGBeDcw47z5Xv3AGkLsACcBCELs=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    gobject-introspection
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    vulkan-tools
+    gdk-pixbuf
+  ];
+
+  pythonPath = with python3Packages; [
+    pygobject3
+    click
+  ];
+
+  # Prevent double wrapping
+  dontWrapGApps = true;
+
+  postFixup = ''
+    makeWrapper ${python3.interpreter} $out/bin/gpu-viewer \
+      --prefix PATH : "${lib.makeBinPath [ clinfo glxinfo lsb-release vdpauinfo vulkan-tools ]}" \
+      --add-flags "$out/share/gpu-viewer/Files/GPUViewer.py" \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+      --chdir "$out/share/gpu-viewer/Files" \
+      ''${makeWrapperArgs[@]} \
+      ''${gappsWrapperArgs[@]}
+  '';
+
+
+  meta = with lib; {
+    homepage = "https://github.com/arunsivaramanneo/GPU-Viewer";
+    description = "A front-end to glxinfo, vulkaninfo, clinfo and es2_info";
+    maintainers = with maintainers; [ GaetanLepage ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4946,6 +4946,8 @@ with pkgs;
     stdenv = gcc9Stdenv;
   };
 
+  gpu-viewer = callPackage ../applications/misc/gpu-viewer { };
+
   greg = callPackage ../applications/audio/greg {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a try at packaging [GPU-Viewer](https://github.com/arunsivaramanneo/GPU-Viewer).
~~Currently, the package builds, but when running it I get~~
```
Traceback (most recent call last):
  File "/nix/store/0mzyp5sdg8avd2m2n5ss254px4l21mpq-gpu-viewer-2.26/share/gpu-viewer/Files/GPUViewer.py", line 3, in <module>
    import gi
ModuleNotFoundError: No module named 'gi'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
