### PR TITLE
perlPackages.ModuleBuild and .FileBaseDir: fix cross-compilation WIP

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9015,6 +9015,9 @@ let
       url = "mirror://cpan/authors/id/K/KI/KIMRYAN/File-BaseDir-0.08.tar.gz";
       hash = "sha256-wGX80+LyKudpk3vMlxuR+AKU1QCfrBQL+6g799NTBeM=";
     };
+    nativeBuildInputs =
+      # Override default intepreter perl.mini, which do not support dynamic linking
+      lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) buildPackages.perl;
     configurePhase = ''
       runHook preConfigure
       perl Build.PL PREFIX="$out" prefix="$out"

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15233,6 +15233,9 @@ let
       url = "mirror://cpan/authors/id/L/LE/LEONT/Module-Build-0.4231.tar.gz";
       hash = "sha256-fg9MaSwXQMGshOoU1+o9i8eYsvsmwJh3Ip4E9DCytxc=";
     };
+    nativeBuildInputs =
+      # Override default intepreter perl.mini, which do not support dynamic linking
+      lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) buildPackages.perl;
     meta = {
       description = "Build and install Perl modules";
       license = with lib.licenses; [ artistic1 gpl1Plus ];


### PR DESCRIPTION
###### Description of changes

This PR fixes #66741, the cross compilation for Perl module ModuleBuild and FileBaseDir. Following command will succeed:

```sh
nix-build -A pkgsCross.aarch64-multiplatform.perlPackages.ModuleBuild
nix-build -A pkgsCross.aarch64-multiplatform.perlPackages.FileBaseDir
```

A cross compiled Perl module gets pkgs.perl.mini passed instead of pkgs.perl. The mini do not allow dynamic loading, which causes errors during build.

definition of perl.mini:
https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/interpreters/perl/default.nix#L34

usage of perl.mini:
https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/perl-modules/generic/default.nix#L46

Following issues suffer from the same problem and can hopefully fixed in a similar way:

- https://github.com/NixOS/nixpkgs/issues/198548
- https://github.com/NixOS/nixpkgs/issues/142122

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
