### PR TITLE
openjfx: fix withWebKit

### DIFF
--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, writeText, gradle_7, pkg-config, perl, cmake
+{ stdenv, lib, fetchFromGitHub, fetchurl, writeText, gradle_7, pkg-config, perl, cmake
 , gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib, ffmpeg_4-headless, python3, ruby, icu68
 , openjdk11-bootstrap
 , withMedia ? true
@@ -70,6 +70,14 @@ let
     outputHash = "sha256-syceJMUEknBDCHK8eGs6rUU3IQn+HnQfURfCrDxYPa9=";
   };
 
+  # ICU data file.
+  # The Gradle build copies this file to the WebKit binary dir, where the WebKit build expects to unzip it.
+  icuDataVersion = s: "71" + s + "1";
+  icuDataZip = fetchurl {
+    url = "https://github.com/unicode-org/icu/releases/download/release-${icuDataVersion "-"}/icu4c-${icuDataVersion "_"}-data-bin-l.zip";
+    sha256 = "sha256-pVWIy0BkICsthA5mxhR9SJQHleMNnaEcGl/AaLi5qZM=";
+  };
+
 in makePackage {
   pname = "openjfx-modular-sdk";
 
@@ -83,7 +91,26 @@ in makePackage {
     substituteInPlace build.gradle \
       --replace 'mavenCentral()' 'mavenLocal(); maven { url uri("${deps}") }' \
       --replace 'name: SWT_FILE_NAME' "files('$swtJar')"
-  '';
+  '' +
+  (if withWebKit then ''
+    # Verify that we are supplying the correct ICU version
+    if ! requiredVersion="$(grep -Po 'defineProperty\("icuVersion", "\K.+(?="\))' build.gradle)"; then
+      echo >&2 "Error: Cannot find required ICU version"
+      exit 1
+    fi
+    providedVersion="${icuDataVersion "."}"
+    if [ "$requiredVersion" != "$providedVersion" ]; then
+      echo >&2 "Error: ICU version mismatch"
+      echo >&2 "  Required: $requiredVersion"
+      echo >&2 "  Provided: $providedVersion"
+      exit 1
+    fi
+    # Providing with a file name matching `icu4c-*.zip`
+    icuZip="$(pwd)/icu4c-data-bin-l.zip"
+    ln -s ${icuDataZip} "$icuZip"
+    substituteInPlace build.gradle \
+      --replace 'icu name: "icu4c-''${icuFileVersion}-data-bin-l", ext: "zip"' "icu files('$icuZip')"
+  '' else "");
 
   installPhase = ''
     cp -r build/modular-sdk $out

--- a/pkgs/development/compilers/openjdk/openjfx/17.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/17.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, writeText, openjdk17_headless, gradle_7
+{ stdenv, lib, fetchFromGitHub, fetchurl, writeText, openjdk17_headless, gradle_7
 , pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib
 , ffmpeg_4-headless, python3, ruby, icu68
 , withMedia ? true
@@ -65,6 +65,14 @@ let
     outputHash = "sha256-dV7/U5GpFxhI13smZ587C6cVE4FRNPY0zexZkYK4Yqo=";
   };
 
+  # ICU data file.
+  # The Gradle build copies this file to the WebKit binary dir, where the WebKit build expects to unzip it.
+  icuDataVersion = s: "71" + s + "1";
+  icuDataZip = fetchurl {
+    url = "https://github.com/unicode-org/icu/releases/download/release-${icuDataVersion "-"}/icu4c-${icuDataVersion "_"}-data-bin-l.zip";
+    sha256 = "sha256-pVWIy0BkICsthA5mxhR9SJQHleMNnaEcGl/AaLi5qZM=";
+  };
+
 in makePackage {
   pname = "openjfx-modular-sdk";
 
@@ -78,7 +86,26 @@ in makePackage {
     substituteInPlace build.gradle \
       --replace 'mavenCentral()' 'mavenLocal(); maven { url uri("${deps}") }' \
       --replace 'name: SWT_FILE_NAME' "files('$swtJar')"
-  '';
+  '' +
+  (if withWebKit then ''
+    # Verify that we are supplying the correct ICU version
+    if ! requiredVersion="$(grep -Po 'defineProperty\("icuVersion", "\K.+(?="\))' build.gradle)"; then
+      echo >&2 "Error: Cannot find required ICU version"
+      exit 1
+    fi
+    providedVersion="${icuDataVersion "."}"
+    if [ "$requiredVersion" != "$providedVersion" ]; then
+      echo >&2 "Error: ICU version mismatch"
+      echo >&2 "  Required: $requiredVersion"
+      echo >&2 "  Provided: $providedVersion"
+      exit 1
+    fi
+    # Providing with a file name matching `icu4c-*.zip`
+    icuZip="$(pwd)/icu4c-data-bin-l.zip"
+    ln -s ${icuDataZip} "$icuZip"
+    substituteInPlace build.gradle \
+      --replace 'icu name: "icu4c-''${icuFileVersion}-data-bin-l", ext: "zip"' "icu files('$icuZip')"
+  '' else "");
 
   installPhase = ''
     cp -r build/modular-sdk $out


### PR DESCRIPTION
###### Description of changes

Continuation of the work in #216611
~Fixes #162064~ and ~Fixes #216609~  only if we would expose an openjdk package with WebKit enabled

**The builds succeed, but I did not have time to actually test the result. There might still be some parts missing.**

All changes are behind the `withWebKit` flag, and currently no package in nixpkgs uses it, therefore, no other packages should be affected.

I have build openjfx versions 11, 17 and 19. (Version 15 does not even seem to build without WebKit.)

Building WebKit takes some time... :snail:

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
