### PR TITLE
flatpak: Fix launching flatpaks with `DBusActivatable=true`

### DIFF
--- a/pkgs/development/libraries/flatpak/binary-path.patch
+++ b/pkgs/development/libraries/flatpak/binary-path.patch
@@ -1,0 +1,29 @@
+diff --git a/common/flatpak-dir.c b/common/flatpak-dir.c
+index eba81fef..134024e2 100644
+--- a/common/flatpak-dir.c
++++ b/common/flatpak-dir.c
+@@ -7532,8 +7532,13 @@ export_desktop_file (const char         *app,
+       g_key_file_remove_key (keyfile, groups[i], "X-GNOME-Bugzilla-ExtraInfoScript", NULL);
+ 
+       new_exec = g_string_new ("");
+-      if ((flatpak = g_getenv ("FLATPAK_BINARY")) == NULL)
+-        flatpak = FLATPAK_BINDIR "/flatpak";
++      if (g_str_has_suffix (name, ".service"))
++      {
++        flatpak = "/run/current-system/sw/bin/flatpak";
++      } else {
++        if ((flatpak = g_getenv ("FLATPAK_BINARY")) == NULL)
++          flatpak = "flatpak";
++      }
+ 
+       g_string_append_printf (new_exec,
+                               "%s run --branch=%s --arch=%s",
+@@ -8867,7 +8872,7 @@ flatpak_dir_deploy (FlatpakDir          *self,
+                                        error))
+         return FALSE;
+       if ((flatpak = g_getenv ("FLATPAK_BINARY")) == NULL)
+-        flatpak = FLATPAK_BINDIR "/flatpak";
++        flatpak = "flatpak";
+ 
+       bin_data = g_strdup_printf ("#!/bin/sh\nexec %s run --branch=%s --arch=%s %s \"$@\"\n",
+                                   flatpak, escaped_branch, escaped_arch, escaped_app);

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -89,6 +89,11 @@ stdenv.mkDerivation (finalAttrs: {
     # https://github.com/NixOS/nixpkgs/issues/53441
     ./unset-env-vars.patch
 
+    # Use flatpak from PATH to avoid references to `/nix/store` in `/desktop` files.
+    # Applications containing `DBusActivatable` entries should be able to find the flatpak binary.
+    # https://github.com/NixOS/nixpkgs/issues/138956
+    ./binary-path.patch
+
     # The icon validator needs to access the gdk-pixbuf loaders in the Nix store
     # and cannot bind FHS paths since those are not available on NixOS.
     finalAttrs.passthru.icon-validator-patch
@@ -174,13 +179,6 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs buildutil
     patchShebangs tests
     PATH=${lib.makeBinPath [vsc-py]}:$PATH patchShebangs --build subprojects/variant-schema-compiler/variant-schema-compiler
-  '';
-
-  preFixup = ''
-    gappsWrapperArgs+=(
-      # Use flatpak from PATH in exported assets (e.g. desktop files).
-      --set FLATPAK_BINARY flatpak
-    )
   '';
 
   passthru = {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #138956

At the moment, flatpak packages containing the line `DBusActivatable=true` fail to launch from both the app menu or via the `gtk-launch` command. (For example [`org.gnome.design.Palette`](https://flathub.org/apps/details/org.gnome.design.Palette))

`journalctl` output:

```
Mar 22 13:06:49 snowflakeos systemd[10420]: dbus-:1.1-org.gnome.design.Palette@0.service: Failed at step EXEC spawning flatpak: No such file or directory
░░ Subject: Process flatpak could not be executed
░░ Defined-By: systemd
░░ Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
░░ 
░░ The process flatpak could not be executed and failed.
░░ 
░░ The error number returned by this process is ERRNO.
```
###### Things done

Added a patch to flatpak that defaults to `/run/current-system/sw/bin/flatpak` if the `FLATPAK_BINARY` variable is not found.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
