### PR TITLE
semgrep{,-core}: 1.14.0 -> 1.15.0

### DIFF
--- a/pkgs/tools/security/semgrep/common.nix
+++ b/pkgs/tools/security/semgrep/common.nix
@@ -1,13 +1,13 @@
 { lib, fetchFromGitHub, fetchzip, stdenv }:
 
 rec {
-  version = "1.14.0";
+  version = "1.15.0";
 
   src = fetchFromGitHub {
     owner = "returntocorp";
     repo = "semgrep";
     rev = "v${version}";
-    sha256 = "sha256-qtiOZRqN+EqJs7kDmNReW4uweEynJd0TrU7vpR/fbqI=";
+    sha256 = "sha256-x+AOt6nn2hN4MODFZCvlq0kZ3VLoS7rVcFGGCEssIu0=";
   };
 
   # submodule dependencies
@@ -24,8 +24,8 @@ rec {
     "cli/src/semgrep/semgrep_interfaces" = fetchFromGitHub {
       owner = "returntocorp";
       repo = "semgrep-interfaces";
-      rev = "deffcb8e0e5166e29ce17b8af72716f45cbb2aa6";
-      sha256 = "sha256-yrVn1fJcAkQd3TMIvrWa5NDb/fN3ngybOycu7DG4pbE=";
+      rev = "ba9241ca8f13dea72a4ca5c5eae99f45c071c8b4";
+      sha256 = "sha256-2rcMmN42445AivcyYLPeE+HBYOyxJijQME1UUr9HISA=";
     };
   };
 
@@ -35,11 +35,11 @@ rec {
     data = {
       x86_64-linux = {
         suffix = "-ubuntu-16.04.tgz";
-        sha256 = "sha256-cnF92jrVeRxDAbDQxicZ4+CfdOD7BJUz2fHjIHEim24=";
+        sha256 = "sha256-vLtV1WAnOD6HhgrWYIP0NfXHKfvXORksdNp5UTG1QWc=";
       };
       x86_64-darwin = {
         suffix = "-osx.zip";
-        sha256 = "sha256-eg6oHTz3vRd4GubvOYiJIjv/NZgXRWHPBmFvSu60S+E=";
+        sha256 = "sha256-6+ENjOOIJ5TSjpnJ5pDudblrWj/FLUe66UGr6V9c0HQ=";
       };
     };
     src = let

--- a/pkgs/tools/security/semgrep/default.nix
+++ b/pkgs/tools/security/semgrep/default.nix
@@ -38,10 +38,8 @@ buildPythonApplication rec {
   SEMGREP_SKIP_BIN = true;
 
   pythonRelaxDeps = [
-    "attrs"
     "boltons"
-    "jsonschema"
-    "typing-extensions"
+    "glom"
   ];
 
   propagatedBuildInputs = with pythonPackages; [


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump semgrep to `1.15.0`

```
λ ./result/bin/semgrep scan --metrics off --lang yaml --config 'r/generic.unicode.security.bidi.contains-bidirectional-characters'
               
               
┌─────────────┐
│ Scan Status │
└─────────────┘
  Scanning 34085 files tracked by git with 1 Code rule:
            
  CODE RULES
  Scanning 1200 files.
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00                
                
┌──────────────┐
│ Scan Summary │
└──────────────┘
Some files were skipped or only partially analyzed.
  Scan was limited to files tracked by git.
  Scan skipped: 2 files larger than 1.0 MB, 89 files matching .semgrepignore patterns
  For a full list of skipped files, run semgrep with the --verbose flag.

(need more rules? `semgrep login` for additional free Semgrep Registry rules)

Ran 1 rule on 1200 files: 0 findings.
If Semgrep missed a finding, please send us feedback to let us know!
  $ semgrep shouldafound --help
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
