### PR TITLE
ocamlPackages.secp256k1-internal: 0.3 → 0.4; ocamlPackages.hidapi: 1.1.1 → 1.1.2

### DIFF
--- a/pkgs/development/ocaml-modules/bigstring/default.nix
+++ b/pkgs/development/ocaml-modules/bigstring/default.nix
@@ -1,12 +1,16 @@
-{ lib, fetchFromGitHub, buildDunePackage }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml }:
 
 buildDunePackage rec {
   pname = "bigstring";
   version = "0.3";
 
-  useDune2 = true;
+  duneVersion = "3";
+  minimalOCamlVersion = "4.03";
 
-  minimumOCamlVersion = "4.03";
+  # Ensure compatibility with OCaml ≥ 5.0
+  preConfigure = lib.optional (lib.versionAtLeast ocaml.version "4.08") ''
+    substituteInPlace src/dune --replace '(libraries bytes bigarray)' ""
+  '';
 
   src = fetchFromGitHub {
     owner = "c-cube";

--- a/pkgs/development/ocaml-modules/hidapi/default.nix
+++ b/pkgs/development/ocaml-modules/hidapi/default.nix
@@ -1,19 +1,21 @@
-{ pkgs, lib, fetchurl, buildDunePackage, pkg-config, dune-configurator
+{ pkgs, lib, fetchFromGitHub, buildDunePackage, pkg-config, dune-configurator
 , bigstring,
 }:
 
 buildDunePackage rec {
   pname = "hidapi";
-  version = "1.1.1";
+  version = "1.1.2";
 
-  useDune2 = true;
+  duneVersion = "3";
 
-  src = fetchurl {
-    url = "https://github.com/vbmithr/ocaml-hidapi/releases/download/${version}/${pname}-${version}.tbz";
-    sha256 = "1j7rd7ajrzla76r3sxljx6fb18f4f4s3jd7vhv59l2ilxyxycai2";
+  src = fetchFromGitHub {
+    owner = "vbmithr";
+    repo = "ocaml-hidapi";
+    rev = version;
+    hash = "sha256-SNQ1/i5wJJgcslIUBe+z5QgHns/waHnILyMUJ46cUwg=";
   };
 
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.03";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ pkgs.hidapi dune-configurator ];

--- a/pkgs/development/ocaml-modules/secp256k1-internal/default.nix
+++ b/pkgs/development/ocaml-modules/secp256k1-internal/default.nix
@@ -11,15 +11,16 @@
 
 buildDunePackage rec {
   pname = "secp256k1-internal";
-  version = "0.3";
+  version = "0.4";
   src = fetchFromGitLab {
     owner = "nomadic-labs";
     repo = "ocaml-secp256k1-internal";
-    rev = version;
-    sha256 = "sha256-1wvQ4RW7avcGsIc0qgDzhGrwOBY0KHrtNVHCj2cgNzo=";
+    rev = "v${version}";
+    hash = "sha256-amVtp94cE1NxClWJgcJvRmilnQlC7z44mORUaxvPn00=";
   };
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     gmp

--- a/pkgs/development/ocaml-modules/uecc/default.nix
+++ b/pkgs/development/ocaml-modules/uecc/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "uecc";
   version = "0.4";
 
+  duneVersion = "3";
+
   src = fetchFromGitLab {
     owner = "nomadic-labs";
     repo = "ocaml-uecc";


### PR DESCRIPTION
###### Description of changes

Compatibility with OCaml 5.0: https://github.com/vbmithr/ocaml-hidapi/blob/1.1.2/CHANGES

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
