### PR TITLE
groff: Fix ghostscript and html output, add X11 support

### DIFF
--- a/pkgs/tools/text/groff/default.nix
+++ b/pkgs/tools/text/groff/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, fetchpatch, perl
-, enableGhostscript ? false, ghostscript # for postscript and html output
+, enableGhostscript ? false
+, ghostscript, gawk, libX11, libXaw, libXt, libXmu # for postscript and html output
 , enableHtml ? false, psutils, netpbm # for html output
 , enableIconv ? false, iconv
 , enableLibuchardet ? false, libuchardet # for detecting input file encoding in preconv(1)
@@ -24,6 +25,7 @@ stdenv.mkDerivation rec {
 
   # Parallel build is failing for missing depends. Known upstream as:
   #   https://savannah.gnu.org/bugs/?62084
+  #   fixed, planned release: 1.23.0
   enableParallelBuilding = false;
 
   patches = [
@@ -47,10 +49,15 @@ stdenv.mkDerivation rec {
       --replace "pnmcut" "${lib.getBin netpbm}/bin/pnmcut" \
       --replace "pnmcrop" "${lib.getBin netpbm}/bin/pnmcrop" \
       --replace "pnmtopng" "${lib.getBin netpbm}/bin/pnmtopng"
-    substituteInPlace tmac/www.tmac \
+    substituteInPlace tmac/www.tmac.in \
       --replace "pnmcrop" "${lib.getBin netpbm}/bin/pnmcrop" \
       --replace "pngtopnm" "${lib.getBin netpbm}/bin/pngtopnm" \
       --replace "@PNMTOPS_NOSETPAGE@" "${lib.getBin netpbm}/bin/pnmtops -nosetpage"
+    substituteInPlace contrib/groffer/roff2.pl \
+      --replace "'gs'" "'${lib.getBin ghostscript}/bin/gs'"
+    substituteInPlace contrib/pdfmark/pdfroff.sh \
+      --replace '$GROFF_GHOSTSCRIPT_INTERPRETER' "${lib.getBin ghostscript}/bin/gs" \
+      --replace '$GROFF_AWK_INTERPRETER' "${lib.getBin gawk}/bin/gawk"
   '';
 
   strictDeps = true;
@@ -58,7 +65,7 @@ stdenv.mkDerivation rec {
     # Required due to the patch that changes .ypp files.
     ++ lib.optional (stdenv.cc.isClang && lib.versionAtLeast stdenv.cc.version "9") bison;
   buildInputs = [ perl bash ]
-    ++ lib.optionals enableGhostscript [ ghostscript ]
+    ++ lib.optionals enableGhostscript [ ghostscript gawk libX11 libXaw libXt libXmu ]
     ++ lib.optionals enableHtml [ psutils netpbm ]
     ++ lib.optionals enableIconv [ iconv ]
     ++ lib.optionals enableLibuchardet [ libuchardet ];
@@ -66,13 +73,14 @@ stdenv.mkDerivation rec {
   # Builds running without a chroot environment may detect the presence
   # of /usr/X11 in the host system, leading to an impure build of the
   # package. To avoid this issue, X11 support is explicitly disabled.
-  # Note: If we ever want to *enable* X11 support, then we'll probably
-  # have to pass "--with-appresdir", too.
-  configureFlags = [
+  configureFlags = lib.optionals (!enableGhostscript) [
     "--without-x"
+  ] ++ [
     "ac_cv_path_PERL=${buildPackages.perl}/bin/perl"
   ] ++ lib.optionals enableGhostscript [
-    "--with-gs=${ghostscript}/bin/gs"
+    "--with-gs=${lib.getBin ghostscript}/bin/gs"
+    "--with-awk=${lib.getBin gawk}/bin/gawk"
+    "--with-appresdir=${placeholder "out"}/lib/X11/app-defaults"
   ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     "gl_cv_func_signbit=yes"
   ];


### PR DESCRIPTION
###### Description of changes

PS and HTML output (table rendering via ghostscript) were broken.

By enabling `enableGhostscript` you also enable X11 support via `man -X` etc.

Tested by building a `man-db` with a groff with ps and html support and running:
```sh
man -X100 man
man --html=<favorite-browser> man
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
