### PR TITLE
ocamlPackages.mirage-block: 3.0.0 → 3.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/mirage-block-ramdisk/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-block-ramdisk/default.nix
@@ -16,6 +16,7 @@ buildDunePackage rec {
   '';
 
   minimalOCamlVersion = "4.06";
+  duneVersion = "3";
 
   propagatedBuildInputs = [ io-page mirage-block ];
 

--- a/pkgs/development/ocaml-modules/mirage-block-unix/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-block-unix/default.nix
@@ -13,6 +13,7 @@ buildDunePackage rec {
   };
 
   minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   propagatedBuildInputs = [ cstruct-lwt logs mirage-block rresult uri ];
 

--- a/pkgs/development/ocaml-modules/mirage-block/combinators.nix
+++ b/pkgs/development/ocaml-modules/mirage-block/combinators.nix
@@ -1,10 +1,12 @@
-{ buildDunePackage, mirage-block, io-page, logs }:
+{ buildDunePackage, mirage-block, logs }:
 
 buildDunePackage rec {
   pname = "mirage-block-combinators";
   inherit (mirage-block) version src;
 
-  propagatedBuildInputs = [ mirage-block io-page logs ];
+  duneVersion = "3";
+
+  propagatedBuildInputs = [ mirage-block logs ];
 
   meta = mirage-block.meta // {
     description = "Block signatures and implementations for MirageOS using Lwt";

--- a/pkgs/development/ocaml-modules/mirage-block/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-block/default.nix
@@ -4,11 +4,13 @@
 
 buildDunePackage rec {
   pname = "mirage-block";
-  version = "3.0.0";
+  version = "3.0.2";
+
+  duneVersion = "3";
 
   src = fetchurl {
-    url = "https://github.com/mirage/mirage-block/releases/download/v${version}/mirage-block-v${version}.tbz";
-    sha256 = "sha256-NB5nJpppMtdi0HDjKcCAqRjO4vIbAMfnP934P+SnzmU=";
+    url = "https://github.com/mirage/mirage-block/releases/download/v${version}/mirage-block-${version}.tbz";
+    hash = "sha256-UALUfeL0G1mfSsLgAb/HpQ6OV12YtY+GUOYG6yhUwAI=";
   };
 
   propagatedBuildInputs = [ cstruct lwt fmt ];


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/mirage-block/blob/v3.0.2/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
