### PR TITLE
nixos/borgbackup: use install for creating repo

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -165,13 +165,11 @@ let
       + '' borgbackup.jobs.${name}.encryption != "none"'';
   };
 
+  # This does little more than tmpfiles, but we can't use tmpfiles because it doesn't seem to support newlines in paths
   mkRepoService = name: cfg:
     nameValuePair "borgbackup-repo-${name}" {
       description = "Create BorgBackup repository ${name} directory";
-      script = ''
-        mkdir -p ${escapeShellArg cfg.path}
-        chown ${cfg.user}:${cfg.group} ${escapeShellArg cfg.path}
-      '';
+      script = "install -d ${escapeShellArg cfg.path} -o ${cfg.user} -g ${cfg.group} -m 0700";
       serviceConfig = {
         # The service's only task is to ensure that the specified path exists
         Type = "oneshot";


### PR DESCRIPTION
###### Description of changes
L: So uh, we actually explained most of this in https://github.com/NixOS/nixpkgs/pull/222635. Running `mkdir`, then `chown`, is really one command more than needed. It also allows for setting permissions right away, as for which, uhm, BorgBackup uses `0077` as default umask, so it seemed to make sense to set them to a matching `0700`. Could also remove that, set `serviceConfig.UMask` in the service, and `--umask` in the `borg serve` command, and uh, base that off some new config option (something like `services.borgbackup.repos.<name>.umask`), but maybe that's a topic for another pull request.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
