### PR TITLE
hh-suite: init at 3.3.0

### DIFF
--- a/pkgs/applications/science/biology/hh-suite/default.nix
+++ b/pkgs/applications/science/biology/hh-suite/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, xxd
+, enableMpi ? false
+, mpi
+, openmp
+}:
+stdenv.mkDerivation rec {
+  pname = "hh-suite";
+  version = "3.3.0";
+
+  src = fetchFromGitHub {
+    owner = "soedinglab";
+    repo = "hh-suite";
+    rev = "v${version}";
+    hash = "sha256-kjNqJddioCZoh/cZL3YNplweIGopWIGzCYQOnKDqZmw=";
+  };
+
+  nativeBuildInputs = [ cmake xxd ];
+  cmakeFlags = lib.optional stdenv.hostPlatform.isx86 "-DHAVE_SSE2=1"
+    ++ lib.optional stdenv.hostPlatform.isAarch "-DHAVE_ARM8=1"
+    ++ lib.optional stdenv.hostPlatform.avx2Support "-DHAVE_AVX2=1"
+    ++ lib.optional stdenv.hostPlatform.sse4_1Support "-DHAVE_SSE4_1=1";
+
+  buildInputs = lib.optional stdenv.cc.isClang openmp
+    ++ lib.optional enableMpi mpi;
+
+  meta = with lib; {
+    description = "Remote protein homology detection suite";
+    homepage = "https://github.com/soedinglab/hh-suite";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ natsukium ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36755,6 +36755,10 @@ with pkgs;
 
   flywheel-cli = callPackage ../applications/science/biology/flywheel-cli { };
 
+  hh-suite = callPackage ../applications/science/biology/hh-suite {
+    inherit (llvmPackages) openmp;
+  };
+
   hisat2 = callPackage ../applications/science/biology/hisat2 { };
 
   htslib = callPackage ../development/libraries/science/biology/htslib { };


### PR DESCRIPTION
###### Description of changes

The HH-suite is an open-source software package for sensitive protein sequence searching based on the pairwise alignment of hidden Markov models (HMMs).

repo
https://github.com/soedinglab/hh-suite

paper
https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-019-3019-7

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
