### PR TITLE
exhaustive: init at 0.10.0

### DIFF
--- a/pkgs/development/tools/exhaustive/default.nix
+++ b/pkgs/development/tools/exhaustive/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "exhaustive";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "nishanths";
+    repo = "exhaustive";
+    rev = "v${version}";
+    hash = "sha256-vMoFIyZcAdObeQD5bGcQHlGpJv/a8yl/2HUVc8aDiIA=";
+  };
+
+  vendorHash = "sha256-i3Cgefe4krvH99N233IeEWkVt9AhdzROkJ5JBeTIaAs=";
+
+  ldflags = [ "-s" "-w" ];
+
+  meta = with lib; {
+    description = "Check exhaustiveness of switch statements of enum-like constants in Go code";
+    homepage = "https://github.com/nishanths/exhaustive";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ meain ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24755,6 +24755,8 @@ with pkgs;
 
   ejabberd = callPackage ../servers/xmpp/ejabberd { erlang = erlang_24; };
 
+  exhaustive = callPackage ../development/tools/exhaustive { };
+
   exhibitor = callPackage ../servers/exhibitor { };
 
   hyp = callPackage ../servers/http/hyp { };


### PR DESCRIPTION
###### Description of changes

New package: https://github.com/nishanths/exhaustive
Description: Check exhaustiveness of switch statements of enum-like constants in Go code. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
