### PR TITLE
libreoffice/wrapper: Don't --chdir

### DIFF
--- a/pkgs/applications/office/libreoffice/wrapper.nix
+++ b/pkgs/applications/office/libreoffice/wrapper.nix
@@ -3,6 +3,7 @@
 # The unwrapped libreoffice derivation
 , unwrapped
 , makeWrapper
+, xorg # for lndir
 , runCommand
 , substituteAll
 # For Emulating wrapGAppsHook
@@ -72,14 +73,13 @@ let
       fi
     '')
   ] ++ [
-    "--chdir" "${unwrapped}/lib/libreoffice/program"
     "--inherit-argv0"
   ] ++ extraMakeWrapperArgs
   );
 in runCommand "${unwrapped.name}-wrapped" {
   inherit (unwrapped) meta;
   paths = [ unwrapped ];
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper xorg.lndir ];
   passthru = {
     inherit unwrapped;
     # For backwards compatibility:
@@ -87,8 +87,7 @@ in runCommand "${unwrapped.name}-wrapped" {
     inherit (unwrapped) kdeIntegration;
   };
 } (''
-  mkdir -p "$out/bin"
-  mkdir -p "$out/share"
+  mkdir -p $out/share
   for dir in ${unwrapped}/share/*; do
     dirname="''${dir##*/}"
     if [[ $dirname == "applications" ]]; then
@@ -97,21 +96,30 @@ in runCommand "${unwrapped.name}-wrapped" {
       ln -s $dir $out/share/
     fi
   done
-
-  ln -s ${unwrapped}/lib $out/lib
   for f in $out/share/applications/*.desktop; do
     substituteInPlace "$f" \
       --replace "Exec=libreoffice${major}.${minor}" "Exec=soffice"
   done
 
+  mkdir -p $out/bin
+  mkdir -p $out/lib/libreoffice/program
+  lndir -silent ${unwrapped}/lib/libreoffice/program $out/lib/libreoffice/program
   for i in sbase scalc sdraw smath swriter simpress soffice unopkg; do
-    makeWrapper ${unwrapped}/lib/libreoffice/program/$i $out/bin/$i ${makeWrapperArgs}
+    # Delete the symlink created by lndir, and replace it by our wrapper
+    rm $out/lib/libreoffice/program/$i
+    makeWrapper \
+      ${unwrapped}/lib/libreoffice/program/$i \
+      $out/lib/libreoffice/program/$i \
+      ${makeWrapperArgs}
 '' + lib.optionalString dbusVerify ''
     # Delete the dbus socket directory after libreoffice quits
-    sed -i 's/^exec -a "$0" //g' $out/bin/"$i"
-    echo 'code="$?"' >> $out/bin/$i
-    echo 'test -n "$dbus_socket_dir" && { rm -rf "$dbus_socket_dir"; kill $dbus_pid; }' >> $out/bin/$i
-    echo 'exit "$code"' >> $out/bin/$i
+    sed -i 's/^exec -a "$0" //g' $out/lib/libreoffice/program/$i
+    echo 'code="$?"' >> $out/lib/libreoffice/program/$i
+    echo 'test -n "$dbus_socket_dir" && { rm -rf "$dbus_socket_dir"; kill $dbus_pid; }' >> $out/lib/libreoffice/program/$i
+    echo 'exit "$code"' >> $out/lib/libreoffice/program/$i
 '' + ''
+    ln -s $out/lib/libreoffice/program/$i $out/bin/$i
   done
+  # A symlink many users rely upon
+  ln -s $out/bin/soffice $out/bin/libreoffice
 '')


### PR DESCRIPTION
To your request @evils . It wasn't trivial, but fortunately it's not hard to test these changes thanks to the separate wrapper derivation.

###### Description of changes

Use lndir and replace it's relevant symlinks with wrappers. Close #223186.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
