### PR TITLE
package modern version of cadquery / cq-editor

### DIFF
--- a/pkgs/development/libraries/opencascade-occt/33157_missing_include.patch
+++ b/pkgs/development/libraries/opencascade-occt/33157_missing_include.patch
@@ -1,0 +1,10 @@
+--- occt-V7_7_0-185d29b/src/ViewerTest/ViewerTest_CmdParser.cxx     2022-11-11 22:19:44.000000000 +0000
++++ occt-V7_7_0-185d29b/src/ViewerTest/ViewerTest_CmdParser.cxx.new 2023-03-22 22:18:45.500057208 +0000
+@@ -21,6 +21,7 @@
+
+ #include <algorithm>
+ #include <iostream>
++#include <limits>
+
+ namespace
+ {

--- a/pkgs/development/libraries/opencascade-occt/default.nix
+++ b/pkgs/development/libraries/opencascade-occt/default.nix
@@ -3,14 +3,19 @@
 
 stdenv.mkDerivation rec {
   pname = "opencascade-occt";
-  version = "7.6.2";
+  version = "7.7.0";
   commit = "V${builtins.replaceStrings ["."] ["_"] version}";
 
   src = fetchurl {
     name = "occt-${commit}.tar.gz";
     url = "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=${commit};sf=tgz";
-    sha256 = "sha256-n3KFrN/mN1SVXfuhEUAQ1fJzrCvhiclxfEIouyj9Z18=";
+    sha256 = "sha256-aEWhf+X0CzaFpXG+l+VpZgXeI8x6vxD4pkTSFjcRxv8=";
   };
+
+  patches = [
+    # There's a missing include <limits>: https://tracker.dev.opencascade.org/view.php?id=33157
+    ./33157_missing_include.patch
+  ];
 
   nativeBuildInputs = [ cmake ninja ];
   buildInputs = [ tcl tk libGL libGLU libXext libXmu libXi ]

--- a/pkgs/development/python-modules/cadquery/default.nix
+++ b/pkgs/development/python-modules/cadquery/default.nix
@@ -6,20 +6,39 @@
 , fetchFromGitHub
 , pyparsing
 , opencascade
+, opencascade-occt
 , stdenv
+, pandas
+, path
+, pybind11
 , python
+, rapidjson
+, click
 , cmake
 , swig
 , smesh
 , freetype
+, jinja2
+, joblib
+, libcxx
 , libGL
 , libGLU
 , libX11
+, logzero
+, llvm
+, clang
+, libclang
 , six
+, toml
+, toposort
+, tqdm
 , pytest
 , makeFontsConf
 , freefont_ttf
+, pybindgen
+, schema
 , Cocoa
+, vtk
 }:
 
 let
@@ -63,16 +82,127 @@ let
     ];
   });
 
+  pywrap = buildPythonPackage rec {
+    pname = "pywrap";
+    version = "0.0.0"; # no version as such
+    src = fetchFromGitHub {
+      owner = "CadQuery";
+      repo = "pywrap";
+      # no versioning. This version is used as a git submodule in OCP.
+      rev = "f3bcde70fd66a2d884fa60a7a9d9f6aa7c3b6e16";
+      sha256 = "QhAvJHV5tFq9bjKOzEpcudZNnmUmNVrJ+BLCZJhO31g=";
+    };
+
+    nativeBuildInputs = [
+    ];
+
+    buildInputs = [
+      clang
+      schema
+      pandas
+      toposort
+      pyparsing
+      path
+      toml
+      tqdm
+      logzero
+      jinja2
+      joblib
+      click
+      pybind11
+    ];
+
+    propagatedBuildInputs = [
+      # TODO needed otherwise you get errors importing logzero
+      clang
+      schema
+      pandas
+      toposort
+      pyparsing
+      path
+      toml
+      tqdm
+      logzero
+      jinja2
+      joblib
+      click
+      pybind11
+    ];
+  };
+
+  # TODO Can't build this!
+
+  # TODO ? https://github.com/NixOS/nixpkgs/issues/84552
+  # [W 230322 23:33:30 translation_unit:48] ./opencascade/Standard_Std.hxx:20:10: fatal error: 'type_traits' file not found
+  # and
+# /build/source/OCP/AIS.cpp:2223:181: error: no matches converting function 'Append' to type 'void (class AIS_ManipulatorObjectSequence::*)(const int&)'
+#  2223 |              (void (AIS_ManipulatorObjectSequence::*)( const int &  ) ) static_cast<void (AIS_ManipulatorObjectSequence::*)( const int &  ) >(&AIS_ManipulatorObjectSequence::Append),
+#       |                                                                                                                                                                                     ^
+# In file included from /nix/store/8pwvarkinzvvq8lf3fayklh5hsmj62vm-opencascade-occt-7.7.0/include/opencascade/NCollection_HSequence.hxx:19,
+#                  from /nix/store/8pwvarkinzvvq8lf3fayklh5hsmj62vm-opencascade-occt-7.7.0/include/opencascade/AIS_Manipulator.hxx:26,
+#                  from /build/source/OCP/AIS.cpp:396:
+
+
+  ocp = toPythonModule (stdenv.mkDerivation rec {
+    pname = "OCP";
+    # giving up on this version for now: the new version has CMake improvements
+#     version = "7.6.3.0";
+#
+#     src = fetchFromGitHub {
+#       owner = "CadQuery";
+#       repo = "OCP";
+#       rev = version;
+#       sha256 = "sha256-43gM7vpVbSrStG1Fg36IKWgZvTIWgqd0C6vfm5iwQ4w=";
+#     };
+    version = "7.7.0.0";
+
+    src = fetchFromGitHub {
+      owner = "CadQuery";
+      repo = "OCP";
+      rev = "690c394abf32617f0c044159ad8a89480d40b240";
+      sha256 = "y4lq0tUY+t6gL2DgQq28uD8a1Cvj7dTUzyoyWAA4J4g=";
+    };
+    patches = [ ./patch_OCP_inheritpythonpath.patch ];
+
+    nativeBuildInputs = [
+      cmake
+
+    ];
+
+    buildInputs = [
+      llvm
+      vtk
+      python
+      pybindgen
+      rapidjson
+      clang
+      libclang
+      opencascade
+      opencascade-occt
+      #pywrap
+    ];
+
+    propagatedBuildInputs = [
+      pywrap
+      libcxx
+    ];
+
+    cmakeFlags = [
+      #"-DPYTHONPATH=$PYTHONPATH"
+      #"-DCXX_INCLUDES='-i ${libcxx}'"
+    ];
+  });
+
 in
   buildPythonPackage rec {
     pname = "cadquery";
-    version = "2.0";
+    version = "2.2.0";
 
     src = fetchFromGitHub {
       owner = "CadQuery";
       repo = pname;
       rev = version;
-      sha256 = "1n63b6cjjrdwdfmwq0zx1xabjnhndk9mgfkm4w7z9ardcfpvg84l";
+      sha256 = "KzwPD+bhCHFiLVAVLn9cLsVke/N3PTh7d2pAzuPeHKI=";
     };
 
     buildInputs = [
@@ -81,7 +211,7 @@ in
 
     propagatedBuildInputs = [
       pyparsing
-      pythonocc-core-cadquery
+      ocp
     ];
 
     FONTCONFIG_FILE = makeFontsConf {
@@ -92,12 +222,16 @@ in
       pytest
     ];
 
-    disabled = pythonOlder "3.6" || pythonAtLeast "3.8";
+    disabled = pythonOlder "3.8" || pythonAtLeast "3.11";
 
     meta = with lib; {
       description = "Parametric scripting language for creating and traversing CAD models";
       homepage = "https://github.com/CadQuery/cadquery";
       license = licenses.asl20;
       maintainers = with maintainers; [ costrouc marcus7070 ];
+    };
+
+    passthru = {
+      inherit ocp pywrap;
     };
   }

--- a/pkgs/development/python-modules/cadquery/patch_OCP_inheritpythonpath.patch
+++ b/pkgs/development/python-modules/cadquery/patch_OCP_inheritpythonpath.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 11a9a4e3..e38fb92c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,7 +25,8 @@ else()
+     set(PLATFORM Linux)
+ endif()
+
+-set(ENV{PYTHONPATH} ${CMAKE_SOURCE_DIR}/pywrap )
++# breaks nixpkgs build
++#set(ENV{PYTHONPATH} ${CMAKE_SOURCE_DIR}/pywrap )
+
+ if( NOT EXISTS ${CMAKE_SOURCE_DIR}/OCP )
+     message( STATUS "Running pywrap")
+@@ -37,7 +38,7 @@ if( NOT EXISTS ${CMAKE_SOURCE_DIR}/OCP )
+             -l ${LIBCLANG_PATH}
+             -i ${CLANG_INCLUDE_DIRS}/
+             -i ${VTK_INCLUDE_DIR}/
+-            -i ${CLANG_INSTALL_PREFIX}/lib/clang/${LLVM_VERSION}/include/
++#            -i ${CLANG_INSTALL_PREFIX}/lib/clang/${LLVM_VERSION}/include/
+             ${CXX_INCLUDES}
+             all ocp.toml ${PLATFORM}
+         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/pkgs/development/python-modules/clang/common.nix
+++ b/pkgs/development/python-modules/clang/common.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, nose
+, sha256
+, version
+}:
+
+buildPythonPackage rec {
+  inherit version;
+  pname = "clang";
+
+  src = fetchPypi {
+    inherit pname sha256 version;
+  };
+
+  checkInputs = [ nose ];
+
+  meta = with lib; {
+    description = "libclang python bindings";
+    homepage    = "https://clang.llvm.org/";
+    license     = licenses.ncsa;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/development/python-modules/clang/default.nix
+++ b/pkgs/development/python-modules/clang/default.nix
@@ -1,0 +1,7 @@
+self: rec {
+  clang_11 = self.callPackage ./common.nix {
+    version = "11.0";
+    sha256 = "sha256:1igqqvnm3yrzy08fz9sszn1r9hr0jkhhms4pzcgckr8zbd3ycf7q";
+  };
+  clang = clang_11;
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1797,6 +1797,11 @@ self: super: with self; {
 
   claripy = callPackage ../development/python-modules/claripy { };
 
+  inherit (import ../development/python-modules/clang self)
+   clang_5
+   clang_11
+   clang;
+
   classify-imports = callPackage ../development/python-modules/classify-imports { };
 
   cld2-cffi = callPackage ../development/python-modules/cld2-cffi { };


### PR DESCRIPTION
BROKEN but maybe a useful starting point for someone — feel free to take it over

For now, consider using https://github.com/marcus7070/cq-flake to run cadquery on NixOS...

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
