### PR TITLE
qt5.overrideScope': only add when allowAliases is enabled

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -18,6 +18,7 @@ Check for any minor version changes.
 , developerBuild ? false
 , decryptSslTraffic ? false
 , debug ? false
+, config
 }:
 
 let
@@ -118,9 +119,6 @@ let
 
       callPackage = self.newScope { inherit qtCompatVersion qtModule srcs stdenv; };
     in {
-
-      # remove before 23.11
-      overrideScope' = lib.warn "qt5 now uses makeScopeWithSplicing which does not have \"overrideScope'\", use \"overrideScope\"." self.overrideScope;
 
       inherit callPackage qtCompatVersion qtModule srcs;
 
@@ -226,6 +224,9 @@ let
         propagatedBuildInputs = [ self.qtbase.dev buildPackages.makeWrapper ]
           ++ lib.optional stdenv.isLinux self.qtwayland.dev;
       } ../hooks/wrap-qt-apps-hook.sh;
+    } // lib.optionalAttrs config.allowAliases {
+      # remove before 23.11
+      overrideScope' = lib.warn "qt5 now uses makeScopeWithSplicing which does not have \"overrideScope'\", use \"overrideScope\"." self.overrideScope;
     };
 
 in makeScopeWithSplicing (generateSplicesForMkScope "qt5") (_: {}) (_: {}) addPackages

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23171,6 +23171,7 @@ with pkgs;
         bison cups dconf harfbuzz libGL perl gtk3 python3
         darwin buildPackages;
       inherit (__splicedPackages.gst_all_1) gstreamer gst-plugins-base;
+      inherit config;
       stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
     });
 


### PR DESCRIPTION
Otherwise it will spam pkgs traversal (e.g. update.nix).

Introduced in 2cbbef006b5b48dc9428d3caa99f853fedc6bfe7

cc @Artturin
