### PR TITLE
copy-tarballs: use all the urls of each file

### DIFF
--- a/maintainers/scripts/copy-tarballs.pl
+++ b/maintainers/scripts/copy-tarballs.pl
@@ -159,12 +159,17 @@ elsif (defined $expr) {
     # Check every fetchurl call discovered by find-tarballs.nix.
     my $mirrored = 0;
     my $have = 0;
-    foreach my $fetch (sort { $a->{url} cmp $b->{url} } @{$fetches}) {
-        my $url = $fetch->{url};
+    foreach my $fetch (sort { $a->{urls}->[0] cmp $b->{urls}->[0] } @{$fetches}) {
+        my $urls = $fetch->{urls};
         my $algo = $fetch->{type};
         my $hash = $fetch->{hash};
         my $name = $fetch->{name};
         my $isPatch = $fetch->{isPatch};
+
+        if ($isPatch) {
+            print STDERR "skipping $urls->[0] (support for patches is missing)\n";
+            next;
+        }
 
         if ($hash =~ /^([a-z0-9]+)-([A-Za-z0-9+\/=]+)$/) {
             $algo = $1;
@@ -180,62 +185,60 @@ elsif (defined $expr) {
             chomp $hash;
         }
 
-        if (defined $ENV{DEBUG}) {
-            print "$url $algo $hash\n";
-            next;
-        }
-
-        if ($url !~ /^http:/ && $url !~ /^https:/ && $url !~ /^ftp:/ && $url !~ /^mirror:/) {
-            print STDERR "skipping $url (unsupported scheme)\n";
-            next;
-        }
-
-        if ($isPatch) {
-            print STDERR "skipping $url (support for patches is missing)\n";
-            next;
-        }
-
-        next if defined $exclude && $url =~ /$exclude/;
-
-        if (alreadyMirrored($algo, $hash)) {
-            $have++;
-            next;
-        }
-
         my $storePath = makeFixedOutputPath(0, $algo, $hash, $name);
 
-        print STDERR "mirroring $url ($storePath, $algo, $hash)...\n";
+        for my $url (@$urls) {
+            if (defined $ENV{DEBUG}) {
+                print "$url $algo $hash\n";
+                next;
+            }
 
-        if ($dryRun) {
+            if ($url !~ /^http:/ && $url !~ /^https:/ && $url !~ /^ftp:/ && $url !~ /^mirror:/) {
+                print STDERR "skipping $url (unsupported scheme)\n";
+                next;
+            }
+
+            next if defined $exclude && $url =~ /$exclude/;
+
+            if (alreadyMirrored($algo, $hash)) {
+                $have++;
+                last;
+            }
+
+            print STDERR "mirroring $url ($storePath, $algo, $hash)...\n";
+
+            if ($dryRun) {
+                $mirrored++;
+                last;
+            }
+
+            # Substitute the output.
+            if (!isValidPath($storePath)) {
+                system("nix-store", "-r", $storePath);
+            }
+
+            # Otherwise download the file using nix-prefetch-url.
+            if (!isValidPath($storePath)) {
+                $ENV{QUIET} = 1;
+                $ENV{PRINT_PATH} = 1;
+                my $fh;
+                my $pid = open($fh, "-|", "nix-prefetch-url", "--type", $algo, $url, $hash) or die;
+                waitpid($pid, 0) or die;
+                if ($? != 0) {
+                    print STDERR "failed to fetch $url: $?\n";
+                    next;
+                }
+                <$fh>; my $storePath2 = <$fh>; chomp $storePath2;
+                if ($storePath ne $storePath2) {
+                    warn "strange: $storePath != $storePath2\n";
+                    next;
+                }
+            }
+
+            uploadFile($storePath, $url);
             $mirrored++;
-            next;
+            last;
         }
-
-        # Substitute the output.
-        if (!isValidPath($storePath)) {
-            system("nix-store", "-r", $storePath);
-        }
-
-        # Otherwise download the file using nix-prefetch-url.
-        if (!isValidPath($storePath)) {
-            $ENV{QUIET} = 1;
-            $ENV{PRINT_PATH} = 1;
-            my $fh;
-            my $pid = open($fh, "-|", "nix-prefetch-url", "--type", $algo, $url, $hash) or die;
-            waitpid($pid, 0) or die;
-            if ($? != 0) {
-                print STDERR "failed to fetch $url: $?\n";
-                next;
-            }
-            <$fh>; my $storePath2 = <$fh>; chomp $storePath2;
-            if ($storePath ne $storePath2) {
-                warn "strange: $storePath != $storePath2\n";
-                next;
-            }
-        }
-
-        uploadFile($storePath, $url);
-        $mirrored++;
     }
 
     print STDERR "mirrored $mirrored files, already have $have files\n";

--- a/maintainers/scripts/find-tarballs.nix
+++ b/maintainers/scripts/find-tarballs.nix
@@ -9,12 +9,12 @@ let
 
   root = expr;
 
-  uniqueUrls = map (x: x.file) (genericClosure {
-    startSet = map (file: { key = file.url; inherit file; }) urls;
+  uniqueFiles = map (x: x.file) (genericClosure {
+    startSet = map (file: { key = with file; (if type == null then "" else type + "+") + hash; inherit file; }) files;
     operator = const [ ];
   });
 
-  urls = map (drv: { url = head (drv.urls or [ drv.url ]); hash = drv.outputHash; isPatch = (drv?postFetch && drv.postFetch != ""); type = drv.outputHashAlgo; name = drv.name; }) fetchurlDependencies;
+  files = map (drv: { urls = drv.urls or [ drv.url ]; hash = drv.outputHash; isPatch = (drv?postFetch && drv.postFetch != ""); type = drv.outputHashAlgo; name = drv.name; }) fetchurlDependencies;
 
   fetchurlDependencies =
     filter
@@ -47,4 +47,4 @@ let
 
   canEval = val: (builtins.tryEval val).success;
 
-in uniqueUrls
+in uniqueFiles


### PR DESCRIPTION
###### Description of changes

Make `copy-tarballs.pl` go through all the urls in `urls` until one is successful, instead of just using the first one.

My intended use case is for TeX Live: we would prefer that packages use CTAN first, because it is very well mirrored and fast, and turn to the daily snapshot https://texlive.info/ only when necessary; the issue being that that CTAN updates daily and many packages disappear quickly, while on the other hand https://texlive.info/ is a single server and quite slower. Having both urls works for Nixpkgs but breaks `copy-tarballs.pl`, hence this PR.

(Side note: I considered creating a `mirror://ctan/...` with `https://texlive.info/` at the bottom. However the daily snapshot URL contains the day of the snapshot, and that information should be kept inside `texlive/default.nix`, not in the mirror list.) 

###### Things done

I can't test this properly as I don't have the keys to S3, so I am hoping somebody else can check that this works as intended.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).