### PR TITLE
buildRustCrate: Add support for build kinds

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -1,129 +1,178 @@
-{ lib, stdenv
-, mkRustcDepArgs, mkRustcFeatureArgs, needUnstableCLI
+{ lib
+, stdenv
+, mkRustcDepArgs
+, mkRustcFeatureArgs
+, needUnstableCLI
 , rust
+, buildRustCrateHelpers
 }:
-
-{ crateName,
-  dependencies,
-  crateFeatures, crateRenames, libName, release, libPath,
-  crateType, metadata, crateBin, hasCrateBin,
-  extraRustcOpts, verbose, colors,
-  buildTests,
-  codegenUnits
+{ crateName
+, dependencies
+, crateFeatures
+, crateRenames
+, release
+, libName
+, libPath
+, libHarness
+, crateType
+, metadata
+, crateBin
+, hasCrateBin
+, extraRustcOpts
+, verbose
+, colors
+, buildKinds
+, buildTests
+, codegenUnits
 }:
+let
+  baseRustcOpts =
+    [
+      (if release then "-C opt-level=3" else "-C debuginfo=2")
+      "-C codegen-units=${toString codegenUnits}"
+      "--remap-path-prefix=$NIX_BUILD_TOP=/"
+      (mkRustcDepArgs dependencies crateRenames)
+      (mkRustcFeatureArgs crateFeatures)
+    ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "--target"
+      (rust.toRustTargetSpec stdenv.hostPlatform)
+    ] ++ lib.optionals (needUnstableCLI dependencies) [
+      "-Z"
+      "unstable-options"
+    ] ++ extraRustcOpts
+    # since rustc 1.42 the "proc_macro" crate is part of the default crate prelude
+    # https://github.com/rust-lang/cargo/commit/4d64eb99a4#diff-7f98585dbf9d30aa100c8318e2c77e79R1021-R1022
+    ++ lib.optional (lib.elem "proc-macro" crateType) "--extern proc_macro"
+  ;
+  rustcMeta = "-C metadata=${metadata} -C extra-filename=-${metadata}";
 
+  # build the final rustc arguments that can be different between different
+  # crates
+  libRustcOpts = lib.concatStringsSep " " (
+    baseRustcOpts
+    ++ [ rustcMeta ]
+    ++ (map (x: "--crate-type ${x}") crateType)
+  );
+
+  binRustcOpts = lib.concatStringsSep " " (
+    baseRustcOpts
+  );
+
+  inherit (buildRustCrateHelpers.kinds) kindToDir isTest isLib isExample isBench isBin;
+  kindTypes = buildRustCrateHelpers.kinds.kind;
+
+  buildTestsNew = buildTests || builtins.any isTest buildKinds;
+  buildLib = builtins.any isLib buildKinds;
+  buildBenches = builtins.any isBench buildKinds;
+  buildBins = builtins.any isBin buildKinds;
+  buildExamples = builtins.any isExample buildKinds;
+
+  crateBinBins = hasCrateBin && builtins.any (t: if t ? kind then isBin t.kind else true) crateBin;
+  crateBinTests = hasCrateBin && builtins.any (t: if t ? kind then isTest t.kind else false) crateBin;
+  crateBinExamples = hasCrateBin && builtins.any (t: if t ? kind then isExample t.kind else false) crateBin;
+  crateBinBenches = hasCrateBin && builtins.any (t: if t ? kind then isBench t.kind else false) crateBin;
+
+  bashBoolToString = t: if t then "1" else "0";
+in
+''
+  runHook preBuild
+
+  # configure & source common build functions
+  LIB_RUSTC_OPTS="${libRustcOpts}"
+  BIN_RUSTC_OPTS="${binRustcOpts}"
+  LIB_EXT="${stdenv.hostPlatform.extensions.sharedLibrary}"
+  LIB_PATH="${libPath}"
+  LIB_NAME="${libName}"
+  LIB_HARNESS=${bashBoolToString libHarness}
+  # Uses lowercase (kind types) for bash indirect substitution in auto discovery
+  ${kindTypes.lib}_DIR="${kindToDir kindTypes.lib}"
+  ${kindTypes.bin}_DIR="${kindToDir kindTypes.bin}"
+  ${kindTypes.example}_DIR="${kindToDir kindTypes.example}"
+  ${kindTypes.bench}_DIR="${kindToDir kindTypes.bench}"
+  ${kindTypes.test}_DIR="${kindToDir kindTypes.test}"
+
+  CRATE_NAME='${lib.replaceStrings ["-"] ["_"] libName}'
+
+  setup_link_paths
+
+  # If not specified it is src/lib.rs
+  # https://doc.rust-lang.org/cargo/guide/project-layout.html
+  if ! [ -e "$LIB_PATH" ]; then
+    LIB_PATH=src/lib.rs
+  fi
+
+  if [ -e "$LIB_PATH" ]; then
+     ${lib.optionalString buildLib ''build_lib_lib "$LIB_PATH"''}
+     ${lib.optionalString buildTestsNew ''build_lib_test "$LIB_PATH" $LIB_HARNESS''}
+     ${lib.optionalString buildBenches ''build_lib_bench "$LIB_PATH" $LIB_HARNESS''}
+     true
+  fi
+
+  ${lib.optionalString (lib.length crateBin > 0) (lib.concatMapStringsSep "\n" (bin:
   let
-    baseRustcOpts =
-      [
-        (if release then "-C opt-level=3" else "-C debuginfo=2")
-        "-C codegen-units=${toString codegenUnits}"
-        "--remap-path-prefix=$NIX_BUILD_TOP=/"
-        (mkRustcDepArgs dependencies crateRenames)
-        (mkRustcFeatureArgs crateFeatures)
-      ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-        "--target" (rust.toRustTargetSpec stdenv.hostPlatform)
-      ] ++ lib.optionals (needUnstableCLI dependencies) [
-        "-Z" "unstable-options"
-      ] ++ extraRustcOpts
-      # since rustc 1.42 the "proc_macro" crate is part of the default crate prelude
-      # https://github.com/rust-lang/cargo/commit/4d64eb99a4#diff-7f98585dbf9d30aa100c8318e2c77e79R1021-R1022
-      ++ lib.optional (lib.elem "proc-macro" crateType) "--extern proc_macro"
-    ;
-    rustcMeta = "-C metadata=${metadata} -C extra-filename=-${metadata}";
+  haveRequiredFeature =
+    if bin ? requiredFeatures then
+    # Check that all element in requiredFeatures are also present in crateFeatures
+      lib.intersectLists bin.requiredFeatures crateFeatures == bin.requiredFeatures
+    else
+      true;
 
-
-    # build the final rustc arguments that can be different between different
-    # crates
-    libRustcOpts = lib.concatStringsSep " " (
-      baseRustcOpts
-      ++ [rustcMeta]
-      ++ (map (x: "--crate-type ${x}") crateType)
-    );
-
-    binRustcOpts = lib.concatStringsSep " " (
-      baseRustcOpts
-    );
-
-    build_bin = if buildTests then "build_bin_test" else "build_bin";
-  in ''
-    runHook preBuild
-
-    # configure & source common build functions
-    LIB_RUSTC_OPTS="${libRustcOpts}"
-    BIN_RUSTC_OPTS="${binRustcOpts}"
-    LIB_EXT="${stdenv.hostPlatform.extensions.sharedLibrary}"
-    LIB_PATH="${libPath}"
-    LIB_NAME="${libName}"
-
-    CRATE_NAME='${lib.replaceStrings ["-"] ["_"] libName}'
-
-    setup_link_paths
-
-    if [[ -e "$LIB_PATH" ]]; then
-       build_lib "$LIB_PATH"
-       ${lib.optionalString buildTests ''build_lib_test "$LIB_PATH"''}
-    elif [[ -e src/lib.rs ]]; then
-       build_lib src/lib.rs
-       ${lib.optionalString buildTests "build_lib_test src/lib.rs"}
-    fi
-
-
-
-    ${lib.optionalString (lib.length crateBin > 0) (lib.concatMapStringsSep "\n" (bin:
-    let
-      haveRequiredFeature = if bin ? requiredFeatures then
-        # Check that all element in requiredFeatures are also present in crateFeatures
-        lib.intersectLists bin.requiredFeatures crateFeatures == bin.requiredFeatures
-      else
-        true;
-    in
-    if haveRequiredFeature then ''
-      mkdir -p target/bin
-      BIN_NAME='${bin.name or crateName}'
-      ${if !bin ? path then ''
-        BIN_PATH=""
-        search_for_bin_path "$BIN_NAME"
-      '' else ''
-        BIN_PATH='${bin.path}'
-      ''}
-        ${build_bin} "$BIN_NAME" "$BIN_PATH"
-    '' else ''
-      echo Binary ${bin.name or crateName} not compiled due to not having all of the required features -- ${lib.escapeShellArg (builtins.toJSON bin.requiredFeatures)} -- enabled.
-    '') crateBin)}
-
-    ${lib.optionalString buildTests ''
-    # When tests are enabled build all the files in the `tests` directory as
-    # test binaries.
-    if [ -d tests ]; then
-      # find all the .rs files (or symlinks to those) in the tests directory, no subdirectories
-      find tests -maxdepth 1 \( -type f -o -type l \) -a -name '*.rs' -print0 | while IFS= read -r -d ''' file; do
-        mkdir -p target/bin
-        build_bin_test_file "$file"
-      done
-
-      # find all the subdirectories of tests/ that contain a main.rs file as
-      # that is also a test according to cargo
-      find tests/ -mindepth 1 -maxdepth 2 \( -type f -o -type l \) -a -name 'main.rs' -print0 | while IFS= read -r -d ''' file; do
-        mkdir -p target/bin
-        build_bin_test_file "$file"
-      done
-
-    fi
-    ''}
-
-    # If crateBin is empty and hasCrateBin is not set then we must try to
-    # detect some kind of bin target based on some files that might exist.
-    ${lib.optionalString (lib.length crateBin == 0 && !hasCrateBin) ''
-      if [[ -e src/main.rs ]]; then
-        mkdir -p target/bin
-        ${build_bin} ${crateName} src/main.rs
-      fi
-      for i in src/bin/*.rs; do #*/
-        mkdir -p target/bin
-        ${build_bin} "$(basename $i .rs)" "$i"
-      done
-    ''}
-    # Remove object files to avoid "wrong ELF type"
-    find target -type f -name "*.o" -print0 | xargs -0 rm -f
-    runHook postBuild
+  # For back compatibility if not specified
+  # 1. a normal binary
+  # 2. Tests if `buildTests` is true
+  # 3. Does not bench
+  # 4. Uses harness (converted to bash 0/1)
+  kind = if !bin ? kind then "bin" else
+  lib.trivial.throwIfNot (isBench bin.kind || isTest bin.kind || isExample bin.kind || isBin bin.kind) ''
+    Binary type must be of kind `bin`, `test`, `bench`, or `example`
   ''
+    bin.kind;
+  test = if bin ? test then bin.test else buildTests;
+  bench = if bin ? bench then bin.bench else false;
+  harness = bashBoolToString (if bin ? harness then bin.harness else true);
+
+  # Require a name or path for all binaries
+  binName = lib.trivial.throwIfNot (bin ? name) "A name is required for binary" bin.name;
+
+  compileCommands = ''
+    mkdir -p target/${kind}
+    BIN_NAME="${binName}"
+    BIN_PATH=""
+    ${if !bin ? path then (
+        if kind == "bin" then
+          ''search_for_bin_path "$BIN_NAME"''
+        else
+          ''search_for_path "${kind}" $BIN_NAME"''
+    ) else ''
+      BIN_PATH="${bin.path}"
+    ''}
+    ${lib.optionalString ((buildBins && isBin kind) || (buildExamples && isExample kind)) ''
+      build_bin_${kind} "$BIN_NAME" "$BIN_PATH" ${harness}
+    ''}
+    ${lib.optionalString (buildTestsNew && (test || isTest kind)) ''
+      build_bin_test "$BIN_NAME" "$BIN_PATH" ${harness}
+    ''}
+    ${lib.optionalString (buildBenches && (bench || isBench kind)) ''
+      build_bin_bench "$BIN_NAME" "$BIN_PATH" ${harness}
+    ''}
+  '';
+  in
+  if !haveRequiredFeature then ''
+    echo Binary ${bin.name or crateName} not compiled due to not having all of the required features -- ${lib.escapeShellArg (builtins.toJSON bin.requiredFeatures)} -- enabled.
+  '' else compileCommands) crateBin)}
+
+
+  # Using cargo 2015 format of disabling auto-discovery when specifying a `crateBin` and there is a kind
+  # specified. Because there is no duplicate detection currently:
+  # https://doc.rust-lang.org/cargo/reference/cargo-targets.html?highlight=target%20auto-disc#target-auto-discovery
+  # Also see the layout specs:
+  # The names of the extra directories, see: https://doc.rust-lang.org/cargo/guide/project-layout.html
+  ${lib.optionalString (buildBins && !crateBinBins) ''auto_build_bins "${crateName}" ${bashBoolToString buildTestsNew}''}
+  ${lib.optionalString (buildExamples && !crateBinExamples) "auto_build_dir ${kindTypes.example} ${bashBoolToString buildTestsNew}"}
+  ${lib.optionalString (buildTestsNew && !crateBinTests) "auto_build_dir ${kindTypes.test} ${bashBoolToString false}"}
+  ${lib.optionalString (buildBenches && !crateBinBenches) "auto_build_dir ${kindTypes.bench} ${bashBoolToString false}"}
+
+  # Remove object files to avoid "wrong ELF type"
+  find target -type f -name "*.o" -print0 | xargs -0 rm -f
+  runHook postBuild
+''

--- a/pkgs/build-support/rust/build-rust-crate/helpers.nix
+++ b/pkgs/build-support/rust/build-rust-crate/helpers.nix
@@ -1,4 +1,4 @@
-{stdenv, lib}:
+{ stdenv, lib }:
 {
   kernel = stdenv.hostPlatform.parsed.kernel.name;
   abi = stdenv.hostPlatform.parsed.abi.name;
@@ -23,4 +23,29 @@
        !lib.strings.hasPrefix (toString (src + ("/" + f))) path
     ) excludedFiles
   ) src;
+
+  kinds = rec {
+    kind = {
+      lib = "lib";
+      test = "test";
+      bin = "bin";
+      bench = "bench";
+      example = "example";
+    };
+
+    kindToDir = t:
+      if isLib t then "lib" else
+      if isBin t then "bin" else
+      if isTest t then "tests" else
+      if isExample t then "examples" else
+      if isBench t then "benches" else
+      builtins.throw "Invalid kind: ${t}";
+
+    isLib = t: t == kind.lib;
+    isBin = t: t == kind.bin;
+    isTest = t: t == kind.test;
+    isBench = t: t == kind.bench;
+    isExample = t: t == kind.example;
+  };
+
 }

--- a/pkgs/build-support/rust/build-rust-crate/install-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/install-crate.nix
@@ -1,51 +1,53 @@
-{ stdenv }:
-crateName: metadata: buildTests:
-if !buildTests then ''
-  runHook preInstall
-  # always create $out even if we do not have binaries. We are detecting binary targets during compilation, if those are missing there is no way to only have $lib
-  mkdir $out
-  if [[ -s target/env ]]; then
-    mkdir -p $lib
-    cp target/env $lib/env
-  fi
-  if [[ -s target/link.final ]]; then
-    mkdir -p $lib/lib
-    cp target/link.final $lib/lib/link
-  fi
-  if [[ "$(ls -A target/lib)" ]]; then
-    mkdir -p $lib/lib
-    cp -r target/lib/* $lib/lib #*/
-    for library in $lib/lib/*.so $lib/lib/*.dylib; do #*/
-      ln -s $library $(echo $library | sed -e "s/-${metadata}//")
-    done
-  fi
-  if [[ "$(ls -A target/build)" ]]; then # */
-    mkdir -p $lib/lib
-    cp -r target/build/* $lib/lib # */
-  fi
-  if [[ -d target/bin ]]; then
-    if [[ "$(ls -A target/bin)" ]]; then
-      mkdir -p $out/bin
-      cp -rP target/bin/* $out/bin # */
+{ lib, stdenv, buildRustCrateHelpers }:
+{ crateName
+, metadata
+, buildKinds
+, buildTests
+}:
+let
+  inherit (buildRustCrateHelpers.kinds) kind kindToDir isTest isLib;
+
+  installLib = ''
+    # always create $out even if we do not have binaries
+    mkdir -p $out
+    if [[ -s target/env ]]; then
+      mkdir -p $lib
+      cp target/env $lib/env
     fi
-  fi
-  runHook postInstall
-'' else
-# for tests we just put them all in the output. No execution.
+    if [[ -s target/link.final ]]; then
+      mkdir -p $lib/lib
+      cp target/link.final $lib/lib/link
+    fi
+    if [[ "$(ls -A target/lib)" ]]; then
+      mkdir -p $lib/lib
+      cp -r target/lib/* $lib/lib #*/
+      for library in $lib/lib/*.so $lib/lib/*.dylib; do #*/
+        ln -s $library $(echo $library | sed -e "s/-${metadata}//")
+      done
+    fi
+    if [[ "$(ls -A target/build)" ]]; then # */
+      mkdir -p $lib/lib
+      cp -r target/build/* $lib/lib # */
+    fi
+  '';
+
+  installKind = k:
+    let
+      dir = kindToDir k;
+    in
+    ''
+      mkdir -p $out/${dir}
+      if [ -e target/${dir} ]; then
+        find target/${dir}/ -type f -executable -exec cp {} $out/${dir} \;
+      fi
+    '';
+in
 ''
   runHook preInstall
-
-  mkdir -p $out/tests
-  if [ -e target/bin ]; then
-    find target/bin/ -type f -executable -exec cp {} $out/tests \;
-  fi
-  if [ -e target/lib ]; then
-    find target/lib/ -type f \! -name '*.rlib' \
-      -a \! -name '*${stdenv.hostPlatform.extensions.sharedLibrary}' \
-      -a \! -name '*.d' \
-      -executable \
-      -print0 | xargs --no-run-if-empty --null install --target $out/tests;
-  fi
-
+  ${lib.concatStringsSep "\n" (builtins.map
+    (k: if isLib k then installLib else installKind k)
+    buildKinds)
+  }
+  ${lib.optionalString (buildTests && !(builtins.any isTest buildKinds)) (installKind kind.test)}
   runHook postInstall
 ''

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -1,19 +1,61 @@
 echo_build_heading() {
-  if (( $# == 1 )); then
-    echo_colored "Building $1"
-  else
-    echo_colored "Building $1 ($2)"
-  fi
+  echo_colored "Building $1 ($2 | kind: $3)"
 }
 
-build_lib() {
-  lib_src=$1
-  echo_build_heading $lib_src ${libName}
+# Whether to use the test harness
+# https://github.com/rust-lang/cargo/blob/9282cf74a38757c217d122bbf998afcda2626595/src/cargo/core/compiler/mod.rs#L1094
+use_test_harness() {
+    local is_test=$1
+    local use_harness=$2
+
+    if [ $is_test -eq 1 ] && [ $use_harness -eq 1 ]; then
+        echo "--test"
+    elif [ $is_test -eq 1 ]; then
+        echo "--cfg test"
+    else
+        echo ""
+    fi
+}
+
+# Crate file names can be the same due to main.rs
+# derive their names using subdirectories
+# tests/foo/main.rs -> foo
+# tests/bar/main.rs -> bar
+# tests/zed.rs -> zed
+derive_crate_name() {
+    local file=$1
+    local dir=$2
+
+    local derived_crate_name="${file//\//_}"
+    # Make sure to strip the top level `tests` directory: see #204051. Note that
+    # a forward slash has now become an underscore due to the substitution
+    # above.
+    derived_crate_name=${derived_crate_name#"$dir_"}
+    derived_crate_name="${derived_crate_name%.rs}"
+
+    echo $derived_crate_name
+}
+
+
+# Call through build_lib_KIND functions
+_build_lib() {
+  local lib_src=$1
+  local is_test=$2
+  local harness=$3
+
+  local test_flags
+  test_flags=$(use_test_harness $is_test $harness)
+
+  # OUT_DIR is for build script output, prefix CRATE
+  if [ ! -d "$CRATE_OUT_DIR" ]; then
+    mkdir -p "$CRATE_OUT_DIR"
+  fi
 
   noisily rustc \
     --crate-name $CRATE_NAME \
     $lib_src \
-    --out-dir target/lib \
+    $test_flags \
+    --out-dir "$CRATE_OUT_DIR" \
     -L dependency=target/deps \
     --cap-lints allow \
     $LINK \
@@ -32,21 +74,54 @@ build_lib() {
   fi
 }
 
-build_bin() {
-  local crate_name=$1
-  local crate_name_=$(echo $crate_name | tr '-' '_')
-  local main_file=""
+build_lib_lib() {
+    local lib_src=$1
+    local is_test=0
+    # harness does not matter
 
-  if [[ ! -z $2 ]]; then
-    main_file=$2
+    echo_build_heading "$LIB_NAME" "$lib_src" "lib"
+    CRATE_OUT_DIR="target/$lib_DIR" _build_lib "$lib_src" $is_test
+}
+
+build_lib_test() {
+    local lib_src=$1
+    local harness=$2
+    local is_test=1
+
+    echo_build_heading "$LIB_NAME" "$lib_src" "lib-test"
+    CRATE_OUT_DIR="target/$test_DIR" _build_lib "$lib_src" $is_test $harness
+}
+
+build_lib_bench() {
+    local lib_src=$1
+    local harness=$2
+    local is_test=1
+
+    echo_build_heading "$LIB_NAME" "$lib_src" "lib-bench"
+    CRATE_OUT_DIR="target/$bench_DIR" _build_lib "$lib_src" $is_test $harness
+}
+
+# Call through build_bin_KIND functions
+_build_bin() {
+  local crate_name=$1
+  local main_file=$2
+  local is_test=$3
+  local harness=$4
+
+  local test_flags=$(use_test_harness $is_test $harness)
+  local crate_name_=$(echo $crate_name | tr '-' '_')
+
+  if [ ! -d "$CRATE_OUT_DIR" ]; then
+    mkdir -p "$CRATE_OUT_DIR"
   fi
-  echo_build_heading $@
+
   noisily rustc \
     --crate-name $crate_name_ \
     $main_file \
+    $test_flags \
     --crate-type bin \
     $BIN_RUSTC_OPTS \
-    --out-dir target/bin \
+    --out-dir "$CRATE_OUT_DIR" \
     -L dependency=target/deps \
     $LINK \
     $EXTRA_LINK_ARGS \
@@ -60,30 +135,110 @@ build_bin() {
     --color ${colors} \
 
   if [ "$crate_name_" != "$crate_name" ]; then
-    mv target/bin/$crate_name_ target/bin/$crate_name
+    mv $CRATE_OUT_DIR/$crate_name_ $CRATE_OUT_DIR/$crate_name
   fi
 }
 
-build_lib_test() {
-    local file="$1"
-    EXTRA_RUSTC_FLAGS="--test $EXTRA_RUSTC_FLAGS" build_lib "$1" "$2"
+build_bin_bin() {
+    local crate_name=$1
+    local main_file=$2
+    local is_test=0
+    # harness does not matter
+
+    echo_build_heading $crate_name $main_file "bin"
+    CRATE_OUT_DIR="target/$bin_DIR" _build_bin "$crate_name" "$main_file" $is_test
+}
+
+build_bin_example() {
+    local crate_name=$1
+    local main_file=$2
+    local is_test=0
+    # harness does not matter
+
+    echo_build_heading $crate_name $main_file "example"
+    CRATE_OUT_DIR="target/$example_DIR" _build_bin "$crate_name" "$main_file" $is_test
 }
 
 build_bin_test() {
-    local crate="$1"
-    local file="$2"
-    EXTRA_RUSTC_FLAGS="--test $EXTRA_RUSTC_FLAGS" build_bin "$1" "$2"
+    local crate_name=$1
+    local main_file=$2
+    local harness=$3
+    local is_test=1
+
+    echo_build_heading $crate_name $main_file "test"
+    CRATE_OUT_DIR="target/$test_DIR" _build_bin "$crate_name" "$main_file" $is_test $harness
 }
 
-build_bin_test_file() {
-    local file="$1"
-    local derived_crate_name="${file//\//_}"
-    # Make sure to strip the top level `tests` directory: see #204051. Note that
-    # a forward slash has now become an underscore due to the substitution
-    # above.
-    derived_crate_name=${derived_crate_name#"tests_"}
-    derived_crate_name="${derived_crate_name%.rs}"
-    build_bin_test "$derived_crate_name" "$file"
+build_bin_bench() {
+    local crate_name=$1
+    local main_file=$2
+    local harness=$3
+    local is_test=1
+
+    echo_build_heading $crate_name $main_file "bench"
+    CRATE_OUT_DIR="target/$bench_DIR" _build_bin "$crate_name" "$main_file" $is_test $harness
+}
+
+auto_build_bins() {
+    local crateName=$1
+    local buildTest=$2
+    # Use harness for auto builds
+    local harness=1
+
+    echo_colored "Autodiscovering bin"
+
+    if [ -e src/main.rs ]; then
+      build_bin_bin "$crateName" "src/main.rs"
+      if [ $buildTest -eq 1 ]; then
+          build_bin_test "$crateName" "src/main.rs" $harness
+      fi
+    fi
+
+    for file in src/bin/*.rs; do
+      build_bin_bin "$(basename $file .rs)" "$file"
+      if [ $buildTest -eq 1 ]; then
+          # TODO: build test & build bench is the same output
+          build_bin_test "$(basename $file .rs)" "$file" $harness
+      fi
+    done
+}
+
+auto_build_dir() {
+    # directory and kind names are subtley different
+    local kind=$1
+    local buildTest=$2
+    echo "Building tests: $1 $2"
+
+    # Use harness for auto builds
+    local harness=1
+    echo_colored "Autodiscovering $kind"
+
+    local dir
+    dir="${kind}_DIR"
+    dir="${!dir}"
+
+    if [ -d "$dir" ]; then
+      # find all the .rs files (or symlinks to those) in the directory, no subdirectories
+      find "$dir" -maxdepth 1 \( -type f -o -type l \) -a -name '*.rs' -print0 | while IFS= read -r -d '' file; do
+        local crate_name=$(derive_crate_name $file $dir)
+        build_bin_$kind "$crate_name" "$file" $harness
+        if [ $buildTest -eq 1 ]; then
+            # TODO: build test & build bench is the same output
+            build_bin_test "$crate_name" "$file" $harness
+        fi
+      done
+
+      # find all the subdirectories of $dir/ that contain a main.rs file as
+      # that is also a test according to cargo
+      find "$dir"/ -mindepth 1 -maxdepth 2 \( -type f -o -type l \) -a -name 'main.rs' -print0 | while IFS= read -r -d '' file; do
+        local crate_name=$(derive_crate_name $file $dir)
+        build_bin_$kind "$crate_name" "$file" $harness
+        if [ $buildTest -eq 1 ]; then
+            # TODO: build test & build bench is the same output
+            build_bin_test "$crate_name" "$file" $harness
+        fi
+      done
+    fi
 }
 
 # Add additional link options that were provided by the build script.
@@ -114,6 +269,33 @@ setup_link_paths() {
      tr '\n' ' ' < target/link > target/link_
      LINK=$(cat target/link_)
   fi
+}
+
+search_for_path() {
+    local kind=$1
+    BIN_NAME=$2
+    BIN_NAME_=$(echo $BIN_NAME | tr '-' '_')
+
+    local dir
+    dir="${kind}_DIR"
+    dir="${!dir}"
+
+    FILES=( "$dir/$BIN_NAME.rs" "$dir/$BIN_NAME/main.rs" "$dir/$BIN_NAME_/main.rs" "$dir/$BIN_NAME_/main.rs")
+
+    for file in "${FILES[@]}";
+    do
+      echo "checking file $file"
+      # first file that exists wins
+      if [[ -e "$file" ]]; then
+              BIN_PATH="$file"
+              break
+      fi
+    done
+
+    if [[ -z "$BIN_PATH" ]]; then
+      echo_error "ERROR: failed to find file for binary target (kind: $kind): $BIN_NAME" >&2
+      exit 1
+    fi
 }
 
 search_for_bin_path() {


### PR DESCRIPTION
Adds proper support for build kinds. Based on cargo.

A new top-level parameter `buildKinds` can specify which build kinds should
be compiled. By default for backwards compatibility the build kinds are
["lib" "bin"], with "test" added if `buildTests` is true.

Currently available build kinds: ["lib" "bin" "test" "example" "bench"].
When a build kind is disabled, all builds of that kind will be skipped.

Additionally, all values in `crateBin` can now take new parameters. This
is to set the kind of binary should be built, and whether it should be
benched or tested. For backwards compatibility if not set, it is of kind
"bin" along with `test` set to true when `buildTests` are true.

```nix
{
  name = "xxx"; # existing
  src_path = "xxx"; # existing
  kind = "bin"; # Same values as `buildKinds` with exclusion of lib
  harness = true;
  test = true;
  bench = true;
  harness = true;
}
```

Setting harness determines whether to use the libtest harness, as in
cargo. For the library, use the top-level `libHarness` parameter.
It only matters when compiling for bench or test kinds.

As before, it is up to the user to create multiple `buildRustCrate`
derivations providing the proper dependencies for different kinds.

Autodiscovery is performed, as in cargo 2015, when no binaries of the
specified kind are set in `crateBin`.

There are no breaking changes to the buildRustCrate api. But this
deprecates the use of `buildTests` in favor of `buildKind = ["test"]`

###### Description of changes

This is marked as a draft until I write a PR for `crate2nix` in case the api ergonomics can be improved.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux - `pkgs.tests.buildRustCrate`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
