### PR TITLE
apacheHttpd: 2.4.55 -> 2.4.56

### DIFF
--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "apache-httpd";
-  version = "2.4.55";
+  version = "2.4.56";
 
   src = fetchurl {
     url = "mirror://apache/httpd/httpd-${version}.tar.bz2";
-    sha256 = "sha256-Eda6GeNsC5PKYuR+b/wtLyiElCaUvODyPznHG9xfaaw=";
+    sha256 = "sha256-2NRfE5i6hO3QW7M8p1k6wpibF8ucegyv5UQtQa/bLXw=";
   };
 
   # FIXME: -dev depends on -doc


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2023-27522 and CVE-2023-25690.

https://downloads.apache.org/httpd/CHANGES_2.4.56
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages failed to build:</summary>
  <ul>
    <li>dropbox-cli</li>
    <li>dropbox-cli.nautilusExtension</li>
    <li>mapcache</li>
  </ul>
</details>
<details>
  <summary>74 packages built:</summary>
  <ul>
    <li>apacheHttpd</li>
    <li>apacheHttpd.dev</li>
    <li>apacheHttpd.doc</li>
    <li>apacheHttpd.man</li>
    <li>apacheHttpdPackages.mod_auth_mellon</li>
    <li>apacheHttpdPackages.mod_ca</li>
    <li>apacheHttpdPackages.mod_crl</li>
    <li>apacheHttpdPackages.mod_cspnonce</li>
    <li>apacheHttpdPackages.mod_csr</li>
    <li>apacheHttpdPackages.mod_dnssd</li>
    <li>apacheHttpdPackages.mod_fastcgi</li>
    <li>apacheHttpdPackages.mod_itk</li>
    <li>apacheHttpdPackages.mod_mbtiles</li>
    <li>apacheHttpdPackages.mod_ocsp</li>
    <li>apacheHttpdPackages.mod_perl</li>
    <li>apacheHttpdPackages.mod_pkcs12</li>
    <li>apacheHttpdPackages.mod_python</li>
    <li>apacheHttpdPackages.mod_scep</li>
    <li>apacheHttpdPackages.mod_spkac</li>
    <li>apacheHttpdPackages.mod_tile</li>
    <li>apacheHttpdPackages.mod_timestamp</li>
    <li>apacheHttpdPackages.mod_wsgi3</li>
    <li>apacheHttpdPackages.subversion</li>
    <li>apacheHttpdPackages.subversion.dev</li>
    <li>apacheHttpdPackages.subversion.man</li>
    <li>cinnamon.cinnamon-gsettings-overrides</li>
    <li>cinnamon.nemo-fileroller</li>
    <li>cinnamon.nemo-with-extensions</li>
    <li>eiciel</li>
    <li>eiciel.nautilusExtension</li>
    <li>gnome.file-roller</li>
    <li>gnome.gnome-control-center</li>
    <li>gnome.gnome-control-center.debug</li>
    <li>gnome.gnome-terminal</li>
    <li>gnome.gnome-user-share</li>
    <li>gnome.nautilus</li>
    <li>gnome.nautilus-python</li>
    <li>gnome.nautilus-python.dev</li>
    <li>gnome.nautilus-python.devdoc</li>
    <li>gnome.nautilus-python.doc</li>
    <li>gnome.nautilus.dev</li>
    <li>gnome.nautilus.devdoc</li>
    <li>haxe</li>
    <li>haxePackages.format</li>
    <li>haxePackages.heaps</li>
    <li>haxePackages.hlopenal</li>
    <li>haxePackages.hlsdl</li>
    <li>haxePackages.hxcpp</li>
    <li>haxePackages.hxcs</li>
    <li>haxePackages.hxjava</li>
    <li>haxePackages.hxnodejs_4</li>
    <li>haxe_4_0</li>
    <li>haxe_4_1</li>
    <li>mate.mate-user-share</li>
    <li>modsecurity_standalone</li>
    <li>modsecurity_standalone.nginx</li>
    <li>nautilus-open-any-terminal</li>
    <li>nautilus-open-any-terminal.dist</li>
    <li>neko</li>
    <li>pantheon.file-roller-contract</li>
    <li>perl534Packages.GoferTransporthttp</li>
    <li>perl534Packages.GoferTransporthttp.devdoc</li>
    <li>perl534Packages.libapreq2</li>
    <li>perl534Packages.mod_perl2</li>
    <li>perl534Packages.mod_perl2.devdoc</li>
    <li>perl536Packages.GoferTransporthttp</li>
    <li>perl536Packages.GoferTransporthttp.devdoc</li>
    <li>perl536Packages.libapreq2</li>
    <li>perl536Packages.mod_perl2</li>
    <li>perl536Packages.mod_perl2.devdoc</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>tomcat_connectors</li>
    <li>xsecurelock</li>
  </ul>
</details>