### PR TITLE
tiledb: 2.3.3 -> 2.8.3, spdlog: 1.10.0 -> 1.11.0, spdlog_0: remove

### DIFF
--- a/pkgs/applications/science/electronics/hal-hardware-analyzer/default.nix
+++ b/pkgs/applications/science/electronics/hal-hardware-analyzer/default.nix
@@ -41,7 +41,7 @@ let
   # no stable hal release yet with recent spdlog/fmt support, remove
   # once 4.0.0 is released - see https://github.com/emsec/hal/issues/452
   spdlog' = spdlog.override {
-    fmt_8 = fmt_8.overrideAttrs (_: rec {
+    fmt = fmt_8.overrideAttrs (_: rec {
       version = "8.0.1";
       src = fetchFromGitHub {
         owner = "fmtlib";

--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -1,27 +1,20 @@
-{ lib, stdenv, fetchFromGitHub, cmake, fmt_8, fetchpatch
+{ lib, stdenv, fetchFromGitHub, cmake, fmt
 , staticBuild ? stdenv.hostPlatform.isStatic
 }:
 
 stdenv.mkDerivation rec {
   pname = "spdlog";
-  version = "1.10.0";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
     owner = "gabime";
     repo  = "spdlog";
     rev   = "v${version}";
-    hash  = "sha256-c6s27lQCXKx6S1FhZ/LiKh14GnXMhZtD1doltU4Avws=";
+    hash  = "sha256-kA2MAb4/EygjwiLEjF9EA7k8Tk//nwcKB1+HlzELakQ=";
   };
 
-  # in master post 1.10.0, see https://github.com/gabime/spdlog/issues/2380
-  patches = lib.optional (lib.versionAtLeast version "1.4.1") (fetchpatch {
-    name = "fix-pkg-config.patch";
-    url = "https://github.com/gabime/spdlog/commit/afb69071d5346b84e38fbcb0c8c32eddfef02a55.patch";
-    sha256 = "0cab2bbv8zyfhrhfvcyfwf5p2fddlq5hs2maampn5w18f6jhvk6q";
-  });
-
   nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ fmt_8 ];
+  propagatedBuildInputs = [ fmt ];
 
   cmakeFlags = [
     "-DSPDLOG_BUILD_SHARED=${if staticBuild then "OFF" else "ON"}"

--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -2,67 +2,50 @@
 , staticBuild ? stdenv.hostPlatform.isStatic
 }:
 
-let
-  generic = { version, sha256 }:
-    stdenv.mkDerivation {
-      pname = "spdlog";
-      inherit version;
+stdenv.mkDerivation rec {
+  pname = "spdlog";
+  version = "1.10.0";
 
-      src = fetchFromGitHub {
-        owner  = "gabime";
-        repo   = "spdlog";
-        rev    = "v${version}";
-        inherit sha256;
-      };
-
-      # in master post 1.10.0, see https://github.com/gabime/spdlog/issues/2380
-      patches = lib.optional (lib.versionAtLeast version "1.4.1") (fetchpatch {
-        name = "fix-pkg-config.patch";
-        url = "https://github.com/gabime/spdlog/commit/afb69071d5346b84e38fbcb0c8c32eddfef02a55.patch";
-        sha256 = "0cab2bbv8zyfhrhfvcyfwf5p2fddlq5hs2maampn5w18f6jhvk6q";
-      });
-
-      nativeBuildInputs = [ cmake ];
-      # spdlog <1.3 uses a bundled version of fmt
-      propagatedBuildInputs = lib.optional (lib.versionAtLeast version "1.3") fmt_8;
-
-      cmakeFlags = [
-        "-DSPDLOG_BUILD_SHARED=${if staticBuild then "OFF" else "ON"}"
-        "-DSPDLOG_BUILD_STATIC=${if staticBuild then "ON" else "OFF"}"
-        "-DSPDLOG_BUILD_EXAMPLE=OFF"
-        "-DSPDLOG_BUILD_BENCH=OFF"
-        "-DSPDLOG_BUILD_TESTS=ON"
-        "-DSPDLOG_FMT_EXTERNAL=ON"
-      ];
-
-      outputs = [ "out" "doc" ]
-        # spdlog <1.4 is header only, no need to split libraries and headers
-        ++ lib.optional (lib.versionAtLeast version "1.4") "dev";
-
-      postInstall = ''
-        mkdir -p $out/share/doc/spdlog
-        cp -rv ../example $out/share/doc/spdlog
-      '';
-
-      doCheck = true;
-
-      meta = with lib; {
-        description    = "Very fast, header only, C++ logging library";
-        homepage       = "https://github.com/gabime/spdlog";
-        license        = licenses.mit;
-        maintainers    = with maintainers; [ obadz ];
-        platforms      = platforms.all;
-      };
-    };
-in
-{
-  spdlog_1 = generic {
-    version = "1.10.0";
-    sha256 = "sha256-c6s27lQCXKx6S1FhZ/LiKh14GnXMhZtD1doltU4Avws=";
+  src = fetchFromGitHub {
+    owner = "gabime";
+    repo  = "spdlog";
+    rev   = "v${version}";
+    hash  = "sha256-c6s27lQCXKx6S1FhZ/LiKh14GnXMhZtD1doltU4Avws=";
   };
 
-  spdlog_0 = generic {
-    version = "0.17.0";
-    sha256 = "112kfh4fbpm5cvrmgbgz4d8s802db91mhyjpg7cwhlywffnzkwr9";
+  # in master post 1.10.0, see https://github.com/gabime/spdlog/issues/2380
+  patches = lib.optional (lib.versionAtLeast version "1.4.1") (fetchpatch {
+    name = "fix-pkg-config.patch";
+    url = "https://github.com/gabime/spdlog/commit/afb69071d5346b84e38fbcb0c8c32eddfef02a55.patch";
+    sha256 = "0cab2bbv8zyfhrhfvcyfwf5p2fddlq5hs2maampn5w18f6jhvk6q";
+  });
+
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [ fmt_8 ];
+
+  cmakeFlags = [
+    "-DSPDLOG_BUILD_SHARED=${if staticBuild then "OFF" else "ON"}"
+    "-DSPDLOG_BUILD_STATIC=${if staticBuild then "ON" else "OFF"}"
+    "-DSPDLOG_BUILD_EXAMPLE=OFF"
+    "-DSPDLOG_BUILD_BENCH=OFF"
+    "-DSPDLOG_BUILD_TESTS=ON"
+    "-DSPDLOG_FMT_EXTERNAL=ON"
+  ];
+
+  outputs = [ "out" "doc" "dev" ] ;
+
+  postInstall = ''
+    mkdir -p $out/share/doc/spdlog
+    cp -rv ../example $out/share/doc/spdlog
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description    = "Very fast, header only, C++ logging library";
+    homepage       = "https://github.com/gabime/spdlog";
+    license        = licenses.mit;
+    maintainers    = with maintainers; [ obadz ];
+    platforms      = platforms.all;
   };
 }

--- a/pkgs/development/libraries/tiledb/default.nix
+++ b/pkgs/development/libraries/tiledb/default.nix
@@ -6,7 +6,7 @@
 , lz4
 , bzip2
 , zstd
-, spdlog_0
+, spdlog
 , tbb
 , openssl
 , boost
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation rec {
   pname = "tiledb";
-  version = "2.3.3";
+  version = "2.8.3";
 
   src = fetchFromGitHub {
     owner = "TileDB-Inc";
     repo = "TileDB";
     rev = version;
-    sha256 = "sha256-3Z5+QUzo2f24q11j6s8KX2vHLFkipFvGk2VFComWW/o=";
+    hash = "sha256-HKMVwrPnk9/mukH3mJ2LEAvA9LBF4PcgBZjbbLhO9qU=";
   };
 
   # (bundled) blosc headers have a warning on some archs that it will be using
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     lz4
     bzip2
     zstd
-    spdlog_0
+    spdlog
     tbb
     openssl
     boost
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
     ln -sf ${catch2}/include/catch2 build/externals/src/ep_catch/single_include
   '';
 
-  doCheck = false; # 9 failing tests due to what seems an overflow
+  doCheck = true;
 
   installTargets = [ "install-tiledb" "doc" ];
 

--- a/pkgs/development/tools/poac/default.nix
+++ b/pkgs/development/tools/poac/default.nix
@@ -7,7 +7,6 @@
 , git2-cpp
 , cacert
 , boost179
-, fmt_8
 , icu
 , libarchive
 , libgit2
@@ -60,7 +59,6 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DPOAC_BUILD_TESTING=OFF"
     "-DCPM_SOURCE_CACHE=${placeholder "out"}/share"
-    "-DFETCHCONTENT_SOURCE_DIR_FMT=${fmt_8}"
     "-DFETCHCONTENT_SOURCE_DIR_GIT2-CPP=${git2-cpp.src}"
     "-DFETCHCONTENT_SOURCE_DIR_GLOB=${glob}"
     "-DFETCHCONTENT_SOURCE_DIR_PACKAGEPROJECT.CMAKE=${package-project-cmake.src}"
@@ -76,7 +74,6 @@ stdenv.mkDerivation rec {
       enableShared = stdenv.isDarwin;
       enableStatic = !stdenv.isDarwin;
     })
-    fmt_8
     git2-cpp
     glob
     package-project-cmake

--- a/pkgs/tools/package-management/micromamba/default.nix
+++ b/pkgs/tools/package-management/micromamba/default.nix
@@ -16,7 +16,6 @@
 , spdlog
 , termcolor
 , tl-expected
-, fmt_9
 }:
 
 let
@@ -33,20 +32,6 @@ let
         sha256 = "1iic0yx7h8s662hi2jqx68w5kpyrab4fr017vxd4wyxb6wyk35dd";
       })
     ];
-  });
-
-  spdlog' = spdlog.overrideAttrs (oldAttrs: {
-    # Use as header-only library.
-    #
-    # Spdlog 1.11 requires fmt version 8 while micromamba requires
-    # version 9. spdlog may use its bundled version of fmt,
-    # though. Micromamba is not calling spdlog functions with
-    # fmt-types in their signature. I.e. we get away with removing
-    # fmt_8 from spdlog's propagated dependencies and using fmt_9 for
-    # micromamba itself.
-    dontBuild = true;
-    cmakeFlags = oldAttrs.cmakeFlags ++ [ "-DSPDLOG_FMT_EXTERNAL=OFF" ];
-    propagatedBuildInputs = [];
   });
 in
 stdenv.mkDerivation rec {
@@ -71,12 +56,11 @@ stdenv.mkDerivation rec {
     yaml-cpp
     libsolv'
     reproc
-    spdlog'
+    spdlog
     termcolor
     ghc_filesystem
     python3
     tl-expected
-    fmt_9
   ];
 
   cmakeFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39468,10 +39468,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
   };
 
-  inherit (callPackages ../development/libraries/spdlog { })
-    spdlog_0 spdlog_1;
-
-  spdlog = spdlog_1;
+  spdlog = callPackage ../development/libraries/spdlog { };
 
   dart = callPackage ../development/compilers/dart { };
 


### PR DESCRIPTION
###### Description of changes

- update tiledb to a version compatible with spdlog, unpin from spdlog_0.
  More recent versions of tiledb exist, but 2.8.3 is the last where the dependencies are easy to handle. I didn't manage to build tiledb >= 2.9.0 because of cmake errors and mixed internal and external dependencies. So I chose the "quick" route and bumped the version of tiledb just a bit and not to the latest possible.
- remove spdlog_0 because it is not used anymore
- update spdlog to the latest release
- cleanup micromamba from a workaround where it used fmt_9 and spdlog used fmt_8. Align both to fmt_9.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux (`pkgsCross.aarch64-multiplatform.spdlog`)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [X] x86_64-windows (`pkgsCross.mingwW64.spdlog`)
  - [X] i686-windos (`pkgsCross.mingw32.spdlog`)
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
