### PR TITLE
rss-bridge: 2022-06-14 -> 2023-03-22

### DIFF
--- a/pkgs/servers/web-apps/rss-bridge/default.nix
+++ b/pkgs/servers/web-apps/rss-bridge/default.nix
@@ -2,21 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "rss-bridge";
-  version = "2022-06-14";
+  version = "2023-03-22";
 
   src = fetchFromGitHub {
     owner = "RSS-Bridge";
     repo = "rss-bridge";
     rev = version;
-    sha256 = "sha256-yH+m65CIZokZSbnv1zfpKC/Qr/mPPC6dG49Zn62X0l4=";
+    sha256 = "sha256-76XmPFb9w//GK9T4H41FxLBpWdTvJA28E0kWCCV/AFM=";
   };
 
-  postPatch = ''
-    substituteInPlace lib/rssbridge.php \
-      --replace "define('PATH_CACHE', PATH_ROOT . 'cache/');" "define('PATH_CACHE', getenv('RSSBRIDGE_DATA') . '/cache/');" \
-      --replace "define('FILE_CONFIG', PATH_ROOT . 'config.ini.php');" "define('FILE_CONFIG', getenv('RSSBRIDGE_DATA') . '/config.ini.php');" \
-      --replace "define('WHITELIST', PATH_ROOT . 'whitelist.txt');" "define('WHITELIST', getenv('RSSBRIDGE_DATA') . '/whitelist.txt');"
-  '';
+  patches = [
+    ./paths.patch
+  ];
 
   installPhase = ''
     mkdir $out/

--- a/pkgs/servers/web-apps/rss-bridge/paths.patch
+++ b/pkgs/servers/web-apps/rss-bridge/paths.patch
@@ -1,0 +1,32 @@
+diff --git a/lib/RssBridge.php b/lib/RssBridge.php
+index 62e8acc5..00eca8be 100644
+--- a/lib/RssBridge.php
++++ b/lib/RssBridge.php
+@@ -25,8 +25,8 @@ final class RssBridge
+         Configuration::verifyInstallation();
+ 
+         $customConfig = [];
+-        if (file_exists(__DIR__ . '/../config.ini.php')) {
+-            $customConfig = parse_ini_file(__DIR__ . '/../config.ini.php', true, INI_SCANNER_TYPED);
++        if (file_exists(getenv('RSSBRIDGE_DATA') . '/config.ini.php')) {
++            $customConfig = parse_ini_file(getenv('RSSBRIDGE_DATA') . '/config.ini.php', true, INI_SCANNER_TYPED);
+         }
+         Configuration::loadConfiguration($customConfig, getenv());
+ 
+diff --git a/lib/bootstrap.php b/lib/bootstrap.php
+index 8e5cf69c..7fece356 100644
+--- a/lib/bootstrap.php
++++ b/lib/bootstrap.php
+@@ -28,10 +28,10 @@ const PATH_LIB_CACHES = __DIR__ . '/../caches/';
+ const PATH_LIB_ACTIONS = __DIR__ . '/../actions/';
+ 
+ /** Path to the cache folder */
+-const PATH_CACHE = __DIR__ . '/../cache/';
++define('PATH_CACHE', getenv('RSSBRIDGE_DATA') . '/cache/');
+ 
+ /** Path to the whitelist file */
+-const WHITELIST = __DIR__ . '/../whitelist.txt';
++define('WHITELIST', getenv('RSSBRIDGE_DATA') . '/whitelist.txt');
+ 
+ /** Path to the default whitelist file */
+ const WHITELIST_DEFAULT = __DIR__ . '/../whitelist.default.txt';


### PR DESCRIPTION
###### Description of changes

https://github.com/RSS-Bridge/rss-bridge/releases/tag/2023-03-22

The new config options don't require any action on the module side, since the config (currently) needs to be [placed manually in the data dir](https://github.com/NixOS/nixpkgs/blob/a64e169e396460d6b5763a1de1dd197df8421688/nixos/modules/services/web-apps/rss-bridge.nix#L45-L48).

###### Things done

[<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->](https://github.com/RSS-Bridge/rss-bridge/releases/tag/2023-03-22)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
