### PR TITLE
Set PHP_INI_SCAN_DIR only if not set

### DIFF
--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -170,19 +170,19 @@ let
               ln -s ${extraInit} $out/lib/php.ini
 
               if test -e $out/bin/php; then
-                wrapProgram $out/bin/php --set PHP_INI_SCAN_DIR $out/lib
+                wrapProgram $out/bin/php --set-default PHP_INI_SCAN_DIR $out/lib
               fi
 
               if test -e $out/bin/php-fpm; then
-                wrapProgram $out/bin/php-fpm --set PHP_INI_SCAN_DIR $out/lib
+                wrapProgram $out/bin/php-fpm --set-default PHP_INI_SCAN_DIR $out/lib
               fi
 
               if test -e $out/bin/phpdbg; then
-                wrapProgram $out/bin/phpdbg --set PHP_INI_SCAN_DIR $out/lib
+                wrapProgram $out/bin/phpdbg --set-default PHP_INI_SCAN_DIR $out/lib
               fi
 
               if test -e $out/bin/php-cgi; then
-                wrapProgram $out/bin/php-cgi --set PHP_INI_SCAN_DIR $out/lib
+                wrapProgram $out/bin/php-cgi --set-default PHP_INI_SCAN_DIR $out/lib
               fi
             '';
           };


### PR DESCRIPTION
Uses the preferred binary wrapper and only sets PHP_INI_SCAN_DIR if it isn’t set yet. This is so that users can provide there own PHP_INI_SCAN_DIR, e.g. to restart the current PHP process without xdebug.
E.g. composer/xdebug-handler uses this mechanism to turn off xdebug (https://github.com/composer/xdebug-handler/blob/cf19e3380ffd84cea4a2cbfcc599ea07ef01f18a/src/XdebugHandler.php#L441)


###### Things done

- Built on platform(s)
  - [x] aarch64-darwin
  - [x] Verified that https://github.com/composer/xdebug-handler works afterwards


#### Reproduction

Given this script with `composer/xdebug-handler` installed:

```php
<?php
include 'vendor/autoload.php';

var_dump('XDEBUG LOADED', extension_loaded('xdebug'));

$handler = new \Composer\XdebugHandler\XdebugHandler('repro');
$handler->setPersistent();
$handler->check();
```

#### Before the change
```
string(13) "XDEBUG LOADED"
bool(true)
Cannot load Zend OPcache - it was already loaded

Warning: Module "mbstring" is already loaded in Unknown on line 0

Warning: Module "filter" is already loaded in Unknown on line 0

Warning: Module "intl" is already loaded in Unknown on line 0

Warning: Module "openssl" is already loaded in Unknown on line 0

Warning: Module "dom" is already loaded in Unknown on line 0

Warning: Module "tokenizer" is already loaded in Unknown on line 0

Warning: Module "xmlwriter" is already loaded in Unknown on line 0

Warning: Module "SimpleXML" is already loaded in Unknown on line 0

Warning: Module "curl" is already loaded in Unknown on line 0

Warning: Module "zlib" is already loaded in Unknown on line 0

Warning: Module "ctype" is already loaded in Unknown on line 0
string(13) "XDEBUG LOADED"
bool(true)
```

#### After the change
```
string(13) "XDEBUG LOADED"
bool(true)
string(13) "XDEBUG LOADED"
bool(false)
```
