### PR TITLE
swift: reduce closure size of swift-lib

### DIFF
--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -619,7 +619,12 @@ in stdenv.mkDerivation {
     # Swift has a separate resource root from Clang, but locates the Clang
     # resource root via subdir or symlink. Provide a default here, but we also
     # patch Swift to prefer NIX_CC if set.
-    ln -s ${clang}/resource-root $lib/lib/swift/clang
+    #
+    # NOTE: We don't symlink directly here, because that'd add a run-time dep
+    # on the full Clang compiler to every Swift executable. The copy here is
+    # just copying the 3 symlinks inside to smaller closures.
+    mkdir $lib/lib/swift/clang
+    cp -P ${clang}/resource-root/* $lib/lib/swift/clang/
 
     ${lib.optionalString stdenv.isDarwin ''
     # Install required library for ObjC interop.


### PR DESCRIPTION
###### Description of changes

The Swift compiler needs the Clang resource-root in `lib/swift/clang`. In our case, this is part of `swift.lib`, which is a run-time dependency of all Swift binaries.

Before, we symlinked `${clang}/resource-root` itself, but now we copy the symlinks within it. This swaps the dependency on `clang-wrapper` for two smaller closures `compiler-rt` and `clang.lib`. The result is roughly half the total closure size for `swift.lib`. (1.2G -> 0.6G on aarch64-darwin)

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).