### PR TITLE
mount-zip: init at 1.0.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1361,6 +1361,12 @@
     githubId = 37193992;
     name = "Arthur Teisseire";
   };
+  arti5an = {
+    email = "artis4n@outlook.com";
+    github = "arti5an";
+    githubId = 14922630;
+    name = "Richard Smith";
+  };
   artturin = {
     email = "artturin@artturin.com";
     matrix = "@artturin:matrix.org";

--- a/pkgs/tools/filesystems/mount-zip/default.nix
+++ b/pkgs/tools/filesystems/mount-zip/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, fuse, boost, gcc, icu, libzip, pandoc
+, pkg-config }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mount-zip";
+  version = "1.0.8";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "mount-zip";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-+slN5eedSddYKgiNLq4KZ5BXwvGQw9859sVfkcIBYeo=";
+  };
+
+  nativeBuildInputs = [ boost gcc icu pandoc pkg-config ];
+  buildInputs = [ fuse libzip ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with lib; {
+    description = "FUSE file system for ZIP archives";
+    homepage = "https://github.com/google/mount-zip";
+    longDescription = ''
+      mount-zip is a tool allowing to open, explore and extract ZIP archives.
+
+      This project is a fork of fuse-zip.
+    '';
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ arti5an ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10329,6 +10329,8 @@ with pkgs;
 
   motrix = callPackage ../tools/networking/motrix { };
 
+  mount-zip = callPackage ../tools/filesystems/mount-zip { };
+
   mpage = callPackage ../tools/text/mpage { };
 
   mprime = callPackage ../tools/misc/mprime { };


### PR DESCRIPTION
###### Description of changes

New package mount-zip, built from https://github.com/google/mount-zip.
A read-only fuse filesystem for opening and working with zip files. Especially useful in TUI file managers such as vifm.

It's basically a modernised, read-only alternative to the now unmaintained fuse-zip. I've been using this version locally for a month or two without issue, so figured I'd contribute to this amazing project and community.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).