### PR TITLE
ocamlPackages.gen: 1.0 → 1.1

### DIFF
--- a/pkgs/applications/science/logic/acgtk/default.nix
+++ b/pkgs/applications/science/logic/acgtk/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitLab, dune_2, ocamlPackages }:
+{ lib, stdenv, fetchFromGitLab, dune_3, ocamlPackages }:
 
 stdenv.mkDerivation {
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   strictDeps = true;
 
-  nativeBuildInputs = with ocamlPackages; [ menhir ocaml findlib dune_2 ];
+  nativeBuildInputs = with ocamlPackages; [ menhir ocaml findlib dune_3 ];
 
   buildInputs = with ocamlPackages; [
     ansiterminal cairo2 cmdliner fmt logs menhirLib mtime sedlex yojson

--- a/pkgs/development/ocaml-modules/gen/default.nix
+++ b/pkgs/development/ocaml-modules/gen/default.nix
@@ -1,22 +1,21 @@
 { lib, buildDunePackage, fetchFromGitHub, ocaml
-, dune-configurator
 , seq
 , qcheck, ounit2
 }:
 
 buildDunePackage rec {
-  version = "1.0";
+  version = "1.1";
   pname = "gen";
   minimalOCamlVersion = "4.03";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "gen";
     rev = "v${version}";
-    hash = "sha256-YWoVcl2TQoMIgU1LoKL16ia31zJjwAMwuphtSXnhtvw=";
+    hash = "sha256-ZytPPGhmt/uANaSgkgsUBOwyQ9ka5H4J+5CnJpEdrNk=";
   };
 
-  buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ seq ];
   checkInputs = [ qcheck ounit2 ];
 

--- a/pkgs/development/ocaml-modules/higlo/default.nix
+++ b/pkgs/development/ocaml-modules/higlo/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "higlo";
   version = "0.8";
-  useDune2 = true;
+  duneVersion = "3";
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "zoggy";

--- a/pkgs/development/ocaml-modules/iri/default.nix
+++ b/pkgs/development/ocaml-modules/iri/default.nix
@@ -5,7 +5,7 @@
 buildDunePackage rec {
   pname = "iri";
   version = "0.6.0";
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchFromGitLab {
     domain = "framagit.org";

--- a/pkgs/development/ocaml-modules/sedlex/default.nix
+++ b/pkgs/development/ocaml-modules/sedlex/default.nix
@@ -47,6 +47,7 @@ buildDunePackage rec {
   inherit (param) version;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "ocaml-community";

--- a/pkgs/development/ocaml-modules/xtmpl/default.nix
+++ b/pkgs/development/ocaml-modules/xtmpl/default.nix
@@ -3,7 +3,7 @@
 buildDunePackage rec {
   pname = "xtmpl";
   version = "0.19.0";
-  useDune2 = true;
+  duneVersion = "3";
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "zoggy";

--- a/pkgs/development/ocaml-modules/xtmpl/ppx.nix
+++ b/pkgs/development/ocaml-modules/xtmpl/ppx.nix
@@ -3,8 +3,9 @@
 buildDunePackage {
   pname = "xtmpl_ppx";
   minimalOCamlVersion = "4.11";
+  duneVersion = "3";
 
-  inherit (xtmpl) src version useDune2;
+  inherit (xtmpl) src version;
 
   buildInputs = [ ppxlib xtmpl ];
 


### PR DESCRIPTION
###### Description of changes

Support for OCaml 5.0: https://github.com/c-cube/gen/blob/v1.1/CHANGELOG.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
