### PR TITLE
elfutils: enable debuginfod support

### DIFF
--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, fetchpatch, pkg-config, musl-fts
 , musl-obstack, m4, zlib, zstd, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs
 , argp-standalone
-, enableDebuginfod ? false, sqlite, curl, libmicrohttpd, libarchive
+, enableDebuginfod ? true, sqlite, curl, libmicrohttpd, libarchive
 , gitUpdater
 }:
 

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -7,7 +7,7 @@
 , ncurses, readline, gmp, mpfr, expat, libipt, zlib, zstd, dejagnu, sourceHighlight
 
 , pythonSupport ? stdenv.hostPlatform == stdenv.buildPlatform && !stdenv.hostPlatform.isCygwin, python3 ? null
-, enableDebuginfod ? false, elfutils
+, enableDebuginfod ? true, elfutils
 , guile ? null
 , safePaths ? [
    # $debugdir:$datadir/auto-load are whitelisted by default by GDB


### PR DESCRIPTION
elfutils contains several libraries, and when debuginfod support is enabled, only libdebuginfod.so depends on libarchive and curl, among others, leading to a large closure size increase.

To mitigate this effect, libdebuginfod.so is moved to a separate output. libarchive and libcurl remain in the build closure, but derivations which depend on, say, libelf, but not libdebuginfod only retain a reference to the out output and not the libdebuginfod output and their runtime closure size does not increase.

Enabling libdebuginfod by default allows to use nixseparatedebuginfod without recompiling gdb and perf, mostly.
This admittedly complex contraption ensures we don't get two copies of libelf (one for systemd withouth debuginfod support, and one for debuginfod enabled gdb) in this case.

The bin output contains build tools, and since curl and libarchive are always in the build closure we dont move debuginfod and debuginfod-find to a separate output.

tested by rebuilding
/nix/store/axqgmkgmhy2rzlbffglhjv1npy5ni0ra-gdb-13.1
/nix/store/73cbnzc96xir60xff5qblhvw6fb7n309-perf-linux-6.1.21
/nix/store/nk7lla63w1pbzyavgz7hcvdhmrd9qgqy-systemtap-6.1.21-4.8
/nix/store/bhss1whsh67b0wa1mj5h3z1p4nwndxd4-valgrind-3.20.0
/nix/store/v2hlzj0gbnycj7ssznvjvhw5bxwxsbmm-hotspot-1.4.1
/nix/store/7cnyh97201zk780zwbh1sh913wflsgjp-heaptrack-1.4.0
/nix/store/1893dw0r67hh6iqbjdhwbpb8dsc1i8iy-networkmanager-1.40.12
/nix/store/xc5yfb7v042ypmbwwswpsq91jwapls4k-dwz-0.14
/nix/store/vfyvlmrnns4k0dppd6fnddkxc1s3dkck-linux-6.1.21
and checking which of these keep the debuginfod reference.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
