### PR TITLE
sage: add libpng to sagelib, import package update patches

### DIFF
--- a/pkgs/applications/science/math/sage/patches/numpy-1.24-upgrade.patch
+++ b/pkgs/applications/science/math/sage/patches/numpy-1.24-upgrade.patch
@@ -1,0 +1,58 @@
+diff --git a/src/sage/misc/persist.pyx b/src/sage/misc/persist.pyx
+index 3ac5f1cc2b..cb1f327c19 100644
+--- a/src/sage/misc/persist.pyx
++++ b/src/sage/misc/persist.pyx
+@@ -157,7 +157,7 @@ def load(*filename, compress=True, verbose=True, **kwargs):
+         ....:     _ = f.write(code)
+         sage: load(t)
+         sage: hello
+-        <fortran object>
++        <fortran ...>
+     """
+     import sage.repl.load
+     if len(filename) != 1:
+diff --git a/src/sage/plot/complex_plot.pyx b/src/sage/plot/complex_plot.pyx
+index 6f0aeab87a..b77c69b2f7 100644
+--- a/src/sage/plot/complex_plot.pyx
++++ b/src/sage/plot/complex_plot.pyx
+@@ -461,6 +461,8 @@ def complex_to_rgb(z_values, contoured=False, tiled=False,
+             rgb[i, j, 2] = b
+ 
+     sig_off()
++    nan_indices = np.isnan(rgb).any(-1)     # Mask for undefined points
++    rgb[nan_indices] = 1                    # Make nan_indices white
+     return rgb
+ 
+ 
+diff --git a/src/sage/plot/histogram.py b/src/sage/plot/histogram.py
+index 3bc2b76b58..388c2d1391 100644
+--- a/src/sage/plot/histogram.py
++++ b/src/sage/plot/histogram.py
+@@ -87,13 +87,8 @@ class Histogram(GraphicPrimitive):
+ 
+         TESTS::
+ 
+-            sage: h = histogram([10,3,5], normed=True)[0]
+-            doctest:warning...:
+-            DeprecationWarning: the 'normed' option is deprecated. Use 'density' instead.
+-            See https://trac.sagemath.org/25260 for details.
++            sage: h = histogram([10,3,5], density=True)[0]
+             sage: h.get_minmax_data()
+-            doctest:warning ...
+-            ...VisibleDeprecationWarning: Passing `normed=True` on non-uniform bins has always been broken, and computes neither the probability density function nor the probability mass function. The result is only correct if the bins are uniform, when density=True will produce the same result anyway. The argument will be removed in a future version of numpy.
+             {'xmax': 10.0, 'xmin': 3.0, 'ymax': 0.476190476190..., 'ymin': 0}
+         """
+         import numpy
+diff --git a/src/sage/repl/ipython_extension.py b/src/sage/repl/ipython_extension.py
+index 798671aab4..cad6a47ca8 100644
+--- a/src/sage/repl/ipython_extension.py
++++ b/src/sage/repl/ipython_extension.py
+@@ -405,7 +405,7 @@ class SageMagics(Magics):
+             ....: C END FILE FIB1.F
+             ....: ''')
+             sage: fib
+-            <fortran object>
++            <fortran ...>
+             sage: from numpy import array
+             sage: a = array(range(10), dtype=float)
+             sage: fib(a, 10)

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -127,6 +127,23 @@ stdenv.mkDerivation rec {
       sha256 = "sha256-9BhQLFB3wUhiXRQsK9L+I62lSjvTfrqMNi7QUIQvH4U=";
     })
 
+    # https://github.com/sagemath/sage/pull/35235
+    (fetchpatch {
+      name = "ipython-8.11-upgrade.patch";
+      url = "https://github.com/sagemath/sage/commit/23471e2d242c4de8789d7b1fc8b07a4b1d1e595a.diff";
+      sha256 = "sha256-wvH4BvDiaBv7jbOP8LvOE5Vs16Kcwz/C9jLpEMohzLQ=";
+    })
+
+    # positively reviewed
+    (fetchpatch {
+      name = "matplotlib-3.7.0-upgrade.patch";
+      url = "https://github.com/sagemath/sage/pull/35177.diff";
+      sha256 = "sha256-YdPnMsjXBm9ZRm6a8hH8rSynkrABjLoIzqwp3F/rKAw=";
+    })
+
+    # rebased from https://github.com/sagemath/sage/pull/34994, merged in sage 10.0.beta2
+    ./patches/numpy-1.24-upgrade.patch
+
     # temporarily paper over https://github.com/jupyter-widgets/ipywidgets/issues/3669
     ./patches/ipywidgets-on_submit-deprecationwarning.patch
 

--- a/pkgs/applications/science/math/sage/sagelib.nix
+++ b/pkgs/applications/science/math/sage/sagelib.nix
@@ -22,6 +22,7 @@
 , gsl
 , iml
 , jinja2
+, libpng
 , lcalc
 , lrcalc
 , gap
@@ -99,6 +100,7 @@ buildPythonPackage rec {
     gd
     readline
     iml
+    libpng
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes

Since the 3.7.0 upgrade (that is, since the last staging-next merge #219444), matplotlib no longer propagates `libpng`. NumPy and IPython were also upgrade and require changes to Sage. This was discovered during the review of #221634.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
