### PR TITLE
gnome.mutter42: 42.7 → 42.9

### DIFF
--- a/pkgs/desktops/gnome/core/mutter/42/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/42/default.nix
@@ -49,13 +49,13 @@
 
 let self = stdenv.mkDerivation rec {
   pname = "mutter";
-  version = "42.7";
+  version = "42.9";
 
   outputs = [ "out" "dev" "man" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "OwmmsHDRMHwD2EMorIS0+m1jmfk4MEo4wpTxso3yipM=";
+    sha256 = "0IDlLyxH+/3wMkixE1TQObSqRT8ZlyiLMK+EHW3O5sM=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/core/mutter/42/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/42/default.nix
@@ -66,10 +66,26 @@ let self = stdenv.mkDerivation rec {
       sha256 = "/npUE3idMSTVlFptsDpZmGWjZ/d2gqruVlJKq4eF4xU=";
     })
 
+    # Fix log spam "Attempting to freeze/thaw notification queue for object ClutterText".
+    # https://gitlab.gnome.org/GNOME/mutter/-/issues/2566
+    # https://github.com/linuxmint/cinnamon/issues/11562 (backported to muffin as well)
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/mutter/-/commit/cff631cb39b1b9d66b791fb51a6f2c3db8e60917.patch";
+      sha256 = "+20GOC0yVQ1HsfGYAxZ0DEw6aTA3eHi/pq/ELKQRmbg=";
+    })
+
     (substituteAll {
       src = ./fix-paths.patch;
       inherit zenity;
     })
+
+    # GLib 2.76 switches from using its own slice allocator to using the system malloc instead.
+    # This makes dragging window between workspace in multitasking view crashes Pantheon's Gala.
+    # Inspiration https://github.com/mate-desktop/mate-desktop/pull/538
+    # Backtrace https://github.com/elementary/gala/issues/1580
+    # Upstream report https://gitlab.gnome.org/GNOME/mutter/-/issues/2495
+    # The patch will not apply on 44.0+, make sure this is fixed when trying to clean this up.
+    ./glib-2-76-gala-crash.patch
   ];
 
   mesonFlags = [

--- a/pkgs/desktops/gnome/core/mutter/42/glib-2-76-gala-crash.patch
+++ b/pkgs/desktops/gnome/core/mutter/42/glib-2-76-gala-crash.patch
@@ -1,0 +1,25 @@
+diff --git a/clutter/clutter/clutter-actor.c b/clutter/clutter/clutter-actor.c
+index d34c8f59f..8835a6a33 100644
+--- a/clutter/clutter/clutter-actor.c
++++ b/clutter/clutter/clutter-actor.c
+@@ -12304,7 +12304,7 @@ clutter_actor_run_actions (ClutterActor       *self,
+                            ClutterEventPhase   phase)
+ {
+   ClutterActorPrivate *priv;
+-  const GList *actions, *l;
++  const GList *actions, *l, *next;
+   gboolean retval = CLUTTER_EVENT_PROPAGATE;
+ 
+   priv = self->priv;
+@@ -12313,9 +12313,10 @@ clutter_actor_run_actions (ClutterActor       *self,
+ 
+   actions = _clutter_meta_group_peek_metas (priv->actions);
+ 
+-  for (l = actions; l; l = l->next)
++  for (l = actions; l; l = next)
+     {
+       ClutterAction *action = l->data;
++      next = l->next;
+       ClutterEventPhase action_phase;
+ 
+       action_phase = clutter_action_get_phase (action);


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/mutter/-/compare/42.7...42.9

###### Description of changes

This is the last mutter42 release, this is now EOL.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
