### PR TITLE
miniupnpd: use iptables-legacy

### DIFF
--- a/pkgs/tools/networking/miniupnpd/default.nix
+++ b/pkgs/tools/networking/miniupnpd/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
 
   passthru.tests = {
     bittorrent-integration = nixosTests.bittorrent;
+    inherit (nixosTests) upnp;
   };
 
   meta = with lib; {

--- a/pkgs/tools/networking/miniupnpd/default.nix
+++ b/pkgs/tools/networking/miniupnpd/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, lib, fetchurl, iptables, libuuid, openssl, pkg-config
+{ stdenv, lib, fetchurl, iptables-legacy, libuuid, openssl, pkg-config
 , which, iproute2, gnused, coreutils, gawk, makeWrapper
 , nixosTests
 }:
 
 let
-  scriptBinEnv = lib.makeBinPath [ which iproute2 iptables gnused coreutils gawk ];
+  scriptBinEnv = lib.makeBinPath [ which iproute2 iptables-legacy gnused coreutils gawk ];
 in
 stdenv.mkDerivation rec {
   pname = "miniupnpd";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "0crv975qqppnj27jba96yysq2911y49vjd74sp9vnjb54z0d9pyi";
   };
 
-  buildInputs = [ iptables libuuid openssl ];
+  buildInputs = [ iptables-legacy libuuid openssl ];
   nativeBuildInputs= [ pkg-config makeWrapper ];
 
 


### PR DESCRIPTION
###### Description of changes

As noted in https://github.com/NixOS/nixpkgs/pull/80984#issuecomment-1189280812 , UPnP-related tests have been failing since we switched to iptables-nft in 21.11. This seems to happen because in practice miniupnpd ends up using iptables-nft for initial setup scripts, but it uses iptables (-legacy) directly from the C code. As such, it is unable to find the chains it needs at runtime.

This PR makes it always use iptables-legacy. I am aware this is a less-than-ideal solution (users will end up having rules in both iptables-nft and iptables-legacy, which can be confusing). However, this is a straightforward fix that at least makes the module functional for now.

As misuzu has noted in https://github.com/NixOS/nixpkgs/pull/80984#issuecomment-1189342730 , we could in theory use miniupnpd nftables backend with the NixOS iptables-nft firewall. In practice, I have not been able to successfully implement this as of now. For one, iptables-based NixOS firewall sets up separate `ip` and `ip6` chains, while miniupnpd's nftables backend seems to assume an `inet` chain (which would be true in a pure-nftables firewall) and so fails to update the rules.

I am interested in eventually putting in some work to support the proper nftables backend in this module (when `networking.nftables.enabled = true;`). I would say that at least https://github.com/NixOS/nixpkgs/pull/207758 is a prerequisite for that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
