### PR TITLE
rustPlatform.buildRustPackage: make auditable the default

### DIFF
--- a/pkgs/applications/terminal-emulators/alacritty/default.nix
+++ b/pkgs/applications/terminal-emulators/alacritty/default.nix
@@ -60,8 +60,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-t6ckX0PYI8UHfXhGRpcX8ly3DzE9A6i9P6f3Ny3DBzw=";
 
-  auditable = true; # TODO: remove when this is the default
-
   nativeBuildInputs = [
     cmake
     installShellFiles

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -45,7 +45,7 @@
 , buildFeatures ? [ ]
 , checkFeatures ? buildFeatures
 , useNextest ? false
-, auditable ? false # TODO: change to true
+, auditable ? true
 
 , depsExtraArgs ? {}
 

--- a/pkgs/development/compilers/rust/cargo-auditable.nix
+++ b/pkgs/development/compilers/rust/cargo-auditable.nix
@@ -41,8 +41,6 @@ let
 in
 
 rustPlatform.buildRustPackage.override { cargo-auditable = bootstrap; } (args // {
-  auditable = true; # TODO: remove when this is the default
-
   nativeBuildInputs = [
     installShellFiles
   ];
@@ -50,4 +48,8 @@ rustPlatform.buildRustPackage.override { cargo-auditable = bootstrap; } (args //
   postInstall = ''
     installManPage cargo-auditable/cargo-auditable.1
   '';
+
+  passthru = {
+    inherit bootstrap;
+  };
 })

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -2,10 +2,13 @@
 , file, curl, pkg-config, python3, openssl, cmake, zlib
 , installShellFiles, makeWrapper, rustPlatform, rustc
 , CoreFoundation, Security
-, auditable ? false # TODO: change to true when this is the default
+, auditable ? true
+, cargo-auditable
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage.override {
+  cargo-auditable = cargo-auditable.bootstrap;
+} {
   pname = "cargo";
   inherit (rustc) version src;
 

--- a/pkgs/development/libraries/libimagequant/default.nix
+++ b/pkgs/development/libraries/libimagequant/default.nix
@@ -24,8 +24,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-0HOmItooNsGq6iTIb9M5IPXMwYh2nQ03qfjomkg0d00=";
 
-  auditable = true; # TODO: remove when this is the default
-
   nativeBuildInputs = [ cargo-c ];
 
   postBuild = ''

--- a/pkgs/development/tools/rust/rust-analyzer/default.nix
+++ b/pkgs/development/tools/rust/rust-analyzer/default.nix
@@ -23,8 +23,6 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-TnMPQPXDXLGLJu5PvEMglPidrtxH89P9dj/YmWc5JiQ=";
   };
 
-  auditable = true; # TODO: remove when this is the default
-
   cargoBuildFlags = [ "--bin" "rust-analyzer" "--bin" "rust-analyzer-proc-macro-srv" ];
   cargoTestFlags = [ "--package" "rust-analyzer" "--package" "proc-macro-srv-cli" ];
 

--- a/pkgs/games/jumpy/default.nix
+++ b/pkgs/games/jumpy/default.nix
@@ -32,8 +32,6 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
-  auditable = true; # TODO: remove when this is the default
-
   nativeBuildInputs = [
     makeWrapper
   ] ++ lib.optionals stdenv.isLinux [

--- a/pkgs/tools/misc/fd/default.nix
+++ b/pkgs/tools/misc/fd/default.nix
@@ -13,8 +13,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-AstE8KGICgPhqRKlJecrE9iPUUWaOvca6ocWf85IzNo=";
 
-  auditable = true; # TODO: remove when this is the default
-
   nativeBuildInputs = [ installShellFiles ];
 
   # skip flaky test

--- a/pkgs/tools/text/mdbook/default.nix
+++ b/pkgs/tools/text/mdbook/default.nix
@@ -13,8 +13,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-TViBclvCJeoOInTt13B7297JDtRkwvOjIf6AVAbpanU=";
 
-  auditable = true; # TODO: remove when this is the default
-
   buildInputs = lib.optionals stdenv.isDarwin [ CoreServices ];
 
   passthru = {

--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -22,8 +22,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "1kfdgh8dra4jxgcdb0lln5wwrimz0dpp33bq3h7jgs8ngaq2a9wp";
 
-  auditable = true; # TODO: remove when this is the default
-
   nativeBuildInputs = [ asciidoctor installShellFiles ]
     ++ lib.optional withPCRE2 pkg-config;
   buildInputs = lib.optional withPCRE2 pcre2

--- a/pkgs/tools/video/rav1e/default.nix
+++ b/pkgs/tools/video/rav1e/default.nix
@@ -25,8 +25,6 @@ in rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-66mVkoqMl+KNCXWsGUbu8nBrazgHP+5dTaT2Ye0btWY=";
 
-  auditable = true; # TODO: remove when this is the default
-
   depsBuildBuild = [ pkg-config ];
 
   nativeBuildInputs = [ cargo-c libgit2 nasm ];


### PR DESCRIPTION
###### Description of changes

#200563

It has been a while since the initial implementation (#204686) was merged, and we haven't had any issues in the past 2 months.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
