### PR TITLE
kanata: 1.2.0 -> 1.3.0

### DIFF
--- a/nixos/modules/services/hardware/kanata.nix
+++ b/nixos/modules/services/hardware/kanata.nix
@@ -86,6 +86,7 @@ let
   mkService = name: keyboard: nameValuePair (mkName name) {
     wantedBy = [ "multi-user.target" ];
     serviceConfig = {
+      Type = "notify";
       ExecStart = ''
         ${getExe cfg.package} \
           --cfg ${mkConfig name keyboard} \
@@ -123,8 +124,7 @@ let
       ProtectKernelModules = true;
       ProtectKernelTunables = true;
       ProtectProc = "invisible";
-      RestrictAddressFamilies =
-        if (keyboard.port == null) then "none" else [ "AF_INET" ];
+      RestrictAddressFamilies = [ "AF_UNIX" ] ++ optional (keyboard.port != null) "AF_INET";
       RestrictNamespaces = true;
       RestrictRealtime = true;
       SystemCallArchitectures = [ "native" ];

--- a/pkgs/tools/system/kanata/default.nix
+++ b/pkgs/tools/system/kanata/default.nix
@@ -7,26 +7,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "kanata";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "jtroo";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-mQSbsJ+3mKoDMg0ewwR7UvXUq+5WA9aTPKWCaTz8nDE=";
+    sha256 = "sha256-gHkcOn37MNpcP6ra1Eur9O4/trPGmAOAGVU1NwiuQGY=";
   };
 
-  cargoHash = "sha256-Pu96OGfnXNaIse/IcwFJWxGMlKOVhZ6DtvgXJkHh+Ao=";
-
-  cargoPatches = [
-    (fetchpatch {
-      name = "serialize-cfg-parsing-tests-for-1.2.0.patch";
-      url = "https://github.com/jtroo/kanata/commit/9ef1e80fbcb40402262e08bd9196d000f73f686d.patch";
-      hash = "sha256-/FhyaYx4usDjGoVfRktf9dtwjY4oXdMQKqxLz00/NPY=";
-    })
-  ];
+  cargoHash = "sha256-C2d7QdgWd9RTQtXLD4mO0txpzo/SbemJx9YYu62QbqA=";
 
   buildFeatures = lib.optional withCmd "cmd";
+
+  postInstall = ''
+    install -Dm 444 assets/kanata-icon.svg $out/share/icons/hicolor/scalable/apps/kanata.svg
+  '';
 
   meta = with lib; {
     description = "A tool to improve keyboard comfort and usability with advanced customization";


### PR DESCRIPTION
###### Description of changes
- kanata: 1.2.0 -> 1.3.0 https://github.com/jtroo/kanata/releases/tag/v1.3.0
- nixos/kanata: notify systemd when starting up is finished
  - set service type to notify
  - allow unix socket which is needed by systemd notify


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
