### PR TITLE
qemu: 7.2.0 -> 8.0.0

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -1,10 +1,10 @@
 { lib, stdenv, fetchurl, fetchpatch, python3Packages, zlib, pkg-config, glib, buildPackages
-, perl, pixman, vde2, alsa-lib, texinfo, flex
+, pixman, vde2, alsa-lib, texinfo, flex
 , bison, lzo, snappy, libaio, libtasn1, gnutls, nettle, curl, ninja, meson, sigtool
 , makeWrapper, runtimeShell, removeReferencesTo
 , attr, libcap, libcap_ng, socat, libslirp
 , CoreServices, Cocoa, Hypervisor, rez, setfile, vmnet
-, guestAgentSupport ? with stdenv.hostPlatform; isLinux || isSunOS || isWindows
+, guestAgentSupport ? with stdenv.hostPlatform; isLinux || isNetBSD || isOpenBSD || isSunOS || isWindows
 , numaSupport ? stdenv.isLinux && !stdenv.isAarch32, numactl
 , seccompSupport ? stdenv.isLinux, libseccomp
 , alsaSupport ? lib.hasSuffix "linux" stdenv.hostPlatform.system && !nixosTestRunner
@@ -37,31 +37,37 @@
 , qemu  # for passthru.tests
 }:
 
+let
+  hexagonSupport = hostCpuTargets == null || lib.elem "hexagon" hostCpuTargets;
+in
+
 stdenv.mkDerivation rec {
   pname = "qemu"
     + lib.optionalString xenSupport "-xen"
     + lib.optionalString hostCpuOnly "-host-cpu-only"
     + lib.optionalString nixosTestRunner "-for-vm-tests";
-  version = "7.2.1";
+  version = "8.0.0";
 
   src = fetchurl {
     url = "https://download.qemu.org/qemu-${version}.tar.xz";
-    sha256 = "jIVpms+dekOl/immTN1WNwsMLRrQdLr3CYqCTReq1zs=";
+    sha256 = "u2DwNBUxGB1sw5ad0ZoBPQQnqH+RgZOXDZrbkRMeVtA=";
   };
 
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  depsBuildBuild = [ buildPackages.stdenv.cc ]
+    ++ lib.optionals hexagonSupport [ pkg-config ];
 
   nativeBuildInputs = [
     makeWrapper removeReferencesTo
-    pkg-config flex bison meson ninja perl
+    pkg-config flex bison meson ninja
 
     # Don't change this to python3 and python3.pkgs.*, breaks cross-compilation
     python3Packages.python python3Packages.sphinx python3Packages.sphinx-rtd-theme
   ]
     ++ lib.optionals gtkSupport [ wrapGAppsHook ]
+    ++ lib.optionals hexagonSupport [ glib ]
     ++ lib.optionals stdenv.isDarwin [ sigtool ];
 
-  buildInputs = [ zlib glib perl pixman
+  buildInputs = [ zlib glib pixman
     vde2 texinfo lzo snappy libtasn1
     gnutls nettle curl libslirp
   ]
@@ -116,15 +122,6 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.com/qemu-project/qemu/-/commit/3e4546d5bd38a1e98d4bd2de48631abf0398a3a2.diff";
       sha256 = "sha256-oC+bRjEHixv1QEFO9XAm4HHOwoiT+NkhknKGPydnZ5E=";
       revert = true;
-    })
-    # glibc >=2.37 compat, see https://lore.kernel.org/qemu-devel/20230110174901.2580297-1-berrange@redhat.com/
-    (fetchpatch {
-      url = "https://gitlab.com/qemu-project/qemu/-/commit/9f0246539ae84a5e21efd1cc4516fc343f08115a.patch";
-      sha256 = "sha256-1iWOWkLH0WP1Hk23fmrRVdX7YZWUXOvWRMTt8QM93BI=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.com/qemu-project/qemu/-/commit/6003159ce18faad4e1bc7bf9c85669019cd4950e.patch";
-      sha256 = "sha256-DKGCbR+VDIFLp6FhER78gyJ3Rn1dD47pMtkcIIMd0B8=";
     })
   ]
   ++ lib.optional nixosTestRunner ./force-uid0-on-9p.patch;
@@ -241,8 +238,6 @@ stdenv.mkDerivation rec {
   # Add a ‘qemu-kvm’ wrapper for compatibility/convenience.
   postInstall = ''
     ln -s $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} $out/bin/qemu-kvm
-  '' + lib.optionalString stdenv.isLinux ''
-    ln -s $out/libexec/virtiofsd $out/bin
   '';
 
   passthru = {
@@ -262,6 +257,5 @@ stdenv.mkDerivation rec {
     mainProgram = "qemu-kvm";
     maintainers = with maintainers; [ eelco qyliss ];
     platforms = platforms.unix;
-    priority = 10; # Prefer virtiofsd from the virtiofsd package.
   };
 }

--- a/pkgs/applications/virtualization/qemu/provide-fallback-for-utimensat.patch
+++ b/pkgs/applications/virtualization/qemu/provide-fallback-for-utimensat.patch
@@ -1,4 +1,4 @@
-From 747a741772cde6bb340eb8bdb493390280de8d16 Mon Sep 17 00:00:00 2001
+From 2ec149ea3f0046fa83e3be74aca192649a60be47 Mon Sep 17 00:00:00 2001
 From: Keno Fischer <keno@juliacomputing.com>
 Date: Sat, 16 Jun 2018 20:56:54 -0400
 Subject: [PATCH] 9p: darwin: Provide fallback impl for utimensat
@@ -29,23 +29,23 @@ Signed-off-by: Will Cohen <wwcohen@gmail.com>
  4 files changed, 111 insertions(+), 1 deletion(-)
 
 diff --git a/hw/9pfs/9p-local.c b/hw/9pfs/9p-local.c
-index d42ce6d8b8..b2c1fa42e1 100644
+index 9d07620235..9c77a431d5 100644
 --- a/hw/9pfs/9p-local.c
 +++ b/hw/9pfs/9p-local.c
-@@ -1085,7 +1085,7 @@ static int local_utimensat(FsContext *s, V9fsPath *fs_path,
+@@ -1081,7 +1081,7 @@ static int local_utimensat(FsContext *s, V9fsPath *fs_path,
          goto out;
      }
  
--    ret = utimensat(dirfd, name, buf, AT_SYMLINK_NOFOLLOW);
+-    ret = qemu_utimensat(dirfd, name, buf, AT_SYMLINK_NOFOLLOW);
 +    ret = utimensat_nofollow(dirfd, name, buf);
      close_preserve_errno(dirfd);
  out:
      g_free(dirpath);
 diff --git a/hw/9pfs/9p-util-darwin.c b/hw/9pfs/9p-util-darwin.c
-index bec0253474..2fc0475292 100644
+index 95146e7354..74ab2a7f99 100644
 --- a/hw/9pfs/9p-util-darwin.c
 +++ b/hw/9pfs/9p-util-darwin.c
-@@ -95,3 +95,99 @@ int qemu_mknodat(int dirfd, const char *filename, mode_t mode, dev_t dev)
+@@ -145,3 +145,99 @@ int qemu_mknodat(int dirfd, const char *filename, mode_t mode, dev_t dev)
  }
  
  #endif
@@ -160,12 +160,12 @@ index db451b0784..320697f347 100644
 +    return utimensat(dirfd, filename, times, AT_SYMLINK_NOFOLLOW);
 +}
 diff --git a/hw/9pfs/9p-util.h b/hw/9pfs/9p-util.h
-index 97e681e167..fd50d6243a 100644
+index c314cf381d..12d57f3398 100644
 --- a/hw/9pfs/9p-util.h
 +++ b/hw/9pfs/9p-util.h
-@@ -36,6 +36,12 @@ static inline int qemu_lsetxattr(const char *path, const char *name,
- #define qemu_lsetxattr lsetxattr
- #endif
+@@ -101,6 +101,12 @@ static inline int errno_to_dotl(int err) {
+ #define qemu_utimensat  utimensat
+ #define qemu_unlinkat   unlinkat
  
 +/* Compatibility with old SDK Versions for Darwin */
 +#if defined(CONFIG_DARWIN) && !defined(UTIME_NOW)
@@ -176,7 +176,7 @@ index 97e681e167..fd50d6243a 100644
  static inline void close_preserve_errno(int fd)
  {
      int serrno = errno;
-@@ -98,6 +104,8 @@ ssize_t flistxattrat_nofollow(int dirfd, const char *filename,
+@@ -163,6 +169,8 @@ ssize_t flistxattrat_nofollow(int dirfd, const char *filename,
                                char *list, size_t size);
  ssize_t fremovexattrat_nofollow(int dirfd, const char *filename,
                                  const char *name);
@@ -186,5 +186,4 @@ index 97e681e167..fd50d6243a 100644
  /*
   * Darwin has d_seekoff, which appears to function similarly to d_off.
 -- 
-2.35.1
-
+2.39.2


### PR DESCRIPTION
###### Description of changes

Now that shaderinclude is Python, I don't think we need Perl any more.

- [x] utimensat Darwin fallback patch is commented out because it needs a rebase.  @willcohen, maybe you're able to take a look at this?
- [x] volunteer needed to look into what's going on with the tests on aarch64-darwin

[ETA: 2023-04-19](https://lore.kernel.org/qemu-devel/168142845428.12506.16330418133795838547@amd.com/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
