### PR TITLE
abcl: explicit update script + makeWrapper

### DIFF
--- a/pkgs/development/compilers/abcl/default.nix
+++ b/pkgs/development/compilers/abcl/default.nix
@@ -1,38 +1,67 @@
-{lib, stdenv, fetchurl, ant, jre, jdk}:
+{ stdenv
+, lib
+, fetchurl
+, ant
+, jre
+, jdk
+, makeWrapper
+}:
+
 stdenv.mkDerivation rec {
   pname = "abcl";
   version = "1.9.1";
-  # or fetchFromGitHub(owner,repo,rev) or fetchgit(rev)
+
   src = fetchurl {
     url = "https://common-lisp.net/project/armedbear/releases/${version}/${pname}-src-${version}.tar.gz";
     sha256 = "sha256-pbxnfJRB9KgzwgpUG93Rb/+SZIRmkd6aHa9mmfj/EeI=";
   };
+
   configurePhase = ''
+    runHook preConfigure
+
     mkdir nix-tools
     export PATH="$PWD/nix-tools:$PATH"
     echo "echo nix-builder.localdomain" > nix-tools/hostname
     chmod a+x nix-tools/*
 
     hostname
+
+    runHook postConfigure
   '';
+
+  buildInputs = [ jre ant jdk jre ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
   buildPhase = ''
+    runHook preBuild
+
     ant
+
+    runHook postBuild
   '';
-  # Fix for https://github.com/armedbear/abcl/issues/484
-  javaOpts =
-    lib.optionalString
-      (lib.versionAtLeast jre.version "17")
-      "--add-opens=java.base/java.util.jar=ALL-UNNAMED";
+
   installPhase = ''
+    runHook preInstall
+
     mkdir -p "$out"/{bin,share/doc/abcl,lib/abcl}
     cp -r README COPYING CHANGES examples/  "$out/share/doc/abcl/"
     cp -r dist/*.jar contrib/ "$out/lib/abcl/"
 
-    echo "#! ${stdenv.shell}" >> "$out/bin/abcl"
-    echo "${jre}/bin/java $javaOpts -cp \"$out/lib/abcl/abcl.jar:$out/lib/abcl/abcl-contrib.jar:\$CLASSPATH\" org.armedbear.lisp.Main \"\$@\"" >> "$out/bin/abcl"
-    chmod a+x "$out"/bin/*
+    makeWrapper ${jre}/bin/java $out/bin/abcl \
+      --prefix CLASSPATH : $out/lib/abcl/abcl.jar \
+      --prefix CLASSPATH : $out/lib/abcl/abcl-contrib.jar \
+      ${lib.optionalString (lib.versionAtLeast jre.version "17")
+        # Fix for https://github.com/armedbear/abcl/issues/484
+        "--add-flags --add-opens=java.base/java.util.jar=ALL-UNNAMED \\"
+      }
+      --add-flags org.armedbear.lisp.Main
+
+    runHook postInstall
   '';
-  buildInputs = [jre ant jdk jre];
+
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "A JVM-based Common Lisp implementation";
     license = lib.licenses.gpl3 ;

--- a/pkgs/development/compilers/abcl/update.sh
+++ b/pkgs/development/compilers/abcl/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update curl
+
+new_version=$(curl https://armedbear.common-lisp.dev/ | grep abcl-src | sed 's;[^>]*>abcl-src-\(.*\).tar[^$]*;\1;' | head -n 1)
+nix-update abcl --version "$new_version"


### PR DESCRIPTION
###### Description of changes
A small refactor in ABCL

- Using makeWrapper to generate the entrypoint binary instead of the echo > $out/bin strategy
- Explicit update script that fetches the latest version from the official site
- Tried adding tests (checkPhase), but I wasn't able to inject JUnit and other dependencies that are downloaded in test time

cc @7c6f434c as maintainer

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
