### PR TITLE
Fix setbfree UI

### DIFF
--- a/pkgs/applications/audio/setbfree/default.nix
+++ b/pkgs/applications/audio/setbfree/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation  rec {
   postPatch = ''
     sed 's#/usr/local#$(out)#g' -i common.mak
     sed 's#/usr/share/fonts/truetype/ttf-bitstream-vera#${ttf_bitstream_vera}/share/fonts/truetype#g' \
-      -i b_synth/Makefile
+      -i common.mak
   '';
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
###### Description of changes
The package was being built without UI because it was applying to the wrong file. Changing the file to be patched to common.mak fixes that.

