### PR TITLE
cachix: 1.3.1 -> 1.3.3

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -194,6 +194,28 @@ in {
     hls-stylish-haskell-plugin = null;
   };
 
+  # needed to build servant
+  http-api-data = super.http-api-data_0_5;
+  attoparsec-iso8601 = super.attoparsec-iso8601_1_1_0_0;
+
+  # requires newer versions to work with GHC 9.4
+  swagger2 = dontCheck super.swagger2;
+  servant = doJailbreak super.servant;
+  servant-server = doJailbreak super.servant-server;
+  servant-auth = doJailbreak super.servant-auth;
+  servant-auth-swagger = doJailbreak super.servant-auth-swagger;
+  servant-swagger = doJailbreak super.servant-swagger;
+  servant-client-core = doJailbreak super.servant-client-core;
+  servant-client = doJailbreak super.servant-client;
+  relude = doJailbreak super.relude;
+
+  cborg = appendPatch (pkgs.fetchpatch {
+    name = "cborg-support-ghc-9.4.patch";
+    url = "https://github.com/well-typed/cborg/pull/304.diff";
+    sha256 = "sha256-W4HldlESKOVkTPhz9nkFrvbj9akCOtF1SbIt5eJqtj8=";
+    relative = "cborg";
+  }) super.cborg;
+
   # https://github.com/tweag/ormolu/issues/941
   ormolu = doDistribute self.ormolu_0_5_3_0;
   fourmolu = overrideCabal (drv: {

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -879,17 +879,17 @@ self: super: builtins.intersectAttrs super {
   domaindriven-core = dontCheck super.domaindriven-core;
 
   cachix = overrideCabal (drv: {
-    version = "1.3.1";
+    version = "1.3.3";
     src = pkgs.fetchFromGitHub {
       owner = "cachix";
       repo = "cachix";
-      rev = "v1.3.1";
-      sha256 = "sha256-fYQrAgxEMdtMAYadff9Hg4MAh0PSfGPiYw5Z4BrvgFU=";
+      rev = "v1.3.3";
+      sha256 = "sha256-xhLCsAkz5c+XIqQ4eGY9bSp3zBgCDCaHXZ2HLk8vqmE=";
     };
     buildDepends = [ self.conduit-concurrent-map ];
     postUnpack = "sourceRoot=$sourceRoot/cachix";
     postPatch = ''
-      sed -i 's/1.3/1.3.1/' cachix.cabal
+      sed -i 's/1.3.2/1.3.3/' cachix.cabal
     '';
   }) (super.cachix.override {
     nix = self.hercules-ci-cnix-store.passthru.nixPackage;
@@ -897,12 +897,12 @@ self: super: builtins.intersectAttrs super {
     hnix-store-core = super.hnix-store-core_0_6_1_0;
   });
   cachix-api = overrideCabal (drv: {
-    version = "1.3.1";
+    version = "1.3.3";
     src = pkgs.fetchFromGitHub {
       owner = "cachix";
       repo = "cachix";
-      rev = "v1.3.1";
-      sha256 = "sha256-fYQrAgxEMdtMAYadff9Hg4MAh0PSfGPiYw5Z4BrvgFU=";
+      rev = "v1.3.3";
+      sha256 = "sha256-xhLCsAkz5c+XIqQ4eGY9bSp3zBgCDCaHXZ2HLk8vqmE=";
     };
     postUnpack = "sourceRoot=$sourceRoot/cachix-api";
   }) super.cachix-api;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19371,7 +19371,7 @@ with pkgs;
   c-blosc = callPackage ../development/libraries/c-blosc { };
 
   # justStaticExecutables is needed due to https://github.com/NixOS/nix/issues/2990
-  cachix = (haskell.lib.compose.justStaticExecutables haskellPackages.cachix).overrideAttrs(o: {
+  cachix = (haskell.lib.compose.justStaticExecutables haskell.packages.ghc94.cachix).overrideAttrs(o: {
     passthru = o.passthru or {} // {
       tests = o.passthru.tests or {} // {
         inherit hci;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -475,7 +475,7 @@ in {
       ghc = bh.compiler.ghc944;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.4.x.nix { };
     };
-    ghc94 = ghc942;
+    ghc94 = ghc944;
     ghc961 = callPackage ../development/haskell-modules {
       buildHaskellPackages = bh.packages.ghc961;
       ghc = bh.compiler.ghc961;


### PR DESCRIPTION
It also uses GHC 9.4, since 9.2 is broken on arm/linux (segfaults).
