### PR TITLE
cimg,gmic,gmic-qt: 3.2.1 -> 3.2.2

### DIFF
--- a/pkgs/development/libraries/cimg/default.nix
+++ b/pkgs/development/libraries/cimg/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cimg";
-  version = "3.2.1";
+  version = "3.2.2";
 
   src = fetchFromGitHub {
-    owner = "dtschump";
+    owner = "GreycLab";
     repo = "CImg";
     rev = "v.${version}";
-    hash = "sha256-MPkZGKewusCw5TsW5NOtnrjqEK2dxRSCal1fn7Yiaio=";
+    hash = "sha256-koXew0Lwb7wW8MQctTjxpo7TNVtrS5MzxQFfUS1gwZs=";
   };
 
   outputs = [ "out" "doc" ];

--- a/pkgs/development/libraries/cimg/default.nix
+++ b/pkgs/development/libraries/cimg/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
       processing applications.
     '';
     license = licenses.cecill-c;
-    maintainers = [ maintainers.AndersonTorres ];
+    maintainers = [ maintainers.AndersonTorres maintainers.lilyinstarlight ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -1,11 +1,12 @@
 { lib
-, mkDerivation
+, stdenv
 , variant ? "standalone"
 , fetchzip
 , fetchpatch
 , cmake
 , pkg-config
 , ninja
+, wrapQtAppsHook
 , opencv3
 , openexr
 , graphicsmagick
@@ -19,12 +20,6 @@
 , gmic
 , qtbase
 , qttools
-, writeShellScript
-, common-updater-scripts
-, gnugrep
-, gnused
-, coreutils
-, jq
 , nix-update-script
 , gimpPlugins
 }:
@@ -50,20 +45,20 @@ assert lib.assertMsg (builtins.hasAttr variant variants) "gmic-qt variant “${v
 
 assert lib.assertMsg (builtins.all (d: d != null) variants.${variant}.extraDeps or []) "gmic-qt variant “${variant}” is missing one of its dependencies.";
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "gmic-qt${lib.optionalString (variant != "standalone") "-${variant}"}";
-  version = "3.2.1";
+  version = "3.2.2";
 
   src = fetchzip {
     url = "https://gmic.eu/files/source/gmic_${version}.tar.gz";
-    hash = "sha256-2lMnn19FcFKnfIjSxOObqxIjqLMUoWgi0ADZBCBePY4=";
+    hash = "sha256-Z6FU0BRTiOIoM6ViYgcwOifat4/IISFJXvyC8PwR5mA=";
   };
 
   patches = [
     (fetchpatch {
-      name = "gmic-qt-3.2.1-fix-system-gmic.patch";
-      url = "https://github.com/c-koi/gmic-qt/commit/e8d7a3523753ff592da63b1d54edf0921c54fe53.patch";
-      hash = "sha256-kBFZo2qvod4pH3oK8gvnmw39x6eMH9zjr4mMcY74mFo=";
+      name = "gmic-3.2.2-cmake-fixes.patch";
+      url = "https://github.com/c-koi/gmic-qt/compare/5379307f9e484ad171b8d09e3572b93d120a9159..420e85e005401d942a3ca5f5c39ee3c867fe8bdd.diff";
+      hash = "sha256-l2y9EFtE3nv8NBSSn6Wo0pLRoYO2hoyb5HZk0QmlSpk=";
     })
   ];
 
@@ -73,6 +68,7 @@ mkDerivation rec {
     cmake
     pkg-config
     ninja
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -115,6 +115,7 @@ stdenv.mkDerivation rec {
     description = variants.${variant}.description;
     homepage = "http://gmic.eu/";
     license = licenses.gpl3Plus;
+    maintainers = [ maintainers.lilyinstarlight ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/graphics/gmic/default.nix
+++ b/pkgs/tools/graphics/gmic/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , fetchurl
 , cmake
 , ninja
@@ -27,31 +26,23 @@
 
 stdenv.mkDerivation rec {
   pname = "gmic";
-  version = "3.2.1";
+  version = "3.2.2";
 
   outputs = [ "out" "lib" "dev" "man" ];
 
   src = fetchFromGitHub {
-    owner = "dtschump";
+    owner = "GreycLab";
     repo = "gmic";
     rev = "v.${version}";
-    hash = "sha256-oEH4GlSV+642TGSJJhV4yzydh1hAQZfzwaiPAZFNQtI=";
+    hash = "sha256-XLDnIs7IRIhQtz+qgdNypJODk6WJRPQ2M6LU6DJ+T7I=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "gmic-3.2.1-fix-system-gmic.patch";
-      url = "https://github.com/GreycLab/gmic/commit/9db3f6a39d9ed67b4279654da88993a8057575ff.patch";
-      hash = "sha256-JznKCs56t6cJ4HLqlhMZjSOupEB8cdkn3j6RgZpcpzo=";
-    })
-  ];
 
   # TODO: build this from source
   # https://github.com/dtschump/gmic/blob/b36b2428db5926af5eea5454f822f369c2d9907e/src/Makefile#L675-L729
   gmic_stdlib = fetchurl {
     name = "gmic_stdlib.h";
     url = "http://gmic.eu/gmic_stdlib${lib.replaceStrings ["."] [""] version}.h";
-    hash = "sha256-f8d9jTVnHwSoyMuiM+Qv86e/BYX9SSx9cl3borihxnc=";
+    hash = "sha256-lABUPhwlzoRODX7z8arOEU0JJszcXREhZ20WRToKNY4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/graphics/gmic/default.nix
+++ b/pkgs/tools/graphics/gmic/default.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Open and full-featured framework for image processing";
     homepage = "https://gmic.eu/";
-    license = licenses.cecill20;
+    license = licenses.cecill21;
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/graphics/gmic/default.nix
+++ b/pkgs/tools/graphics/gmic/default.nix
@@ -111,6 +111,7 @@ stdenv.mkDerivation rec {
     description = "Open and full-featured framework for image processing";
     homepage = "https://gmic.eu/";
     license = licenses.cecill21;
+    maintainers = [ maintainers.lilyinstarlight ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Description of changes

I updated the three G'MIC packages (which required one upstream PR to fix gmic-qt) and made a few drive-by fixes

Changelog: https://discuss.pixls.us/t/on-the-road-to-3-3/34786 (notably includes a critical bug fix to enable mutexes for the command line tool when using parallel computing)

Drive-bys:
* Fix repo owner for cimg and gmic, since the repository was moved a while ago to GreycLab
* Remove unused args from packages
* Make gmic-qt use `stdenv.mkDerivation` instead of `qt5.mkDerivation` (see #180841, and this would also be a requirement to building with Qt6)

Upstream PR to fix CMakeLists: c-koi/gmic-qt#176

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>10 packages built:</summary>
  <ul>
    <li>cimg</li>
    <li>darktable</li>
    <li>gimp-with-plugins</li>
    <li>gimpPlugins.gmic</li>
    <li>gmic</li>
    <li>gmic-qt</li>
    <li>imgcat</li>
    <li>openroad</li>
    <li>phash</li>
    <li>photoprism</li>
  </ul>
</details>