### PR TITLE
squashfsTools: 4.5.1 -> 4.6

### DIFF
--- a/pkgs/tools/filesystems/squashfs/4k-align.patch
+++ b/pkgs/tools/filesystems/squashfs/4k-align.patch
@@ -1,9 +1,11 @@
 This patch is an old patch; see below for the original message body. The patch
-has been updated twice: Once to apply to squashfs 4.4, commit
-52eb4c279cd283ed9802dd1ceb686560b22ffb67, and later to apply to squashfs 4.5,
-commit 0496d7c3de3e09da37ba492081c86159806ebb07.
+has been updated several times to be compatible with new releases.
 
-From 7bda7c75748f36b0a50f93e46144d5a4de4974ad Mon Sep 17 00:00:00 2001
+ * To apply to squashfs 4.4, commit 52eb4c279cd283ed9802dd1ceb686560b22ffb67.
+ * To apply to squashfs 4.5, commit 0496d7c3de3e09da37ba492081c86159806ebb07.
+ * To apply to squashfs 4.6, commit f7623b3d9953a1190fec181708c9489ef3522b9f.
+
+From af8a6dca694ddd38d8a775a2b5f9a24fe2d10153 Mon Sep 17 00:00:00 2001
 From: Amin Hassani <ahassani@google.com>
 Date: Thu, 15 Dec 2016 10:43:15 -0800
 Subject: [PATCH] mksquashfs 4K aligns the files inside the squashfs image
@@ -21,23 +23,23 @@ increased_size = (number_of_unfragmented_files_in_image + number of fragments) *
 
 The 4k alignment can be enabled by flag '-4k-align'
 ---
- squashfs-tools/mksquashfs.c | 17 +++++++++++++++++
- 1 file changed, 17 insertions(+)
+ squashfs-tools/mksquashfs.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
 
 diff --git a/squashfs-tools/mksquashfs.c b/squashfs-tools/mksquashfs.c
-index aaa4b00..eb2fb23 100644
+index 3429aac..db164c2 100644
 --- a/squashfs-tools/mksquashfs.c
 +++ b/squashfs-tools/mksquashfs.c
-@@ -99,6 +99,8 @@ int nopad = FALSE;
- int exit_on_error = FALSE;
- long long start_offset = 0;
- int sleep_time = 0;
+@@ -82,6 +82,8 @@ int noI = FALSE;
+ int noId = FALSE;
+ int noD = FALSE;
+ int noX = FALSE;
 +int do_4k_align = FALSE;
 +#define ALIGN_UP(bytes, size) (bytes = (bytes + size - 1) & ~(size - 1))
  
- long long global_uid = -1, global_gid = -1;
- 
-@@ -1553,6 +1555,9 @@ static void unlock_fragments()
+ /* block size used to build filesystem */
+ int block_size = SQUASHFS_FILE_SIZE;
+@@ -1624,6 +1626,9 @@ static void unlock_fragments()
  	 * queue at this time.
  	 */
  	while(!queue_empty(locked_fragment)) {
@@ -47,7 +49,7 @@ index aaa4b00..eb2fb23 100644
  		write_buffer = queue_get(locked_fragment);
  		frg = write_buffer->block;	
  		size = SQUASHFS_COMPRESSED_SIZE_BLOCK(fragment_table[frg].size);
-@@ -2460,6 +2465,9 @@ static void *frag_deflator(void *arg)
+@@ -2627,6 +2632,9 @@ static void *frag_deflator(void *arg)
  		write_buffer->size = compressed_size;
  		pthread_mutex_lock(&fragment_mutex);
  		if(fragments_locked == FALSE) {
@@ -57,7 +59,7 @@ index aaa4b00..eb2fb23 100644
  			fragment_table[file_buffer->block].size = c_byte;
  			fragment_table[file_buffer->block].start_block = bytes;
  			write_buffer->block = bytes;
-@@ -2850,6 +2858,10 @@ static struct file_info *write_file_blocks(int *status, struct dir_ent *dir_ent,
+@@ -3021,6 +3029,10 @@ static struct file_info *write_file_blocks(int *status, struct dir_ent *dir_ent,
  	struct file_info *file;
  	int bl_hash = 0;
  
@@ -68,15 +70,15 @@ index aaa4b00..eb2fb23 100644
  	if(pre_duplicate(read_size, dir_ent->inode, read_buffer, &bl_hash))
  		return write_file_blocks_dup(status, dir_ent, read_buffer, dup, bl_hash);
  
-@@ -5975,6 +5987,7 @@ static void print_options(FILE *stream, char *name, int total_mem)
- 	fprintf(stream, "actions from <f>\n");
- 	fprintf(stream, "-false-action-file <f>\tas -false-action, but read ");
- 	fprintf(stream, "actions from <f>\n");
+@@ -6169,6 +6181,7 @@ static void print_options(FILE *stream, char *name, int total_mem)
+ 	fprintf(stream, "or metadata.  This is\n\t\t\tequivalent to ");
+ 	fprintf(stream, "specifying -noI -noD -noF and -noX\n");
+ 	fprintf(stream, "\nFilesystem build options:\n");
 +	fprintf(stream, "-4k-align\t\tenables 4k alignment of all files\n");
- 	fprintf(stream, "\nFilesystem filter options:\n");
- 	fprintf(stream, "-p <pseudo-definition>\tAdd pseudo file definition\n");
- 	fprintf(stream, "-pf <pseudo-file>\tAdd list of pseudo file definitions\n");
-@@ -6198,6 +6211,7 @@ static void print_summary()
+ 	fprintf(stream, "-tar\t\t\tread uncompressed tar file from standard in (stdin)\n");
+ 	fprintf(stream, "-no-strip\t\tact like tar, and do not strip leading ");
+ 	fprintf(stream, "directories\n\t\t\tfrom source files\n");
+@@ -6690,6 +6703,7 @@ static void print_summary()
  		"compressed", no_fragments ? "no" : noF ? "uncompressed" :
  		"compressed", no_xattrs ? "no" : noX ? "uncompressed" :
  		"compressed", noI || noId ? "uncompressed" : "compressed");
@@ -84,15 +86,15 @@ index aaa4b00..eb2fb23 100644
  	printf("\tduplicates are %sremoved\n", duplicate_checking ? "" :
  		"not ");
  	printf("Filesystem size %.2f Kbytes (%.2f Mbytes)\n", bytes / 1024.0,
-@@ -7499,6 +7513,9 @@ print_compressor_options:
- 			root_name = argv[i];
- 		} else if(strcmp(argv[i], "-version") == 0) {
- 			print_version("mksquashfs");
-+
+@@ -8417,6 +8431,8 @@ print_compressor_options:
+ 		} else if(strcmp(argv[i], "-comp") == 0) {
+ 			/* parsed previously */
+ 			i++;
 +		} else if(strcmp(argv[i], "-4k-align") == 0) {
 +			do_4k_align = TRUE;
  		} else {
  			ERROR("%s: invalid option\n\n", argv[0]);
  			print_options(stderr, argv[0], total_mem);
 -- 
-2.32.0
+2.39.2
+

--- a/pkgs/tools/filesystems/squashfs/default.nix
+++ b/pkgs/tools/filesystems/squashfs/default.nix
@@ -14,21 +14,16 @@
 
 stdenv.mkDerivation rec {
   pname = "squashfs";
-  version = "4.5.1";
+  version = "4.6";
 
   src = fetchFromGitHub {
     owner = "plougher";
     repo = "squashfs-tools";
     rev = version;
-    sha256 = "sha256-Y3ZPjeE9HN1F+NtGe6EchYziWrTPVQ4SuKaCvNbXMKI=";
+    hash = "sha256-igpZ7OWmQeVprVo56E13gwWLIPLmZ9Me0/DqGTmRBLY=";
   };
 
   patches = [
-    # remove once https://github.com/plougher/squashfs-tools/pull/177 is merged and in a release
-    (fetchpatch {
-      url = "https://github.com/plougher/squashfs-tools/commit/6100e82c7e7f18f503c003c67c87791025d5f01b.patch";
-      sha256 = "sha256-bMBQsbSKQ4E7r9avns2QaomGAYl3s82m58gYyTQdB08=";
-    })
     # This patch adds an option to pad filesystems (increasing size) in
     # exchange for better chunking / binary diff calculation.
     ./4k-align.patch

--- a/pkgs/tools/filesystems/squashfs/default.nix
+++ b/pkgs/tools/filesystems/squashfs/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "squashfs";
-  version = "4.6";
+  version = "4.6.1";
 
   src = fetchFromGitHub {
     owner = "plougher";
     repo = "squashfs-tools";
     rev = version;
-    hash = "sha256-igpZ7OWmQeVprVo56E13gwWLIPLmZ9Me0/DqGTmRBLY=";
+    hash = "sha256-C/awQpp1Q/0adx3YVNTq6ruEAzcjL5G7SkOCgpvAA50=";
   };
 
   patches = [


### PR DESCRIPTION
###### Description of changes

* Update squashfs-tools to 4.6. [Changelog](https://github.com/plougher/squashfs-tools/releases/tag/4.6).
* I had to rebase the 4k alignment patch for this, but the conflicts were easy to resolve, only due to context changes, nothing substantial.
* I confirmed that passing `-4k-align` can still be used and produces a valid squashfs, I did not confirm whether it is actually 4k aligned.
* As far as I can tell there are no breaking changes, so I don’t think an entry in the release notes is needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

This is a copy of #221836 but now targeted at `staging`.