### PR TITLE
python3Packages.libtmux: fix disabledTestPaths in darwin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4658,6 +4658,12 @@
     github = "ethindp";
     githubId = 8030501;
   };
+  ethinx = {
+    email = "eth2net@gmail.com";
+    github = "ethinx";
+    githubId = 965612;
+    name = "York Wong";
+  };
   Etjean = {
     email = "et.jean@outlook.fr";
     github = "Etjean";

--- a/pkgs/development/python-modules/libtmux/default.nix
+++ b/pkgs/development/python-modules/libtmux/default.nix
@@ -46,7 +46,8 @@ buildPythonPackage rec {
   ];
 
   disabledTestPaths = lib.optionals stdenv.isDarwin [
-    "test_test.py"
+    "tests/test_test.py"
+    "tests/legacy_api/test_test.py"
   ];
 
   pythonImportsCheck = [ "libtmux" ];

--- a/pkgs/development/python-modules/libtmux/default.nix
+++ b/pkgs/development/python-modules/libtmux/default.nix
@@ -43,6 +43,9 @@ buildPythonPackage rec {
   disabledTests = [
     # Fail with: 'no server running on /tmp/tmux-1000/libtmux_test8sorutj1'.
     "test_new_session_width_height"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # tests/test_pane.py:113: AssertionError
+    "test_capture_pane_start"
   ];
 
   disabledTestPaths = lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
###### Description of changes

Closes #221505.

Change `disabledTestPaths` in the `libtmux` derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
