### PR TITLE
shell_gpt: init at 0.7.3

### DIFF
--- a/pkgs/tools/misc/shell_gpt/default.nix
+++ b/pkgs/tools/misc/shell_gpt/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "shell_gpt";
+  version = "0.7.3";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-lS8zLtsh8Uz782KJwHqifEQnWQswbCXRVIfXWAmWtvI=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    python3.pkgs.pythonRelaxDepsHook
+    python3
+    pip
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    markdown-it-py
+    rich
+    distro
+    typer
+    requests
+  ];
+
+  pythonRelaxDeps = [ "requests" "rich" "distro" "typer" ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    mainProgram = "sgpt";
+    homepage = "https://github.com/TheR1D/shell_gpt";
+    description = "Access ChatGPT from your terminal";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ mglolenstine ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32770,6 +32770,8 @@ with pkgs;
 
   shadowfox = callPackage ../tools/networking/shadowfox { };
 
+  shell_gpt = callPackage ../tools/misc/shell_gpt { };
+
   shfmt = callPackage ../tools/text/shfmt { };
 
   shortwave = callPackage ../applications/audio/shortwave { };


### PR DESCRIPTION
###### Description of changes
Added package for [`shell_gpt`](https://github.com/TheR1D/shell_gpt).
It's a CLI application that provides quick access to the ChatGPT bot.

Tests exist for this package, but they require a ChatGPT token to run, which is asked for interactively, and the token is private.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
