### PR TITLE
 [Backport release-22.11] python3Packages.pytest-shutil: Fixing build failures

### DIFF
--- a/pkgs/development/python-modules/pytest-shutil/default.nix
+++ b/pkgs/development/python-modules/pytest-shutil/default.nix
@@ -11,7 +11,6 @@
 , mock
 , path
 , execnet
-, contextlib2
 , termcolor
 , six
 
@@ -32,6 +31,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
+      --replace "contextlib2" 'contextlib2;python_version<"3"' \
       --replace "path.py" "path"
   '';
 
@@ -44,7 +44,6 @@ buildPythonPackage rec {
     mock
     path
     execnet
-    contextlib2
     termcolor
     six
   ];

--- a/pkgs/development/python-modules/pytest-shutil/default.nix
+++ b/pkgs/development/python-modules/pytest-shutil/default.nix
@@ -1,14 +1,33 @@
-{ lib, isPyPy, buildPythonPackage, fetchPypi
-, pytest, cmdline, pytest-cov, coverage, setuptools-git, mock, path, execnet
-, contextlib2, termcolor, six }:
+{ lib
+, isPyPy
+, buildPythonPackage
+, fetchPypi
+
+# build
+, pytest
+
+# runtime
+, setuptools-git
+, mock
+, path
+, execnet
+, contextlib2
+, termcolor
+, six
+
+# tests
+, cmdline
+, pytestCheckHook
+ }:
 
 buildPythonPackage rec {
   pname = "pytest-shutil";
   version = "1.7.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0q8j0ayzmnvlraml6i977ybdq4xi096djhf30n2m1rvnvrhm45nq";
+    hash = "sha256-2BZSYd5251CFBcNB2UwCsRPclj8nRUOrynTb+r0CEmE=";
   };
 
   postPatch = ''
@@ -16,13 +35,31 @@ buildPythonPackage rec {
       --replace "path.py" "path"
   '';
 
-  buildInputs = [ pytest ];
-  checkInputs = [ cmdline pytest ];
-  propagatedBuildInputs = [ pytest-cov coverage setuptools-git mock path execnet contextlib2 termcolor six ];
+  buildInputs = [
+    pytest
+  ];
 
-  checkPhase = ''
-    py.test ${lib.optionalString isPyPy "-k'not (test_run or test_run_integration)'"}
-  '';
+  propagatedBuildInputs = [
+    setuptools-git
+    mock
+    path
+    execnet
+    contextlib2
+    termcolor
+    six
+  ];
+
+  checkInputs = [
+    cmdline
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    "test_pretty_formatter"
+  ] ++ lib.optionals isPyPy [
+    "test_run"
+    "test_run_integration"
+  ];
 
   meta = with lib; {
     description = "A goodie-bag of unix shell and environment tools for py.test";


### PR DESCRIPTION
###### Description of changes

pytest-shutil fails to build on release 22.11 on Python 3.11 because it declares a dependency on contextlib2 which fails to build on Python 3.11.  The upstream pytest-shutil contextlib2 dependency should actually be conditional and only applies to Python <3.  Upstream made this change and nixpkgs master has the fixes.  This is a backport that just cherry-picks the two relevant commits from master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

