### PR TITLE
tiv: add imagemagick to path

### DIFF
--- a/pkgs/applications/misc/tiv/default.nix
+++ b/pkgs/applications/misc/tiv/default.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, fetchFromGitHub, imagemagick }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, imagemagick
+}:
 
 stdenv.mkDerivation rec {
   pname = "tiv";
@@ -11,11 +16,18 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-mCgybL4af19zqECN1pBV+WnxMq2ZtlK5GDTQO3u9CK0=";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   buildInputs = [ imagemagick ];
 
   makeFlags = [ "prefix=$(out)" ];
 
   preConfigure = "cd src/main/cpp";
+
+  postFixup = ''
+    wrapProgram $out/bin/tiv \
+      --prefix PATH : ${lib.makeBinPath [ imagemagick ]}
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/stefanhaustein/TerminalImageViewer";


### PR DESCRIPTION
###### Description of changes

Required for e.g. jpg and png support, c.f. https://github.com/stefanhaustein/TerminalImageViewer/issues/56

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
