### PR TITLE
doc/python: use callPackage from the python scope

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -877,26 +877,17 @@ buildPythonPackage rec {
 }
 ```
 
-It takes an argument `buildPythonPackage`. We now call this function using
-`callPackage` in the definition of our environment
+It takes an argument `buildPythonPackage`. We now call this function using the
+`callPackage` from the `python38Packages` scope in the definition of our environment
 
 ```nix
 with import <nixpkgs> {};
 
 ( let
-    toolz = callPackage /path/to/toolz/release.nix {
-      buildPythonPackage = python38Packages.buildPythonPackage;
-    };
+    toolz = python38Packages.callPackage /path/to/toolz/release.nix { };
   in python38.withPackages (ps: [ ps.numpy toolz ])
 ).env
 ```
-
-Important to remember is that the Python version for which the package is made
-depends on the `python` derivation that is passed to `buildPythonPackage`. Nix
-tries to automatically pass arguments when possible, which is why generally you
-don't explicitly define which `python` derivation should be used. In the above
-example we use `buildPythonPackage` that is part of the set `python38Packages`,
-and in this case the `python38` interpreter is automatically used.
 
 ## Reference {#reference}
 

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -857,19 +857,23 @@ Let's split the package definition from the environment definition.
 We first create a function that builds `toolz` in `~/path/to/toolz/release.nix`
 
 ```nix
-{ lib, buildPythonPackage }:
+{ lib
+, pythonPackages
+}:
 
-buildPythonPackage rec {
+pythonPackages.buildPythonPackage rec {
   pname = "toolz";
-  version = "0.10.0";
+  version = "0.12.0";
 
-  src = fetchPypi {
+  src = pythonPackages.fetchPypi {
     inherit pname version;
-    hash = "sha256-CP3V73yWSArRHBLUct4hrNMjWZlvaaUlkpm1QP66RWA=";
+    hash = "sha256-iMVwhhxEDuPy9gN8RlRhMij/QMk6bCXg66cNFygsYZQ=";
   };
 
+  nativeCheckInputs = with pythonPackages; [ pytestCheckHook ];
+
   meta = with lib; {
-    homepage = "https://github.com/pytoolz/toolz/";
+    homepage = "https://github.com/pytoolz/toolz";
     description = "List processing tools and functional utilities";
     license = licenses.bsd3;
     maintainers = with maintainers; [ fridh ];
@@ -877,14 +881,15 @@ buildPythonPackage rec {
 }
 ```
 
-It takes an argument `buildPythonPackage`. We now call this function using the
-`callPackage` from the `python38Packages` scope in the definition of our environment
+It takes an argument `python38Packages`. We now call this function using `callPackage`
 
 ```nix
 with import <nixpkgs> {};
 
 ( let
-    toolz = python38Packages.callPackage /path/to/toolz/release.nix { };
+    toolz = callPackage /path/to/toolz/release.nix {
+      pythonPackages = __splicedPackages.python38Packages;
+    };
   in python38.withPackages (ps: [ ps.numpy toolz ])
 ).env
 ```


### PR DESCRIPTION
this is simpler and allows for multiple attrs from the python scope

remove unnecessary obvious note

Closes https://github.com/NixOS/nixpkgs/issues/72167

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
