### PR TITLE
sapling: fix build

### DIFF
--- a/pkgs/applications/version-management/sapling/default.nix
+++ b/pkgs/applications/version-management/sapling/default.nix
@@ -166,15 +166,20 @@ python3Packages.buildPythonApplication {
 
   HGNAME = "sl";
   SAPLING_OSS_BUILD = "true";
-  SAPLING_VERSION = version;
   SAPLING_VERSION_HASH = versionHash;
+
+  # Python setuptools version 66 and newer does not support upstream Sapling's
+  # version numbers (e.g. "0.2.20230124-180750-hf8cd450a"). Change the version
+  # number to something supported by setuptools (e.g. "0.2.20230124").
+  # https://github.com/facebook/sapling/issues/571
+  SAPLING_VERSION = builtins.elemAt (builtins.split "-" version) 0;
 
   # just a simple check phase, until we have a running test suite. this should
   # help catch issues like lack of a LOCALE_ARCHIVE setting (see GH PR #202760)
   doCheck = true;
   installCheckPhase = ''
-    echo -n "testing sapling version; should be \"${version}\"... "
-    $out/bin/sl version | grep -qw "${version}"
+    echo -n "testing sapling version; should be \"$SAPLING_VERSION\"... "
+    $out/bin/sl version | grep -qw "$SAPLING_VERSION"
     echo "OK!"
   '';
 


### PR DESCRIPTION
Nixpkgs commit 451c6321 upgraded setuptools from version 65.0.3 to version 67.4.0. This upgrade introduced a breaking change in setuptools [1] which causes the Sapling package's build to fail:

    setuptools.extern.packaging.version.InvalidVersion: Invalid version: '0.2.20230124-180750-hf8cd450a'

This is an upstream issue [2]. For now, work around this issue in Nixpkgs by truncating Sapling's version number.

Before 451c6321:

    $ nix-env -q sapling
    sapling-0.2.20230228-144002-h9440b05e

    $ sl --version
    Sapling 0.2.20230228-144002-h9440b05e

After this patch:

    $ nix-env -q sapling
    sapling-0.2.20230228-144002-h9440b05e

    $ sl --version
    Sapling 0.2.20230228

Refs: 451c63214766d3bb8d078620cff4dc74463c5bc8

[1] https://github.com/pypa/setuptools/blob/be6c0218bcba78dbd4ea0b5a8bb9acd5d5306240/CHANGES.rst#v6600
[2] https://github.com/facebook/sapling/issues/571

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
