### PR TITLE
tzdata: 2022g -> 2023a

### DIFF
--- a/pkgs/data/misc/tzdata/0001-Add-exe-extension-for-MS-Windows-binaries.patch
+++ b/pkgs/data/misc/tzdata/0001-Add-exe-extension-for-MS-Windows-binaries.patch
@@ -2,7 +2,7 @@ diff --git a/Makefile b/Makefile
 index a9a989e..4da737b 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -579,8 +579,8 @@ install:	all $(DATA) $(REDO) $(MANS)
+@@ -606,8 +606,8 @@ install:	all $(DATA) $(REDO) $(MANS)
  			-t '$(DESTDIR)$(TZDEFAULT)'
  		cp -f $(TABDATA) '$(DESTDIR)$(TZDIR)/.'
  		cp tzselect '$(DESTDIR)$(BINDIR)/.'

--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "tzdata";
-  version = "2022g";
+  version = "2023a";
 
   srcs = [
     (fetchurl {
       url = "https://data.iana.org/time-zones/releases/tzdata${version}.tar.gz";
-      hash = "sha256-RJHbgoGulKhNk55Ce92D3DifJnZNJ9mlxS14LBZ2RHg=";
+      hash = "sha256-oqJ+23r1o4TPzv2une+tan7SPz8s/a89U5TB6CmXELw=";
     })
     (fetchurl {
       url = "https://data.iana.org/time-zones/releases/tzcode${version}.tar.gz";
-      hash = "sha256-lhC7C5ZW/0BMNhpB8yhtpTBktUadhPAMnLIxTIYU2nQ=";
+      hash = "sha256-bczNJqE6S3HFPlc6C/MrmN5GeqMxa4Lf0l//22yfxGo=";
     })
   ];
 
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
     "AR=${stdenv.cc.targetPrefix}ar"
   ] ++ lib.optionals stdenv.hostPlatform.isWindows [
     "CFLAGS+=-DHAVE_DIRECT_H"
+    "CFLAGS+=-DHAVE_SETENV=0"
     "CFLAGS+=-DHAVE_SYMLINK=0"
     "CFLAGS+=-DRESERVE_STD_EXT_IDS"
   ];


### PR DESCRIPTION
###### Description of changes

https://mm.icann.org/pipermail/tz-announce/2023-March/000077.html

I also fixed the Windows cross-build, which was broken since 2022g.

Maintainers: @ajs124 @fpletz 

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux (`pkgsCross.aarch64-multiplatform.tzdata`)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [X] x86_64-windows (`pkgsCross.mingwW64.tzdata`)
  - [X] i686-windows (`pkgsCross.mingw32.tzdata`)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).