### PR TITLE
proxysql: 2.5.0 -> 2.5.1

### DIFF
--- a/pkgs/servers/sql/proxysql/default.nix
+++ b/pkgs/servers/sql/proxysql/default.nix
@@ -25,6 +25,7 @@
 , pcre
 , perl
 , python3
+, prometheus-cpp
 , re2
 , zlib
 , texinfo
@@ -32,13 +33,13 @@
 
 stdenv.mkDerivation rec {
   pname = "proxysql";
-  version = "2.5.0";
+  version = "2.5.1";
 
   src = fetchFromGitHub {
     owner = "sysown";
     repo = pname;
     rev = version;
-    hash = "sha256-psQzKycavS9xr24wGiRkr255IXW79AoG9fUEBkvPMZk=";
+    hash = "sha256-Z85/oSV2TUKEoum09G6OHNw6K/Evt1wMCcleTcc96EY=";
   };
 
   patches = [
@@ -115,12 +116,13 @@ stdenv.mkDerivation rec {
           { f = "libssl"; p = openssl; }
           { f = "lz4"; p = lz4; }
           { f = "pcre"; p = pcre; }
+          { f = "prometheus-cpp"; p = prometheus-cpp; }
           { f = "re2"; p = re2; }
         ]
       )}
 
     pushd libhttpserver
-    tar xf libhttpserver-0.18.1.tar.gz
+    tar xf libhttpserver-*.tar.gz
     sed -i s_/bin/pwd_${coreutils}/bin/pwd_g libhttpserver/configure.ac
     popd
 
@@ -129,9 +131,8 @@ stdenv.mkDerivation rec {
     ln -s ${nlohmann_json.src}/single_include/nlohmann/json.hpp .
     popd
 
-    pushd prometheus-cpp
-    tar xf v0.9.0.tar.gz
-    replace_dep prometheus-cpp/3rdparty "${civetweb.src}" civetweb
+    pushd prometheus-cpp/prometheus-cpp/3rdparty
+    replace_dep . "${civetweb.src}" civetweb
     popd
 
     sed -i s_/usr/bin/env_${coreutils}/bin/env_g libssl/openssl/config
@@ -145,6 +146,10 @@ stdenv.mkDerivation rec {
     popd
 
     pushd libdaemon/libdaemon
+    autoreconf
+    popd
+
+    pushd pcre/pcre
     autoreconf
     popd
 

--- a/pkgs/servers/sql/proxysql/makefiles.patch
+++ b/pkgs/servers/sql/proxysql/makefiles.patch
@@ -36,10 +36,10 @@ index e7dae058..09c28859 100644
  	install -m 0755 etc/init.d/proxysql /etc/init.d
  ifeq ($(DISTRO),"CentOS Linux")
 diff --git a/deps/Makefile b/deps/Makefile
-index 23ef204c..3fbcc4a7 100644
+index 55a45ba9..8443d439 100644
 --- a/deps/Makefile
 +++ b/deps/Makefile
-@@ -65,10 +65,7 @@ endif
+@@ -66,10 +66,7 @@ endif
  
  
  libinjection/libinjection/src/libinjection.a:
@@ -50,8 +50,8 @@ index 23ef204c..3fbcc4a7 100644
  	cd libinjection/libinjection && patch -p1 < ../libinjection_sqli.c.patch
  endif
  ifeq ($(UNAME_S),Darwin)
-@@ -80,8 +77,6 @@ endif
- libinjection: libinjection/libinjection/src/libinjection.a
+@@ -83,8 +80,6 @@ libinjection: libinjection/libinjection/src/libinjection.a
+ 
  
  libssl/openssl/libssl.a:
 -	cd libssl && rm -rf openssl-openssl-*/ openssl-3*/ || true
@@ -59,42 +59,35 @@ index 23ef204c..3fbcc4a7 100644
  	cd libssl/openssl && patch crypto/ec/curve448/curve448.c < ../curve448.c-multiplication-overflow.patch
  	cd libssl/openssl && patch crypto/asn1/a_time.c < ../a_time.c-multiplication-overflow.patch
  	cd libssl/openssl && ./config no-ssl3 no-tests
-@@ -99,9 +94,6 @@ ifeq ($(MIN_VERSION),$(lastword $(SORTED_VERSIONS)))
- endif
+@@ -95,8 +90,6 @@ libssl: libssl/openssl/libssl.a
+ 
  
  libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a re2/re2/obj/libre2.a
 -	cd libhttpserver && rm -rf libhttpserver-*/ || true
--	cd libhttpserver && tar -zxf libhttpserver-0.18.1.tar.gz
--#ifeq ($(REQUIRE_PATCH), true)
- 	cd libhttpserver/libhttpserver && patch src/httpserver/basic_auth_fail_response.hpp < ../basic_auth_fail_response.hpp.patch
- 	cd libhttpserver/libhttpserver && patch src/httpserver/create_webserver.hpp < ../create_webserver.hpp.patch
- 	cd libhttpserver/libhttpserver && patch src/httpserver/deferred_response.hpp < ../deferred_response.hpp.patch
-@@ -112,7 +104,6 @@ libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a: libmicrohttpd/libmi
- 	cd libhttpserver/libhttpserver && patch src/httpserver/http_response.hpp < ../http_response.hpp.patch
- 	cd libhttpserver/libhttpserver && patch src/httpserver/string_response.hpp < ../string_response.hpp.patch
- 	cd libhttpserver/libhttpserver && patch -p0 < ../re2_regex.patch
--#endif
- 	cd libhttpserver/libhttpserver && patch -p0 < ../final_val_post_process.patch
- 	cd libhttpserver/libhttpserver && patch -p0 < ../empty_uri_log_crash.patch
- ifeq ($(UNAME_S),FreeBSD)
-@@ -124,35 +115,17 @@ endif
- libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a
+-	cd libhttpserver && tar -zxf libhttpserver-*.tar.gz
+ 	cd libhttpserver/libhttpserver && patch -p1 < ../noexcept.patch
+ 	cd libhttpserver/libhttpserver && patch -p1 < ../re2_regex.patch
+ 	cd libhttpserver/libhttpserver && patch -p1 < ../final_val_post_process.patch
+@@ -112,8 +105,6 @@ libhttpserver: libhttpserver/libhttpserver/build/src/.libs/libhttpserver.a
+ 
  
  libev/libev/.libs/libev.a:
 -	cd libev && rm -rf libev-*/ || true
--	cd libev && tar -zxf libev-4.24.tar.gz
- 	cd libev/libev && patch ev.c < ../ev.c-multiplication-overflow.patch
- 	cd libev/libev  && ./configure
+-	cd libev && tar -zxf libev-*.tar.gz
+ #	cd libev/libev && patch ev.c < ../ev.c-multiplication-overflow.patch
+ 	cd libev/libev && ./configure
  	cd libev/libev && CC=${CC} CXX=${CXX} ${MAKE}
- ev: libev/libev/.libs/libev.a
+@@ -122,8 +113,6 @@ ev: libev/libev/.libs/libev.a
+ 
  
  curl/curl/lib/.libs/libcurl.a: libssl/openssl/libssl.a
 -	cd curl && rm -rf curl-*/ || true
 -	cd curl && tar -zxf curl-*.tar.gz
--	#cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --with-ssl=$(shell pwd)/../../libssl/openssl/ && CC=${CC} CXX=${CXX} ${MAKE}
- 	cd curl/curl && patch configure < ../configure.patch
- 	cd curl/curl && CFLAGS=-fPIC ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --without-librtmp --without-libpsl --without-zstd --with-ssl=$(shell pwd)/libssl/openssl/ --enable-shared=no && CC=${CC} CXX=${CXX} ${MAKE}
- curl: curl/curl/lib/.libs/libcurl.a
+ #	cd curl/curl && ./configure --disable-debug --disable-ftp --disable-ldap --disable-ldaps --disable-rtsp --disable-proxy --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --disable-manual --disable-ipv6 --disable-sspi --disable-crypto-auth --disable-ntlm-wb --disable-tls-srp --without-nghttp2 --without-libidn2 --without-libssh2 --without-brotli --with-ssl=$(shell pwd)/../../libssl/openssl/ && CC=${CC} CXX=${CXX} ${MAKE}
+ #	cd curl/curl && patch configure < ../configure.patch
+ 	cd curl/curl && autoreconf -fi
+@@ -133,16 +122,6 @@ curl: curl/curl/lib/.libs/libcurl.a
+ 
  
  libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a:
 -	cd libmicrohttpd && rm -rf libmicrohttpd-*/ || true
@@ -103,26 +96,25 @@ index 23ef204c..3fbcc4a7 100644
 -	cd libmicrohttpd && ln -s libmicrohttpd-0.9.55 libmicrohttpd
 -	cd libmicrohttpd && tar -zxf libmicrohttpd-0.9.55.tar.gz
 -else
--	cd libmicrohttpd && ln -s libmicrohttpd-0.9.68 libmicrohttpd
--	cd libmicrohttpd && tar -zxf libmicrohttpd-0.9.68.tar.gz
--	cd libmicrohttpd/libmicrohttpd && patch src/microhttpd/connection.c < ../connection.c-snprintf-overflow.patch
+-	cd libmicrohttpd && ln -s libmicrohttpd-0.9.75 libmicrohttpd
+-	cd libmicrohttpd && tar -zxf libmicrohttpd-0.9.75.tar.gz
+-#	cd libmicrohttpd/libmicrohttpd && patch src/microhttpd/connection.c < ../connection.c-snprintf-overflow.patch
 -endif
--ifeq ($(UNAME_S),Darwin)
--	cd libmicrohttpd/libmicrohttpd && patch src/microhttpd/mhd_sockets.c < ../mhd_sockets.c-issue-5977.patch
--endif
- 	cd libmicrohttpd/libmicrohttpd && ./configure --enable-https && CC=${CC} CXX=${CXX} ${MAKE}
- microhttpd: libmicrohttpd/libmicrohttpd/src/microhttpd/.libs/libmicrohttpd.a
+ ifeq ($(UNAME_S),Darwin)
+ 	cd libmicrohttpd/libmicrohttpd && patch src/microhttpd/mhd_sockets.c < ../mhd_sockets.c-issue-5977.patch
+ endif
+@@ -159,10 +138,7 @@ cityhash/cityhash/src/.libs/libcityhash.a:
  
-@@ -163,8 +136,6 @@ cityhash/cityhash/src/.libs/libcityhash.a:
  cityhash: cityhash/cityhash/src/.libs/libcityhash.a
  
- lz4/lz4/liblz4.a:
+-
+ lz4/lz4/lib/liblz4.a:
 -	cd lz4 && rm -rf lz4-*/ || true
--	cd lz4 && tar -zxf lz4-1.7.5.tar.gz
+-	cd lz4 && tar -zxf lz4-*.tar.gz
  	cd lz4/lz4 && CC=${CC} CXX=${CXX} ${MAKE}
- lz4: lz4/lz4/liblz4.a
  
-@@ -189,8 +160,6 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-s
+ lz4: lz4/lz4/lib/liblz4.a
+@@ -187,8 +163,6 @@ clickhouse-cpp: clickhouse-cpp/clickhouse-cpp/clickhouse/libclickhouse-cpp-lib-s
  
  
  libdaemon/libdaemon/libdaemon/.libs/libdaemon.a:
@@ -131,41 +123,44 @@ index 23ef204c..3fbcc4a7 100644
  	cd libdaemon/libdaemon && cp ../config.guess . && chmod +x config.guess && cp ../config.sub . && chmod +x config.sub && ./configure --disable-examples
  	cd libdaemon/libdaemon && CC=${CC} CXX=${CXX} ${MAKE}
  
-@@ -264,17 +233,12 @@ sqlite3/sqlite3/sqlite3.o:
- sqlite3: sqlite3/sqlite3/sqlite3.o
+@@ -265,8 +239,6 @@ sqlite3: sqlite3/sqlite3/sqlite3.o
+ 
  
  libconfig/libconfig/lib/.libs/libconfig++.a:
 -	cd libconfig && rm -rf libconfig-*/ || true
--	cd libconfig && tar -zxf libconfig-1.7.2.tar.gz
+-	cd libconfig && tar -zxf libconfig-*.tar.gz
  	cd libconfig/libconfig && ./configure --disable-examples
  	cd libconfig/libconfig && CC=${CC} CXX=${CXX} ${MAKE}
  
- libconfig: libconfig/libconfig/lib/.libs/libconfig++.a
+@@ -274,9 +246,6 @@ libconfig: libconfig/libconfig/lib/.libs/libconfig++.a
+ 
  
  prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a:
 -	cd prometheus-cpp && rm -rf prometheus-cpp-*/ || true
--	cd prometheus-cpp && tar -zxf v0.9.0.tar.gz
--	cd prometheus-cpp && tar --strip-components=1 -zxf civetweb-v1.11.tar.gz -C prometheus-cpp/3rdparty/civetweb
+-	cd prometheus-cpp && tar -zxf prometheus-cpp-*.tar.gz
+-	cd prometheus-cpp && tar --strip-components=1 -zxf civetweb-*.tar.gz -C prometheus-cpp/3rdparty/civetweb
  	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../serial_exposer.patch
- 	cd prometheus-cpp/prometheus-cpp && patch -p0 < ../registry_counters_reset.patch
- 	cd prometheus-cpp/prometheus-cpp && patch -p0 < ../include_limits.patch
-@@ -284,10 +248,6 @@ prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a:
- prometheus-cpp: prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a
+ 	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../registry_counters_reset.patch
+ 	cd prometheus-cpp/prometheus-cpp && patch -p1 < ../fix_old_distros.patch
+@@ -287,11 +256,6 @@ prometheus-cpp: prometheus-cpp/prometheus-cpp/lib/libprometheus-cpp-core.a
+ 
  
  re2/re2/obj/libre2.a:
 -	cd re2 && rm -rf re2-*/ || true
--	cd re2 && tar -zxf re2.tar.gz
+-	cd re2 && tar -zxf re2-*.tar.gz
 -#	cd re2/re2 && sed -i -e 's/-O3 -g /-O3 -fPIC /' Makefile
 -#	cd re2/re2 && patch util/mutex.h < ../mutex.h.patch
- 	cd re2/re2 && patch re2/onepass.cc < ../onepass.cc-multiplication-overflow.patch
+-#	cd re2/re2 && patch re2/onepass.cc < ../onepass.cc-multiplication-overflow.patch
  ifeq ($(UNAME_S),Darwin)
- 	cd re2/re2 && sed -i '' -e 's/-O3 /-O3 -fPIC -DMEMORY_SANITIZER -DRE2_ON_VALGRIND /' Makefile
-@@ -301,8 +261,6 @@ endif
- re2: re2/re2/obj/libre2.a
+ 	cd re2/re2 && sed -i '' -e 's/-O3 -g/-O3 -g -std=c++11 -fPIC -DMEMORY_SANITIZER -DRE2_ON_VALGRIND /' Makefile
+ #	cd re2/re2 && sed -i '' -e 's/RE2_CXXFLAGS?=-std=c++11 /RE2_CXXFLAGS?=-std=c++11 -fPIC /' Makefile
+@@ -305,9 +269,6 @@ re2: re2/re2/obj/libre2.a
+ 
  
  pcre/pcre/.libs/libpcre.a:
 -	cd pcre && rm -rf pcre-*/ || true
--	cd pcre && tar -zxf pcre-8.44.tar.gz
- 	cd pcre/pcre && patch pcretest.c < ../pcretest.c-multiplication-overflow.patch
+-	cd pcre && tar -zxf pcre-*.tar.gz
+-#	cd pcre/pcre && patch pcretest.c < ../pcretest.c-multiplication-overflow.patch
  	cd pcre/pcre && ./configure
  	cd pcre/pcre && CC=${CC} CXX=${CXX} ${MAKE}
+ 


### PR DESCRIPTION
###### Description of changes
https://github.com/sysown/proxysql/releases/tag/v2.5.1

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).