### PR TITLE
ocamlPackages.hex: 1.4.0 → 1.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/bls12-381-signature/default.nix
+++ b/pkgs/development/ocaml-modules/bls12-381-signature/default.nix
@@ -16,6 +16,8 @@ buildDunePackage rec {
     sha256 = "sha256-KaUpAT+BWxmUP5obi4loR9vVUeQmz3p3zG3CBolUuL4=";
   };
 
+  duneVersion = "3";
+
   minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [ bls12-381 ];

--- a/pkgs/development/ocaml-modules/bls12-381/default.nix
+++ b/pkgs/development/ocaml-modules/bls12-381/default.nix
@@ -14,6 +14,7 @@ buildDunePackage rec {
   };
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     ff-sig

--- a/pkgs/development/ocaml-modules/bls12-381/gen.nix
+++ b/pkgs/development/ocaml-modules/bls12-381/gen.nix
@@ -11,7 +11,7 @@ buildDunePackage rec {
     sha256 = "qocIfQdv9rniOUykRulu2zWsqkzT0OrsGczgVKALRuk=";
   };
 
-  useDune2 = true;
+  duneVersion = "3";
 
   minimalOCamlVersion = "4.08";
 

--- a/pkgs/development/ocaml-modules/bls12-381/legacy.nix
+++ b/pkgs/development/ocaml-modules/bls12-381/legacy.nix
@@ -13,7 +13,9 @@
 buildDunePackage rec {
   pname = "bls12-381-legacy";
 
-  inherit (bls12-381-gen) version src useDune2 doCheck;
+  inherit (bls12-381-gen) version src doCheck;
+
+  duneVersion = "3";
 
   minimalOCamlVersion = "4.08";
 

--- a/pkgs/development/ocaml-modules/hex/default.nix
+++ b/pkgs/development/ocaml-modules/hex/default.nix
@@ -1,19 +1,18 @@
-{ lib, fetchurl, buildDunePackage, bigarray-compat, cstruct }:
+{ lib, fetchurl, buildDunePackage, cstruct }:
 
 buildDunePackage rec {
   pname = "hex";
-  version = "1.4.0";
+  version = "1.5.0";
 
-  useDune2 = true;
-
-  minimumOCamlVersion = "4.02";
+  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-${pname}/releases/download/v${version}/hex-v${version}.tbz";
-    sha256 = "07b9y0lmnflsslkrm6xilkj40n8sf2hjqkyqghnk7sw5l0plkqsp";
+    url = "https://github.com/mirage/ocaml-${pname}/releases/download/v${version}/hex-${version}.tbz";
+    hash = "sha256-LmfuyhsDBJMHowgxtc1pS8stPn8qa0+1l/vbZHNRtNw=";
   };
 
-  propagatedBuildInputs = [ bigarray-compat cstruct ];
+  propagatedBuildInputs = [ cstruct ];
   doCheck = true;
 
   meta = {


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/ocaml-hex/blob/v1.5.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
