### PR TITLE
ultrablue-server: init at unstable-2023-01-25

### DIFF
--- a/pkgs/os-specific/linux/ultrablue-server/default.nix
+++ b/pkgs/os-specific/linux/ultrablue-server/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+}:
+
+buildGoModule {
+  pname = "ultrablue-server";
+  version = "unstable-fosdem2023";
+
+  src = fetchFromGitHub {
+    owner = "ANSSI-FR";
+    repo = "ultrablue";
+    # Do not use a more recent
+    rev = "tags/fosdem-2023";
+    hash = "sha256-rnUbgZI+SycYCDUoSziOy+WxRFvyM3XJWJnk3+t0eb4=";
+    # rev = "6de04af6e353e38c030539c5678e5918f64be37e";
+  };
+
+  sourceRoot = "source/server";
+
+  vendorSha256 = "sha256-249LWguTHIF0HNIo8CsE/HWpAtBw4P46VPvlTARLTpw=";
+  doCheck = false;
+
+  meta = with lib; {
+    description = "User-friendly Lightweight TPM Remote Attestation over Bluetooth";
+    homepage = "https://github.com/ANSSI-FR/ultrablue";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8487,6 +8487,8 @@ with pkgs;
 
   jamulus = libsForQt5.callPackage ../applications/audio/jamulus { };
 
+  ultrablue-server = callPackage ../os-specific/linux/ultrablue-server { };
+
   ibm-sw-tpm2 = callPackage ../tools/security/ibm-sw-tpm2 { };
 
   ibniz = callPackage ../tools/graphics/ibniz { };


### PR DESCRIPTION
###### Description of changes

https://github.com/ANSSI-FR/ultrablue

Ultrablue is a remote attestation (TPM2) server which uses Bluetooth to perform the verification with a Bluetooth client pre-enrolled, usually your phone.

In an upcoming PR, I will add an integration for systemd stage 1 and legacy stage 1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
