### PR TITLE
jpegoptim: apply patch for CVE-2023-27781

### DIFF
--- a/pkgs/applications/graphics/jpegoptim/default.nix
+++ b/pkgs/applications/graphics/jpegoptim/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, libjpeg }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, libjpeg }:
 
 stdenv.mkDerivation rec {
   version = "1.5.2";
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-PROQvOqsis8we58OOZ/kuY+L/CoV7XfnY9wvrpsTJu8=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2023-27781.patch";
+      url = "https://github.com/tjko/jpegoptim/commit/29a073ad297a0954f5e865264e24755d0ffe53ed.patch";
+      hash = "sha256-YUjVg0cvElhzMG3b4t5bqcqnHAuzDoNvSqe0yvlgX4E=";
+    })
+  ];
 
   # There are no checks, it seems.
   doCheck = false;


### PR DESCRIPTION
###### Description of changes

See https://github.com/tjko/jpegoptim/issues/132
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>7 packages built:</summary>
  <ul>
    <li>akkoma-frontends.akkoma-fe</li>
    <li>curtail</li>
    <li>discourse</li>
    <li>discourseAllPlugins</li>
    <li>image_optim</li>
    <li>jpegoptim</li>
    <li>sacad</li>
  </ul>
</details>