### PR TITLE
[WIP] File set combinators

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@
 /lib/debug.nix              @edolstra @Profpatsch
 /lib/asserts.nix            @edolstra @Profpatsch
 /lib/path.*                 @infinisil @fricklerhandwerk
+/lib/fileset.nix            @infinisil
 
 # Nixpkgs Internals
 /default.nix                                     @Ericson2314
@@ -61,6 +62,7 @@
 /doc/build-aux/pandoc-filters @jtojnar
 /doc/contributing/ @fricklerhandwerk
 /doc/contributing/contributing-to-documentation.chapter.md @jtojnar @fricklerhandwerk
+/doc/functions/fileset.section.md @infinisil
 
 # NixOS Internals
 /nixos/default.nix                                    @infinisil

--- a/doc/doc-support/default.nix
+++ b/doc/doc-support/default.nix
@@ -14,6 +14,7 @@ let
     { name = "options"; description = "NixOS / nixpkgs option handling"; }
     { name = "path"; description = "path functions"; }
     { name = "filesystem"; description = "filesystem functions"; }
+    { name = "fileset"; description = "file set functions"; }
     { name = "sources"; description = "source filtering functions"; }
     { name = "cli"; description = "command-line serialization functions"; }
   ];

--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -11,4 +11,5 @@
  <xi:include href="functions/debug.section.xml" />
  <xi:include href="functions/prefer-remote-fetch.section.xml" />
  <xi:include href="functions/nix-gitignore.section.xml" />
+ <xi:include href="functions/fileset.section.xml" />
 </chapter>

--- a/doc/functions/fileset.section.md
+++ b/doc/functions/fileset.section.md
@@ -91,10 +91,10 @@ difference
 - src (recursive directory)
 ```
 
-Another important function is [`filter`](#function-library-lib.fileset.filter), which filters out files based on a predicate function:
+Another important function is [`fileFilter`](#function-library-lib.fileset.fileFilter), which filters out files based on a predicate function:
 ```nix
 # Filter for C files contained in ./.
-filter
+fileFilter
   (file: file.ext == "c")
   ./.
 ```

--- a/doc/functions/fileset.section.md
+++ b/doc/functions/fileset.section.md
@@ -3,7 +3,7 @@
 The [`lib.fileset`](#sec-functions-library-fileset) functions allow you to work with _file sets_.
 File sets efficiently represent a set of local files.
 They can easily be created and combined for complex behavior.
-Their files can also be imported into the store and used as a derivation source.
+Their files can also be added to the Nix store and used as a derivation source.
 
 The best way to experiment with file sets is to start a `nix repl` and load the file set functions:
 ```
@@ -104,9 +104,9 @@ fileFilter
   - main.c (regular)
 ```
 
-File sets can be imported into the store using the [`importToStore`](#function-library-lib.fileset.importToStore) function. This function requires the `entryPoint` argument to indicate where the resulting string (via `outPath`, see [`toString`](https://nixos.org/manual/nix/stable/language/builtins.html?highlight=outPath#builtins-toString)) should be focused on, meaning that when you `cd ${importToStore ...}`, the files will be available at paths relative to `entryPoint`:
+File sets can be added to the Nix store using the [`addToStore`](#function-library-lib.fileset.addToStore) function. This function requires the `entryPoint` argument to indicate where the resulting string (via `outPath`, see [`toString`](https://nixos.org/manual/nix/stable/language/builtins.html?highlight=outPath#builtins-toString)) should be focused on, meaning that when you `cd ${addToStore ...}`, the files will be available at paths relative to `entryPoint`:
 ```nix
-nix-repl> importToStore {
+nix-repl> addToStore {
             entryPoint = ./.;
             fileset = union ./Makefile ./src;
           }
@@ -129,7 +129,7 @@ $ find .
 Sometimes we also want to make files outside of the `entryPoint` accessible. This can be done using the optional `base` argument:
 
 ```nix
-nix-repl> importToStore {
+nix-repl> addToStore {
             base = ../.;
             entryPoint = ./.;
             fileset = unions [
@@ -163,7 +163,7 @@ As you can see, when changing to the `outPath` directory, we can still find the 
 Note however that the directory name `project` is included in the store path, meaning that the hashes will change when you rename that directory.
 Therefore `base` should not be set higher up than the current version control root directory, otherwise the result can change even when no files in the directory changed.
 
-Lastly, here's an example of how we can define derivation sources using file sets using [`importToStore`](#function-library-lib.fileset.importToStore):
+Lastly, here's an example of how we can define derivation sources using file sets using [`addToStore`](#function-library-lib.fileset.addToStore):
 ```nix
 # default.nix
 with import <nixpkgs> {};
@@ -177,7 +177,7 @@ in
 fs.trace {} sourceFiles
 stdenv.mkDerivation {
   name = "my-project";
-  src = fs.importToStore {
+  src = fs.addToStore {
     entryPoint = ./.;
     fileset = sourceFiles;
   };

--- a/doc/functions/fileset.section.md
+++ b/doc/functions/fileset.section.md
@@ -1,0 +1,206 @@
+# File sets {#sec-fileset}
+
+The [`lib.fileset`](#sec-functions-library-fileset) functions allow you to work with _file sets_.
+File sets efficiently represent a set of local files.
+They can easily be created and combined for complex behavior.
+Their files can also be imported into the store and used as a derivation source.
+
+The best way to experiment with file sets is to start a `nix repl` and load the file set functions:
+```
+$ nix repl -f '<nixpkgs/lib>'
+
+nix-repl> :a fileset
+Added 13 variables
+
+nix-repl>
+```
+
+The most basic way to create file sets is by passing a [path](https://nixos.org/manual/nix/stable/language/values.html#type-path) to [`coerce`](#function-library-lib.fileset.coerce). The resulting file set depends on the path:
+- If the path points to a file, the result is a file set only consisting of that single file.
+- If the path points to a directory, all files in that directory will be in the resulting file set.
+
+Let's try to create a file set containing just a local `Makefile` file:
+```nix
+nix-repl> coerce ./Makefile
+{ __noEval = «error: error: File sets are not intended to be directly inspected or evaluated. Instead prefer:
+       - If you want to print a file set, use the `lib.fileset.trace` or `lib.fileset.pretty` function.
+       - If you want to check file sets for equality, use the `lib.fileset.equals` function.»; _base = /home/user/my/project; _tree = { ... }; _type = "fileset"; }
+```
+
+As you can see from the error message, we can't just print a file set directly. Instead let's use the [`trace`](#function-library-lib.fileset.trace) function as suggested:
+
+```nix
+nix-repl> trace {} (coerce ./Makefile) null
+trace: /home/user/my/project
+trace: - Makefile (regular)
+null
+```
+
+From now on we'll use this simplified presentation of file set expressions and their resulting values:
+```nix
+coerce ./Makefile
+```
+```
+/home/user/my/project
+- Makefile (regular)
+```
+
+For convenience, all file set operations implicitly call [`coerce`](#function-library-lib.fileset.coerce) on arguments that are expected to be file sets, allowing us to simplify it to just:
+
+```nix
+# Implicit coerce when passing to `trace`
+./Makefile
+```
+```
+/home/user/my/project
+- Makefile (regular)
+```
+
+Files need to exist, otherwise an error is thrown:
+```nix
+./non-existent
+```
+```
+error: lib.fileset.trace: Expected second argument "/home/user/my/project/non-existent" to be a path that exists, but it doesn't.
+```
+
+File sets can be composed using the functions [`union`](#function-library-lib.fileset.union) (and the list-based equivalent [`unions`](#function-library-lib.fileset.unions)), [`intersect`](#function-library-lib.fileset.intersect) (and the list-based equivalent [`intersects`](#function-library-lib.fileset.intersects)) and [`difference`](#function-library-lib.fileset.difference), the most useful of which are [`unions`](#function-library-lib.fileset.unions) and [`difference`](#function-library-lib.fileset.difference):
+
+```nix
+# The file set containing the files from all list elements
+unions [
+  ./Makefile
+  ./src
+]
+```
+```
+/home/user/my/project
+- Makefile (regular)
+- src (recursive directory)
+```
+
+```nix
+# All files in ./. except ./Makefile
+difference
+  ./.
+  ./Makefile
+```
+```
+/home/user/my/project
+- README.md (regular)
+- src (recursive directory)
+```
+
+Another important function is [`filter`](#function-library-lib.fileset.filter), which filters out files based on a predicate function:
+```nix
+# Filter for C files contained in ./.
+filter
+  (file: file.ext == "c")
+  ./.
+```
+```
+/home/user/my/project
+- src
+  - main.c (regular)
+```
+
+File sets can be imported into the store using the [`importToStore`](#function-library-lib.fileset.importToStore) function. This function requires the `entryPoint` argument to indicate where the resulting string (via `outPath`, see [`toString`](https://nixos.org/manual/nix/stable/language/builtins.html?highlight=outPath#builtins-toString)) should be focused on, meaning that when you `cd ${importToStore ...}`, the files will be available at paths relative to `entryPoint`:
+```nix
+nix-repl> importToStore {
+            entryPoint = ./.;
+            fileset = union ./Makefile ./src;
+          }
+{
+  outPath = "/nix/store/4p6kpi1znyvih3qjzrzcwbh9sx1qdjpj-source";
+  root = "/nix/store/4p6kpi1znyvih3qjzrzcwbh9sx1qdjpj-source";
+  subpath = "./.";
+}
+
+$ cd /nix/store/4p6kpi1znyvih3qjzrzcwbh9sx1qdjpj-source
+
+$ find .
+.
+./src
+./src/main.c
+./src/main.h
+./Makefile
+```
+
+Sometimes we also want to make files outside of the `entryPoint` accessible. This can be done using the optional `base` argument:
+
+```nix
+nix-repl> importToStore {
+            base = ../.;
+            entryPoint = ./.;
+            fileset = unions [
+              ./Makefile
+              ./src
+              # This file is not in ./.!
+              ../utils.nix
+            ];
+          }
+{
+  outPath = "/nix/store/348vyqsfz2rijgzxpks9x2yjpxvh073w-source/project";
+  root = "/nix/store/348vyqsfz2rijgzxpks9x2yjpxvh073w-source";
+  subpath = "./project";
+}
+
+$ cd /nix/store/348vyqsfz2rijgzxpks9x2yjpxvh073w-source/project
+
+$ find .
+.
+./Makefile
+./src
+./src/main.h
+./src/main.c
+
+$ cat ../utils.nix
+# These are utils!
+```
+
+As you can see, when changing to the `outPath` directory, we can still find the same files as before, but now we also have access to `../utils.nix`.
+
+Note however that the directory name `project` is included in the store path, meaning that the hashes will change when you rename that directory.
+Therefore `base` should not be set higher up than the current version control root directory, otherwise the result can change even when no files in the directory changed.
+
+Lastly, here's an example of how we can define derivation sources using file sets using [`importToStore`](#function-library-lib.fileset.importToStore):
+```nix
+# default.nix
+with import <nixpkgs> {};
+let
+  fs = lib.fileset;
+  sourceFiles = fs.unions [
+    ./Makefile
+    ./src
+  ];
+in
+fs.trace {} sourceFiles
+stdenv.mkDerivation {
+  name = "my-project";
+  src = fs.importToStore {
+    entryPoint = ./.;
+    fileset = sourceFiles;
+  };
+  dontBuild = true;
+  installPhase = ''
+    find . > $out
+  '';
+}
+```
+
+```
+$ nix-build
+trace: /home/user/my/project
+trace: - Makefile (regular)
+trace: - src (recursive directory)
+/nix/store/zz7b9zndh6575kagkdy9277zi9dmhz5f-my-project
+
+$ cat result
+.
+./src
+./src/main.h
+./src/main.c
+./Makefile
+```
+
+This covers the basics of almost all functions available, see the full reference [here](#sec-functions-library-fileset).

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -54,6 +54,7 @@ let
     # Eval-time filesystem handling
     path = callLibs ./path;
     filesystem = callLibs ./filesystem.nix;
+    fileset = callLibs ./fileset.nix;
     sources = callLibs ./sources.nix;
 
     # back-compat aliases

--- a/lib/fileset.nix
+++ b/lib/fileset.nix
@@ -438,8 +438,8 @@ in {
       fileset :: FileSet,
     } -> {
       outPath :: String,
-      root :: String,
-      subpath :: String,
+      _root :: String,
+      _subpath :: String,
     }
   */
   importToStore = { name ? "source", base ? entryPoint, entryPoint, fileset }:
@@ -497,8 +497,8 @@ in {
       };
       components = removePrefix base entryPoint;
     in {
-      inherit root;
-      subpath = toSubpath components;
+      _root = root;
+      _subpath = toSubpath components;
       outPath =
         if components == [] then
           root

--- a/lib/fileset.nix
+++ b/lib/fileset.nix
@@ -528,9 +528,9 @@ in {
     };
 
   /*
-  Coerce a value to a fileset:
+  Coerce a value to a file set:
 
-  - If the value is a fileset already, return it directly
+  - If the value is a file set already, return it directly
 
   - If the value is a path pointing to a file, return a file set with that single file
 
@@ -625,7 +625,7 @@ in {
   */
   union = lhs: rhs:
     let
-      normalised = _normaliseBase "intersect" [
+      normalised = _normaliseBase "union" [
         {
           context = "first argument";
           value = lhs;

--- a/lib/fileset.nix
+++ b/lib/fileset.nix
@@ -198,13 +198,13 @@ let
   # null    | 2 null  | 2 attrs | 2 dir | 2 str |
   # attrs   | 3 attrs | 1 rec   | 2 dir |   -   |
   # dir     | 3 dir   | 3 dir   | 2 dir |   -   |
-  # str     | 3 str   |   -     |   -   | 3 str |
+  # str     | 3 str   |   -     |   -   | 2 str |
   _unionTree = lhs: rhs:
     # Branch 1
     if isAttrs lhs && isAttrs rhs then
       mapAttrs (name: _unionTree lhs.${name}) rhs
     # Branch 2
-    else if lhs == null || rhs == "directory" then
+    else if lhs == null || isString rhs then
       rhs
     # Branch 3
     else
@@ -218,13 +218,13 @@ let
   # null    | 2 null  | 2 null  | 2 null  | 2 null |
   # attrs   | 3 null  | 1 rec   | 2 attrs |   -    |
   # dir     | 3 null  | 3 attrs | 2 dir   |   -    |
-  # str     | 3 null  |   -     |   -     | 3 str  |
+  # str     | 3 null  |   -     |   -     | 2 str  |
   _intersectTree = lhs: rhs:
     # Branch 1
     if isAttrs lhs && isAttrs rhs then
       mapAttrs (name: _intersectTree lhs.${name}) rhs
     # Branch 2
-    else if lhs == null || rhs == "directory" then
+    else if lhs == null || isString rhs then
       lhs
     # Branch 3
     else

--- a/lib/fileset.nix
+++ b/lib/fileset.nix
@@ -1,0 +1,840 @@
+# Add this to docs somewhere: If you pass the same arguments to the same functions, you will get the same result
+{ lib }:
+let
+  # TODO: Add builtins.traceVerbose or so to all the operations for debugging
+  # TODO: Document limitation that empty directories won't be included
+  # TODO: Point out that equality comparison using `==` doesn't quite work because there's multiple representations for all files in a directory: "directory" and `readDir path`.
+  # TODO: subset and superset check functions. Can easily be implemented with `difference` and `isEmpty`
+  # TODO: Write down complexity of each operation, most should be O(1)!
+  # TODO: Implement an operation for optionally including a file if it exists.
+  # TODO: Derive property tests from https://en.wikipedia.org/wiki/Algebra_of_sets
+
+  inherit (builtins)
+    isAttrs
+    isString
+    isPath
+    isList
+    typeOf
+    readDir
+    match
+    pathExists
+    seq
+    ;
+
+  inherit (lib.trivial)
+    mapNullable
+    ;
+
+  inherit (lib.lists)
+    head
+    tail
+    foldl'
+    length
+    elemAt
+    all
+    imap0
+    drop
+    commonPrefix
+    ;
+
+  inherit (lib.strings)
+    concatStringsSep
+    ;
+
+  inherit (lib.attrsets)
+    mapAttrs
+    attrNames
+    attrValues
+    ;
+
+  inherit (lib.sources)
+    pathType
+    ;
+
+  inherit (lib.path)
+    append
+    deconstruct
+    construct
+    hasPrefix
+    removePrefix
+    ;
+
+  inherit (lib.path.components)
+    toSubpath
+    fromSubpath
+    ;
+
+  # Internal file set structure:
+  #
+  # # A set of files
+  # <fileset> = {
+  #   _type = "fileset";
+  #
+  #   # The base path, only files under this path can be represented
+  #   # Always a directory
+  #   _base = <path>;
+  #
+  #   # A tree representation of all included files
+  #   _tree = <tree>;
+  # };
+  #
+  # # A directory entry value
+  # <tree> =
+  #   # A nested directory
+  #   <directory>
+  #
+  #   # A nested file
+  #   | <file>
+  #
+  #   # A removed file or directory
+  #   # This is represented like this instead of removing the entry from the attribute set because:
+  #   # - It improves laziness
+  #   # - It allows keeping the attribute set as a `builtins.readDir` cache
+  #   | null
+  #
+  # # A directory
+  # <directory> =
+  #   # The inclusion state for every directory entry
+  #   { <name> = <tree>; }
+  #
+  #   # All files in a directory, recursively.
+  #   # Semantically this is equivalent to `builtins.readDir path`, but lazier, because
+  #   # operations that don't require the entry listing can avoid it.
+  #   # This string is chosen to be compatible with `builtins.readDir` for a simpler implementation
+  #   "directory";
+  #
+  # # A file
+  # <file> =
+  #   # A file with this filetype
+  #   # These strings match `builtins.readDir` for a simpler implementation
+  #   "regular" | "symlink" | "unknown"
+
+  # Create a fileset structure
+  # Type: Path -> <tree> -> <fileset>
+  _create = base: tree: {
+    _type = "fileset";
+    # All properties are internal
+    _base = base;
+    _tree = tree;
+    # Double __ to make it be evaluated and ordered first
+    __noEval = throw ''
+      File sets are not intended to be directly inspected or evaluated. Instead prefer:
+      - If you want to print a file set, use the `lib.fileset.trace` or `lib.fileset.pretty` function.
+      - If you want to check file sets for equality, use the `lib.fileset.equals` function.
+    '';
+  };
+
+  # Coerce a value to a fileset
+  # Type: String -> String -> Any -> <fileset>
+  _coerce = function: context: value:
+    if value._type or "" == "fileset" then
+      value
+    else if ! isPath value then
+      throw "lib.fileset.${function}: Expected ${context} to be a path, but got a ${typeOf value}."
+    else if ! pathExists value then
+      throw "lib.fileset.${function}: Expected ${context} \"${toString value}\" to be a path that exists, but it doesn't."
+    else
+      let
+        type = pathType value;
+      in
+      if type == "directory" then
+        _create value type
+      else
+        # Always coerce to a directory
+        _create (dirOf value)
+          (_nestTree
+            (dirOf value)
+            [ (baseNameOf value) ]
+            type
+          );
+
+  # Nest a tree under some further components
+  # Type: Path -> [ String ] -> <tree> -> <tree>
+  _nestTree = targetBase: extraComponents: tree:
+    let
+      recurse = index: focusPath:
+        if index == length extraComponents then
+          tree
+        else
+          let
+            focusedName = elemAt extraComponents index;
+          in
+          mapAttrs
+            (name: _:
+              if name == focusedName then
+                recurse (index + 1) (append focusPath name)
+              else
+                null
+            )
+            (readDir focusPath);
+    in
+    recurse 0 targetBase;
+
+  # Expand "directory" to { <name> = <tree>; }
+  # Type: Path -> <directory> -> { <name> = <tree>; }
+  _directoryEntries = path: value:
+    if isAttrs value then
+      value
+    else
+      readDir path;
+
+  # The following tables are a bit complicated, but they nicely explain the
+  # corresponding implementations, here's the legend:
+  #
+  # lhs\rhs: The values for the left hand side and right hand side arguments
+  # null: null, an excluded file/directory
+  # attrs: satisfies `isAttrs value`, an explicitly listed directory containing nested trees
+  # dir: "directory", a recursively included directory
+  # str: "regular", "symlink" or "unknown", a filetype string
+  # rec: A result computed by recursing
+  # -: Can't occur because one argument is a directory while the other is a file
+  # <number>: Indicates that the result is computed by the branch with that number
+
+  # The union of two <tree>'s
+  # Type: <tree> -> <tree> -> <tree>
+  #
+  # lhs\rhs |   null  |   attrs |   dir |   str |
+  # ------- | ------- | ------- | ----- | ----- |
+  # null    | 2 null  | 2 attrs | 2 dir | 2 str |
+  # attrs   | 3 attrs | 1 rec   | 2 dir |   -   |
+  # dir     | 3 dir   | 3 dir   | 2 dir |   -   |
+  # str     | 3 str   |   -     |   -   | 3 str |
+  _unionTree = lhs: rhs:
+    # Branch 1
+    if isAttrs lhs && isAttrs rhs then
+      mapAttrs (name: _unionTree lhs.${name}) rhs
+    # Branch 2
+    else if lhs == null || rhs == "directory" then
+      rhs
+    # Branch 3
+    else
+      lhs;
+
+  # The intersection of two <tree>'s
+  # Type: <tree> -> <tree> -> <tree>
+  #
+  # lhs\rhs |   null  |   attrs |   dir   |   str  |
+  # ------- | ------- | ------- | ------- | ------ |
+  # null    | 2 null  | 2 null  | 2 null  | 2 null |
+  # attrs   | 3 null  | 1 rec   | 2 attrs |   -    |
+  # dir     | 3 null  | 3 attrs | 2 dir   |   -    |
+  # str     | 3 null  |   -     |   -     | 3 str  |
+  _intersectTree = lhs: rhs:
+    # Branch 1
+    if isAttrs lhs && isAttrs rhs then
+      mapAttrs (name: _intersectTree lhs.${name}) rhs
+    # Branch 2
+    else if lhs == null || rhs == "directory" then
+      lhs
+    # Branch 3
+    else
+      rhs;
+
+  # The difference between two <tree>'s
+  # Type: Path -> <tree> -> <tree> -> <tree>
+  #
+  # lhs\rhs |   null  |   attrs |   dir  |   str  |
+  # ------- | ------- | ------- | ------ | ------ |
+  # null    | 1 null  | 1 null  | 1 null | 1 null |
+  # attrs   | 2 attrs | 3 rec   | 1 null |   -    |
+  # dir     | 2 dir   | 3 rec   | 1 null |   -    |
+  # str     | 2 str   |   -     |   -    | 1 null |
+  _differenceTree = path: lhs: rhs:
+    # Branch 1
+    if isString rhs || lhs == null then
+      null
+    # Branch 2
+    else if rhs == null then
+      lhs
+    # Branch 3
+    else
+      mapAttrs (name: lhsValue:
+        _differenceTree (append path name) lhsValue rhs.${name}
+      ) (_directoryEntries path lhs);
+
+  # Whether two <tree>'s are equal
+  # Type: Path -> <tree> -> <tree> -> <tree>
+  #
+  # | lhs\rhs |   null  |   attrs |   dir  |   str   |
+  # | ------- | ------- | ------- | ------ | ------- |
+  # | null    | 1 true  | 1 rec   | 1 rec  | 1 false |
+  # | attrs   | 2 rec   | 3 rec   | 3 rec  |   -     |
+  # | dir     | 2 rec   | 3 rec   | 4 true |   -     |
+  # | str     | 2 false |   -     |   -    | 4 true  |
+  _equalsTree = path: lhs: rhs:
+    # Branch 1
+    if lhs == null then
+      _isEmptyTree path rhs
+    # Branch 2
+    else if rhs == null then
+      _isEmptyTree path lhs
+    # Branch 3
+    else if isAttrs lhs || isAttrs rhs then
+      let
+        lhs' = _directoryEntries path lhs;
+        rhs' = _directoryEntries path rhs;
+      in
+      all (name:
+        _equalsTree (append path name) lhs'.${name} rhs'.${name}
+      ) (attrNames lhs')
+    # Branch 4
+    else
+      true;
+
+  # Whether a tree is empty, containing no files
+  # Type: Path -> <tree> -> Bool
+  _isEmptyTree = path: tree:
+    if isAttrs tree || tree == "directory" then
+      let
+        entries = _directoryEntries path tree;
+      in
+      all (name: _isEmptyTree (append path name) entries.${name}) (attrNames entries)
+    else
+      tree == null;
+
+  # Simplifies a tree, optionally expanding all "directory"'s into complete listings
+  # Type: Bool -> Path -> <tree> -> <tree>
+  _simplifyTree = expand: base: tree:
+    let
+      recurse = focusPath: tree:
+        if tree == "directory" && expand || isAttrs tree then
+          let
+            expanded = _directoryEntries focusPath tree;
+            transformedSubtrees = mapAttrs (name: recurse (append focusPath name)) expanded;
+            values = attrValues transformedSubtrees;
+          in
+          if all (value: value == "emptyDir") values then
+            "emptyDir"
+          else if all (value: isNull value || value == "emptyDir") values then
+            null
+          else if !expand && all (value: isString value || value == "emptyDir") values then
+            "directory"
+          else
+            mapAttrs (name: value: if value == "emptyDir" then null else value) transformedSubtrees
+        else
+          tree;
+      result = recurse base tree;
+    in
+    if result == "emptyDir" then
+      null
+    else
+      result;
+
+  _prettyTreeSuffix = tree:
+    if isAttrs tree then
+      ""
+    else if tree == "directory" then
+      " (recursive directory)"
+    else
+      " (${tree})";
+
+  # Pretty-print all files included in the file set.
+  # Type: (b -> String -> b) -> b -> Path -> FileSet -> b
+  _prettyFoldl' = f: start: base: tree:
+    let
+      traceTreeAttrs = start: indent: tree:
+        # Nix should really be evaluating foldl''s second argument before starting the iteration
+        # See the same problem in Haskell:
+        # - https://stackoverflow.com/a/14282642
+        # - https://gitlab.haskell.org/ghc/ghc/-/issues/12173
+        # - https://well-typed.com/blog/90/#a-postscript-which-foldl
+        # - https://old.reddit.com/r/haskell/comments/21wvk7/foldl_is_broken/
+        seq start
+          (foldl' (prev: name:
+            let
+              subtree = tree.${name};
+
+              intermediate =
+                f prev "${indent}- ${name}${_prettyTreeSuffix subtree}";
+            in
+            if subtree == null then
+              # Don't print anything at all if this subtree is empty
+              prev
+            else if isAttrs subtree then
+              # A directory with explicit entries
+              # Do print this node, but also recurse
+              traceTreeAttrs intermediate "${indent}  " subtree
+            else
+              # Either a file, or a recursively included directory
+              # Do print this node but no further recursion needed
+              intermediate
+          ) start (attrNames tree));
+
+      intermediate =
+        if tree == null then
+          f start "${toString base} (empty)"
+        else
+          f start "${toString base}${_prettyTreeSuffix tree}";
+    in
+    if isAttrs tree then
+      traceTreeAttrs intermediate "" tree
+    else
+      intermediate;
+
+  # Coerce and normalise the bases of multiple file set values passed to user-facing functions
+  # Type: String -> [ { context :: String, value :: Any } ] -> { commonBase :: Path, trees :: [ <tree> ] }
+  _normaliseBase = function: list:
+    let
+      processed = map ({ context, value }:
+        let
+          fileset = _coerce function context value;
+        in {
+          inherit fileset context;
+          baseParts = deconstruct fileset._base;
+        }
+      ) list;
+
+      first = head processed;
+
+      commonComponents = foldl' (components: el:
+        if first.baseParts.root != el.baseParts.root then
+          throw "lib.fileset.${function}: Expected file sets to have the same filesystem root, but ${first.context} has root \"${toString first.baseParts.root}\" while ${el.context} has root \"${toString el.baseParts.root}\"."
+        else
+          commonPrefix components el.baseParts.components
+      ) first.baseParts.components (tail processed);
+
+      commonBase = construct {
+        root = first.baseParts.root;
+        components = commonComponents;
+      };
+
+      commonComponentsLength = length commonComponents;
+
+      trees = map (value:
+        _nestTree
+          commonBase
+          (drop commonComponentsLength value.baseParts.components)
+          value.fileset._tree
+      ) processed;
+    in
+    {
+      inherit commonBase trees;
+    };
+
+in {
+
+  /*
+  Import a file set into the store.
+  This function takes an attribute set as an argument with these attributes:
+
+  - `fileset`: The set of files to import into the store.
+    Use the `lib.fileset` combinator functions to define this value.
+
+  - `entryPoint`: The local directory that the resulting directory should focus on, meaning that if you `cd` into the resulting directory, all files in the fileset are accessible at paths relative to the `entryPoint`.
+    This means that changing this value likely also requires changes to the code consuming the result, so it should generally be avoided.
+
+  - `base` (optional, defaults to `entryPoint`): The directory under which all file set operations set must be contained.
+    This means that everything outside of this path cannot influence the result of this import, including the name of the `base` directory itself.
+    Changing `base` does not affect which files are available in the result, so it can generally be safely changed without breaking anything.
+    By changing `base` to a directory higher up, you can adjust the `fileset` to include more files that weren't under `base` before.
+
+  Note that directories containing no files that are in the `fileset` will not be imported into the store.
+  If you need to ensure such directories exist in the result, consider creating and including a hidden file.
+
+  Type:
+    importToStore :: {
+      (optional) base :: Path,
+      entryPoint :: Path,
+      fileset :: FileSet,
+    } -> {
+      outPath :: String,
+      root :: String,
+      subpath :: String,
+    }
+  */
+  importToStore = { name ? "source", base ? entryPoint, entryPoint, fileset }:
+    let
+      actualFileset = _coerce "importToStore" "fileset attribute" fileset;
+
+      # Directories that recursively have no files in them will always be `null`
+      sparseTree =
+        let
+          recurse = focusPath: tree:
+            if tree == "directory" || isAttrs tree then
+              let
+                entries = _directoryEntries focusPath tree;
+                sparseSubtrees = mapAttrs (name: recurse (append focusPath name)) entries;
+                values = attrValues sparseSubtrees;
+              in
+              if all isNull values then
+                null
+              else if all isString values then
+                "directory"
+              else
+                sparseSubtrees
+            else
+              tree;
+          resultingTree = recurse actualFileset._base actualFileset._tree;
+          # The fileset's _base might be below the base of the `importToStore`, so we need to lift the tree up to `base`
+          extraBaseNesting = removePrefix base actualFileset._base;
+        in _nestTree base extraBaseNesting resultingTree;
+
+      baseComponentsLength = length (deconstruct base).components;
+
+      # This function is called often for the filter, so it should be fast
+      inSet = components:
+        let
+          recurse = index: localTree:
+            if index == length components then
+              localTree != null
+            else if localTree ? ${elemAt components index} then
+              recurse (index + 1) localTree.${elemAt components index}
+            else
+              localTree == "directory";
+        in recurse baseComponentsLength sparseTree;
+    in
+    if ! hasPrefix base entryPoint then
+      throw "lib.fileset.importToStore: The entryPoint \"${toString entryPoint}\" is not under the base \"${toString base}\"."
+    # Ensure that the entryPoint exists in the result
+    else if ! inSet (deconstruct entryPoint).components then
+      throw "lib.fileset.importToStore: The fileset contains no files under the entryPoint \"${toString entryPoint}\"."
+    else
+    let
+      root = builtins.path {
+        inherit name;
+        path = base;
+        filter = pathString: _: inSet (fromSubpath "./${pathString}");
+      };
+      components = removePrefix base entryPoint;
+    in {
+      inherit root;
+      subpath = toSubpath components;
+      outPath =
+        if components == [] then
+          root
+        else
+          "${root}/${concatStringsSep "/" components}";
+    };
+
+  /*
+  Coerce a value to a fileset:
+
+  - If the value is a fileset already, return it directly
+
+  - If the value is a path pointing to a file, return a file set with that single file
+
+  - If the value is a path pointing to a directory, return a file set with all files contained in that directory
+
+  This function is mostly not needed because all functions in `lib.fileset` will implicitly apply it for arguments that are expected to be a file set.
+
+  Type:
+    coerce :: Any -> FileSet
+  */
+  coerce = value: _coerce "coerce" "argument" value;
+
+  /*
+  Incrementally evaluate and trace a file set in a pretty way.
+  Functionally this is the same as splitting the result from `lib.fileset.pretty` into lines and tracing those.
+  However this function can do the same thing incrementally, so it can already start printing the result as the first lines are known.
+
+  The `expand` argument (false by default) controls whether all files should be printed individually.
+
+  Type:
+    trace :: { expand :: Bool ? false } -> FileSet -> Any -> Any
+
+  Example:
+    trace {} (unions [ ./foo.nix ./bar/baz.c ./qux ])
+    =>
+    trace: /home/user/src/myProject
+    trace: - bar
+    trace:   - baz.c (regular)
+    trace: - foo.nix (regular)
+    trace: - qux (recursive directory)
+    null
+
+    trace { expand = true; } (unions [ ./foo.nix ./bar/baz.c ./qux ])
+    =>
+    trace: /home/user/src/myProject
+    trace: - bar
+    trace:   - baz.c (regular)
+    trace: - foo.nix (regular)
+    trace: - qux
+    trace:   - florp.c (regular)
+    trace:   - florp.h (regular)
+    null
+  */
+  trace = { expand ? false }: maybeFileset:
+    let
+      fileset = _coerce "trace" "second argument" maybeFileset;
+      simpleTree = _simplifyTree expand fileset._base fileset._tree;
+    in
+    _prettyFoldl' (acc: el: builtins.trace el acc) (x: x)
+      fileset._base
+      simpleTree;
+
+  /*
+  The same as `lib.fileset.trace`, but instead of tracing each line, the result is returned as a string.
+
+  Type:
+    pretty :: { expand :: Bool ? false } -> FileSet -> String
+  */
+  pretty = { expand ? false }: maybeFileset:
+    let
+      fileset = _coerce "pretty" "second argument" maybeFileset;
+      simpleTree = _simplifyTree expand fileset._base fileset._tree;
+    in
+    _prettyFoldl' (acc: el: "${acc}\n${el}") ""
+      fileset._base
+      simpleTree;
+
+  /*
+  The file set containing all files that are in either of two given file sets.
+  Recursively, the first argument is evaluated first, only evaluating the second argument if necessary.
+
+      union a b = a ⋃ b
+
+  Type:
+    union :: FileSet -> FileSet -> FileSet
+  */
+  union = lhs: rhs:
+    let
+      normalised = _normaliseBase "intersect" [
+        {
+          context = "first argument";
+          value = lhs;
+        }
+        {
+          context = "second argument";
+          value = rhs;
+        }
+      ];
+    in
+    _create normalised.commonBase
+      (_unionTree
+        (elemAt normalised.trees 0)
+        (elemAt normalised.trees 1)
+      );
+
+  /*
+  The file containing all files from that are in any of the given file sets.
+  Recursively, the elements are evaluated from left to right, only evaluating arguments on the right if necessary.
+
+  Type:
+    unions :: [FileSet] -> FileSet
+  */
+  unions = list:
+    let
+      annotated = imap0 (i: el: {
+        context = "element ${toString i} of the argument";
+        value = el;
+      }) list;
+
+      normalised = _normaliseBase "unions" annotated;
+
+      tree = foldl' _unionTree (head normalised.trees) (tail normalised.trees);
+    in
+    if ! isList list then
+      throw "lib.fileset.unions: Expected argument to be a list, but got a ${typeOf list}."
+    else if length list == 0 then
+      throw "lib.fileset.unions: Expected argument to be a list with at least one element, but it contains no elements."
+    else
+      _create normalised.commonBase tree;
+
+  /*
+  The file set containing all files that are in both given sets.
+  Recursively, the first argument is evaluated first, only evaluating the second argument if necessary.
+
+      intersect a b == a ⋂ b
+
+  Type:
+    intersect :: FileSet -> FileSet -> FileSet
+  */
+  intersect = lhs: rhs:
+    let
+      normalised = _normaliseBase "intersect" [
+        {
+          context = "first argument";
+          value = lhs;
+        }
+        {
+          context = "second argument";
+          value = rhs;
+        }
+      ];
+    in
+    _create normalised.commonBase
+      (_intersectTree
+        (elemAt normalised.trees 0)
+        (elemAt normalised.trees 1)
+      );
+
+  /*
+  The file set containing all files that are in all the given sets.
+  Recursively, the elements are evaluated from left to right, only evaluating arguments on the right if necessary.
+
+  Type:
+    intersects :: [FileSet] -> FileSet
+  */
+  intersects = list:
+    let
+      annotated = imap0 (i: el: {
+        context = "element ${toString i} of the argument";
+        value = el;
+      }) list;
+
+      normalised = _normaliseBase "intersects" annotated;
+
+      tree = foldl' _intersectTree (head normalised.trees) (tail normalised.trees);
+    in
+    if ! isList list then
+      throw "lib.fileset.intersects: Expected argument to be a list, but got a ${typeOf list}."
+    else if length list == 0 then
+      throw "lib.fileset.intersects: Expected argument to be a list with at least one element, but it contains no elements."
+    else
+      _create normalised.commonBase tree;
+
+  /*
+  The file set containing all files that are in the first file set but not in the second.
+  Recursively, the second argument is evaluated first, only evaluating the first argument if necessary.
+
+      difference a b == a ∖ b
+
+  Type:
+    difference :: FileSet -> FileSet -> FileSet
+  */
+  difference = lhs: rhs:
+    let
+      normalised = _normaliseBase "difference" [
+        {
+          context = "first argument";
+          value = lhs;
+        }
+        {
+          context = "second argument";
+          value = rhs;
+        }
+      ];
+    in
+    _create normalised.commonBase
+      (_differenceTree normalised.commonBase
+        (elemAt normalised.trees 0)
+        (elemAt normalised.trees 1)
+      );
+
+  /*
+  Filter a file set to only contain files matching some predicate.
+
+  The predicate is called with an attribute set containing these attributes:
+
+  - `name`: The filename
+
+  - `type`: The type of the file, either "regular", "symlink" or "unknown"
+
+  - `ext`: The file extension or `null` if the file has none.
+
+    More formally:
+    - `ext` contains no `.`
+    - `.${ext}` is a suffix of the `name`
+
+  - Potentially other attributes in the future
+
+  Type:
+    filter ::
+      ({
+        name :: String,
+        type :: String,
+        ext :: String | Null,
+        ...
+      } -> Bool)
+      -> FileSet
+      -> FileSet
+  */
+  filter = predicate: maybeFileset:
+    let
+      fileset = _coerce "filter" "second argument" maybeFileset;
+      recurse = focusPath: tree:
+        mapAttrs (name: subtree:
+          if isAttrs subtree || subtree == "directory" then
+            recurse (append focusPath name) subtree
+          else if
+            predicate {
+              inherit name;
+              type = subtree;
+              ext = mapNullable head (match ".*\\.(.*)" name);
+              # To ensure forwards compatibility with more arguments being added in the future,
+              # adding an attribute which can't be deconstructed :)
+              "This attribute is passed to prevent fileFilter predicate functions from breaking when more attributes are added in the future. Please add `...` to the function to handle this and further arguments." = null;
+            }
+          then
+            subtree
+          else
+            null
+        ) (_directoryEntries focusPath tree);
+    in
+    _create fileset._base (recurse fileset._base fileset._tree);
+
+  /*
+  A file set containing all files that are contained in a directory whose name satisfies the given predicate.
+  Only directories under the given path are checked, this is to ensure that components outside of the given path cannot influence the result.
+  Consequently this function does not accept a file set as an argument.
+  If you need to filter files in a file set based on components, use `intersect myFileSet (directoryMatches myPredicate myPath)` instead.
+
+  Type:
+    directoryMatches :: (String -> Bool) -> Path -> FileSet
+
+  Example:
+    # Select all files in hidden directories within ./.
+    directoryMatches (hasPrefix ".") ./.
+
+    # Select all files in directories named `build` within ./src
+    directoryMatches (name: name == "build") ./src
+  */
+  directoryMatches = predicate: path:
+    let
+      recurse = focusPath:
+        mapAttrs (name: type:
+          if type == "directory" then
+            if predicate name then
+              type
+            else
+              recurse (append focusPath name)
+          else
+            null
+        ) (readDir focusPath);
+    in
+    if path._type or null == "fileset" then
+      throw ''
+        lib.fileset.directoryMatches: Expected second argument to be a path, but it's a file set.
+            If you need to filter files in a file set, use `intersect myFileSet (directoryMatches myPredicate myPath)` instead.''
+    else if ! isPath path then
+      throw "lib.fileset.directoryMatches: Expected second argument to be a path, but got a ${typeOf path}."
+    else if pathType path != "directory" then
+      throw "lib.fileset.directoryMatches: Expected second argument \"${toString path}\" to be a directory, but it's not."
+    else
+      _create path (recurse path);
+
+  /*
+  Check whether two file sets contain the same files.
+
+  Type:
+    equals :: FileSet -> FileSet -> Bool
+  */
+  equals = lhs: rhs:
+    let
+      normalised = _normaliseBase "equals" [
+        {
+          context = "first argument";
+          value = lhs;
+        }
+        {
+          context = "second argument";
+          value = rhs;
+        }
+      ];
+    in
+    _equalsTree normalised.commonBase
+      (elemAt normalised.trees 0)
+      (elemAt normalised.trees 1);
+
+  /*
+  Check whether a file set contains no files.
+
+  Type:
+    isEmpty :: FileSet -> Bool
+  */
+  isEmpty = maybeFileset:
+    let
+      fileset = _coerce "isEmpty" "argument" maybeFileset;
+    in
+    _isEmptyTree fileset._base fileset._tree;
+}

--- a/lib/fileset.nix
+++ b/lib/fileset.nix
@@ -572,6 +572,7 @@ in {
       };
       components = removePrefix base entryPoint;
     in {
+      # TODO: Consider not exposing these properties and instead letting `mkDerivation` parse `src`, splitting the `outPath` itself. This would make this functionality more general.
       _root = root;
       _subpath = toSubpath components;
       outPath =

--- a/lib/fileset.nix
+++ b/lib/fileset.nix
@@ -115,7 +115,7 @@ let
   # Type: Path -> <tree> -> <fileset>
   _create = base: tree: {
     _type = "fileset";
-    # All properties are internal
+    # All attributes are internal
     _base = base;
     _tree = tree;
     # Double __ to make it be evaluated and ordered first
@@ -634,6 +634,31 @@ in {
       _singleton path
     else
       _create path null;
+
+  /*
+  Return the common ancestor directory of all file set operations used to construct this file set, meaning that nothing outside the this directory can influence the set of files included.
+
+  Type:
+    getInfluenceBase :: FileSet -> Path
+
+  Example:
+    getInfluenceBase ./Makefile
+    => ./.
+
+    getInfluenceBase ./src
+    => ./src
+
+    getInfluenceBase (fileFilter (file: false) ./.)
+    => ./.
+
+    getInfluenceBase (union ./Makefile ../default.nix)
+    => ../.
+  */
+  getInfluenceBase = maybeFileset:
+    let
+      fileset = _coerce "getInfluenceBase" "argument" maybeFileset;
+    in
+    fileset._base;
 
   /*
   Incrementally evaluate and trace a file set in a pretty way.

--- a/lib/fileset.nix
+++ b/lib/fileset.nix
@@ -47,7 +47,7 @@ let
     attrValues
     ;
 
-  inherit (lib.sources)
+  inherit (lib.filesystem)
     pathType
     ;
 

--- a/lib/fileset.nix
+++ b/lib/fileset.nix
@@ -701,6 +701,21 @@ in {
       simpleTree;
 
   /*
+  The same as `lib.fileset.trace`, but instead of taking an argument for the value to return, the given file set is returned instead.
+
+  Type:
+    traceVal :: { expand :: Bool ? false } -> FileSet -> FileSet
+  */
+  traceVal = { expand ? false }: maybeFileset:
+    let
+      fileset = _coerce "traceVal" "second argument" maybeFileset;
+      simpleTree = _simplifyTree expand fileset._base fileset._tree;
+    in
+    _prettyFoldl' (acc: el: builtins.trace el acc) fileset
+      fileset._base
+      simpleTree;
+
+  /*
   The same as `lib.fileset.trace`, but instead of tracing each line, the result is returned as a string.
 
   Type:

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -612,6 +612,19 @@ rec {
     # Input list
     list: sublist count (length list) list;
 
+  commonPrefixLength = lhs: rhs:
+    let
+      minLength = min (length lhs) (length rhs);
+      recurse = index:
+        if index >= minLength || elemAt lhs index != elemAt rhs index then
+          index
+        else
+          recurse (index + 1);
+    in recurse 0;
+
+  commonPrefix = lhs: rhs:
+    take (commonPrefixLength lhs rhs) lhs;
+
   /* Return a list consisting of at most `count` elements of `list`,
      starting at index `start`.
 

--- a/lib/path/default.nix
+++ b/lib/path/default.nix
@@ -413,6 +413,16 @@ in /* No rec! Add dependencies on this file at the top. */ {
           ${subpathInvalidReason subpath}'';
     joinRelPath (splitRelPath subpath);
 
+  commonAncestor = a: b:
+    let
+      a' = deconstructPath a;
+      b' = deconstructPath b;
+    in
+    if a'.root != b'.root then
+      throw "lib.path.commonAncestor: Given paths don't have the same filesystem root"
+    else
+      a'.root + ("/" + concatStringsSep "/" (lib.lists.commonPrefix a'.components b'.components));
+
   deconstruct = path: deconstructPath path;
   construct = { root, components }: root + ("/" + concatStringsSep "/" components);
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -437,6 +437,20 @@ else let
       inherit doCheck doInstallCheck;
 
       inherit outputs;
+
+      ${if attrs ? src then "src" else null} =
+        if attrs.src ? _root && attrs.src ? _subpath then
+          attrs.src.root
+        else
+          attrs.src;
+
+      # TODO simplify by adding to unpackPhase instead.
+      #      This wasn't done yet to avoid a mass rebuild while working on this.
+      postUnpack = if attrs.src ? _root && attrs.src ? _subpath && attrs.src._subpath != "./." then ''
+        sourceRoot="$sourceRoot"/${lib.escapeShellArg attrs.src._subpath}
+        ${attrs.postUnpack or ""}
+      '' else attrs.postUnpack or null;
+
     } // lib.optionalAttrs (__contentAddressed) {
       inherit __contentAddressed;
       # Provide default values for outputHashMode and outputHashAlgo because

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -438,18 +438,15 @@ else let
 
       inherit outputs;
 
-      ${if attrs ? src then "src" else null} =
-        if attrs.src ? _root && attrs.src ? _subpath then
-          attrs.src.root
-        else
-          attrs.src;
+      ${if attrs ? src._root && attrs.src ? _subpath then "src" else null} =
+        attrs.src._root;
 
       # TODO simplify by adding to unpackPhase instead.
       #      This wasn't done yet to avoid a mass rebuild while working on this.
-      postUnpack = if attrs.src ? _root && attrs.src ? _subpath && attrs.src._subpath != "./." then ''
+      ${if attrs ? src._root && attrs.src ? _subpath then "postUnpack" else null} = ''
         sourceRoot="$sourceRoot"/${lib.escapeShellArg attrs.src._subpath}
         ${attrs.postUnpack or ""}
-      '' else attrs.postUnpack or null;
+      '';
 
     } // lib.optionalAttrs (__contentAddressed) {
       inherit __contentAddressed;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -163,22 +163,7 @@ let
 
 , env ? { }
 
-# Only applies if `src` is unset
-# If set, requires srcWorkDir to be set too
-# Includes all files from the file set
-, srcFileset ? null
-
-, src ?
-    if srcFileset == null then
-      null
-    else if srcWorkDir == null then
-      throw "stdenv.mkDerivation: Setting the `srcFileset` attribute requires also setting the `srcWorkDir` attribute."
-    else
-      lib.fileset.toSource {
-        root = lib.path.commonAncestor (lib.fileset.getInfluenceBase srcFileset) srcWorkDir;
-        fileset = srcFileset;
-        extraExistingDirs = [ srcWorkDir ];
-      }
+, src ? null
 
 , srcWorkDir ? null
 
@@ -191,7 +176,7 @@ let
       throw "stdenv.mkDerivation: The `srcWorkDir` attribute \"${toString srcWorkDir}\" does not exist."
     else if lib.filesystem.pathType srcWorkDir != "directory" then
       throw "stdenv.mkDerivation: The `srcWorkDir` attribute \"${toString srcWorkDir}\" is not a directory"
-    # All of the following conditions for `src` are always fulfilled if `src` is set via `srcFileset`
+    # All of the following conditions are always fulfilled if `src = lib.fileset.toSource { ... }`
     else if ! src._isLibCleanSourceWith or false then
       throw "stdenv.mkDerivation: If the `srcWorkDir` attribute is set, `src` must be a source-like value produced by the functions in `lib.sources`."
     else if ! builtins.isPath src.origSrc then
@@ -332,7 +317,7 @@ else let
   derivationArg =
     (removeAttrs attrs
       (["meta" "passthru" "pos"
-       "srcFileset" "srcWorkDir"
+       "srcWorkDir"
        "checkInputs" "installCheckInputs"
        "nativeCheckInputs" "nativeInstallCheckInputs"
        "__contentAddressed"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -438,15 +438,22 @@ else let
 
       inherit outputs;
 
-      ${if attrs ? src._root && attrs.src ? _subpath then "src" else null} =
-        attrs.src._root;
+      ${if attrs ? src then "src" else null} =
+        if attrs ? src._root && attrs.src ? _subpath then
+          attrs.src._root
+        else
+          attrs.src;
 
       # TODO simplify by adding to unpackPhase instead.
       #      This wasn't done yet to avoid a mass rebuild while working on this.
-      ${if attrs ? src._root && attrs.src ? _subpath then "postUnpack" else null} = ''
-        sourceRoot="$sourceRoot"/${lib.escapeShellArg attrs.src._subpath}
-        ${attrs.postUnpack or ""}
-      '';
+      ${if attrs ? src then "postUnpack" else null} =
+        if attrs ? src._root && attrs.src ? _subpath then
+          ''
+            sourceRoot="$sourceRoot"/${lib.escapeShellArg attrs.src._subpath}
+            ${attrs.postUnpack or ""}
+          ''
+        else
+          attrs.postUnpack or null;
 
     } // lib.optionalAttrs (__contentAddressed) {
       inherit __contentAddressed;


### PR DESCRIPTION
This PR rethinks @roberth's original [source combinators](https://github.com/NixOS/nixpkgs/pull/112083) into a more composable datatype: Sets of files. Nothing is decided yet, but I'm really amazed by how well this is working.

The abstraction here allows efficient and lazy operations on a set of files. Typical set operations are supported, including union, intersection, difference and filtering.

This work is sponsored by [Antithesis](https://antithesis.com/) :sparkles: 

Update: This has now been mostly incrementally merged! See https://github.com/NixOS/nixpkgs/issues/266356 for more info.

### Plan
1. [x] Get the code fully working, but without fully commented code
2. [x] Write clean introduction and reference documentation
   1. [x] Reference
   2. [x] Introduction
4. [x] Make a Discourse post, showing off the concept and how people can try it out, to get wider feedback: https://discourse.nixos.org/t/easy-source-filtering-with-file-sets/29117
6. [ ] ~~Iterate the above until everybody is happy with the design~~
    Despite reaching out to the community, not much feedback was given. This does mean that there's no complaints about it either though. Because of this, I'll move towards implementing it, see https://github.com/NixOS/nixpkgs/pull/222981#issuecomment-1641110172
8. [x] Split up this PR into smaller more incremental PR's, see https://github.com/NixOS/nixpkgs/issues/266356