### PR TITLE
neovide-bin: init at 0.10.3

### DIFF
--- a/pkgs/applications/editors/neovim/neovide/bin.nix
+++ b/pkgs/applications/editors/neovim/neovide/bin.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, undmg
+, unzip
+, makeWrapper
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "neovide-bin";
+  version = "0.10.3";
+
+  src = fetchurl {
+    url = "https://github.com/neovide/neovide/releases/download/${version}/Neovide.dmg.zip";
+    sha256 = "sha256-+oupgom7NpUb1q4Uok7EE3zs7Ji8sWtXdvWCCtfIVFk=";
+  };
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  nativeBuildInputs = [ makeWrapper unzip undmg ];
+
+  sourceRoot = "Neovide.app";
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    ${unzip}/bin/unzip $src -d $TMPDIR
+    /usr/bin/hdiutil mount $TMPDIR/Neovide.dmg
+    cp -R /Volumes/Neovide/Neovide.app .
+    /usr/bin/hdiutil unmount /Volumes/Neovide
+    rm -r $TMPDIR/Neovide.dmg
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{Applications/Neovide.app,bin}
+    cp -R . $out/Applications/Neovide.app
+    makeWrapper $out/Applications/Neovide.app/Contents/MacOS/neovide $out/bin/neovide
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "No Nonsense Neovim Client in Rust";
+    homepage = "https://neovide.dev";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ stepbrobd ];
+    mainProgram = "neovide";
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34132,6 +34132,7 @@ with pkgs;
   gnvim = callPackage ../applications/editors/neovim/gnvim/wrapper.nix { };
 
   neovide = callPackage ../applications/editors/neovim/neovide { };
+  neovide-bin = callPackage ../applications/editors/neovim/neovide/bin.nix { };
 
   neovim-remote = callPackage ../applications/editors/neovim/neovim-remote.nix { };
 


### PR DESCRIPTION
###### Description of changes

The [`neovide`](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/editors/neovim/neovide/default.nix) package cannot be used as a MacOS application and cannot be added to "Home Manager Apps" managed by `nix-darwin`.

I'm adding `neovide-bin` specifically for darwin systems and it uses Neovide binary provided in original repo's [release](https://github.com/neovide/neovide/releases) section.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
