### PR TITLE
nixos/system/boot/systemd: add Ultrablue remote attestation in initrd

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1330,6 +1330,7 @@
   ./system/boot/systemd/user.nix
   ./system/boot/systemd/userdbd.nix
   ./system/boot/systemd/homed.nix
+  ./system/boot/systemd/ultrablue.nix
   ./system/boot/timesyncd.nix
   ./system/boot/tmp.nix
   ./system/boot/uvesafb.nix

--- a/nixos/modules/system/boot/systemd/ultrablue.nix
+++ b/nixos/modules/system/boot/systemd/ultrablue.nix
@@ -1,0 +1,39 @@
+{ pkgs, config, lib, ... }:
+
+let
+  cfg = config.boot.initrd.systemd.ultrablue;
+in
+{
+  options.boot.initrd.systemd.ultrablue = {
+    enable = lib.mkEnableOption (lib.mdDoc "the Ultrablue remote attestation server");
+    package = (lib.mkPackageOptionMD pkgs "Ultrablue server package" {
+      default = "ultrablue-server";
+    });
+  };
+  config = lib.mkIf cfg.enable {
+    boot.initrd.systemd = {
+      storePaths = [
+        "${cfg.package}/bin/ultrablue-server"
+        "${pkgs.toybox}/bin/sleep"
+      ];
+
+      services.ultrablue-server = {
+        after = [ "bluetooth.service" ];
+        wants = [ "bluetooth.service" "cryptsetup-pre.target" ];
+        before = [ "cryptsetup.target" ];
+        wantedBy = [ "cryptsetup.target" ];
+
+        unitConfig.DefaultDependencies = false;
+
+        serviceConfig = {
+          Type = "oneshot";
+          # TODO: upstream hack, brrr
+          ExecStartPre = "${pkgs.toybox}/bin/sleep 5";
+          ExecStart = "${cfg.package}/bin/ultrablue-server";
+          TimeoutSec = 60;
+          StandardOutput = "tty";
+        };
+      };
+    };
+  };
+}

--- a/nixos/tests/systemd-initrd-luks-ultrablue.nix
+++ b/nixos/tests/systemd-initrd-luks-ultrablue.nix
@@ -1,0 +1,55 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }: let
+
+  keyfile = pkgs.writeText "luks-keyfile" ''
+    MIGHAoGBAJ4rGTSo/ldyjQypd0kuS7k2OSsmQYzMH6TNj3nQ/vIUjDn7fqa3slt2
+    gV6EK3TmTbGc4tzC1v4SWx2m+2Bjdtn4Fs4wiBwn1lbRdC6i5ZYCqasTWIntWn+6
+    FllUkMD5oqjOR/YcboxG8Z3B5sJuvTP9llsF+gnuveWih9dpbBr7AgEC
+  '';
+
+in {
+  name = "systemd-initrd-luks-keyfile-with-ultrablue";
+
+  # This tests that ultrablue does not break boot if bluetooth is unavailable.
+  nodes.machine = { pkgs, ... }: {
+    # Use systemd-boot
+    virtualisation = {
+      emptyDiskImages = [ 512 ];
+      useBootLoader = true;
+      useEFIBoot = true;
+    };
+    boot.loader.systemd-boot.enable = true;
+
+    environment.systemPackages = with pkgs; [ cryptsetup ];
+    boot.initrd.systemd = {
+      enable = true;
+      emergencyAccess = true;
+      ultrablue.enable = true;
+    };
+
+    specialisation.boot-luks.configuration = {
+      boot.initrd.luks.devices = lib.mkVMOverride {
+        cryptroot = {
+          device = "/dev/vdc";
+          keyFile = "/etc/cryptroot.key";
+        };
+      };
+      virtualisation.bootDevice = "/dev/mapper/cryptroot";
+      boot.initrd.secrets."/etc/cryptroot.key" = keyfile;
+    };
+  };
+
+  testScript = ''
+    # Create encrypted volume
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("cryptsetup luksFormat -q --iter-time=1 -d ${keyfile} /dev/vdc")
+
+    # Boot from the encrypted disk
+    machine.succeed("bootctl set-default nixos-generation-1-specialisation-boot-luks.conf")
+    machine.succeed("sync")
+    machine.crash()
+
+    # Boot and decrypt the disk
+    machine.wait_for_unit("multi-user.target")
+    assert "/dev/mapper/cryptroot on / type ext4" in machine.succeed("mount")
+  '';
+})

--- a/pkgs/os-specific/linux/ultrablue-server/default.nix
+++ b/pkgs/os-specific/linux/ultrablue-server/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, fetchFromGitHub
+, buildGoModule
+}:
+
+buildGoModule {
+  pname = "ultrablue-server";
+  version = "unstable-fosdem2023";
+
+  src = fetchFromGitHub {
+    owner = "ANSSI-FR";
+    repo = "ultrablue";
+    # Do not use a more recent
+    rev = "tags/fosdem-2023";
+    hash = "sha256-rnUbgZI+SycYCDUoSziOy+WxRFvyM3XJWJnk3+t0eb4=";
+    # rev = "6de04af6e353e38c030539c5678e5918f64be37e";
+  };
+
+  sourceRoot = "source/server";
+
+  vendorSha256 = "sha256-249LWguTHIF0HNIo8CsE/HWpAtBw4P46VPvlTARLTpw=";
+  doCheck = false;
+
+  meta = with lib; {
+    description = "User-friendly Lightweight TPM Remote Attestation over Bluetooth";
+    homepage = "https://github.com/ANSSI-FR/ultrablue";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8487,6 +8487,8 @@ with pkgs;
 
   jamulus = libsForQt5.callPackage ../applications/audio/jamulus { };
 
+  ultrablue-server = callPackage ../os-specific/linux/ultrablue-server { };
+
   ibm-sw-tpm2 = callPackage ../tools/security/ibm-sw-tpm2 { };
 
   ibniz = callPackage ../tools/graphics/ibniz { };


### PR DESCRIPTION
###### Description of changes

Depends on #222062.

This offers a stage1 ultrablue remote attestation with a default timeout to fallback on classical measures.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
