### PR TITLE
python310Packages.simpleitk: init at 2.2.1

### DIFF
--- a/pkgs/development/libraries/itk/generic.nix
+++ b/pkgs/development/libraries/itk/generic.nix
@@ -3,10 +3,7 @@
 { lib, stdenv, fetchFromGitHub, cmake, makeWrapper
 , pkg-config, libX11, libuuid, xz, vtk, Cocoa }:
 
-stdenv.mkDerivation rec {
-  pname = "itk";
-  inherit version;
-
+let
   itkGenericLabelInterpolatorSrc = fetchFromGitHub {
     owner = "InsightSoftwareConsortium";
     repo = "ITKGenericLabelInterpolator";
@@ -20,6 +17,18 @@ stdenv.mkDerivation rec {
     rev = "24825c8d246e941334f47968553f0ae388851f0c";
     hash = "sha256-deJbza36c0Ohf9oKpO2T4po37pkyI+2wCSeGL4r17Go=";
   };
+
+  itkSimpleITKFiltersSrc = fetchFromGitHub {
+    owner = "InsightSoftwareConsortium";
+    repo = "ITKSimpleITKFilters";
+    rev = "bb896868fc6480835495d0da4356d5db009592a6";
+    hash = "sha256-MfaIA0xxA/pzUBSwnAevr17iR23Bo5iQO2cSyknS3o4=";
+  };
+in
+
+stdenv.mkDerivation {
+  pname = "itk";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "InsightSoftwareConsortium";
@@ -36,6 +45,7 @@ stdenv.mkDerivation rec {
       --replace "@OPENJPEG_INSTALL_LIB_DIR@" "@OPENJPEG_INSTALL_FULL_LIB_DIR@"
     ln -sr ${itkGenericLabelInterpolatorSrc} Modules/External/ITKGenericLabelInterpolator
     ln -sr ${itkAdaptiveDenoisingSrc} Modules/External/ITKAdaptiveDenoising
+    ln -sr ${itkSimpleITKFiltersSrc} Modules/External/ITKSimpleITKFilters
   '';
 
   cmakeFlags = [
@@ -45,6 +55,7 @@ stdenv.mkDerivation rec {
     "-DModule_ITKMINC=ON"
     "-DModule_ITKIOMINC=ON"
     "-DModule_ITKIOTransformMINC=ON"
+    "-DModule_SimpleITKFilters=ON"
     "-DModule_ITKVtkGlue=ON"
     "-DModule_ITKReview=ON"
     "-DModule_MGHIO=ON"
@@ -69,7 +80,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Insight Segmentation and Registration Toolkit";
-    homepage = "https://www.itk.org/";
+    homepage = "https://www.itk.org";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [viric];
   };

--- a/pkgs/development/libraries/simpleitk/default.nix
+++ b/pkgs/development/libraries/simpleitk/default.nix
@@ -4,12 +4,10 @@ stdenv.mkDerivation rec {
   pname = "simpleitk";
   version = "2.2.1";
 
-  outputs = [ "out" "dev" ];
-
   src = fetchFromGitHub {
     owner = "SimpleITK";
     repo = "SimpleITK";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-0YxmixUTXpjegZQv7DDCNTWFTH8QEWqQQszee7aQ5EI=";
   };
 

--- a/pkgs/development/python-modules/simpleitk/default.nix
+++ b/pkgs/development/python-modules/simpleitk/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, cmake
+, swig4
+, itk
+, numpy
+, simpleitk
+, scikit-build
+}:
+
+buildPythonPackage rec {
+  inherit (simpleitk) pname version src meta;
+  format = "pyproject";
+  disabled = pythonOlder "3.8";
+
+  sourceRoot = "source/Wrapping/Python";
+  preBuild = ''
+    make
+  '';
+
+  nativeBuildInputs = [ cmake swig4 scikit-build ];
+  propagatedBuildInputs = [ itk simpleitk numpy ];
+
+  pythonImportsCheck = [ "SimpleITK" ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10742,6 +10742,10 @@ self: super: with self; {
 
   simplehound = callPackage ../development/python-modules/simplehound { };
 
+  simpleitk = callPackage ../development/python-modules/simpleitk {
+    inherit (pkgs) simpleitk;
+  };
+
   simplejson = callPackage ../development/python-modules/simplejson { };
 
   simplekml = callPackage ../development/python-modules/simplekml { };


### PR DESCRIPTION
###### Description of changes

Add a package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@cfhammill 
