### PR TITLE
nixos/flatpak: fix launching flatpaks with `DBusActivatable=true`

### DIFF
--- a/nixos/modules/services/desktops/flatpak.nix
+++ b/nixos/modules/services/desktops/flatpak.nix
@@ -34,6 +34,8 @@ in {
 
     services.dbus.packages = [ pkgs.flatpak ];
 
+    services.dbus.implementation = "broker";
+
     systemd.packages = [ pkgs.flatpak ];
 
     environment.profiles = [

--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -18,6 +18,7 @@
 , libXi
 , libXext
 , gnome
+, systemd
 }:
 
 stdenv.mkDerivation rec {
@@ -36,6 +37,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
+    systemd
     makeWrapper
   ] ++ lib.optionals withIntrospection [
     gobject-introspection
@@ -67,6 +69,7 @@ stdenv.mkDerivation rec {
     # including the entire dbus closure in libraries linked with
     # the at-spi2-core libraries.
     "-Ddbus_daemon=/run/current-system/sw/bin/dbus-daemon"
+    "-Ddbus_broker=/run/current-system/sw/bin/dbus-broker-launch"
   ];
 
   passthru = {

--- a/pkgs/os-specific/linux/systemd/0015-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
+++ b/pkgs/os-specific/linux/systemd/0015-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
@@ -19,8 +19,8 @@ index 22d3632e6e..1e8bbb242b 100644
  
 -#define DEFAULT_PATH_NORMAL PATH_SBIN_BIN("/usr/local/") ":" PATH_SBIN_BIN("/usr/")
 -#define DEFAULT_PATH_NORMAL_NULSTR PATH_SBIN_BIN_NULSTR("/usr/local/") PATH_SBIN_BIN_NULSTR("/usr/")
-+#define DEFAULT_PATH_NORMAL "@defaultPathNormal@"
-+#define DEFAULT_PATH_NORMAL_NULSTR "@defaultPathNormal@\0"
++#define DEFAULT_PATH_NORMAL "@defaultPathNormal@" ":" PATH_SBIN_BIN("/run/current-system/sw/")
++#define DEFAULT_PATH_NORMAL_NULSTR "@defaultPathNormal@\0" PATH_SBIN_BIN_NULSTR("/run/current-system/sw/")
  #define DEFAULT_PATH_SPLIT_USR DEFAULT_PATH_NORMAL ":" PATH_SBIN_BIN("/")
  #define DEFAULT_PATH_SPLIT_USR_NULSTR DEFAULT_PATH_NORMAL_NULSTR PATH_SBIN_BIN_NULSTR("/")
 -#define DEFAULT_PATH_COMPAT PATH_SPLIT_SBIN_BIN("/usr/local/") ":" PATH_SPLIT_SBIN_BIN("/usr/") ":" PATH_SPLIT_SBIN_BIN("/")


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #138956

At the moment, flatpak packages containing the line `DBusActivatable=true` fail to launch from both the app menu or via the `gtk-launch` command.

`journalctl` output:

```
Mar 22 13:06:49 snowflakeos systemd[10420]: dbus-:1.1-org.gnome.design.Palette@0.service: Failed at step EXEC spawning flatpak: No such file or directory
░░ Subject: Process flatpak could not be executed
░░ Defined-By: systemd
░░ Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
░░ 
░░ The process flatpak could not be executed and failed.
░░ 
░░ The error number returned by this process is ERRNO.
```

###### Things done

- Add `/run/current-system/sw/` to systemd's `DEFAULT_PATH_NORMAL`. Allowing it to check and execute more than just systemd commands.

- Make `services.flatpak.enable` use `services.dbus.implementation = "broker"`.
  https://github.com/NixOS/nixpkgs/issues/138956#issuecomment-1343907051

- Compile `at-spi2-core` with a path to `dbus-broker`
   Fixes issue with a11y when `services.dbus.implementation = "broker"` is set. 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
