### PR TITLE
sca2d: init at 0.2.0

### DIFF
--- a/pkgs/development/tools/sca2d/default.nix
+++ b/pkgs/development/tools/sca2d/default.nix
@@ -2,7 +2,6 @@
 , python3
 , fetchFromGitLab
 , fetchFromGitHub
-,
 }:
 let
   python = python3.override {

--- a/pkgs/development/tools/sca2d/default.nix
+++ b/pkgs/development/tools/sca2d/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, python3
+, fetchFromGitLab
+, fetchFromGitHub
+,
+}:
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      lark010 = super.lark.overridePythonAttrs (old: rec {
+        version = "0.10.0";
+
+        src = fetchFromGitHub {
+          owner = "lark-parser";
+          repo = "lark";
+          rev = "refs/tags/${version}";
+          sha256 = "sha256-ctdPPKPSD4weidyhyj7RCV89baIhmuxucF3/Ojx1Efo=";
+        };
+
+        disabledTestPaths = [ "tests/test_nearley/test_nearley.py" ];
+      });
+    };
+    self = python;
+  };
+in
+python.pkgs.buildPythonApplication rec {
+  pname = "sca2d";
+  version = "0.2.0";
+  format = "setuptools";
+
+  src = fetchFromGitLab {
+    owner = "bath_open_instrumentation_group";
+    repo = "sca2d";
+    rev = "v${version}";
+    hash = "sha256-P+7g57AH8H7q0hBE2I9w8A+bN5M6MPbc9gA0b889aoQ=";
+  };
+
+  propagatedBuildInputs = with python.pkgs; [ lark010 colorama ];
+
+  pythonImportsCheck = [ "sca2d" ];
+
+  meta = with lib; {
+    description = "An experimental static code analyser for OpenSCAD";
+    homepage = "https://gitlab.com/bath_open_instrumentation_group/sca2d";
+    changelog = "https://gitlab.com/bath_open_instrumentation_group/sca2d/-/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ traxys ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18758,6 +18758,8 @@ with pkgs;
 
   semantik = libsForQt5.callPackage ../applications/office/semantik { };
 
+  sca2d = callPackage ../development/tools/sca2d {  };
+
   sconsPackages = dontRecurseIntoAttrs (callPackage ../development/tools/build-managers/scons { });
   scons = sconsPackages.scons_4_1_0;
 


### PR DESCRIPTION
###### Description of changes

[sca2d](https://gitlab.com/bath_open_instrumentation_group/sca2d) is a static analyzer for [OpenSCAD](https://openscad.org/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
