### PR TITLE
Revert "python3Packages.scooby: unbreak"

### DIFF
--- a/pkgs/development/python-modules/scooby/default.nix
+++ b/pkgs/development/python-modules/scooby/default.nix
@@ -25,11 +25,6 @@ buildPythonPackage rec {
     hash = "sha256-wKbCIA6Xp+VYhcQ5ZpHo5usB+ksnMAJyv5naBvl4Cxo=";
   };
 
-  postPatch = ''
-    # Drop broken version specifier
-    sed -i '/python_requires/d' setup.py
-  '';
-
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#221874
A better version of that change is included in https://github.com/NixOS/nixpkgs/pull/221432.