### PR TITLE
init: lib.{collect',flattenAttrs}

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -78,10 +78,10 @@ let
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
       getAttrFromPath attrVals attrValues getAttrs catAttrs filterAttrs
-      filterAttrsRecursive foldlAttrs foldAttrs collect nameValuePair mapAttrs
-      mapAttrs' mapAttrsToList concatMapAttrs mapAttrsRecursive mapAttrsRecursiveCond
-      genAttrs isDerivation toDerivation optionalAttrs
-      zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
+      filterAttrsRecursive foldlAttrs foldAttrs collect collect'
+      nameValuePair mapAttrs mapAttrs' mapAttrsToList concatMapAttrs
+      mapAttrsRecursive mapAttrsRecursiveCond genAttrs isDerivation toDerivation
+      optionalAttrs zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting showAttrPath getOutput getBin
       getLib getDev getMan chooseDevOutputs zipWithNames zip
       recurseIntoAttrs dontRecurseIntoAttrs cartesianProductOfSets

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -78,7 +78,7 @@ let
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
       getAttrFromPath attrVals attrValues getAttrs catAttrs filterAttrs
-      filterAttrsRecursive foldlAttrs foldAttrs collect collect'
+      filterAttrsRecursive foldlAttrs foldAttrs collect collect' flattenAttrs
       nameValuePair mapAttrs mapAttrs' mapAttrsToList concatMapAttrs
       mapAttrsRecursive mapAttrsRecursiveCond genAttrs isDerivation toDerivation
       optionalAttrs zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -565,6 +565,45 @@ runTests {
   };
 
   # code from the example
+  testCollect'Example = let
+    drvf = name: derivation { inherit name; builder = "builder"; system = "system"; };
+    drv1 = drvf "drv1";
+    drv2 = drvf "drv2";
+  in {
+    expr = collect'
+      (_: v: isDerivation v)
+      (path: value: { inherit path value; })
+      {
+        a = drv1;
+        b = {
+          c = drv2;
+        };
+        not-a-derivation = 42;
+      };
+    expected = [
+      { path = [ "a" ]; value = drv1; }
+      { path = [ "b" "c" ]; value = drv2; }
+    ];
+  };
+
+  testCollect'TopLevel = let
+    attrs = {
+      a = 1;
+      b = {
+        c = 2;
+      };
+    };
+  in {
+    expr = collect'
+      (_: _: true)
+      (path: value: { inherit path value; })
+      attrs;
+    expected = [
+      { path = [ ]; value = attrs; }
+    ];
+  };
+
+  # code from the example
   testRecursiveUpdateUntil = {
     expr = recursiveUpdateUntil (path: l: r: path == ["foo"]) {
       # first attribute set


### PR DESCRIPTION
###### Description of changes

This change adds an advanced version of lib.collect that exposes the attribute path, and a function to flatten an attribute set. These are mostly inteded for use with Nix flakes where packages are a flat set of derivations. That is, this allows flakes to define packages (or other outputs) as a tree of derivations (or other types) and flatten them before exposing.

In particular, this is useful for flakes that want to expose cross-compiled variants of packages so the user can run, for example, `nix build path:.#go-linux-amd64-v3` independent of the current system (as in `packages.${system}`). In this case, Go is used as an example since the build system has an excellent support for cross-compilation out-of-the-box (assuming Cgo is disabled).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
