### PR TITLE
libidn2: 2.3.2 -> 2.3.4

### DIFF
--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "libidn2";
-  version = "2.3.2";
+  version = "2.3.4";
 
   src = fetchurl {
-    url = "mirror://gnu/libidn/${pname}-${version}.tar.gz";
-    sha256 = "sha256-dpQM1Od46Ak1eanRlbJf/16Tbp3GJCBoUotDenZ2T5E=";
+    url = "https://ftp.gnu.org/gnu/libidn/${pname}-${version}.tar.gz";
+    sha256 = "sha256-k8q6crTgUdH41PWgdqtjyZt3+u4Bm3K5eDsmeYbbtF8=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
###### Description of changes

Update libidn2 to current latest version, see: https://lists.gnu.org/archive/html/info-gnu/2022-10/msg00004.html and https://gitlab.com/libidn/libidn2/-/releases.

This change was motivated by manual test run of https://github.com/tiiuae/sbomnix/tree/main/scripts/nixupdate, which pointed out that libidn2 is currently not up-to-date in nix unstable.

Manual update attempt using the earlier mirror `mirror://gnu/libidn/` failed due to:
```
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
do not know how to unpack source archive /nix/store/1v5l3gnb0j8ckwv6ms17gl4b6g5nbx3j-libidn2-2.3.4.tar.gz
```
Which is assumably the same reason why r-ryantm also failed to automatically update: https://r.ryantm.com/log/libidn2/2023-03-05.log.

It's not fully clear why changing the mirror to master repository (https://ftp.gnu.org/pub/gnu/) resolves the update issue.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
