### PR TITLE
tmpreaper: init at 1.6.17

### DIFF
--- a/pkgs/tools/misc/tmpreaper/default.nix
+++ b/pkgs/tools/misc/tmpreaper/default.nix
@@ -8,12 +8,6 @@ stdenv.mkDerivation rec {
   pname = "tmpreaper";
   version = "1.6.17";
 
-  preConfigure = ''
-    if ! stdenv.isDarwin then
-      throw "Error: tmpreaper is not supported on non-Darwin platforms"
-    fi
-  '';
-
   buildInputs = [ autoconf automake ];
 
   installPhase = ''
@@ -32,4 +26,5 @@ stdenv.mkDerivation rec {
   homepage = "https://packages.debian.org/sid/tmpreaper";
   description = "Clean up files in directories based on their age";
   license = "GPL-2.0-only";
+  platforms = platforms.darwin;
 }

--- a/pkgs/tools/misc/tmpreaper/default.nix
+++ b/pkgs/tools/misc/tmpreaper/default.nix
@@ -8,6 +8,12 @@ stdenv.mkDerivation rec {
   pname = "tmpreaper";
   version = "1.6.17";
 
+  preConfigure = ''
+    if ! stdenv.isDarwin then
+      throw "Error: tmpreaper is not supported on non-Darwin platforms"
+    fi
+  '';
+
   buildInputs = [ autoconf automake ];
 
   installPhase = ''

--- a/pkgs/tools/misc/tmpreaper/default.nix
+++ b/pkgs/tools/misc/tmpreaper/default.nix
@@ -23,8 +23,12 @@ stdenv.mkDerivation rec {
     url = "https://deb.debian.org/debian/pool/main/t/tmpreaper/tmpreaper_${version}.tar.gz";
     sha256 = sha256-default;
   };
-  homepage = "https://packages.debian.org/sid/tmpreaper";
-  description = "Clean up files in directories based on their age";
-  license = "GPL-2.0-only";
-  platforms = platforms.darwin;
+
+  meta = {
+    platforms = [ "x86_64-darwin" "aarch64-darwin" ];
+    homepage = "https://packages.debian.org/sid/tmpreaper";
+    description = "Clean up files in directories based on their age";
+    license = "GPL-2.0-only";
+  };
+
 }

--- a/pkgs/tools/misc/tmpreaper/default.nix
+++ b/pkgs/tools/misc/tmpreaper/default.nix
@@ -1,27 +1,12 @@
-{ stdenv, fetchurl, autoconf, automake }:
+{ sstdenv, fetchurl, bash, findutils, gawk, grep, sed, tar }:
 
-let
-  inherit (stdenv.lib) optional;
-  sha256-default = "1ca94d156eb68160ec9b6ed8b97d70fbee996de21437f0cf7d0c3b46709fecbc";
-in
+
 stdenv.mkDerivation rec {
   pname = "tmpreaper";
   version = "1.6.17";
-
-  buildInputs = [ autoconf automake ];
-
-  installPhase = ''
-    mkdir -p $out/sbin
-    cp tmpreaper $out/sbin
-    mkdir -p $out/share/man/man8
-    cp tmpreaper.8 $out/share/man/man8
-  '';
-
-  doCheck = false;
-
   src = fetchurl {
     url = "https://deb.debian.org/debian/pool/main/t/tmpreaper/tmpreaper_${version}.tar.gz";
-    sha256 = sha256-default;
+    sha256 = "1ca94d156eb68160ec9b6ed8b97d70fbee996de21437f0cf7d0c3b46709fecbc";;
   };
 
   meta = {
@@ -31,4 +16,5 @@ stdenv.mkDerivation rec {
     license = "GPL-2.0-only";
   };
 
+  buildInputs = [ bash findutils gawk grep sed tar ];
 }

--- a/pkgs/tools/misc/tmpreaper/default.nix
+++ b/pkgs/tools/misc/tmpreaper/default.nix
@@ -23,12 +23,7 @@ stdenv.mkDerivation rec {
     url = "https://deb.debian.org/debian/pool/main/t/tmpreaper/tmpreaper_${version}.tar.gz";
     sha256 = sha256-default;
   };
-
-  meta = {
-    platforms = [ "x86_64-darwin" "aarch64-darwin" ];
-    homepage = "https://packages.debian.org/sid/tmpreaper";
-    description = "Clean up files in directories based on their age";
-    license = "GPL-2.0-only";
-  };
-
+  homepage = "https://packages.debian.org/sid/tmpreaper";
+  description = "Clean up files in directories based on their age";
+  license = "GPL-2.0-only";
 }

--- a/pkgs/tools/misc/tmpreaper/default.nix
+++ b/pkgs/tools/misc/tmpreaper/default.nix
@@ -1,4 +1,4 @@
-{ sstdenv, fetchurl, bash, findutils, gawk, grep, sed, tar }:
+{ stdenv, fetchurl, bash, findutils, gawk, grep, sed, tar }:
 
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/misc/tmpreaper/default.nix
+++ b/pkgs/tools/misc/tmpreaper/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, autoconf, automake }:
+
+let
+  inherit (stdenv.lib) optional;
+  sha256-default = "1ca94d156eb68160ec9b6ed8b97d70fbee996de21437f0cf7d0c3b46709fecbc";
+in
+stdenv.mkDerivation rec {
+  pname = "tmpreaper";
+  version = "1.6.17";
+
+  buildInputs = [ autoconf automake ];
+
+  installPhase = ''
+    mkdir -p $out/sbin
+    cp tmpreaper $out/sbin
+    mkdir -p $out/share/man/man8
+    cp tmpreaper.8 $out/share/man/man8
+  '';
+
+  doCheck = false;
+
+  src = fetchurl {
+    url = "https://deb.debian.org/debian/pool/main/t/tmpreaper/tmpreaper_${version}.tar.gz";
+    sha256 = sha256-default;
+  };
+
+  meta = {
+    platforms = [ "x86_64-darwin" "aarch64-darwin" ];
+    homepage = "https://packages.debian.org/sid/tmpreaper";
+    description = "Clean up files in directories based on their age";
+    license = "GPL-2.0-only";
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12824,6 +12824,8 @@ with pkgs;
 
   tmpwatch = callPackage ../tools/misc/tmpwatch  { };
 
+  tmpreaper = callPackage ../tools/misc/tmpreaper { };
+
   tmpmail = callPackage ../applications/networking/tmpmail { };
 
   tmux = callPackage ../tools/misc/tmux { };


### PR DESCRIPTION
###### Description of changes

This package provides a program that can be used to clean out temporary-file directories.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
