### PR TITLE
usbguard-notifier: init at 0.1.0

### DIFF
--- a/pkgs/os-specific/linux/usbguard-notifier/default.nix
+++ b/pkgs/os-specific/linux/usbguard-notifier/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  libqb,
+  usbguard,
+  librsvg,
+  libnotify,
+  catch2,
+  asciidoc,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "usbguard-notifier";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Cropi";
+    repo = pname;
+    rev = "${pname}-${version}";
+    hash = "sha256-gWvCGSbOuey2ELAPD2WCG4q77IClL0S7rE2RaUJDc1I=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config asciidoc ];
+  buildInputs = [ libqb usbguard librsvg libnotify ];
+
+  configureFlags = [ "CPPFLAGS=-I${catch2}/include/catch2" ];
+
+  prePatch = ''
+    substituteInPlace configure.ac \
+      --replace 'AC_MSG_FAILURE([Cannot detect the systemd system unit dir])' \
+        'systemd_unit_dir="$out/lib/systemd/user"'
+  '';
+
+  meta = {
+    description = "Notifications for detecting usbguard policy and device presence changes";
+    homepage = "https://github.com/Cropi/usbguard-notifier";
+    maintainers = with lib.maintainers; [ fpletz ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27163,6 +27163,8 @@ with pkgs;
 
   usbguard = callPackage ../os-specific/linux/usbguard { };
 
+  usbguard-notifier = callPackage ../os-specific/linux/usbguard-notifier { };
+
   usbrelay = callPackage ../os-specific/linux/usbrelay { };
   usbrelayd = callPackage ../os-specific/linux/usbrelay/daemon.nix { };
 


### PR DESCRIPTION
###### Description of changes

New package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

