### PR TITLE
apacheHttpdPackages.mod_tile: Update and use cmake to build mod_tile.so and renderd

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_tile/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_tile/default.nix
@@ -1,76 +1,65 @@
-{ lib
+{ fetchFromGitHub
+, lib
 , stdenv
-, fetchFromGitHub
-, fetchpatch
-, autoreconfHook
+, cmake
+, pkg-config
 , apacheHttpd
 , apr
-, cairo
-, iniparser
-, mapnik
+, aprutil
 , boost
-, icu
+, cairo
+, curl
+, glib
+, gtk2
 , harfbuzz
-, libjpeg
-, libtiff
-, libwebp
-, proj
-, sqlite
+, icu
+, iniparser
+, libmemcached
+, mapnik
 }:
 
 stdenv.mkDerivation rec {
   pname = "mod_tile";
-  version = "unstable-2017-01-08";
+  version = "0.6.1+unstable=2023-03-09";
 
   src = fetchFromGitHub {
     owner = "openstreetmap";
     repo = "mod_tile";
-    rev = "e25bfdba1c1f2103c69529f1a30b22a14ce311f1";
-    sha256 = "12c96avka1dfb9wxqmjd57j30w9h8yx4y4w34kyq6xnf6lwnkcxp";
+    rev = "f521540df1003bb000d7367a59ad612161eab0f0";
+    sha256 = "sha256-jIqeplAQt4W97PNKm6ZDGPDUc/PEiLM5yEdPeI+H03A=";
   };
 
-  patches = [
-    # Pull upstream fix for -fno-common toolchains:
-    #  https://github.com/openstreetmap/mod_tile/pull/202
-    (fetchpatch {
-      name = "fno-common";
-      url = "https://github.com/openstreetmap/mod_tile/commit/a22065b8ae3c018820a5ca9bf8e2b2bb0a0bfeb4.patch";
-      sha256 = "1ywfa14xn9aa96vx1adn1ndi29qpflca06x986bx9c5pqk761yz3";
-    })
+  nativeBuildInputs = [
+    cmake
+    pkg-config
   ];
 
-  # test is broken and I couldn't figure out a better way to disable it.
-  postPatch = ''
-    echo "int main(){return 0;}" > src/gen_tile_test.cpp
-  '';
-
-  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [
     apacheHttpd
     apr
-    cairo
-    iniparser
-    mapnik
+    aprutil
     boost
-    icu
+    cairo
+    curl
+    glib
     harfbuzz
-    libjpeg
-    libtiff
-    libwebp
-    proj
-    sqlite
+    icu
+    iniparser
+    libmemcached
+    mapnik
   ];
 
-  configureFlags = [
-    "--with-apxs=${apacheHttpd.dev}/bin/apxs"
-  ];
-
-  installPhase = ''
-    mkdir -p $out/modules
-    make install-mod_tile DESTDIR=$out
-    mv $out${apacheHttpd}/* $out
-    rm -rf $out/nix
+  # the install script wants to install mod_tile.so into apache's modules dir
+  postPatch = ''
+    sed -i "s|\''${HTTPD_MODULES_DIR}|$out/modules|" CMakeLists.txt
   '';
+
+  enableParallelBuilding = true;
+
+  # We need to either disable the `render_speedtest` and `download_tile` tests
+  # or fix the URLs they try to download from
+  #cmakeFlags = [ "-DENABLE_TESTS=1" ];
+  #doCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/openstreetmap/mod_tile";


### PR DESCRIPTION
###### Description of changes

the openstreetmap `mod_tile` repo also contains the sourcecode of the `renderd` daemon, but the derivation did not build that so far.
While inspecting that, I have seem that the project uses cmake nowadays, so I changed the derivation, which also makes it a bit simpler. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
