### PR TITLE
zf: init at 0.8.0

### DIFF
--- a/pkgs/tools/misc/zf/default.nix
+++ b/pkgs/tools/misc/zf/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zig,
+  testers,
+  zf,
+}:
+stdenv.mkDerivation rec {
+  pname = "zf";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "natecraddock";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    fetchSubmodules = true;
+    hash = "sha256-MzlSU5x2lb6PJZ/iNAi2aebfuClBprlfHMIG/4OPmuc=";
+  };
+
+  nativeBuildInputs = [ zig ];
+
+  dontConfigure = true;
+
+  preBuild = ''
+    export HOME=$TMPDIR
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    zig build -Drelease-safe -Dcpu=baseline --prefix $out install
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion {package = zf;};
+
+  meta = with lib; {
+    homepage = "https://github.com/natecraddock/zf";
+    description = "A commandline fuzzy finder that prioritizes matches on filenames";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ dit7ya mmlb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39633,4 +39633,6 @@ with pkgs;
   udict = callPackage ../applications/misc/udict { };
 
   duden = callPackage ../applications/misc/duden { };
+
+  zf = callPackage ../tools/misc/zf { };
 }


### PR DESCRIPTION
###### Description of changes

zf is a commandline fuzzy finder that prioritizes matches on filenames.
https://github.com/natecraddock/zf

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).