### PR TITLE
mydumper: 0.13.1-1 -> 0.14.1-1

### DIFF
--- a/pkgs/tools/backup/mydumper/default.nix
+++ b/pkgs/tools/backup/mydumper/default.nix
@@ -1,43 +1,35 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, cmake
-, pkg-config
-, glib
-, zlib
-, pcre
-, libmysqlclient
-, libressl
+{ lib, stdenv, fetchFromGitHub
+, cmake, pkg-config, sphinx
+, glib , pcre
+, libmysqlclient, libressl
+, zlib, zstd
 }:
-
-let inherit (lib) getDev; in
 
 stdenv.mkDerivation rec {
   pname = "mydumper";
-  version = "0.13.1-1";
+  version = "0.14.1-1";
 
   src = fetchFromGitHub {
-    owner  = "maxbube";
+    owner  = "mydumper";
     repo = "mydumper";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Oknivkyr3wOfjnDccEeFVt7D2l1CkeWgXahsQCtAc0I=";
+    hash = "sha256-I8COArsIO8+09SNa3DrgoGpvhLj08I8UvT2H9k9mJNQ=";
   };
 
-  nativeBuildInputs = [
-    cmake
-    pkg-config
-  ];
+  outputs = [ "out" "doc" "man" ];
+
+  nativeBuildInputs = [ cmake pkg-config sphinx ];
 
   buildInputs = [
-    glib
-    zlib
-    pcre
-    libmysqlclient
-    libressl
+    glib pcre
+    libmysqlclient libressl
+    zlib zstd
   ];
 
   cmakeFlags = [
-    "-DMYSQL_INCLUDE_DIR=${getDev libmysqlclient}/include/mysql"
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    "-DMYSQL_INCLUDE_DIR=${lib.getDev libmysqlclient}/include/mysql"
+    "-DWITH_ZSTD=ON"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
Update mydumper to version 0.14.1-1.
Fixed application launch and added documentation.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
