### PR TITLE
tuba: init at 0.1.0

### DIFF
--- a/pkgs/applications/misc/tuba/default.nix
+++ b/pkgs/applications/misc/tuba/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, vala
+, meson
+, ninja
+, python3
+, pkg-config
+, wrapGAppsHook
+, desktop-file-utils
+, gtk4
+, libadwaita
+, json-glib
+, glib
+, glib-networking
+, libxml2
+, libgee
+, libsoup
+, libsecret
+, gst_all_1
+, nix-update-script
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tuba";
+  version = "0.1.0";
+  src = fetchFromGitHub {
+    owner = "GeopJr";
+    repo = "Tuba";
+    rev = "v${version}";
+    hash = "sha256-dkURVzbDBrE4bBUvf2fPqvgLKE07tn7jl3OudZpEWUo=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    vala
+    python3
+    wrapGAppsHook
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    glib
+    glib-networking
+    json-glib
+    libxml2
+    libgee
+    libsoup
+    gtk4
+    libadwaita
+    libsecret
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-libav
+    gst-plugins-base
+    (gst-plugins-good.override { gtkSupport = true; })
+    gst-plugins-bad
+  ]);
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "tuba";
+    };
+  };
+
+  meta = with lib; {
+    description = "Browse the Fediverse";
+    homepage = "https://tuba.geopjr.dev/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ chuangzhu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33938,6 +33938,8 @@ with pkgs;
 
   ttyper = callPackage ../applications/misc/ttyper { };
 
+  tuba = callPackage ../applications/misc/tuba { };
+
   tudu = callPackage ../applications/office/tudu { };
 
   tumpa = callPackage ../applications/misc/tumpa {


### PR DESCRIPTION
###### Description of changes

[Tuba](https://tuba.geopjr.dev/) is a new GTK app for various Fediverse servers. It is the fork of now archived Mastodon application [Tootle](https://github.com/bleakgrey/tootle). I've been using this in my personal overlay for quite a while, and since there is a release now, I guess I'm going to maintain it.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).