### PR TITLE
newlib: improve the nano version

### DIFF
--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -1,18 +1,27 @@
-{ stdenv, fetchurl, buildPackages
+{ stdenv, fetchurl, buildPackages, lib, fetchpatch
 , # "newlib-nano" is what the official ARM embedded toolchain calls this build
   # configuration that prioritizes low space usage. We include it as a preset
   # for embedded projects striving for a similar configuration.
   nanoizeNewlib ? false
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "newlib";
   version = "4.1.0";
 
   src = fetchurl {
-    url = "ftp://sourceware.org/pub/newlib/newlib-${version}.tar.gz";
+    url = "ftp://sourceware.org/pub/newlib/newlib-${finalAttrs.version}.tar.gz";
     sha256 = "0m01sjjyj0ib7bwlcrvmk1qkkgd66zf1dhbw716j490kymrf75pj";
   };
+
+  patches = lib.optionals nanoizeNewlib [
+    # https://bugs.gentoo.org/723756
+    (fetchpatch {
+      name = "newlib-3.3.0-no-nano-cxx.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-libs/newlib/files/newlib-3.3.0-no-nano-cxx.patch?id=9ee5a1cd6f8da6d084b93b3dbd2e8022a147cfbf";
+      sha256 = "sha256-S3mf7vwrzSMWZIGE+d61UDH+/SK/ao1hTPee1sElgco=";
+    })
+  ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
@@ -45,8 +54,22 @@ stdenv.mkDerivation rec {
 
   dontDisableStatic = true;
 
+  # apply necessary nano changes from https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/manifest/copy_nano_libraries.sh?rev=4c50be6ccb9c4205a5262a3925317073&hash=1375A7B0A1CD0DB9B9EB0D2B574ADF66
+  postInstall = lib.optionalString nanoizeNewlib ''
+    mkdir -p $out${finalAttrs.passthru.incdir}/newlib-nano
+    cp $out${finalAttrs.passthru.incdir}/newlib.h $out${finalAttrs.passthru.incdir}/newlib-nano/
+
+    (
+      cd $out${finalAttrs.passthru.libdir}
+
+      for f in librdimon.a libc.a libg.a; do
+        cp "$f" "''${f%%\.a}_nano.a"
+      done
+    )
+  '';
+
   passthru = {
     incdir = "/${stdenv.targetPlatform.config}/include";
     libdir = "/${stdenv.targetPlatform.config}/lib";
   };
-}
+})

--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -82,4 +82,17 @@ stdenv.mkDerivation (finalAttrs: {
     incdir = "/${stdenv.targetPlatform.config}/include";
     libdir = "/${stdenv.targetPlatform.config}/lib";
   };
+
+  meta = with lib; {
+    description = "a C library intended for use on embedded systems";
+    homepage = "https://sourceware.org/newlib/";
+    # arch has "bsd" while gentoo has "NEWLIB LIBGLOSS GPL-2" while COPYING has "gpl2"
+    # there are 5 copying files in total
+    # COPYING
+    # COPYING.LIB
+    # COPYING.LIBGLOSS
+    # COPYING.NEWLIB
+    # COPYING3
+    license = licenses.gpl2Plus;
+  };
 })

--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -31,25 +31,32 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   configurePlatforms = [ "build" "target" ];
+  # flags copied from https://community.arm.com/support-forums/f/compilers-and-libraries-forum/53310/gcc-arm-none-eabi-what-were-the-newlib-compilation-options
+  # sort alphabetically
   configureFlags = [
     "--host=${stdenv.buildPlatform.config}"
-
+  ] ++ (if !nanoizeNewlib then [
     "--disable-newlib-supplied-syscalls"
     "--disable-nls"
-    "--enable-newlib-retargetable-locking"
-  ] ++ (if !nanoizeNewlib then [
+    "--enable-newlib-io-c99-formats"
     "--enable-newlib-io-long-long"
+    "--enable-newlib-reent-check-verify"
     "--enable-newlib-register-fini"
+    "--enable-newlib-retargetable-locking"
   ] else [
-    "--enable-newlib-reent-small"
-    "--disable-newlib-fvwrite-in-streamio"
     "--disable-newlib-fseek-optimization"
-    "--disable-newlib-wide-orient"
-    "--enable-newlib-nano-malloc"
+    "--disable-newlib-fvwrite-in-streamio"
+    "--disable-newlib-supplied-syscalls"
     "--disable-newlib-unbuf-stream-opt"
+    "--disable-newlib-wide-orient"
+    "--disable-nls"
     "--enable-lite-exit"
     "--enable-newlib-global-atexit"
     "--enable-newlib-nano-formatted-io"
+    "--enable-newlib-nano-malloc"
+    "--enable-newlib-reent-check-verify"
+    "--enable-newlib-reent-small"
+    "--enable-newlib-retargetable-locking"
   ]);
 
   dontDisableStatic = true;

--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildPackages, lib, fetchpatch
+{ stdenv, fetchurl, buildPackages, lib, fetchpatch, texinfo
 , # "newlib-nano" is what the official ARM embedded toolchain calls this build
   # configuration that prioritizes low space usage. We include it as a preset
   # for embedded projects striving for a similar configuration.
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "newlib";
-  version = "4.1.0";
+  version = "4.3.0.20230120";
 
   src = fetchurl {
     url = "ftp://sourceware.org/pub/newlib/newlib-${finalAttrs.version}.tar.gz";
-    sha256 = "0m01sjjyj0ib7bwlcrvmk1qkkgd66zf1dhbw716j490kymrf75pj";
+    sha256 = "sha256-g6Yqma9Z4465sMWO0JLuJNcA//Q6IsA+QzlVET7zUVA=";
   };
 
   patches = lib.optionals nanoizeNewlib [
@@ -23,7 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  depsBuildBuild = [
+    buildPackages.stdenv.cc
+    texinfo # for makeinfo
+  ];
 
   # newlib expects CC to build for build platform, not host platform
   preConfigure = ''


### PR DESCRIPTION
apply patch from gentoo because there's no libstdc++.a libsupc++.a or their nano versions

this matches upstream arm more
https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads

-lc_nano is used in nano.specs but 'libc_nano.a' is not installed without these changes

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
