### PR TITLE
CODEOWNERS: add superherointj to vscode (2th path)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -238,7 +238,7 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 
 # VsCode Extensions
 /pkgs/applications/editors/vscode @superherointj
-/pkgs/applications/editors/vscode/extensions   @jonringer
+/pkgs/applications/editors/vscode/extensions   @jonringer @superherointj
 
 # Prometheus exporter modules and tests
 /nixos/modules/services/monitoring/prometheus/exporters.nix  @WilliButz


### PR DESCRIPTION
CODEOWNERS: add superherointj to vscode (2th path)

As previous entry did not work for subfolders. This follow up patch was necessary.