### PR TITLE
ocamlPackages.mirage-logs: 1.2.0 → 1.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-logs/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-logs/default.nix
@@ -1,20 +1,20 @@
 { lib, fetchurl, buildDunePackage
-, logs, lwt, mirage-clock, mirage-profile, ptime
-, alcotest, stdlib-shims
+, logs, lwt, mirage-clock, ptime
+, alcotest
 }:
 
 buildDunePackage rec {
   pname = "mirage-logs";
-  version = "1.2.0";
+  version = "1.3.0";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
-    url = "https://github.com/mirage/mirage-logs/releases/download/v${version}/mirage-logs-v${version}.tbz";
-    sha256 = "0h0amzjxy067jljscib7fvw5q8k0adqa8m86affha9hq5jsh07a1";
+    url = "https://github.com/mirage/mirage-logs/releases/download/v${version}/mirage-logs-${version}.tbz";
+    hash = "sha256-c1YQIutqp58TRz+a9Vd/69FCv0jnGRvFnei9BtSbOxA=";
   };
 
-  propagatedBuildInputs = [ logs lwt mirage-clock mirage-profile ptime stdlib-shims ];
+  propagatedBuildInputs = [ logs lwt mirage-clock ptime ];
 
   doCheck = true;
   checkInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/mirage-profile/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-profile/default.nix
@@ -7,7 +7,7 @@ buildDunePackage rec {
   pname = "mirage-profile";
   version = "0.9.1";
 
-  useDune2 = true;
+  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/mirage-profile/releases/download/v${version}/mirage-profile-v${version}.tbz";

--- a/pkgs/development/ocaml-modules/shared-memory-ring/default.nix
+++ b/pkgs/development/ocaml-modules/shared-memory-ring/default.nix
@@ -2,19 +2,20 @@
 , buildDunePackage
 , fetchurl
 , ppx_cstruct
-, mirage-profile
 , cstruct
+, lwt
 , ounit
-, stdlib-shims
 }:
 
 buildDunePackage rec {
   pname = "shared-memory-ring";
   version = "3.1.1";
 
+  duneVersion = "3";
+
   src = fetchurl {
     url = "https://github.com/mirage/shared-memory-ring/releases/download/v${version}/shared-memory-ring-${version}.tbz";
-    sha256 = "sha256-KW8grij/OAnFkdUdRRZF21X39DvqayzkTWeRKwF8uoU=";
+    hash = "sha256-KW8grij/OAnFkdUdRRZF21X39DvqayzkTWeRKwF8uoU=";
   };
 
   buildInputs = [
@@ -22,13 +23,12 @@ buildDunePackage rec {
   ];
 
   propagatedBuildInputs = [
-    mirage-profile
     cstruct
-    stdlib-shims
   ];
 
   doCheck = true;
   checkInputs = [
+    lwt
     ounit
   ];
 

--- a/pkgs/development/ocaml-modules/shared-memory-ring/lwt.nix
+++ b/pkgs/development/ocaml-modules/shared-memory-ring/lwt.nix
@@ -14,6 +14,8 @@ buildDunePackage {
 
   inherit (shared-memory-ring) version src;
 
+  duneVersion = "3";
+
   buildInputs = [
     ppx_cstruct
   ];


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/mirage-logs/blob/v1.3.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
