### PR TITLE
libpg_query: also build shared library

### DIFF
--- a/pkgs/development/libraries/libpg_query/default.nix
+++ b/pkgs/development/libraries/libpg_query/default.nix
@@ -13,11 +13,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ which ];
 
-  makeFlags = [ "build" ];
+  makeFlags = [ "build" "build_shared" ];
 
   installPhase = ''
     install -Dm644 -t $out/lib libpg_query.a
     install -Dm644 -t $out/include pg_query.h
+  '' + lib.optionalString stdenv.isLinux ''
+    install -Dm644 -t $out/lib libpg_query.so
+  '' + lib.optionalString stdenv.isDarwin ''
+    install -Dm644 -t $out/lib libpg_query.dylib
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/libpg_query/default.nix
+++ b/pkgs/development/libraries/libpg_query/default.nix
@@ -24,6 +24,11 @@ stdenv.mkDerivation rec {
     install -Dm644 -t $out/lib libpg_query.dylib
   '';
 
+  doCheck = true;
+  checkPhase = ''
+    make test
+  '';
+
   meta = with lib; {
     homepage = "https://github.com/pganalyze/libpg_query";
     description = "C library for accessing the PostgreSQL parser outside of the server environment";

--- a/pkgs/development/libraries/libpg_query/default.nix
+++ b/pkgs/development/libraries/libpg_query/default.nix
@@ -25,9 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = true;
-  checkPhase = ''
-    make test
-  '';
+  checkTarget = "test";
 
   meta = with lib; {
     homepage = "https://github.com/pganalyze/libpg_query";

--- a/pkgs/development/libraries/libpg_query/default.nix
+++ b/pkgs/development/libraries/libpg_query/default.nix
@@ -18,10 +18,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -Dm644 -t $out/lib libpg_query.a
     install -Dm644 -t $out/include pg_query.h
-  '' + lib.optionalString stdenv.isLinux ''
-    install -Dm644 -t $out/lib libpg_query.so
-  '' + lib.optionalString stdenv.isDarwin ''
-    install -Dm644 -t $out/lib libpg_query.dylib
+    install -Dm644 -t $out/lib libpg_query${stdenv.hostPlatform.extensions.sharedLibrary}
   '';
 
   doCheck = true;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I'm working in an environment (Common Lisp) where I need to be able to load and interact with `libpg_query` dynamically, but the existing derivation only calls the `make` target that builds the static lib. This commit enables and installs the shared library.

Works for me on Darwin, but unsure if any further steps are idiomatic or needed, e.g. patchelf on Linux, please advise if so.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
