### PR TITLE
[WIP] lib.sources.predicateFilter: init

### DIFF
--- a/lib/path/tests/unit.nix
+++ b/lib/path/tests/unit.nix
@@ -3,7 +3,7 @@
 { libpath }:
 let
   lib = import libpath;
-  inherit (lib.path) append subpath;
+  inherit (lib.path) hasPrefix hasProperPrefix append subpath;
 
   cases = lib.runTests {
     # Test examples from the lib.path.append documentation
@@ -38,6 +38,40 @@ let
     testAppendExample8 = {
       expr = (builtins.tryEval (append /foo "../bar")).success;
       expected = false;
+    };
+
+    testHasPrefixExample1 = {
+      expr = hasPrefix /foo /foo/bar;
+      expected = true;
+    };
+    testHasPrefixExample2 = {
+      expr = hasPrefix /foo /foo;
+      expected = true;
+    };
+    testHasPrefixExample3 = {
+      expr = hasPrefix /foo/bar /foo;
+      expected = false;
+    };
+    testHasPrefixExample4 = {
+      expr = hasPrefix /. /foo;
+      expected = true;
+    };
+
+    testHasProperPrefixExample1 = {
+      expr = hasProperPrefix /foo /foo/bar;
+      expected = true;
+    };
+    testHasProperPrefixExample2 = {
+      expr = hasProperPrefix /foo /foo;
+      expected = false;
+    };
+    testHasProperPrefixExample3 = {
+      expr = hasProperPrefix /foo/bar /foo;
+      expected = false;
+    };
+    testHasProperPrefixExample4 = {
+      expr = hasProperPrefix /. /foo;
+      expected = true;
     };
 
     # Test examples from the lib.path.subpath.isValid documentation

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -270,6 +270,19 @@ let
       outPath = builtins.path { inherit filter name; path = origSrc; };
     };
 
+  predicateFilter = { name ? "source", src, predicate }:
+    let
+      isFiltered = src ? _isLibCleanSourceWith;
+      origSrc = if isFiltered then src.origSrc else src;
+      removeBase = lib.path.subpath.removePrefix (lib.path.deconstructPath origSrc).subpath;
+    in lib.cleanSourceWith {
+      inherit name src;
+      filter = absolutePath: type:
+        assert lib.isString absolutePath;
+        let subpath = removeBase (lib.substring 1 (-1) absolutePath);
+        in predicate { inherit type subpath; };
+    };
+
 in {
   inherit
     pathType
@@ -289,5 +302,6 @@ in {
     sourceFilesBySuffices
 
     trace
+    predicateFilter
     ;
 }

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -290,6 +290,20 @@ let
       inherit (orig) name origSrc;
       filter = pathString: type: predicate { subpath = toSubpath pathString; inherit type; }
         && orig.filter pathString type;
+      };
+
+  unionPath = root: list:
+    lib.sources.predicateFilterPath {
+      src = root;
+      predicate = { path, ... }:
+        lib.any (el: lib.path.hasPrefix path el || lib.path.hasPrefix el path) list;
+    };
+
+  unionSubpath = root: list:
+    lib.sources.predicateFilterSubpath {
+      src = root;
+      predicate = { subpath, ... }:
+        lib.any (el: lib.path.subpath.hasPrefix subpath el || lib.path.subpath.hasPrefix el subpath) list;
     };
 
 in {
@@ -313,5 +327,7 @@ in {
     trace
     predicateFilterPath
     predicateFilterSubpath
+    unionPath
+    unionSubpath
     ;
 }


### PR DESCRIPTION
###### Description of changes

WIP! This function may not be needed in the end because a higher-level abstraction might be better suited.

This PR adds `lib.sources.predicateFilter`, which is like `builtins.{path,filter}` or `lib.sources.cleanSourceWith`, except that it calls the filtering function with relative paths, specifically subpaths, as introduced in https://github.com/NixOS/nixpkgs/pull/205190. It also improves on the interface a bit by not using ordered arguments. The useful `lib.path.subpath.hasPrefix` function is also introduced here, relating to https://github.com/NixOS/nixpkgs/pull/210423. This is more generally related to https://github.com/NixOS/nixpkgs/issues/210426.

```nix
# test.nix
let lib = import <nixpkgs/lib>;
in lib.sources.predicateFilter {
  src = <nixpkgs>;
  predicate = { subpath, ... }:
    let
      included =
        # Include lib/systems recursively
        ## Include all parents of the target directory (but not recursively)
        lib.path.subpath.hasPrefix subpath "lib/systems"
        ## Include all children of the target directory (recursively)
        || lib.path.subpath.hasPrefix "lib/systems" subpath

        # Include a single file from nixos/modules/system/boot/loader
        ## Inclued all parents of the target directory (but not recursively)
        || lib.path.subpath.hasPrefix subpath "nixos/modules/system/boot/loader"
        ## Include the single file that we want (we should have lib.path.subpath.equals instead though)
        || subpath == "./nixos/modules/system/boot/loader/efi.nix";
    in
      if included
      then builtins.trace "Including ${subpath}" true
      else false;
}
```

```
$ nix-instantiate --eval --read-write-mode test.nix -I nixpkgs=$PWD -A outPath
trace: Including ./lib
trace: Including ./lib/systems
trace: Including ./lib/systems/architectures.nix
trace: Including ./lib/systems/default.nix
trace: Including ./lib/systems/doubles.nix
trace: Including ./lib/systems/examples.nix
trace: Including ./lib/systems/flake-systems.nix
trace: Including ./lib/systems/inspect.nix
trace: Including ./lib/systems/parse.nix
trace: Including ./lib/systems/platforms.nix
trace: Including ./nixos
trace: Including ./nixos/modules
trace: Including ./nixos/modules/system
trace: Including ./nixos/modules/system/boot
trace: Including ./nixos/modules/system/boot/loader
trace: Including ./nixos/modules/system/boot/loader/efi.nix
"/nix/store/1n07g9i2ikgdypizxaj9m56m8f18dav2-source"
```

Most notably, as is also the case with all the `lib.path` functions, this function works exactly the same way with the [lazy trees PR](https://github.com/NixOS/nix/pull/6530), despite it causing [breakages for other source filters](https://github.com/NixOS/nix/pull/6530#issuecomment-1470361519).

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles: 

###### Things done
