### PR TITLE
lib/customisation: callPackageWith should abort with errors

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -176,7 +176,7 @@ rec {
       # Only show the error for the first missing argument
       error = errorForArg (lib.head missingArgs);
 
-    in if missingArgs == [] then makeOverridable f allArgs else throw error;
+    in if missingArgs == [] then makeOverridable f allArgs else abort error;
 
 
   /* Like callPackage, but for a function that returns an attribute

--- a/pkgs/applications/networking/instant-messengers/signalbackup-tools/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signalbackup-tools/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, clang14Stdenv, fetchFromGitHub, openssl, sqlite }:
+{ lib, stdenv, llvmPackages_14, fetchFromGitHub, openssl, sqlite }:
 
-(if stdenv.isDarwin then clang14Stdenv else stdenv).mkDerivation rec {
+(if stdenv.isDarwin then llvmPackages_14.stdenv else stdenv).mkDerivation rec {
   pname = "signalbackup-tools";
   version = "20230316";
 

--- a/pkgs/applications/networking/remote/aws-workspaces/default.nix
+++ b/pkgs/applications/networking/remote/aws-workspaces/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib
 , makeWrapper, dpkg, fetchurl, autoPatchelfHook
-, curl, libkrb5, lttng-ust, libpulseaudio, gtk3, openssl_1_1, icu70, webkitgtk, librsvg, gdk-pixbuf, libsoup, glib-networking, graphicsmagick_q16, libva, libusb, hiredis
+, curl, libkrb5, lttng-ust, libpulseaudio, gtk3, openssl_1_1, icu70, webkitgtk, librsvg, gdk-pixbuf, libsoup, glib-networking, graphicsmagick_q16, libva, libusb1, hiredis
 }:
 
 stdenv.mkDerivation rec {
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     glib-networking
     graphicsmagick_q16
     hiredis
-    libusb
+    libusb1
     libva
   ];
 

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1352,7 +1352,7 @@ buildLuarocksPackage {
   };
 }) {};
 
-lua-resty-session = callPackage({ lua_pack, buildLuarocksPackage, fetchgit, luaOlder, lua, lua-ffi-zlib, lua-resty-openssl }:
+lua-resty-session = callPackage({ buildLuarocksPackage, fetchgit, luaOlder, lua, lua-resty-openssl /*, lua_pack, lua-ffi-zlib */  }:
 buildLuarocksPackage {
   pname = "lua-resty-session";
   version = "4.0.3-1";
@@ -1374,12 +1374,13 @@ buildLuarocksPackage {
  '') ["date" "path"]) ;
 
   disabled = (luaOlder "5.1");
-  propagatedBuildInputs = [ lua lua-ffi-zlib lua-resty-openssl lua_pack ];
+  propagatedBuildInputs = [ lua lua-resty-openssl /* lua_pack lua-ffi-zlib */ ];
 
   meta = {
     homepage = "https://github.com/bungle/lua-resty-session";
     description = "Session Library for OpenResty - Flexible and Secure";
     license.fullName = "BSD";
+    broken = true; # lua_pack and lua-ffi-zlib are unpackaged, causing this package to not evaluate
   };
 }) {};
 

--- a/pkgs/tools/audio/stt/default.nix
+++ b/pkgs/tools/audio/stt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, autoPatchelfHook, bzip2, lzma }:
+{ stdenv, lib, fetchurl, autoPatchelfHook, bzip2, xz }:
 
 stdenv.mkDerivation rec {
   pname = "stt";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     bzip2
-    lzma
+    xz
     stdenv.cc.cc.lib
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -494,7 +494,7 @@ with pkgs;
 
   dinghy = with python3Packages; toPythonApplication dinghy;
 
-  djhtml = callPackage ../development/tools/djhtml { };
+  djhtml = python3Packages.callPackage ../development/tools/djhtml { };
 
   deadcode = callPackage ../development/tools/deadcode { };
 


### PR DESCRIPTION
ofborg relies on the behavior that existed prior to
1c00bf3, where evaluation would
immediately abort due to a missing argument (whether it be an aliased
package when `allowAliases = false;` or a typo'd or otherwise
nonexistent package).

If `callPackageWith` `throw`s instead of `abort`s, the following
`nix-env` invocation does not fail fast but instead silently skips the
attribute (assuming there is a package that has an aliased package in
its `autoArgs`):

    $ nix-env -qa --json --file . --arg config '{ allowAliases = false; }' &>/dev/null
    $ echo $?
    0

This does change the error output when there is a missing package (for
any of the reasons mentioned above), though. Before this change, the
errors looked like this:

    $ nix-build -A hello --arg config '{ allowAliases = false; }'
    error:
           … while calling the 'throw' builtin

             at /home/vin/workspace/vcs/nixpkgs/master/lib/customisation.nix:179:65:

              178|
              179|     in if missingArgs == [] then makeOverridable f allArgs else throw error;
                 |                                                                 ^
              180|

           error: Function called without required argument "bash_5" at /home/vin/workspace/vcs/nixpkgs/master/pkgs/applications/misc/hello/default.nix:8, did you mean "bash" or "bashdb"?

And the errors now look like this:

    $ nix-build -A hello --arg config '{ allowAliases = false; }'
    error:
           … while calling the 'abort' builtin

             at /home/vin/workspace/vcs/nixpkgs/master/lib/customisation.nix:179:65:

              178|
              179|     in if missingArgs == [] then makeOverridable f allArgs else abort error;
                 |                                                                 ^
              180|

           error: evaluation aborted with the following error message: 'Function called without required argument "bash_5" at /home/vin/workspace/vcs/nixpkgs/master/pkgs/applications/misc/hello/default.nix:8, did you mean "bash" or "bashdb"?'

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

cc @infinisil: Is there a way to preserve the throw behavior / conditionally enable the abort behavior instead of doing it all the time? The error message an `abort` produces vs a `throw` is less than ideal, but I don't see a way to allow it to be configured, and I was hesitant to add `, config ? { abortOnMissingArg = true; }` or something.

cc @teto: I hand-edited the generated lua packages because `lua-resty-session` depended on two unpackaged packages (`lua_pack` and `lua-ffi-zlib`), and I was unable to get the generator/update script to do the right thing (it kept erroring because `luarocks nix [package]` would fail (where `[package]` seemingly changed every time). I commented out the problematic package names and marked `lua-resty-session` as a whole as broken.