### PR TITLE
writeArgbashShellApplication

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -361,6 +361,7 @@ rec {
         ''
         else checkPhase;
     };
+
   /*
     Similar to writeShellApplication but runs the provided text through argbash
     to generate an options parser before using writeShellApplication under the hood.

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, stdenvNoCC, lndir, runtimeShell, shellcheck, haskell }:
+{ lib, stdenv, stdenvNoCC, lndir, runtimeShell, shellcheck, haskell, argbash }:
 
 let
   inherit (lib)
@@ -360,6 +360,62 @@ rec {
           runHook postCheck
         ''
         else checkPhase;
+    };
+  /*
+    Similar to writeShellApplication but runs the provided text through argbash
+    to generate an options parser before using writeShellApplication under the hood.
+
+    Example:
+
+    Writes my-file to /nix/store/<store path>/bin/my-file and makes executable.
+
+    > my-file --help
+    A cow greets you from an argbash-generated, nix-packaged script.
+    Usage: my-file [-n|--name <arg>] [-h|--help]
+      -n, --name: The name to greet (default: 'Lev')
+      -h, --help: Prints help
+
+    writeShellApplication {
+      name = "my-file";
+      runtimeInputs = [ cowsay ];
+      text = ''
+        # ARG_OPTIONAL_SINGLE([name], [n], [The name to greet], [Lev])
+        # ARG_HELP([A cow greets you from an argbash-generated, nix-packaged script.])
+        # ARGBASH_GO
+        # [ <-- needed because of Argbash
+
+        cowsay "Hello, $_arg_name!"
+
+        # ] <-- needed because of Argbash
+       '';
+    }
+
+  */
+  writeArgbashShellApplication =
+    { name
+    , text
+    , runtimeInputs ? [ ]
+    , checkPhase ? null
+    }:
+    let
+      templateFile = builtins.toFile "templateSource.m4" text;
+      argbashedText = runCommandLocal "${name}-argbashed"
+        {
+          buildInputs = [ argbash ];
+        } ''
+        # Run argbash on the input
+        argbash -o "argbashed-script.sh" "${templateFile}"
+
+        # Copy the output script to the $out directory
+        mkdir -p $out
+        cp "argbashed-script.sh" "$out/argbashed-script.sh"
+      '';
+    in
+    writeShellApplication {
+      inherit name;
+      inherit runtimeInputs;
+      inherit checkPhase;
+      text = builtins.readFile "${argbashedText}/argbashed-script.sh";
     };
 
   # Create a C binary

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -404,18 +404,14 @@ rec {
           buildInputs = [ argbash ];
         } ''
         # Run argbash on the input
-        argbash -o "argbashed-script.sh" "${templateFile}"
-
-        # Copy the output script to the $out directory
-        mkdir -p $out
-        cp "argbashed-script.sh" "$out/argbashed-script.sh"
+        argbash -o "$out" "${templateFile}"
       '';
     in
     writeShellApplication {
       inherit name;
       inherit runtimeInputs;
       inherit checkPhase;
-      text = builtins.readFile "${argbashedText}/argbashed-script.sh";
+      text = builtins.readFile "${argbashedText}";
     };
 
   # Create a C binary

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -104,7 +104,7 @@ let
     import ../build-support/trivial-builders {
       inherit lib;
       inherit (self) runtimeShell stdenv stdenvNoCC haskell;
-      inherit (self.pkgsBuildHost) shellcheck;
+      inherit (self.pkgsBuildHost) shellcheck argbash;
       inherit (self.pkgsBuildHost.xorg) lndir;
     };
 


### PR DESCRIPTION
###### Description of changes

Added a trivial builder `writeArgbashShellApplication` which runs `argbash` (from https://argbash.dev) on the source prior to building it with `writeShellApplication`. This is useful for generating argument parsers for bash scripts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
