### PR TITLE
phpDocumentor: init at 3.3.1

### DIFF
--- a/pkgs/tools/misc/phpDocumentor/default.nix
+++ b/pkgs/tools/misc/phpDocumentor/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, makeWrapper, lib, php }:
+
+stdenv.mkDerivation rec {
+  pname = "phpDocumentor";
+  version = "3.3.1";
+
+  src = fetchurl {
+    url = "https://github.com/phpDocumentor/phpDocumentor/releases/download/v${version}/phpDocumentor.phar";
+    sha256 = "SpPSeP1FgfF3YJAxNNhfzePUDZP3OcjGSPPtAsnD57s=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -D $src $out/libexec/phpDocumentor/phpDocumentor.phar
+    makeWrapper ${php}/bin/php $out/bin/phpdoc \
+      --add-flags "$out/libexec/phpDocumentor/phpDocumentor.phar"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "PHP documentation generator";
+    license = licenses.mit;
+    homepage = "https://phpdoc.org";
+    changelog = "https://github.com/phpDocumentor/phpDocumentor/releases/tag/v${version}";
+    maintainers = with maintainers; teams.php.members;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1571,6 +1571,8 @@ with pkgs;
 
   pferd = callPackage ../tools/misc/pferd { };
 
+  phpDocumentor = callPackage ../tools/misc/phpDocumentor { };
+
   proycon-wayout = callPackage ../tools/wayland/proycon-wayout { };
 
   q = callPackage ../tools/networking/q { };


### PR DESCRIPTION
###### Description of changes

Adds https://phpdoc.org/ at version 3.3.1.
I added it to tools/misc.

I thought if https://github.com/NixOS/nixpkgs/pull/217207 `phpunit` should go to `development/tools/misc`, maybe `phpDocumentor` should just go into `tools/misc.` Don't know really. Feels like there should be a "php tools" folder somewhere, since `phpDocumentor` obviously only works for PHP.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).