### PR TITLE
git-ps-rs: init at 6.5.0 

### DIFF
--- a/pkgs/development/tools/git-ps-rs/default.nix
+++ b/pkgs/development/tools/git-ps-rs/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, stdenv
+, pkg-config
+, libgpg-error
+, gpgme
+, dbus
+, openssl
+, Security
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "git-ps-rs";
+  version = "6.5.0";
+
+  src = fetchFromGitHub {
+    owner = "uptech";
+    repo = "git-ps-rs";
+    rev = version;
+    hash = "sha256-4wSm3H+98ZJZ+fZdLYshPKafRkPq98Pv3Lwh9o0be6U=";
+  };
+
+  cargoHash = "sha256-1p46xvo7abMPlVP8BeQ1j/8QQpK3kCgbTL3cdidfq04=";
+
+  nativeBuildInputs = [
+    pkg-config
+    gpgme # gpgme runs a small script at build time so has to go here
+  ];
+
+  buildInputs = [ openssl dbus libgpg-error ]
+    ++ lib.optionals stdenv.isDarwin [ Security ];
+
+  meta = with lib; {
+    description = "Tool for working with a stack of patches";
+    homepage = "https://git-ps.sh/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ alizter ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1900,6 +1900,10 @@ with pkgs;
 
   git-privacy = callPackage ../applications/version-management/git-privacy { };
 
+  git-ps-rs = callPackage ../development/tools/git-ps-rs {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   git-publish = python3Packages.callPackage ../applications/version-management/git-publish { };
 
   git-quick-stats = callPackage ../applications/version-management/git-quick-stats { };


### PR DESCRIPTION
Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: cbcdb8e6-64d3-4181-9f25-90047248efc3 -->

###### Description of changes

Added the git-ps-rs tool:
- https://git-ps.sh/
- https://github.com/uptech/git-ps-rs

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
