### PR TITLE
authenticator: fix aarch64 build

### DIFF
--- a/pkgs/applications/misc/authenticator/default.nix
+++ b/pkgs/applications/misc/authenticator/default.nix
@@ -78,8 +78,5 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ austinbutler ];
     platforms = lib.platforms.linux;
-    # Fails to build on aarch64 with error
-    # "a label can only be part of a statement and a declaration is not a statement"
-    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2814,13 +2814,13 @@ with pkgs;
   audiowaveform = callPackage ../tools/audio/audiowaveform { };
 
   authenticator = callPackage ../applications/misc/authenticator rec {
-    # Remove when GTK is upgraded past 4.8
+    # Remove when GTK is upgraded to at least the version below
     # https://github.com/NixOS/nixpkgs/issues/216770
     gtk4 = pkgs.gtk4.overrideAttrs (_: rec {
-      version = "4.9.4";
+      version = "4.10.0";
       src = fetchurl {
         url = "mirror://gnome/sources/gtk/${lib.versions.majorMinor version}/gtk-${version}.tar.xz";
-        sha256 = "sha256-kaOv1YQB1OXYHjCwjuPxE6R2j/EBQDNqcqMmx3JyvjA=";
+        sha256 = "sha256-jcHnw7OkZ3Lw+kFqjKP9IdDQs7A/swfS5zJ+vuaWJuQ=";
       };
     });
     wrapGAppsHook4 = wrapGAppsHook.override { gtk3 = gtk4; };


### PR DESCRIPTION
###### Description of changes

Use a newer version of gtk4 with authenticator, a version which successfuly builds on aarch64.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

