### PR TITLE
waybar: package mediaplayer module separately

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -140,6 +140,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - Nebula now runs as a system user and group created for each nebula network, using the `CAP_NET_ADMIN` ambient capability on launch rather than starting as root. Ensure that any files each Nebula instance needs to access are owned by the correct user and group, by default `nebula-${networkName}`.
 
+- The `withMediaPlayer` argument of the `waybar` package has been replaced by a dedicated `waybar-custom-modules.mediaplayer` package to avoid unnecessary re-complication. The executable is now named `waybar-mediaplayer` (without `.py` extension).
+
 - In `mastodon` it is now necessary to specify location of file with `PostgreSQL` database password. In `services.mastodon.database.passwordFile` parameter default value `/var/lib/mastodon/secrets/db-password` has been changed to `null`.
 
 - The `--target-host` and `--build-host` options of `nixos-rebuild` no longer treat the `localhost` value specially – to build on/deploy to local machine, omit the relevant flag.

--- a/pkgs/applications/misc/waybar/custom-modules.nix
+++ b/pkgs/applications/misc/waybar/custom-modules.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenvNoCC
+, glib
+, gobject-introspection
+, playerctl
+, python3
+, waybar
+, wrapGAppsHook
+}:
+
+{
+  mediaplayer = stdenvNoCC.mkDerivation rec {
+    pname = "mediaplayer";
+    version = waybar.version;
+
+    src = waybar.src;
+
+    dontBuild = true;
+    dontConfigure = true;
+
+    strictDeps = true;
+    nativeBuildInputs = [ gobject-introspection wrapGAppsHook ];
+
+    propagatedBuildInputs = [
+      glib
+      playerctl
+      python3.pkgs.pygobject3
+    ];
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp $src/resources/custom_modules/mediaplayer.py $out/bin/waybar-mediaplayer
+
+      wrapProgram $out/bin/waybar-mediaplayer \
+        --prefix PYTHONPATH : "$PYTHONPATH:$out/${python3.sitePackages}"
+    '';
+
+    doInstallCheck = true;
+
+    installCheckPhase = ''
+      if $out/bin/waybar-mediaplayer --help >/dev/null; then
+        echo "waybar-mediaplayer --help passed"
+      fi
+    '';
+
+    meta = waybar.meta // {
+      description = "A media player module based on playerctl for Waybar";
+      homepage = "https://github.com/Alexays/Waybar/tree/${version}/resources/custom_modules";
+      platforms = lib.platforms.linux;
+    };
+  };
+}

--- a/pkgs/applications/misc/waybar/default.nix
+++ b/pkgs/applications/misc/waybar/default.nix
@@ -4,7 +4,6 @@
 , meson
 , pkg-config
 , ninja
-, wrapGAppsHook
 , wayland
 , wlroots
 , gtkmm3
@@ -31,7 +30,6 @@
 , udevSupport     ? true,  udev
 , upowerSupport   ? true,  upower
 , wireplumberSupport ? true, wireplumber
-, withMediaPlayer ? mprisSupport && false, glib, gobject-introspection, python3
 }:
 
 stdenv.mkDerivation rec {
@@ -46,13 +44,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    meson ninja pkg-config scdoc wrapGAppsHook
-  ] ++ lib.optional withMediaPlayer gobject-introspection;
-
-  propagatedBuildInputs = lib.optionals withMediaPlayer [
-    glib
-    playerctl
-    python3.pkgs.pygobject3
+    meson ninja pkg-config scdoc
   ];
 
   strictDeps = false;
@@ -99,13 +91,6 @@ stdenv.mkDerivation rec {
     "-Dgtk-layer-shell=enabled"
     "-Dman-pages=enabled"
   ];
-
-  preFixup = lib.optionalString withMediaPlayer ''
-      cp $src/resources/custom_modules/mediaplayer.py $out/bin/waybar-mediaplayer.py
-
-      wrapProgram $out/bin/waybar-mediaplayer.py \
-        --prefix PYTHONPATH : "$PYTHONPATH:$out/${python3.sitePackages}"
-    '';
 
   meta = with lib; {
     changelog = "https://github.com/alexays/waybar/releases/tag/${version}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30680,6 +30680,7 @@ with pkgs;
   rootbar = callPackage ../applications/misc/rootbar { };
 
   waybar = callPackage ../applications/misc/waybar { };
+  waybar-custom-modules = recurseIntoAttrs (callPackages ../applications/misc/waybar/custom-modules.nix { });
 
   waylock = callPackage ../applications/misc/waylock {
     zig = zig_0_10;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Similarly to [sway-contrib](https://github.com/NixOS/nixpkgs/blob/41214830851cf31c75a23a30d8361f5c37afcfac/pkgs/applications/window-managers/sway/contrib.nix), I suggest to package `waybar-mediaplayer` on its own under `waybar-custom-modules` (and maybe others in the future)  to avoid the entire rebuild of `waybar` for the addition of a Python script. Please let me know what are your thoughts :slightly_smiling_face: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
