### PR TITLE
rust-hypervisor-firmware: init at 0.4.2

### DIFF
--- a/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
+++ b/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, fetchFromGitHub
+, makeRustPlatform
+, hostPlatform
+, targetPlatform
+, lld
+}:
+
+let
+  arch = targetPlatform.qemuArch;
+
+  target = ./. + "/${arch}-unknown-none.json";
+
+  cross = import ../../../.. {
+    system = hostPlatform.system;
+    crossSystem = lib.systems.examples."${arch}-embedded" // {
+      rustc.config = "${arch}-unknown-none";
+      rustc.platform = lib.importJSON target;
+    };
+  };
+
+  inherit (cross) rustPlatform;
+
+in
+
+rustPlatform.buildRustPackage rec {
+  pname = "rust-hypervisor-firmware";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "cloud-hypervisor";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-hKk5pcop8rb5Q+IVchcl+XhMc3DCBBPn5P+AkAb9XxI=";
+  };
+
+  cargoSha256 = "sha256-edi6/Md6KebKM3wHArZe1htUCg0/BqMVZKA4xEH25GI=";
+
+  RUSTC_BOOTSTRAP = 1;
+
+  nativeBuildInputs = [
+    lld
+  ];
+
+  RUSTFLAGS = "-C linker=lld -C linker-flavor=ld.lld";
+
+  # Tests don't work for `no_std`. See https://os.phil-opp.com/testing/
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/cloud-hypervisor/rust-hypervisor-firmware";
+    description = "A simple firmware that is designed to be launched from anything that supports loading ELF binaries and running them with the PVH booting standard";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ astro ];
+    platforms = [ "x86_64-none" ];
+  };
+}

--- a/pkgs/applications/virtualization/rust-hypervisor-firmware/x86_64-unknown-none.json
+++ b/pkgs/applications/virtualization/rust-hypervisor-firmware/x86_64-unknown-none.json
@@ -1,0 +1,20 @@
+{
+  "llvm-target": "x86_64-unknown-none",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "arch": "x86_64",
+  "target-endian": "little",
+  "target-pointer-width": "64",
+  "target-c-int-width": "32",
+  "os": "none",
+  "executables": true,
+  "linker": "rust-lld",
+  "linker-flavor": "ld.lld",
+  "panic-strategy": "abort",
+  "disable-redzone": true,
+  "features": "-mmx,-sse,+soft-float",
+  "code-model": "small",
+  "relocation-model": "pic",
+  "pre-link-args": {
+    "ld.lld": ["--script=x86_64-unknown-none.ld"]
+  }
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25399,6 +25399,8 @@ with pkgs;
 
   qboot = pkgsi686Linux.callPackage ../applications/virtualization/qboot { };
 
+  rust-hypervisor-firmware = callPackage ../applications/virtualization/rust-hypervisor-firmware { };
+
   OVMF = callPackage ../applications/virtualization/OVMF { };
   OVMFFull = callPackage ../applications/virtualization/OVMF {
     secureBoot = true;


### PR DESCRIPTION
###### Description of changes

This package is useful for booting with an initrd in cloud-hypervisor.

It validates the changes in #215408.

Due to the cross-compiling Rust config required for this crate, the code seems rather hacky. I am curious what better approaches reviewers will come up with.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
