### PR TITLE
babashka: 1.1.173 → 1.2.174

### DIFF
--- a/pkgs/build-support/build-graalvm-native-image/default.nix
+++ b/pkgs/build-support/build-graalvm-native-image/default.nix
@@ -34,6 +34,9 @@ let
     "dontUnpack"
     "LC_ALL"
     "meta"
+    "buildPhase"
+    "nativeBuildInputs"
+    "installPhase"
   ];
 in
 stdenv.mkDerivation ({

--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -1,26 +1,43 @@
-{ lib, buildGraalvmNativeImage, fetchurl, writeScript }:
+{ lib
+, buildGraalvmNativeImage
+, graalvmCEPackages
+, removeReferencesTo
+, fetchurl
+, writeScript }:
 
 buildGraalvmNativeImage rec {
   pname = "babashka";
-  version = "1.1.173";
+  version = "1.2.174";
 
   src = fetchurl {
     url = "https://github.com/babashka/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
-    sha256 = "sha256-p/KGDCocTksvUwj6x5l1xUEM1OZ4pNHtXL4mTgg7JUI=";
+    sha256 = "sha256-5ZvqbOU69ZZNIT5Mh7+Cg5s+gLhOnFMSIO4ZI9t6D/8=";
   };
 
+  graalvmDrv = graalvmCEPackages.graalvm19-ce;
+
   executable = "bb";
+
+  nativeBuildInputs = [ removeReferencesTo ];
 
   extraNativeImageBuildArgs = [
     "-H:+ReportExceptionStackTraces"
     "--no-fallback"
     "--native-image-info"
+    "--enable-preview"
   ];
 
   installCheckPhase = ''
     $out/bin/bb --version | grep '${version}'
     $out/bin/bb '(+ 1 2)' | grep '3'
     $out/bin/bb '(vec (dedupe *input*))' <<< '[1 1 1 1 2]' | grep '[1 2]'
+  '';
+
+  # As of v1.2.174, this will remove references to ${graalvmDrv}/conf/chronology,
+  # not sure the implications of this but this file is not available in
+  # graalvm19-ce anyway.
+  postInstall = ''
+    remove-references-to -t ${graalvmDrv} $out/bin/${executable}
   '';
 
   passthru.updateScript = writeScript "update-babashka" ''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump `babashka` to its latest version. According to the changelog, this version uses GraalVM with JDK 19, so use it too here: https://github.com/babashka/babashka/blob/master/CHANGELOG.md#12174-2023-03-01

Needed a few fixes in `buildGraalvmNativeImage` builder too, so this PR also includes them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
