### PR TITLE
woodpecker-pipeline-transform: init at 0.1.1

### DIFF
--- a/pkgs/development/tools/continuous-integration/woodpecker-pipeline-transform/default.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker-pipeline-transform/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitea }:
+buildGoModule rec {
+  pname = "woodpecker-pipeline-transform";
+  version = "0.1.1";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "lafriks";
+    repo = "woodpecker-pipeline-transform";
+    rev = "v${version}";
+    sha256 = "sha256-tWDMbOkajZ3BB32Vl630EZrY+Owm72MD2Z2JjMucVkI=";
+  };
+
+  vendorHash = "sha256-qKzGALMagf6QHeLdABfNGG4f/3K/F6CjVYjOJtyTNoM=";
+
+  meta = with lib; {
+    description = "Utility to convert different pipelines to Woodpecker CI pipelines";
+    homepage = "https://codeberg.org/lafriks/woodpecker-pipeline-transform";
+    license = licenses.mit;
+    mainProgram = "pipeline-convert";
+    maintainers = with maintainers; [ ambroisie ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13393,6 +13393,8 @@ with pkgs;
 
   woodpecker-cli = callPackage ../development/tools/continuous-integration/woodpecker/cli.nix { };
 
+  woodpecker-pipeline-transform = callPackage ../development/tools/continuous-integration/woodpecker-pipeline-transform { };
+
   woodpecker-server = callPackage ../development/tools/continuous-integration/woodpecker/server.nix {
     woodpecker-frontend = callPackage ../development/tools/continuous-integration/woodpecker/frontend.nix { };
   };


### PR DESCRIPTION
###### Description of changes

I'm not sure on the attribute name and `pname` since this is the name of the repository, but the executable has a more generic name (as documented in `meta.mainProgram`).
###### Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
