### PR TITLE
fuc: init at 1.1.6

### DIFF
--- a/pkgs/tools/misc/fuc/add_missing_feature.patch
+++ b/pkgs/tools/misc/fuc/add_missing_feature.patch
@@ -1,0 +1,11 @@
+diff --git a/cpz/src/main.rs b/cpz/src/main.rs
+index 4e7ce8d..0d0922d 100644
+--- a/cpz/src/main.rs
++++ b/cpz/src/main.rs
+@@ -1,5 +1,6 @@
+ #![feature(once_cell)]
+ #![feature(let_chains)]
++#![feature(main_separator_str)]
+ 
+ use std::{
+     borrow::Cow,

--- a/pkgs/tools/misc/fuc/default.nix
+++ b/pkgs/tools/misc/fuc/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, clippy
+, rustfmt
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "fuc";
+  version = "1.1.6";
+
+  src = fetchFromGitHub {
+    owner = "SUPERCILEX";
+    repo = "fuc";
+    rev = version;
+    hash = "sha256-kbEIZljIWs/GYOQ/XCBgWsBcEwm05bf7bZmAwq+eWXo=";
+  };
+
+  patches = [ ./add_missing_feature.patch ];
+
+  cargoHash = "sha256-AD3LdBMmyf6xM7sWUDxYZs3NltnAkEfAdxYLAbnRM4M=";
+
+  RUSTC_BOOTSTRAP = 1;
+
+  cargoBuildFlags = [ "--workspace" "--bin cpz" "--bin rmz" ];
+
+  nativeCheckInputs = [ clippy rustfmt ];
+
+  meta = with lib; {
+    description = "Modern, performance focused unix commands";
+    homepage = "https://github.com/SUPERCILEX/fuc";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dit7ya ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2189,6 +2189,8 @@ with pkgs;
 
   fsuae-launcher = libsForQt5.callPackage ../applications/emulators/fs-uae/launcher.nix { };
 
+  fuc = callPackage ../tools/misc/fuc { };
+
   fuse-emulator = callPackage ../applications/emulators/fuse-emulator { };
 
   fw = callPackage ../tools/misc/fw {


### PR DESCRIPTION
###### Description of changes

https://github.com/SUPERCILEX/fuc
Modern, performance focused unix commands 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
