### PR TITLE
python310Packages.jupyter-cache: fix build

### DIFF
--- a/pkgs/development/python-modules/jupyter-cache/default.nix
+++ b/pkgs/development/python-modules/jupyter-cache/default.nix
@@ -10,11 +10,14 @@
 , sqlalchemy
 , tabulate
 , pythonOlder
+, setuptools
+, pythonRelaxDepsHook
 }:
 
 buildPythonPackage rec {
   pname = "jupyter-cache";
   version = "0.5.0";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
@@ -23,10 +26,10 @@ buildPythonPackage rec {
     sha256 = "87408030a4c8c14fe3f8fe62e6ceeb24c84e544c7ced20bfee45968053d07801";
   };
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "nbclient>=0.2,<0.6" "nbclient"
-  '';
+  nativeBuildInputs = [
+    setuptools
+    pythonRelaxDepsHook
+  ];
 
   propagatedBuildInputs = [
     attrs
@@ -37,6 +40,11 @@ buildPythonPackage rec {
     pyyaml
     sqlalchemy
     tabulate
+  ];
+
+  pythonRelaxDeps = [
+    "nbclient"
+    "sqlalchemy" # See https://github.com/executablebooks/jupyter-cache/pull/93
   ];
 
   pythonImportsCheck = [ "jupyter_cache" ];


### PR DESCRIPTION
-------

###### Description of changes
Relax dependency on SQLAlchemy.
https://hydra.nixos.org/build/212794787
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->