### PR TITLE
gow: init at unstable-2023-02-08

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15765,6 +15765,15 @@
     github = "deviant";
     githubId = 68829907;
   };
+  v3s1e = {
+    name = "Veselin Ivanov";
+    email = "v3s1ez@gmail.com";
+    github = "v3s1e";
+    githubId = 51268394;
+    keys = [{
+      fingerprint = "87CF 5D9C 165C 0161 15F4  FED2 B09D DF9D 424E 10D3";
+    }];
+  };
   vaci = {
     email = "vaci@vaci.org";
     github = "vaci";

--- a/pkgs/development/tools/gow/default.nix
+++ b/pkgs/development/tools/gow/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "gow";
+  version = "unstable-2023-02-08";
+
+  src = fetchFromGitHub {
+    owner = "mitranim";
+    repo = pname;
+    rev = "36c8536a96b851631e800bb00f73383fc506f210";
+    sha256 = "sha256-q56s97j+Npurb942TeQhJPqq1vl/XFe7a2Dj5fw7EtQ=";
+  };
+
+  vendorSha256 = "sha256-o6KltbjmAN2w9LMeS9oozB0qz9tSMYmdDW3CwUNChzA=";
+
+  tags = [ "mitranim" "gow" "go" "golang" "file" "watch" "watcher" "gowatch" "go-watch" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/mitranim/gow";
+    description = "Missing watch mode for Go commands";
+    maintainers = with maintainers; [ v3s1e ];
+    license = licenses.unlicense;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26727,6 +26727,8 @@ with pkgs;
 
   gotools = callPackage ../development/tools/gotools { };
 
+  gow = callPackage ../development/tools/gow { };
+
   gotop = callPackage ../tools/system/gotop {
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };


### PR DESCRIPTION
###### Description of changes

`gow` is the missing file watcher for the `go` toolchain.
See: https://github.com/mitranim/gow

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
