### PR TITLE
mfc5890cn{lpr,cupswrapper}: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9307,6 +9307,12 @@
     githubId = 458783;
     name = "Martin Gammelsæter";
   };
+  martinramm = {
+    email = "martin-ramm@gmx.de";
+    github = "MartinRamm";
+    githubId = 31626748;
+    name = "Martin Ramm";
+  };
   marzipankaiser = {
     email = "nixos@gaisseml.de";
     github = "marzipankaiser";

--- a/pkgs/misc/cups/drivers/mfc5890cncupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfc5890cncupswrapper/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, findutils
+, stdenv
+, fetchurl
+, dpkg
+, makeWrapper
+, coreutils
+, gnugrep
+, gnused
+, mfc5890cnlpr
+, pkgsi686Linux
+, psutils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mfc5890cncupswrapper";
+  version = "1.1.2-2";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf006170/${pname}-${version}.i386.deb";
+    hash = "sha256-UOCwzB09/a1/2rliY+hTrslSvO5ztVj51auisPx7OIQ=";
+  };
+
+  unpackPhase = ''
+    dpkg-deb -x $src $out
+  '';
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    lpr=${mfc5890cnlpr}/usr/local/Brother/Printer/mfc5890cn
+    dir=$out/usr/local/Brother/Printer/mfc5890cn
+
+    interpreter=${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2
+    patchelf --set-interpreter "$interpreter" "$dir/cupswrapper/brcupsconfpt1"
+
+    #comment out lpadmin commands to prohibit changes to CUPS config by just installing this driver.
+    substituteInPlace $dir/cupswrapper/cupswrappermfc5890cn \
+      --replace "lpadmin" "#lpadmin" \
+      --replace "/usr/" "$out/usr/"
+
+    #mfc5890cnlpr is a dependency of this package. Link all files of mfc5890cnlpr into the $out/usr folder, as other scripts depend on these files being present.
+    #Ideally, we would use substituteInPlace for each file this package actually requires. But the scripts of Brother use variables to dynamically build the paths
+    #at runtime, making this approach more complex. Hence, the easier route of simply linking all files was choosen.
+    find "$lpr" -type f -exec sh -c "mkdir -vp \$(echo '{}' | sed 's|$lpr|$dir|g' | xargs dirname) && ln -s '{}' \$(echo '{}' | sed 's|$lpr|$dir|g')" \;
+
+    mkdir -p $out/usr/share/ppd/
+    mkdir -p $out/usr/lib64/cups/filter
+    sed -i '941,972d' $dir/cupswrapper/cupswrappermfc5890cn
+    $dir/cupswrapper/cupswrappermfc5890cn
+
+    chmod +x $out/usr/lib64/cups/filter/brlpdwrappermfc5890cn
+    wrapProgram $out/usr/lib64/cups/filter/brlpdwrappermfc5890cn --prefix PATH : ${lib.makeBinPath [coreutils psutils gnugrep gnused]}
+
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+    ln $out/usr/lib64/cups/filter/brlpdwrappermfc5890cn $out/lib/cups/filter
+    ln $dir/cupswrapper/cupswrappermfc5890cn $out/lib/cups/filter
+    ln $out/usr/share/ppd/brmfc5890cn.ppd $out/share/cups/model
+    '';
+
+  meta = with lib; {
+    description = "Brother MFC-5890CN CUPS wrapper driver.";
+    londDescription = "Brother MFC-5890CN CUPS wrapper driver. Use the connection string 'lpd://\${IP_ADDRESS}/binary_p1' when connecting to this printer via the network.";
+    homepage = "http://www.brother.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ martinramm ];
+  };
+}

--- a/pkgs/misc/cups/drivers/mfc5890cnlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfc5890cnlpr/default.nix
@@ -1,0 +1,75 @@
+{ stdenv
+, a2ps
+, lib
+, fetchurl
+, dpkg
+, makeWrapper
+, coreutils
+, file
+, gawk
+, ghostscript
+, gnused
+, pkgsi686Linux
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mfc5890cnlpr";
+  version = "1.1.2-2";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf006168/${pname}-${version}.i386.deb";
+    sha256 = "119h3s1p9pv83mrfv6cmxpc0v33xf8c9nw5clj9yafv3aizxy6dp";
+  };
+
+  unpackPhase = ''
+    dpkg-deb -x $src $out
+  '';
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    dir=$out/usr/local/Brother/Printer/mfc5890cn
+
+    patchelf --set-interpreter ${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2 $dir/lpd/brmfc5890cnfilter
+
+    wrapProgram $dir/inf/setupPrintcapij \
+      --prefix PATH : ${lib.makeBinPath [
+        coreutils
+      ]}
+
+    substituteInPlace $dir/lpd/filtermfc5890cn \
+      --replace "/usr/" "$out/usr/"
+
+    wrapProgram $dir/lpd/filtermfc5890cn \
+      --prefix PATH : ${lib.makeBinPath [
+        a2ps
+        coreutils
+        file
+        ghostscript
+        gnused
+      ]}
+
+    substituteInPlace $dir/lpd/psconvertij2 \
+      --replace '`which gs`' "${ghostscript}/bin/gs"
+
+    wrapProgram $dir/lpd/psconvertij2 \
+      --prefix PATH : ${lib.makeBinPath [
+        gnused
+        gawk
+      ]}
+  '';
+
+  meta = with lib; {
+    description = "Brother MFC-5890CN LPR printer driver";
+    homepage = "http://www.brother.com/";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ martinramm ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38691,6 +38691,8 @@ with pkgs;
   mfcl8690cdwcupswrapper = callPackage ../misc/cups/drivers/mfcl8690cdwcupswrapper { };
   mfcl8690cdwlpr = callPackage ../misc/cups/drivers/mfcl8690cdwlpr { };
 
+  mfc5890cnlpr = callPackage ../misc/cups/drivers/mfc5890cnlpr { };
+
   mfc9140cdncupswrapper = callPackage ../misc/cups/drivers/mfc9140cdncupswrapper { };
   mfc9140cdnlpr = callPackage ../misc/cups/drivers/mfc9140cdnlpr { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -38691,6 +38691,7 @@ with pkgs;
   mfcl8690cdwcupswrapper = callPackage ../misc/cups/drivers/mfcl8690cdwcupswrapper { };
   mfcl8690cdwlpr = callPackage ../misc/cups/drivers/mfcl8690cdwlpr { };
 
+  mfc5890cncupswrapper = callPackage ../misc/cups/drivers/mfc5890cncupswrapper { };
   mfc5890cnlpr = callPackage ../misc/cups/drivers/mfc5890cnlpr { };
 
   mfc9140cdncupswrapper = callPackage ../misc/cups/drivers/mfc9140cdncupswrapper { };


### PR DESCRIPTION
###### Motivation for this change

Printer does not support IPP and the generic brother drivers available are not compatible with this printer.

###### Shoutout
These packages are largely based on the packages of mfc9140cdn, added in #125890. Therefore want to thank @mweinelt for his previous work. Thank you very much!!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] After installing `pkgs.mfc5890cncupswrapper` to `services.printing.drivers` in `configuration.nix`, the driver is available in the CUPS dashboard
- [x] After adding a Brother MFC-5890CN printer via network connection to CUPS (as per instructions of Brother via the connection string `lpd://${IP_ADDRESS}/binary_p1`), I can print a sample page.
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
