### PR TITLE
teams-for-linux: 1.0.53 → 1.0.59, add updateScript

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -89,6 +89,8 @@ stdenv.mkDerivation rec {
     categories = [ "Network" "InstantMessaging" "Chat" ];
   })];
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "Unofficial Microsoft Teams client for Linux";
     homepage = "https://github.com/IsmaelMartinez/teams-for-linux";

--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "teams-for-linux";
-  version = "1.0.53";
+  version = "1.0.59";
 
   src = fetchFromGitHub {
     owner = "IsmaelMartinez";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-zigcOshtRQuQxJBXPWVmTjj5+4AorR5WW8lHVInUKFg=";
+    sha256 = "sha256-82uRZEktKHMQhozG5Zpa2DFu1VZOEDBWpsbfgMzoXY8=";
   };
 
   offlineCache = fetchYarnDeps {

--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/update.sh
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/update.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix jq common-updater-scripts
+
+set -euo pipefail
+
+nixpkgs="$(git rev-parse --show-toplevel || (printf 'Could not find root of nixpkgs repo\nAre we running from within the nixpkgs git repo?\n' >&2; exit 1))"
+
+stripwhitespace() {
+    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+nixeval() {
+    nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1" | jq -r .
+}
+
+vendorhash() {
+    (nix --extra-experimental-features nix-command build --impure --argstr nixpkgs "$nixpkgs" --argstr attr "$1" --expr '{ nixpkgs, attr }: let pkgs = import nixpkgs {}; in with pkgs.lib; (getAttrFromPath (splitString "." attr) pkgs).overrideAttrs (attrs: { outputHash = fakeHash; })' --no-link 2>&1 >/dev/null | tail -n3 | grep -F got: | cut -d: -f2- | stripwhitespace) 2>/dev/null || true
+}
+
+findpath() {
+    path="$(nix --extra-experimental-features nix-command eval --json --impure -f "$nixpkgs" "$1.meta.position" | jq -r . | cut -d: -f1)"
+    outpath="$(nix --extra-experimental-features nix-command eval --json --impure --expr "builtins.fetchGit \"$nixpkgs\"")"
+
+    if [ -n "$outpath" ]; then
+        path="${path/$(echo "$outpath" | jq -r .)/$nixpkgs}"
+    fi
+
+    echo "$path"
+}
+
+attr="${UPDATE_NIX_ATTR_PATH:-teams-for-linux}"
+version="$(cd "$nixpkgs" && list-git-tags --pname="$(nixeval "$attr".pname)" --attr-path="$attr" | grep '^v' | sed -e 's|^v||' | sort -V | tail -n1)"
+
+pkgpath="$(findpath "$attr")"
+
+updated="$(cd "$nixpkgs" && update-source-version "$attr" "$version" --file="$pkgpath" --print-changes | jq -r length)"
+
+if [ "$updated" -eq 0 ]; then
+    echo 'update.sh: Package version not updated, nothing to do.'
+    exit 0
+fi
+
+curhash="$(nixeval "$attr.offlineCache.outputHash")"
+newhash="$(vendorhash "$attr.offlineCache")"
+
+if [ -n "$newhash" ] && [ "$curhash" != "$newhash" ]; then
+    sed -i -e "s|\"$curhash\"|\"$newhash\"|" "$pkgpath"
+else
+    echo 'update.sh: New vendorHash same as old vendorHash, nothing to do.'
+fi


### PR DESCRIPTION
###### Description of changes

Add update script (based on existing one I use for `sonic-pi`, which is in a similar situation with a FOD that isn't directly supported by nix-update right now) and bump version

The only changes in the 1.0.53 -> 1.0.56 bump is supporting a custom app title (which didn't come with release notes it seems...), a command line flag to disable the notification sound ([notes](https://github.com/ismaelmartinez/teams-for-linux/releases/tag/1.0.55)), and several bug fixes ([notes](https://github.com/ismaelmartinez/teams-for-linux/releases))

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).