### PR TITLE
ocamlPackages.routes: 1.0.0 → 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/routes/default.nix
+++ b/pkgs/development/ocaml-modules/routes/default.nix
@@ -2,14 +2,14 @@
 
 buildDunePackage rec {
   pname = "routes";
-  version = "1.0.0";
+  version = "2.0.0";
 
-  useDune2 = true;
+  duneVersion = "3";
   minimalOCamlVersion = "4.05";
 
   src = fetchurl {
     url = "https://github.com/anuragsoni/routes/releases/download/${version}/routes-${version}.tbz";
-    sha256 = "sha256-WSlASDTA1UX+NhW38/XuLkOkdwjIxz0OUkX6Nd2iROg=";
+    hash = "sha256-O2KdaYwrAOUEwTtM14NUgGNxnc8BWAycP1EEuB6w1og=";
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

https://github.com/anuragsoni/routes/blob/2.0.0/CHANGES.md#200

cc maintainers (@ulrikstrid @anmonteiro).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
