### PR TITLE
jetbrains.idea-ultimate - aarch64-linux

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -13,12 +13,12 @@
 
 let
   platforms = lib.platforms.linux ++ [ "x86_64-darwin" "aarch64-darwin" ];
-  ideaPlatforms = [ "x86_64-darwin" "i686-darwin" "i686-linux" "x86_64-linux" "aarch64-darwin" ];
+  ideaPlatforms = [ "x86_64-darwin" "i686-darwin" "i686-linux" "x86_64-linux" "aarch64-darwin" "aarch64-linux"];
 
   inherit (stdenv.hostPlatform) system;
 
   versions = builtins.fromJSON (lib.readFile (./versions.json));
-  versionKey = if stdenv.isLinux then "linux" else system;
+  versionKey = system;
   products = versions.${versionKey} or (throw "Unsupported system: ${system}");
 
   package = if stdenv.isDarwin then ./darwin.nix else ./linux.nix;
@@ -65,7 +65,8 @@ let
           ls -d $PWD/bin/lldb/linux/x64/lib/python3.8/lib-dynload/* |
           xargs patchelf \
             --replace-needed libssl.so.10 libssl.so \
-            --replace-needed libcrypto.so.10 libcrypto.so
+            --replace-needed libcrypto.so.10 libcrypto.so \
+            --replace-needed libcrypt.so.1 libcrypt.so
 
           autoPatchelf $PWD/bin
 

--- a/pkgs/applications/editors/jetbrains/versions.json
+++ b/pkgs/applications/editors/jetbrains/versions.json
@@ -1,5 +1,5 @@
 {
-  "linux": {
+  "x86_64-linux": {
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
@@ -103,6 +103,113 @@
       "version": "2022.3.4",
       "sha256": "c33f72b5e26f347983b7bae92608d9b4343dcbb400736addb0793407aedc3260",
       "url": "https://download.jetbrains.com/webstorm/WebStorm-2022.3.4.tar.gz",
+      "build_number": "223.8836.50"
+    }
+  },
+  "aarch64-linux": {
+    "clion": {
+      "update-channel": "CLion RELEASE",
+      "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
+      "version": "2022.3.3",
+      "sha256": "1b46ff0791bcb38ecb39c5f4a99941f99ed73d4f6d924a2042fdb55afc5fc03d",
+      "url": "https://download.jetbrains.com/cpp/CLion-2022.3.3-aarch64.tar.gz",
+      "build_number": "223.8836.42"
+    },
+    "datagrip": {
+      "update-channel": "DataGrip RELEASE",
+      "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
+      "version": "2022.3.3",
+      "sha256": "a5575ff7e80dd4e9390eb64fc54ed4a924403950da0c38da548de3c4bd97b34b",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2022.3.3-aarch64.tar.gz",
+      "build_number": "223.8617.3"
+    },
+    "gateway": {
+      "update-channel": "Gateway RELEASE",
+      "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.tar.gz",
+      "version": "2022.3.2",
+      "sha256": "987f6dca9518da262f556ba1a5afe6190cc5c13a6692c194b4f9ee05d4e66318",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-223.8617.56.tar.gz",
+      "build_number": "223.8617.56"
+    },
+    "goland": {
+      "update-channel": "GoLand RELEASE",
+      "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
+      "version": "2022.3.3",
+      "sha256": "8c85b56b4e226739a0e36549f5f80fed4cbf2b2798eff442499f5779396a6917",
+      "url": "https://download.jetbrains.com/go/goland-2022.3.3-aarch64.tar.gz",
+      "build_number": "223.8836.34"
+    },
+    "idea-community": {
+      "update-channel": "IntelliJ IDEA RELEASE",
+      "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.tar.gz",
+      "version": "2022.3.3",
+      "sha256": "699492fb5a9de750250fdaadca5fc9212114ee445a50875b59bbc99f0187c2e4",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2022.3.3-aarch64.tar.gz",
+      "build_number": "223.8836.41"
+    },
+    "idea-ultimate": {
+      "update-channel": "IntelliJ IDEA RELEASE",
+      "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.tar.gz",
+      "version": "2022.3.3",
+      "sha256": "f08955f6e65fb3c68684536ac21f52ec0c15b728ed9c486e724dddcb6b603562",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2022.3.3-aarch64.tar.gz",
+      "build_number": "223.8836.41"
+    },
+    "mps": {
+      "update-channel": "MPS RELEASE",
+      "url-template": "https://download.jetbrains.com/mps/{versionMajorMinor}/MPS-{version}.tar.gz",
+      "version": "2022.2",
+      "sha256": "aaee4d2bb9bc34d0b4bc62c7ef08139cc6144b433ba1675ef306e6d3d95e37a1",
+      "url": "https://download.jetbrains.com/mps/2022.2/MPS-2022.2-aarch64.tar.gz",
+      "build_number": "222.3345.1295"
+    },
+    "phpstorm": {
+      "update-channel": "PhpStorm RELEASE",
+      "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
+      "version": "2022.3.3",
+      "sha256": "d79a66032dfb85b16cef4ff308eb0161e06a831cee1fa93f2b7ca46fb1dc2ea9",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2022.3.3-aarch64.tar.gz",
+      "build_number": "223.8836.42",
+      "version-major-minor": "2022.3"
+    },
+    "pycharm-community": {
+      "update-channel": "PyCharm RELEASE",
+      "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.tar.gz",
+      "version": "2022.3.3",
+      "sha256": "fe84e586ce8da916abf481e02959742a20bab6ba3cdf447370ac8b2d5115211c",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2022.3.3-aarch64.tar.gz",
+      "build_number": "223.8836.43"
+    },
+    "pycharm-professional": {
+      "update-channel": "PyCharm RELEASE",
+      "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
+      "version": "2022.3.3",
+      "sha256": "50c37aafd9fbe3a78d97cccf4f7abd80266c548d1c7ea4751b08c52810f16f2d",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2022.3.3-aarch64.tar.gz",
+      "build_number": "223.8836.43"
+    },
+    "rider": {
+      "update-channel": "Rider RELEASE",
+      "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
+      "version": "2022.3.3",
+      "sha256": "e4607ae70bd0acf827535aa329e3da73ddf3a3fa78b54b5c8d18eae6ef52919c",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2022.3.3-aarch64.tar.gz",
+      "build_number": "223.8836.53"
+    },
+    "ruby-mine": {
+      "update-channel": "RubyMine RELEASE",
+      "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
+      "version": "2022.3.3",
+      "sha256": "18dec5191b07a455d3c3dcb0bcc146fbe83ebb411addaf89e895d373728d932e",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2022.3.3-aarch64.tar.gz",
+      "build_number": "223.8836.42"
+    },
+    "webstorm": {
+      "update-channel": "WebStorm RELEASE",
+      "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
+      "version": "2022.3.4",
+      "sha256": "c33f72b5e26f347983b7bae92608d9b4343dcbb400736addb0793407aedc3260",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2022.3.4-aarch64.tar.gz",
       "build_number": "223.8836.50"
     }
   },

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -57,22 +57,22 @@ openjdk17.overrideAttrs (oldAttrs: rec {
   buildPhase = ''
     runHook preBuild
 
-    mkdir -p jcef_linux_x64/jmods
-    cp ${jetbrains.jcef}/* jcef_linux_x64/jmods
+    mkdir -p jcef_linux_${if stdenv.isAarch64 then "aarch64" else "x64"}/jmods
+    cp ${jetbrains.jcef}/* jcef_linux_${if stdenv.isAarch64 then "aarch64" else "x64"}/jmods
 
     sed \
         -e "s/OPENJDK_TAG=.*/OPENJDK_TAG=${openjdkTag}/" \
         -e "s/SOURCE_DATE_EPOCH=.*//" \
         -e "s/export SOURCE_DATE_EPOCH//" \
         -i jb/project/tools/common/scripts/common.sh
-    sed -i "s/STATIC_CONF_ARGS/STATIC_CONF_ARGS \$configureFlags/" jb/project/tools/linux/scripts/mkimages_x64.sh
+    sed -i "s/STATIC_CONF_ARGS/STATIC_CONF_ARGS \$configureFlags/" jb/project/tools/linux/scripts/mkimages_${if stdenv.isAarch64 then "aarch64" else "x64"}.sh
     sed \
         -e "s/create_image_bundle \"jb/#/" \
         -e "s/echo Creating /exit 0 #/" \
-        -i jb/project/tools/linux/scripts/mkimages_x64.sh
+        -i jb/project/tools/linux/scripts/mkimages_${if stdenv.isAarch64 then "aarch64" else "x64"}.sh
 
     patchShebangs .
-    ./jb/project/tools/linux/scripts/mkimages_x64.sh ${build} ${if debugBuild then "fd" else "jcef"}
+    ./jb/project/tools/linux/scripts/mkimages_${if stdenv.isAarch64 then "aarch64" else "x64"}.sh ${build} ${if debugBuild then "fd" else "jcef"}
 
     runHook postBuild
   '';
@@ -84,9 +84,9 @@ openjdk17.overrideAttrs (oldAttrs: rec {
   in ''
     runHook preInstall
 
-    mv build/linux-x86_64-server-${buildType}/images/jdk/man build/linux-x86_64-server-${buildType}/images/jbrsdk${jcefSuffix}-${javaVersion}-linux-x64${debugSuffix}-b${build}
-    rm -rf build/linux-x86_64-server-${buildType}/images/jdk
-    mv build/linux-x86_64-server-${buildType}/images/jbrsdk${jcefSuffix}-${javaVersion}-linux-x64${debugSuffix}-b${build} build/linux-x86_64-server-${buildType}/images/jdk
+    mv build/linux-${if stdenv.isAarch64 then "aarch64" else "x86_64"}-server-${buildType}/images/jdk/man build/linux-${if stdenv.isAarch64 then "aarch64" else "x86_64"}-server-${buildType}/images/jbrsdk${jcefSuffix}-${javaVersion}-linux-${if stdenv.isAarch64 then "aarch64" else "x64"}${debugSuffix}-b${build}
+    rm -rf build/linux-${if stdenv.isAarch64 then "aarch64" else "x86_64"}-server-${buildType}/images/jdk
+    mv build/linux-${if stdenv.isAarch64 then "aarch64" else "x86_64"}-server-${buildType}/images/jbrsdk${jcefSuffix}-${javaVersion}-linux-${if stdenv.isAarch64 then "aarch64" else "x64"}${debugSuffix}-b${build} build/linux-${if stdenv.isAarch64 then "aarch64" else "x86_64"}-server-${buildType}/images/jdk
   '' + oldAttrs.installPhase + "runHook postInstall";
 
   postInstall = ''

--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -11,7 +11,6 @@
 , lib
 , ant
 , ninja
-, clang
 , debugBuild ? false
 
 , glib


### PR DESCRIPTION
###### Description of changes
Adding aarch64-linux as a supported platform for `jetbrains.idea-ultimate`

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
