### PR TITLE
neovim: generate init.lua by default

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -73,10 +73,13 @@ let
       meta.platforms = neovim-drv.meta.platforms;
     }) (''
       source ${nmt}/bash-lib/assertions.sh
-      vimrc="${writeText "init.lua" neovim-drv.initRc}"
-      vimrcGeneric="$out/patched.lua"
+      vimrc="${writeText "init.vim" neovim-drv.initRc}"
+      luarc="${writeText "init.lua" neovim-drv.luaRcContent}"
+      luarcGeneric="$out/patched.lua"
+      vimrcGeneric="$out/patched.vim"
       mkdir $out
       ${pkgs.perl}/bin/perl -pe "s|\Q$NIX_STORE\E/[a-z0-9]{32}-|$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-|g" < "$vimrc" > "$vimrcGeneric"
+      ${pkgs.perl}/bin/perl -pe "s|\Q$NIX_STORE\E/[a-z0-9]{32}-|$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-|g" < "$luarc" > "$luarcGeneric"
     '' + buildCommand);
 
 in
@@ -89,6 +92,9 @@ rec {
   nvim_with_plugins = wrapNeovim2 "-with-plugins" nvimConfNix;
 
   singlelinesconfig = runTest (wrapNeovim2 "-single-lines" nvimConfSingleLines) ''
+      assertFileContains \
+        "$luarcGeneric" \
+        "vim.cmd.source \"/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-init.vim"
       assertFileContent \
         "$vimrcGeneric" \
         "${./init-single-lines.vim}"

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -73,8 +73,8 @@ let
       meta.platforms = neovim-drv.meta.platforms;
     }) (''
       source ${nmt}/bash-lib/assertions.sh
-      vimrc="${writeText "init.vim" neovim-drv.initRc}"
-      vimrcGeneric="$out/patched.vim"
+      vimrc="${writeText "init.lua" neovim-drv.initRc}"
+      vimrcGeneric="$out/patched.lua"
       mkdir $out
       ${pkgs.perl}/bin/perl -pe "s|\Q$NIX_STORE\E/[a-z0-9]{32}-|$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-|g" < "$vimrc" > "$vimrcGeneric"
     '' + buildCommand);

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -32,22 +32,22 @@ let
     # set to false if you want to control where to save the generated config
     # (e.g., in ~/.config/init.vim or project/.nvimrc)
     , wrapRc ? true
+    # vimL code that should be sourced as part of the generated init.lua file
     , neovimRcContent ? null
-    , neovimLuaRcContent ? null
+    # lua code to put into the generated init.lua file
+    , luaRcContent ? ""
     # entry to load in packpath
     , packpathDirs
     , ...
   }:
 
-  # we can not have both, a lua and a vimL init file, at least one needs to be
-  # null
-  assert isNull neovimRcContent || isNull neovimLuaRcContent;
-
   let
 
-    selectLua = isNull neovimRcContent;
-    rcContent = if !selectLua then "source ${writeText "init.vim" neovimRcContent}"
-                else if isNull neovimLuaRcContent then "" else neovimLuaRcContent;
+    rcContent = ''
+      ${luaRcContent}
+    '' + lib.optionalString (!isNull neovimRcContent) ''
+      vim.cmd.source "${writeText "init.vim" neovimRcContent}"
+    '';
 
     wrapperArgsStr = if lib.isString wrapperArgs then wrapperArgs else lib.escapeShellArgs wrapperArgs;
 

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -46,8 +46,7 @@ let
   let
 
     selectLua = isNull neovimRcContent;
-    initFileName = "init." + (if selectLua then "lua" else "vim");
-    rcContent = if !selectLua then neovimRcContent
+    rcContent = if !selectLua then "source ${writeText "init.vim" neovimRcContent}"
                 else if isNull neovimLuaRcContent then "" else neovimLuaRcContent;
 
     wrapperArgsStr = if lib.isString wrapperArgs then wrapperArgs else lib.escapeShellArgs wrapperArgs;
@@ -77,7 +76,7 @@ let
     finalMakeWrapperArgs =
       [ "${neovim-unwrapped}/bin/nvim" "${placeholder "out"}/bin/nvim" ]
       ++ [ "--set" "NVIM_SYSTEM_RPLUGIN_MANIFEST" "${placeholder "out"}/rplugin.vim" ]
-      ++ lib.optionals wrapRc [ "--add-flags" "-u ${writeText initFileName rcContent}" ]
+      ++ lib.optionals wrapRc [ "--add-flags" "-u ${writeText "init.lua" rcContent}" ]
       ++ commonWrapperArgs
       ;
 

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -94,6 +94,7 @@ let
       inherit python3Env rubyEnv;
       withRuby = rubyEnv != null;
       inherit wrapperArgs;
+      luaRcContent = rcContent;
 
       # Remove the symlinks created by symlinkJoin which we need to perform
       # extra actions upon


### PR DESCRIPTION
Fix #211998. @teto can you please review this and assert that I am really doing what  you propose in #211998.

###### Description of changes

Added a new argument `neovimLuaRcContent` to the wrapper. If neither `neovimLuaRcContent` nor `neovimRcContent` is given the wrapper creates a init.lua file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
