### PR TITLE
easyrsa: use OpenSSL 1.1.x instead of 3.x

### DIFF
--- a/pkgs/tools/networking/easyrsa/default.nix
+++ b/pkgs/tools/networking/easyrsa/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, openssl, runtimeShell }:
+{ lib, stdenv, fetchFromGitHub, openssl_1_1, runtimeShell }:
 
 let
   version = "3.0.8";
@@ -22,7 +22,7 @@ in stdenv.mkDerivation {
     install -D -m755 easyrsa3/easyrsa $out/bin/easyrsa
     substituteInPlace $out/bin/easyrsa \
       --subst-var out \
-      --subst-var-by openssl ${openssl.bin}/bin/openssl
+      --subst-var-by openssl ${openssl_1_1.bin}/bin/openssl
 
     # Helper utility
     cat > $out/bin/easyrsa-init <<EOF


### PR DESCRIPTION
This version of easyrsa (3.0.8) is not actually compatible with OpenSSL 3.x, support was only added in easyrsa 3.0.9: https://github.com/OpenVPN/easy-rsa/releases/tag/v3.0.9 Using OpenSSL 1.1.x instead fixes several problems with easyrsa, including https://github.com/OpenVPN/easy-rsa/issues/454

I'm proposing to put this right into 22.11 because unstable already has a newer version of easyrsa that's just OpenSSL 3.x compatible.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
