### PR TITLE
phpPackages.phpunit: init at 10.0.16

### DIFF
--- a/pkgs/development/php-packages/phpunit/default.nix
+++ b/pkgs/development/php-packages/phpunit/default.nix
@@ -1,0 +1,33 @@
+{ mkDerivation, fetchurl, makeWrapper, lib, php }:
+let
+  pname = "phpunit";
+  version = "10.0.16";
+in
+mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://phar.phpunit.de/phpunit-${version}.phar";
+    sha256 = "e/wUIri2y4yKI1V+U/vAD3ef2ZeKxBcFrb0Ay/rlTtM=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -D $src $out/libexec/phpunit/phpunit.phar
+    makeWrapper ${php}/bin/php $out/bin/phpunit \
+      --add-flags "$out/libexec/phpunit/phpunit.phar"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "PHP testing framework";
+    license = licenses.bsd3;
+    homepage = "https://phpunit.de";
+    maintainers = with maintainers; teams.php.members;
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -199,6 +199,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     phpstan = callPackage ../development/php-packages/phpstan { };
 
+    phpunit = callPackage ../development/php-packages/phpunit { };
+
     psalm = callPackage ../development/php-packages/psalm { };
 
     psysh = callPackage ../development/php-packages/psysh { };


### PR DESCRIPTION
###### Description of changes

Added [phpunit](https://phpunit.de/).
I used https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/php-packages/phpcs/default.nix as base.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).