### PR TITLE
swayws: unstable-2022-03-10 -> 1.2.0

### DIFF
--- a/pkgs/applications/window-managers/sway/ws-update-Cargo-lock.patch
+++ b/pkgs/applications/window-managers/sway/ws-update-Cargo-lock.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index f01f824..e00d079 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -328,7 +328,7 @@ dependencies = [
+
+ [[package]]
+ name = "swayws"
+-version = "1.1.1"
++version = "1.2.0"
+ dependencies = [
+  "clap",
+  "env_logger",

--- a/pkgs/applications/window-managers/sway/ws.nix
+++ b/pkgs/applications/window-managers/sway/ws.nix
@@ -2,16 +2,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "swayws";
-  version = "unstable-2022-03-10";
+  version = "1.2.0";
 
   src = fetchFromGitLab {
     owner = "w0lff";
     repo = pname;
-    rev = "514f3c664439cf2c11bb9096c7e1d3b8c0b898a2";
-    sha256 = "sha256-vUnbn79v08riYLMBI8BxeBPpe/pHOWlraG7QAaohw3s=";
+    rev = "v${version}";
+    sha256 = "sha256-f0kXy7/31imgHHqKPmW9K+QrLqroaPaXwlJkzOoezRU=";
   };
 
-  cargoSha256 = "sha256-PvKpcTewajvbzUHPssBahWVcAQB3V/aMmOJ/wA0Nrv4=";
+  cargoSha256 = "sha256-VYT6wV59fraAoJgR/i6GlO8s7LUoehGtxPAggEL1eLo=";
+  # Required patch until upstream fixes https://gitlab.com/w0lff/swayws/-/issues/1
+  cargoPatches = [
+    ./ws-update-Cargo-lock.patch
+  ];
 
   # swayws does not have any tests
   doCheck = false;


### PR DESCRIPTION
###### Description of changes
- [Changelog](https://gitlab.com/w0lff/swayws/-/compare/514f3c664439cf2c11bb9096c7e1d3b8c0b898a2...v1.2.0?from_project_id=28532095&straight=false)
- Upstream forgot to bump Cargo.lock from version `1.1.1` to `1.2.0`, added a patch to fix that

Fixes https://github.com/NixOS/nixpkgs/issues/222534

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
