### PR TITLE
(visidata) 2.10.2 -> 2.11

### DIFF
--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -2,25 +2,41 @@
 , lib
 , buildPythonApplication
 , fetchFromGitHub
-, python-dateutil
-, pandas
-, requests
-, lxml
-, openpyxl
-, xlrd
-, h5py
-, odfpy
-, psycopg2
-, pyshp
+# python requirements
+, beautifulsoup4
+, boto3
+, faker
 , fonttools
-, pyyaml
-, pdfminer-six
-, vobject
-, tabulate
-, wcwidth
-, zstandard
-, setuptools
+, h5py
 , importlib-metadata
+, lxml
+, matplotlib
+, numpy
+, odfpy
+, openpyxl
+, pandas
+, pdfminer-six
+, praw
+, psutil
+, psycopg2
+, pyarrow
+, pyshp
+, pypng
+, python-dateutil
+, pyyaml
+, requests
+, seaborn
+, setuptools
+, sh
+, tabulate
+, urllib3
+, vobject
+, wcwidth
+, xlrd
+, xlwt
+, zstandard
+, zulip
+# other
 , git
 , withPcap ? true, dpkt, dnslib
 , withXclip ? stdenv.isLinux, xclip
@@ -29,13 +45,13 @@
 }:
 buildPythonApplication rec {
   pname = "visidata";
-  version = "2.10.2";
+  version = "2.11";
 
   src = fetchFromGitHub {
     owner = "saulpw";
     repo = "visidata";
     rev = "v${version}";
-    hash = "sha256-OKCrlUWHgbaLZJPVvs9lnw4cD27pRoO7F9oel1NzT6A=";
+    hash = "sha256-G/9paJFJsRfIxMJ2hbuVS7pxCfSUCK69DNV2DHi60qA=";
   };
 
   propagatedBuildInputs = [
@@ -47,11 +63,13 @@ buildPythonApplication rec {
     lxml
     openpyxl
     xlrd
+    xlwt
     h5py
     psycopg2
+    boto3
     pyshp
     #mapbox-vector-tile
-    #pypng
+    pypng
     fonttools
     #sas7bdat
     #xport
@@ -66,6 +84,22 @@ buildPythonApplication rec {
     wcwidth
     zstandard
     odfpy
+    urllib3
+    pyarrow
+    seaborn
+    matplotlib
+    sh
+    psutil
+    numpy
+
+    #requests_cache
+    beautifulsoup4
+
+    faker
+    praw
+    zulip
+    #pyairtable
+
     setuptools
     importlib-metadata
   ] ++ lib.optionals withPcap [ dpkt dnslib ]
@@ -81,14 +115,16 @@ buildPythonApplication rec {
   checkPhase = ''
     runHook preCheck
     # disable some tests which require access to the network
-    rm tests/load-http.vd            # http
-    rm tests/graph-cursor-nosave.vd  # http
-    rm tests/messenger-nosave.vd     # dns
+    rm -f tests/load-http.vd            # http
+    rm -f tests/graph-cursor-nosave.vd  # http
+    rm -f tests/messenger-nosave.vd     # dns
 
     # tests use git to compare outputs to references
     git init -b "test-reference"
-    git config user.name "nobody"; git config user.email "no@where"
-    git add .; git commit -m "test reference"
+    git config user.name "nobody"
+    git config user.email "no@where"
+    git add .
+    git commit -m "test reference"
 
     substituteInPlace dev/test.sh --replace "bin/vd" "$out/bin/vd"
     bash dev/test.sh


### PR DESCRIPTION
###### Description of changes

Updates `visidata` to 2.11 ( https://github.com/saulpw/visidata/releases/tag/v2.11 )

- I also updated the dependencies from the requirements.txt which led to the addition of some python deps
- The `checkPhase` uses `rm -f` now, because if removing the test fails (the http test will be removed in 2.12) that should not fail the build

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
