### PR TITLE
[22.11] tsm-client: 8.1.15.1 -> 8.1.17.2 (security update, backport)

### DIFF
--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -53,17 +53,14 @@
 # going to the `downloadPage` (see `meta` below).
 # Find the "Backup-archive client" table on that page.
 # Look for "Download Documents" of the latest release.
-# Here, two links must be checked if existing:
-# * "IBM Spectrum Protect Client ... Downloads and READMEs":
-#   In the table at the page's bottom,
-#   check the date of the "Linux x86_64 client"
-# * "IBM Spectrum Protect BA client ... interim fix downloads"
-# Look for the "Linux x86_64 client ..." rows
-# in the table at the bottom of each page.
-# Follow the "HTTPS" link of the row with the latest date stamp.
-# In the directory listing to show up, pick the big `.tar` file.
+# Follow the "Download Information" link.
+# Look for the "Linux x86_64 client ..." rows in the table at
+# the bottom of the page and follow their "HTTPS" links (one
+# link per row -- each link might point to the latest release).
+# In the directory listings to show up,
+# check the big `.tar` file.
 #
-# (as of 2022-09-29)
+# (as of 2022-12-10)
 
 
 let
@@ -108,10 +105,10 @@ let
 
   unwrapped = stdenv.mkDerivation rec {
     name = "tsm-client-${version}-unwrapped";
-    version = "8.1.15.2";
+    version = "8.1.17.0";
     src = fetchurl {
       url = mkSrcUrl version;
-      hash = "sha512-ljygVoW7zR+LVHf4LSoBn3qEHISobsxheLxs9NyKWQiwPWpfhSgJO+bX4QRzAmrpSTNrETxHkuXqzGSHaaBlzg==";
+      hash = "sha512-MP8BjnESFoEzl6jdhtuwX9PolDF7o4QL7i1NeDV0ltIJMUOqSeAULpTJ1bbErJokJSbrj41kDwMVI+ZuAUb1eA==";
     };
     inherit meta passthru;
 

--- a/pkgs/tools/backup/tsm-client/default.nix
+++ b/pkgs/tools/backup/tsm-client/default.nix
@@ -105,10 +105,10 @@ let
 
   unwrapped = stdenv.mkDerivation rec {
     name = "tsm-client-${version}-unwrapped";
-    version = "8.1.17.0";
+    version = "8.1.17.2";
     src = fetchurl {
       url = mkSrcUrl version;
-      hash = "sha512-MP8BjnESFoEzl6jdhtuwX9PolDF7o4QL7i1NeDV0ltIJMUOqSeAULpTJ1bbErJokJSbrj41kDwMVI+ZuAUb1eA==";
+      hash = "sha512-DZCXb3fZO2VYJJJUdjGt9TSdrYNhf8w7QMgEERzX8xb74jjA+UPNI2dbNCeja/vrgRYLYipWZPyjTQJmkxlM/g==";
     };
     inherit meta passthru;
 


### PR DESCRIPTION
###### Description of changes

Backport #205374 and #222073 to NixOS 22.11, as they contain security updates.

IBM's "Authorized Program Analysis Report"s (something like release notes, for both updates): https://www.ibm.com/support/pages/node/6845804


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
