### PR TITLE
Microsoft Intune

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1201,6 +1201,7 @@
   ./services/security/hologram-agent.nix
   ./services/security/hologram-server.nix
   ./services/security/infnoise.nix
+  ./services/security/intune.nix
   ./services/security/jitterentropy-rngd.nix
   ./services/security/kanidm.nix
   ./services/security/munge.nix

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -700,6 +700,7 @@ let
               || cfg.pamMount
               || cfg.enableKwallet
               || cfg.enableGnomeKeyring
+              || config.services.intune.enable
               || cfg.googleAuthenticator.enable
               || cfg.gnupg.enable
               || cfg.failDelay.enable
@@ -726,6 +727,7 @@ let
                 kwalletd = "${pkgs.plasma5Packages.kwallet.bin}/bin/kwalletd5";
               }; }
               { name = "gnome_keyring"; enable = cfg.enableGnomeKeyring; control = "optional"; modulePath = "${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so"; }
+              { name = "intune"; enable = config.services.intune.enable; control = "optional"; modulePath = "${pkgs.intune-portal}/lib/security/pam_intune.so"; }
               { name = "gnupg"; enable = cfg.gnupg.enable; control = "optional"; modulePath = "${pkgs.pam_gnupg}/lib/security/pam_gnupg.so"; settings = {
                 store-only = cfg.gnupg.storeOnly;
               }; }
@@ -867,6 +869,7 @@ let
           { name = "gnupg"; enable = cfg.gnupg.enable; control = "optional"; modulePath = "${pkgs.pam_gnupg}/lib/security/pam_gnupg.so"; settings = {
             no-autostart = cfg.gnupg.noAutostart;
           }; }
+          { name = "intune"; enable = config.services.intune.enable; control = "optional"; modulePath = "${pkgs.intune-portal}/lib/security/pam_intune.so"; }
         ];
       };
     };

--- a/nixos/modules/services/security/intune.nix
+++ b/nixos/modules/services/security/intune.nix
@@ -1,0 +1,32 @@
+{ config
+, pkgs
+, lib
+, ...
+}:
+let
+  cfg = config.services.intune;
+in
+{
+  options.services.intune = {
+    enable = lib.mkEnableOption (lib.mdDoc "Microsoft Intune");
+  };
+
+
+  config = lib.mkIf cfg.enable {
+    users.users.microsoft-identity-broker = {
+      group = "microsoft-identity-broker";
+      isSystemUser = true;
+    };
+
+    users.groups.microsoft-identity-broker = { };
+    environment.systemPackages = [ pkgs.microsoft-identity-broker pkgs.intune-portal ];
+    systemd.packages = [ pkgs.microsoft-identity-broker pkgs.intune-portal ];
+
+    systemd.tmpfiles.packages = [ pkgs.intune-portal ];
+    services.dbus.packages = [ pkgs.microsoft-identity-broker ];
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ rhysmdnz ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -425,6 +425,7 @@ in {
   inspircd = handleTest ./inspircd.nix {};
   installer = handleTest ./installer.nix {};
   installer-systemd-stage-1 = handleTest ./installer-systemd-stage-1.nix {};
+  intune = handleTest ./intune.nix {};
   invoiceplane = handleTest ./invoiceplane.nix {};
   iodine = handleTest ./iodine.nix {};
   ipv6 = handleTest ./ipv6.nix {};

--- a/nixos/tests/intune.nix
+++ b/nixos/tests/intune.nix
@@ -1,0 +1,56 @@
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "intune";
+  meta = {
+    maintainers = with pkgs.lib.maintainers; [ rhysmdnz ];
+  };
+  enableOCR = true;
+
+  nodes.machine =
+    { nodes, ... }:
+    let user = nodes.machine.users.users.alice;
+    in {
+      services.intune.enable=true;
+      services.gnome.gnome-keyring.enable = true;
+      imports = [ ./common/user-account.nix ./common/x11.nix ];
+      test-support.displayManager.auto.user = user.name;
+      environment = {
+        variables.DBUS_SESSION_BUS_ADDRESS = "unix:path=/run/user/${builtins.toString user.uid}/bus";
+      };
+    };
+  nodes.pam =
+    { nodes, ... }:
+    let user = nodes.machine.users.users.alice;
+    in {
+      services.intune.enable=true;
+      imports = [ ./common/user-account.nix ];
+    };
+
+  testScript = ''
+    start_all()
+
+    # Check System Daemons successfully start
+    machine.succeed("systemctl start microsoft-identity-device-broker.service")
+    machine.succeed("systemctl start intune-daemon.service")
+
+    # Check User Daemons and intune-portal execurtable works
+    # Going any further than starting it would require internet access and a microsoft account
+    machine.wait_for_x()
+    # TODO: This needs an unlocked user keychain before it will work
+    #machine.succeed("su - alice -c 'systemctl start --user microsoft-identity-broker.service'")
+    machine.succeed("su - alice -c 'systemctl start --user intune-agent.service'")
+    machine.succeed("su - alice -c intune-portal >&2 &")
+    machine.wait_for_text("Intune Agent")
+
+    # Check logging in creates password file
+    def login_as_alice():
+        pam.wait_until_tty_matches("1", "login: ")
+        pam.send_chars("alice\n")
+        pam.wait_until_tty_matches("1", "Password: ")
+        pam.send_chars("foobar\n")
+        pam.wait_until_tty_matches("1", "alice\@pam")
+
+    pam.wait_for_unit("multi-user.target")
+    login_as_alice()
+    pam.wait_for_file("/run/intune/1000/pwquality")
+  '';
+})

--- a/pkgs/by-name/in/intune-portal/package.nix
+++ b/pkgs/by-name/in/intune-portal/package.nix
@@ -1,0 +1,109 @@
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, libuuid
+, xorg
+, curlMinimal
+, openssl
+, libsecret
+, webkitgtk
+, libsoup
+, gtk3
+, atk
+, pango
+, glib
+, sqlite
+, zlib
+, systemd
+, msalsdk-dbusclient
+, pam
+, dbus
+}:
+stdenv.mkDerivation rec {
+  pname = "intune-portal";
+  version = "1.2312.35-jammy";
+
+  src = fetchurl {
+    url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/i/${pname}/${pname}_${version}_amd64.deb";
+    hash = "sha256-mgcnqj/+4ffMf4PhMW4ovCotLilyudGOpn0qqXZCmzc=";
+  };
+
+  nativeBuildInputs = [ dpkg ];
+
+  buildPhase =
+    let
+      libPath = {
+        intune = lib.makeLibraryPath [
+          stdenv.cc.cc.lib
+          libuuid
+          xorg.libX11
+          curlMinimal
+          openssl
+          libsecret
+          webkitgtk
+          libsoup
+          gtk3
+          atk
+          glib
+          pango
+          sqlite
+          zlib
+          systemd
+          msalsdk-dbusclient
+          dbus
+        ];
+        pam = lib.makeLibraryPath [ pam ];
+      };
+    in
+    ''
+      runHook preBuild
+
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath ${libPath.intune} opt/microsoft/intune/bin/intune-portal
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath ${libPath.intune} opt/microsoft/intune/bin/intune-agent
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath ${libPath.intune} opt/microsoft/intune/bin/intune-daemon
+      patchelf --set-rpath ${libPath.pam} ./usr/lib/x86_64-linux-gnu/security/pam_intune.so
+
+      runHook postBuild
+    '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -a opt/microsoft/intune/bin/* $out/bin/
+    cp -a usr/share $out
+    cp -a lib $out
+    mkdir -p $out/lib/security
+    cp -a ./usr/lib/x86_64-linux-gnu/security/pam_intune.so $out/lib/security/
+    cp -a usr/lib/tmpfiles.d $out/lib
+
+    substituteInPlace $out/share/applications/intune-portal.desktop \
+      --replace /opt/microsoft/intune/bin/intune-portal $out/bin/intune-portal
+
+    substituteInPlace $out/lib/systemd/user/intune-agent.service \
+      --replace \
+        ExecStart=/opt/microsoft/intune/bin/intune-agent \
+        ExecStart=$out/bin/intune-agent
+
+    substituteInPlace $out/lib/systemd/system/intune-daemon.service \
+      --replace \
+        ExecStart=/opt/microsoft/intune/bin/intune-daemon \
+        ExecStart=$out/bin/intune-daemon
+
+    runHook postInstall
+  '';
+
+  # Without this network requests fail
+  dontPatchELF = true;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "Microsoft Intune Portal allows you to securely access corporate apps, data, and resources";
+    homepage = "https://www.microsoft.com/";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ rhysmdnz ];
+  };
+}

--- a/pkgs/by-name/in/intune-portal/package.nix
+++ b/pkgs/by-name/in/intune-portal/package.nix
@@ -19,6 +19,7 @@
 , msalsdk-dbusclient
 , pam
 , dbus
+, nixosTests
 }:
 stdenv.mkDerivation rec {
   pname = "intune-portal";
@@ -97,7 +98,10 @@ stdenv.mkDerivation rec {
   # Without this network requests fail
   dontPatchELF = true;
 
-  passthru.updateScript = ./update.sh;
+  passthru = {
+    updateScript = ./update.sh;
+    tests = { inherit (nixosTests) intune; };
+  };
 
   meta = with lib; {
     description = "Microsoft Intune Portal allows you to securely access corporate apps, data, and resources";

--- a/pkgs/by-name/in/intune-portal/update.sh
+++ b/pkgs/by-name/in/intune-portal/update.sh
@@ -1,0 +1,26 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p curl gzip dpkg common-updater-scripts
+
+index_file=$(curl -sL https://packages.microsoft.com/ubuntu/22.04/prod/dists/jammy/main/binary-amd64/Packages.gz | gzip -dc)
+
+latest_version="0"
+
+echo "$index_file" | while read -r line; do
+    if [[ "$line" =~ ^Package:[[:space:]]*(.*) ]]; then
+        Package="${BASH_REMATCH[1]}"
+    fi
+    if [[ "$line" =~ ^Version:[[:space:]]*(.*) ]]; then
+        Version="${BASH_REMATCH[1]}"
+    fi
+
+    if ! [[ "$line" ]] && [[ "${Package}" == "intune-portal" ]]; then
+        if ( dpkg --compare-versions ${Version} gt ${latest_version} ); then
+            latest_version="${Version}"
+
+            echo $latest_version
+        fi
+
+        Package=""
+        Version=""
+    fi
+done | tail -n 1 | (read version; update-source-version intune-portal $version)

--- a/pkgs/by-name/jn/jnr-posix/package.nix
+++ b/pkgs/by-name/jn/jnr-posix/package.nix
@@ -1,0 +1,82 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, dpkg
+, jdk
+, makeWrapper
+, maven
+, which
+}:
+let
+  pname = "jnr-posix";
+  version = "3.1.18";
+
+  src = fetchFromGitHub {
+    owner = "jnr";
+    repo = "jnr-posix";
+    rev = "jnr-posix-${version}";
+    hash = "sha256-zx8I9rsu9Kjef+LatDA1WIuO7Vgo0/JM5nGi3pSWch4=";
+  };
+
+  deps = stdenv.mkDerivation {
+    name = "${pname}-${version}-deps";
+    inherit src;
+
+    nativeBuildInputs = [ jdk maven ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      mvn package -Dmaven.test.skip=true -Dmaven.repo.local=$out/.m2 -Dmaven.wagon.rto=5000
+
+      runHook postBuild
+    '';
+
+    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+    installPhase = ''
+      runHook preInstall
+
+      find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete
+      find $out/.m2 -type f -iname '*.pom' -exec sed -i -e 's/\r\+$//' {} \;
+
+      runHook postInstall
+    '';
+
+    outputHashMode = "recursive";
+    outputHash = "sha256-gOw0KUFyZEMONwLwlHSiV+ZZ7JQhjZwg708Q1IciUfo=";
+
+    doCheck = false;
+  };
+in
+stdenv.mkDerivation rec {
+  inherit version pname src;
+
+  nativeBuildInputs = [ maven which ];
+
+  postPatch = ''
+    sed -i "s/\/usr\/bin\/id/$(which id | sed 's#/#\\/#g')/g" src/main/java/jnr/posix/JavaPOSIX.java
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    mvn package --offline -Dmaven.test.skip=true -Dmaven.repo.local=$(cp -dpR ${deps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D target/${pname}-${version}.jar $out/share/java/${pname}-${version}.jar
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "jnr-posix is a lightweight cross-platform POSIX emulation layer for Java, written in Java and is part of the JNR project";
+    homepage = "https://github.com/jnr/jnr-posix";
+    license = with licenses; [ epl20 gpl2Only lgpl21Only ];
+    maintainers = with lib.maintainers; [ rhysmdnz ];
+  };
+}

--- a/pkgs/by-name/mi/microsoft-identity-broker/package.nix
+++ b/pkgs/by-name/mi/microsoft-identity-broker/package.nix
@@ -90,6 +90,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = ./update.sh;
+    tests = { inherit (nixosTests) intune; };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/mi/microsoft-identity-broker/package.nix
+++ b/pkgs/by-name/mi/microsoft-identity-broker/package.nix
@@ -1,0 +1,103 @@
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, openjdk11
+, jnr-posix
+, makeWrapper
+, openjfx17
+, zip
+, nixosTests
+, bash
+}:
+stdenv.mkDerivation rec {
+  pname = "microsoft-identity-broker";
+  version = "1.6.1";
+
+  src = fetchurl {
+    url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/${pname}/${pname}_${version}_amd64.deb";
+    hash = "sha256-DYXGqMBUGKw4xsWpD973t5ZccBTh0LmVfLMX1T5DNms=";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper openjdk11 zip ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    rm opt/microsoft/identity-broker/lib/jnr-posix-3.1.4.jar
+    jar -uf opt/microsoft/identity-broker/lib/javafx-graphics-15-linux.jar -C ${openjfx17}/modules_libs/javafx.graphics/ libglass.so
+    jar -uf opt/microsoft/identity-broker/lib/javafx-graphics-15-linux.jar -C ${openjfx17}/modules_libs/javafx.graphics/ libglassgtk3.so
+    jar -uf opt/microsoft/identity-broker/lib/javafx-graphics-15-linux.jar -C ${openjfx17}/modules_libs/javafx.graphics/ libprism_es2.so
+    zip -d opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar libavplugin-54.so
+    zip -d opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar libavplugin-56.so
+    zip -d opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar libavplugin-57.so
+    zip -d opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar libavplugin-ffmpeg-56.so
+    zip -d opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar libavplugin-ffmpeg-57.so
+    zip -d opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar libavplugin-ffmpeg-58.so
+    jar -uf opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar -C ${openjfx17}/modules_libs/javafx.media/ libavplugin.so
+    jar -uf opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar -C ${openjfx17}/modules_libs/javafx.media/ libfxplugins.so
+    jar -uf opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar -C ${openjfx17}/modules_libs/javafx.media/ libgstreamer-lite.so
+    jar -uf opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar -C ${openjfx17}/modules_libs/javafx.media/ libjfxmedia.so
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/microsoft-identity-broker
+    cp -a opt/microsoft/identity-broker/lib/* $out/lib/microsoft-identity-broker
+    cp -a usr/* $out
+    for jar in $out/lib/microsoft-identity-broker/*.jar; do
+      classpath="$classpath:$jar"
+    done
+    classpath="$classpath:${jnr-posix}/share/java/jnr-posix-${jnr-posix.version}.jar"
+    mkdir -p $out/bin
+    makeWrapper ${openjdk11}/bin/java $out/bin/microsoft-identity-broker \
+      --add-flags "-classpath $classpath com.microsoft.identity.broker.service.IdentityBrokerService" \
+      --add-flags "-verbose"
+    makeWrapper ${openjdk11}/bin/java $out/bin/microsoft-identity-device-broker \
+      --add-flags "-verbose" \
+      --add-flags "-classpath $classpath" \
+      --add-flags "com.microsoft.identity.broker.service.DeviceBrokerService" \
+      --add-flags "save"
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    substituteInPlace \
+      $out/lib/systemd/user/microsoft-identity-broker.service \
+      $out/lib/systemd/system/microsoft-identity-device-broker.service \
+      $out/share/dbus-1/system-services/com.microsoft.identity.devicebroker1.service \
+      $out/share/dbus-1/services/com.microsoft.identity.broker1.service \
+      --replace \
+        ExecStartPre=sh \
+        ExecStartPre=${bash}/bin/sh \
+      --replace \
+        ExecStartPre=!sh \
+        ExecStartPre=!${bash}/bin/sh \
+      --replace \
+        /opt/microsoft/identity-broker/bin/microsoft-identity-broker \
+        $out/bin/microsoft-identity-broker \
+      --replace \
+        /opt/microsoft/identity-broker/bin/microsoft-identity-device-broker \
+        $out/bin/microsoft-identity-device-broker \
+      --replace \
+        /usr/lib/jvm/java-11-openjdk-amd64 \
+        ${openjdk11}/bin/java
+  '';
+
+  passthru = {
+    updateScript = ./update.sh;
+  };
+
+  meta = with lib; {
+    description = "Microsoft Authentication Broker for Linux";
+    homepage = "https://www.microsoft.com/";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ rhysmdnz ];
+  };
+}

--- a/pkgs/by-name/mi/microsoft-identity-broker/update.sh
+++ b/pkgs/by-name/mi/microsoft-identity-broker/update.sh
@@ -1,0 +1,26 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p curl gzip dpkg common-updater-scripts
+
+index_file=$(curl -sL https://packages.microsoft.com/ubuntu/22.04/prod/dists/jammy/main/binary-amd64/Packages.gz | gzip -dc)
+
+latest_version="0"
+
+echo "$index_file" | while read -r line; do
+    if [[ "$line" =~ ^Package:[[:space:]]*(.*) ]]; then
+        Package="${BASH_REMATCH[1]}"
+    fi
+    if [[ "$line" =~ ^Version:[[:space:]]*(.*) ]]; then
+        Version="${BASH_REMATCH[1]}"
+    fi
+
+    if ! [[ "$line" ]] && [[ "${Package}" == "microsoft-identity-broker" ]]; then
+        if ( dpkg --compare-versions ${Version} gt ${latest_version} ); then
+            latest_version="${Version}"
+
+            echo $latest_version
+        fi
+
+        Package=""
+        Version=""
+    fi
+done | tail -n 1 | (read version; update-source-version microsoft-identity-broker $version)

--- a/pkgs/by-name/ms/msalsdk-dbusclient/package.nix
+++ b/pkgs/by-name/ms/msalsdk-dbusclient/package.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, sdbus-cpp
+}:
+stdenv.mkDerivation rec {
+  pname = "msalsdk-dbusclient";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/${pname}/${pname}_${version}_amd64.deb";
+    hash = "sha256-AVPrNxCjXGza2gGETP0YrlXeEgI6AjlrSVTtqKb2UBI=";
+  };
+
+  nativeBuildInputs = [ dpkg ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    install -m 755 usr/lib/libmsal_dbus_client.so $out/lib/
+    patchelf --set-rpath ${lib.makeLibraryPath [ stdenv.cc.cc.lib sdbus-cpp ]} $out/lib/libmsal_dbus_client.so
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+  meta = with lib; {
+    description = "Microsoft Authentication Library cross platform Dbus client for talking to microsoft-identity-broker";
+    homepage = "https://github.com/AzureAD/microsoft-authentication-library-for-cpp";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ rhysmdnz ];
+  };
+}

--- a/pkgs/by-name/ms/msalsdk-dbusclient/update.sh
+++ b/pkgs/by-name/ms/msalsdk-dbusclient/update.sh
@@ -1,0 +1,26 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p curl gzip dpkg common-updater-scripts
+
+index_file=$(curl -sL https://packages.microsoft.com/ubuntu/22.04/prod/dists/jammy/main/binary-amd64/Packages.gz | gzip -dc)
+
+latest_version="0"
+
+echo "$index_file" | while read -r line; do
+    if [[ "$line" =~ ^Package:[[:space:]]*(.*) ]]; then
+        Package="${BASH_REMATCH[1]}"
+    fi
+    if [[ "$line" =~ ^Version:[[:space:]]*(.*) ]]; then
+        Version="${BASH_REMATCH[1]}"
+    fi
+
+    if ! [[ "$line" ]] && [[ "${Package}" == "msalsdk-dbusclient" ]]; then
+        if ( dpkg --compare-versions ${Version} gt ${latest_version} ); then
+            latest_version="${Version}"
+
+            echo $latest_version
+        fi
+
+        Package=""
+        Version=""
+    fi
+done | tail -n 1 | (read version; update-source-version msalsdk-dbusclient $version)


### PR DESCRIPTION
###### Description of changes

This adds the required packaged and module for Microsoft Intune Portal resolving #196237

This includes a change to microsoft edge to use the msalsdk-dbusclient library which allows it to access the logged in intune users session.

Currently this is missing running the pam module on password change. This is blocked on solving #227043. Should be possible to follow up later. Just means if you change your password the new password won't be available to compliance polices until you log in again.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
