### PR TITLE
gitea-actions-runner: unstable-2023-02-08 -> unstable-2023-03-18

### DIFF
--- a/pkgs/development/tools/continuous-integration/gitea-actions-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitea-actions-runner/default.nix
@@ -2,17 +2,23 @@
 
 buildGoModule rec {
   pname = "gitea-actions-runner";
-  version = "unstable-2023-02-08";
+  version = "unstable-2023-03-18";
 
   src = fetchFromGitea {
     domain = "gitea.com";
     owner = "gitea";
     repo = "act_runner";
-    rev = "990cf93c7136669408eb1832cd05df3ad4dd81b3";
-    sha256 = "1ysp7g199dzh1zpxxhki88pn96qghln7a5g8zfjip9173q1rgiyb";
+    rev = "9eb8b08a69e8b1c699c9c07a06c1ff8e5f6ad0fe";
+    sha256 = "sha256-B8vD+86X8cqZhPmDmEjHgSsq3TdJuCf9h3XgdXC7hQY=";
   };
 
-  vendorSha256 = "0a3q7rsk37dc6v3vnqaywkimaqvyjmkrwljhcjcnswsdfcgng62b";
+  vendorSha256 = "sha256-K/d/ip8icc+rjTmajsGxw5aij1VMW6wJJu4LCkKqaVQ=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X gitea.com/gitea/act_runner/cmd.version=${version}"
+  ];
 
   meta = with lib; {
     mainProgram = "act_runner";


### PR DESCRIPTION
###### Description of changes

Updates gitea-actions-runner.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
