### PR TITLE
llvmPackages_git.llvm: run the tests on macOS

### DIFF
--- a/pkgs/development/compilers/llvm/git/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/git/llvm/default.nix
@@ -16,9 +16,10 @@
 , release_version
 , zlib
 , which
+, sysctl
 , buildLlvmTools
 , debugVersion ? false
-, doCheck ? stdenv.isLinux && (!stdenv.isx86_32) && (!stdenv.hostPlatform.isMusl)
+, doCheck ? (!stdenv.isx86_32 /* TODO: why */) && (!stdenv.hostPlatform.isMusl)
   && (stdenv.hostPlatform == stdenv.buildPlatform)
 , enableManpages ? false
 , enableSharedLibraries ? !stdenv.hostPlatform.isStatic
@@ -85,11 +86,59 @@ in stdenv.mkDerivation (rec {
 
   propagatedBuildInputs = [ ncurses zlib ];
 
-  nativeCheckInputs = [ which ];
+  nativeCheckInputs = [
+    which
+  ] ++ lib.optional stdenv.isDarwin sysctl;
 
   patches = [
     ./gnu-install-dirs.patch
-  ] ++ lib.optional enablePolly ./gnu-install-dirs-polly.patch;
+
+    # Running the tests involves invoking binaries (like `opt`) that depend on
+    # the LLVM dylibs and reference them by absolute install path (i.e. their
+    # nix store path).
+    #
+    # Because we have not yet run the install phase (we're running these tests
+    # as part of `checkPhase` instead of `installCheckPhase`) these absolute
+    # paths do not exist yet; to work around this we point the loader (`ld` on
+    # unix, `dyld` on macOS) at the `lib` directory which will later become this
+    # package's `lib` output.
+    #
+    # Previously we would just set `LD_LIBRARY_PATH` to include the build `lib`
+    # dir but:
+    #   - this doesn't generalize well to other platforms; `lit` doesn't forward
+    #     `DYLD_LIBRARY_PATH` (macOS):
+    #     + https://github.com/llvm/llvm-project/blob/0d89963df354ee309c15f67dc47c8ab3cb5d0fb2/llvm/utils/lit/lit/TestingConfig.py#L26
+    #   - even if `lit` forwarded this env var, we actually cannot set
+    #     `DYLD_LIBRARY_PATH` in the child processes `lit` launches because
+    #     `DYLD_LIBRARY_PATH` (and `DYLD_FALLBACK_LIBRARY_PATH`) is cleared for
+    #     "protected processes" (i.e. the python interpreter that runs `lit`):
+    #     https://stackoverflow.com/a/35570229
+    #   - other LLVM subprojects deal with this issue by having their `lit`
+    #     configuration set these env vars for us; it makes sense to do the same
+    #     for LLVM:
+    #     + https://github.com/llvm/llvm-project/blob/4c106cfdf7cf7eec861ad3983a3dd9a9e8f3a8ae/clang-tools-extra/test/Unit/lit.cfg.py#L22-L31
+    #
+    # !!! TODO: look into upstreaming this patch
+    ./llvm-lit-cfg-add-libs-to-dylib-path.patch
+
+    # `lit` has a mode where it executes run lines as a shell script which is
+    # constructs; this is problematic for macOS because it means that there's
+    # another process in between `lit` and the binaries being tested. As noted
+    # above, this means that `DYLD_LIBRARY_PATH` is cleared which means that our
+    # tests fail with dyld errors.
+    #
+    # To get around this we patch `lit` to reintroduce `DYLD_LIBRARY_PATH`, when
+    # present in the test configuration.
+    #
+    # It's not clear to me why this isn't an issue for LLVM developers running
+    # on macOS (nothing about this _seems_ nix specific)..
+    ./lit-shell-script-runner-set-dyld-library-path.patch
+  ] ++ lib.optionals enablePolly [
+    ./gnu-install-dirs-polly.patch
+
+    # Just like the `llvm-lit-cfg` patch, but for `polly`.
+    ./polly-lit-cfg-add-libs-to-dylib-path.patch
+  ];
 
   postPatch = optionalString stdenv.isDarwin ''
     substituteInPlace cmake/modules/AddLLVM.cmake \
@@ -132,12 +181,6 @@ in stdenv.mkDerivation (rec {
     cmakeFlagsArray+=(
       -DLLVM_LIT_ARGS="-svj''${NIX_BUILD_CORES} --no-progress-bar"
     )
-  '';
-
-  # hacky fix: created binaries need to be run before installation
-  preBuild = ''
-    mkdir -p $out/
-    ln -sv $PWD/lib $out
   '';
 
   # E.g. mesa.drivers use the build-id as a cache key (see #93946):
@@ -215,14 +258,6 @@ in stdenv.mkDerivation (rec {
       ])
     )
   ];
-
-  postBuild = ''
-    rm -fR $out
-  '';
-
-  preCheck = ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD/lib
-  '';
 
   postInstall = ''
     mkdir -p $python/share

--- a/pkgs/development/compilers/llvm/git/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/git/llvm/default.nix
@@ -4,6 +4,7 @@
 , runCommand
 , fetchpatch
 , cmake
+, darwin
 , ninja
 , python3
 , libffi
@@ -144,6 +145,14 @@ in stdenv.mkDerivation (rec {
     substituteInPlace cmake/modules/AddLLVM.cmake \
       --replace 'set(_install_name_dir INSTALL_NAME_DIR "@rpath")' "set(_install_name_dir)" \
       --replace 'set(_install_rpath "@loader_path/../''${CMAKE_INSTALL_LIBDIR}''${LLVM_LIBDIR_SUFFIX}" ''${extra_libdir})' ""
+    # As of LLVM 15, marked as XFAIL on arm64 macOS but lit doesn't seem to pick
+    # this up: https://github.com/llvm/llvm-project/blob/c344d97a125b18f8fed0a64aace73c49a870e079/llvm/test/MC/ELF/cfi-version.ll#L7
+    rm test/MC/ELF/cfi-version.ll
+
+    # This test tries to call `sw_vers` by absolute path (`/usr/bin/sw_vers`)
+    # thus fails under the sandbox:
+    substituteInPlace unittests/Support/Host.cpp \
+      --replace '/usr/bin/sw_vers' "${(builtins.toString darwin.DarwinTools) + "/bin/sw_vers" }"
   '' + ''
     # FileSystem permissions tests fail with various special bits
     substituteInPlace unittests/Support/CMakeLists.txt \

--- a/pkgs/development/compilers/llvm/git/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/git/llvm/default.nix
@@ -150,10 +150,59 @@ in stdenv.mkDerivation (rec {
     rm test/MC/ELF/cfi-version.ll
 
     # This test tries to call `sw_vers` by absolute path (`/usr/bin/sw_vers`)
-    # thus fails under the sandbox:
+    # and thus fails under the sandbox:
     substituteInPlace unittests/Support/Host.cpp \
       --replace '/usr/bin/sw_vers' "${(builtins.toString darwin.DarwinTools) + "/bin/sw_vers" }"
-  '' + ''
+   '' + optionalString (stdenv.isDarwin && stdenv.hostPlatform.isx86) ''
+    # This test tries to call the intrinsics `@llvm.roundeven.f32` and
+    # `@llvm.roundeven.f64` which seem to (incorrectly?) lower to `roundevenf`
+    # and `roundeven` on x86_64 macOS.
+    #
+    # However these functions are glibc specific so the test fails:
+    #   - https://www.gnu.org/software/gnulib/manual/html_node/roundevenf.html
+    #   - https://www.gnu.org/software/gnulib/manual/html_node/roundeven.html
+    #
+    # TODO(@rrbutani): this seems to run fine on `aarch64-darwin`, why does it
+    # pass there?
+    substituteInPlace test/ExecutionEngine/Interpreter/intrinsics.ll \
+      --replace "%roundeven32 = call float @llvm.roundeven.f32(float 0.000000e+00)" "" \
+      --replace "%roundeven64 = call double @llvm.roundeven.f64(double 0.000000e+00)" ""
+
+    # This test fails on darwin x86_64 because `sw_vers` reports a different
+    # macOS version than what LLVM finds by reading
+    # `/System/Library/CoreServices/SystemVersion.plist` (which is passed into
+    # the sandbox on macOS).
+    #
+    # The `sw_vers` provided by nixpkgs reports the macOS version associated
+    # with the `CoreFoundation` framework with which it was built. Because
+    # nixpkgs pins the SDK for `aarch64-darwin` and `x86_64-darwin` what
+    # `sw_vers` reports is not guaranteed to match the macOS version of the host
+    # that's building this derivation.
+    #
+    # Astute readers will note that we only _patch_ this test on aarch64-darwin
+    # (to use the nixpkgs provided `sw_vers`) instead of disabling it outright.
+    # So why does this test pass on aarch64?
+    #
+    # Well, it seems that `sw_vers` on aarch64 actually links against the _host_
+    # CoreFoundation framework instead of the nixpkgs provided one.
+    #
+    # Not entirely sure what the right fix is here. I'm assuming aarch64
+    # `sw_vers` doesn't intentionally link against the host `CoreFoundation`
+    # (still digging into how this ends up happening, will follow up) but that
+    # aside I think the more pertinent question is: should we be patching LLVM's
+    # macOS version detection logic to use `sw_vers` instead of reading host
+    # paths? This *is* a way in which details about builder machines can creep
+    # into the artifacts that are produced, affecting reproducibility, but it's
+    # not clear to me when/where/for what this even gets used in LLVM.
+    #
+    # TODO(@rrbutani): fix/follow-up
+    substituteInPlace unittests/Support/Host.cpp \
+      --replace "getMacOSHostVersion" "DISABLED_getMacOSHostVersion"
+
+    # This test fails with a `dysmutil` crash; have not yet dug into what's
+    # going on here (TODO(@rrbutani)).
+    rm test/tools/dsymutil/ARM/obfuscated.test
+    '' + ''
     # FileSystem permissions tests fail with various special bits
     substituteInPlace unittests/Support/CMakeLists.txt \
       --replace "Path.cpp" ""

--- a/pkgs/development/compilers/llvm/git/llvm/lit-shell-script-runner-set-dyld-library-path.patch
+++ b/pkgs/development/compilers/llvm/git/llvm/lit-shell-script-runner-set-dyld-library-path.patch
@@ -1,0 +1,26 @@
+diff --git a/utils/lit/lit/TestRunner.py b/utils/lit/lit/TestRunner.py
+index 0242e0b75af3..d732011306f7 100644
+--- a/utils/lit/lit/TestRunner.py
++++ b/utils/lit/lit/TestRunner.py
+@@ -1029,6 +1029,12 @@ def executeScript(test, litConfig, tmpBase, commands, cwd):
+             f.write('@echo off\n')
+         f.write('\n@if %ERRORLEVEL% NEQ 0 EXIT\n'.join(commands))
+     else:
++        # This env var is *purged* when invoking subprocesses so we have to
++        # manually set it from within the bash script in order for the commands
++        # in run lines to see this var:
++        if "DYLD_LIBRARY_PATH" in test.config.environment:
++            f.write(f'export DYLD_LIBRARY_PATH="{test.config.environment["DYLD_LIBRARY_PATH"]}"\n')
++
+         for i, ln in enumerate(commands):
+             match = re.match(kPdbgRegex, ln)
+             if match:
+@@ -1363,7 +1369,7 @@ def applySubstitutions(script, substitutions, conditions={},
+         return processed
+ 
+     process = processLine if recursion_limit is None else processLineToFixedPoint
+-    
++
+     return [unescapePercents(process(ln)) for ln in script]
+ 
+ 

--- a/pkgs/development/compilers/llvm/git/llvm/llvm-lit-cfg-add-libs-to-dylib-path.patch
+++ b/pkgs/development/compilers/llvm/git/llvm/llvm-lit-cfg-add-libs-to-dylib-path.patch
@@ -1,0 +1,79 @@
+diff --git a/test/Unit/lit.cfg.py b/test/Unit/lit.cfg.py
+index 81e8dc04acea..479ff95681e2 100644
+--- a/test/Unit/lit.cfg.py
++++ b/test/Unit/lit.cfg.py
+@@ -3,6 +3,7 @@
+ # Configuration file for the 'lit' test runner.
+ 
+ import os
++import platform
+ import subprocess
+ 
+ import lit.formats
+@@ -55,3 +56,26 @@ if sys.platform in ['win32', 'cygwin'] and os.path.isdir(config.shlibdir):
+ # Win32 may use %SYSTEMDRIVE% during file system shell operations, so propogate.
+ if sys.platform == 'win32' and 'SYSTEMDRIVE' in os.environ:
+     config.environment['SYSTEMDRIVE'] = os.environ['SYSTEMDRIVE']
++
++# Add the LLVM dynamic libs to the platform-specific loader search path env var:
++#
++# TODO: this is copied from `clang`'s `lit.cfg.py`; should unify..
++def find_shlibpath_var():
++    if platform.system() in ['Linux', 'FreeBSD', 'NetBSD', 'OpenBSD', 'SunOS']:
++        yield 'LD_LIBRARY_PATH'
++    elif platform.system() == 'Darwin':
++        yield 'DYLD_LIBRARY_PATH'
++    elif platform.system() == 'Windows':
++        yield 'PATH'
++    elif platform.system() == 'AIX':
++        yield 'LIBPATH'
++
++for shlibpath_var in find_shlibpath_var():
++    shlibpath = os.path.pathsep.join(
++        (config.shlibdir,
++         config.environment.get(shlibpath_var, '')))
++    config.environment[shlibpath_var] = shlibpath
++    break
++else:
++    lit_config.warning("unable to inject shared library path on '{}'"
++                       .format(platform.system()))
+diff --git a/test/lit.cfg.py b/test/lit.cfg.py
+index 75a38b4c5dad..856fc75c9d74 100644
+--- a/test/lit.cfg.py
++++ b/test/lit.cfg.py
+@@ -42,6 +42,26 @@ llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
+ llvm_config.with_system_environment(
+     ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])
+ 
++# Add the LLVM dynamic libs to the platform-specific loader search path env var:
++#
++# TODO: this is copied from `clang`'s `lit.cfg.py`; should unify..
++def find_shlibpath_var():
++    if platform.system() in ['Linux', 'FreeBSD', 'NetBSD', 'OpenBSD', 'SunOS']:
++        yield 'LD_LIBRARY_PATH'
++    elif platform.system() == 'Darwin':
++        yield 'DYLD_LIBRARY_PATH'
++    elif platform.system() == 'Windows':
++        yield 'PATH'
++    elif platform.system() == 'AIX':
++        yield 'LIBPATH'
++
++for shlibpath_var in find_shlibpath_var():
++    shlibpath = config.llvm_shlib_dir
++    llvm_config.with_environment(shlibpath_var, shlibpath, append_path = True)
++    break
++else:
++    lit_config.warning("unable to inject shared library path on '{}'"
++                       .format(platform.system()))
+ 
+ # Set up OCAMLPATH to include newly built OCaml libraries.
+ top_ocaml_lib = os.path.join(config.llvm_lib_dir, 'ocaml')
+@@ -318,7 +338,7 @@ def have_cxx_shared_library():
+ 
+     try:
+         readobj_cmd = subprocess.Popen(
+-            [readobj_exe, '--needed-libs', readobj_exe], stdout=subprocess.PIPE)
++            [readobj_exe, '--needed-libs', readobj_exe], stdout=subprocess.PIPE, env=config.environment)
+     except OSError:
+         print('could not exec llvm-readobj')
+         return False

--- a/pkgs/development/compilers/llvm/git/llvm/polly-lit-cfg-add-libs-to-dylib-path.patch
+++ b/pkgs/development/compilers/llvm/git/llvm/polly-lit-cfg-add-libs-to-dylib-path.patch
@@ -1,0 +1,24 @@
+diff --git a/tools/polly/test/lit.cfg b/tools/polly/test/lit.cfg
+index 41e3a589c61e..09f3b17498b0 100644
+--- a/tools/polly/test/lit.cfg
++++ b/tools/polly/test/lit.cfg
+@@ -36,9 +36,17 @@ base_paths = [config.llvm_tools_dir, config.environment['PATH']]
+ path = os.path.pathsep.join(base_paths + config.extra_paths)
+ config.environment['PATH'] = path
+ 
++# (Copied from polly/test/Unit/lit.cfg)
++if platform.system() == 'Darwin':
++    shlibpath_var = 'DYLD_LIBRARY_PATH'
++elif platform.system() == 'Windows':
++    shlibpath_var = 'PATH'
++else:
++    shlibpath_var = 'LD_LIBRARY_PATH'
++
+ path = os.path.pathsep.join((config.llvm_libs_dir,
+-                              config.environment.get('LD_LIBRARY_PATH','')))
+-config.environment['LD_LIBRARY_PATH'] = path
++                              config.environment.get(shlibpath_var,'')))
++config.environment[shlibpath_var] = path
+ 
+ llvm_config.use_default_substitutions()
+ 


### PR DESCRIPTION
###### Description of changes

Port of c7231c0b6d8 ("llvmPackages_15.llvm: run the tests on macOS").

The sysctl native check input was taken from
6d0c87602fe ("llvmPackages_15.llvm: add in a missing check dep"), because it looks like it was supposed to be part of c7231c0b6d8 instead.

New PR for #220759, which I rebased badly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
