### PR TITLE
raysession: init at 0.13.1

### DIFF
--- a/pkgs/applications/audio/raysession/default.nix
+++ b/pkgs/applications/audio/raysession/default.nix
@@ -1,0 +1,44 @@
+{ lib, fetchurl, buildPythonApplication, pydbus, pyliblo, pyqt5, qttools, which }:
+
+buildPythonApplication rec {
+  pname = "raysession";
+  version = "0.13.1";
+
+  src = fetchurl {
+    url = "https://github.com/Houston4444/RaySession/releases/download/v${version}/RaySession-${version}-source.tar.gz";
+    sha256 = "sha256-iiFRtX43u9BHe7a4ojza7kav+dMW9e05dPi7Gf9d1GM=";
+  };
+
+  postPatch = ''
+    # Fix installation path of xdg schemas.
+    substituteInPlace Makefile --replace '$(DESTDIR)/' '$(DESTDIR)$(PREFIX)/'
+    # Do not wrap an importable module with a shell script.
+    chmod -x src/daemon/desktops_memory.py
+  '';
+
+  format = "other";
+
+  nativeBuildInputs = [
+    pyqt5   # pyuic5 and pyrcc5 to build resources.
+    qttools # lrelease to build translations.
+    which   # which to find lrelease.
+  ];
+
+  propagatedBuildInputs = [ pydbus pyliblo pyqt5 ];
+
+  dontWrapQtApps = true; # The program is a python script.
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postFixup = ''
+    wrapPythonProgramsIn "$out/share/raysession/src" "$out $pythonPath"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Houston4444/RaySession";
+    description = "Session manager for Linux musical programs";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11395,6 +11395,10 @@ with pkgs;
 
   pystring = callPackage ../development/libraries/pystring { };
 
+  raysession = python3Packages.callPackage ../applications/audio/raysession {
+    inherit (qt5) qttools;
+  };
+
   rbw = callPackage ../tools/security/rbw {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Description of changes

Fixes #194022

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
