### PR TITLE
Extract eglexternalplatform from egl-wayland, remove includedir from egl-wayland pkg-config

### DIFF
--- a/pkgs/development/libraries/egl-wayland/default.nix
+++ b/pkgs/development/libraries/egl-wayland/default.nix
@@ -36,6 +36,12 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  postPatch = ''
+    # Declares an includedir but doesn't install any headers
+    # CMake's `pkg_check_modules(NAME wayland-eglstream IMPORTED_TARGET)` considers this an error
+    sed -i -e '/includedir/d' wayland-eglstream.pc.in
+  '';
+
   depsBuildBuild = [
     pkg-config
   ];
@@ -58,12 +64,6 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     eglexternalplatform
   ];
-
-  postFixup = ''
-    # Doubled prefix in pc file after postbuild hook replaces includedir prefix variable with dev output path
-    substituteInPlace $dev/lib/pkgconfig/wayland-eglstream.pc \
-      --replace "=$dev/$dev" "=$dev"
-  '';
 
   meta = with lib; {
     description = "The EGLStream-based Wayland external platform";

--- a/pkgs/development/libraries/egl-wayland/default.nix
+++ b/pkgs/development/libraries/egl-wayland/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , fetchpatch
+, eglexternalplatform
 , pkg-config
 , meson
 , ninja
@@ -13,35 +14,7 @@
 , wayland-protocols
 }:
 
-let
-  eglexternalplatform = stdenv.mkDerivation {
-    pname = "eglexternalplatform";
-    version = "1.1";
-
-    src = fetchFromGitHub {
-      owner = "Nvidia";
-      repo = "eglexternalplatform";
-      rev = "7c8f8e2218e46b1a4aa9538520919747f1184d86";
-      sha256 = "0lr5s2xa1zn220ghmbsiwgmx77l156wk54c7hybia0xpr9yr2nhb";
-    };
-
-    installPhase = ''
-      mkdir -p "$out/include/"
-      cp interface/eglexternalplatform.h "$out/include/"
-      cp interface/eglexternalplatformversion.h "$out/include/"
-
-      substituteInPlace eglexternalplatform.pc \
-        --replace "/usr/include/EGL" "$out/include"
-      mkdir -p "$out/share/pkgconfig"
-      cp eglexternalplatform.pc "$out/share/pkgconfig/"
-    '';
-
-    meta = with lib; {
-      license = licenses.mit;
-    };
-  };
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "egl-wayland";
   version = "1.1.11";
 
@@ -75,7 +48,6 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    eglexternalplatform
     libGL
     libX11
     libdrm
@@ -83,11 +55,14 @@ in stdenv.mkDerivation rec {
     wayland-protocols
   ];
 
+  propagatedBuildInputs = [
+    eglexternalplatform
+  ];
+
   postFixup = ''
     # Doubled prefix in pc file after postbuild hook replaces includedir prefix variable with dev output path
     substituteInPlace $dev/lib/pkgconfig/wayland-eglstream.pc \
-      --replace "=$dev/$dev" "=$dev" \
-      --replace "Requires:" "Requires.private:"
+      --replace "=$dev/$dev" "=$dev"
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/eglexternalplatform/default.nix
+++ b/pkgs/development/libraries/eglexternalplatform/default.nix
@@ -1,0 +1,40 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "eglexternalplatform";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "Nvidia";
+    repo = "eglexternalplatform";
+    rev = "7c8f8e2218e46b1a4aa9538520919747f1184d86";
+    sha256 = "0lr5s2xa1zn220ghmbsiwgmx77l156wk54c7hybia0xpr9yr2nhb";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/include/
+    cp interface/* $out/include/
+
+    substituteInPlace eglexternalplatform.pc \
+      --replace "/usr/include/EGL" "$out/include"
+    install -Dm644 {.,$out/share/pkgconfig}/eglexternalplatform.pc
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The EGL External Platform interface";
+    homepage = "https://github.com/NVIDIA/eglexternalplatform";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ hedning ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19874,6 +19874,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo;
   };
 
+  eglexternalplatform = callPackage ../development/libraries/eglexternalplatform { };
+
   egl-wayland = callPackage ../development/libraries/egl-wayland { };
 
   elastix = callPackage ../development/libraries/science/biology/elastix {


### PR DESCRIPTION
###### Description of changes

https://github.com/NixOS/nixpkgs/pull/222213#issuecomment-1476637265 :

```
-- Checking for module 'wayland-eglstream'
--   Found wayland-eglstream, version 1.1.11

...

CMake Error in src/platforms/eglstream-kms/server/CMakeLists.txt:
  Imported target "PkgConfig::WAYLAND_EGLSTREAM" includes non-existent path

    "/nix/store/ccq99g0bgd45zp625drrpf7n9l7sdpvc-egl-wayland-1.1.11-dev/include"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```

So

- `egl-wayland`'s `wayland-eglstream.pc` has an `includedir` variable and includes it in its `Cflags`
- `egl-wayland` doesn't actually install any headers though
- CMake sees this discrepancy, and complains about it

1. Is the `includedir` a mistake? In which case, we should remove the `includedir` & `Cflags`.
2. Is `egl-wayland` supposed to install some headers but doesn't? In which case, we should fix the install.
3. Is it trying to point at `eglexternalplatform`'s includes? In which case, we should do the same thing as 1. + revert the second half of this patching to propagate the dependency again.
https://github.com/NixOS/nixpkgs/blob/1603d11595a232205f03d46e635d919d1e1ec5b9/pkgs/development/libraries/egl-wayland/default.nix#L76-L81

---

Solving this in the widest possible way by doing what #207534 previously tried to do:
1. Extract `eglexternalplatform` from `egl-wayland`
2. Propagate `eglexternalplatform` from `egl-wayland` and keep the `Requires` as-is, in case anything actually depends on it
3. Remove any references to `egl-wayland`'s own, non-existent `includedir`

Tested by building `mir` and the bumped version of it from https://github.com/NixOS/nixpkgs/pull/222213.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
