### PR TITLE
nix-init: 0.1.1 -> 0.2.0

### DIFF
--- a/pkgs/tools/nix/nix-init/default.nix
+++ b/pkgs/tools/nix/nix-init/default.nix
@@ -1,42 +1,80 @@
 { lib
+, writeText
 , rustPlatform
 , fetchFromGitHub
+, curl
 , installShellFiles
 , makeWrapper
 , pkg-config
+, bzip2
+, libgit2_1_5
+, openssl
+, zlib
 , zstd
 , stdenv
 , darwin
+, spdx-license-list-data
 , nix
 , nurl
-, callPackage
-, spdx-license-list-data
 }:
+
+let
+  get-nix-license = import ./get-nix-license.nix {
+    inherit lib writeText;
+  };
+in
 
 rustPlatform.buildRustPackage rec {
   pname = "nix-init";
-  version = "0.1.1";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nix-init";
     rev = "v${version}";
-    hash = "sha256-x9UrBCnEGz6nI1XGBLjIeiF3qi3EvynAfafiuhQdt9Q=";
+    hash = "sha256-/lH8zO6ah7/HVZ7jOxTgs2iKND1UlGP5EQLtx6JsFxo=";
   };
 
-  cargoHash = "sha256-RUfprANAbj8w8LPRwQEF9SD9fhWb1CEcwbvOa6DX9Xk=";
+  cargoHash = "sha256-jI/hysUq3JGe0hdZTQQw49BfcTWMx6jg+QAkd1QeBv4=";
 
   nativeBuildInputs = [
+    curl
     installShellFiles
     makeWrapper
     pkg-config
   ];
 
   buildInputs = [
+    bzip2
+    curl
+    libgit2_1_5
+    openssl
+    zlib
     zstd
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security
+  ] ++ lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+    darwin.apple_sdk.frameworks.CoreFoundation
   ];
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ "reqwest/rustls-tls" ];
+
+  checkFlags = [
+    # requires internet access
+    "--skip=lang::rust::tests"
+  ];
+
+  postPatch = ''
+    mkdir -p data
+    ln -s ${get-nix-license} data/get-nix-license.rs
+  '';
+
+  preBuild = ''
+    cargo run -p license-store-cache \
+      -j $NIX_BUILD_CORES --frozen \
+      data/license-store-cache.zstd ${spdx-license-list-data.json}/json/details
+  '';
 
   postInstall = ''
     wrapProgram $out/bin/nix-init \
@@ -46,8 +84,6 @@ rustPlatform.buildRustPackage rec {
   '';
 
   GEN_ARTIFACTS = "artifacts";
-  NIX_LICENSES = callPackage ./license.nix { };
-  SPDX_LICENSE_LIST_DATA = "${spdx-license-list-data.json}/json/details";
   ZSTD_SYS_USE_PKG_CONFIG = true;
 
   meta = with lib; {


### PR DESCRIPTION
Diff: https://github.com/nix-community/nix-init/compare/v0.1.1...v0.2.0

Changelog: https://github.com/nix-community/nix-init/blob/v0.2.0/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
