### PR TITLE
zrok: init at 0.3.4

### DIFF
--- a/pkgs/tools/networking/zrok/default.nix
+++ b/pkgs/tools/networking/zrok/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchzip, patchelf }:
+
+stdenv.mkDerivation rec {
+  pname = "zrok";
+  version = "0.3.4";
+
+  src = fetchzip {
+    url = "https://github.com/openziti/zrok/releases/download/v${version}/zrok_${version}_linux_amd64.tar.gz";
+    stripRoot = false;
+    sha256 = "sha256-lfsKOo53DarrczQfFhZED2vmzxIyq/TCPtVZECLMV3U=";
+  };
+
+  installPhase = let
+    interpreter = "$(< \"$NIX_CC/nix-support/dynamic-linker\")";
+  in ''
+    mkdir -p $out/bin
+    cp zrok $out/bin/
+    chmod +x $out/bin/zrok
+    patchelf --set-interpreter "${interpreter}" "$out/bin/zrok"
+  '';
+
+  meta = {
+    description = "Geo-scale, next-generation sharing platform built on top of OpenZiti";
+    homepage = "https://zrok.io";
+    maintainers = [ lib.maintainers.bandresen ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.apsl20;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39116,6 +39116,8 @@ with pkgs;
 
   zoneminder = callPackage ../servers/zoneminder { };
 
+  zrok = callPackage ../tools/networking/zrok { };
+
   xcp = callPackage ../tools/misc/xcp { };
 
   zxcvbn-c = callPackage ../development/libraries/zxcvbn-c { };


### PR DESCRIPTION
###### Description of changes

Initialization of a binary package for zrok. [^1]
zrok describes itself as "Geo-scale, next-generation sharing platform built on top of OpenZiti."
At the moment I would describe zrok as a neat alternative to ngrok and other similar tunneling software in its "public" mode.
zrok also has a private mode and further goals about sharing.
See https://github.com/openziti/zrok/blob/main/docs/getting-started.md or https://zrok.io for further information.

[^1]: I'm interested in mentorship to create a source derived zrok package but it both uses npm and go modules to create a single binary. I don't have anything worth sharing but I've played around with both node2nix and gomod2nix and need more interactive help.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Tested connection to the zrok.io service and sharing worked fine.