### PR TITLE
skippy-xd: richardgv/skippy-xd unstable-2023-03-10 -> dreamcat4 0.6.0

### DIFF
--- a/pkgs/tools/X11/skippy-xd/default.nix
+++ b/pkgs/tools/X11/skippy-xd/default.nix
@@ -14,12 +14,12 @@
 }:
 stdenv.mkDerivation rec {
   pname = "skippy-xd";
-  version = "unstable-2015-03-01";
+  version = "0.6.0";
   src = fetchFromGitHub {
-    owner = "richardgv";
+    owner = "dreamcat4";
     repo = "skippy-xd";
-    rev = "397216ca67074c71314f5e9a6e3f1710ccabc29e";
-    sha256 = "sha256-iP6g3iS1aPPkauBLHbgZH/l+TXbWyIJ2TmbrSiNTkn0=";
+    rev = "d0557c3144fc67568a49d7207efef89c1d5777a0";
+    sha256 = "sha256-dnoPUPCvuR/HhqIz1WAsmWL/CkfTf11YEkbrkVWM4dc=";
   };
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [


### PR DESCRIPTION
###### Description of changes
Updating to the latest release 0.6.0 and switching to the currently actively maintained fork from dreamcat4.

The changelog to the latest release can be found [here](https://github.com/dreamcat4/skippy-xd/releases/tag/v2023.03.10) although the version currently available seems to be much older.

The [fork from dreamcat4](https://github.com/dreamcat4/skippy-xd) seems to be the currently active fork of this project and sees feature updates as well as fixes for decade-old bugs. It would be nice to have that available in nixpkgs. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
