### PR TITLE
python310Packages.certbot: 2.3.0 -> 2.4.0

### DIFF
--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -26,13 +26,13 @@
 
 buildPythonPackage rec {
   pname = "certbot";
-  version = "2.3.0";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-LhipH6kw/fKBy+nHrC5F7HtCdDbUWSjL85LiEC1bGT8=";
+    hash = "sha256-BQsdhlYABZtz5+SORiCVnWMZdMmiWGM9W1YLqObyFo8=";
   };
 
   sourceRoot = "source/${pname}";


### PR DESCRIPTION
###### Description of changes

This updates the certbot python package to version `2.4.0` which contains a fix to a deprecated call causing most of the certbot packages to not be buildable.

<details>
<summary>Example error here while trying to build `python311Packages.certbot-dns-google` :</summary>

```
==================================== ERRORS ====================================
_________ ERROR collecting certbot-dns-google/tests/dns_google_test.py _________
tests/dns_google_test.py:16: in <module>
    from certbot.plugins import dns_test_common
/nix/store/51gm8f9i29lzxcirsy9sip28m7wmryi7-python3.11-certbot-2.3.0/lib/python3.11/site-packages/certbot/plugins/dns_test_common.py:13: in <module>
    from certbot.plugins.dns_common import DNSAuthenticator
/nix/store/51gm8f9i29lzxcirsy9sip28m7wmryi7-python3.11-certbot-2.3.0/lib/python3.11/site-packages/certbot/plugins/dns_common.py:16: in <module>
    from certbot import configuration
/nix/store/51gm8f9i29lzxcirsy9sip28m7wmryi7-python3.11-certbot-2.3.0/lib/python3.11/site-packages/certbot/configuration.py:11: in <module>
    from certbot import util
/nix/store/51gm8f9i29lzxcirsy9sip28m7wmryi7-python3.11-certbot-2.3.0/lib/python3.11/site-packages/certbot/util.py:26: in <module>
    from certbot._internal import constants
/nix/store/51gm8f9i29lzxcirsy9sip28m7wmryi7-python3.11-certbot-2.3.0/lib/python3.11/site-packages/certbot/_internal/constants.py:6: in <module>
    import pkg_resources
/nix/store/jva4lzwjzby09h5mrlnv54jd8j21hcbx-python3.11-setuptools-67.4.0/lib/python3.11/site-packages/pkg_resources/__init__.py:3257: in <module>
    @_call_aside
/nix/store/jva4lzwjzby09h5mrlnv54jd8j21hcbx-python3.11-setuptools-67.4.0/lib/python3.11/site-packages/pkg_resources/__init__.py:3232: in _call_aside
    f(*args, **kwargs)
/nix/store/jva4lzwjzby09h5mrlnv54jd8j21hcbx-python3.11-setuptools-67.4.0/lib/python3.11/site-packages/pkg_resources/__init__.py:3283: in _initialize_master_working_set
    tuple(dist.activate(replace=False) for dist in working_set)
/nix/store/jva4lzwjzby09h5mrlnv54jd8j21hcbx-python3.11-setuptools-67.4.0/lib/python3.11/site-packages/pkg_resources/__init__.py:3283: in <genexpr>
    tuple(dist.activate(replace=False) for dist in working_set)
/nix/store/jva4lzwjzby09h5mrlnv54jd8j21hcbx-python3.11-setuptools-67.4.0/lib/python3.11/site-packages/pkg_resources/__init__.py:2804: in activate
    declare_namespace(pkg)
/nix/store/jva4lzwjzby09h5mrlnv54jd8j21hcbx-python3.11-setuptools-67.4.0/lib/python3.11/site-packages/pkg_resources/__init__.py:2298: in declare_namespace
    warnings.warn(msg, DeprecationWarning, stacklevel=2)
E   DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
E   Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
=========================== short test summary info ============================
ERROR tests/dns_google_test.py - DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('go...
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 0.32s ===============================
```
</details>

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
