### PR TITLE
spotifywm: behave as patch with same binary name as spotify

### DIFF
--- a/pkgs/applications/audio/spotifywm/default.nix
+++ b/pkgs/applications/audio/spotifywm/default.nix
@@ -14,8 +14,6 @@ stdenv.mkDerivation {
 
   buildInputs = [ xorg.libX11 ];
 
-  propagatedBuildInputs = [ spotify ];
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/applications/audio/spotifywm/default.nix
+++ b/pkgs/applications/audio/spotifywm/default.nix
@@ -36,6 +36,6 @@ stdenv.mkDerivation {
     description = "Wrapper around Spotify that correctly sets class name before opening the window";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ jqueiroz ];
+    maintainers = with maintainers; [ jqueiroz the-argus ];
   };
 }

--- a/pkgs/applications/audio/spotifywm/default.nix
+++ b/pkgs/applications/audio/spotifywm/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, spotify, xorg, runtimeShell }:
+{ lib, stdenv, fetchFromGitHub, spotify, xorg, makeWrapper }:
 stdenv.mkDerivation {
   pname = "spotifywm-unstable";
   version = "2022-10-26";
@@ -10,15 +10,25 @@ stdenv.mkDerivation {
     sha256 = "sha256-AsXqcoqUXUFxTG+G+31lm45gjP6qGohEnUSUtKypew0=";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   buildInputs = [ xorg.libX11 ];
 
   propagatedBuildInputs = [ spotify ];
 
   installPhase = ''
-    echo "#!${runtimeShell}" > spotifywm
-    echo "LD_PRELOAD="$out/lib/spotifywm.so" ${spotify}/bin/spotify \$*" >> spotifywm
-    install -Dm644 spotifywm.so $out/lib/spotifywm.so
-    install -Dm755 spotifywm $out/bin/spotifywm
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib}
+    install -Dm644 spotifywm.so $out/lib/
+    ln -sf ${spotify}/bin/spotify $out/bin/spotify
+
+    # wrap spotify to use spotifywm.so
+    wrapProgram $out/bin/spotify --set LD_PRELOAD "$out/lib/spotifywm.so"
+    # backwards compatibility for people who are using the "spotifywm" binary
+    ln -sf $out/bin/spotify $out/bin/spotifywm
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

This change serves to make spotifywm behave as a wrapper/patch instead of being its own separate package using ``bin/spotifywm`` instead of ``bin/spotify``.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
