### PR TITLE
microbin: 1.1.0 -> 1.2.1, add figsoda as a maintainer

### DIFF
--- a/pkgs/servers/microbin/default.nix
+++ b/pkgs/servers/microbin/default.nix
@@ -5,20 +5,21 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "microbin";
-  version = "1.1.0";
+  version = "1.2.1";
 
-  # GitHub sources do not have Cargo.lock
+  # The GitHub source is outdated
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-gfEO7Rrzc4KSnSXFrMmGLrTXuZIUCdumt2N429nHPi8=";
+    hash = "sha256-OLg0ejs9nanMNlY0lcnJ/RoRwefrXEaaROwx5aPx4u8=";
   };
 
-  cargoSha256 = "sha256-k/5CG8bf5RuO6K9mEj6seqV6AuWMqatBRDaSS0guhi0=";
+  cargoHash = "sha256-XdHP0XruqtyLyGbLHielnmTAc3ZgeIyyZnknO+5k4Xo=";
 
   meta = with lib; {
     description = "A tiny, self-contained, configurable paste bin and URL shortener written in Rust";
     homepage = "https://github.com/szabodanika/microbin";
+    changelog = "https://github.com/szabodanika/microbin/releases/tag/v${version}";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ dit7ya ];
+    maintainers = with maintainers; [ dit7ya figsoda ];
   };
 }


### PR DESCRIPTION
Changelog: https://github.com/szabodanika/microbin/releases/tag/v1.2.1

###### Description of changes

closes #200119

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
