### PR TITLE
firebird-emu: 1.5 -> 1.6

### DIFF
--- a/pkgs/applications/emulators/firebird-emu/default.nix
+++ b/pkgs/applications/emulators/firebird-emu/default.nix
@@ -2,28 +2,19 @@
 
 mkDerivation rec {
   pname = "firebird-emu";
-  version = "1.5";
+  version = "1.6";
 
   src = fetchFromGitHub {
     owner = "nspire-emus";
     repo = "firebird";
     rev = "v${version}";
-    sha256 = "sha256-T62WB6msdB6/wIulqd/468JrCEiPGUrvtpjkZyo4wiA=";
     fetchSubmodules = true;
+    hash = "sha256-ZptjlnOiF+hKuKYvBFJL95H5YQuR99d4biOco/MVEmE=";
   };
 
   nativeBuildInputs = [ qmake ];
 
   buildInputs = [ qtbase qtdeclarative ];
-
-  makeFlags = [ "INSTALL_ROOT=$(out)" ];
-
-  # Attempts to install to /usr/bin and /usr/share/applications, which Nix does
-  # not use.
-  prePatch = ''
-    substituteInPlace firebird.pro \
-      --replace '/usr/' '/'
-  '';
 
   meta = {
     homepage = "https://github.com/nspire-emus/firebird";


### PR DESCRIPTION
###### Description of changes

Supersedes #221758.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
