### PR TITLE
passage: add missing dependency on tree(1)

### DIFF
--- a/pkgs/tools/security/passage/default.nix
+++ b/pkgs/tools/security/passage/default.nix
@@ -1,5 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, makeBinaryWrapper, bash, age, git ? null
-, xclip ? null }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeBinaryWrapper
+, bash
+, age
+, git ? null
+, xclip ? null
+# Used to pretty-print list of all stored passwords, but is not needed to fetch
+# or store password by its name. Most users would want this dependency.
+, tree ? null
+}:
 
 stdenv.mkDerivation {
   pname = "passage";
@@ -14,7 +24,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
-  extraPath = lib.makeBinPath [ age git xclip ];
+  extraPath = lib.makeBinPath [ age git xclip tree ];
 
   # Using $0 is bad, it causes --help to mention ".passage-wrapped".
   postInstall = ''


### PR DESCRIPTION
Dependency on tree(1) is used to pretty-print list of all stored passwords.
Techically, is not needed to fetch or store password by its name, but without
it "passage" without arguments would print error.
