### PR TITLE
clazy: init at 1.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2348,6 +2348,12 @@
     githubId = 51231053;
     name = "Daniel";
   };
+  cadkin = {
+    email = "cva@siliconslumber.net";
+    name = "Cameron Adkins";
+    github = "cadkin";
+    githubId = 34077838;
+  };
   cafkafk = {
     email = "christina@cafkafk.com";
     matrix = "@cafkafk:matrix.cafkafk.com";

--- a/pkgs/development/tools/analysis/clazy/default.nix
+++ b/pkgs/development/tools/analysis/clazy/default.nix
@@ -1,0 +1,56 @@
+{
+    lib
+  , stdenv
+  , fetchFromGitHub
+  , llvmPackages
+  , cmake
+  , makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "clazy";
+  version = "1.11";
+
+  src = fetchFromGitHub {
+    owner  = "KDE";
+    repo   = "clazy";
+    rev    = "v${version}";
+    sha256 = "sha256-kcl4dUg84fNdizKUS4kpvIKFfajtTRdz+MYUbKcMFvg=";
+  };
+
+  buildInputs = [
+    llvmPackages.llvm
+    llvmPackages.libclang
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/clazy \
+      --suffix PATH               : "${llvmPackages.clang}/bin/"                            \
+      --suffix CPATH              : "$(<${llvmPackages.clang}/nix-support/libc-cflags)"     \
+      --suffix CPATH              : "${llvmPackages.clang}/resource-root/include"           \
+      --suffix CPLUS_INCLUDE_PATH : "$(<${llvmPackages.clang}/nix-support/libcxx-cxxflags)" \
+      --suffix CPLUS_INCLUDE_PATH : "$(<${llvmPackages.clang}/nix-support/libc-cflags)"     \
+      --suffix CPLUS_INCLUDE_PATH : "${llvmPackages.clang}/resource-root/include"
+
+    wrapProgram $out/bin/clazy-standalone \
+      --suffix CPATH              : "$(<${llvmPackages.clang}/nix-support/libc-cflags)"     \
+      --suffix CPATH              : "${llvmPackages.clang}/resource-root/include"           \
+      --suffix CPLUS_INCLUDE_PATH : "$(<${llvmPackages.clang}/nix-support/libcxx-cxxflags)" \
+      --suffix CPLUS_INCLUDE_PATH : "$(<${llvmPackages.clang}/nix-support/libc-cflags)"     \
+      --suffix CPLUS_INCLUDE_PATH : "${llvmPackages.clang}/resource-root/include"
+  '';
+
+  meta = {
+    description = "Qt-oriented static code analyzer based on the Clang framework";
+    homepage = "https://github.com/KDE/clazy";
+    license = lib.licenses.lgpl2Plus;
+    maintainers = [ lib.maintainers.cadkin ];
+    platforms = lib.platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14419,6 +14419,11 @@ with pkgs;
     inherit (llvmPackages_latest) clang;
   };
 
+  clazy = callPackage ../development/tools/analysis/clazy {
+    llvmPackages = llvmPackages_latest;
+    stdenv = llvmPackages_latest.stdenv;
+  };
+
   #Use this instead of stdenv to build with clang
   clangStdenv = if stdenv.cc.isClang then stdenv else lowPrio llvmPackages.stdenv;
   clang-sierraHack-stdenv = overrideCC stdenv buildPackages.clang-sierraHack;


### PR DESCRIPTION
###### Description of changes

[Repo Link](https://github.com/KDE/clazy) - Clazy is a static analyzer for Qt projects. It is used as a component in QtCreator to provide analysis on the fly.

I'm working on updates for QtCreator as well and this package is needed for full code model support. In my test scenario with the updated QtCreator, pointing `Clang-Tidy` to `pkgs.clang-tools` and `Clazy-Standalone` to this package properly enables static analysis.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
