### PR TITLE
olive-editor: 1.2 -> 2023-03-20

### DIFF
--- a/pkgs/applications/video/olive-editor/default.nix
+++ b/pkgs/applications/video/olive-editor/default.nix
@@ -1,34 +1,69 @@
-{ lib, stdenv, fetchFromGitHub
-, pkg-config, which, qmake, wrapQtAppsHook
-, qtmultimedia, frei0r, opencolorio_1, ffmpeg-full, CoreFoundation }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, which
+, frei0r
+, opencolorio
+, ffmpeg-full
+, CoreFoundation
+, cmake
+, wrapQtAppsHook
+, openimageio2
+, openexr_3
+, portaudio
+, imath
+, qtwayland
+, qtmultimedia
+, qttools
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "olive-editor";
-  version = "0.1.2";
+  version = "unstable-2023-03-20";
 
   src = fetchFromGitHub {
+    fetchSubmodules = true;
     owner = "olive-editor";
     repo = "olive";
-    rev = version;
-    sha256 = "151g6jwhipgbq4llwib92sq23p1s9hm6avr7j4qq3bvykzrm8z1a";
+    rev = "8ca16723613517c41304de318169d27c571b90af";
+    sha256 = "sha256-lL90+8L7J7pjvhbqfeIVF0WKgl6qQzNun8pL9YPL5Is=";
   };
 
-  patches = [
-    ./q-painter-path.patch
+  cmakeFlags = [
+    "-DBUILD_QT6=1"
   ];
+
+  # https://github.com/olive-editor/olive/issues/2200
+  patchPhase = ''
+    runHook prePatch
+    substituteInPlace ./app/node/project/serializer/serializer.h \
+      --replace 'QStringRef' 'QStringView'
+    substituteInPlace ./app/node/project/serializer/serializer.cpp \
+      --replace 'QStringRef' 'QStringView'
+    substituteInPlace ./app/node/project/serializer/serializer230220.cpp \
+      --replace 'QStringRef' 'QStringView'
+    runHook postPatch
+  '';
 
   nativeBuildInputs = [
     pkg-config
     which
-    qmake
+    cmake
     wrapQtAppsHook
   ];
 
   buildInputs = [
     ffmpeg-full
     frei0r
-    opencolorio_1
+    opencolorio
+    openimageio2
+    imath
+    openexr_3
+    portaudio
+    qtwayland
     qtmultimedia
+    qttools
   ] ++ lib.optional stdenv.isDarwin CoreFoundation;
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10563,7 +10563,7 @@ with pkgs;
 
   ola = callPackage ../applications/misc/ola { };
 
-  olive-editor = libsForQt5.callPackage ../applications/video/olive-editor {
+  olive-editor = qt6Packages.callPackage ../applications/video/olive-editor {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation;
   };
 


### PR DESCRIPTION
###### Description of changes

The olive-editor is working on 0.2, but it is not yet released. In the meantime, the following notice is [visible on their website](https://www.olivevideoeditor.org/download.php):

> Olive is currently offered in two versions. The 0.1 (aka April 2019) pre-rewrite version and the current unstable 0.2 nightly builds. Both are technically alpha software, but 0.1 was much further along in development, so it's generally considered more stable and usable than the current nightlies, which are still under heavy development. Unfortunately we don't have the resources to support both at once, so bug reports for 0.1 likely won't be accepted; please use it at your own risk.

Given that 0.1.x is almost 4 years old, I think we should favour this new in-development version of Olive in Nixpkgs. The original 0.1 Olive is plagued with bugs, so I think it's time for an upgrade.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
