### PR TITLE
rtl-wmbus: init at unstable-2022-05-07

### DIFF
--- a/pkgs/applications/radio/rtl-wmbus/default.nix
+++ b/pkgs/applications/radio/rtl-wmbus/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  version = "unstable-2022-05-07";
+  pname = "rtl-wmbus";
+
+  src = fetchFromGitHub {
+    owner = "xaelsouth";
+    repo = pname;
+    rev = "388e7adb8e87caba2fcd50de979a6473e66d475b";
+    sha256 = "sha256-PuKoF57wUKJDZu9EwpdRP34+MBPnhEp4VKOfEE/Kog0";
+  };
+
+  makeFlags = [
+    "COMMIT_HASH="
+    "TAG=${src.rev}"
+    "BRANCH="
+    "CHANGES="
+  ];
+
+  preBuild = ''
+    substituteInPlace Makefile \
+      --replace "CC=gcc" "CC?=gcc" \
+      --replace "/usr" ""
+  '';
+
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  meta = with lib; {
+    description = "Software defined receiver for Wireless M-Bus with RTL-SDR";
+    homepage = "https://github.com/xaelsouth/rtl-wmbus";
+    license = licenses.bsd2;
+    mainProgram = "rtl_wmbus";
+    maintainers = with maintainers; [ snicket2100 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33137,6 +33137,8 @@ with pkgs;
 
   rtl-sdr = callPackage ../applications/radio/rtl-sdr { };
 
+  rtl-wmbus = callPackage ../applications/radio/rtl-wmbus { };
+
   rubyripper = callPackage ../applications/audio/rubyripper { };
 
   rucredstash = callPackage ../tools/security/rucredstash {


### PR DESCRIPTION
###### Description of changes

https://github.com/xaelsouth/rtl-wmbus

Demodulates and decodes WM-BUS messages, a wireless protocol for remote reading of smart meters.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
