### PR TITLE
gscreenshot: init at 3.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3285,6 +3285,12 @@
       fingerprint = "5B08 313C 6853 E5BF FA91  A817 0176 0B4F 9F53 F154";
     }];
   };
+  davisrichard437 = {
+    email = "davisrichard437@gmail.com";
+    github = "davisrichard437";
+    githubId = 85075437;
+    name = "Richard Davis";
+  };
   davorb = {
     email = "davor@davor.se";
     github = "davorb";

--- a/pkgs/applications/graphics/gscreenshot/0001-Changing-paths-to-be-nix-compatible.patch
+++ b/pkgs/applications/graphics/gscreenshot/0001-Changing-paths-to-be-nix-compatible.patch
@@ -1,0 +1,25 @@
+From a4822ee9e894f5f5b3110f41f65a698dd845a41d Mon Sep 17 00:00:00 2001
+From: Richard Davis <davisrichard437@gmail.com>
+Date: Fri, 24 Mar 2023 11:45:23 -0400
+Subject: [PATCH] Changing paths to be nix-compatible.
+
+---
+ dist/desktop/gscreenshot.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dist/desktop/gscreenshot.desktop b/dist/desktop/gscreenshot.desktop
+index a5d2bcd..9d289e2 100644
+--- a/dist/desktop/gscreenshot.desktop
++++ b/dist/desktop/gscreenshot.desktop
+@@ -2,7 +2,7 @@
+ Type=Application
+ Name=gscreenshot
+ Comment=A simple screenshot utility
+-TryExec=/usr/bin/gscreenshot
++TryExec=gscreenshot
+ Exec=gscreenshot
+ Icon=gscreenshot
+ Categories=Graphics;
+-- 
+2.39.2
+

--- a/pkgs/applications/graphics/gscreenshot/default.nix
+++ b/pkgs/applications/graphics/gscreenshot/default.nix
@@ -1,0 +1,90 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+, gettext
+, gobject-introspection
+, gtk3
+, wrapGAppsHook
+, xdg-utils
+, scrot
+, slop
+, xclip
+, grim
+, slurp
+, wl-clipboard
+, waylandSupport ? true
+, x11Support ? true
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "gscreenshot";
+  version = "3.4.0";
+
+  src = fetchFromGitHub {
+    owner = "thenaterhood";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "YuISiTUReX9IQpckIgbt03CY7klnog/IeOtfBoQ1DZM=";
+  };
+
+  # needed for wrapGAppsHook to function
+  strictDeps = false;
+  # tests require a display and fail
+  doCheck = false;
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+  propagatedBuildInputs = [
+    gettext
+    gobject-introspection
+    gtk3
+    xdg-utils
+  ] ++ lib.optionals waylandSupport [
+    # wayland deps
+    grim
+    slurp
+    wl-clipboard
+  ] ++ lib.optionals x11Support [
+    # X11 deps
+    scrot
+    slop
+    xclip
+    python3Packages.xlib
+  ] ++ (with python3Packages; [
+    pillow
+    pygobject3
+    setuptools
+  ]);
+
+  patches = [ ./0001-Changing-paths-to-be-nix-compatible.patch ];
+
+  meta = {
+    description = "A screenshot frontend (CLI and GUI) for a variety of screenshot backends";
+
+    longDescription = ''
+      gscreenshot provides a common frontend and expanded functionality to a
+      number of X11 and Wayland screenshot and region selection utilties.
+
+      In a nutshell, gscreenshot supports the following:
+
+      - Capturing a full-screen screenshot
+      - Capturing a region of the screen interactively
+      - Capturing a window interactively
+      - Capturing the cursor
+      - Capturing the cursor, using an alternate cursor glyph
+      - Capturing a screenshot with a delay
+      - Showing a notification when a screenshot is taken
+      - Capturing a screenshot from the command line or a custom script
+      - Capturing a screenshot using a GUI
+      - Saving to a variety of image formats including 'bmp', 'eps', 'gif', 'jpeg', 'pcx', 'pdf', 'ppm', 'tiff', 'png', and 'webp'.
+      - Copying a screenshot to the system clipboard
+      - Opening a screenshot in the configured application after capture
+
+      Other than region selection, gscreenshot's CLI is non-interactive and is suitable for use in scripts.
+    '';
+
+    homepage = "https://github.com/thenaterhood/gscreenshot";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.davisrichard437 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29552,6 +29552,8 @@ with pkgs;
 
   grisbi = callPackage ../applications/office/grisbi { gtk = gtk3; };
 
+  gscreenshot = callPackage ../applications/graphics/gscreenshot { };
+
   gtkpod = callPackage ../applications/audio/gtkpod { };
 
   q4wine = libsForQt5.callPackage ../applications/misc/q4wine { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`gscreenshot` (https://github.com/thenaterhood/gscreenshot) is a screenshot frontend (CLI and GUI) for a variety of screenshot backends. These changes provide a default, fully-functional X11 configuration. I was unsure how this might work, but I would love suggestions for how to idiomatically package other configurations (particularly the recommended Wayland default).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
