### PR TITLE
lbreakouthd: 1.1 -> 1.1.1

### DIFF
--- a/pkgs/games/lgames/lbreakouthd/default.nix
+++ b/pkgs/games/lgames/lbreakouthd/default.nix
@@ -1,20 +1,20 @@
 { lib
 , stdenv
 , fetchurl
+, directoryListingUpdater
 , SDL2
 , SDL2_image
 , SDL2_mixer
 , SDL2_ttf
-, directoryListingUpdater
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (self: {
   pname = "lbreakouthd";
-  version = "1.1";
+  version = "1.1.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/lgames/${pname}-${version}.tar.gz";
-    hash = "sha256-5hjS0aJ5f8Oe0aSuVgcV10h5OmWsaMHF5B9wYVFrlDY=";
+    url = "mirror://sourceforge/lgames/lbreakouthd-${self.version}.tar.gz";
+    hash = "sha256-ljnZpuV9HPPR5bgdbyE8gUtb4m+JppxGm3MV691sw7E=";
   };
 
   buildInputs = [
@@ -27,17 +27,17 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   passthru.updateScript = directoryListingUpdater {
-    inherit pname version;
+    inherit (self) pname version;
     url = "https://lgames.sourceforge.io/LBreakoutHD/";
     extraRegex = "(?!.*-win(32|64)).*";
   };
 
-  meta = with lib; {
-    broken = stdenv.isDarwin;
+  meta = {
     homepage = "https://lgames.sourceforge.io/LBreakoutHD/";
     description = "A widescreen Breakout clone";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ AndersonTorres ];
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ AndersonTorres ];
     inherit (SDL2.meta) platforms;
+    broken = stdenv.isDarwin;
   };
-}
+})


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Hopefully closes https://github.com/NixOS/nixpkgs/issues/221250
Supercedes https://github.com/NixOS/nixpkgs/pull/221423

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
