### PR TITLE
remote-exec: init at 1.13.2

### DIFF
--- a/pkgs/tools/misc/remote-exec/default.nix
+++ b/pkgs/tools/misc/remote-exec/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildPythonApplication
+, click
+, pydantic
+, toml
+, watchdog
+, pytestCheckHook
+, rsync
+}:
+
+buildPythonApplication rec {
+  pname = "remote-exec";
+  version = "1.13.2";
+
+  src = fetchFromGitHub {
+    owner = "remote-cli";
+    repo = "remote";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-xaxkN6XukV9HiLYehwVTBZB8bUyjgpfg+pPfAGrOkgo=";
+  };
+
+  # remove legacy endpoints, we use --multi now
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace '"mremote' '#"mremote'
+  '';
+
+  propagatedBuildInputs = [
+    click
+    pydantic
+    toml
+    watchdog
+  ];
+
+  # disable pytest --cov
+  preCheck = ''
+    rm setup.cfg
+  '';
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    rsync
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = lib.optionals stdenv.isDarwin [
+    # `watchdog` dependency does not correctly detect fsevents on darwin.
+    # this only affects `remote --stream-changes`
+    "test/test_file_changes.py"
+  ];
+
+  meta = with lib; {
+    description = "Work with remote hosts seamlessly via rsync and ssh";
+    homepage = "https://github.com/remote-cli/remote";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11714,6 +11714,8 @@ with pkgs;
 
   remote-touchpad = callPackage ../tools/inputmethods/remote-touchpad { };
 
+  remote-exec = python3Packages.callPackage ../tools/misc/remote-exec { };
+
   reposurgeon = callPackage ../applications/version-management/reposurgeon { };
 
   reptyr = callPackage ../os-specific/linux/reptyr { };


### PR DESCRIPTION
###### Description of changes

This is a nice tool to have working on remote machines.
It is essentially a `rsync`-run command-`rsync` flow.

<https://github.com/remote-cli/remote/>

Fixes #170791

Package name is subject to bikeshedding.
They've (re?)named themselves `remote`, but this is so incredibly difficult to search for. Their github org is named `remote-cli`, while the Pypi package is named `remote-exec`. 
I went for the latter.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
