### PR TITLE
crc: 2.14.0 -> 2.15.0

### DIFF
--- a/pkgs/applications/networking/cluster/crc/default.nix
+++ b/pkgs/applications/networking/cluster/crc/default.nix
@@ -10,25 +10,26 @@
 }:
 
 let
-  openShiftVersion = "4.12.1";
-  okdVersion = "4.11.0-0.okd-2022-11-05-030711";
+  openShiftVersion = "4.12.5";
+  okdVersion = "4.12.0-0.okd-2023-02-18-033438";
   podmanVersion = "4.3.1";
   writeKey = "cvpHsNcmGCJqVzf6YxrSnVlwFSAZaYtp";
+  gitHash = "sha256-zk/26cG2Rt3jpbhKgprtq2vx7pIQVi7cPUA90uoQa80=";
 in
 buildGoModule rec {
-  version = "2.14.0";
+  version = "2.15.0";
   pname = "crc";
-  gitCommit = "868d96cd4f73dad72df54475c52c65f9741dc240";
+  gitCommit = "72256c3cb00ac01519b26658dd5cfb0dd09b37a1";
   modRoot = "cmd/crc";
 
   src = fetchFromGitHub {
     owner = "crc-org";
     repo = "crc";
     rev = "v${version}";
-    sha256 = "sha256-q1OJJTveXoNzW9lohQOY7LVR3jOyiQZX5nHBgRupxTM=";
+    hash = gitHash;
   };
 
-  vendorSha256 = null;
+  vendorHash = null;
 
   nativeBuildInputs = [ git ];
 

--- a/pkgs/applications/networking/cluster/crc/update.sh
+++ b/pkgs/applications/networking/cluster/crc/update.sh
@@ -25,6 +25,9 @@ CRC_COMMIT=$(curl --silent ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
     https://api.github.com/repos/crc-org/crc/tags |
     jq -r "map(select(.name == \"${LATEST_TAG_NAME}\")) | .[0] | .commit.sha")
 
+CRC_GIT_PREFETCH=$(nix-prefetch-url --unpack https://github.com/crc-org/crc/archive/${CRC_COMMIT}.tar.gz)
+CRC_GIT_HASH=$(nix hash to-sri --type sha256 ${CRC_GIT_PREFETCH})
+
 FILE_MAKEFILE=${WORKDIR}/Makefile
 curl --silent https://raw.githubusercontent.com/crc-org/crc/${CRC_COMMIT}/Makefile >$FILE_MAKEFILE
 
@@ -44,6 +47,9 @@ sed -i "s|version = \".*\"|version = \"${CRC_VERSION:-}\"|" \
     ${NIXPKGS_CRC_FOLDER}/default.nix
 
 sed -i "s|gitCommit = \".*\"|gitCommit = \"${CRC_COMMIT:-}\"|" \
+    ${NIXPKGS_CRC_FOLDER}/default.nix
+
+sed -i "s|gitHash = \".*\"|gitHash = \"${CRC_GIT_HASH}\"|" \
     ${NIXPKGS_CRC_FOLDER}/default.nix
 
 sed -i "s|openShiftVersion = \".*\"|openShiftVersion = \"${OPENSHIFT_VERSION:-}\"|" \


### PR DESCRIPTION
###### Description of changes

<https://github.com/crc-org/crc/releases/v2.15.0>

This change also updates the `update.sh` script in a separate commit to fix an issue with the git hash not being updated as found in https://github.com/NixOS/nixpkgs/pull/217528

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).