### PR TITLE
nixos/borgbackup: use tmpfiles rules for repos

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -166,7 +166,7 @@ let
   };
 
   mkRepoTmpfilesRule = cfg:
-    "d ${cfg.path} 0700 ${cfg.user} ${cfg.group}";
+    "d '${cfg.path}' 0700 ${cfg.user} ${cfg.group}";
 
   mkAuthorizedKey = cfg: appendOnly: key:
     let


### PR DESCRIPTION
###### Description of changes
T.: Currently, `services.borgbackup.repos` sets up an individual systemd service for every single repo. All that service does's create a directory n chown't (which btw, even'f this change as is ain't approved, could be done in a single step w `install`, omitting the need for a service `script` as a simple `ExecStart` should be enough then). Now, systemd does've it's own thing for doing just that; systemd-tmpfiles, so we thought maybe using `tmpfiles.rules` 'd be more sensible.

Some notes:
- We're explicitly setting permissionsa `0700`. The original service just left them on default, `0755`, but since `borg serve` 's called without `--umask` n the default umask for Borg's `0077`, I don't think this's an issue here. Related, one could add a `permissions` or `umask` option that sets both the permissions for the dir (in the tmpfiles rule) n `--umask` for `borg serve` (in the SSH key forced command), but that requires inverting a binary mask n I dunno whether there's a simple/preferred way doing that in Nix.
- I asked in the NixOS room on Matrix'f there was a rationale for not just using tmpfiles rules, but didn't get a reply. We were wondering'f maybe't was that, that way, repos can be quickly re-set up during system runtime, but afaik that should be doable w just `systemctl restart systemd-tmpfiles-setup`, too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).