### PR TITLE
git-dive: 0.1.4 -> 0.1.5

### DIFF
--- a/pkgs/applications/version-management/git-dive/default.nix
+++ b/pkgs/applications/version-management/git-dive/default.nix
@@ -4,21 +4,25 @@
 , pkg-config
   # libgit2-sys doesn't support libgit2 1.6 yet
 , libgit2_1_5
+, oniguruma
 , zlib
+, stdenv
+, darwin
+, git
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "git-dive";
-  version = "0.1.4";
+  version = "0.1.5";
 
   src = fetchFromGitHub {
     owner = "gitext-rs";
     repo = "git-dive";
     rev = "v${version}";
-    hash = "sha256-nl6JEVOU5eDntPOItYCooBi3zx2ceyRLtelr97uYiOY=";
+    hash = "sha256-LOvrPId/GBWPq73hdCdaMNKH7K7cmGmlkepkQiwGC60=";
   };
 
-  cargoHash = "sha256-johUvl2hPlgn+2wgFJUR6/pR7lx1NzE4ralcjhVqkik=";
+  cargoHash = "sha256-JDybjIUjj9ivJ5hJJB9bvGB18TdwEXQZfKfXPkyopK0=";
 
   nativeBuildInputs = [
     pkg-config
@@ -26,16 +30,31 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     libgit2_1_5
+    oniguruma
     zlib
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
   ];
+
+  nativeCheckInputs = [
+    git
+  ];
+
+  # don't use vendored libgit2
+  buildNoDefaultFeatures = true;
 
   checkFlags = [
     # requires internet access
     "--skip=screenshot"
   ];
 
-  # don't use vendored libgit2
-  buildNoDefaultFeatures = true;
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    git config --global user.name nixbld
+    git config --global user.email nixbld@example.com
+  '';
+
+  RUSTONIG_SYSTEM_LIBONIG = true;
 
   meta = with lib; {
     description = "Dive into a file's history to find root cause";


### PR DESCRIPTION
Diff: https://github.com/gitext-rs/git-dive/compare/v0.1.4...v0.1.5

Changelog: https://github.com/gitext-rs/git-dive/blob/v0.1.5/CHANGELOG.md

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
