### PR TITLE
portfolio-filemanager: 0.9.14 -> 0.9.15

### DIFF
--- a/pkgs/applications/file-managers/portfolio-filemanager/default.nix
+++ b/pkgs/applications/file-managers/portfolio-filemanager/default.nix
@@ -13,11 +13,12 @@
 , ninja
 , pkg-config
 , wrapGAppsHook
+, nix-update-script
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "portfolio";
-  version = "0.9.14";
+  version = "0.9.15";
 
   format = "other";
 
@@ -25,7 +26,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "tchx84";
     repo = "Portfolio";
     rev = "v${version}";
-    hash = "sha256-mrb202ON0B6VlY+U+jN0jJmbT36jQ8krNnuODynaCUA=";
+    hash = "sha256-/OwHeeUjpjm35O7mySoAfKt7Rsp1EK2WE+tfiV3oiQg=";
   };
 
   postPatch = ''
@@ -64,6 +65,12 @@ python3.pkgs.buildPythonApplication rec {
   postInstall = ''
     ln -s dev.tchx84.Portfolio "$out/bin/portfolio"
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "portfolio-filemanager";
+    };
+  };
 
   meta = with lib; {
     description = "A minimalist file manager for those who want to use Linux mobile devices";

--- a/pkgs/applications/file-managers/portfolio-filemanager/default.nix
+++ b/pkgs/applications/file-managers/portfolio-filemanager/default.nix
@@ -78,6 +78,6 @@ python3.pkgs.buildPythonApplication rec {
     changelog = "https://github.com/tchx84/Portfolio/blob/v${version}/CHANGELOG.md";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ dotlambda ];
+    maintainers = with maintainers; [ dotlambda chuangzhu ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Updates, and fixes updateScript.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).