### PR TITLE
gopass-jsonapi: Don't wrap with gopass

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -53,6 +53,9 @@ buildGoModule rec {
       --prefix PATH : "${wrapperPath}" \
       --set GOPASS_NO_REMINDER true
   '';
+  passthru = {
+    inherit wrapperPath;
+  };
 
   meta = with lib; {
     description = "The slightly more awesome Standard Unix Password Manager for Teams. Written in Go";

--- a/pkgs/tools/security/gopass/jsonapi.nix
+++ b/pkgs/tools/security/gopass/jsonapi.nix
@@ -1,9 +1,7 @@
 { lib
-, makeWrapper
 , buildGoModule
 , fetchFromGitHub
 , installShellFiles
-, gopass
 }:
 
 buildGoModule rec {
@@ -21,16 +19,11 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  nativeBuildInputs = [ installShellFiles makeWrapper ];
+  nativeBuildInputs = [ installShellFiles ];
 
   ldflags = [
     "-s" "-w" "-X main.version=${version}" "-X main.commit=${src.rev}"
   ];
-
-  postFixup = ''
-    wrapProgram $out/bin/gopass-jsonapi \
-      --prefix PATH : "${lib.makeBinPath [ gopass ]}"
-  '';
 
   meta = with lib; {
     description = "Enables communication with gopass via JSON messages";

--- a/pkgs/tools/security/gopass/jsonapi.nix
+++ b/pkgs/tools/security/gopass/jsonapi.nix
@@ -1,7 +1,9 @@
 { lib
+, makeWrapper
 , buildGoModule
 , fetchFromGitHub
 , installShellFiles
+, gopass
 }:
 
 buildGoModule rec {
@@ -19,11 +21,16 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
 
   ldflags = [
     "-s" "-w" "-X main.version=${version}" "-X main.commit=${src.rev}"
   ];
+
+  postFixup = ''
+    wrapProgram $out/bin/gopass-jsonapi \
+      --prefix PATH : "${gopass.wrapperPath}"
+  '';
 
   meta = with lib; {
     description = "Enables communication with gopass via JSON messages";


### PR DESCRIPTION
###### Description of changes

gopass-jsonapi uses gopass' Golang API now, no need for wrapping with gopass. However, using the same `git` and `gpg` deps as `gopass`, fixes very hard to debug issues with `gopass-jsonapi`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
