### PR TITLE
ocamlPackages.ezjsonm: 1.2.0 → 1.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/cooltt/default.nix
+++ b/pkgs/development/ocaml-modules/cooltt/default.nix
@@ -6,6 +6,7 @@
 , cmdliner
 , containers
 , ezjsonm
+, findlib
 , menhir
 , menhirLib
 , ppx_deriving
@@ -28,7 +29,9 @@ let
       sha256 = "sha256:15v1cggm7awp11iwl3lzpaar91jzivhdxggp5mr48gd28kfipzk2";
     };
 
-    propagatedBuildInputs = [ ezjsonm ];
+    duneVersion = "3";
+
+    propagatedBuildInputs = [ ezjsonm findlib ];
 
     meta = {
       description = "Extensible Library Management and Path Resolution";
@@ -63,6 +66,7 @@ buildDunePackage {
   version = "unstable-2022-04-28";
 
   minimalOCamlVersion = "4.13";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "RedPRL";

--- a/pkgs/development/ocaml-modules/cow/default.nix
+++ b/pkgs/development/ocaml-modules/cow/default.nix
@@ -1,10 +1,10 @@
-{ lib, fetchurl, buildDunePackage, ocaml, alcotest
+{ lib, fetchurl, buildDunePackage, alcotest
 , uri, xmlm, omd, ezjsonm
 }:
 
 buildDunePackage rec {
-  useDune2 = true;
-  minimumOCamlVersion = "4.02.3";
+  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   version = "2.4.0";
   pname = "cow";
@@ -16,7 +16,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ xmlm uri ezjsonm omd ];
   checkInputs = [ alcotest ];
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
 
   meta = with lib; {
     description = "Caml on the Web";

--- a/pkgs/development/ocaml-modules/ezjsonm/default.nix
+++ b/pkgs/development/ocaml-modules/ezjsonm/default.nix
@@ -2,13 +2,13 @@
 
 buildDunePackage rec {
   pname = "ezjsonm";
-  version = "1.2.0";
+  version = "1.3.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ezjsonm/releases/download/v${version}/ezjsonm-v${version}.tbz";
-    sha256 = "1q6cf63cc614lr141rzhm2w4rhi1snfqai6fmkhvfjs84hfbw2w7";
+    url = "https://github.com/mirage/ezjsonm/releases/download/v${version}/ezjsonm-${version}.tbz";
+    hash = "sha256-CGM+Dw52eoroGTXKfnTxaTuFp5xFAtVo7t/1Fw8M13s=";
   };
 
   propagatedBuildInputs = [ jsonm hex sexplib0 ];

--- a/pkgs/development/ocaml-modules/lustre-v6/default.nix
+++ b/pkgs/development/ocaml-modules/lustre-v6/default.nix
@@ -5,6 +5,7 @@ buildDunePackage rec {
   version = "6.107.3";
 
   minimalOCamlVersion = "4.12";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lustre-v6.v${version}.tgz";

--- a/pkgs/development/ocaml-modules/mustache/default.nix
+++ b/pkgs/development/ocaml-modules/mustache/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "mustache";
   version = "3.1.0";
-  useDune2 = true;
+  duneVersion = "3";
   src = fetchFromGitHub {
     owner = "rgrinberg";
     repo = "ocaml-mustache";

--- a/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yaml/default.nix
@@ -7,6 +7,7 @@ buildDunePackage rec {
   version = "0.1.1";
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v${version}/ppx_deriving_yaml-${version}.tbz";

--- a/pkgs/development/ocaml-modules/yaml/default.nix
+++ b/pkgs/development/ocaml-modules/yaml/default.nix
@@ -10,10 +10,11 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/avsm/ocaml-yaml/releases/download/v${version}/yaml-${version}.tbz";
-    sha256 = "sha256-0KngriGEpp5tcgK/43B9EEOdMacSQYYCNLGfAgRS7Mc=";
+    hash = "sha256-0KngriGEpp5tcgK/43B9EEOdMacSQYYCNLGfAgRS7Mc=";
   };
 
   minimalOCamlVersion = "4.13";
+  duneVersion = "3";
 
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ bos ctypes ];

--- a/pkgs/development/ocaml-modules/yaml/yaml-sexp.nix
+++ b/pkgs/development/ocaml-modules/yaml/yaml-sexp.nix
@@ -5,6 +5,8 @@ buildDunePackage rec {
 
   inherit (yaml) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ yaml ppx_sexp_conv sexplib ];
 
   meta = yaml.meta // {


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/ezjsonm/blob/v1.3.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
