### PR TITLE
cargo-makima: init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6571,6 +6571,13 @@
     github = "ius";
     githubId = 529626;
   };
+  ivabus = {
+    name = "Ivan Bushchik";
+    email = "ivabus@ivabus.dev";
+    matrix = "@ivabus:matrix.org";
+    github = "ivabus";
+    githubId = 71599788;
+  };
   ivan = {
     email = "ivan@ludios.org";
     github = "ivan";

--- a/pkgs/development/tools/rust/cargo-makima/default.nix
+++ b/pkgs/development/tools/rust/cargo-makima/default.nix
@@ -1,0 +1,13 @@
+{ lib, rustPlatform, fetchCrate }:
+
+ rustPlatform.buildRustPackage rec {
+   pname = "cargo-makima";
+   version = "0.1.1";
+
+   src = fetchCrate {
+     inherit pname version;
+     sha256 = "sha256-hqt2c3vHmjl1m98EGzwwCbM+9SZuJ5v6IlNLk0GgEEA";
+   };
+
+   cargoSha256 = "sha256-+mYz0S1TMolXf0u6Q69SHG+ZPe/wR6I+ugMoOhzSwNg=";
+ }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16058,6 +16058,7 @@ with pkgs;
   cargo-make = callPackage ../development/tools/rust/cargo-make {
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };
+  cargo-makima = callPackage ../development/tools/rust/cargo-makima { };
   cargo-modules = callPackage ../development/tools/rust/cargo-modules { };
   cargo-mommy = callPackage ../development/tools/rust/cargo-mommy { };
   cargo-msrv = callPackage ../development/tools/rust/cargo-msrv {


### PR DESCRIPTION
Sorry, for trying to merge this. It is half-joke package.

[cargo-makima](https://crates.io/crates/cargo-makima) is cargo plugin (wrapper) that prints messages on each cargo output.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


