### PR TITLE
lmms: Add support for Carla

### DIFF
--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, cmake, pkg-config, alsa-lib ? null, carla ? null, fftwFloat, fltk13
+{ lib, fetchFromGitHub, fetchpatch, cmake, pkg-config, alsa-lib ? null, carla ? null, fftwFloat, fltk13
 , fluidsynth ? null, lame ? null, libgig ? null, libjack2 ? null, libpulseaudio ? null
 , libsamplerate, libsoundio ? null, libsndfile, libvorbis ? null, portaudio ? null
 , qtbase, qtx11extras, qttools, SDL ? null, mkDerivation }:
@@ -37,9 +37,12 @@ mkDerivation rec {
     SDL # TODO: switch to SDL2 in the next version
   ];
 
-  patchPhase = ''
-     sed  -i "s/CARLA_EXPORT/CARLA_API_EXPORT/g" -i plugins/carlabase/carla.h;
-  '';
+  patches = [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/packages/lmms/trunk/lmms-carla-export.patch";
+      sha256 = "sha256-wlSewo93DYBN2PvrcV58dC9kpoo9Y587eCeya5OX+j4=";
+    })
+  ];
 
   cmakeFlags = [ "-DWANT_QT5=ON" ];
 

--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -39,7 +39,7 @@ mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/packages/lmms/trunk/lmms-carla-export.patch";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/cf64acc45e3264c6923885867e2dbf8b7586a36b/trunk/lmms-carla-export.patch";
       sha256 = "sha256-wlSewo93DYBN2PvrcV58dC9kpoo9Y587eCeya5OX+j4=";
     })
   ];

--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, cmake, pkg-config, alsa-lib ? null, fftwFloat, fltk13
+{ lib, fetchFromGitHub, cmake, pkg-config, alsa-lib ? null, carla ? null, fftwFloat, fltk13
 , fluidsynth ? null, lame ? null, libgig ? null, libjack2 ? null, libpulseaudio ? null
 , libsamplerate, libsoundio ? null, libsndfile, libvorbis ? null, portaudio ? null
 , qtbase, qtx11extras, qttools, SDL ? null, mkDerivation }:
@@ -18,6 +18,7 @@ mkDerivation rec {
   nativeBuildInputs = [ cmake qttools pkg-config ];
 
   buildInputs = [
+    carla
     alsa-lib
     fftwFloat
     fltk13
@@ -35,6 +36,10 @@ mkDerivation rec {
     qtx11extras
     SDL # TODO: switch to SDL2 in the next version
   ];
+
+  patchPhase = ''
+     sed  -i "s/CARLA_EXPORT/CARLA_API_EXPORT/g" -i plugins/carlabase/carla.h;
+  '';
 
   cmakeFlags = [ "-DWANT_QT5=ON" ];
 


### PR DESCRIPTION
Add Carla as an optional dependency and the needed patch.
This adds the Carla rack and Carla instrument LMMS plugins.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).