### PR TITLE
tony: fix build with GCC 12

### DIFF
--- a/pkgs/applications/audio/tony/default.nix
+++ b/pkgs/applications/audio/tony/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkg-config, wrapQtAppsHook
+{ lib, stdenv, fetchurl, fetchpatch2, pkg-config, wrapQtAppsHook
 , alsa-lib, boost, bzip2, fftw, fftwFloat, libX11, libfishsound, libid3tag
 , libjack2, liblo, libmad, libogg, liboggz, libpulseaudio, libsamplerate
 , libsndfile, lrdf, opusfile, qtbase, qtsvg, rubberband, serd, sord
@@ -12,6 +12,22 @@ stdenv.mkDerivation rec {
     url = "https://code.soundsoftware.ac.uk/attachments/download/2616/${pname}-${version}.tar.gz";
     sha256 = "03g2bmlj08lmgvh54dyd635xccjn730g4wwlhpvsw04bffz8b7fp";
   };
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/sonic-visualiser/svcore/commit/5a7b517e43b7f0b3f03b7fc3145102cf4e5b0ffc.patch";
+      stripLen = 1;
+      extraPrefix = "svcore/";
+      sha256 = "sha256-DOCdQqCihkR0g/6m90DbJxw00QTpyVmFzCxagrVWKiI=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/sonic-visualiser/svgui/commit/5b6417891cff5cc614e8c96664d68674eb12b191.patch";
+      stripLen = 1;
+      extraPrefix = "svgui/";
+      excludes = [ "svgui/widgets/CSVExportDialog.cpp" ];
+      sha256 = "sha256-pBCtoMXgjreUm/D0pl6+R9x1Ovwwwj8Ohv994oMX8XA=";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config wrapQtAppsHook ];
 


### PR DESCRIPTION
###### Description of changes

This backports compilation fixes from updates to tony dependencies. (Tony itself has not been rebundled with newer dependencies yet.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
