### PR TITLE
[staging-22.11] curl: Backport fixes from 8.0.0

### DIFF
--- a/pkgs/tools/networking/curl/CVE-2023-27533.patch
+++ b/pkgs/tools/networking/curl/CVE-2023-27533.patch
@@ -1,0 +1,239 @@
+From 9078855e11431eaeb7fdaa9158901fc5c833485b Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Thu, 23 Feb 2023 18:14:35 +0100
+Subject: [PATCH 1/2] telnet: parse telnet options without sscanf
+
+Closes #10596
+---
+ lib/telnet.c | 136 +++++++++++++++++++++++++++++----------------------
+ 1 file changed, 77 insertions(+), 59 deletions(-)
+
+diff --git a/lib/telnet.c b/lib/telnet.c
+index 48cd0d743..b60e8aa0f 100644
+--- a/lib/telnet.c
++++ b/lib/telnet.c
+@@ -774,18 +774,15 @@ static CURLcode check_telnet_options(struct Curl_easy *data)
+ {
+   struct curl_slist *head;
+   struct curl_slist *beg;
+-  char option_keyword[128] = "";
+-  char option_arg[256] = "";
+   struct TELNET *tn = data->req.p.telnet;
+-  struct connectdata *conn = data->conn;
+   CURLcode result = CURLE_OK;
+-  int binary_option;
+ 
+   /* Add the user name as an environment variable if it
+      was given on the command line */
+   if(data->state.aptr.user) {
+-    msnprintf(option_arg, sizeof(option_arg), "USER,%s", conn->user);
+-    beg = curl_slist_append(tn->telnet_vars, option_arg);
++    char buffer[256];
++    msnprintf(buffer, sizeof(buffer), "USER,%s", data->conn->user);
++    beg = curl_slist_append(tn->telnet_vars, buffer);
+     if(!beg) {
+       curl_slist_free_all(tn->telnet_vars);
+       tn->telnet_vars = NULL;
+@@ -795,68 +792,89 @@ static CURLcode check_telnet_options(struct Curl_easy *data)
+     tn->us_preferred[CURL_TELOPT_NEW_ENVIRON] = CURL_YES;
+   }
+ 
+-  for(head = data->set.telnet_options; head; head = head->next) {
+-    if(sscanf(head->data, "%127[^= ]%*[ =]%255s",
+-              option_keyword, option_arg) == 2) {
+-
+-      /* Terminal type */
+-      if(strcasecompare(option_keyword, "TTYPE")) {
+-        strncpy(tn->subopt_ttype, option_arg, 31);
+-        tn->subopt_ttype[31] = 0; /* String termination */
+-        tn->us_preferred[CURL_TELOPT_TTYPE] = CURL_YES;
+-        continue;
+-      }
++  for(head = data->set.telnet_options; head && !result; head = head->next) {
++    size_t olen;
++    char *option = head->data;
++    char *arg;
++    char *sep = strchr(option, '=');
++    if(sep) {
++      olen = sep - option;
++      arg = ++sep;
++      switch(olen) {
++      case 5:
++        /* Terminal type */
++        if(strncasecompare(option, "TTYPE", 5)) {
++          strncpy(tn->subopt_ttype, arg, 31);
++          tn->subopt_ttype[31] = 0; /* String termination */
++          tn->us_preferred[CURL_TELOPT_TTYPE] = CURL_YES;
++        }
++        else
++          result = CURLE_UNKNOWN_OPTION;
++        break;
+ 
+-      /* Display variable */
+-      if(strcasecompare(option_keyword, "XDISPLOC")) {
+-        strncpy(tn->subopt_xdisploc, option_arg, 127);
+-        tn->subopt_xdisploc[127] = 0; /* String termination */
+-        tn->us_preferred[CURL_TELOPT_XDISPLOC] = CURL_YES;
+-        continue;
+-      }
++      case 8:
++        /* Display variable */
++        if(strncasecompare(option, "XDISPLOC", 8)) {
++          strncpy(tn->subopt_xdisploc, arg, 127);
++          tn->subopt_xdisploc[127] = 0; /* String termination */
++          tn->us_preferred[CURL_TELOPT_XDISPLOC] = CURL_YES;
++        }
++        else
++          result = CURLE_UNKNOWN_OPTION;
++        break;
+ 
+-      /* Environment variable */
+-      if(strcasecompare(option_keyword, "NEW_ENV")) {
+-        beg = curl_slist_append(tn->telnet_vars, option_arg);
+-        if(!beg) {
+-          result = CURLE_OUT_OF_MEMORY;
+-          break;
++      case 7:
++        /* Environment variable */
++        if(strncasecompare(option, "NEW_ENV", 7)) {
++          beg = curl_slist_append(tn->telnet_vars, arg);
++          if(!beg) {
++            result = CURLE_OUT_OF_MEMORY;
++            break;
++          }
++          tn->telnet_vars = beg;
++          tn->us_preferred[CURL_TELOPT_NEW_ENVIRON] = CURL_YES;
+         }
+-        tn->telnet_vars = beg;
+-        tn->us_preferred[CURL_TELOPT_NEW_ENVIRON] = CURL_YES;
+-        continue;
+-      }
++        else
++          result = CURLE_UNKNOWN_OPTION;
++        break;
+ 
+-      /* Window Size */
+-      if(strcasecompare(option_keyword, "WS")) {
+-        if(sscanf(option_arg, "%hu%*[xX]%hu",
+-                  &tn->subopt_wsx, &tn->subopt_wsy) == 2)
+-          tn->us_preferred[CURL_TELOPT_NAWS] = CURL_YES;
+-        else {
+-          failf(data, "Syntax error in telnet option: %s", head->data);
+-          result = CURLE_SETOPT_OPTION_SYNTAX;
+-          break;
++      case 2:
++        /* Window Size */
++        if(strncasecompare(option, "WS", 2)) {
++          if(sscanf(arg, "%hu%*[xX]%hu",
++                    &tn->subopt_wsx, &tn->subopt_wsy) == 2)
++            tn->us_preferred[CURL_TELOPT_NAWS] = CURL_YES;
++          else {
++            failf(data, "Syntax error in telnet option: %s", head->data);
++            result = CURLE_SETOPT_OPTION_SYNTAX;
++          }
+         }
+-        continue;
+-      }
++        else
++          result = CURLE_UNKNOWN_OPTION;
++        break;
+ 
+-      /* To take care or not of the 8th bit in data exchange */
+-      if(strcasecompare(option_keyword, "BINARY")) {
+-        binary_option = atoi(option_arg);
+-        if(binary_option != 1) {
+-          tn->us_preferred[CURL_TELOPT_BINARY] = CURL_NO;
+-          tn->him_preferred[CURL_TELOPT_BINARY] = CURL_NO;
++      case 6:
++        /* To take care or not of the 8th bit in data exchange */
++        if(strncasecompare(option, "BINARY", 6)) {
++          int binary_option = atoi(arg);
++          if(binary_option != 1) {
++            tn->us_preferred[CURL_TELOPT_BINARY] = CURL_NO;
++            tn->him_preferred[CURL_TELOPT_BINARY] = CURL_NO;
++          }
+         }
+-        continue;
++        else
++          result = CURLE_UNKNOWN_OPTION;
++        break;
++      default:
++        failf(data, "Unknown telnet option %s", head->data);
++        result = CURLE_UNKNOWN_OPTION;
++        break;
+       }
+-
+-      failf(data, "Unknown telnet option %s", head->data);
+-      result = CURLE_UNKNOWN_OPTION;
+-      break;
+     }
+-    failf(data, "Syntax error in telnet option: %s", head->data);
+-    result = CURLE_SETOPT_OPTION_SYNTAX;
+-    break;
++    else {
++      failf(data, "Syntax error in telnet option: %s", head->data);
++      result = CURLE_SETOPT_OPTION_SYNTAX;
++    }
+   }
+ 
+   if(result) {
+-- 
+2.39.2
+
+
+From 385d95cf6ae0f123ca413fa7e27b4518b418cb65 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 6 Mar 2023 12:07:33 +0100
+Subject: [PATCH 2/2] telnet: only accept option arguments in ascii
+
+To avoid embedded telnet negotiation commands etc.
+
+Reported-by: Harry Sintonen
+Closes #10728
+---
+ lib/telnet.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/lib/telnet.c b/lib/telnet.c
+index b60e8aa0f..5a6bab64b 100644
+--- a/lib/telnet.c
++++ b/lib/telnet.c
+@@ -770,6 +770,17 @@ static void printsub(struct Curl_easy *data,
+   }
+ }
+ 
++static bool str_is_nonascii(const char *str)
++{
++  size_t len = strlen(str);
++  while(len--) {
++    if(*str & 0x80)
++      return TRUE;
++    str++;
++  }
++  return FALSE;
++}
++
+ static CURLcode check_telnet_options(struct Curl_easy *data)
+ {
+   struct curl_slist *head;
+@@ -781,6 +792,8 @@ static CURLcode check_telnet_options(struct Curl_easy *data)
+      was given on the command line */
+   if(data->state.aptr.user) {
+     char buffer[256];
++    if(str_is_nonascii(data->conn->user))
++      return CURLE_BAD_FUNCTION_ARGUMENT;
+     msnprintf(buffer, sizeof(buffer), "USER,%s", data->conn->user);
+     beg = curl_slist_append(tn->telnet_vars, buffer);
+     if(!beg) {
+@@ -800,6 +813,8 @@ static CURLcode check_telnet_options(struct Curl_easy *data)
+     if(sep) {
+       olen = sep - option;
+       arg = ++sep;
++      if(str_is_nonascii(arg))
++        continue;
+       switch(olen) {
+       case 5:
+         /* Terminal type */
+-- 
+2.39.2
+

--- a/pkgs/tools/networking/curl/CVE-2023-27534.patch
+++ b/pkgs/tools/networking/curl/CVE-2023-27534.patch
@@ -1,0 +1,119 @@
+From a26e05bfe7c59633ef1b2298223bd416d8a21759 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Thu, 9 Mar 2023 16:22:11 +0100
+Subject: [PATCH] curl_path: create the new path with dynbuf
+
+Closes #10729
+---
+ lib/curl_path.c | 71 ++++++++++++++++++++++++-------------------------
+ 1 file changed, 35 insertions(+), 36 deletions(-)
+
+diff --git a/lib/curl_path.c b/lib/curl_path.c
+index b55e83047..ad2deb095 100644
+--- a/lib/curl_path.c
++++ b/lib/curl_path.c
+@@ -32,66 +32,65 @@
+ #include "escape.h"
+ #include "memdebug.h"
+ 
++#define MAX_SSHPATH_LEN 100000 /* arbitrary */
++
+ /* figure out the path to work with in this particular request */
+ CURLcode Curl_getworkingpath(struct Curl_easy *data,
+                              char *homedir,  /* when SFTP is used */
+                              char **path) /* returns the  allocated
+                                              real path to work with */
+ {
+-  char *real_path = NULL;
+   char *working_path;
+   size_t working_path_len;
++  struct dynbuf npath;
+   CURLcode result =
+     Curl_urldecode(data->state.up.path, 0, &working_path,
+                    &working_path_len, REJECT_ZERO);
+   if(result)
+     return result;
+ 
++  /* new path to switch to in case we need to */
++  Curl_dyn_init(&npath, MAX_SSHPATH_LEN);
++
+   /* Check for /~/, indicating relative to the user's home directory */
+-  if(data->conn->handler->protocol & CURLPROTO_SCP) {
+-    real_path = malloc(working_path_len + 1);
+-    if(!real_path) {
++  if((data->conn->handler->protocol & CURLPROTO_SCP) &&
++     (working_path_len > 3) && (!memcmp(working_path, "/~/", 3))) {
++    /* It is referenced to the home directory, so strip the leading '/~/' */
++    if(Curl_dyn_addn(&npath, &working_path[3], working_path_len - 3)) {
+       free(working_path);
+       return CURLE_OUT_OF_MEMORY;
+     }
+-    if((working_path_len > 3) && (!memcmp(working_path, "/~/", 3)))
+-      /* It is referenced to the home directory, so strip the leading '/~/' */
+-      memcpy(real_path, working_path + 3, working_path_len - 2);
+-    else
+-      memcpy(real_path, working_path, 1 + working_path_len);
+   }
+-  else if(data->conn->handler->protocol & CURLPROTO_SFTP) {
+-    if((working_path_len > 1) && (working_path[1] == '~')) {
+-      size_t homelen = strlen(homedir);
+-      real_path = malloc(homelen + working_path_len + 1);
+-      if(!real_path) {
+-        free(working_path);
+-        return CURLE_OUT_OF_MEMORY;
+-      }
+-      /* It is referenced to the home directory, so strip the
+-         leading '/' */
+-      memcpy(real_path, homedir, homelen);
+-      real_path[homelen] = '/';
+-      real_path[homelen + 1] = '\0';
+-      if(working_path_len > 3) {
+-        memcpy(real_path + homelen + 1, working_path + 3,
+-               1 + working_path_len -3);
+-      }
++  else if((data->conn->handler->protocol & CURLPROTO_SFTP) &&
++          (working_path_len > 2) && !memcmp(working_path, "/~/", 3)) {
++    size_t len;
++    const char *p;
++    int copyfrom = 3;
++    if(Curl_dyn_add(&npath, homedir)) {
++      free(working_path);
++      return CURLE_OUT_OF_MEMORY;
+     }
+-    else {
+-      real_path = malloc(working_path_len + 1);
+-      if(!real_path) {
+-        free(working_path);
+-        return CURLE_OUT_OF_MEMORY;
+-      }
+-      memcpy(real_path, working_path, 1 + working_path_len);
++    /* Copy a separating '/' if homedir does not end with one */
++    len = Curl_dyn_len(&npath);
++    p = Curl_dyn_ptr(&npath);
++    if(len && (p[len-1] != '/'))
++      copyfrom = 2;
++
++    if(Curl_dyn_addn(&npath,
++                     &working_path[copyfrom], working_path_len - copyfrom)) {
++      free(working_path);
++      return CURLE_OUT_OF_MEMORY;
+     }
+   }
+ 
+-  free(working_path);
++  if(Curl_dyn_len(&npath)) {
++    free(working_path);
+ 
+-  /* store the pointer for the caller to receive */
+-  *path = real_path;
++    /* store the pointer for the caller to receive */
++    *path = Curl_dyn_ptr(&npath);
++  }
++  else
++    *path = working_path;
+ 
+   return CURLE_OK;
+ }
+-- 
+2.39.2
+

--- a/pkgs/tools/networking/curl/CVE-2023-27535.patch
+++ b/pkgs/tools/networking/curl/CVE-2023-27535.patch
@@ -1,0 +1,165 @@
+From 7046191b5b956d2ff028f02da5d2c558bda33c46 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Thu, 9 Mar 2023 17:47:06 +0100
+Subject: [PATCH] ftp: add more conditions for connection reuse
+
+Reported-by: Harry Sintonen
+Closes #10730
+---
+ lib/ftp.c     | 29 +++++++++++++++++++++++++++--
+ lib/ftp.h     |  5 +++++
+ lib/setopt.c  |  2 +-
+ lib/url.c     | 17 +++++++++++++++--
+ lib/urldata.h |  4 ++--
+ 5 files changed, 50 insertions(+), 7 deletions(-)
+
+diff --git a/lib/ftp.c b/lib/ftp.c
+index f1a25b23d..9e8ccd54d 100644
+--- a/lib/ftp.c
++++ b/lib/ftp.c
+@@ -4107,6 +4107,8 @@ static CURLcode ftp_disconnect(struct Curl_easy *data,
+   }
+ 
+   freedirs(ftpc);
++  Curl_safefree(ftpc->account);
++  Curl_safefree(ftpc->alternative_to_user);
+   Curl_safefree(ftpc->prevpath);
+   Curl_safefree(ftpc->server_os);
+   Curl_pp_disconnect(pp);
+@@ -4374,11 +4376,32 @@ static CURLcode ftp_setup_connection(struct Curl_easy *data,
+ {
+   char *type;
+   struct FTP *ftp;
++  CURLcode result = CURLE_OK;
++  struct ftp_conn *ftpc = &conn->proto.ftpc;
+ 
+-  data->req.p.ftp = ftp = calloc(sizeof(struct FTP), 1);
++  ftp = calloc(sizeof(struct FTP), 1);
+   if(!ftp)
+     return CURLE_OUT_OF_MEMORY;
+ 
++  /* clone connection related data that is FTP specific */
++  if(data->set.str[STRING_FTP_ACCOUNT]) {
++    ftpc->account = strdup(data->set.str[STRING_FTP_ACCOUNT]);
++    if(!ftpc->account) {
++      free(ftp);
++      return CURLE_OUT_OF_MEMORY;
++    }
++  }
++  if(data->set.str[STRING_FTP_ALTERNATIVE_TO_USER]) {
++    ftpc->alternative_to_user =
++      strdup(data->set.str[STRING_FTP_ALTERNATIVE_TO_USER]);
++    if(!ftpc->alternative_to_user) {
++      Curl_safefree(ftpc->account);
++      free(ftp);
++      return CURLE_OUT_OF_MEMORY;
++    }
++  }
++  data->req.p.ftp = ftp;
++
+   ftp->path = &data->state.up.path[1]; /* don't include the initial slash */
+ 
+   /* FTP URLs support an extension like ";type=<typecode>" that
+@@ -4413,7 +4436,9 @@ static CURLcode ftp_setup_connection(struct Curl_easy *data,
+   /* get some initial data into the ftp struct */
+   ftp->transfer = PPTRANSFER_BODY;
+   ftp->downloadsize = 0;
+-  conn->proto.ftpc.known_filesize = -1; /* unknown size for now */
++  ftpc->known_filesize = -1; /* unknown size for now */
++  ftpc->use_ssl = data->set.use_ssl;
++  ftpc->ccc = data->set.ftp_ccc;
+ 
+   return CURLE_OK;
+ }
+diff --git a/lib/ftp.h b/lib/ftp.h
+index 7f6f4328d..12061a334 100644
+--- a/lib/ftp.h
++++ b/lib/ftp.h
+@@ -119,6 +119,8 @@ struct FTP {
+    struct */
+ struct ftp_conn {
+   struct pingpong pp;
++  char *account;
++  char *alternative_to_user;
+   char *entrypath; /* the PWD reply when we logged on */
+   char *file;    /* url-decoded file name (or path) */
+   char **dirs;   /* realloc()ed array for path components */
+@@ -153,6 +155,9 @@ struct ftp_conn {
+   curl_off_t known_filesize; /* file size is different from -1, if wildcard
+                                 LIST parsing was done and wc_statemach set
+                                 it */
++  unsigned char use_ssl;   /* if AUTH TLS is to be attempted etc, for FTP or
++                              IMAP or POP3 or others! (type: curl_usessl)*/
++  unsigned char ccc;       /* ccc level for this connection */
+   BIT(ftp_trying_alternative);
+ };
+ 
+diff --git a/lib/setopt.c b/lib/setopt.c
+index f7029be67..dd80b7017 100644
+--- a/lib/setopt.c
++++ b/lib/setopt.c
+@@ -2342,7 +2342,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
+     arg = va_arg(param, long);
+     if((arg < CURLUSESSL_NONE) || (arg >= CURLUSESSL_LAST))
+       return CURLE_BAD_FUNCTION_ARGUMENT;
+-    data->set.use_ssl = (curl_usessl)arg;
++    data->set.use_ssl = (unsigned char)arg;
+     break;
+ 
+   case CURLOPT_SSL_OPTIONS:
+diff --git a/lib/url.c b/lib/url.c
+index a9847e890..9164f9f5d 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -1379,11 +1379,24 @@ ConnectionExists(struct Curl_easy *data,
+          (check->httpversion >= 20) &&
+          (data->state.httpwant < CURL_HTTP_VERSION_2_0))
+         continue;
+-
+-      if(get_protocol_family(needle->handler) == PROTO_FAMILY_SSH) {
++#ifdef USE_SSH
++      else if(get_protocol_family(needle->handler) == PROTO_FAMILY_SSH) {
+         if(!ssh_config_matches(needle, check))
+           continue;
+       }
++#endif
++#ifndef CURL_DISABLE_FTP
++      else if(get_protocol_family(needle->handler) & PROTO_FAMILY_FTP) {
++        /* Also match ACCOUNT, ALTERNATIVE-TO-USER, USE_SSL and CCC options */
++        if(Curl_timestrcmp(needle->proto.ftpc.account,
++                           check->proto.ftpc.account) ||
++           Curl_timestrcmp(needle->proto.ftpc.alternative_to_user,
++                           check->proto.ftpc.alternative_to_user) ||
++           (needle->proto.ftpc.use_ssl != check->proto.ftpc.use_ssl) ||
++           (needle->proto.ftpc.ccc != check->proto.ftpc.ccc))
++          continue;
++      }
++#endif
+ 
+       if((needle->handler->flags&PROTOPT_SSL)
+ #ifndef CURL_DISABLE_PROXY
+diff --git a/lib/urldata.h b/lib/urldata.h
+index ee230ac5b..f10858b15 100644
+--- a/lib/urldata.h
++++ b/lib/urldata.h
+@@ -1786,8 +1786,6 @@ struct UserDefined {
+ #ifndef CURL_DISABLE_NETRC
+   unsigned char use_netrc;        /* enum CURL_NETRC_OPTION values  */
+ #endif
+-  curl_usessl use_ssl;   /* if AUTH TLS is to be attempted etc, for FTP or
+-                            IMAP or POP3 or others! */
+   unsigned int new_file_perms;      /* when creating remote files */
+   unsigned int new_directory_perms; /* when creating remote dirs */
+   int ssh_auth_types;    /* allowed SSH auth types */
+@@ -1846,6 +1844,8 @@ struct UserDefined {
+   BIT(mail_rcpt_allowfails); /* allow RCPT TO command to fail for some
+                                 recipients */
+ #endif
++  unsigned char use_ssl;   /* if AUTH TLS is to be attempted etc, for FTP or
++                              IMAP or POP3 or others! (type: curl_usessl)*/
+   unsigned char connect_only; /* make connection/request, then let
+                                  application use the socket */
+   BIT(is_fread_set); /* has read callback been set to non-NULL? */
+-- 
+2.39.2
+

--- a/pkgs/tools/networking/curl/CVE-2023-27536.patch
+++ b/pkgs/tools/networking/curl/CVE-2023-27536.patch
@@ -1,0 +1,51 @@
+From 218d2b05c12d80649276e455c9c81e88494c48eb Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Fri, 10 Mar 2023 09:22:43 +0100
+Subject: [PATCH] url: only reuse connections with same GSS delegation
+
+Reported-by: Harry Sintonen
+Closes #10731
+---
+ lib/url.c     | 6 ++++++
+ lib/urldata.h | 1 +
+ 2 files changed, 7 insertions(+)
+
+diff --git a/lib/url.c b/lib/url.c
+index af7045998..9164f9f5d 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -1368,6 +1368,11 @@ ConnectionExists(struct Curl_easy *data,
+         }
+       }
+ 
++      /* GSS delegation differences do not actually affect every connection
++         and auth method, but this check takes precaution before efficiency */
++      if(needle->gssapi_delegation != check->gssapi_delegation)
++        continue;
++
+       /* If multiplexing isn't enabled on the h2 connection and h1 is
+          explicitly requested, handle it: */
+       if((needle->handler->protocol & PROTO_FAMILY_HTTP) &&
+@@ -1836,6 +1841,7 @@ static struct connectdata *allocate_conn(struct Curl_easy *data)
+   conn->fclosesocket = data->set.fclosesocket;
+   conn->closesocket_client = data->set.closesocket_client;
+   conn->lastused = Curl_now(); /* used now */
++  conn->gssapi_delegation = data->set.gssapi_delegation;
+ 
+   return conn;
+   error:
+diff --git a/lib/urldata.h b/lib/urldata.h
+index e6d030e58..aaae3d8d8 100644
+--- a/lib/urldata.h
++++ b/lib/urldata.h
+@@ -1152,6 +1152,7 @@ struct connectdata {
+   unsigned char ip_version; /* copied from the Curl_easy at creation time */
+   unsigned char httpversion; /* the HTTP version*10 reported by the server */
+   unsigned char connect_only;
++  unsigned char gssapi_delegation; /* inherited from set.gssapi_delegation */
+ };
+ 
+ /* The end of connectdata. */
+-- 
+2.39.2
+

--- a/pkgs/tools/networking/curl/CVE-2023-27537.patch
+++ b/pkgs/tools/networking/curl/CVE-2023-27537.patch
@@ -1,0 +1,37 @@
+From 8cb54e6c5f164bb878da15000adf1083e2fed3dc Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Thu, 9 Mar 2023 18:01:34 +0100
+Subject: [PATCH] CURLSHOPT_SHARE.3: HSTS sharing is not thread-safe
+
+Reported-by: Hiroki Kurosawa
+Closes #10732
+---
+ docs/libcurl/opts/CURLSHOPT_SHARE.3 | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/docs/libcurl/opts/CURLSHOPT_SHARE.3 b/docs/libcurl/opts/CURLSHOPT_SHARE.3
+index 78593b632..e88a8e7b2 100644
+--- a/docs/libcurl/opts/CURLSHOPT_SHARE.3
++++ b/docs/libcurl/opts/CURLSHOPT_SHARE.3
+@@ -56,8 +56,7 @@ implemented until 7.23.0.
+ Put the connection cache in the share object and make all easy handles using
+ this share object share the connection cache.
+ 
+-Note that due to a known bug, it is not safe to share connections this way
+-between multiple concurrent threads.
++It is not supported to share connections between multiple concurrent threads.
+ 
+ Connections that are used for HTTP/1.1 Pipelining or HTTP/2 multiplexing only
+ get additional transfers added to them if the existing connection is held by
+@@ -81,6 +80,8 @@ multi handle will share PSL cache by default without using this option.
+ .IP CURL_LOCK_DATA_HSTS
+ The in-memory HSTS cache.
+ 
++It is not supported to share the HSTS between multiple concurrent threads.
++
+ Added in 7.88.0
+ .SH PROTOCOLS
+ All
+-- 
+2.39.2
+

--- a/pkgs/tools/networking/curl/CVE-2023-27538.patch
+++ b/pkgs/tools/networking/curl/CVE-2023-27538.patch
@@ -1,0 +1,27 @@
+From 6c9eb51e7024c8517e42a0c5ea6e8233eb8d25c4 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Fri, 10 Mar 2023 08:22:51 +0100
+Subject: [PATCH] url: fix the SSH connection reuse check
+
+Reported-by: Harry Sintonen
+Closes #10735
+---
+ lib/url.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/url.c b/lib/url.c
+index 9164f9f5d..a3626afa7 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -1380,7 +1380,7 @@ ConnectionExists(struct Curl_easy *data,
+          (data->state.httpwant < CURL_HTTP_VERSION_2_0))
+         continue;
+ #ifdef USE_SSH
+-      else if(get_protocol_family(needle->handler) == PROTO_FAMILY_SSH) {
++      if(get_protocol_family(needle->handler) & PROTO_FAMILY_SSH) {
+         if(!ssh_config_matches(needle, check))
+           continue;
+       }
+-- 
+2.39.2
+

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -59,10 +59,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./7.79.1-darwin-no-systemconfiguration.patch
+    # curl 7.86.0 fixes
     ./CVE-2022-43551.patch
     ./CVE-2022-43552.patch
+    # curl 7.88.0 fixes
     ./CVE-2023-23915.patch # also fixes CVE-2023-23914
     ./CVE-2023-23916.patch
+    # curl 8.0.0 fixes
+    ./CVE-2023-27533.patch
+    ./CVE-2023-27534.patch
+    ./CVE-2023-27535.patch
+    ./CVE-2023-27536.patch
+    ./CVE-2023-27537.patch
+    ./CVE-2023-27538.patch
   ];
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];


### PR DESCRIPTION
###### Description of changes

https://daniel.haxx.se/blog/2023/03/20/curl-8-0-0-is-here/

Fixes: CVE-2023-27533, CVE-2023-27534, CVE-2023-27535, CVE-2023-27536,
       CVE-2023-27537, CVE-2023-27538


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
