### PR TITLE
aeolus: Add stops file to fix the UI

### DIFF
--- a/pkgs/applications/audio/aeolus/default.nix
+++ b/pkgs/applications/audio/aeolus/default.nix
@@ -4,6 +4,7 @@
 
 stdenv.mkDerivation rec {
   pname = "aeolus";
+  stopsVersion = "0.4.0";
   version = "0.10.4";
 
   src = fetchurl {
@@ -11,16 +12,36 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-J9xrd/N4LrvGgi89Yj4ob4ZPUAEchrXJJQ+YVJ29Qhk=";
   };
 
+  stops = fetchurl {
+    url = "https://kokkinizita.linuxaudio.org/linuxaudio/downloads/stops-${stopsVersion}.tar.bz2";
+    sha256 = "0e79a0b8e006cb0f67bfcf1e9097db0b4e10c1bb30e6d5c401a29e882411fcb0";
+  };
+
   buildInputs = [
     libclthreads zita-alsa-pcmi alsa-lib libjack2 libclxclient
     libX11 libXft readline
   ];
 
-  patchPhase = ''sed "s@ldconfig.*@@" -i source/Makefile'';
+  patchPhase = ''
+    sed "s@ldconfig.*@@" -i source/Makefile
+    sed -i 's@/etc@'$out'/etc@' -i source/main.cc
+  '';
 
   preBuild = "cd source";
 
   makeFlags = [ "DESTDIR=" "PREFIX=$(out)" ];
+
+
+  postInstall = ''
+    mkdir -p $out/share/stops
+    tar xavf ${stops} --strip-components=1 -C $out/share/stops/
+    mkdir $out/etc
+    cat <<EOF >$out/etc/aeolus.conf
+    # Aeolus system wide default options
+    # use ~/.aeolusrc for local options
+    -u -S $out/share/stops/
+    EOF
+  '';
 
   meta = {
     description = "Synthetized (not sampled) pipe organ emulator";


### PR DESCRIPTION
The stops file was missing, this resulted in a broken empty UI

###### Description of changes

Added the stops file

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
