### PR TITLE
ocamlPackages.macaddr: 5.3.0 → 5.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/ipaddr/cstruct.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/cstruct.nix
@@ -7,6 +7,8 @@ buildDunePackage rec {
 
   inherit (ipaddr) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ ipaddr cstruct ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/ipaddr/default.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/default.nix
@@ -1,6 +1,6 @@
 { lib, buildDunePackage
 , macaddr, domain-name, stdlib-shims
-, ounit, ppx_sexp_conv
+, ounit2, ppx_sexp_conv
 }:
 
 buildDunePackage rec {
@@ -8,9 +8,12 @@ buildDunePackage rec {
 
   inherit (macaddr) version src;
 
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
+
   propagatedBuildInputs = [ macaddr domain-name stdlib-shims ];
 
-  checkInputs = [ ppx_sexp_conv ounit ];
+  checkInputs = [ ppx_sexp_conv ounit2 ];
   doCheck = true;
 
   meta = macaddr.meta // {

--- a/pkgs/development/ocaml-modules/ipaddr/sexp.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/sexp.nix
@@ -1,5 +1,5 @@
 { lib, buildDunePackage
-, ipaddr, ipaddr-cstruct, ounit, ppx_sexp_conv
+, ipaddr, ipaddr-cstruct, ounit2, ppx_sexp_conv
 }:
 
 buildDunePackage rec {
@@ -7,9 +7,11 @@ buildDunePackage rec {
 
   inherit (ipaddr) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ ipaddr ];
 
-  checkInputs = [ ipaddr-cstruct ounit ppx_sexp_conv ];
+  checkInputs = [ ipaddr-cstruct ounit2 ppx_sexp_conv ];
   doCheck = true;
 
   meta = ipaddr.meta // {

--- a/pkgs/development/ocaml-modules/macaddr/cstruct.nix
+++ b/pkgs/development/ocaml-modules/macaddr/cstruct.nix
@@ -7,6 +7,8 @@ buildDunePackage {
 
   inherit (macaddr) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ macaddr cstruct ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/macaddr/default.nix
+++ b/pkgs/development/ocaml-modules/macaddr/default.nix
@@ -1,19 +1,20 @@
 { lib, fetchurl, buildDunePackage
-, ppx_sexp_conv, ounit
+, ppx_sexp_conv, ounit2
 }:
 
 buildDunePackage rec {
   pname = "macaddr";
-  version = "5.3.0";
+  version = "5.4.0";
 
   minimalOCamlVersion = "4.04";
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-ipaddr/releases/download/v${version}/ipaddr-${version}.tbz";
-    sha256 = "0mdp38mkvk2f5h2q7nb9fc70a8hyssblnl7kam0d8r5lckgrx5rn";
+    hash = "sha256-WmYpG/cQtF9+lVDs1WIievUZ1f7+iZ2hufsdD1HHNeo=";
   };
 
-  checkInputs = [ ppx_sexp_conv ounit ];
+  checkInputs = [ ppx_sexp_conv ounit2 ];
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/macaddr/sexp.nix
+++ b/pkgs/development/ocaml-modules/macaddr/sexp.nix
@@ -1,5 +1,5 @@
 { lib, buildDunePackage
-, macaddr, ppx_sexp_conv, macaddr-cstruct, ounit
+, macaddr, ppx_sexp_conv, macaddr-cstruct, ounit2
 }:
 
 buildDunePackage {
@@ -7,9 +7,11 @@ buildDunePackage {
 
   inherit (macaddr) version src;
 
+  duneVersion = "3";
+
   propagatedBuildInputs = [ ppx_sexp_conv ];
 
-  checkInputs = [ macaddr-cstruct ounit ];
+  checkInputs = [ macaddr-cstruct ounit2 ];
   doCheck = true;
 
   meta = macaddr.meta // {

--- a/pkgs/development/ocaml-modules/mirage-net/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-net/default.nix
@@ -6,11 +6,11 @@ buildDunePackage rec {
   pname = "mirage-net";
   version = "4.0.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-net/releases/download/v${version}/mirage-net-v${version}.tbz";
-    sha256 = "sha256-Zo7/0Ye4GgqzJFCHDBXbuJ/5ETl/8ziolRgH4lDhlM4=";
+    hash = "sha256-Zo7/0Ye4GgqzJFCHDBXbuJ/5ETl/8ziolRgH4lDhlM4=";
   };
 
   propagatedBuildInputs = [ cstruct fmt lwt macaddr mirage-device ];

--- a/pkgs/development/ocaml-modules/mirage/runtime.nix
+++ b/pkgs/development/ocaml-modules/mirage/runtime.nix
@@ -8,6 +8,7 @@ buildDunePackage rec {
   inherit (functoria-runtime) src version;
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [ ipaddr functoria-runtime fmt logs lwt ];
   checkInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/tuntap/default.nix
+++ b/pkgs/development/ocaml-modules/tuntap/default.nix
@@ -6,9 +6,9 @@ buildDunePackage rec {
   pname = "tuntap";
   version = "2.0.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
-  minimumOCamlVersion = "4.04.2";
+  minimalOCamlVersion = "4.04.2";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-tuntap/releases/download/v${version}/tuntap-v${version}.tbz";


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/ocaml-ipaddr/blob/v5.4.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
