### PR TITLE
treewide: don't hardcode /nix/store (no rebuilds changes)

### DIFF
--- a/pkgs/applications/networking/ids/suricata/default.nix
+++ b/pkgs/applications/networking/ids/suricata/default.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation rec {
 
   postConfigure = ''
     # Avoid unintended clousure growth.
-    sed -i 's|/nix/store/\(.\{8\}\)[^-]*-|/nix/store/\1...-|g' ./src/build-info.h
+    sed -i 's|${builtins.storeDir}/\(.\{8\}\)[^-]*-|${builtins.storeDir}/\1...-|g' ./src/build-info.h
   '';
 
   hardeningDisable = [ "stackprotector" ];

--- a/pkgs/applications/networking/mailreaders/evolution/evolution/wrapper.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/wrapper.nix
@@ -23,7 +23,7 @@ symlinkJoin {
     fixSymlink () {
      local link=$1
      local target=$(readlink $link);
-     local newtarget=$(sed "s@/nix/store/[^/]*/@$out/@" <<< "$target")
+     local newtarget=$(sed "s@${builtins.storeDir}/[^/]*/@$out/@" <<< "$target")
      if [[ $target != $newtarget ]] && [[ -d $newtarget ]]; then
        echo fixing link to point to $newtarget instead of $target
        rm $link
@@ -35,7 +35,7 @@ symlinkJoin {
     fixSymlink $out/lib/systemd/user
     for i in $out/share/dbus-1/services/*.service $out/lib/systemd/user/*.service; do
       echo fixing service file $i to point to $out
-      sed -i "s@/nix/store/[^/]*/@$out/@" $i
+      sed -i "s@${builtins.storeDir}/[^/]*/@$out/@" $i
     done
   '';
 }

--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation rec {
     # notably texlive, and we don't want texlive to become a runtime
     # dependency
     for file in $(find $out -name Makefile) ; do
-      sed -i "s@/nix/store/[^/]*/bin/@@" "$file" ;
+      sed -i "s@${builtins.storeDir}/[^/]*/bin/@@" "$file" ;
     done;
 
     # reference cycle

--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -176,7 +176,7 @@ stdenvNoCC.mkDerivation (args // {
           # Note that toString is necessary here as it results in the path at
           # eval time (i.e. to the file in your local Nixpkgs checkout) rather
           # than the Nix store path of the path after it's been imported.
-          if lib.isPath nugetDeps && !lib.hasPrefix "/nix/store/" (toString nugetDeps)
+          if lib.isPath nugetDeps && !lib.hasPrefix "${builtins.storeDir}/" (toString nugetDeps)
           then toString nugetDeps
           else ''$(mktemp -t "${pname}-deps-XXXXXX.nix")'';
       in

--- a/pkgs/build-support/fetchdocker/default.nix
+++ b/pkgs/build-support/fetchdocker/default.nix
@@ -3,7 +3,7 @@ let
   stripScheme =
     builtins.replaceStrings [ "https://" "http://" ] [ "" "" ];
   stripNixStore =
-    s: lib.removePrefix "/nix/store/" s;
+    s: lib.removePrefix "${builtins.storeDir}/" s;
 in
 { name
 , registry         ? "https://registry-1.docker.io/v2/"

--- a/pkgs/build-support/release/nix-build.nix
+++ b/pkgs/build-support/release/nix-build.nix
@@ -140,7 +140,7 @@ stdenv.mkDerivation (
       (lib.optional doCoverityAnalysis args.cov-build) ++
       (lib.optional doCoverityAnalysis args.xz);
 
-    lcovFilter = ["/nix/store/*"] ++ lcovFilter;
+    lcovFilter = ["${builtins.storeDir}/*"] ++ lcovFilter;
 
     inherit lcovExtraTraceFiles;
 

--- a/pkgs/games/cataclysm-dda/wrapper.nix
+++ b/pkgs/games/cataclysm-dda/wrapper.nix
@@ -34,7 +34,7 @@ else symlinkJoin {
         cp "$1" "''${1}.bk"
         unlink "$1"
         mv "''${1}.bk" "$1"
-        sed -i "$1" -e "s,/nix/store/.\+\(/bin/cataclysm-tiles\),$out\1,"
+        sed -i "$1" -e "s,${builtins.storeDir}/.\+\(/bin/cataclysm-tiles\),$out\1,"
     }
     for script in "$out/share/applications/cataclysm-dda.desktop" \
                   "$out/Applications/Cataclysm.app/Contents/MacOS/Cataclysm.sh"

--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -115,7 +115,7 @@ stdenv.mkDerivation rec {
     + lib.optionalString (kernel != null) ''
       make install_driver
       kernel_dev=${kernel.dev}
-      kernel_dev=''${kernel_dev#/nix/store/}
+      kernel_dev=''${kernel_dev#${builtins.storeDir}/}
       kernel_dev=''${kernel_dev%%-linux*dev*}
       if test -f "$out/lib/modules/${kernel.modDirVersion}/extra/scap.ko"; then
           sed -i "s#$kernel_dev#................................#g" $out/lib/modules/${kernel.modDirVersion}/extra/scap.ko

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -304,8 +304,8 @@ stdenv.mkDerivation (finalAttrs: {
         if dl.pkg == null then ''
           # remove the dependency on the library by replacing it with an invalid path
           for file in $(grep -lr '"${dl.name}"' src); do
-            echo "patching dlopen(\"${dl.name}\", …) in $file to an invalid store path ("/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-not-implemented/${dl.name}")…"
-            substituteInPlace "$file" --replace '"${dl.name}"' '"/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-not-implemented/${dl.name}"'
+            echo "patching dlopen(\"${dl.name}\", …) in $file to an invalid store path ("${builtins.storeDir}/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-not-implemented/${dl.name}")…"
+            substituteInPlace "$file" --replace '"${dl.name}"' '"${builtins.storeDir}/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-not-implemented/${dl.name}"'
           done
         '' else ''
           # ensure that the library we provide actually exists


### PR DESCRIPTION
improve experience for other store locations

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
