### PR TITLE
neomutt: 20220429 -> 20230407

### DIFF
--- a/pkgs/applications/networking/mailreaders/neomutt/default.nix
+++ b/pkgs/applications/networking/mailreaders/neomutt/default.nix
@@ -1,29 +1,36 @@
 { lib, stdenv, fetchFromGitHub, gettext, makeWrapper, tcl, which
 , ncurses, perl , cyrus_sasl, gss, gpgme, libkrb5, libidn, libxml2, notmuch, openssl
-, lmdb, libxslt, docbook_xsl, docbook_xml_dtd_42, w3m, mailcap, sqlite, zlib
-, zstd, enableZstd ? true, enableMixmaster ? false
+, lua, lmdb, libxslt, docbook_xsl, docbook_xml_dtd_42, w3m, mailcap, sqlite, zlib
+, pkg-config, zstd, enableZstd ? true, enableMixmaster ? false, enableLua ? false
 }:
 
 stdenv.mkDerivation rec {
-  version = "20220429";
+  version = "20230407";
   pname = "neomutt";
 
   src = fetchFromGitHub {
     owner  = "neomutt";
     repo   = "neomutt";
     rev    = version;
-    sha256 = "sha256-LBY7WtmEMg/PcMS/Tc5XEYunIWjoI4IQfUJURKgy1YA=";
+    sha256 = "sha256-cTZua1AbLMjkMhlUk2aMttj6HdwpJYnRYPuvukSxfwc=";
   };
+
+  patches = [
+    # https://github.com/neomutt/neomutt/issues/3773#issuecomment-1493295144
+    ./fix-open-very-large-mailbox.patch
+  ];
 
   buildInputs = [
     cyrus_sasl gss gpgme libkrb5 libidn ncurses
     notmuch openssl perl lmdb
     mailcap sqlite
   ]
-  ++ lib.optional enableZstd zstd;
+  ++ lib.optional enableZstd zstd
+  ++ lib.optional enableLua lua;
 
   nativeBuildInputs = [
     docbook_xsl docbook_xml_dtd_42 gettext libxml2 libxslt.bin makeWrapper tcl which zlib w3m
+    pkg-config
   ];
 
   enableParallelBuilding = true;
@@ -46,10 +53,6 @@ stdenv.mkDerivation rec {
       --replace /etc/mime.types ${mailcap}/etc/mime.types
   '';
 
-  preBuild = ''
-    export HOME=$(mktemp -d)
-  '';
-
   configureFlags = [
     "--enable-autocrypt"
     "--gpgme"
@@ -66,12 +69,8 @@ stdenv.mkDerivation rec {
     "--zlib"
   ]
   ++ lib.optional enableZstd "--zstd"
+  ++ lib.optional enableLua "--lua"
   ++ lib.optional enableMixmaster "--mixmaster";
-
-  # Fix missing libidn in mutt;
-  # this fix is ugly since it links all binaries in mutt against libidn
-  # like pgpring, pgpewrap, ...
-  NIX_LDFLAGS = "-lidn";
 
   postInstall = ''
     wrapProgram "$out/bin/neomutt" --prefix PATH : "$out/libexec/neomutt"
@@ -83,8 +82,8 @@ stdenv.mkDerivation rec {
     cp -r ${fetchFromGitHub {
       owner = "neomutt";
       repo = "neomutt-test-files";
-      rev = "8629adab700a75c54e8e28bf05ad092503a98f75";
-      sha256 = "1ci04nqkab9mh60zzm66sd6mhsr6lya8wp92njpbvafc86vvwdlr";
+      rev = "1569b826a56c39fd09f7c6dd5fc1163ff5a356a2";
+      sha256 = "sha256-MaH2zEH1Wq3C0lFxpEJ+b/A+k2aKY/sr1EtSPAuRPp8=";
     }} $(pwd)/test-files
     chmod -R +w test-files
     (cd test-files && ./setup.sh)

--- a/pkgs/applications/networking/mailreaders/neomutt/fix-open-very-large-mailbox.patch
+++ b/pkgs/applications/networking/mailreaders/neomutt/fix-open-very-large-mailbox.patch
@@ -1,0 +1,51 @@
+diff --git a/mutt_mailbox.c b/mutt_mailbox.c
+index 5581a8187..22f0ca21a 100644
+--- a/mutt_mailbox.c
++++ b/mutt_mailbox.c
+@@ -160,6 +160,9 @@ int mutt_mailbox_check(struct Mailbox *m_cur, CheckStatsFlags flags)
+   st_ctx.st_dev = 0;
+   st_ctx.st_ino = 0;
+
++  if (kInMboxOpen)
++    return 0;
++
+ #ifdef USE_IMAP
+   if (flags & MUTT_MAILBOX_CHECK_FORCE)
+     mutt_update_num_postponed();
+diff --git a/mx.c b/mx.c
+index 4bf5af141..a4e9f83f5 100644
+--- a/mx.c
++++ b/mx.c
+@@ -295,6 +295,8 @@ bool mx_mbox_ac_link(struct Mailbox *m)
+   return true;
+ }
+
++int kInMboxOpen = 0;
++
+ /**
+  * mx_mbox_open - Open a mailbox and parse it
+  * @param m     Mailbox to open
+@@ -386,8 +388,10 @@ bool mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
+   m->msg_tagged = 0;
+   m->vcount = 0;
+
++  kInMboxOpen = 1;
+   enum MxOpenReturns rc = m->mx_ops->mbox_open(m);
+   m->opened++;
++  kInMboxOpen = 0;
+
+   if ((rc == MX_OPEN_OK) || (rc == MX_OPEN_ABORT))
+   {
+diff --git a/mx.h b/mx.h
+index 741431570..43e40bf32 100644
+--- a/mx.h
++++ b/mx.h
+@@ -38,6 +38,8 @@ extern const struct MxOps *mx_ops[];
+
+ extern struct EnumDef MboxTypeDef;
+
++extern int kInMboxOpen;
++
+ typedef uint8_t MsgOpenFlags;      ///< Flags for mx_msg_open_new(), e.g. #MUTT_ADD_FROM
+ #define MUTT_MSG_NO_FLAGS       0  ///< No flags are set
+ #define MUTT_ADD_FROM     (1 << 0) ///< add a From_ line


### PR DESCRIPTION
###### Description of changes

https://github.com/neomutt/neomutt/releases/tag/20230327
https://github.com/neomutt/neomutt/releases/tag/20230407

neomutt-test-files: updated to latest version.

Cleaned up old hacks (?) now that pkg-config is used. Exposes Lua feature as `enableLua` flag in function signature.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
