### PR TITLE
gnuradio: fix on darwin-aarch64

### DIFF
--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -6,6 +6,7 @@
 , pkg-config
 # See https://files.ettus.com/manual_archive/v3.15.0.0/html/page_build_guide.html for dependencies explanations
 , boost
+, ncurses
 , enableCApi ? true
 # requires numpy
 , enablePythonApi ? false
@@ -105,6 +106,7 @@ stdenv.mkDerivation rec {
     # However, if enableLibuhd_Python_api *or* enableUtils is on, we need
     # pythonEnv for runtime as well. The utilities' runtime dependencies are
     # handled at the environment
+    ++ optionals (enableExamples) [ ncurses ncurses.dev ]
     ++ optionals (enablePythonApi || enableUtils) [ pythonEnv ]
     ++ optionals (enableDpdk) [ dpdk ]
   ;
@@ -124,7 +126,7 @@ stdenv.mkDerivation rec {
   ];
 
   postPhases = [ "installFirmware" "removeInstalledTests" ]
-    ++ optionals (enableUtils) [ "moveUdevRules" ]
+    ++ optionals (enableUtils && stdenv.targetPlatform.isLinux) [ "moveUdevRules" ]
   ;
 
   # UHD expects images in `$CMAKE_INSTALL_PREFIX/share/uhd/images`

--- a/pkgs/development/libraries/volk/2.5.0.nix
+++ b/pkgs/development/libraries/volk/2.5.0.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     owner = "gnuradio";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-kI4IuO6TLplo5lLAGIPWQWtePcjIEWB9XaJDA6WlqSg=";
+    sha256 = "sha256-XvX6emv30bSB29EFm6aC+j8NGOxWqHCNv0Hxtdrq/jc=";
     fetchSubmodules = true;
   };
 
@@ -58,4 +58,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
   };
 }
-


### PR DESCRIPTION
- A hash mistake prevented volk 2.5.0 from being built on darwin-aarch64 (the patch phase fails).
- gnuradio's moveUdevRules should only be run on Linux targets.
- Adding ncurses to gnuradio's buildInputs when examples are enabled allows the toy ASCII art DFT viewer to be built.