### PR TITLE
kubectl-gadget: init at 0.14.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8186,6 +8186,12 @@
     githubId = 735008;
     name = "Louis Taylor";
   };
+  kranurag7 = {
+    email = "contact.anurag7@gmail.com";
+    github = "kranurag7";
+    githubId = "81210977";
+    name = "Anurag";
+  };
   kranzes = {
     email = "personal@ilanjoselevich.com";
     github = "Kranzes";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8189,7 +8189,7 @@
   kranurag7 = {
     email = "contact.anurag7@gmail.com";
     github = "kranurag7";
-    githubId = "81210977";
+    githubId = 81210977;
     name = "Anurag";
   };
   kranzes = {

--- a/pkgs/applications/networking/cluster/kubectl-gadget/default.nix
+++ b/pkgs/applications/networking/cluster/kubectl-gadget/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kubectl-gadget";
+  version = "0.14.0";
+
+  src = fetchFromGitHub {
+    owner = "inspektor-gadget";
+    repo = "inspektor-gadget";
+    rev = "v${version}";
+    hash = "sha256:16i9biyvzkpgxyfb41afaarnlm59vy02nspln5zq69prg6mp8rwa";
+  };
+
+  vendorHash = "sha256-Kj8gP5393++nPeX38TX6duB9OO/ql7hpRA5gTTtTl+M=";
+
+  CGO_ENABLED = 0;
+
+  ldflags = [
+    "-X main.version=v${version}"
+  ];
+
+  subPackages = [ "cmd/kubectl-gadget" ];
+
+  meta = with lib; {
+    description = "A collection of gadgets for troubleshooting Kubernetes applications using eBPF";
+    homepage = "https://inspektor-gadget.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ kranurag7 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31218,6 +31218,8 @@ with pkgs;
 
   kubectl-example = callPackage ../applications/networking/cluster/kubectl-example { };
 
+  kubectl-gadget = callPackage ../applications/networking/cluster/kubectl-gadget { };
+
   kubectl-images = callPackage ../applications/networking/cluster/kubectl-images { };
 
   kubectl-node-shell = callPackage ../applications/networking/cluster/kubectl-node-shell { };


### PR DESCRIPTION
###### Description of changes
kubectl-gadget is a collection of gadgets that allow you to troubleshoot and get insights from your kubernetes cluster using eBPF. 

https://github.com/inspektor-gadget/inspektor-gadget/tree/main/cmd/kubectl-gadget

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
