### PR TITLE
osu-lazer: 2023.301.0 -> 2023.305.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14120,6 +14120,16 @@
     githubId = 22163194;
     name = "Stel Abrego";
   };
+  stepbrobd = {
+    name = "StepBroBD";
+    github = "StepBroBD";
+    githubId = 81826728;
+    email = "Hi@StepBroBD.com";
+    matrix = "@stepbrobd:matrix.org";
+    keys = [{
+      fingerprint = "5D8B FA8B 286A C2EF 6EE4  8598 F742 B72C 8926 1A51";
+    }];
+  };
   stephank = {
     email = "nix@stephank.nl";
     matrix = "@skochen:matrix.org";

--- a/pkgs/games/osu-lazer/bin.nix
+++ b/pkgs/games/osu-lazer/bin.nix
@@ -1,28 +1,68 @@
-{ appimageTools, lib, fetchurl }:
+{ lib
+, stdenv
+, fetchurl
+, fetchzip
+, appimageTools
+}:
 
-appimageTools.wrapType2 rec {
+let
   pname = "osu-lazer-bin";
-  version = "2023.301.0";
+  version = "2023.305.0";
+  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/ppy/osu/releases/download/${version}/osu.AppImage";
-    sha256 = "sha256-0c74bGOY9f2K52xE7CZy/i3OfyCC+a6XGI30c6hI7jM=";
+  osu-lazer-bin-src = {
+    aarch64-darwin = {
+      url = "https://github.com/ppy/osu/releases/download/${version}/osu.app.Apple.Silicon.zip";
+      sha256 = "sha256-nL5j0b4vD/tTYPPBLiMxiPWLHnP5hqco0DJ+7EZRSZY=";
+    };
+    x86_64-darwin = {
+      url = "https://github.com/ppy/osu/releases/download/${version}/osu.app.Intel.zip";
+      sha256 = "sha256-Er48BIzJlSzDaGb6IfhZoV62kj5GJ/rw9ifUw+ZCJkc=";
+    };
+    x86_64-linux = {
+      url = "https://github.com/ppy/osu/releases/download/${version}/osu.AppImage";
+      sha256 = "sha256-W3XJ7HtJM5iFI8OOTTu8IBHMerZSCETHMemkoTislK8=";
+    };
+  }.${stdenv.system} or (throw "${pname}-${version}: ${stdenv.system} is unsupported.");
+
+  linux = appimageTools.wrapType2 rec {
+    inherit name pname version meta;
+
+    src = fetchurl (osu-lazer-bin-src);
+
+    extraPkgs = pkgs: with pkgs; [ icu ];
+
+    extraInstallCommands =
+      let contents = appimageTools.extract { inherit pname version src; };
+      in
+      ''
+        mv -v $out/bin/${pname}-${version} $out/bin/osu\!
+        install -m 444 -D ${contents}/osu\!.desktop -t $out/share/applications
+        for i in 16 32 48 64 96 128 256 512 1024; do
+          install -D ${contents}/osu\!.png $out/share/icons/hicolor/''${i}x$i/apps/osu\!.png
+        done
+      '';
   };
 
-  extraPkgs = pkgs: with pkgs; [ icu ];
+  darwin = stdenv.mkDerivation rec {
+    inherit name pname version meta;
 
-  extraInstallCommands =
-    let contents = appimageTools.extract { inherit pname version src; };
-    in ''
-      mv -v $out/bin/${pname}-${version} $out/bin/osu\!
-      install -m 444 -D ${contents}/osu\!.desktop -t $out/share/applications
-      for i in 16 32 48 64 96 128 256 512 1024; do
-        install -D ${contents}/osu\!.png $out/share/icons/hicolor/''${i}x$i/apps/osu\!.png
-      done
+    src = fetchzip (osu-lazer-bin-src // { stripRoot = false; });
+
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+      APP_DIR="$out/Applications"
+      mkdir -p "$APP_DIR"
+      cp -r . "$APP_DIR"
+      runHook postInstall
     '';
+  };
 
   meta = with lib; {
-    description = "Rhythm is just a *click* away (AppImage version for score submission and multiplayer)";
+    description = "Rhythm is just a *click* away (AppImage version for score submission and multiplayer, and binary distribution for Darwin systems)";
     homepage = "https://osu.ppy.sh";
     license = with licenses; [
       mit
@@ -30,8 +70,14 @@ appimageTools.wrapType2 rec {
       unfreeRedistributable # osu-framework contains libbass.so in repository
     ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = [ maintainers.delan ];
+    maintainers = with maintainers; [ delan stepbrobd ];
     mainProgram = "osu!";
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ];
   };
-}
+
+  passthru.updateScript = ./update-bin.sh;
+in
+if stdenv.isDarwin
+then darwin
+else linux
+

--- a/pkgs/games/osu-lazer/default.nix
+++ b/pkgs/games/osu-lazer/default.nix
@@ -17,13 +17,13 @@
 
 buildDotnetModule rec {
   pname = "osu-lazer";
-  version = "2023.301.0";
+  version = "2023.305.0";
 
   src = fetchFromGitHub {
     owner = "ppy";
     repo = "osu";
     rev = version;
-    sha256 = "sha256-SUVxe3PdUch8NYR7X4fatbmSpyYewI69usBDICcSq3s=";
+    sha256 = "sha256-gkAHAiTwCYXTSIHrM3WWLBLbC7S9x1cAaEhSYvtNsvQ=";
   };
 
   projectFile = "osu.Desktop/osu.Desktop.csproj";

--- a/pkgs/games/osu-lazer/update-bin.sh
+++ b/pkgs/games/osu-lazer/update-bin.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=../../../. -i bash -p unzip curl jq common-updater-scripts
+set -eo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+bin_file="$(realpath ./bin.nix)"
+
+new_version="$(curl -s "https://api.github.com/repos/ppy/osu/releases?per_page=1" | jq -r '.[0].name')"
+old_version="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./bin.nix)"
+if [[ "$new_version" == "$old_version" ]]; then
+    echo "Already up to date."
+    exit 0
+fi
+
+cd ../../..
+
+echo "Updating osu-lazer-bin from $old_version to $new_version..."
+sed -Ei.bak '/ *version = "/s/".+"/"'"$new_version"'"/' "$bin_file"
+rm "$bin_file.bak"
+
+for pair in \
+    'aarch64-darwin osu.app.Apple.Silicon.zip' \
+    'x86_64-darwin osu.app.Intel.zip' \
+    'x86_64-linux osu.AppImage'; do
+    set -- $pair
+    echo "Prefetching binary for $1..."
+    prefetch_output=$(nix --extra-experimental-features nix-command store prefetch-file --json --hash-type sha256 "https://github.com/ppy/osu/releases/download/$new_version/$2")
+    if [[ "$1" == *"darwin"* ]]; then
+        store_path=$(jq -r '.storePath' <<<"$prefetch_output")
+        tmpdir=$(mktemp -d)
+        unzip -q "$store_path" -d "$tmpdir"
+        hash=$(nix --extra-experimental-features nix-command hash path "$tmpdir")
+        rm -r "$tmpdir"
+    else
+        hash=$(jq -r '.hash' <<<"$prefetch_output")
+    fi
+    echo "$1 ($2): sha256 = $hash"
+    sed -Ei.bak '/ *'"$1"' = /{N;N; s@("sha256-)[^;"]+@"'"$hash"'@}' "$bin_file"
+    rm "$bin_file.bak"
+done

--- a/pkgs/games/osu-lazer/update.sh
+++ b/pkgs/games/osu-lazer/update.sh
@@ -3,7 +3,8 @@
 set -eo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-deps_file="$(realpath "./deps.nix")"
+deps_file="$(realpath ./deps.nix)"
+bin_file="$(realpath ./bin.nix)"
 
 new_version="$(curl -s "https://api.github.com/repos/ppy/osu/releases?per_page=1" | jq -r '.[0].name')"
 old_version="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
@@ -15,7 +16,22 @@ fi
 cd ../../..
 
 if [[ "$1" != "--deps-only" ]]; then
-    update-source-version osu-lazer "$new_version"
+  update-source-version osu-lazer "$new_version"
+  sed -Ei.bak '/ *version = "/s/".+"/"'"$new_version"'"/' "$bin_file"
+  rm "$bin_file.bak"
+  for pair in \
+    'aarch64-darwin osu.app.Apple.Silicon.zip' \
+    'x86_64-darwin osu.app.Intel.zip' \
+    'x86_64-linux osu.AppImage' \
+  ; do
+    set -- $pair
+    nix-prefetch-url "https://github.com/ppy/osu/releases/download/$new_version/$2" | while read -r hash; do
+      nix --extra-experimental-features nix-command hash to-sri --type sha256 "$hash" | while read -r hash; do
+        sed -Ei.bak '/ *'"$1"' = "sha256-/s@".+"@"'"$hash"'"@' "$bin_file"
+        rm "$bin_file.bak"
+      done
+    done
+  done
 fi
 
 $(nix-build . -A osu-lazer.fetch-deps --no-out-link) "$deps_file"

--- a/pkgs/games/osu-lazer/update.sh
+++ b/pkgs/games/osu-lazer/update.sh
@@ -3,35 +3,19 @@
 set -eo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-deps_file="$(realpath ./deps.nix)"
-bin_file="$(realpath ./bin.nix)"
+deps_file="$(realpath "./deps.nix")"
 
 new_version="$(curl -s "https://api.github.com/repos/ppy/osu/releases?per_page=1" | jq -r '.[0].name')"
 old_version="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
 if [[ "$new_version" == "$old_version" ]]; then
-  echo "Up to date"
-  exit 0
+    echo "Up to date"
+    exit 0
 fi
 
 cd ../../..
 
 if [[ "$1" != "--deps-only" ]]; then
-  update-source-version osu-lazer "$new_version"
-  sed -Ei.bak '/ *version = "/s/".+"/"'"$new_version"'"/' "$bin_file"
-  rm "$bin_file.bak"
-  for pair in \
-    'aarch64-darwin osu.app.Apple.Silicon.zip' \
-    'x86_64-darwin osu.app.Intel.zip' \
-    'x86_64-linux osu.AppImage' \
-  ; do
-    set -- $pair
-    nix-prefetch-url "https://github.com/ppy/osu/releases/download/$new_version/$2" | while read -r hash; do
-      nix --extra-experimental-features nix-command hash to-sri --type sha256 "$hash" | while read -r hash; do
-        sed -Ei.bak '/ *'"$1"' = "sha256-/s@".+"@"'"$hash"'"@' "$bin_file"
-        rm "$bin_file.bak"
-      done
-    done
-  done
+    update-source-version osu-lazer "$new_version"
 fi
 
 $(nix-build . -A osu-lazer.fetch-deps --no-out-link) "$deps_file"


### PR DESCRIPTION
###### Description of changes

This PR is a duplicate of #219954, the original PR is inactive for two weeks and I have made changes to fix the update script and some styling changes based on the reviews in the original PR.

1. https://github.com/NixOS/nixpkgs/pull/219954#discussion_r1129983988

Extracted the osu-lazer-bin update script from update.sh to update-bin.sh 

2. https://github.com/NixOS/nixpkgs/pull/219954#discussion_r1129987407

Made the file url and hash to be in the same attrset.

3. https://github.com/NixOS/nixpkgs/pull/219954#issuecomment-1460850713

Fixed incorrect hash produced by `nix-prefetch-url` for darwin systems.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
