### PR TITLE
qt6: build qtdoc and some clear up

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -47,6 +47,7 @@ let
           ./patches/0004-qtbase-fix-locating-tzdir-on-NixOS.patch
           ./patches/0005-qtbase-deal-with-a-font-face-at-index-0-as-Regular-f.patch
           ./patches/0006-qtbase-qt-cmake-always-use-cmake-from-path.patch
+          ./patches/0007-qtbase-find-qt-tools-in-QTTOOLSPATH.patch
         ];
       };
       env = callPackage ./qt-env.nix { };

--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -49,6 +49,20 @@ else # Only set up Qt once.
     }
     envBuildHostHooks+=(qmakePathHook)
 
+    export QTTOOLSPATH=
+
+    declare -Ag qttoolsPathSeen=()
+    qtToolsHook() {
+        # Skip this path if we have seen it before.
+        # MUST use 'if' because 'qttoolsPathSeen[$]' may be unset.
+        if [ -n "${qttoolsPathSeen[$1]-}" ]; then return; fi
+        qttoolsPathSeen[$1]=1
+        if [ -d "$1/libexec" ]; then
+            QTTOOLSPATH="${QTTOOLSPATH}${QTTOOLSPATH:+:}$1/libexec"
+        fi
+    }
+    envBuildHostHooks+=(qtToolsHook)
+
     postPatchMkspecs() {
         # Prevent this hook from running multiple times
         dontPatchMkspecs=1

--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -61,7 +61,7 @@ else # Only set up Qt once.
             QTTOOLSPATH="${QTTOOLSPATH}${QTTOOLSPATH:+:}$1/libexec"
         fi
     }
-    envBuildHostHooks+=(qtToolsHook)
+    addEnvHooks "$hostOffset" qtToolsHook
 
     postPatchMkspecs() {
         # Prevent this hook from running multiple times

--- a/pkgs/development/libraries/qt-6/modules/qtdoc.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdoc.nix
@@ -1,9 +1,26 @@
 { qtModule
 , qtdeclarative
+, qtbase
+, qttools
 }:
 
 qtModule {
   pname = "qtdoc";
+  # avoid fix-qt-builtin-paths hook substitute QT_INSTALL_DOCS to qtdoc's path
+  postPatch = ''
+    for file in $(grep -rl '$QT_INSTALL_DOCS'); do
+      substituteInPlace $file \
+          --replace '$QT_INSTALL_DOCS' "${qtbase}/share/doc"
+    done
+  '';
+  nativeBuildInputs = [ qttools ];
   qtInputs = [ qtdeclarative ];
+  cmakeFlags = [
+    "-DCMAKE_MESSAGE_LOG_LEVEL=STATUS"
+  ];
+  dontUseNinjaBuild = true;
+  buildFlags = [ "docs" ];
+  dontUseNinjaInstall = true;
+  installFlags = [ "install_docs" ];
   outputs = [ "out" ];
 }

--- a/pkgs/development/libraries/qt-6/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-6/modules/qttools.nix
@@ -3,12 +3,16 @@
 , lib
 , qtbase
 , qtdeclarative
+, llvmPackages
 , cups
-, substituteAll
 }:
 
 qtModule {
   pname = "qttools";
+  buildInputs = [
+    llvmPackages.libclang
+    llvmPackages.llvm
+  ];
   qtInputs = [ qtbase qtdeclarative ];
   propagatedBuildInputs = lib.optionals stdenv.isDarwin [ cups ];
   patches = [

--- a/pkgs/development/libraries/qt-6/patches/0007-qtbase-find-qt-tools-in-QTTOOLSPATH.patch
+++ b/pkgs/development/libraries/qt-6/patches/0007-qtbase-find-qt-tools-in-QTTOOLSPATH.patch
@@ -1,0 +1,46 @@
+From 31d808a7b0d52a01c3f2875202cd29410a94b39a Mon Sep 17 00:00:00 2001
+From: rewine <luhongxu@deepin.org>
+Date: Wed, 29 Mar 2023 11:51:33 +0800
+Subject: [PATCH] qtbase-find-tools-in-PATH
+
+1. find qt's tools in `QTTOOLSPATH` env
+   qt assumes that all components use the same install prefix
+   we can't get the real prefix for qttools when build qtbase
+   we will add /libexec to `QTTOOLSPATH` in qtToolsHook
+   find_path will also search in 'PATH' by default
+   see `CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH`
+
+2. disable tool_dependencies_enabled
+   We can guarantee the build order of qt components in nixpkgs
+   tools in qttools always build before qtdoc
+   qdoc_bin is not a build target now, since we find it in `QTTOOLSPATH`
+
+---
+ cmake/QtDocsHelpers.cmake | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/cmake/QtDocsHelpers.cmake b/cmake/QtDocsHelpers.cmake
+index 48ed5a32..9409d22d 100644
+--- a/cmake/QtDocsHelpers.cmake
++++ b/cmake/QtDocsHelpers.cmake
+@@ -47,9 +47,14 @@ function(qt_internal_add_docs)
+         set(doc_tools_libexec "${QT_BUILD_INTERNALS_RELOCATABLE_INSTALL_PREFIX}/${INSTALL_LIBEXECDIR}")
+     endif()
+ 
+-    set(qdoc_bin "${doc_tools_bin}/qdoc${CMAKE_EXECUTABLE_SUFFIX}")
+-    set(qtattributionsscanner_bin "${doc_tools_libexec}/qtattributionsscanner${CMAKE_EXECUTABLE_SUFFIX}")
+-    set(qhelpgenerator_bin "${doc_tools_libexec}/qhelpgenerator${CMAKE_EXECUTABLE_SUFFIX}")
++    set(tool_dependencies_enabled FALSE)
++
++    find_path(qdoc_path name qdoc PATHS ENV QTTOOLSPATH)
++    find_path(qtattributionsscanner_path name qtattributionsscanner PATHS ENV QTTOOLSPATH)
++    find_path(qhelpgenerator_path name qhelpgenerator PATHS ENV QTTOOLSPATH)
++    set(qdoc_bin "${qdoc_path}/qdoc${CMAKE_EXECUTABLE_SUFFIX}")
++    set(qtattributionsscanner_bin "${qtattributionsscanner_path}/qtattributionsscanner${CMAKE_EXECUTABLE_SUFFIX}")
++    set(qhelpgenerator_bin "${qhelpgenerator_path}/qhelpgenerator${CMAKE_EXECUTABLE_SUFFIX}")
+ 
+     get_target_property(target_type ${target} TYPE)
+     if (NOT target_type STREQUAL "INTERFACE_LIBRARY")
+-- 
+2.38.1
+


### PR DESCRIPTION
###### Description of changes
fix build for qtdoc

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
