### PR TITLE
ffmpeg_6: init at 6.0

### DIFF
--- a/pkgs/development/libraries/ffmpeg/6.nix
+++ b/pkgs/development/libraries/ffmpeg/6.nix
@@ -1,0 +1,4 @@
+import ./generic.nix rec {
+  version = "6.0";
+  sha256 = "sha256-RVbgsafIbeUUNXmUbDQ03ZN42oaUo0njqROo7KOQgv0=";
+}

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -227,6 +227,7 @@
 , libxml2
 , xz
 , nv-codec-headers
+, nv-codec-headers-11
 , openal
 , ocl-icd # OpenCL ICD
 , opencl-headers  # OpenCL headers
@@ -348,7 +349,14 @@ stdenv.mkDerivation (finalAttrs: {
       --replace VK_EXT_VIDEO_DECODE VK_KHR_VIDEO_DECODE
   '';
 
-  patches = map (patch: fetchpatch patch) extraPatches;
+  patches = map (patch: fetchpatch patch) (extraPatches
+    ++ (lib.optional (lib.versionAtLeast version "6" && lib.versionOlder version "6.1")
+      { # this can be removed post 6.1
+        name = "fix_aacps_tablegen";
+        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/814178f92647be2411516bbb82f48532373d2554";
+        hash = "sha256-FQV9/PiarPXCm45ldtCsxGHjlrriL8DKpn1LaKJ8owI=";
+      }
+    ));
 
   configurePlatforms = [];
   setOutputFlags = false; # Only accepts some of them
@@ -539,7 +547,7 @@ stdenv.mkDerivation (finalAttrs: {
   # TODO This was always in buildInputs before, why?
   buildInputs = optionals withFullDeps [ libdc1394 ]
   ++ optionals (withFullDeps && !stdenv.isDarwin) [ libraw1394 ] # TODO where does this belong to
-  ++ optionals (withNvdec || withNvenc) [ nv-codec-headers ]
+  ++ optionals (withNvdec || withNvenc) [ (if (lib.versionAtLeast version "6") then nv-codec-headers-11 else nv-codec-headers) ]
   ++ optionals withAlsa [ alsa-lib ]
   ++ optionals withAom [ libaom ]
   ++ optionals withAss [ libass ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19890,6 +19890,18 @@ with pkgs;
     ffmpegVariant = "full";
   };
 
+  ffmpeg_6 = callPackage ../development/libraries/ffmpeg/6.nix {
+     inherit (darwin.apple_sdk.frameworks)
+      Cocoa CoreServices CoreAudio CoreMedia AVFoundation MediaToolbox
+      VideoDecodeAcceleration VideoToolbox;
+  };
+  ffmpeg_6-headless = ffmpeg_6.override {
+    ffmpegVariant = "headless";
+  };
+  ffmpeg_6-full = ffmpeg_6.override {
+    ffmpegVariant = "full";
+  };
+
   # Aliases
   # Please make sure this is updated to the latest version on the next major
   # update to ffmpeg


### PR DESCRIPTION
###### Description of changes

[Changelog](https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/ea3d24bbe3c58b171e55fe2151fc7ffaca3ab3d2:/Changelog#l4)
Fixes #219190

@doronbehar also ran into the cuvid/ffnvcodec error [here](https://github.com/NixOS/nixpkgs/pull/218309#issuecomment-1450423904), but was referring to a 2019 version of the configure script, whereas the current version demands a more recent nv-codec-headers. I'm passing nv-codec-headers-11 here, but this also affects ffmpeg 4/5, and while they still build fine, I'm unable to test if the bump breaks nvdec.

[The patch](https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/814178f92647be2411516bbb82f48532373d2554) is necessary if `hardcoded-tables` is enabled (enabled by default).
I'm uncertain about the correct patch source: there's an [alternative GitHub version](https://github.com/FFmpeg/FFmpeg/commit/814178f92647be2411516bbb82f48532373d2554.patch) of the patch, but that's just a mirror.

Alternatively, we could package a non-release revision, but that seems less predictable than cherry-picking this commit.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
