### PR TITLE
binutils: don't embed timestamps into PE files to improve determinism

### DIFF
--- a/pkgs/development/tools/misc/binutils/PE-dont-embed-timestamps.patch
+++ b/pkgs/development/tools/misc/binutils/PE-dont-embed-timestamps.patch
@@ -1,0 +1,26 @@
+pe: don't embed current timestampl into PE files by default
+
+Make builds more deterministic by default: use --no-insert-timestamp.
+--- a/ld/emultempl/pe.em
++++ b/ld/emultempl/pe.em
+@@ -159,7 +159,7 @@ static int support_old_code = 0;
+ static char * thumb_entry_symbol = NULL;
+ static lang_assignment_statement_type *image_base_statement = 0;
+ static unsigned short pe_dll_characteristics = DEFAULT_DLL_CHARACTERISTICS;
+-static bool insert_timestamp = true;
++static bool insert_timestamp = false;
+ static const char *emit_build_id;
+ #ifdef PDB_H
+ static int pdb;
+--- a/ld/emultempl/pep.em
++++ b/ld/emultempl/pep.em
+@@ -180,7 +180,7 @@ static flagword real_flags = IMAGE_FILE_LARGE_ADDRESS_AWARE;
+ static int support_old_code = 0;
+ static lang_assignment_statement_type *image_base_statement = 0;
+ static unsigned short pe_dll_characteristics = DEFAULT_DLL_CHARACTERISTICS;
+-static bool insert_timestamp = true;
++static bool insert_timestamp = false;
+ static const char *emit_build_id;
+ #ifdef PDB_H
+ static int pdb;
+

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -88,6 +88,10 @@ stdenv.mkDerivation (finalAttrs: {
     # not need to know binutils' BINDIR at all. It's an absolute path
     # where libraries are stored.
     ./plugins-no-BINDIR.patch
+
+    # Disable current timestamp embedding into PE files. Improve output
+    # file determinism: https://github.com/NixOS/nixpkgs/issues/221419
+    ./PE-dont-embed-timestamps.patch
   ]
   ++ lib.optional targetPlatform.isiOS ./support-ios.patch
   # Adds AVR-specific options to "size" for compatibility with Atmel's downstream distribution


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
