### PR TITLE
pypy3Packages.greenlet: Hide the derivation

### DIFF
--- a/pkgs/development/python-modules/greenlet/default.nix
+++ b/pkgs/development/python-modules/greenlet/default.nix
@@ -6,13 +6,12 @@
 , psutil
 , pytestCheckHook
 }:
-
-
-buildPythonPackage rec {
+if isPyPy
+then null # builtin for pypy
+else buildPythonPackage rec {
   pname = "greenlet";
   version = "2.0.2";
   format = "setuptools";
-  disabled = isPyPy; # builtin for pypy
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION

###### Description of changes

greenlet is a built-in module on PyPy.  The third-party greenlet module is incompatible with PyPy.  Python packages that declare a greenlet dependency in their packaging metadata have this dependency satisfied by the built-in package on PyPy and the third-party package on CPython.

Some Pytho0n packages in nixpkgs have greenlet supplied as a build input.  This breaks on PyPy because there is currently no logic in place to automatically substitute the builtin package in that case.

This change is meant to supply this automatic substitution - by automatically making the greenlet derivation null on PyPy.

An example of a package that this fixes is `pypy3Packages.pytest-twisted`.  Before the change, it fails to build:

```
nix-repl> :b legacyPackages.x86_64-linux.pypy3Packages.pytest-twisted
error: greenlet-2.0.2 not supported for interpreter pypy3.9
```

and after the change it succeeds:

```
nix-repl> :b legacyPackages.x86_64-linux.pypy3Packages.pytest-twisted

This derivation produced the following outputs:
  dist -> /nix/store/mr5i47ipv02wvq1q9zbig6ca1ywyz6k7-pypy3.9-pytest-twisted-1.13.2-dist
  out -> /nix/store/9jl9zzl0sl1qzcr8yadaz51y61i05dn2-pypy3.9-pytest-twisted-1.13.2
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
