### PR TITLE
rustPlatform.importCargoLock: handle workspace Cargo.toml false positives

### DIFF
--- a/pkgs/build-support/rust/replace-workspace-values.py
+++ b/pkgs/build-support/rust/replace-workspace-values.py
@@ -63,8 +63,16 @@ def replace_dependencies(
 
 
 def main() -> None:
+    top_cargo_toml = load_file(sys.argv[2])
+
+    if "workspace" not in top_cargo_toml:
+        # If top_cargo_toml is not a workspace manifest, then this script was probably
+        # ran on something that does not actually use workspace dependencies
+        print(f"{sys.argv[2]} is not a workspace manifest, doing nothing.")
+        return
+
     crate_manifest = load_file(sys.argv[1])
-    workspace_manifest = load_file(sys.argv[2])["workspace"]
+    workspace_manifest = top_cargo_toml["workspace"]
 
     if "workspace" in crate_manifest:
         return


### PR DESCRIPTION
###### Description of changes
A cargo dependency to nurl (upstream trunk branch), nix-compat, currently references [a Cargo.toml](https://cs.tvl.fyi/depot/-/blob/tvix/nix-compat/Cargo.toml), which contains the word "workspace" in a comment but does not actually use workspaces. 

Since `replace-workspace-values.py` is run after [grepping for "workspace"](https://github.com/NixOS/nixpkgs/blob/cece2880925ae3ef222953859a37055919489474/pkgs/build-support/rust/import-cargo-lock.nix#L179-L182), it currently crashes on this. To work around this, we check if the top-level Cargo.toml actually has a "workspace" key, and then do nothing and continue if it doesn't. That way, we can keep the grep for "workspace", so we don't need to run the Python script for every dep, but still handle false positives. If the top-level Cargo.toml *should* have a workspace key but doesn't, the build should still fail, just elsewhere (and hopefully logging that we did nothing helps track that down).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

