### PR TITLE
plumed: init at 2.8.2

### DIFF
--- a/pkgs/applications/science/chemistry/cp2k/default.nix
+++ b/pkgs/applications/science/chemistry/cp2k/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, python3, gfortran, blas, lapack
 , fftw, libint, libvori, libxc, mpi, gsl, scalapack, openssh, makeWrapper
-, libxsmm, spglib, which, pkg-config
+, libxsmm, spglib, which, pkg-config, plumed, zlib
 , enableElpa ? false
 , elpa
 } :
@@ -34,6 +34,8 @@ in stdenv.mkDerivation rec {
     scalapack
     blas
     lapack
+    plumed
+    zlib
   ] ++ lib.optional enableElpa elpa;
 
   propagatedBuildInputs = [ mpi ];
@@ -64,7 +66,8 @@ in stdenv.mkDerivation rec {
     AR         = ar -r
     DFLAGS     = -D__FFTW3 -D__LIBXC -D__LIBINT -D__parallel -D__SCALAPACK \
                  -D__MPI_VERSION=3 -D__F2008 -D__LIBXSMM -D__SPGLIB \
-                 -D__MAX_CONTR=4 -D__LIBVORI ${lib.optionalString enableElpa "-D__ELPA"}
+                 -D__MAX_CONTR=4 -D__LIBVORI ${lib.optionalString enableElpa "-D__ELPA"} \
+                 -D__PLUMED2
     CFLAGS    = -fopenmp
     FCFLAGS    = \$(DFLAGS) -O2 -ffree-form -ffree-line-length-none \
                  -ftree-vectorize -funroll-loops -msse2 \
@@ -77,8 +80,11 @@ in stdenv.mkDerivation rec {
                  -lxcf03 -lxc -lxsmmf -lxsmm -lsymspg \
                  -lint2 -lstdc++ -lvori \
                  -lgomp -lpthread -lm \
-                 -fopenmp ${lib.optionalString enableElpa "$(pkg-config --libs elpa)"}
+                 -fopenmp ${lib.optionalString enableElpa "$(pkg-config --libs elpa)"} \
+                 -lz -ldl -lstdc++ ${lib.optionalString (mpi.pname == "openmpi") "$(mpicxx --showme:link)"} \
+                 -lplumed
     LDFLAGS    = \$(FCFLAGS) \$(LIBS)
+    include ${plumed}/lib/plumed/src/lib/Plumed.inc
     EOF
   '';
 

--- a/pkgs/development/libraries/science/chemistry/plumed/default.nix
+++ b/pkgs/development/libraries/science/chemistry/plumed/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, blas
+}:
+
+assert !blas.isILP64;
+
+stdenv.mkDerivation rec {
+  pname = "plumed";
+  version = "2.8.2";
+
+  src = fetchFromGitHub {
+    owner = "plumed";
+    repo = "plumed2";
+    rev = "v${version}";
+    hash = "sha256-ugYhJq8KFjT8rkAOX/yZ9IlEklXCwRxKH49REd2QN9E=";
+  };
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  buildInputs = [ blas ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Molecular metadynamics library";
+    homepage = "https://github.com/plumed/plumed2";
+    license = licenses.lgpl3Only;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24224,6 +24224,8 @@ with pkgs;
     mail = callPackage ../development/libraries/gsignond/plugins/mail.nix { };
   };
 
+  plumed = callPackage ../development/libraries/science/chemistry/plumed { };
+
   ### DEVELOPMENT / LIBRARIES / AGDA
 
   agdaPackages = callPackage ./agda-packages.nix {


### PR DESCRIPTION
###### Description of changes

Addition of the plumed Meta molecular dynamics library. The CP2K integration has been directly enabled, Gromacs, LAMMPS and OpenMM could follow. Prerequisite for the NWchem 7.2 update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).