### PR TITLE
python310Packages.pytest-testinfra: init at 8.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6589,6 +6589,11 @@
       fingerprint = "78C2 E81C 828A 420B 269A  EBC1 49FA 39F8 A7F7 35F9";
     }];
   };
+  hulr = {
+    github = "hulr";
+    githubId = 17255815;
+    name = "hulr";
+  };
   humancalico = {
     email = "humancalico@disroot.org";
     github = "humancalico";

--- a/pkgs/development/python-modules/pytest-testinfra/default.nix
+++ b/pkgs/development/python-modules/pytest-testinfra/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools-scm
+, ansible-core
+, paramiko
+, pytestCheckHook
+, pytest-xdist
+, pywinrm
+, salt
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-testinfra";
+  version = "8.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-m0CCi1j7esK/8pzBRlk0rfQ08Q3VoQj2BTXe5SZgpj0=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    ansible-core
+    paramiko
+    pytestCheckHook
+    pytest-xdist
+    pywinrm
+    salt
+  ];
+
+  # markers don't get added when docker is not available (leads to warnings):
+  # https://github.com/pytest-dev/pytest-testinfra/blob/8.1.0/test/conftest.py#L228
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    sed -i '54imarkers = \
+    \ttestinfra_hosts(host_selector): mark test to run on selected hosts \
+    \tdestructive: mark test as destructive \
+    \tskip_wsl: skip test on WSL, no systemd support' setup.cfg
+    '';
+
+  # docker is required for all disabled tests
+  disabledTests = [
+    # test/test_backends.py
+    "test_command"
+    "test_encoding"
+    "test_ansible_any_error_fatal"
+    "test_user_connection"
+    "test_sudo"
+    "test_docker_encoding"
+  ];
+
+  disabledTestPaths = [
+    "test/test_modules.py"
+  ];
+
+  meta = with lib; {
+    description = "Pytest plugin for testing your infrastructure";
+    homepage = "https://github.com/pytest-dev/pytest-testinfra";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ hulr ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-testinfra/default.nix
+++ b/pkgs/development/python-modules/pytest-testinfra/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     \ttestinfra_hosts(host_selector): mark test to run on selected hosts \
     \tdestructive: mark test as destructive \
     \tskip_wsl: skip test on WSL, no systemd support' setup.cfg
-    '';
+  '';
 
   # docker is required for all disabled tests
   disabledTests = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9718,6 +9718,8 @@ self: super: with self; {
 
   pytest-test-utils = callPackage ../development/python-modules/pytest-test-utils { };
 
+  pytest-testinfra = callPackage ../development/python-modules/pytest-testinfra { };
+
   pytest-testmon = callPackage ../development/python-modules/pytest-testmon { };
 
   pytest-timeout = callPackage ../development/python-modules/pytest-timeout { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[testinfra.readthedocs.io](https://testinfra.readthedocs.io)

With Testinfra you can write unit tests in Python to test actual state of your servers configured by management tools like Salt, Ansible, Puppet, Chef and so on.

Testinfra aims to be a Serverspec equivalent in python and is written as a plugin to the powerful Pytest test engine.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
