### PR TITLE
rofi-blezz: init at unstable-2022-09-07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7306,6 +7306,12 @@
     githubId = 32305209;
     name = "John Children";
   };
+  johnjohnstone = {
+   email = "jjohnstone@riseup.net";
+   github = "johnjohnstone";
+   githubId = 3208498;
+   name = "John Johnstone";
+  };
   johnmh = {
     email = "johnmh@openblox.org";
     github = "JohnMH";

--- a/pkgs/by-name/ro/rofi-blezz/0001-Patch-plugindir-to-output.patch
+++ b/pkgs/by-name/ro/rofi-blezz/0001-Patch-plugindir-to-output.patch
@@ -1,0 +1,25 @@
+From 7f5a652150aef9c098d2d5d4bc4f6d497609c47c Mon Sep 17 00:00:00 2001
+From: john johnstone <jjohnstone@riseup.net>
+Date: Sat, 11 Mar 2023 22:29:18 +0000
+Subject: [PATCH] plugin install dir patch for nix
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 31d96d0..a7a589d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -54,7 +54,7 @@ dnl ---------------------------------------------------------------------
+ PKG_CHECK_MODULES([glib],     [glib-2.0 >= 2.40 gio-unix-2.0 gmodule-2.0])
+ PKG_CHECK_MODULES([rofi],     [rofi])
+ 
+-[rofi_PLUGIN_INSTALL_DIR]="`$PKG_CONFIG --variable=pluginsdir rofi`"
++[rofi_PLUGIN_INSTALL_DIR]="`echo $out/lib/rofi`"
+ AC_SUBST([rofi_PLUGIN_INSTALL_DIR])
+ 
+ LT_INIT([disable-static])
+-- 
+2.39.2
+

--- a/pkgs/by-name/ro/rofi-blezz/0002-Patch-add-cairo.patch
+++ b/pkgs/by-name/ro/rofi-blezz/0002-Patch-add-cairo.patch
@@ -1,0 +1,38 @@
+From ed8943fdd9ffe7d53a89b7cd18a08165708884ad Mon Sep 17 00:00:00 2001
+From: john johnstone <jjohnstone@riseup.net>
+Date: Sun, 12 Mar 2023 04:41:44 +0000
+Subject: [PATCH] patch cairo
+
+---
+ Makefile.am  | 4 ++--
+ configure.ac | 1 +
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index cef4046..ba7051a 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -6,6 +6,6 @@ plugin_LTLIBRARIES = blezz.la
+ blezz_la_SOURCES=\
+ 		 src/blezz.c
+ 
+-blezz_la_CFLAGS= @glib_CFLAGS@ @rofi_CFLAGS@
+-blezz_la_LIBADD= @glib_LIBS@ @rofi_LIBS@
++blezz_la_CFLAGS= @glib_CFLAGS@ @rofi_CFLAGS@ @cairo_CFLAGS@
++blezz_la_LIBADD= @glib_LIBS@ @rofi_LIBS@ @cairo_LIBS@
+ blezz_la_LDFLAGS= -module -avoid-version
+diff --git a/configure.ac b/configure.ac
+index a7a589d..ce4e649 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -53,6 +53,7 @@ dnl PKG_CONFIG based dependencies
+ dnl ---------------------------------------------------------------------
+ PKG_CHECK_MODULES([glib],     [glib-2.0 >= 2.40 gio-unix-2.0 gmodule-2.0])
+ PKG_CHECK_MODULES([rofi],     [rofi])
++PKG_CHECK_MODULES([cairo],    [cairo cairo-xcb])
+ 
+ [rofi_PLUGIN_INSTALL_DIR]="`echo $out/lib/rofi`"
+ AC_SUBST([rofi_PLUGIN_INSTALL_DIR])
+-- 
+2.39.2
+

--- a/pkgs/by-name/ro/rofi-blezz/package.nix
+++ b/pkgs/by-name/ro/rofi-blezz/package.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, cairo
+, pkg-config
+, rofi-unwrapped
+}:
+
+stdenv.mkDerivation {
+  pname = "rofi-blezz";
+  version = "2023-03-27";
+
+  src = fetchFromGitHub {
+    owner = "davatorium";
+    repo = "rofi-blezz";
+    rev = "3a00473471e7c56d2c349ad437937107b7d8e961";
+    sha256 = "sha256-hY5UA7nyL6QoOBIZTjEiR0zjZFhkUkRa50r5rVZDnbg=";
+  };
+
+  patches = [
+    ./0001-Patch-plugindir-to-output.patch
+    ./0002-Patch-add-cairo.patch
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    cairo
+    rofi-unwrapped
+  ];
+
+  meta = with lib; {
+    description = "A plugin for rofi that emulates blezz behaviour";
+    homepage = "https://github.com/davatorium/rofi-blezz";
+    license = licenses.mit;
+    maintainers = with maintainers; [ johnjohnstone ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
###### Description of changes
Adds rofi-blezz

###### Things done

Tested on sway and i3

- Built on platform(s)
  - [ X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
