### PR TITLE
komikku: add webkitgtk-6.0 support

### DIFF
--- a/pkgs/applications/graphics/komikku/default.nix
+++ b/pkgs/applications/graphics/komikku/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitLab
+, fetchpatch
 , desktop-file-utils
 , gettext
 , glib
@@ -28,6 +29,18 @@ python3.pkgs.buildPythonApplication rec {
     rev = "v${version}";
     hash = "sha256-SzK86uzdGnNFNtbvw56n3AxjxcCBjHFs9wD98TVggAo=";
   };
+
+  patches = [
+    # https://gitlab.com/valos/Komikku/-/merge_requests/208
+    (fetchpatch {
+      url = "https://gitlab.com/valos/Komikku/-/commit/c9a09817acd767a7cb4ceea9b212fffd798eae61.patch";
+      hash = "sha256-McjQApLY7OKbdelrTeh3aRw90B6T9V5FtLL5Y62BmGA=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.com/valos/Komikku/-/commit/bda93631420f6a69a50be0068f259d60b9558930.patch";
+      hash = "sha256-Xu+IaQKf0I99a2uh97j8xSlGYSJHuNPMy/zZtWRxLaM=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
###### Description of changes

See the discussion here: https://github.com/NixOS/nixpkgs/pull/220440#issuecomment-1484040684.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).