### PR TITLE
woeusb-ng: 0.2.10 -> 0.2.12

### DIFF
--- a/pkgs/tools/misc/woeusb-ng/default.nix
+++ b/pkgs/tools/misc/woeusb-ng/default.nix
@@ -1,25 +1,49 @@
-{ lib, python3Packages, fetchFromGitHub, p7zip, parted, grub2 }:
+{ lib
+, python3Packages
+, fetchFromGitHub
+, wrapGAppsHook
+, p7zip
+, parted
+, grub2
+}:
+
 with python3Packages;
 
 buildPythonApplication rec {
   pname = "woeusb-ng";
-  version = "0.2.10";
-
-  propagatedBuildInputs = [ p7zip parted grub2 termcolor wxPython_4_0 six ];
+  version = "0.2.12";
 
   src = fetchFromGitHub {
     owner = "WoeUSB";
     repo = "WoeUSB-ng";
     rev = "v${version}";
-    sha256 = "sha256-Nsdk3SMRzj1fqLrp5Na5V3rRDMcIReL8uDb8K2GQNWI=";
+    hash = "sha256-2opSiXbbk0zDRt6WqMh97iAt6/KhwNDopOas+OZn6TU=";
   };
 
-  postInstall = ''
-    # TODO: the gui requires additional polkit-actions to work correctly, therefore it is currently disabled
-    rm $out/bin/woeusbgui
+  postPatch = ''
+    substituteInPlace setup.py WoeUSB/*.py miscellaneous/* \
+      --replace "/usr/local/" "$out/" \
+      --replace "/usr/" "$out/"
   '';
 
-  # checks fail, because of polkit-actions and should be reenabled when the gui is fixed.
+  nativeBuildInputs = [
+    wrapGAppsHook
+  ];
+
+  propagatedBuildInputs = [
+    p7zip
+    parted
+    grub2
+    termcolor
+    wxPython_4_2
+    six
+  ];
+
+  preConfigure = ''
+    mkdir -p $out/bin $out/share/applications $out/share/polkit-1/actions
+  '';
+
+  # Unable to access the X Display, is $DISPLAY set properly?
   doCheck = false;
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

The GUI actually launches with sudo, so not removing it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
