### PR TITLE
meraki-cli: init at 1.5.0

### DIFF
--- a/pkgs/tools/admin/meraki-cli/default.nix
+++ b/pkgs/tools/admin/meraki-cli/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, argcomplete
+, jinja2
+, meraki
+, rich
+, fetchPypi
+, buildPythonApplication
+, pytestCheckHook
+, requests-mock
+}:
+
+buildPythonApplication rec {
+  pname = "meraki-cli";
+  version = "1.5.0";
+  format = "setuptools";
+
+  src = fetchPypi {
+    pname = "meraki_cli";
+    inherit version;
+    hash = "sha256-YOyeovqRqt6ZMXgLnIxRvPkcW259K8NIBGdb3PwjkMg=";
+  };
+
+  disabledTests = [
+    # requires files not in PyPI tarball
+    "TestDocVersions"
+    "TestHelps"
+    # requires running "pip install"
+    "TestUpgrade"
+  ];
+
+  propagatedBuildInputs = [
+    argcomplete
+    jinja2
+    meraki
+    rich
+  ];
+
+  nativeBuildInputs = [
+    pytestCheckHook
+  ];
+
+  nativeCheckInputs = [
+    requests-mock
+  ];
+
+  pythonImportsCheck = [
+    "meraki_cli"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/PackeTsar/meraki-cli";
+    description = "A simple CLI tool to automate and control your Cisco Meraki Dashboard";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dylanmtaylor ];
+    platforms = platforms.unix;
+    mainProgram = "meraki";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18425,6 +18425,8 @@ with pkgs;
 
   mdl = callPackage ../development/tools/misc/mdl { };
 
+  meraki-cli = python3Packages.callPackage ../tools/admin/meraki-cli { };
+
   python-matter-server = with python3Packages; toPythonApplication python-matter-server;
 
   minify = callPackage ../development/web/minify { };


### PR DESCRIPTION
###### Description of changes

Adds the meraki-cli package. Closes #222264.

~~This depends on the Meraki Python module being packaged first.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
