### PR TITLE
pythonPackages.pyrr: 0.10.3 -> unstable-2022-07-22

### DIFF
--- a/pkgs/development/python-modules/pyrr/default.nix
+++ b/pkgs/development/python-modules/pyrr/default.nix
@@ -1,21 +1,22 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , setuptools
 , multipledispatch
 , numpy
 }:
 
 buildPythonPackage rec {
-  version = "0.10.3";
   pname = "pyrr";
+  version = "unstable-2022-07-22";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "3c0f7b20326e71f706a610d58f2190fff73af01eef60c19cb188b186f0ec7e1d";
+  src = fetchFromGitHub {
+    owner = "adamlwgriffiths";
+    repo = "Pyrr";
+    rev = "f6c8698c48a75f3fb7ad0d47d0ce80a04f87ba2f";
+    hash = "sha256-u9O52MQskZRzw0rBH6uPdXdikWLJe7wyBZGNKIFA4BA=";
   };
 
-  buildInputs = [ setuptools ];
   propagatedBuildInputs = [ multipledispatch numpy ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

[It stopped building](https://hydra.nixos.org/build/212587393/nixlog/3) on python39Packages.pyrr, which is needed for pkgs.friture to work, due to some other old dependencies. There are no new releases on PyPI.

Tested build of friture, python39Packages.pyrr and python3Packages.pyrr on x86_64-linux: all three previously failed builds work.



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] (friture) Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
