### PR TITLE
sdrangel: 7.10.0 -> 7.11.0

### DIFF
--- a/pkgs/applications/radio/sdrangel/default.nix
+++ b/pkgs/applications/radio/sdrangel/default.nix
@@ -50,13 +50,13 @@
 
 mkDerivation rec {
   pname = "sdrangel";
-  version = "7.10.0";
+  version = "7.11.0";
 
   src = fetchFromGitHub {
     owner = "f4exb";
     repo = "sdrangel";
     rev = "v${version}";
-    hash = "sha256-hsYt7zGG6CSWeQ9A3GPt65efjZGPu33O5pIhnZjFgmY=";
+    hash = "sha256-zWux84a1MCK0XJXRXcaLHieJ47d4n/wO/xdwTYuuGJw=";
   };
 
   nativeBuildInputs = [ cmake ninja pkg-config ];

--- a/pkgs/development/libraries/dab_lib/default.nix
+++ b/pkgs/development/libraries/dab_lib/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation {
   pname = "dab_lib";
-  version = "unstable-2021-12-28";
+  version = "unstable-2023-03-25";
 
   src = fetchFromGitHub {
     owner = "JvanKatwijk";
     repo = "dab-cmdline";
-    rev = "d23adb3616bb11d98a909aceecb5a3b9507a674c";
-    sha256 = "sha256-n/mgsldgXEOLHZEL1cmsqXgFXByWoMeNXNoDWqPpipA=";
+    rev = "d615e2ba085f91dc7764cc28dfc4c9df49ee1a93";
+    hash = "sha256-KSkOg0a5iq+13kClQqj+TaEP/PsLUrm8bMmiJEAZ+C4=";
   };
 
   sourceRoot = "source/library/";

--- a/pkgs/development/libraries/dab_lib/default.nix
+++ b/pkgs/development/libraries/dab_lib/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation {
   pname = "dab_lib";
-  version = "unstable-2023-03-25";
+  version = "unstable-2023-03-02";
 
   src = fetchFromGitHub {
     owner = "JvanKatwijk";


### PR DESCRIPTION
###### Description of changes
Updated sdrangel to 7.11.0 ([Changelog](https://github.com/f4exb/sdrangel/releases/tag/v7.11.0))
Updated dab_lib to its latest unstable version to work around a build failure (no changelog available)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

