### PR TITLE
neorg-haskell-parser: init at unstable-2023-01-18

### DIFF
--- a/pkgs/tools/misc/neorg-haskell-parser/default.nix
+++ b/pkgs/tools/misc/neorg-haskell-parser/default.nix
@@ -1,0 +1,67 @@
+{ mkDerivation
+, fetchFromGitHub
+, aeson
+, base
+, bytestring
+, containers
+, hspec
+, HUnit
+, lib
+, megaparsec
+, optparse-applicative
+, pandoc-types
+, parser-combinators
+, text
+, these
+, transformers
+, vector
+}:
+
+mkDerivation rec {
+  pname = "neorg-haskell-parser";
+  version = "unstable-2023-03-17";
+
+  src = fetchFromGitHub {
+    owner = "Simre1";
+    repo = pname;
+    rev = "685cd09f5ac7ff06dac4609a30eca3db693cf548";
+    hash = "sha256-8EmRGUWyaP9cBGwlNBO5vJXBCCNK6691tPX7gbTulNo=";
+  };
+
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base
+    bytestring
+    containers
+    megaparsec
+    parser-combinators
+    text
+    these
+    transformers
+    vector
+  ];
+  executableHaskellDepends = [
+    aeson
+    base
+    bytestring
+    containers
+    optparse-applicative
+    pandoc-types
+    text
+    transformers
+  ];
+  testHaskellDepends = [
+    base
+    hspec
+    HUnit
+    text
+    these
+  ];
+  mainProgram = "neorg-pandoc";
+
+  description = "Neorg Haskell Parser aims to be a complete implementation of the Neorg markup specification";
+  homepage = "https://github.com/Simre1/neorg-haskell-parser";
+  license = lib.licenses.mit;
+  maintainers = with maintainers; [ GaetanLepage ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10133,6 +10133,10 @@ with pkgs;
 
   neofetch = callPackage ../tools/misc/neofetch { };
 
+  neorg-haskell-parser = with haskell.lib.compose; lib.pipe
+    (haskellPackages.callPackage ../tools/misc/neorg-haskell-parser { })
+    [ justStaticExecutables doJailbreak ];
+
   nerdfonts = callPackage ../data/fonts/nerdfonts { };
 
   netatalk = callPackage ../tools/filesystems/netatalk { };


### PR DESCRIPTION
###### Description of changes

Add the [Neorg haskell parser](https://github.com/Simre1/neorg-haskell-parser).
Right now, one test is failing.
I opened an [issue upstream](https://github.com/Simre1/neorg-haskell-parser/issues/14).
I also set `doCheck = false;` to let the derivation build succesfully.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
