### PR TITLE
wayland: build libraries on darwin

### DIFF
--- a/pkgs/development/libraries/wayland/darwin.patch
+++ b/pkgs/development/libraries/wayland/darwin.patch
@@ -1,0 +1,74 @@
+diff --git a/meson.build b/meson.build
+index 35c3b95..f27e472 100644
+--- a/meson.build
++++ b/meson.build
+@@ -16,7 +16,7 @@ config_h.set_quoted('PACKAGE', meson.project_name())
+ config_h.set_quoted('PACKAGE_VERSION', meson.project_version())
+ 
+ cc_args = []
+-if host_machine.system() != 'freebsd'
++if host_machine.system() not in ['darwin', 'freebsd']
+ 	cc_args += ['-D_POSIX_C_SOURCE=200809L']
+ endif
+ add_project_arguments(cc_args, language: 'c')
+@@ -52,7 +52,7 @@ foreach f: have_funcs
+ endforeach
+ config_h.set10('HAVE_XUCRED_CR_PID', cc.has_member('struct xucred', 'cr_pid', prefix : '#include <sys/ucred.h>'))
+ have_broken_msg_cmsg_cloexec = false
+-if host_machine.system() == 'freebsd'
++if host_machine.system() in ['darwin', 'freebsd']
+ 	have_broken_msg_cmsg_cloexec = not cc.compiles('''
+ #include <sys/param.h> /* To get __FreeBSD_version. */
+ #if __FreeBSD_version < 1300502 || \
+@@ -69,7 +69,7 @@ endif
+ config_h.set10('HAVE_BROKEN_MSG_CMSG_CLOEXEC', have_broken_msg_cmsg_cloexec)
+ 
+ if get_option('libraries')
+-	if host_machine.system() == 'freebsd'
++	if host_machine.system() in ['darwin', 'freebsd']
+ 		# When building for FreeBSD, epoll(7) is provided by a userspace
+ 		# wrapper around kqueue(2).
+ 		epoll_dep = dependency('epoll-shim')
+diff --git a/src/event-loop.c b/src/event-loop.c
+index 37cf95d..49a38cb 100644
+--- a/src/event-loop.c
++++ b/src/event-loop.c
+@@ -48,6 +48,13 @@
+ 
+ #define TIMER_REMOVED -2
+ 
++#ifdef __APPLE__
++struct itimerspec {
++	struct timespec it_interval;
++	struct timespec it_value;
++};
++#endif
++
+ struct wl_event_loop;
+ struct wl_event_source_interface;
+ struct wl_event_source_timer;
+diff --git a/src/wayland-os.c b/src/wayland-os.c
+index a9066ca..483fe64 100644
+--- a/src/wayland-os.c
++++ b/src/wayland-os.c
+@@ -69,17 +69,19 @@ wl_os_socket_cloexec(int domain, int type, int protocol)
+ {
+ 	int fd;
+ 
++#ifdef SOCK_CLOEXEC
+ 	fd = socket(domain, type | SOCK_CLOEXEC, protocol);
+ 	if (fd >= 0)
+ 		return fd;
+ 	if (errno != EINVAL)
+ 		return -1;
++#endif
+ 
+ 	fd = socket(domain, type, protocol);
+ 	return set_cloexec_or_close(fd);
+ }
+ 
+-#if defined(__FreeBSD__)
++#if defined(__APPLE__) || defined(__FreeBSD__)
+ int
+ wl_os_socket_peercred(int sockfd, uid_t *uid, gid_t *gid, pid_t *pid)
+ {

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -8,7 +8,7 @@
 , wayland-scanner
 , expat
 , libxml2
-, withLibraries ? stdenv.isLinux
+, withLibraries ? stdenv.isLinux || stdenv.isDarwin
 , withTests ? stdenv.isLinux
 , libffi
 , epoll-shim
@@ -40,6 +40,10 @@ stdenv.mkDerivation rec {
     url = "https://gitlab.freedesktop.org/wayland/wayland/-/releases/${version}/downloads/${pname}-${version}.tar.xz";
     sha256 = "1b0ixya9bfw5c9jx8mzlr7yqnlyvd3jv5z8wln9scdv8q5zlvikd";
   };
+
+  patches = [
+    ./darwin.patch
+  ];
 
   postPatch = lib.optionalString withDocumentation ''
     patchShebangs doc/doxygen/gen-doxygen.py


### PR DESCRIPTION
###### Description of changes

This PR includes a minimal patch that allows building Wayland libraries on Darwin. The patch is rather trivial, and should be extensible to support more exotic platforms. The patch is also compatible with version 1.21.92.

The reason for doing it downstream is that upstream seems to be less active in supporting more exotic platforms. [The PR for the OpenBSD port](https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/256) has been stalled for 7 months, for example.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
