### PR TITLE
fetchpatch: add fetchpatchVersion to have version in function result …

### DIFF
--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -4,7 +4,7 @@
 # often change with updating of git or cgit.
 # stripLen acts as the -p parameter when applying a patch.
 
-{ lib, fetchurl, patchutils }:
+{ lib, fetchurl, patchutils, fetchpatchVersion }:
 
 { relative ? null
 , stripLen ? 0
@@ -14,6 +14,7 @@
 , includes ? []
 , revert ? false
 , postFetch ? ""
+, passthru ? {}
 , ...
 }@args:
 let
@@ -87,7 +88,10 @@ fetchurl ({
     ${patchutils}/bin/interdiff "$out" /dev/null > "$tmpfile"
     mv "$tmpfile" "$out"
   '' + postFetch;
+
+  passthru = { inherit fetchpatchVersion; } // passthru;
+
 } // builtins.removeAttrs args [
   "relative" "stripLen" "decode" "extraPrefix" "excludes" "includes" "revert"
-  "postFetch"
+  "postFetch" "passthru"
 ])

--- a/pkgs/build-support/fetchpatch/tests.nix
+++ b/pkgs/build-support/fetchpatch/tests.nix
@@ -1,7 +1,7 @@
 { testers, fetchpatch, ... }:
 
 let
-  isFetchpatch2 = fetchpatch.version == 2;
+  isFetchpatch2 = fetchpatch.fetchpatchVersion == 2;
 in
 
 {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -870,16 +870,20 @@ with pkgs;
   fetchpatch = callPackage ../build-support/fetchpatch {
     # 0.3.4 would change hashes: https://github.com/NixOS/nixpkgs/issues/25154
     patchutils = buildPackages.patchutils_0_3_3;
+    fetchpatchVersion = 1;
   } // {
     tests = pkgs.tests.fetchpatch;
-    version = 1;
+    # must be duplicated to have the version in the function result and the function
+    fetchpatchVersion = 1;
   };
 
   fetchpatch2 = callPackage ../build-support/fetchpatch {
     patchutils = buildPackages.patchutils_0_4_2;
+    fetchpatchVersion = 2;
   } // {
     tests = pkgs.tests.fetchpatch2;
-    version = 2;
+    # must be duplicated to have the version in the function result and the function
+    fetchpatchVersion = 2;
   };
 
   fetchs3 = callPackage ../build-support/fetchs3 { };


### PR DESCRIPTION
…and function

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
