### PR TITLE
nu_scripts: init at unstable-2023-03-16

### DIFF
--- a/pkgs/shells/nushell/nu_scripts/default.nix
+++ b/pkgs/shells/nushell/nu_scripts/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "nu_scripts";
+  version = "unstable-2023-03-16";
+
+  src = fetchFromGitHub {
+    owner = "nushell";
+    repo = pname;
+    rev = "00b0039653be5dd2e6567ce8feea82064d27ae11";
+    sha256 = "0m17cj5wzp94f01kwgs1dh76zwsl2irr7b06i9sb5skqxmmdnjnz";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/nu_scripts
+    mv ./* $out/share/nu_scripts
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A place to share Nushell scripts with each other";
+    homepage = "https://github.com/nushell/nu_scripts";
+    license = lib.licenses.free;
+
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.CardboardTurkey ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26828,6 +26828,8 @@ with pkgs;
     inherit (darwin.apple_sdk_11_0.frameworks) AppKit Security;
   };
 
+  nu_scripts = callPackage ../shells/nushell/nu_scripts { };
+
   nettools = if stdenv.isLinux
     then callPackage ../os-specific/linux/net-tools { }
     else unixtools.nettools;


### PR DESCRIPTION
###### Description of changes

nu_scripts is a place to share Nushell scripts with each other. Most importantly (in my opinion) it contains completions for commonly used commands.

This package can be used in conjunction with, for example, [home-manager](https://rycee.gitlab.io/home-manager/options.html#opt-programs.nushell.extraConfig) to declaratively include the scripts:

```nix
  home-manager.users.CardboardTurkey.programs.nushell.extraConfig = ''
        use ${pkgs.nu_scripts}/share/nu_scripts/git/git.nu *
        use ${pkgs.nu_scripts}/share/nu_scripts/custom-completions/git/git-completions.nu *
        '';
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
