### PR TITLE
xrootd: implement fetchxrd and add test-xrdcp

### DIFF
--- a/pkgs/tools/networking/xrootd/default.nix
+++ b/pkgs/tools/networking/xrootd/default.nix
@@ -22,14 +22,14 @@
 , externalEtc ? "/etc"
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xrootd";
   version = "5.5.2";
 
   src = fetchFromGitHub {
     owner = "xrootd";
     repo = "xrootd";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-2zVCOcjL8TUbo38Dx7W8431ziouzuAdCfogsIMSOOmQ=";
   };
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "out" "dev" "man" ];
 
   passthru.tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
-    test-runner = callPackage ./test-runner.nix { };
+    test-runner = callPackage ./test-runner.nix { xrootd = finalAttrs.finalPackage; };
   };
 
   nativeBuildInputs = [
@@ -100,4 +100,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ ShamrockLee ];
   };
-}
+})

--- a/pkgs/tools/networking/xrootd/default.nix
+++ b/pkgs/tools/networking/xrootd/default.nix
@@ -16,7 +16,7 @@
 , systemd
 , voms
 , zlib
-, enableTests ? stdenv.isLinux
+, enableTestRunner ? true
   # If not null, the builder will
   # move "$out/etc" to "$out/etc.orig" and symlink "$out/etc" to externalEtc.
 , externalEtc ? "/etc"
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "out" "dev" "man" ];
 
-  passthru.tests = lib.optionalAttrs enableTests {
+  passthru.tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
     test-runner = callPackage ./test-runner.nix { };
   };
 
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     systemd
     voms
   ]
-  ++ lib.optionals enableTests [
+  ++ lib.optionals enableTestRunner [
     cppunit
   ];
 
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
     install -m 644 -t "$out/lib/systemd/system" ../packaging/common/*.service ../packaging/common/*.socket
   '';
 
-  cmakeFlags = lib.optionals enableTests [
+  cmakeFlags = lib.optionals enableTestRunner [
     "-DENABLE_TESTS=TRUE"
   ];
 

--- a/pkgs/tools/networking/xrootd/fetchxrd.nix
+++ b/pkgs/tools/networking/xrootd/fetchxrd.nix
@@ -1,0 +1,42 @@
+{ lib
+, runCommandLocal
+, buildPlatform
+, xrootd
+}:
+
+{ name ? ""
+, pname ? ""
+, version ? ""
+, urls ? [ ]
+, url ? if urls == [ ] then abort "Expect either non-empty `urls` or `url`" else builtins.head urls
+, hash ? lib.fakeHash
+}:
+
+(runCommandLocal name
+  {
+    nativeBuildInputs = [ xrootd ];
+    outputHashAlgo = null;
+    outputHashMode = "flat";
+    outputHash = hash;
+    inherit url;
+    urls = if urls == [ ] then lib.singleton url else urls;
+  }
+  # Set [DY]LD_LIBRARY_PATH to workaround #169677
+  # TODO: Remove the library path after #200830 get merged
+  ''
+    for u in $urls; do
+      ${lib.optionalString buildPlatform.isDarwin "DY"}LD_LIBRARY_PATH=${lib.makeLibraryPath [ xrootd ]} xrdcp --force "$u" "$out"
+      ret=$?
+      (( ret != 0 )) || break
+    done
+    if (( ret )); then
+      echo "xrdcp failed trying to download any of the urls" >&2
+      exit $ret
+    fi
+  '').overrideAttrs (finalAttrs: prevAttrs:
+if (pname != "" && version != "") then {
+  inherit pname version;
+  name = with finalAttrs; "${pname}-${version}";
+} else {
+  name = if (name != "") then name else (baseNameOf finalAttrs.url);
+})


### PR DESCRIPTION
###### Description of changes

This PR:
1. Adopt the fixed-point style of stdenv and make `passthru.tests` test cases follow the `finalAttrs.finalPackage`, so that people who override the package attribute can use the tests.
2. Implement `fetchxrd` with the `xrdcp` binary the way `fetchurl` is implemented with `curl`.
3. Use `fetchxrd` to implement `passthru.tests.test-xrdcp`. With this test, it should be safe to just merge the auto-update PRs by r-ryantm.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
