### PR TITLE
i3lock-fancy-rapid: 2019-10-09 -> unstable-2021-04-21

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-fancy-rapid.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy-rapid.nix
@@ -1,16 +1,18 @@
 { lib, stdenv, fetchFromGitHub, xorg, i3lock }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "i3lock-fancy-rapid";
-  version = "2019-10-09";
+  version = "unstable-2021-04-21";
+
   src = fetchFromGitHub {
     owner = "yvbbrjdr";
     repo = "i3lock-fancy-rapid";
-    rev = "c67f09bc8a48798c7c820d7d4749240b10865ce0";
-    sha256 = "0jhvlj6v6wx70239pgkjxd42z1s2bzfg886ra6n1rzsdclf4rkc6";
+    rev = "6eeebd4caa177b82fa5010b5e8828cce3f89fb97";
+    hash = "sha256-EoX8ts0yV/zkb4wgEh4P8noU+UraRS4w9pp+76v+Nm0=";
   };
 
   buildInputs = [ xorg.libX11 ];
+
   propagatedBuildInputs = [ i3lock ];
 
   postPatch = ''
@@ -19,8 +21,12 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     install -D i3lock-fancy-rapid $out/bin/i3lock-fancy-rapid
     ln -s $out/bin/i3lock-fancy-rapid $out/bin/i3lock
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
Closes #221298

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).