### PR TITLE
haskell.packages.ghc96: bump memory and parallel

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -67,6 +67,8 @@ self: super: {
   tasty-inspection-testing = doDistribute self.tasty-inspection-testing_0_2;
   # Too strict bounds on ghc-prim and template-haskell
   aeson = doDistribute (doJailbreak self.aeson_2_1_2_1);
+  # Too strict bounds on ghc-prim
+  memory = doDistribute self.memory_0_18_0;
 
   ghc-lib = doDistribute self.ghc-lib_9_6_1_20230312;
   ghc-lib-parser = doDistribute self.ghc-lib-parser_9_6_1_20230312;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -144,6 +144,8 @@ self: super: {
   generically = jailbreakWhileRevision 0 super.generically;
   # Revision 3 lifts offending template-haskell bound
   hackage-security = jailbreakWhileRevision 2 super.hackage-security;
+  # Revision 6 lifts offending base bound
+  parallel = jailbreakWhileRevision 5 super.parallel;
 
   #
   # Compilation failure workarounds

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -151,6 +151,18 @@ self: super: {
   # Compilation failure workarounds
   #
 
+  # Add missing Functor instance for Tuple2
+  # https://github.com/haskell-foundation/foundation/pull/572
+  foundation = appendPatches [
+      (pkgs.fetchpatch {
+        name = "foundation-pr-572.patch";
+        url =
+          "https://github.com/haskell-foundation/foundation/commit/d3136f4bb8b69e273535352620e53f2196941b35.patch";
+        sha256 = "sha256-oPadhQdCPJHICdCPxn+GsSQUARIYODG8Ed6g2sK+eC4=";
+        stripLen = 1;
+      })
+    ] (super.foundation);
+
   # Test suite doesn't compile with base-4.18 / GHC 9.6
   # https://github.com/dreixel/syb/issues/40
   syb = dontCheck super.syb;


### PR DESCRIPTION
###### Description of changes

This change enables using the memory and parallel package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
