### PR TITLE
pulsar: init at 1.103.0

### DIFF
--- a/pkgs/applications/editors/pulsar/default.nix
+++ b/pkgs/applications/editors/pulsar/default.nix
@@ -1,0 +1,62 @@
+{ fetchurl, autoPatchelfHook, dpkg, makeWrapper, wrapGAppsHook, xdg-utils
+, stdenv, lib, zlib, glib, alsa-lib, dbus, gtk3, atk, pango, freetype, fontconfig
+, gdk-pixbuf, cairo, cups, expat, libgpg-error, nspr
+, nss, xorg, libcap, systemd, libnotify, libsecret, libuuid, at-spi2-atk
+, at-spi2-core, libdbusmenu, libdrm, mesa, imagemagick, openssl_1_1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pulsar";
+  version = "1.103.0";
+
+  src = fetchurl {
+    url = "https://github.com/pulsar-edit/pulsar/releases/download/v${version}/Linux.pulsar_${version}_amd64.deb";
+    sha256 = "sha256-PZF+JaeAqsn/kxgQwyEn4Igm7GUsc+ie2FBXwHOSY5o=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg makeWrapper wrapGAppsHook ];
+
+  buildInputs = [
+    stdenv.cc.cc zlib glib dbus gtk3 atk pango freetype
+    fontconfig gdk-pixbuf cairo cups expat libgpg-error alsa-lib nspr nss
+    xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
+    xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
+    xorg.libXcursor xorg.libxkbfile xorg.libXScrnSaver xorg.libxshmfence
+    libcap systemd libnotify
+    xorg.libxcb libsecret libuuid at-spi2-atk at-spi2-core libdbusmenu
+    libdrm gtk3 mesa imagemagick openssl_1_1
+  ];
+
+  runtimeDependencies =
+    [ (lib.getLib systemd) libnotify libdbusmenu xdg-utils ];
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    cp -R "opt" "$out"
+    cp -R "usr/share" "$out/share"
+    # chmod -R g-w "$out"
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper $out/opt/Pulsar/pulsar $out/bin/pulsar \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
+      "''${gappsWrapperArgs[@]}"
+    substituteInPlace $out/share/applications/pulsar.desktop \
+      --replace "/opt/Pulsar/pulsar" "pulsar"
+  '';
+
+  meta = with lib; {
+    description = "A Community-led Hyper-Hackable Text Editor, Forked from Atom, built on Electron";
+    homepage = "https://github.com/pulsar-edit/pulsar";
+    changelog = "https://github.com/pulsar-edit/pulsar/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ anpin ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39541,4 +39541,6 @@ with pkgs;
   udict = callPackage ../applications/misc/udict { };
 
   duden = callPackage ../applications/misc/duden { };
+
+  pulsar = callPackage ../applications/editors/pulsar {};
 }


### PR DESCRIPTION
Pulsar is Community-led Hyper-Hackable Text Editor, Forked from Atom
https://github.com/NixOS/nixpkgs/issues/205152
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
