### PR TITLE
ruby: disable parallel install

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -95,6 +95,10 @@ let
         propagatedBuildInputs = op jemallocSupport jemalloc;
 
         enableParallelBuilding = true;
+        # /build/ruby-2.7.7/lib/fileutils.rb:882:in `chmod':
+        #   No such file or directory @ apply2files - ...-ruby-2.7.7-devdoc/share/ri/2.7.0/system/ARGF/inspect-i.ri (Errno::ENOENT)
+        # make: *** [uncommon.mk:373: do-install-all] Error 1
+        enableParallelInstalling = false;
 
         patches = op (lib.versionOlder ver.majMin "3.1") ./do-not-regenerate-revision.h.patch
           ++ op (atLeast30 && useBaseRuby) (


### PR DESCRIPTION
Without the change parallel installs fail as:

    installing rdoc:                    ...-ruby-2.7.7-devdoc/share/ri/2.7.0/system
    Traceback (most recent call last):
            13: from ./tool/rbinstall.rb:954:in `<main>'
            12: from ./tool/rbinstall.rb:954:in `each'
            11: from ./tool/rbinstall.rb:957:in `block in <main>'
            10: from ./tool/rbinstall.rb:438:in `block in <main>'
             9: from ./tool/rbinstall.rb:262:in `install_recursive'
             8: from ./tool/rbinstall.rb:262:in `each'
             7: from ./tool/rbinstall.rb:271:in `block in install_recursive'
             6: from ./tool/rbinstall.rb:174:in `install'
             5: from /build/ruby-2.7.7/lib/fileutils.rb:876:in `install'
             4: from /build/ruby-2.7.7/lib/fileutils.rb:1587:in `fu_each_src_dest'
             3: from /build/ruby-2.7.7/lib/fileutils.rb:1605:in `fu_each_src_dest0'
             2: from /build/ruby-2.7.7/lib/fileutils.rb:1589:in `block in fu_each_src_dest'
             1: from /build/ruby-2.7.7/lib/fileutils.rb:882:in `block in install'
    /build/ruby-2.7.7/lib/fileutils.rb:882:in `chmod': No such file or directory @ apply2files - ...-ruby-2.7.7-devdoc/share/ri/2.7.0/system/ARGF/inspect-i.ri (Errno::ENOENT)
    make: *** [uncommon.mk:373: do-install-all] Error 1
    make: *** Waiting for unfinished jobs....

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
