### PR TITLE
SPSDK fix and Pynitrokey 0.4.31 -> 0.4.34

### DIFF
--- a/pkgs/development/python-modules/spsdk/default.nix
+++ b/pkgs/development/python-modules/spsdk/default.nix
@@ -27,6 +27,7 @@
 , pyserial
 , ruamel-yaml
 , sly
+, typing-extensions
 , pytestCheckHook
 , voluptuous
 }:
@@ -52,8 +53,10 @@ buildPythonPackage rec {
     "cmsis-pack-manager"
     "deepmerge"
     "jinja2"
+    "pycryptodome"
     "pylink-square"
     "pyocd"
+    "typing-extensions"
   ];
 
   pythonRemoveDeps = [
@@ -85,6 +88,7 @@ buildPythonPackage rec {
     pyserial
     ruamel-yaml
     sly
+    typing-extensions
   ];
 
   nativeCheckInputs = [

--- a/pkgs/tools/security/pynitrokey/default.nix
+++ b/pkgs/tools/security/pynitrokey/default.nix
@@ -1,4 +1,4 @@
-{ python3Packages, lib, nrfutil }:
+{ python3Packages, lib, nrfutil, libnitrokey }:
 
 with python3Packages;
 
@@ -42,6 +42,12 @@ buildPythonApplication rec {
     "python-dateutil"
     "spsdk"
     "typing_extensions"
+  ];
+
+  # libnitrokey is not propagated to users of pynitrokey
+  # It is only usable from the wrapped bin/nitropy
+  makeWrapperArgs = [
+    "--set LIBNK_PATH ${lib.makeLibraryPath [ libnitrokey ]}"
   ];
 
   # no tests

--- a/pkgs/tools/security/pynitrokey/default.nix
+++ b/pkgs/tools/security/pynitrokey/default.nix
@@ -1,36 +1,36 @@
-{ python3Packages, lib, nrfutil  }:
+{ python3Packages, lib, nrfutil }:
 
 with python3Packages;
 
 buildPythonApplication rec {
   pname = "pynitrokey";
-  version = "0.4.31";
+  version = "0.4.34";
   format = "flit";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-nqw5wUzQxKCBzYBRhqB6v7WWrF1Ojf8z6Kf1YUA9+wU=";
+    hash = "sha256-lMXoDkNiAmGb6e4u/vZMcmXUclwW402YUGihLjWIr+U=";
   };
 
   propagatedBuildInputs = [
+    certifi
+    cffi
     click
     cryptography
     ecdsa
+    frozendict
     fido2
     intelhex
+    nkdfu
     nrfutil
-    pyserial
+    python-dateutil
     pyusb
     requests
-    pygments
-    python-dateutil
     spsdk
+    tqdm
     urllib3
-    cffi
-    cbor
-    nkdfu
-    fido2
     tlv8
+    typing-extensions
   ];
 
   nativeBuildInputs = [
@@ -39,7 +39,9 @@ buildPythonApplication rec {
 
   pythonRelaxDeps = [
     "cryptography"
+    "python-dateutil"
     "spsdk"
+    "typing_extensions"
   ];
 
   # no tests


### PR DESCRIPTION
###### Description of changes

Relax more dependencies in python3Packages.spsdk as it is broken:
- pycryptodome:  expected <v3.17, nixos provides v3.17 ([changelog](https://github.com/Legrandin/pycryptodome/blob/master/Changelog.rst))
- typing-extensions: expected <v4.5, nixos provides v4.5 ([changelog](https://github.com/python/typing_extensions/blob/main/CHANGELOG.md))

Update pynitrokey to v0.4.34 ([changelog](https://github.com/Nitrokey/pynitrokey/releases))
- Re-order dependencies to match pyproject.toml in pynitrokey
- Relax dependencies in pynitrokey:
  - typing-extensions: expected v4.3.x, nixos provides v4.5 ([changelog](https://github.com/python/typing_extensions/blob/main/CHANGELOG.md))
  - python-dateutil: expected v2.7.x, nixos provides 2.8.2 ([changelog](https://github.com/dateutil/dateutil/releases))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
closes https://github.com/NixOS/nixpkgs/pull/222465