### PR TITLE
flatpak: patch for references to store again

### DIFF
--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -89,6 +89,10 @@ stdenv.mkDerivation (finalAttrs: {
     # https://github.com/NixOS/nixpkgs/issues/53441
     ./unset-env-vars.patch
 
+    # Always use flatpak from PATH to avoid references to the Nix store in launchers.
+    # Using FLATPAK_BINARY instead has the disadvantage of needing to wrap every user.
+    ./use-flatpak-from-path.patch
+
     # The icon validator needs to access the gdk-pixbuf loaders in the Nix store
     # and cannot bind FHS paths since those are not available on NixOS.
     finalAttrs.passthru.icon-validator-patch
@@ -174,13 +178,6 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs buildutil
     patchShebangs tests
     PATH=${lib.makeBinPath [vsc-py]}:$PATH patchShebangs --build subprojects/variant-schema-compiler/variant-schema-compiler
-  '';
-
-  preFixup = ''
-    gappsWrapperArgs+=(
-      # Use flatpak from PATH in exported assets (e.g. desktop files).
-      --set FLATPAK_BINARY flatpak
-    )
   '';
 
   passthru = {

--- a/pkgs/development/libraries/flatpak/use-flatpak-from-path.patch
+++ b/pkgs/development/libraries/flatpak/use-flatpak-from-path.patch
@@ -1,0 +1,34 @@
+From 5515c31ce221159841c279c90c994ef071fe773b Mon Sep 17 00:00:00 2001
+From: Lorenz Brun <lorenz@brun.one>
+Date: Thu, 16 Mar 2023 01:19:17 +0100
+Subject: [PATCH] Use flatpak from PATH
+
+---
+ common/flatpak-dir.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/common/flatpak-dir.c b/common/flatpak-dir.c
+index 84816389..06c17f94 100644
+--- a/common/flatpak-dir.c
++++ b/common/flatpak-dir.c
+@@ -7593,7 +7593,7 @@ export_desktop_file (const char         *app,
+ 
+       new_exec = g_string_new ("");
+       if ((flatpak = g_getenv ("FLATPAK_BINARY")) == NULL)
+-        flatpak = FLATPAK_BINDIR "/flatpak";
++        flatpak = "flatpak";
+ 
+       g_string_append_printf (new_exec,
+                               "%s run --branch=%s --arch=%s",
+@@ -8939,7 +8939,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
+                                        error))
+         return FALSE;
+       if ((flatpak = g_getenv ("FLATPAK_BINARY")) == NULL)
+-        flatpak = FLATPAK_BINDIR "/flatpak";
++        flatpak = "flatpak";
+ 
+       bin_data = g_strdup_printf ("#!/bin/sh\nexec %s run --branch=%s --arch=%s %s \"$@\"\n",
+                                   flatpak, escaped_branch, escaped_arch, escaped_app);
+-- 
+2.39.2
+


### PR DESCRIPTION
###### Description of changes

In #141913 we switched from patching flatpak to not store store paths in launchers to wrapping it with FLATPAK_BINARY. But this has the disadvantage of needing to wrap every consumer of Flatpak (see #200873).

On @jtojnar's suggestion this goes back to patching over using FLATPAK_BINARY.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
