### PR TITLE
 erlang: cross compile support 

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -192,6 +192,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
   `component.settings`. The unix module now supports using SSH keys from Kanidm via
   `services.kanidm.unix.sshIntegration = true`.
 
+- `beam.interpreters.erlang` may now be cross-compiled using the derivations under `pkgsCross`. This also includes all derivations under `beam.packages` and `beam_minimal`.
+
 - `glibc` has been updated to version 2.42.
 
   This version no longer makes the stack executable when a shared library requires this. A symptom

--- a/pkgs/development/beam-modules/ex_doc/default.nix
+++ b/pkgs/development/beam-modules/ex_doc/default.nix
@@ -5,6 +5,7 @@
   fetchMixDeps,
   mixRelease,
   nix-update-script,
+  pkgsBuildHost,
 
   # for tests
   beam27Packages,
@@ -13,6 +14,7 @@
 # Based on ../elixir-ls/default.nix
 
 let
+  buildElixir = pkgsBuildHost.beam_minimal.packages.erlang.elixir;
   pname = "ex_doc";
   version = "0.40.1";
   src = fetchFromGitHub {
@@ -49,6 +51,18 @@ mixRelease {
 
     updateScript = nix-update-script { };
   };
+
+  configurePhase = ''
+    runHook preConfigure
+    ${buildElixir}/bin/mix deps.compile --no-deps-check
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    ${buildElixir}/bin/mix do escript.build
+    runHook postBuild
+  '';
 
   meta = {
     homepage = "https://github.com/elixir-lang/ex_doc";

--- a/pkgs/development/beam-modules/hex/default.nix
+++ b/pkgs/development/beam-modules/hex/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   writeText,
   elixir,
+  pkgsBuildHost,
 }:
 
 let
@@ -40,7 +41,7 @@ let
         export HEX_OFFLINE=1
         export HEX_HOME=./
         export MIX_ENV=prod
-        mix compile
+        ${pkgsBuildHost.beam_minimal.packages.erlang.elixir}/bin/mix compile
         runHook postBuild
       '';
 

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -15,6 +15,7 @@
   lib,
   makeWrapper,
   nix-update-script,
+  pkgsBuildHost,
   stdenv,
 }:
 
@@ -31,16 +32,21 @@ let
     versionOlder
     ;
 
+  otpVersion = getVersion erlang;
+
   compatibilityMsg = ''
     Unsupported elixir and erlang OTP combination.
 
     elixir ${version}
-    erlang OTP ${getVersion erlang} is not >= ${minimumOTPVersion} ${
+    erlang OTP ${otpVersion} is not >= ${minimumOTPVersion} ${
       optionalString (maximumOTPVersion != null) "and <= ${maximumOTPVersion}"
     }
 
     See https://hexdocs.pm/elixir/${version}/compatibility-and-deprecations.html
   '';
+
+  erlBuilder = pkgsBuildHost.beam_minimal.interpreters."erlang_${versions.major otpVersion}";
+  isCross = stdenv.hostPlatform != stdenv.buildPlatform;
 
   maxShiftMajor = toString ((toInt (versions.major maximumOTPVersion)) + 1);
   maxAssert =
@@ -80,7 +86,13 @@ else
 
     inherit version debugInfo;
 
-    nativeBuildInputs = [ makeWrapper ];
+    strictDeps = true;
+
+    nativeBuildInputs = [
+      makeWrapper
+    ]
+    ++ (optionals isCross [ erlBuilder ])
+    ++ (optionals (!isCross) [ erlang ]);
     buildInputs = [ erlang ];
 
     env = {

--- a/pkgs/development/tools/build-managers/rebar/default.nix
+++ b/pkgs/development/tools/build-managers/rebar/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   erlang,
+  pkgsBuildHost,
 }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +19,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ erlang ];
 
-  buildPhase = "escript bootstrap";
+  buildPhase = "${pkgsBuildHost.beam_minimal.interpreters.erlang}/bin/escript bootstrap";
+
   installPhase = ''
     mkdir -p $out/bin
     cp rebar $out/bin/rebar

--- a/pkgs/development/tools/build-managers/rebar3/default.nix
+++ b/pkgs/development/tools/build-managers/rebar3/default.nix
@@ -12,6 +12,7 @@
   git,
   gnused,
   nix,
+  pkgsBuildHost,
   rebar3-nix,
 }:
 
@@ -19,6 +20,7 @@ let
   version = "3.26.0";
   owner = "erlang";
   deps = import ./rebar-deps.nix { inherit fetchFromGitHub fetchgit fetchHex; };
+  escript = "${pkgsBuildHost.beam_minimal.interpreters.erlang}/bin/escript";
   rebar3 = stdenv.mkDerivation rec {
     pname = "rebar3";
     inherit version erlang;
@@ -51,7 +53,7 @@ let
     '';
 
     buildPhase = ''
-      HOME=. escript bootstrap
+      HOME=. ${escript} bootstrap
     '';
 
     checkPhase = ''


### PR DESCRIPTION
###### Description of changes

This, building on top of NixOS/nixpkgs#100835, builds a minimal erlang for the build platform as an input for the cross-compiled erlang. Still need to get the rest of this bootstrap OTP into the path for the rest of the build system to find, as some utilities are not installed by default.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

Tested with `nix build .#pkgsCross.aarch64-multiplatform.beam.packages.erlang_25.erlang`. Build completes, but I have no ARM machines to test with.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
