### PR TITLE
ocamlPakages.tsdl: updates

### DIFF
--- a/pkgs/development/ocaml-modules/tsdl-image/default.nix
+++ b/pkgs/development/ocaml-modules/tsdl-image/default.nix
@@ -9,13 +9,15 @@
 
 buildDunePackage rec {
   pname = "tsdl-image";
-  version = "0.3.2";
+  version = "0.5";
+
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "sanette";
     repo = pname;
     rev = version;
-    sha256 = "sha256-u6VYAwq+2oLn2Kw1+KQRVPswAqeKDSAaPfGLPrzn30s=";
+    hash = "sha256-khLhVJuiLNNWw76gTeg4W32v5XbkwAg11bIOWl67u2k=";
   };
 
   buildInputs = [

--- a/pkgs/development/ocaml-modules/tsdl-mixer/default.nix
+++ b/pkgs/development/ocaml-modules/tsdl-mixer/default.nix
@@ -9,13 +9,15 @@
 
 buildDunePackage rec {
   pname = "tsdl-mixer";
-  version = "0.3.2";
+  version = "0.5";
+
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "sanette";
     repo = pname;
     rev = version;
-    sha256 = "sha256-UDRhwnanrn87/PYVnacur1z/LsKuUu2G+0QQXjTw/IE=";
+    hash = "sha256-HGtO5iO3lxuVa707MDIhw0pgDZLHt9qY+Rd24sFkags=";
   };
 
   buildInputs = [

--- a/pkgs/development/ocaml-modules/tsdl-ttf/default.nix
+++ b/pkgs/development/ocaml-modules/tsdl-ttf/default.nix
@@ -9,13 +9,15 @@
 
 buildDunePackage rec {
   pname = "tsdl-ttf";
-  version = "0.3.2";
+  version = "0.5";
+
+  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "sanette";
     repo = pname;
     rev = version;
-    sha256 = "sha256-COBLF9K8thRROJJGeg4wxqrjB3aBa4CGYkf8HdAQ2o0";
+    hash = "sha256-ai9ChsA3HZzTxT9AuHsY1UIA2Q3U3CcOA7jRSG4MDsQ=";
   };
 
   buildInputs = [

--- a/pkgs/development/ocaml-modules/tsdl/default.nix
+++ b/pkgs/development/ocaml-modules/tsdl/default.nix
@@ -7,16 +7,17 @@ else
 
 let
   pname = "tsdl";
-  version = "0.9.9";
+  version = "1.0.0";
   webpage = "https://erratique.ch/software/${pname}";
 in
 
 stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-${pname}-${version}";
+  pname = "ocaml${ocaml.version}-${pname}";
+  inherit version;
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    sha256 = "sha256-GqFz+bYG2ESkAEJyP8DKud4JFfU5MGLulzJa5Z4sptQ=";
+    hash = "sha256-XdgzCj9Uqplt/8Jk8rSFaQf8zu+9SZa8b9ZIlW/gjyE=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
