### PR TITLE
fira: remove Fira Mono

### DIFF
--- a/pkgs/applications/editors/apostrophe/default.nix
+++ b/pkgs/applications/editors/apostrophe/default.nix
@@ -2,7 +2,7 @@
 , wrapGAppsHook, pkg-config, desktop-file-utils
 , appstream-glib, pythonPackages, glib, gobject-introspection
 , gtk3, webkitgtk, glib-networking, gnome, gspell, texlive
-, shared-mime-info, libhandy, fira, sassc
+, shared-mime-info, libhandy, fira, fira-mono, sassc
 }:
 
 let
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
       --replace 'url("/app/share/fonts/FiraSans-Regular.ttf") format("ttf")'             \
                 'url("${fira}/share/fonts/opentype/FiraSans-Regular.otf") format("otf")' \
       --replace 'url("/app/share/fonts/FiraMono-Regular.ttf") format("ttf")'             \
-                'url("${fira}/share/fonts/opentype/FiraMono-Regular.otf") format("otf")'
+                'url("${fira-mono}/share/fonts/opentype/FiraMono-Regular.otf") format("otf")'
 
     patchShebangs --build build-aux/meson_post_install.py
   '';

--- a/pkgs/data/fonts/fira/default.nix
+++ b/pkgs/data/fonts/fira/default.nix
@@ -15,7 +15,7 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out/share/fonts/opentype
-    cp otf/*.otf $out/share/fonts/opentype
+    cp otf/FiraSans*.otf $out/share/fonts/opentype
 
     runHook postInstall
   '';


### PR DESCRIPTION
(This is my first pull request here and I'm mildly overwhelmed with the things I should do below. If someone wants to help, I'd appreciate it. I'm not even sure how I go about testing the change on my own system. )

###### Description of changes

Change the build commands to only copy FiraSans*.otf. Fira Mono is covered by a different derivation "fira-mono"

I ran into an error when I tried to install "fira" and "fira-mono", so I investigated it and the reason is that the mozilla/Fira repository contains a sneaky 3 extra `FiraMono*.otf` files. They are being packaged by both [fira-mono](https://github.com/NixOS/nixpkgs/blob/nixpkgs-unstable/pkgs/data/fonts/fira-mono/default.nix) and [fira](https://github.com/NixOS/nixpkgs/blob/nixpkgs-unstable/pkgs/data/fonts/fira/default.nix)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
