### PR TITLE
nanovna-saver: 0.5.4 -> 0.6.0

### DIFF
--- a/pkgs/applications/science/electronics/nanovna-saver/default.nix
+++ b/pkgs/applications/science/electronics/nanovna-saver/default.nix
@@ -3,38 +3,35 @@
   python3,
   fetchFromGitHub,
   fetchpatch,
-  wrapQtAppsHook,
+  qt6,
 }:
 python3.pkgs.buildPythonApplication rec {
   pname = "nanovna-saver";
-  version = "0.5.4";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "NanoVNA-Saver";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-CLfgDQt2rOXtWwvEhlXEstPp28nFhuhiAPYL6EjZVu4=";
+    sha256 = "sha256-2vDjAdEL8eNje5bm/1m+Fdi+PCGxpXwpxe2KvlLYB58=";
   };
 
-  # Fix for https://github.com/NanoVNA-Saver/nanovna-saver/issues/579
-  # Try dropping the patch in the next release after v0.5.4
-  patches = [
-    (fetchpatch {
-      name = "remote-changelog-from-setup-py.patch";
-      url = "https://github.com/NanoVNA-Saver/${pname}/commit/d654ea0441939e4e1c599d1333b587a185394fbe.diff";
-      sha256 = "sha256-ifOhiWD0EYyQZRKp2W3G6crmWslca+/21APmhpfP/xE=";
-    })
+   nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+    qt6.qtbase
   ];
-
-  nativeBuildInputs = [ wrapQtAppsHook ];
 
   propagatedBuildInputs = with python3.pkgs; [
     cython
     scipy
-    pyqt5
+    pyqt6
     pyserial
     numpy
+    setuptools
+    setuptools-scm
   ];
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   doCheck = false;
 


### PR DESCRIPTION
###### Description of changes

Update nanovna-saver from 0.5.4 to 0.6.0.


###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
