### PR TITLE
lighttpd: Disable tests for DES and MD5

### DIFF
--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -22,6 +22,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-FqyNuV5xlim6YZSbmfiib+upRqgdGFIVsoN5u0EWsLQ=";
   };
 
+  patches = [
+    # disable tests for des/md5, which we don't support any more
+    ./disable-legacy-crypt-tests.patch
+  ];
+
   postPatch = ''
     patchShebangs tests
     # Linux sandbox has an empty hostname and not /etc/hosts, which fails some tests

--- a/pkgs/servers/http/lighttpd/disable-legacy-crypt-tests.patch
+++ b/pkgs/servers/http/lighttpd/disable-legacy-crypt-tests.patch
@@ -1,0 +1,37 @@
+diff --git a/tests/mod-fastcgi.t b/tests/mod-fastcgi.t
+index 25016e60..e0427046 100755
+--- a/tests/mod-fastcgi.t
++++ b/tests/mod-fastcgi.t
+@@ -79,7 +79,7 @@ EOF
+ 	ok($tf->handle_http($t) == 0, 'FastCGI + bin-copy-environment');
+ 
+ SKIP: {
+-	skip "no crypt-des under openbsd", 2 if $^O eq 'openbsd';
++	skip "no crypt-des", 2;
+ 
+ 	$t->{REQUEST}  = ( <<EOF
+ GET /get-server-env.php?env=REMOTE_USER HTTP/1.0
+diff --git a/tests/request.t b/tests/request.t
+index f56a4300..36e67b88 100755
+--- a/tests/request.t
++++ b/tests/request.t
+@@ -1105,7 +1105,7 @@ $t->{RESPONSE} = [ { 'HTTP-Protocol' => 'HTTP/1.0', 'HTTP-Status' => 200 } ];
+ ok($tf->handle_http($t) == 0, 'Basic-Auth: Valid Auth-token - plain');
+ 
+ SKIP: {
+-	skip "no crypt-des under openbsd", 2 if $^O eq 'openbsd';
++	skip "no crypt-des", 2;
+ $t->{REQUEST}  = ( <<EOF
+ GET /server-config HTTP/1.0
+ Host: auth-htpasswd.example.org
+@@ -1162,9 +1162,7 @@ $t->{RESPONSE} = [ { 'HTTP-Protocol' => 'HTTP/1.0', 'HTTP-Status' => 401 } ];
+ ok($tf->handle_http($t) == 0, 'Basic-Auth: Valid Auth-token - htpasswd (apr-md5, wrong password)');
+ 
+ SKIP: {
+-	skip "no crypt-md5 under cygwin", 1 if $^O eq 'cygwin';
+-	skip "no crypt-md5 under darwin", 1 if $^O eq 'darwin';
+-	skip "no crypt-md5 under openbsd",1 if $^O eq 'openbsd';
++	skip "no crypt-md5", 1;
+ $t->{REQUEST}  = ( <<EOF
+ GET /server-config HTTP/1.0
+ Host: auth-htpasswd.example.org


### PR DESCRIPTION
These are legacy ciphers, which we don't support any longer.

Made it into a patch, because I failed at the proper substitution multiple times.

cc  #221461, #220557

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
