### PR TITLE
rsonpath: init at 0.3.2

### DIFF
--- a/pkgs/development/tools/misc/rsonpath/default.nix
+++ b/pkgs/development/tools/misc/rsonpath/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, withSimd ? true
+, stdenv
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rsonpath";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "v0ldek";
+    repo = "rsonpath";
+    rev = "v${version}";
+    hash = "sha256-ip8+Wy9rmTzFccmjYWb3Nk+gkq3g4e1ty/5+ldIOO10=";
+  };
+
+  cargoHash = "sha256-5V0H2FeHI1SByzLsviOR+qHwYhZGiNmMawCTYjk2P24=";
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "default-optimizations"
+  ] ++ lib.optionals withSimd [
+    "simd"
+  ];
+
+  meta = with lib; {
+    description = "Blazing fast Rust JSONPath query engine";
+    homepage = "https://github.com/v0ldek/rsonpath";
+    changelog = "https://github.com/v0ldek/rsonpath/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ figsoda ];
+    # build fails on platforms without simd support, even when withSimd = false
+    broken = !stdenv.isx86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18731,6 +18731,8 @@ with pkgs;
 
   rsass = callPackage ../development/tools/misc/rsass { };
 
+  rsonpath = callPackage ../development/tools/misc/rsonpath { };
+
   rufo = callPackage ../development/tools/rufo { };
 
   samurai = callPackage ../development/tools/build-managers/samurai { };


### PR DESCRIPTION
###### Description of changes

https://github.com/v0ldek/rsonpath

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
