### PR TITLE
Pantheon: Backport style fixes for Epiphany 44 and a crash fix for mail

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -29,6 +30,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-IY+ml/ftLSk0A3Emi0ZL2wxIDIngNU6QKbHErRAaaMA=";
   };
+
+  patches = [
+    # MessageListItem: avoid crashing on empty Mime
+    # https://github.com/elementary/mail/pull/828
+    (fetchpatch {
+      url = "https://github.com/elementary/mail/commit/7cb412dee4cc8c0bfab55057c47d5ecce6918788.patch";
+      sha256 = "sha256-7rYvgFeVmV/rVYzC/xt/lioRlveM0d8ORqZdMYkm/d4=";
+    })
+  ];
 
   nativeBuildInputs = [
     libxml2

--- a/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , gettext
 , meson
@@ -19,6 +20,27 @@ stdenvNoCC.mkDerivation rec {
     rev = version;
     sha256 = "sha256-KUo9IbB10JRgFrn6I5y4+34PEihuwp78b+YsX2Wqip8=";
   };
+
+  patches = [
+    # All patches listed below are fixes for Epiphany 44.
+    # https://github.com/elementary/browser/discussions/82
+    (fetchpatch {
+      url = "https://github.com/elementary/stylesheet/commit/c0028159dd5a7767ead9a12e9a4cfb693159c823.patch";
+      sha256 = "sha256-JgJ6FoE2aSTmjJ7klAoYXITbxJwy1HFGvr6F6lVQysY=";
+    })
+    (fetchpatch {
+      url = "https://github.com/elementary/stylesheet/commit/2b9aa7aabce8ab2656340de41f7d5194ddd62078.patch";
+      sha256 = "sha256-84sCbVw3JChw25FIKG4eFbj3EkDioefJp5Q938TwXPc=";
+    })
+    (fetchpatch {
+      url = "https://github.com/elementary/stylesheet/commit/88682d3e931fdd46682d3ac8f1f1e700e2514c56.patch";
+      sha256 = "sha256-2/yYO9Upt33bZembRRuvcfwpQunD1hhJ/BC2DZSuWPk=";
+    })
+    (fetchpatch {
+      url = "https://github.com/elementary/stylesheet/commit/bb15232abc6167a305b4404467498d11901aea69.patch";
+      sha256 = "sha256-L6y61CVRTakSHDvFanhbpsSzLkiSp5Dsm0Fg3RKccQk=";
+    })
+  ];
 
   nativeBuildInputs = [
     gettext


### PR DESCRIPTION
###### Description of changes


When granite is presented, new version of libadwaita no longer handles the style, this makes epiphany 44 looks very broken. We are likely going to land 44 faster than elementary I think. This PR picks up the fixes.

Also backport a crash fix ([another](https://github.com/NixOS/nixpkgs/pull/220916) one!) for elementary-mail.

<div align="center"><img src="https://user-images.githubusercontent.com/20080233/225925186-70dbd1c7-6546-4640-be33-e6179c4ea7be.png" width=80%></div>
<div align="center"><i>Which tab are we at right now?</i></p>

</div>



/cc #218143

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
