### PR TITLE
shotwell: 0.31.5 → 0.31.7 + Fix build with Vala 0.56.4

### DIFF
--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -1,5 +1,7 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchurl
+, fetchpatch2
 , meson
 , ninja
 , gtk3
@@ -31,6 +33,7 @@
 , gobject-introspection
 , itstool
 , libsecret
+, libportal-gtk3
 , gsettings-desktop-schemas
 , python3
 }:
@@ -39,12 +42,21 @@
 
 stdenv.mkDerivation rec {
   pname = "shotwell";
-  version = "0.31.5";
+  version = "0.31.7";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-OwSPxs6ZsjLR4OqbjbB0CDyGyI07bWMTaiz4IXqkXBk=";
+    sha256 = "sha256-gPCj2HVS+L3vpeNig77XZ9AFdtqMyWpEo9NKQjXEmeA=";
   };
+
+  patches = [
+    # Fix build with vala 0.56.4, can be removed on next update
+    # https://gitlab.gnome.org/GNOME/shotwell/-/merge_requests/69
+    (fetchpatch2 {
+      url = "https://gitlab.gnome.org/GNOME/shotwell/-/commit/cd82759231e5ece2fa0dea40397c9051d15fd5c2.patch";
+      hash = "sha256-Vy2kvUlmPdEEuPB1RTcI5pGYNveeiQ+lId0YVlWo4wU=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson
@@ -86,6 +98,7 @@ stdenv.mkDerivation rec {
     gcr
     gnome.adwaita-icon-theme
     libsecret
+    libportal-gtk3
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

https://hydra.nixos.org/job/nixpkgs/trunk/shotwell.x86_64-linux

Cherry-pick of https://github.com/NixOS/nixpkgs/commit/8d9561b04c4a0e83e64684c4157fa98c8ab75959 https://github.com/NixOS/nixpkgs/commit/2bea4f5dcd7ce23a2b74fead077a3620ff189e24

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
