### PR TITLE
netbox: workaround to allow composible python packageOverrides

### DIFF
--- a/pkgs/servers/web-apps/netbox/default.nix
+++ b/pkgs/servers/web-apps/netbox/default.nix
@@ -8,10 +8,10 @@
 , plugins ? ps: [] }:
 
 let
-  py = python3.override {
-    packageOverrides = self: super: {
+  py = python3 // {
+    pkgs = python3.pkgs.overrideScope (self: super: {
       django = super.django_4;
-    };
+    });
   };
 
   extraBuildInputs = plugins py.pkgs;


### PR DESCRIPTION
the `packageOverrides` of python unfortunately does not compose. Since `netbox`'s definition uses `packageOverrides` internally, this means something like `netbox.override { python3 = python3.override { packageOverrides { ... }; }; }` won't work as expected, since only the package override defined last is applied.

see https://github.com/NixOS/nixpkgs/issues/44426 for related discussion.

###### Description of changes

replaces the use of `.override` with `.overrideScope`, as suggested in https://github.com/NixOS/nixpkgs/issues/44426#issuecomment-1338223044

(note: there's an alternative solution which also does the trick:

~~~nix
python3.override (super: { 
 packageOverrides = 
   let ours = self: super: { django = super.django_4; }; 
   in if super ? packageOverrides
    then lib.composeExtensions super.packageOverrides ours
    else ours;
})
~~~

I do not know if there are any advantages or disadvantages to either approach, so I've gone with the one suggested in the above-linked comment)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
