### PR TITLE
haskell.packages.*.vector: clean up and unify overrides, run tests

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -78,6 +78,15 @@ self: super: {
     guardian
   ;
 
+  vector = overrideCabal (old: {
+    # Too strict bounds on doctest which isn't used, but is part of the configuration
+    jailbreak = true;
+    # vector-doctest seems to be broken when executed via ./Setup test
+    testTarget = lib.concatStringsSep " " [
+      "vector-tests-O0"
+      "vector-tests-O2"
+    ];
+  }) super.vector;
 
   # There are numerical tests on random data, that may fail occasionally
   lapack = dontCheck super.lapack;
@@ -207,10 +216,6 @@ self: super: {
   ABList = dontCheck super.ABList;
 
   pandoc-cli = throwIfNot (versionOlder super.pandoc.version "3.0.0") "pandoc-cli contains the pandoc executable starting with 3.0, this needs to be considered now." (markBroken (dontDistribute super.pandoc-cli));
-
-  # sse2 flag due to https://github.com/haskell/vector/issues/47.
-  # Jailbreak is necessary for QuickCheck dependency.
-  vector = doJailbreak (if pkgs.stdenv.isi686 then appendConfigureFlag "--ghc-options=-msse2" super.vector else super.vector);
 
   inline-c-cpp = overrideCabal (drv: {
     patches = drv.patches or [] ++ [

--- a/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.8.x.nix
@@ -118,9 +118,6 @@ self: super: {
 
   ormolu = super.ormolu_0_2_0_0;
 
-  # vector 0.12.2 indroduced doctest checks that don’t work on older compilers
-  vector = dontCheck super.vector;
-
   ghc-api-compat = doDistribute (unmarkBroken super.ghc-api-compat_8_6);
 
   mime-string = disableOptimization super.mime-string;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -81,7 +81,6 @@ self: super: {
   tar = doJailbreak super.tar;
   time-compat = doJailbreak super.time-compat;
   tuple = addBuildDepend self.base-orphans super.tuple;
-  vector = doJailbreak (dontCheck super.vector);
   vector-binary-instances = doJailbreak super.vector-binary-instances;
   vector-th-unbox = doJailbreak super.vector-th-unbox;
   zlib = doJailbreak super.zlib;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -60,8 +60,6 @@ self: super: {
   # https://mail.haskell.org/pipermail/haskell-cafe/2022-October/135613.html
   language-javascript_0_7_0_0 = dontCheck super.language-javascript_0_7_0_0;
 
-  vector = dontCheck super.vector;
-
   # Apply patches from head.hackage.
   language-haskell-extract = appendPatch (pkgs.fetchpatch {
     url = "https://gitlab.haskell.org/ghc/head.hackage/-/raw/dfd024c9a336c752288ec35879017a43bd7e85a0/patches/language-haskell-extract-0.2.4.patch";

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -137,7 +137,6 @@ in {
   tomland = doJailbreak super.tomland;
   type-equality = doJailbreak super.type-equality;
   unordered-containers = doJailbreak super.unordered-containers;
-  vector = dontCheck super.vector;
   vector-binary-instances = doJailbreak super.vector-binary-instances;
 
   hpack = overrideCabal (drv: {

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -110,16 +110,6 @@ self: super: {
   # XXX: 1.3 supports 9.6 properly, but is intended for bifunctors >= 5.6
   semialign = doJailbreak super.semialign;
 
-  # Not using latest vector version yet…
-  vector = doDistribute (overrideCabal {
-    jailbreak = true;
-    # vector-doctest seems to be broken when executed via ./Setup test
-    testTarget = lib.concatStringsSep " " [
-      "vector-tests-O0"
-      "vector-tests-O2"
-    ];
-  } super.vector);
-
   #
   # Too strict bounds, waiting on Revision in nixpkgs
   #


### PR DESCRIPTION
- The dontCheck overrides are not necessary completely. It seems that there is some kind of issue with the doctest suite, but we can run the other ones.

- We need a jailbreak everywhere due to doctest (ironically), so we can move that into the common configuration.

- The i686 issue has been closed upstream. Tested locally to confirm that it is indeed not a problem anymore.

We may want to wait with merging until the next iteration as it is probably a big rebuild.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
