### PR TITLE
forgejo: 1.18.5-0 -> 1.19.0-2

### DIFF
--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -21,13 +21,13 @@
 
 buildGoModule rec {
   pname = "forgejo";
-  version = "1.18.5-0";
+  version = "1.19.0-2";
 
   src = fetchurl {
     name = "${pname}-src-${version}.tar.gz";
     # see https://codeberg.org/forgejo/forgejo/releases
-    url = "https://codeberg.org/attachments/bb93c0c9-98c4-465c-bcff-e07ac3ee72a3";
-    hash = "sha256-jyaJ7W/K1Nn44ZhyJHZD+dKObU3hYx6mmDzvbvrR7gw=";
+    url = "https://codeberg.org/attachments/2bf497db-fa91-4260-9c98-5c791b6b397c";
+    hash = "sha256-neDIT+V3qHR8xgP4iy4TJQ6PCWO3svpSA7FLCacQSMI=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
###### Description of changes

changelog: https://codeberg.org/forgejo/forgejo/src/commit/7770a851287532549488f268b70171d3c796f57e/RELEASE-NOTES.md#1-19-0-2

I would like to point out one point from the release notes:
> [...]
> -   [Semantic version](https://forgejo.org/docs/latest/user/semver)
> 
>     Since v1.18.5, in addition to the Forgejo release number, a [semantic version](https://semver.org/#semantic-versioning-200) number (e.g. `v3.0.0`) can be obtained from the `number` key of a new `/api/forgejo/v1/version` endpoint.
> 
>     Now, it reflects the Gitea version that Forgejo depends on, is no longer prefixed with `v` (e.g. `3.0.0+0-gitea-1.19.0`), and can be obtained from the `version` key of the same endpoint.
>
> [...]

This will be become more relevant in the future, see https://codeberg.org/forgejo/forgejo/issues/207#issuecomment-820215


Yesterday's PR #222193 (_gitea: 1.18.5 -> 1.19.0_) already fixed the nixos test and `static-root-path.patch` :)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).