### PR TITLE
postman: 9.31.0 -> 10.12.0

### DIFF
--- a/pkgs/development/web/postman/darwin.nix
+++ b/pkgs/development/web/postman/darwin.nix
@@ -11,12 +11,12 @@ let
   dist = {
     aarch64-darwin = {
       arch = "arm64";
-      sha256 = "sha256-zvGWkV92qDsiveS1tvkY6jHIr/Xj3ARSOqov+MCRM+o=";
+      sha256 = "sha256-dJM85/6JCNqSXtrglEjP11cypGkj8+zHPo0qNANyylU=";
     };
 
     x86_64-darwin = {
       arch = "64";
-      sha256 = "sha256-LuXC1ucEsrxqx8wAkBkot2wXbUUVp+FIQPx9/2+tfIw=";
+      sha256 = "sha256-36T7S/F35hRCmXXYA8DWwwLsuJiUVU9UBY7eAXjzx1s=";
     };
   }.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
 

--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -2,13 +2,13 @@
 
 let
   pname = "postman";
-  version = "9.31.0";
+  version = "10.12.0";
   meta = with lib; {
     homepage = "https://www.getpostman.com";
     description = "API Development Environment";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.postman;
-    platforms = [ "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
     maintainers = with maintainers; [ johnrichardrinehart evanjs tricktron Crafter ];
   };
 

--- a/pkgs/development/web/postman/linux.nix
+++ b/pkgs/development/web/postman/linux.nix
@@ -43,13 +43,27 @@
 , copyDesktopItems
 }:
 
+let
+  dist = {
+    aarch64-linux = {
+      arch = "arm64";
+      sha256 = "sha256-ciQ9LqtaOosUAtcZiwOQ+8gB5dTut8pXHAjUsoQEEB8=";
+    };
+
+    x86_64-linux = {
+      arch = "64";
+      sha256 = "sha256-QaIj+SOQGR6teUIdLB3D5klRlYrna1MoE3c6UXYEoB4=";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+in
 stdenv.mkDerivation rec {
   inherit pname version meta;
 
   src = fetchurl {
-    url = "https://dl.pstmn.io/download/version/${version}/linux64";
-    sha256 = "sha256-ZCfPE+bvPEQjEvUO/FQ1iNR9TG6GtI4vmj6yJ7B62iw=";
-    name = "${pname}.tar.gz";
+    url = "https://dl.pstmn.io/download/version/${version}/linux${dist.arch}";
+    inherit (dist) sha256;
+    name = "${pname}-${version}.tar.gz";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
###### Description of changes

Update Postman from 9.31.0 to 10.12.0 . Release notes are here: https://www.postman.com/release-notes/postman-app/

Also added support for aarch64 linux.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
