### PR TITLE
Upgrade to the latest version of Node18

### DIFF
--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -9,8 +9,8 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "18.14.2";
-  sha256 = "sha256-+8Nk3SX+4srMDyAz2y2GEV/AdXUxDqDmRAi4Fw0JxoU=";
+  version = "18.15.0";
+  sha256 = "0dxa9mcda1jpbw721i3yx6141sm0d5j1h8sw362355zz318dci4f";
   patches = [
     ./disable-darwin-v8-system-instrumentation.patch
     ./bypass-darwin-xcrun-node16.patch


### PR DESCRIPTION
###### Description of changes

Upgrade node 18 to the latest version available.

## Things done
```
nix-build -E 'with import <nixpkgs> { }; callPackage ./pkgs/development/web/nodejs/update.nix { majorVersion = "18"; }' 
/nix/store/ll82slvlqahf27wk65xabdnxv02cldj3-update-nodejs
```

This is the output from that command sequence. 

I searched the pulls and could not find a pull that does the same thing.
