### PR TITLE
lib/customisation: add NoMkOverridable variants of callPackage

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -112,6 +112,7 @@ let
       noDepEntry fullDepEntry packEntry stringAfter;
     inherit (self.customisation) overrideDerivation makeOverridable
       callPackageWith callPackagesWith extendDerivation hydraJob
+      callPackageWithNoMkOverridable callPackagesWithNoMkOverridable
       makeScope makeScopeWithSplicing;
     inherit (self.derivations) lazyDerivation;
     inherit (self.meta) addMetaAttrs dontDistribute setName updateName

--- a/pkgs/development/beam-modules/lib.nix
+++ b/pkgs/development/beam-modules/lib.nix
@@ -1,19 +1,6 @@
-{ __splicedPackages, lib }:
+{ callPackageNoMkOverridable, makeOverridable }:
 
-let
-  pkgs = __splicedPackages;
-in
-rec {
-
-  /* Similar to callPackageWith/callPackage, but without makeOverridable
-  */
-  callPackageWith = autoArgs: fn: args:
-    let
-      f = if pkgs.lib.isFunction fn then fn else import fn;
-      auto = builtins.intersectAttrs (lib.functionArgs f) autoArgs;
-    in f (auto // args);
-
-  callPackage = callPackageWith pkgs;
+{
 
   /* Uses generic-builder to evaluate provided drv containing OTP-version
   specific data.
@@ -31,10 +18,10 @@ rec {
   */
   callErlang = drv: args:
     let
-      builder = callPackage ../../development/interpreters/erlang/generic-builder.nix args;
+      builder = callPackageNoMkOverridable ../../development/interpreters/erlang/generic-builder.nix args;
     in
-      callPackage drv {
-        mkDerivation = pkgs.makeOverridable builder;
+      callPackageNoMkOverridable drv {
+        mkDerivation = makeOverridable builder;
       };
 
   /* Uses generic-builder to evaluate provided drv containing Elixir version
@@ -52,10 +39,10 @@ rec {
   */
   callElixir = drv: args:
     let
-      builder = callPackage ../interpreters/elixir/generic-builder.nix args;
+      builder = callPackageNoMkOverridable ../interpreters/elixir/generic-builder.nix args;
     in
-      callPackage drv {
-        mkDerivation = pkgs.makeOverridable builder;
+      callPackageNoMkOverridable drv {
+        mkDerivation = makeOverridable builder;
       };
 
   /* Uses generic-builder to evaluate provided drv containing Elixir version
@@ -73,10 +60,10 @@ rec {
   */
   callLFE = drv: args:
     let
-      builder = callPackage ../interpreters/lfe/generic-builder.nix args;
+      builder = callPackageNoMkOverridable ../interpreters/lfe/generic-builder.nix args;
     in
-      callPackage drv {
-        mkDerivation = pkgs.makeOverridable builder;
+      callPackageNoMkOverridable drv {
+        mkDerivation = makeOverridable builder;
       };
 
 }

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -146,6 +146,12 @@ in
 
   newScope = extra: lib.callPackageWith (splicedPackagesWithXorg // extra);
 
+  callPackageNoMkOverridable = pkgs.newScopeNoMkOverridable { };
+
+  callPackagesNoMkOverridable = lib.callPackagesWithNoMkOverridable splicedPackagesWithXorg;
+
+  newScopeNoMkOverridable = extra: lib.callPackageWithNoMkOverridable (splicedPackagesWithXorg // extra);
+
   # prefill 2 fields of the function for convenience
   makeScopeWithSplicing = lib.makeScopeWithSplicing splicePackages pkgs.newScope;
 


### PR DESCRIPTION
in some places we want to use callPackage but don't want to inject the makeOverridable attrs so far import with manual inherits has been used

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
