### PR TITLE
xkeyboard_config: 2.33 -> 2.39

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3117,11 +3117,11 @@ self: with self; {
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   xkeyboardconfig = callPackage ({ stdenv, pkg-config, fetchurl }: stdenv.mkDerivation {
     pname = "xkeyboard-config";
-    version = "2.38";
+    version = "2.39";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.38.tar.xz";
-      sha256 = "0wn8asnbz111194ksi2mysa6ikn4kqgd9rpfydl8icc6mcdsk406";
+      url = "mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.39.tar.xz";
+      sha256 = "10m6mbjymi7qf30g5yd400kqijdjg7ym9qjzh0bc3c7pxwrzbias";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     strictDeps = true;

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3115,18 +3115,18 @@ self: with self; {
   }) {};
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xkeyboardconfig = callPackage ({ stdenv, pkg-config, fetchurl, libX11, xorgproto, python3 }: stdenv.mkDerivation {
+  xkeyboardconfig = callPackage ({ stdenv, pkg-config, fetchurl }: stdenv.mkDerivation {
     pname = "xkeyboard-config";
-    version = "2.33";
+    version = "2.38";
     builder = ./builder.sh;
     src = fetchurl {
-      url = "mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.33.tar.bz2";
-      sha256 = "1g6kn7l0mixw50kgn7d97gwv1990c5rczr2x776q3xywss8dfzv5";
+      url = "mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.38.tar.xz";
+      sha256 = "0wn8asnbz111194ksi2mysa6ikn4kqgd9rpfydl8icc6mcdsk406";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     strictDeps = true;
-    nativeBuildInputs = [ pkg-config python3 ];
-    buildInputs = [ libX11 xorgproto ];
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ ];
     meta.platforms = lib.platforms.unix;
   }) {};
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -2,11 +2,11 @@
   callPackage,
   lib, stdenv, makeWrapper, fetchurl, fetchpatch, fetchFromGitLab, buildPackages,
   automake, autoconf, libiconv, libtool, intltool,
-  freetype, tradcpp, fontconfig, meson, ninja, ed, fontforge,
+  freetype, tradcpp, fontconfig, meson, ninja, ed, fontforge, gettext,
   libGL, spice-protocol, zlib, libGLU, dbus, libunwind, libdrm, netbsd,
   ncompress,
   mesa, udev, bootstrap_cmds, bison, flex, clangStdenv, autoreconfHook,
-  mcpp, libepoxy, openssl, pkg-config, llvm, libxslt, libxcrypt,
+  mcpp, libepoxy, openssl, pkg-config, llvm, libxslt, libxcrypt, perl, python3,
   ApplicationServices, Carbon, Cocoa, Xplugin,
   xorg
 }:
@@ -539,9 +539,9 @@ self: super:
   });
 
   xkeyboardconfig = super.xkeyboardconfig.overrideAttrs (attrs: {
-    prePatch = "patchShebangs rules/merge.py";
-    nativeBuildInputs = attrs.nativeBuildInputs ++ [ intltool libxslt ];
-    configureFlags = [ "--with-xkb-rules-symlink=xorg" ];
+    prePatch = "patchShebangs rules/compat/map-variants.py rules/merge.py rules/xml2lst.pl";
+    nativeBuildInputs = attrs.nativeBuildInputs ++ [ meson ninja gettext libxslt perl python3 ];
+    mesonFlags = [ "-Dxorg-rules-symlinks=true" ];
 
     # 1: compatibility for X11/xkb location
     # 2: I think pkg-config/ is supposed to be in /lib/

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -75,7 +75,7 @@ mirror://xorg/individual/app/xwininfo-1.1.4.tar.bz2
 mirror://xorg/individual/app/xwud-1.0.5.tar.bz2
 mirror://xorg/individual/data/xbitmaps-1.1.2.tar.bz2
 mirror://xorg/individual/data/xcursor-themes-1.0.6.tar.bz2
-mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.38.tar.xz
+mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.39.tar.xz
 mirror://xorg/individual/doc/xorg-docs-1.7.1.tar.bz2
 mirror://xorg/individual/doc/xorg-sgml-doctools-1.11.tar.bz2
 mirror://xorg/individual/driver/xf86-input-evdev-2.10.6.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -75,7 +75,7 @@ mirror://xorg/individual/app/xwininfo-1.1.4.tar.bz2
 mirror://xorg/individual/app/xwud-1.0.5.tar.bz2
 mirror://xorg/individual/data/xbitmaps-1.1.2.tar.bz2
 mirror://xorg/individual/data/xcursor-themes-1.0.6.tar.bz2
-mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.33.tar.bz2
+mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.38.tar.xz
 mirror://xorg/individual/doc/xorg-docs-1.7.1.tar.bz2
 mirror://xorg/individual/doc/xorg-sgml-doctools-1.11.tar.bz2
 mirror://xorg/individual/driver/xf86-input-evdev-2.10.6.tar.bz2


### PR DESCRIPTION
###### Description of changes

The [release notes](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/master/NEWS) aren't really helpful and given it's a new build system, I did a [diff](https://gist.github.com/ether42/9862653105520fee4ec9c054ad7b83af) because I'm not too familiar with this package (ignoring `etc` and `lib` that are just symlinked in `overrides.nix`):
 - Javanese hasn't been removed, just [moved](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/commit/3fa0dfde2637d9a0032c1395ff6a965d546ff08c).
 - A lot of updates, new translations and layouts (nearly two years worth of updates).

Explanation of changes:
 - `-Dxorg-rules-symlinks=true` replaces `--with-xkb-rules-symlink=xorg`, without that `share/X11/xkb/rules/xorg*` wouldn't be generated.
 - There's a new Perl script hence the dependency on Perl.
 - gettext is necessary to generate the translations.
 - I edited `overrides.nix` and did not special case `xkeyboardconfig` in `generate-expr-from-tarballs.pl` as that seems to be the way to go (I believe we could drop pkg-config in `default.nix`, but again, not sure we want to special case).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Apparently, there are more than 5k packages impacted (at least that's what `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` tells me) so I followed https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#rebasing-between-branches-ie-from-master-to-staging and couldn't really rebuild everything locally. I believe the CI will?

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
