### PR TITLE
tonelib-noisereducer: init at 1.2.0

### DIFF
--- a/pkgs/applications/audio/tonelib-noisereducer/default.nix
+++ b/pkgs/applications/audio/tonelib-noisereducer/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, alsa-lib
+, freetype
+, libglvnd
+, mesa
+, curl
+, libXcursor
+, libXinerama
+, libXrandr
+, libXrender
+, libjack2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tonelib-noisereducer";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "https://tonelib.net/download/221222/ToneLib-NoiseReducer-amd64.deb";
+    sha256 = "sha256-27JuFVmamIUUKRrpjlsE0E6x+5X9RutNGPiDf5dxitI=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    alsa-lib
+    freetype
+    libglvnd
+    mesa
+  ] ++ runtimeDependencies;
+
+  runtimeDependencies = map lib.getLib [
+    curl
+    libXcursor
+    libXinerama
+    libXrandr
+    libXrender
+    libjack2
+  ];
+
+  unpackCmd = "dpkg -x $curSrc source";
+
+  installPhase = ''
+    mv usr $out
+ '';
+
+  meta = with lib; {
+    description = "ToneLib NoiseReducer – two-unit noise reduction rack effect plugin";
+    homepage = "https://tonelib.net/tl-noisereducer.html";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ orivej ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33851,6 +33851,8 @@ with pkgs;
 
   tonelib-metal = callPackage ../applications/audio/tonelib-metal { };
 
+  tonelib-noisereducer = callPackage ../applications/audio/tonelib-noisereducer { };
+
   tony = libsForQt5.callPackage ../applications/audio/tony { };
 
   toot = callPackage ../applications/misc/toot { };


### PR DESCRIPTION
###### Description of changes

https://tonelib.net/tl-noisereducer.html is a royalty-free audio noise gate.

It provides vst and vst3 plugins and a standalone application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
