### PR TITLE
git-archive-all: init at 1.23.1

### DIFF
--- a/pkgs/applications/version-management/git-archive-all/default.nix
+++ b/pkgs/applications/version-management/git-archive-all/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, git
+, pytestCheckHook
+, pytest-mock
+}:
+
+buildPythonApplication rec {
+  pname = "git-archive-all";
+  version = "1.23.1";
+
+  src = fetchFromGitHub {
+    owner = "Kentzo";
+    repo = "git-archive-all";
+    rev = version;
+    hash = "sha256-fIPjggOx+CEorj1bazz8s81ZdppkTL0OlA5tRqCYZyc=";
+  };
+
+  # * Don't use pinned dependencies
+  # * Remove formatter and coverage generator
+  # * Don't fail on warnings. Almost all tests output this warning:
+  #   ResourceWarning: unclosed file [...]/repo.tar
+  #   https://github.com/Kentzo/git-archive-all/issues/90
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace pycodestyle==2.5.0 "" \
+      --replace pytest==5.2.2 pytest \
+      --replace pytest-cov==2.8.1 "" \
+      --replace pytest-mock==1.11.2 pytest-mock \
+      --replace "--cov=git_archive_all --cov-report=term --cov-branch" "" \
+      --replace "filterwarnings = error" ""
+    substituteInPlace test_git_archive_all.py \
+      --replace "import pycodestyle" ""
+  '';
+
+  nativeCheckInputs = [
+    git
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  disabledTests = [ "pycodestyle" ];
+
+  preCheck = ''
+    export HOME="$(mktemp -d)"
+  '';
+
+  meta = with lib; {
+    description = "Archive a repository with all its submodules";
+    longDescription = ''
+      A python script wrapper for git-archive that archives a git superproject
+      and its submodules, if it has any. Takes into account .gitattributes
+    '';
+    homepage = "https://github.com/Kentzo/git-archive-all";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1813,6 +1813,8 @@ with pkgs;
 
   git-appraise = callPackage ../applications/version-management/git-appraise { };
 
+  git-archive-all = python3.pkgs.callPackage ../applications/version-management/git-archive-all { };
+
   git-backup = callPackage ../applications/version-management/git-backup {
     openssl = openssl_1_1;
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
