### PR TITLE
cogl: Add missing patch decompression

### DIFF
--- a/pkgs/development/libraries/cogl/default.nix
+++ b/pkgs/development/libraries/cogl/default.nix
@@ -41,11 +41,13 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       url = "https://bug787443.bugzilla-attachments.gnome.org/attachment.cgi?id=359589";
       sha256 = "0f0d9iddg8zwy853phh7swikg4yzhxxv71fcag36f8gis0j5p998";
+      decode = "xz -d";
     })
 
     (fetchpatch {
       url = "https://bug787443.bugzilla-attachments.gnome.org/attachment.cgi?id=361056";
       sha256 = "09fyrdci4727fg6qm5aaapsbv71sf4wgfaqz8jqlyy61dibgg490";
+      decode = "xz -d";
     })
   ];
 


### PR DESCRIPTION
It appears that the Bugzilla server started delivering compressed attachments at some point.

###### Description of changes

Use recently added capability to pass patch content through an intermediate program, in this case to decompress it using `xz`. As I'm new to nix, not sure if `xz` needs to be added as an explicit dependency or not.

This change *should probably be backported* since otherwise uncached builds of `cogl` fail due to Gnome Bugzilla server behavioral change.

Sparked from https://discourse.nixos.org/t/normalized-patch-is-empty/26122

Related PR: https://github.com/NixOS/nixpkgs/pull/133604

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).