### PR TITLE
gitea: 1.18.5 -> 1.19.0

### DIFF
--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -93,7 +93,7 @@ let
       api_token = server.succeed(
           "curl --fail -X POST http://test:totallysafe@localhost:3000/api/v1/users/test/tokens "
           + "-H 'Accept: application/json' -H 'Content-Type: application/json' -d "
-          + "'{\"name\":\"token\"}' | jq '.sha1' | xargs echo -n"
+          + "'{\"name\":\"token\",\"scopes\":[\"all\"]}' | jq '.sha1' | xargs echo -n"
       )
 
       server.succeed(

--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -15,12 +15,12 @@
 
 buildGoModule rec {
   pname = "gitea";
-  version = "1.18.5";
+  version = "1.19.0";
 
   # not fetching directly from the git repo, because that lacks several vendor files for the web UI
   src = fetchurl {
     url = "https://dl.gitea.io/gitea/${version}/gitea-src-${version}.tar.gz";
-    hash = "sha256-OGPn4fknYfzmuAi6CL8m/Ih4uRNraVDmpBm20qT3lKk=";
+    hash = "sha256-9nDzXSGYxYw34/Ekmj44VdGLVhRsGL2e5gfyoyPUqGQ=";
   };
 
   vendorHash = null;

--- a/pkgs/applications/version-management/gitea/static-root-path.patch
+++ b/pkgs/applications/version-management/gitea/static-root-path.patch
@@ -1,10 +1,10 @@
-diff --git a/modules/setting/setting.go b/modules/setting/setting.go
-index 45e55a2..9d18ee4 100644
---- a/modules/setting/setting.go
-+++ b/modules/setting/setting.go
-@@ -667,7 +667,7 @@ func NewContext() {
+diff --git a/modules/setting/server.go b/modules/setting/server.go
+index 183906268..fa02e8915 100644
+--- a/modules/setting/server.go
++++ b/modules/setting/server.go
+@@ -319,7 +319,7 @@ func loadServerFrom(rootCfg ConfigProvider) {
  	OfflineMode = sec.Key("OFFLINE_MODE").MustBool()
- 	DisableRouterLog = sec.Key("DISABLE_ROUTER_LOG").MustBool()
+ 	Log.DisableRouterLog = sec.Key("DISABLE_ROUTER_LOG").MustBool()
  	if len(StaticRootPath) == 0 {
 -		StaticRootPath = AppWorkPath
 +		StaticRootPath = "@data@"


### PR DESCRIPTION

###### Description of changes
ChangeLog: https://github.com/go-gitea/gitea/releases/tag/v1.19.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
