### PR TITLE
haredo: init at 1.0.2

### DIFF
--- a/pkgs/development/tools/build-managers/haredo/default.nix
+++ b/pkgs/development/tools/build-managers/haredo/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenvNoCC, fetchFromSourcehut, hare, scdoc }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "haredo";
+  version = "1.0.2";
+
+  src = fetchFromSourcehut {
+    owner = "~autumnull";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-cCAzDRjJSMxrEIRCFD5z+Dss/KzBXnuGqwbi6Ox9Aq4=";
+  };
+
+  nativeBuildInputs = [ hare scdoc ];
+
+  dontConfigure = true;
+  preBuild = ''
+    export HARECACHE=$(mktemp -d)
+  '';
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    homepage = "https://sr.ht/~autumnull/haredo";
+    description = "A simple and unix-idiomatic build automator";
+    license = licenses.wtfpl;
+    maintainers = with maintainers; [ stonks3141 ];
+    inherit (hare.meta) platforms badPlatforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18100,6 +18100,10 @@ with pkgs;
 
   halfempty = callPackage ../development/tools/halfempty {};
 
+  haredo = callPackage ../development/tools/build-managers/haredo {
+    inherit (harePackages) hare;
+  };
+
   hcloud = callPackage ../development/tools/hcloud { };
 
   hclfmt = callPackage ../development/tools/hclfmt { };


### PR DESCRIPTION
###### Description of changes

[haredo](https://sr.ht/~autumnull/haredo) is a simple and unix-idiomatic build automator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Closes #221574.