### PR TITLE
dmd: build process compatibility with 2.101 and 2.102

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -1,6 +1,5 @@
 import ./generic.nix {
-  version = "2.100.2";
-  dmdSha256 = "sha256-o4+G3ARXIGObYHtHooYZKr+Al6kHpiwpMIog3i4BlDM=";
-  druntimeSha256 = "sha256-qXvY1ECN4mPwOGgOE1FWwvxoRvlSww3tGLWgBdhzAKo=";
-  phobosSha256 = "sha256-kTHRaAKG7cAGb4IE/NGHWaZ8t7ZceKj03l6E8wLzJzs=";
+  version = "2.101.2";
+  dmdSha256 = "sha256-qxhDb8CD3ou+eQLiVnR9K1/FYEv2HhSNtapV9VXtS5w=";
+  phobosSha256 = "sha256-XKpTm/GdaRY8TTjWQ2h2jbUlSZZ7VRP6MyLJyDUjKiE=";
 }


### PR DESCRIPTION
###### Description of changes

Upstreaming the changes from [OldDDerivations](https://github.com/dukc/olddderivations) necessary to be compatible with newer DMD versions, 2.101.x and 2.102.x.

~~I didn't actually upgrade the version, because @ThomasMader IIRC wants the LDC and DMD compilers to use the same frontend version. This will make such an upgrade less work in the future, though.~~

EDIT: it seems there currently is an [LDC update in reviews](218905). If it gets in first, I could update the hashes.

EDIT2: Said version bump was merged so including a verion bump to 2.101.2 here too.

The needed changes are relatively big because the DRuntime and DMD repositories were merged between versions 2.100 and 2.101.

###### Things done

Test-built it with `nix-build -E 'with import ./default.nix {}; dmd'` at project root directory and compiled and ran a "hello world" with the result. I have tested at OldDDerivations that 2.101 and 2.102 also do build with these changes compined with needed updates of the hashes.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
