### PR TITLE
Xfce updates

### DIFF
--- a/nixos/tests/xfce.nix
+++ b/nixos/tests/xfce.nix
@@ -26,7 +26,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     };
 
   testScript = { nodes, ... }: let
-    user = nodes.machine.config.users.users.alice;
+    user = nodes.machine.users.users.alice;
   in ''
       machine.wait_for_x()
       machine.wait_for_file("${user.home}/.Xauthority")

--- a/pkgs/desktops/xfce/applications/mousepad/default.nix
+++ b/pkgs/desktops/xfce/applications/mousepad/default.nix
@@ -3,10 +3,10 @@
 mkXfceDerivation {
   category = "apps";
   pname = "mousepad";
-  version = "0.5.10";
+  version = "0.6.0";
   odd-unstable = false;
 
-  sha256 = "sha256-AKyFCzQE6OfMzKh5Lk16W01255vPeco1II80oLqT4oM=";
+  sha256 = "sha256-VmpCjR8/3rsCGkVGhT+IdC6kaQkGz8G2ktFhJk32DeQ=";
 
   nativeBuildInputs = [ gobject-introspection ];
 

--- a/pkgs/desktops/xfce/applications/orage/default.nix
+++ b/pkgs/desktops/xfce/applications/orage/default.nix
@@ -1,44 +1,31 @@
 { lib
 , mkXfceDerivation
-, dbus-glib
 , gtk3
 , libical
 , libnotify
 , libxfce4ui
 , popt
 , tzdata
-, xfce4-panel
-, withPanelPlugin ? true
 }:
 
 mkXfceDerivation {
   category = "apps";
   pname = "orage";
-  version = "4.16.0";
-  odd-unstable = false;
-  sha256 = "sha256-Q2vTjfhbhG7TrkGeU5oVBB+UvrV5QFtl372wgHU4cxw=";
+  version = "4.18.0";
+
+  sha256 = "sha256-vL9zexPbQKPqIzK5UqUIxkE9I7hEupkDOJehMgj2Leo=";
 
   buildInputs = [
-    dbus-glib
     gtk3
     libical
     libnotify
     libxfce4ui
     popt
-  ]
-  ++ lib.optionals withPanelPlugin [
-    xfce4-panel
   ];
 
   postPatch = ''
     substituteInPlace src/parameters.c        --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
     substituteInPlace src/tz_zoneinfo_read.c  --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
-    substituteInPlace tz_convert/tz_convert.c --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
-  '';
-
-  postConfigure = ''
-    # ensure pkgs.libical is used instead of one included in the orage sources
-    rm -rf libical
   '';
 
   meta = with lib; {

--- a/pkgs/desktops/xfce/applications/parole/default.nix
+++ b/pkgs/desktops/xfce/applications/parole/default.nix
@@ -7,9 +7,9 @@
 mkXfceDerivation {
   category = "apps";
   pname = "parole";
-  version = "4.16.0";
+  version = "4.18.0";
 
-  sha256 = "sha256-9Rvhc8asFEb/+OU6uhuHKPl7w5mWBfzGP5ia0tiyDB4=";
+  sha256 = "sha256-TLH9ZUggjclJlbBg3EBVgbcrdiMZ8n+cGDgfNgYNiPI=";
 
   postPatch = ''
     substituteInPlace src/plugins/mpris2/Makefile.am \

--- a/pkgs/desktops/xfce/applications/ristretto/default.nix
+++ b/pkgs/desktops/xfce/applications/ristretto/default.nix
@@ -11,9 +11,10 @@
 mkXfceDerivation {
   category = "apps";
   pname = "ristretto";
-  version = "0.12.4";
+  version = "0.13.0";
+  odd-unstable = false;
 
-  sha256 = "sha256-pspS9zRvDOMz4+Ud43uT4gsDQhB51bwmaXPXcGlOhsY=";
+  sha256 = "sha256-K1cC5NnRv/C5ZiwMAmaQ8qxvlxHRsJ4F1TgR9CN8Qgc=";
 
   buildInputs = [
     glib

--- a/pkgs/desktops/xfce/applications/xfburn/default.nix
+++ b/pkgs/desktops/xfce/applications/xfburn/default.nix
@@ -3,9 +3,10 @@
 mkXfceDerivation {
   category = "apps";
   pname = "xfburn";
-  version = "0.6.2";
+  version = "0.7.0";
+  odd-unstable = false;
 
-  sha256 = "sha256-AUonNhMs2HBF1WBLdZNYmASTOxYt6A6WDKNtvZaGXQk=";
+  sha256 = "sha256-/CuV2tqja5fa2H2mmU9BP6tZHoCZZML5d2LL/CG3rno=";
 
   nativeBuildInputs = [ libxslt docbook_xsl ];
   buildInputs = [ exo gtk3 libburn libisofs libxfce4ui ];

--- a/pkgs/desktops/xfce/applications/xfce4-notifyd/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-notifyd/default.nix
@@ -2,9 +2,11 @@
 , mkXfceDerivation
 , glib
 , gtk3
+, libcanberra-gtk3
 , libnotify
 , libxfce4ui
 , libxfce4util
+, sqlite
 , xfce4-panel
 , xfconf
 }:
@@ -12,16 +14,18 @@
 mkXfceDerivation {
   category = "apps";
   pname = "xfce4-notifyd";
-  version = "0.6.5";
+  version = "0.8.2";
 
-  sha256 = "sha256-NUEqQk9EcDl23twbo+DUt7QYZrPmWpsRzmi5wIdolqw=";
+  sha256 = "sha256-M8L2HWTuQDl/prD7s6uptkW4XDscpk6fc+epoxjFNS8=";
 
   buildInputs = [
     gtk3
     glib
+    libcanberra-gtk3
     libnotify
     libxfce4ui
     libxfce4util
+    sqlite
     xfce4-panel
     xfconf
   ];
@@ -30,6 +34,7 @@ mkXfceDerivation {
 
   configureFlags = [
     "--enable-dbus-start-daemon"
+    "--enable-sound"
   ];
 
   meta = with lib; {

--- a/pkgs/desktops/xfce/core/libxfce4ui/default.nix
+++ b/pkgs/desktops/xfce/core/libxfce4ui/default.nix
@@ -4,16 +4,16 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "libxfce4ui";
-  version = "4.18.1";
+  version = "4.18.2";
 
-  sha256 = "sha256-1kzvFr/WeTl3HpVMJZRBgsvmG8VtYkdEbIQSniJIaHA=";
+  sha256 = "sha256-h9D0boBCCC4txnSRc6VcdNbrm8D21LwE63Q/LsExFNE=";
 
   nativeBuildInputs = [ gobject-introspection vala ];
   buildInputs =  [ gtk3 libstartup_notification libgtop libepoxy xfconf ];
   propagatedBuildInputs = [ libxfce4util libICE libSM ];
 
   configureFlags = [
-    "--with-vendor-info='NixOS'"
+    "--with-vendor-info=NixOS"
   ];
 
   meta = with lib; {

--- a/pkgs/desktops/xfce/core/thunar/default.nix
+++ b/pkgs/desktops/xfce/core/thunar/default.nix
@@ -21,9 +21,9 @@
 let unwrapped = mkXfceDerivation {
   category = "xfce";
   pname = "thunar";
-  version = "4.18.3";
+  version = "4.18.4";
 
-  sha256 = "sha256-sYn1gBzqEFcB3jHWxmoqqv0Cxa3mui/j0kgBqJMgJrc=";
+  sha256 = "sha256-tdk0sWUzTmYXk+dOPVOpjmODpqmhzQc9jAOCk2+yNKM=";
 
   nativeBuildInputs = [
     docbook_xsl

--- a/pkgs/desktops/xfce/core/xfce4-panel/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel/default.nix
@@ -16,9 +16,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "xfce4-panel";
-  version = "4.18.1";
+  version = "4.18.2";
 
-  sha256 = "sha256-5GJO8buOTnRGnm3+kesrZjTprCY1qiyookpW6dzI2AE=";
+  sha256 = "sha256-kqc+5pClmAPEkyNWKj4uPgwFFKBDWrwFHqRDWjYrwa4=";
 
   nativeBuildInputs = [
     gobject-introspection

--- a/pkgs/desktops/xfce/core/xfce4-power-manager/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-power-manager/default.nix
@@ -4,9 +4,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "xfce4-power-manager";
-  version = "4.18.0";
+  version = "4.18.1";
 
-  sha256 = "sha256-vl0SfZyVGxZYnSa2nCnYlqT05Hm7PLzOxgAGzapkKVI=";
+  sha256 = "sha256-H9tu94ZQLLQhXIDtIWL3qZJo/ux2xC2Y9m7uwwey8M8=";
 
   nativeBuildInputs = [ automakeAddFlags exo ];
   buildInputs = [ gtk3 libnotify libxfce4ui libxfce4util upower xfconf xfce4-panel ];

--- a/pkgs/desktops/xfce/core/xfce4-session/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-session/default.nix
@@ -3,9 +3,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "xfce4-session";
-  version = "4.18.0";
+  version = "4.18.1";
 
-  sha256 = "sha256-eSQXVMdwxr/yE806Tly8CLimmJso6k4muuTR7RHPU3U=";
+  sha256 = "sha256-mG+tyQ319fvQpitT6sb46R+8AF+3gxqPHMiGMAaqnSo=";
 
   buildInputs = [ exo gtk3 glib libxfce4ui libxfce4util libwnck xfconf polkit iceauth ];
 

--- a/pkgs/desktops/xfce/core/xfce4-settings/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-settings/default.nix
@@ -16,9 +16,9 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "xfce4-settings";
-  version = "4.18.1";
+  version = "4.18.2";
 
-  sha256 = "sha256-Uy5dObnMV+fpt8RdyFOsYVPN8Dyx1zzOu0pDak01ipQ=";
+  sha256 = "sha256-u8xto4tP9fsaPaY6dzv4Bj/C6qvltT5wXJlV+TzP5uE=";
 
   postPatch = ''
     for f in xfsettingsd/pointers.c dialogs/mouse-settings/main.c; do


### PR DESCRIPTION
###### Description of changes

https://repology.org/projects/?category=xfce&inrepo=nix_unstable&outdated=on

**Note that this PR does NOT address https://github.com/NixOS/nixpkgs/pull/218143#issuecomment-1474664639.**

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review pr 221278` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages marked as broken and skipped:</summary>
  <ul>
    <li>xfce.thunar-bare</li>
    <li>xfce.xfce4-embed-plugin</li>
    <li>xfce.xfce4-namebar-plugin</li>
    <li>xmonad_log_applet_xfce</li>
  </ul>
</details>
<details>
  <summary>52 packages built:</summary>
  <ul>
    <li>xfce.exo</li>
    <li>xfce.garcon</li>
    <li>xfce.libxfce4ui</li>
    <li>xfce.mousepad</li>
    <li>xfce.orage</li>
    <li>xfce.parole</li>
    <li>xfce.ristretto</li>
    <li>xfce.thunar</li>
    <li>xfce.thunar-archive-plugin</li>
    <li>xfce.thunar-dropbox-plugin</li>
    <li>xfce.thunar-media-tags-plugin</li>
    <li>xfce.thunar-volman</li>
    <li>xfce.xfburn</li>
    <li>xfce.xfce4-appfinder</li>
    <li>xfce.xfce4-battery-plugin</li>
    <li>xfce.xfce4-clipman-plugin</li>
    <li>xfce.xfce4-cpufreq-plugin</li>
    <li>xfce.xfce4-cpugraph-plugin</li>
    <li>xfce.xfce4-datetime-plugin</li>
    <li>xfce.xfce4-dict</li>
    <li>xfce.xfce4-dockbarx-plugin</li>
    <li>xfce.xfce4-eyes-plugin</li>
    <li>xfce.xfce4-fsguard-plugin</li>
    <li>xfce.xfce4-genmon-plugin</li>
    <li>xfce.xfce4-i3-workspaces-plugin</li>
    <li>xfce.xfce4-mailwatch-plugin</li>
    <li>xfce.xfce4-mpc-plugin</li>
    <li>xfce.xfce4-netload-plugin</li>
    <li>xfce.xfce4-notes-plugin</li>
    <li>xfce.xfce4-notifyd</li>
    <li>xfce.xfce4-panel</li>
    <li>xfce.xfce4-panel-profiles</li>
    <li>xfce.xfce4-power-manager</li>
    <li>xfce.xfce4-pulseaudio-plugin</li>
    <li>xfce.xfce4-screensaver</li>
    <li>xfce.xfce4-screenshooter</li>
    <li>xfce.xfce4-sensors-plugin</li>
    <li>xfce.xfce4-session</li>
    <li>xfce.xfce4-settings</li>
    <li>xfce.xfce4-systemload-plugin</li>
    <li>xfce.xfce4-taskmanager</li>
    <li>xfce.xfce4-terminal</li>
    <li>xfce.xfce4-time-out-plugin</li>
    <li>xfce.xfce4-timer-plugin</li>
    <li>xfce.xfce4-verve-plugin</li>
    <li>xfce.xfce4-weather-plugin</li>
    <li>xfce.xfce4-whiskermenu-plugin</li>
    <li>xfce.xfce4-windowck-plugin</li>
    <li>xfce.xfce4-xkb-plugin</li>
    <li>xfce.xfdashboard</li>
    <li>xfce.xfdesktop</li>
    <li>xfce.xfwm4</li>
  </ul>
</details>