### PR TITLE
k3s: Adjust Go tags to dynamically link against sqlite

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_23/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_23/default.nix
@@ -22,6 +22,7 @@
 , fetchgit
 , zstd
 , yq-go
+, sqlite
 , nixosTests
 , k3s
 , pkgsBuildBuild
@@ -174,10 +175,12 @@ let
     vendorSha256 = k3sVendorSha256;
 
     nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ libseccomp ];
+    buildInputs = [ libseccomp sqlite.dev ];
 
     subPackages = [ "cmd/server" ];
     ldflags = versionldflags;
+
+    tags = [ "libsqlite3" "linux" ];
 
     # create the multicall symlinks for k3s
     postInstall = ''

--- a/pkgs/applications/networking/cluster/k3s/1_24/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_24/default.nix
@@ -22,6 +22,7 @@
 , fetchgit
 , zstd
 , yq-go
+, sqlite
 , nixosTests
 , k3s
 , pkgsBuildBuild
@@ -172,10 +173,12 @@ let
     vendorSha256 = k3sVendorSha256;
 
     nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ libseccomp ];
+    buildInputs = [ libseccomp sqlite.dev ];
 
     subPackages = [ "cmd/server" ];
     ldflags = versionldflags;
+
+    tags = [ "libsqlite3" "linux" ];
 
     # create the multicall symlinks for k3s
     postInstall = ''

--- a/pkgs/applications/networking/cluster/k3s/1_25/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_25/default.nix
@@ -22,6 +22,7 @@
 , fetchgit
 , zstd
 , yq-go
+, sqlite
 , nixosTests
 , pkgsBuildBuild
 , k3s
@@ -171,10 +172,12 @@ let
     vendorSha256 = k3sVendorSha256;
 
     nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ libseccomp ];
+    buildInputs = [ libseccomp sqlite.dev ];
 
     subPackages = [ "cmd/server" ];
     ldflags = versionldflags;
+
+    tags = [ "libsqlite3" "linux" ];
 
     # create the multicall symlinks for k3s
     postInstall = ''

--- a/pkgs/applications/networking/cluster/k3s/1_26/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_26/default.nix
@@ -22,6 +22,7 @@
 , fetchgit
 , zstd
 , yq-go
+, sqlite
 , nixosTests
 , pkgsBuildBuild
 }:
@@ -175,10 +176,12 @@ let
     vendorSha256 = k3sVendorSha256;
 
     nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ libseccomp ];
+    buildInputs = [ libseccomp sqlite.dev ];
 
     subPackages = [ "cmd/server" ];
     ldflags = versionldflags;
+
+    tags = [ "libsqlite3" "linux" ];
 
     # create the multicall symlinks for k3s
     postInstall = ''


### PR DESCRIPTION
###### Description of changes

This commit changes the derivations for k3s to prefer dynamically linking against `pkgs.sqlite` as opposed the the current default that leads to a package dependency ([go-sqlite3](https://github.com/mattn/go-sqlite3)) being compiled without any relevant build tags, which it in turn defaults to manually compiling an entire sqlite3 amalgation for itself.

In addition to just linking sqlite3 dynamically, this also fixes k3s filling the system logs with repeated (around every 40 seconds) warning messages caused by the vendored sqlite3 amalgation not being compiled with `SQLITE_ENABLE_DBSTAT_VTAB=1`.

Since this is simply a packaging change, there are no external changes for users of this package except for fewer warnings in the system journal and a slightly smaller package size.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
