### PR TITLE
linuxManualConfig: install GDB scripts

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -36,10 +36,7 @@ let
 
     debug = {
       # Necessary for BTF
-      DEBUG_INFO                = mkMerge [
-        (whenOlder "5.2" (if (features.debug or false) then yes else no))
-        (whenBetween "5.2" "5.18" yes)
-      ];
+      DEBUG_INFO                = yes;
       DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT = whenAtLeast "5.18" yes;
       # Reduced debug info conflict with BTF and have been enabled in
       # aarch64 defconfig since 5.13
@@ -62,6 +59,8 @@ let
       SUNRPC_DEBUG              = yes;
       # Provide access to tunables like sched_migration_cost_ns
       SCHED_DEBUG               = yes;
+
+      GDB_SCRIPTS               = yes;
     };
 
     power-management = {

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -156,8 +156,7 @@ let
       configurePhase = ''
         runHook preConfigure
 
-        mkdir build
-        export buildRoot="$(pwd)/build"
+        export buildRoot=$(mktemp -d)
 
         echo "manual-config configurePhase buildRoot=$buildRoot pwd=$PWD"
 
@@ -275,8 +274,8 @@ let
         mkdir -p $dev/lib/modules/${modDirVersion}/{build,source}
 
         # To save space, exclude a bunch of unneeded stuff when copying.
-        (cd .. && rsync --archive --prune-empty-dirs \
-            --exclude='/build/' \
+        (cd "$NIX_BUILD_TOP" && cd "$sourceRoot" &&
+         rsync --archive --prune-empty-dirs \
             * $dev/lib/modules/${modDirVersion}/source/)
 
         cd $dev/lib/modules/${modDirVersion}/source

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -198,18 +198,14 @@ let
       '';
 
       buildFlags = [
+        "DTC_FLAGS=-@"
         "KBUILD_BUILD_VERSION=1-NixOS"
 
         # Set by default in the kernel since a73619a845d5,
         # replicated here to apply to older versions.
         # Makes __FILE__ relative to the build directory.
         "KCPPFLAGS=-fmacro-prefix-map=$(sourceRoot)/="
-
-        kernelConf.target
-        "vmlinux"  # for "perf" and things like that
-      ] ++ optional isModular "modules"
-        ++ optionals buildDTBs ["dtbs" "DTC_FLAGS=-@"]
-      ++ extraMakeFlags;
+      ] ++ extraMakeFlags;
 
       installFlags = [
         "INSTALL_PATH=$(out)"


### PR DESCRIPTION
###### Description of changes

linux is unusual in that we include its sources in an output.  There's no point unpacking into /build when we're going to copy the sources into $dev later.  Let's unpack directly into the final destination of the code, and save copying a whole kernel source tree (often across filesystems!).

This also means that Kbuild knows the location of the sources, which will allow us to install the GDB scripts — some scripts are generated, and some are not, so the generated ones end up in the build directory, accompanied by symlinks to the non-generated ones in the source directory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
