### PR TITLE
maintainers/team-list: add 3 new members to LLVM

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -428,6 +428,9 @@ with lib.maintainers; {
       ericson2314
       lovek323
       primeos
+      qyliss
+      raitobezarius
+      rrbutani
       sternenseemann
     ];
     scope = "Maintain LLVM package sets and related packages";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -424,11 +424,11 @@ with lib.maintainers; {
 
   llvm = {
     members = [
-      ericson2314
-      sternenseemann
-      lovek323
       dtzWill
+      ericson2314
+      lovek323
       primeos
+      sternenseemann
     ];
     scope = "Maintain LLVM package sets and related packages";
     shortName = "LLVM";


### PR DESCRIPTION
###### Description of changes

The three of us have been working on getting the different LLVM
versions in sync, and discussing plans for 16, 17, and upgrading the
default (in the Compilers Team Matrix room).  Being notified of PRs will be useful, so that we can make
sure that new PRs don't introduce further unnecessary deltas between
different LLVM versions, which has been a problem so far.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
