### PR TITLE
pbm: init at 1.2.2

### DIFF
--- a/doc/languages-frameworks/dotnet.section.md
+++ b/doc/languages-frameworks/dotnet.section.md
@@ -105,6 +105,7 @@ To package Dotnet applications, you can use `buildDotnetModule`. This has simila
      <ProjectReference Include="../foo/bar.fsproj" />
      <PackageReference Include="bar" Version="*" Condition=" '$(ContinuousIntegrationBuild)'=='true' "/>
   ```
+* `useSdkAsRuntime` can be used to link full dotnet sdk into result package, which is required for dotnet tools.
 * `executables` is used to specify which executables get wrapped to `$out/bin`, relative to `$out/lib/$pname`. If this is unset, all executables generated will get installed. If you do not want to install any, set this to `[]`. This gets done in the `preFixup` phase.
 * `runtimeDeps` is used to wrap libraries into `LD_LIBRARY_PATH`. This is how dotnet usually handles runtime dependencies.
 * `buildType` is used to change the type of build. Possible values are `Release`, `Debug`, etc. By default, this is set to `Release`.

--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -36,6 +36,8 @@
 
   # The path to publish the project to. When unset, the directory "$out/lib/$pname" is used.
 , installPath ? null
+  # Use full dotnet sdk at runtime intead of just the runtime.
+, useSdkAsRuntime ? false
   # The binaries that should get installed to `$out/bin`, relative to `$out/lib/$pname/`. These get wrapped accordingly.
   # Unfortunately, dotnet has no method for doing this automatically.
   # If unset, all executables in the projects root will get installed. This may cause bloat!
@@ -92,7 +94,7 @@ let
     else dotnet-sdk.meta.platforms;
 
   inherit (callPackage ./hooks {
-    inherit dotnet-sdk dotnet-test-sdk disabledTests nuget-source dotnet-runtime runtimeDeps buildType;
+    inherit dotnet-sdk dotnet-test-sdk disabledTests nuget-source dotnet-runtime runtimeDeps buildType useSdkAsRuntime;
     runtimeId =
       if runtimeId != null
       then runtimeId
@@ -151,6 +153,8 @@ stdenvNoCC.mkDerivation (args // {
   makeWrapperArgs = args.makeWrapperArgs or [ ] ++ [
     "--prefix LD_LIBRARY_PATH : ${dotnet-sdk.icu}/lib"
   ];
+
+  useSdkAsRuntime = useSdkAsRuntime;
 
   # Stripping breaks the executable
   dontStrip = args.dontStrip or true;

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/default.nix
@@ -10,6 +10,7 @@
 , runtimeDeps
 , buildType
 , runtimeId
+, useSdkAsRuntime
 }:
 assert (builtins.isString runtimeId);
 
@@ -61,11 +62,12 @@ in
     } ./dotnet-install-hook.sh) { };
 
   dotnetFixupHook = callPackage ({ }:
+    let dep = if useSdkAsRuntime then dotnet-sdk else dotnet-runtime; in
     makeSetupHook {
       name = "dotnet-fixup-hook";
-      propagatedBuildInputs = [ dotnet-runtime ];
+      propagatedBuildInputs = [ dep ];
       substitutions = {
-        dotnetRuntime = dotnet-runtime;
+        dotnetRuntime = dep;
         runtimeDeps = libraryPath;
       };
     } ./dotnet-fixup-hook.sh) { };

--- a/pkgs/development/tools/fsautocomplete/default.nix
+++ b/pkgs/development/tools/fsautocomplete/default.nix
@@ -1,0 +1,52 @@
+{ buildDotnetModule, mkNugetDeps, emptyFile, lib, dotnet-sdk }:
+let
+  fsautocomplete = buildDotnetModule rec {
+    pname = "fsautocomplete";
+    version = "0.58.2";
+    inherit dotnet-sdk;
+    nugetDeps = mkNugetDeps {
+      name = pname;
+      nugetDeps = { fetchNuGet }: [
+        (fetchNuGet { inherit pname version; sha256 = "sha256-xZFTxdD4ma5IlPZNqOSwJv/1ixicm21FY+WVS574QiI="; })
+      ];
+    };
+    dontUnpack = true;
+    dontInstall = true;
+    useSdkAsRuntime = true;
+    configurePhase = ''
+      # Generate a NuGet.config file to make sure everything,
+      # including things like <Sdk /> dependencies, is restored from the proper source
+      cat <<EOF > "./NuGet.config"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <clear />
+          <add key="nugetSource" value="${fsautocomplete.passthru.nuget-source}/lib" />
+        </packageSources>
+      </configuration>
+      EOF
+    '';
+
+    executables = ".dotnet/tools/${pname}";
+    buildPhase = ''
+      #set env variable to install tool where fixupHook will be able to find it
+      export DOTNET_CLI_HOME=$out/lib/${pname}
+      dotnet tool install --configfile ./NuGet.config --global ${pname}
+
+      cd $out
+      #removing text files that contains nix store paths to temp nuget sources we made
+      find . -name 'project.assets.json' -delete
+      find . -name '.nupkg.metadata' -delete
+    '';
+
+    meta = with lib; {
+      description = "The FsAutoComplete project (FSAC) provides a backend service for rich editing or intellisense features for editors.";
+      homepage = "https://github.com/fsharp/FsAutoComplete";
+      changelog = "https://github.com/fsharp/FsAutoComplete/releases/tag/v${version}";
+      license = licenses.asl20;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ gbtb ];
+    };
+  };
+in
+fsautocomplete

--- a/pkgs/tools/admin/pbm/default.nix
+++ b/pkgs/tools/admin/pbm/default.nix
@@ -1,0 +1,53 @@
+# copied from fsautocomplete until https://github.com/NixOS/nixpkgs/issues/216285 is resolved
+{ buildDotnetModule, mkNugetDeps, emptyFile, lib, dotnet-sdk }:
+let
+  fsautocomplete = buildDotnetModule rec {
+    pname = "pbm";
+    version = "1.2.2";
+    inherit dotnet-sdk;
+    nugetDeps = mkNugetDeps {
+      name = pname;
+      nugetDeps = { fetchNuGet }: [
+        (fetchNuGet { inherit pname version; sha256 = "sha256-DkbaUYnt6aJEFKp3wWceWxq87fzswjdMQvECCWiq+FU="; })
+      ];
+    };
+    dontUnpack = true;
+    dontInstall = true;
+    useSdkAsRuntime = true;
+    configurePhase = ''
+      # Generate a NuGet.config file to make sure everything,
+      # including things like <Sdk /> dependencies, is restored from the proper source
+      cat <<EOF > "./NuGet.config"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <clear />
+          <add key="nugetSource" value="${fsautocomplete.passthru.nuget-source}/lib" />
+        </packageSources>
+      </configuration>
+      EOF
+    '';
+
+    executables = ".dotnet/tools/${pname}";
+    buildPhase = ''
+      #set env variable to install tool where fixupHook will be able to find it
+      export DOTNET_CLI_HOME=$out/lib/${pname}
+      dotnet tool install --configfile ./NuGet.config --global ${pname}
+
+      cd $out
+      #removing text files that contains nix store paths to temp nuget sources we made
+      find . -name 'project.assets.json' -delete
+      find . -name '.nupkg.metadata' -delete
+    '';
+
+    meta = with lib; {
+      description = "CLI for managing Akka.NET applications and Akka.NET Clusters.";
+      homepage = "https://cmd.petabridge.com/index.html";
+      changelog = "https://cmd.petabridge.com/articles/RELEASE_NOTES.html";
+      license = licenses.unfree;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ anpin ];
+    };
+  };
+in
+fsautocomplete

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40705,4 +40705,6 @@ with pkgs;
   isolate = callPackage ../tools/security/isolate { };
 
   reindeer = callPackage ../development/tools/reindeer { };
+
+  pbm = callPackage ../tools/admin/pbm { };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40488,6 +40488,8 @@ with pkgs;
     stdenv = crossLibcStdenv;
   };
 
+  fsautocomplete = callPackage ../development/tools/fsautocomplete { };
+
   omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { };
 
   wasmtime = callPackage ../development/interpreters/wasmtime {


### PR DESCRIPTION
###### Description of changes
[pbm](https://cmd.petabridge.com/index.htm) is a `dotnet-tool` for managing Akka.NET applications and Akka.NET Clusters. Related to https://github.com/NixOS/nixpkgs/pull/206407 and https://github.com/NixOS/nixpkgs/issues/216285

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
