### PR TITLE
pomerium: 0.20.0 -> 0.21.2

### DIFF
--- a/nixos/tests/pomerium.nix
+++ b/nixos/tests/pomerium.nix
@@ -20,6 +20,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
   }; in {
     pomerium = { pkgs, lib, ... }: {
       imports = [ (base "192.168.1.1") ];
+      environment.systemPackages = with pkgs; [ chromium ];
       services.pomerium = {
         enable = true;
         settings = {
@@ -97,6 +98,12 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
         )
         pomerium.succeed(
             "curl -L --resolve login.required:80:127.0.0.1 http://login.required | grep 'hello I am login page'"
+        )
+
+    with subtest("ui"):
+        pomerium.succeed(
+          # check for a string that only appears if the UI is displayed correctly
+            "chromium --no-sandbox --headless --disable-gpu --dump-dom --host-resolver-rules='MAP login.required 127.0.0.1:80' http://login.required/.pomerium | grep 'contact your administrator'"
         )
   '';
 })

--- a/pkgs/servers/http/pomerium/default.nix
+++ b/pkgs/servers/http/pomerium/default.nix
@@ -111,9 +111,12 @@ buildGoModule rec {
     install -Dm0755 $GOPATH/bin/pomerium $out/bin/pomerium
   '';
 
-  passthru.tests = {
-    inherit (nixosTests) pomerium;
-    inherit pomerium-cli;
+  passthru = {
+    tests = {
+      inherit (nixosTests) pomerium;
+      inherit pomerium-cli;
+    };
+    updateScript = ./updater.sh;
   };
 
   meta = with lib; {

--- a/pkgs/servers/http/pomerium/default.nix
+++ b/pkgs/servers/http/pomerium/default.nix
@@ -14,25 +14,24 @@ let
 in
 buildGoModule rec {
   pname = "pomerium";
-  version = "0.20.0";
+  version = "0.21.2";
   src = fetchFromGitHub {
     owner = "pomerium";
     repo = "pomerium";
     rev = "v${version}";
-    sha256 = "sha256-J8ediRreV80lzPcKIOSl1CNHp04ZW9ePyNyejlN50cE=";
+    sha256 = "sha256-wsfbG4VAS3U3voDdry35QlWknlWIfThZQalf9S/9GO0=";
   };
 
-  vendorSha256 = "sha256-V8asyi1Nm+h3KK/loBRZQN6atfEGUEdRydeZsp9wyQY=";
+  vendorSha256 = "sha256-8g3jhxKIT0EGUXh0hrvDbw3i04khqlAfGzM6k4q3O8g=";
 
   ui = mkYarnPackage {
     inherit version;
     src = "${src}/ui";
 
-    # update pomerium-ui-package.json when updating package, sourced from ui/package.json
-    packageJSON = ./pomerium-ui-package.json;
+    packageJSON = ./package.json;
     offlineCache = fetchYarnDeps {
       yarnLock = "${src}/ui/yarn.lock";
-      sha256 = "sha256:1n6swanrds9hbd4yyfjzpnfhsb8fzj1pwvvcg3w7b1cgnihclrmv";
+      sha256 = lib.fileContents ./yarn-hash;
     };
 
     buildPhase = ''

--- a/pkgs/servers/http/pomerium/package.json
+++ b/pkgs/servers/http/pomerium/package.json
@@ -29,7 +29,7 @@
     "@fontsource/dm-sans": "^4.5.1",
     "@mui/icons-material": "^5.3.1",
     "@mui/material": "^5.4.0",
-    "luxon": "^2.3.0",
+    "luxon": "^2.5.2",
     "markdown-to-jsx": "^7.1.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/pkgs/servers/http/pomerium/updater.sh
+++ b/pkgs/servers/http/pomerium/updater.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p gnugrep coreutils curl wget jq nix-update prefetch-yarn-deps
+
+set -euo pipefail
+pushd "$(dirname "${BASH_SOURCE[0]}")"
+
+owner="pomerium"
+repo="pomerium"
+version=`curl -s "https://api.github.com/repos/$owner/$repo/tags" | jq -r .[0].name | grep -oP "^v\K.*"`
+url="https://raw.githubusercontent.com/$owner/$repo/v$version/"
+
+if [[ "$UPDATE_NIX_OLD_VERSION" == "$version" ]]; then
+    echo "Already up to date!"
+    exit 0
+fi
+
+rm -f package.json yarn.lock
+wget "$url/ui/yarn.lock" "$url/ui/package.json"
+echo $(prefetch-yarn-deps) > yarn-hash
+rm -f yarn.lock
+
+popd
+nix-update pomerium --version $version

--- a/pkgs/servers/http/pomerium/yarn-hash
+++ b/pkgs/servers/http/pomerium/yarn-hash
@@ -1,0 +1,1 @@
+085nghha82q30b3vgzs76xsa85kbxqk7mjrknxxc5z7awrjhdmkb


### PR DESCRIPTION
###### Description of changes

- update package to 0.21.2
- add update script to bump Yarn hash and `package.json`
- add NixOS test for web UI

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
