### PR TITLE
qtcreator-qt6: init at 9.0.2

### DIFF
--- a/pkgs/development/tools/qtcreator/qt6.nix
+++ b/pkgs/development/tools/qtcreator/qt6.nix
@@ -1,0 +1,102 @@
+{ stdenv
+, lib
+, fetchurl
+, cmake
+, pkg-config
+, ninja
+, python3
+, qtbase
+, qt5compat
+, qtdeclarative
+, qtdoc
+, qtquick3d
+, qtquicktimeline
+, qtserialport
+, qtsvg
+, qttools
+, qtwebengine
+, qtshadertools
+, wrapQtAppsHook
+, yaml-cpp
+, litehtml
+, gumbo
+, llvmPackages
+, rustc-demangle
+, elfutils
+, perf
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qtcreator";
+  version = "9.0.2";
+
+  src = fetchurl {
+    url = "https://download.qt.io/official_releases/${pname}/${lib.versions.majorMinor version}/${version}/qt-creator-opensource-src-${version}.tar.xz";
+    sha256 = "sha256-7KWMxcoNOXiWlAVCYZzyA/WWLuPIggCBIics23Ifoyg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qttools
+    wrapQtAppsHook
+    python3
+    ninja
+  ];
+
+  buildInputs = [
+    qtbase
+    qtdoc
+    qtsvg
+    qtquick3d
+    qtwebengine
+    qtserialport
+    qtshadertools
+    qt5compat
+    qtdeclarative
+    qtquicktimeline
+    yaml-cpp
+    litehtml
+    gumbo
+    llvmPackages.libclang
+    llvmPackages.llvm
+    rustc-demangle
+    elfutils
+  ];
+
+  cmakeFlags = [
+    # workaround for missing CMAKE_INSTALL_DATAROOTDIR
+    # in pkgs/development/tools/build-managers/cmake/setup-hook.sh
+    "-DCMAKE_INSTALL_DATAROOTDIR=${placeholder "out"}/share"
+    # qtdeclarative in nixpkgs does not provide qmlsc
+    # fix can't find Qt6QmlCompilerPlusPrivate
+    "-DQT_NO_FIND_QMLSC=TRUE"
+    "-DWITH_DOCS=ON"
+    "-DBUILD_DEVELOPER_DOCS=ON"
+    "-DBUILD_QBS=OFF"
+    "-DQTC_CLANG_BUILDMODE_MATCH=ON"
+    "-DCLANGTOOLING_LINK_CLANG_DYLIB=ON"
+  ];
+
+  qtWrapperArgs = [
+    "--set-default PERFPROFILER_PARSER_FILEPATH ${lib.getBin perf}/bin"
+  ];
+
+  postInstall = ''
+    substituteInPlace $out/share/applications/org.qt-project.qtcreator.desktop \
+      --replace "Exec=qtcreator" "Exec=$out/bin/qtcreator"
+  '';
+
+  meta = with lib; {
+    description = "Cross-platform IDE tailored to the needs of Qt developers";
+    longDescription = ''
+      Qt Creator is a cross-platform IDE (integrated development environment)
+      tailored to the needs of Qt developers. It includes features such as an
+      advanced code editor, a visual debugger and a GUI designer.
+    '';
+    homepage = "https://wiki.qt.io/Qt_Creator";
+    license = licenses.lgpl3Plus;
+    maintainers = [ maintainers.rewine ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18677,6 +18677,12 @@ with pkgs;
     inherit (linuxPackages) perf;
   };
 
+  qtcreator-qt6 = qt6Packages.callPackage ../development/tools/qtcreator/qt6.nix {
+    inherit (linuxPackages) perf;
+    stdenv = llvmPackages_14.stdenv;
+    llvmPackages = llvmPackages_14;
+  };
+
   qxmledit = libsForQt5.callPackage ../applications/editors/qxmledit {} ;
 
   r10k = callPackage ../tools/system/r10k { };


### PR DESCRIPTION
###### Description of changes

Remove qtcreator(qt5) when  this is verified to be stable to use

Superseded：https://github.com/NixOS/nixpkgs/pull/189504
fix https://github.com/NixOS/nixpkgs/issues/173751
fix https://github.com/NixOS/nixpkgs/issues/197006
fix https://github.com/NixOS/nixpkgs/issues/219735
fix https://github.com/NixOS/nixpkgs/issues/119959

The following issues remain unresolved：

- https://github.com/NixOS/nixpkgs/issues/59580
- https://github.com/NixOS/nixpkgs/issues/59581

```
                                                                            
CMake Warning at cmake/QtCreatorDocumentation.cmake:187 (message):
  No qdoc binary found: No documentation targets were generated             
Call Stack (most recent call first):                                        
  cmake/QtCreatorDocumentation.cmake:285 (qdoc_build_qdocconf_file)         
  doc/CMakeLists.txt:38 (add_qtc_documentation)                             
                                                                            
                                                                            
-- The following packages have been found:

 * Qt6CoreTools (required version >= 6.4.3)
 * Qt6Core (required version >= 6.2.0)
 * Qt6Concurrent
 * OpenGL
 * PkgConfig
 * XKB (required version >= 0.5.0), XKB API common to servers and clients., <http://xkbcommon.org>
 * Vulkan
 * Qt6GuiTools (required version >= 6.4.3)
 * Qt6DBusTools (required version >= 6.4.3)
 * Qt6Gui
 * Qt6Network
 * Qt6WidgetsTools (required version >= 6.4.3)
 * Qt6PrintSupport
 * Qt6QmlTools (required version >= 6.4.3)
 * Qt6Qml
 * Qt6Sql
 * Qt6Xml
 * Qt6Core5Compat
 * Qt6LinguistTools
 * WrapVulkanHeaders
 * Qt6DesignerComponentsPrivate
 * Qt6Quick
 * Qt6QuickWidgets
 * Qt6Help
 * Qt6SerialPort
 * Qt6Svg
 * Qt6ToolsTools (required version >= 6.4.3)
 * Qt6Tools
 * LLVM
 * Clang
 * Qt6Test
 * Qt6SvgWidgets
 * Qt6WebEngineCoreTools (required version >= 6.4.3)
 * Qt6WebEngineWidgets
 * yaml-cpp
 * Googletest, Google Testing and Mocking Framework, <https://github.com/google/googletest>
 * Qt6Quick3DTools (required version >= 6.4.3)
 * Qt6ShaderToolsTools (required version >= 6.4.3)
 * Qt6ShaderTools (required version >= 6.4.3)
 * Qt6Quick3DRuntimeRender (required version >= 6.4.3)
 * Qt6Quick3D
 * Qt6Quick3DAssetImport
 * Qt6Quick3DParticles
 * Qt6Quick3DAssetUtils
 * Qt6QuickTimeline
 * Threads
 * Qt6
 * Qt5
 * elfutils, a collection of utilities and libraries to read, create and modify ELF binary files, <https://sourceware.org/elfutils/>
 * Zstd
 * LibRustcDemangle, Demangling for Rust symbols, written in Rust., <https://github.com/alexcrichton/rustc-demangle>
   Demangling of Rust symbols
 * Python3

-- The following packages have not been found:

 * litehtml

-- The following features have been enabled:

 * Build documentation
 * Library 3rd_cplusplus
 * Library KSyntaxHighlighting
 * Library AdvancedDockingSystem
 * Library Aggregation
 * Library ExtensionSystem
 * Library Utils
 * Library LanguageUtils
 * Library CPlusPlus
 * Library Modeling
 * Library QmlJS
 * Library QmlDebug
 * Library QmlEditorWidgets
 * Library GLSL
 * Library LanguageServerProtocol
 * Library SqliteC, with CONDITION Qt5_VERSION VERSION_GREATER_EQUAL 6.2.0
 * Library Sqlite, with CONDITION Qt5_VERSION VERSION_GREATER_EQUAL 6.2.0
 * Library Tracing, with CONDITION TARGET Qt6::ShaderTools AND TARGET Qt5::Quick
 * Library designerintegrationv2
 * Library ProParser
 * Library shared_help
 * Plugin Core
 * Plugin TextEditor
 * Plugin SerialTerminal, with CONDITION TARGET Qt5::SerialPort
 * Plugin HelloWorld
 * Plugin ImageViewer
 * Plugin Marketplace
 * Plugin UpdateInfo
 * Plugin Welcome
 * Plugin BinEditor
 * Plugin CodePaster
 * Plugin DiffEditor
 * Plugin EmacsKeys
 * Plugin Macros
 * Plugin ProjectExplorer
 * Plugin SilverSearcher
 * Plugin Bookmarks
 * Plugin CppEditor
 * Plugin Help, with CONDITION TARGET Qt5::Help
 * QtWebEngine help viewer, with CONDITION BUILD_HELPVIEWERBACKEND_QTWEBENGINE AND TARGET Qt5::WebEngineWidgets
 * litehtml help viewer, with CONDITION TARGET qlitehtml
 * Plugin ResourceEditor
 * Plugin Nim
 * Plugin Conan
 * Plugin ClassView
 * Plugin GLSLEditor
 * Plugin ModelEditor
 * Plugin QtSupport
 * Plugin Todo
 * Plugin VcsBase
 * Plugin Bazaar
 * Plugin Beautifier
 * Plugin ClangFormat, with CONDITION TARGET clang-cpp AND LLVM_PACKAGE_VERSION VERSION_GREATER_EQUAL 10.0.0 AND ( QTC_CLANG_BUILDMODE_MATCH OR CLANGTOOLING_LINK_CLANG_DYLIB )
 * Plugin ClearCase
 * Plugin CVS
 * Plugin Designer, with CONDITION TARGET Qt5::DesignerComponents AND TARGET Qt5::Designer
 * Plugin Docker
 * Plugin FakeVim
 * Plugin GenericProjectManager
 * Plugin Git
 * Plugin Mercurial
 * Plugin MesonProjectManager
 * Plugin Perforce
 * Plugin QmakeProjectManager
 * Plugin QmlJSTools
 * Plugin QmlProjectManager, with CONDITION TARGET Qt5::QuickWidgets
 * Plugin ScxmlEditor
 * Plugin Subversion
 * Plugin CompilationDatabaseProjectManager
 * Plugin LanguageClient
 * Plugin CMakeProjectManager
 * Plugin Debugger
 * Plugin Coco
 * Plugin GitLab
 * Plugin Android
 * Plugin AutoTest
 * Plugin AutotoolsProjectManager
 * Plugin BareMetal
 * Plugin ClangCodeModel
 * Plugin ClangTools, with CONDITION TARGET yaml-cpp
 * Plugin Cppcheck
 * Plugin IncrediBuild
 * Plugin Ios
 * Plugin Python
 * Plugin QmlJSEditor
 * Plugin QmlPreview, with CONDITION TARGET QmlProjectManager
 * Plugin QmlProfiler, with CONDITION TARGET Tracing AND TARGET Qt6::ShaderTools
 * Plugin RemoteLinux
 * Plugin Valgrind
 * Plugin PerfProfiler, with CONDITION TARGET Tracing
 * Plugin QbsProjectManager
 * Plugin CtfVisualizer, with CONDITION TARGET Tracing
 * Plugin Squish
 * Plugin Boot2Qt
 * Plugin QmlDesigner, with CONDITION Qt5_VERSION VERSION_GREATER_EQUAL 6.2.0 AND TARGET Qt5::QuickWidgets AND TARGET Qt5::Svg
 * Plugin assetexporterplugin, with CONDITION TARGET QmlDesigner
 * Plugin componentsplugin, with CONDITION TARGET QmlDesigner
 * Plugin qmlpreviewplugin, with CONDITION TARGET QmlDesigner
 * Plugin qtquickplugin, with CONDITION TARGET QmlDesigner
 * Plugin StudioPlugin, with CONDITION TARGET QmlDesigner
 * Plugin StudioWelcome, with CONDITION TARGET Qt5::QuickWidgets AND TARGET QmlDesigner
 * Plugin Qnx
 * Plugin WebAssembly
 * Plugin McuSupport
 * Library qml2puppet_static
 * Qt Quick 3D support, with CONDITION TARGET Qt5::Quick3D
 * Qt Quick 3D asset import, with CONDITION TARGET Qt5::Quick3DAssetImport
 * Qt Quick 3D particles, with CONDITION TARGET Qt5::Quick3DParticles
 * Qt Quick 3D asset utils, with CONDITION TARGET Qt5::Quick3DAssetUtils
 * Library sdktoolLib
 * Library perfparser_lib
 * Include developer documentation

-- The following features have been disabled:

 * Build online documentation
 * Build tests
 * Build with sanitize, SANITIZE_FLAGS=''
 * Build with Crashpad
 * Library Nanotrace
 * Build Qbs
 * Native WebKit help viewer, with CONDITION FWWebKit AND FWAppKit
 * ProjectStorage
 * Build with QmlDom
 * multilanguage-support in qml2puppet, with CONDITION TARGET QtCreator::multilanguage-support

```


1. litehtml use `find_dependency(gumbo)` but gumbo only provide pkg-config file.
https://github.com/archlinux/svntogit-packages/blob/1cc60cd7bed3034608eb137ff82761e7ec88acb5/trunk/PKGBUILD#LL29C48-L29C56
https://github.com/NixOS/nixpkgs/pull/223361
cc @fgaz 

2. qdoc （Should be provided by qttools）not found，this also caused qtdoc to not be packaged correctly
https://github.com/NixOS/nixpkgs/pull/223271


3. optional runtime dependencies：
https://github.com/NixOS/nixpkgs/pull/223254

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
