### PR TITLE
libxcrypt: add -legacy variant

### DIFF
--- a/pkgs/development/compilers/graalvm/community-edition/buildGraalvmProduct.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/buildGraalvmProduct.nix
@@ -6,6 +6,7 @@
 , perl
 , unzip
 , zlib
+, libxcrypt-legacy
   # extra params
 , product
 , javaVersion
@@ -46,6 +47,7 @@ stdenv.mkDerivation ({
   buildInputs = [
     stdenv.cc.cc.lib # libstdc++.so.6
     zlib
+    libxcrypt-legacy # libcrypt.so.1 (default is .2 now)
   ] ++ extraBuildInputs;
 
   unpackPhase = ''

--- a/pkgs/development/libraries/libxcrypt/default.nix
+++ b/pkgs/development/libraries/libxcrypt/default.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv, fetchurl, perl, nixosTests }:
+{ lib, stdenv, fetchurl, perl
+# Update the enabled crypt scheme ids in passthru when the enabled hashes change
+, enableHashes ? "strong"
+, nixosTests
+}:
 
 stdenv.mkDerivation rec {
   pname = "libxcrypt";
@@ -15,8 +19,7 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    # Update the enabled crypt scheme ids in passthru when the enabled hashes change
-    "--enable-hashes=strong"
+    "--enable-hashes=${enableHashes}"
     "--enable-obsolete-api=glibc"
     "--disable-failure-tokens"
   ] ++ lib.optionals (stdenv.hostPlatform.isMusl || stdenv.hostPlatform.libc == "bionic") [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22242,6 +22242,7 @@ with pkgs;
       fetchurl = stdenv.fetchurlBoot;
     };
   };
+  libxcrypt-legacy = libxcrypt.override { enableHashes = "all"; };
 
   libxdg_basedir = callPackage ../development/libraries/libxdg-basedir { };
 


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
