### PR TITLE
matrix-commander: 3.5.0 > 6.0.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
@@ -7,7 +7,6 @@
 , python-magic
 , markdown
 , pillow
-, urllib3
 , aiofiles
 , notify2
 , dbus-python
@@ -45,7 +44,6 @@ buildPythonApplication rec {
     python-magic
     markdown
     pillow
-    urllib3
     aiofiles
     notify2
     dbus-python

--- a/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
+++ b/pkgs/applications/networking/instant-messengers/matrix-commander/default.nix
@@ -17,13 +17,13 @@
 
 buildPythonApplication rec {
   pname = "matrix-commander";
-  version = "3.5.0";
+  version = "6.0.1";
 
   src = fetchFromGitHub {
     owner = "8go";
     repo = "matrix-commander";
     rev = "v${version}";
-    sha256 = "sha256-/hNTaajZTyeIcGILIXqUVbBvZ8AUNZKBDsZ4Gr5RL2o=";
+    sha256 = "sha256-NSoMGUQjy4TQXdzZcQfO2rUQDsuSzQnoGDpqFiLQHVQ=";
   };
 
   format = "pyproject";


### PR DESCRIPTION
###### Description of changes

https://github.com/8go/matrix-commander/releases/tag/v6.0.1

###### Things done

successfully built on x86-64:

<details>

    mcn@x270 ~/projects/nixpkgs (master) nix-build -A matrix-commander
    this derivation will be built:
      /nix/store/w955x0liah3xrr4gmnskdz6fglzb29nk-matrix-commander-6.0.1.drv
    these 20 paths will be fetched (2.50 MiB download, 13.13 MiB unpacked):
      /nix/store/1ix201j4l4cw6gn3gpxmf908zwkbnidd-pip-build-hook.sh
      /nix/store/1rgli2fs1j19zj6chqdzl2asgv9vswqh-python3.10-wheel-0.38.4
      /nix/store/514z6l6q63cnmr23gvw6xindcy3qs4p9-python3.10-trio-0.22.0
      /nix/store/56x81qaj0avb6q1d91friama6326r46z-python3.10-aiohttp-3.8.4
      /nix/store/5cnz3bzmd802nzn4478cg9cjgdxx6m2a-python3.10-typing-extensions-4.5.0
      /nix/store/5dlm0shjkznll1ddkgywjyhakincm10r-python3.10-python-socks-2.1.1
      /nix/store/7xj728vwxxfd345r4nfn3ndf75r0zmgl-python3.10-sortedcontainers-2.4.0
      /nix/store/8g01495bnm45gdzhk1b3dgl60ian9d7j-python3.10-aiohttp-socks-0.8.0
      /nix/store/frbipp0vfgd0q3kwv0ji79bkzv440zw5-python3.10-unpaddedbase64-2.1.0
      /nix/store/hllvha80g10zb6fiwcp0429kxwk0bzak-python3.10-matrix-nio-0.20.1
      /nix/store/ib8dhih7kbk15mgznsyy60ik2s2iy1rx-wrap-python-hook
      /nix/store/iqjm5nirl5sfy3vim2wsg9s2bspz87sj-python3.10-pyrsistent-0.19.3
      /nix/store/jdhykmja86ih19bwlrap4z3kabwv56gm-python3.10-async-timeout-4.0.2
      /nix/store/jl45bvbs1apwxizp61sjldcbw9a8rbzy-python3.10-six-1.16.0
      /nix/store/l26ry4dyi1jr92zdhvr6ja40i7siif9v-python3.10-jsonschema-4.17.3
      /nix/store/nbyd7aybqm8hd7pxma59dhmlxbq1nmvg-python3.10-sniffio-1.3.0
      /nix/store/qg3jn6cd12kphciq49grn38hk5fzgs0v-python3.10-setuptools-67.4.0
      /nix/store/r43p69krw1cn6p4x22ir3rfqbx7pbfq3-python-catch-conflicts-hook
      /nix/store/w39dcfyzz9hbgqnmmbkmbx1966aw533h-python3.10-yarl-1.8.2
      /nix/store/wiwnbh452vm73qcngbdfswm3wjy23w8y-python3.10-urllib3-1.26.14
    copying path '/nix/store/qg3jn6cd12kphciq49grn38hk5fzgs0v-python3.10-setuptools-67.4.0' from 'https://cache.nixos.org'...
    copying path '/nix/store/wiwnbh452vm73qcngbdfswm3wjy23w8y-python3.10-urllib3-1.26.14' from 'https://cache.nixos.org'...
    copying path '/nix/store/ib8dhih7kbk15mgznsyy60ik2s2iy1rx-wrap-python-hook' from 'https://cache.nixos.org'...
    copying path '/nix/store/frbipp0vfgd0q3kwv0ji79bkzv440zw5-python3.10-unpaddedbase64-2.1.0' from 'https://cache.nixos.org'...
    copying path '/nix/store/jl45bvbs1apwxizp61sjldcbw9a8rbzy-python3.10-six-1.16.0' from 'https://cache.nixos.org'...
    copying path '/nix/store/nbyd7aybqm8hd7pxma59dhmlxbq1nmvg-python3.10-sniffio-1.3.0' from 'https://cache.nixos.org'...
    copying path '/nix/store/7xj728vwxxfd345r4nfn3ndf75r0zmgl-python3.10-sortedcontainers-2.4.0' from 'https://cache.nixos.org'...
    copying path '/nix/store/5cnz3bzmd802nzn4478cg9cjgdxx6m2a-python3.10-typing-extensions-4.5.0' from 'https://cache.nixos.org'...
    copying path '/nix/store/1rgli2fs1j19zj6chqdzl2asgv9vswqh-python3.10-wheel-0.38.4' from 'https://cache.nixos.org'...
    copying path '/nix/store/iqjm5nirl5sfy3vim2wsg9s2bspz87sj-python3.10-pyrsistent-0.19.3' from 'https://cache.nixos.org'...
    copying path '/nix/store/514z6l6q63cnmr23gvw6xindcy3qs4p9-python3.10-trio-0.22.0' from 'https://cache.nixos.org'...
    copying path '/nix/store/jdhykmja86ih19bwlrap4z3kabwv56gm-python3.10-async-timeout-4.0.2' from 'https://cache.nixos.org'...
    copying path '/nix/store/1ix201j4l4cw6gn3gpxmf908zwkbnidd-pip-build-hook.sh' from 'https://cache.nixos.org'...
    copying path '/nix/store/w39dcfyzz9hbgqnmmbkmbx1966aw533h-python3.10-yarl-1.8.2' from 'https://cache.nixos.org'...
    copying path '/nix/store/l26ry4dyi1jr92zdhvr6ja40i7siif9v-python3.10-jsonschema-4.17.3' from 'https://cache.nixos.org'...
    copying path '/nix/store/56x81qaj0avb6q1d91friama6326r46z-python3.10-aiohttp-3.8.4' from 'https://cache.nixos.org'...
    copying path '/nix/store/r43p69krw1cn6p4x22ir3rfqbx7pbfq3-python-catch-conflicts-hook' from 'https://cache.nixos.org'...
    copying path '/nix/store/5dlm0shjkznll1ddkgywjyhakincm10r-python3.10-python-socks-2.1.1' from 'https://cache.nixos.org'...
    copying path '/nix/store/8g01495bnm45gdzhk1b3dgl60ian9d7j-python3.10-aiohttp-socks-0.8.0' from 'https://cache.nixos.org'...
    copying path '/nix/store/hllvha80g10zb6fiwcp0429kxwk0bzak-python3.10-matrix-nio-0.20.1' from 'https://cache.nixos.org'...
    building '/nix/store/w955x0liah3xrr4gmnskdz6fglzb29nk-matrix-commander-6.0.1.drv'...
    Sourcing python-remove-tests-dir-hook
    Sourcing python-catch-conflicts-hook.sh
    Sourcing python-remove-bin-bytecode-hook.sh
    Sourcing pip-build-hook
    Using pipBuildPhase
    Using pipShellHook
    Sourcing pip-install-hook
    Using pipInstallPhase
    Sourcing python-imports-check-hook.sh
    Using pythonImportsCheckPhase
    Sourcing python-namespaces-hook
    Sourcing python-catch-conflicts-hook.sh
    unpacking sources
    unpacking source archive /nix/store/i6b15sq3c2k585ac2qryl1kv4m9xidqp-source
    source root is source
    setting SOURCE_DATE_EPOCH to timestamp 315619200 of file source/tests/test.wav
    patching sources
    configuring
    no configure script, doing nothing
    building
    Executing pipBuildPhase
    Creating a wheel...
    WARNING: The directory '/homeless-shelter/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
    Processing /build/source
      Running command Preparing metadata (pyproject.toml)
      running dist_info
      creating /build/pip-modern-metadata-28ze14ob/matrix_commander.egg-info
      writing /build/pip-modern-metadata-28ze14ob/matrix_commander.egg-info/PKG-INFO
      writing dependency_links to /build/pip-modern-metadata-28ze14ob/matrix_commander.egg-info/dependency_links.txt
      writing entry points to /build/pip-modern-metadata-28ze14ob/matrix_commander.egg-info/entry_points.txt
      writing requirements to /build/pip-modern-metadata-28ze14ob/matrix_commander.egg-info/requires.txt
      writing top-level names to /build/pip-modern-metadata-28ze14ob/matrix_commander.egg-info/top_level.txt
      writing manifest file '/build/pip-modern-metadata-28ze14ob/matrix_commander.egg-info/SOURCES.txt'
      reading manifest file '/build/pip-modern-metadata-28ze14ob/matrix_commander.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      adding license file 'LICENSE'
      writing manifest file '/build/pip-modern-metadata-28ze14ob/matrix_commander.egg-info/SOURCES.txt'
      creating '/build/pip-modern-metadata-28ze14ob/matrix_commander-6.0.1.dist-info'
      Preparing metadata (pyproject.toml) ... done
    Building wheels for collected packages: matrix-commander
      Running command Building wheel for matrix-commander (pyproject.toml)
      running bdist_wheel
      running build
      running build_py
      creating build
      creating build/lib
      creating build/lib/matrix_commander
      copying matrix_commander/matrix_commander.py -> build/lib/matrix_commander
      copying matrix_commander/__init__.py -> build/lib/matrix_commander
      running egg_info
      creating matrix_commander.egg-info
      writing matrix_commander.egg-info/PKG-INFO
      writing dependency_links to matrix_commander.egg-info/dependency_links.txt
      writing entry points to matrix_commander.egg-info/entry_points.txt
      writing requirements to matrix_commander.egg-info/requires.txt
      writing top-level names to matrix_commander.egg-info/top_level.txt
      writing manifest file 'matrix_commander.egg-info/SOURCES.txt'
      reading manifest file 'matrix_commander.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      adding license file 'LICENSE'
      writing manifest file 'matrix_commander.egg-info/SOURCES.txt'
      copying matrix_commander/matrix-commander-tui -> build/lib/matrix_commander
      installing to build/bdist.linux-x86_64/wheel
      running install
      running install_lib
      creating build/bdist.linux-x86_64
      creating build/bdist.linux-x86_64/wheel
      creating build/bdist.linux-x86_64/wheel/matrix_commander
      copying build/lib/matrix_commander/matrix_commander.py -> build/bdist.linux-x86_64/wheel/matrix_commander
      copying build/lib/matrix_commander/__init__.py -> build/bdist.linux-x86_64/wheel/matrix_commander
      copying build/lib/matrix_commander/matrix-commander-tui -> build/bdist.linux-x86_64/wheel/matrix_commander
      running install_egg_info
      Copying matrix_commander.egg-info to build/bdist.linux-x86_64/wheel/matrix_commander-6.0.1-py3.10.egg-info
      running install_scripts
      creating build/bdist.linux-x86_64/wheel/matrix_commander-6.0.1.dist-info/WHEEL
      creating '/build/pip-wheel-tcxz_p7m/.tmp-fyg_343_/matrix_commander-6.0.1-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
      adding 'matrix_commander/__init__.py'
      adding 'matrix_commander/matrix-commander-tui'
      adding 'matrix_commander/matrix_commander.py'
      adding 'matrix_commander-6.0.1.dist-info/LICENSE'
      adding 'matrix_commander-6.0.1.dist-info/METADATA'
      adding 'matrix_commander-6.0.1.dist-info/WHEEL'
      adding 'matrix_commander-6.0.1.dist-info/entry_points.txt'
      adding 'matrix_commander-6.0.1.dist-info/top_level.txt'
      adding 'matrix_commander-6.0.1.dist-info/RECORD'
      removing build/bdist.linux-x86_64/wheel
      Building wheel for matrix-commander (pyproject.toml) ... done
      Created wheel for matrix-commander: filename=matrix_commander-6.0.1-py3-none-any.whl size=119878 sha256=0bbab6b19c8f17511b925102580242a29c316c65612a903de00c01ae037e2cff
      Stored in directory: /build/pip-ephem-wheel-cache-5t2ib4oo/wheels/79/4b/9b/fc24941d75fdb959a71ee80195b2c89d6ae9389f9f0f80fb22
    Successfully built matrix-commander
    Finished creating a wheel...
    Finished executing pipBuildPhase
    glibPreInstallPhase
    installing
    Executing pipInstallPhase
    /build/source/dist /build/source
    Processing ./matrix_commander-6.0.1-py3-none-any.whl
    Requirement already satisfied: aiohttp in /nix/store/56x81qaj0avb6q1d91friama6326r46z-python3.10-aiohttp-3.8.4/lib/python3.10/site-packages (from matrix-commander==6.0.1) (3.8.4)
    Requirement already satisfied: notify2 in /nix/store/w33qcn9dnywaplfnvrz2p19n5s7ghmvx-python3.10-notify2-0.3.1/lib/python3.10/site-packages (from matrix-commander==6.0.1) (0.3.1)
    Requirement already satisfied: pyxdg in /nix/store/zbwz3j13r3n84p17mvjiyq2kyfiiv5c6-python3.10-pyxdg-0.28/lib/python3.10/site-packages (from matrix-commander==6.0.1) (0.28)
    Requirement already satisfied: matrix-nio[e2e]>=0.14.1 in /nix/store/hllvha80g10zb6fiwcp0429kxwk0bzak-python3.10-matrix-nio-0.20.1/lib/python3.10/site-packages (from matrix-commander==6.0.1) (0.20.1)
    Requirement already satisfied: Pillow in /nix/store/l9lywfcg3k98c3jg1hhlgsw1j3sq0113-python3.10-pillow-9.4.0/lib/python3.10/site-packages (from matrix-commander==6.0.1) (9.4.0)
    Requirement already satisfied: python-magic in /nix/store/jdzkz15l7dhrzicxwvprli8nid1v7479-python3.10-python-magic-0.4.27/lib/python3.10/site-packages (from matrix-commander==6.0.1) (0.4.27)
    Requirement already satisfied: markdown in /nix/store/jna2jfgff3r9gh0kk01p254rzhps55ir-python3.10-markdown-3.4.1/lib/python3.10/site-packages (from matrix-commander==6.0.1) (3.4.1)
    Requirement already satisfied: aiofiles>=0.6.0 in /nix/store/ws293ym08bpmig6kz54hzgwby5lzi6rs-python3.10-aiofiles-22.1.0/lib/python3.10/site-packages (from matrix-commander==6.0.1) (22.1.0)
    Requirement already satisfied: h11 in /nix/store/rfps6b4md5kl66gqbxjmgn69ndfaanp6-python3.10-h11-0.14.0/lib/python3.10/site-packages (from matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (0.14.0)
    Requirement already satisfied: jsonschema<5.0.0,>=4.4.0 in /nix/store/l26ry4dyi1jr92zdhvr6ja40i7siif9v-python3.10-jsonschema-4.17.3/lib/python3.10/site-packages (from matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (4.17.3)
    Requirement already satisfied: logbook<2.0.0,>=1.5.3 in /nix/store/krf2848m5nfqn5ajdfvzpxp4wdlswzg5-python3.10-logbook-1.5.3/lib/python3.10/site-packages (from matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (1.5.3)
    Requirement already satisfied: unpaddedbase64<3.0.0,>=2.1.0 in /nix/store/frbipp0vfgd0q3kwv0ji79bkzv440zw5-python3.10-unpaddedbase64-2.1.0/lib/python3.10/site-packages (from matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (2.1.0)
    Requirement already satisfied: aiohttp-socks in /nix/store/8g01495bnm45gdzhk1b3dgl60ian9d7j-python3.10-aiohttp-socks-0.8.0/lib/python3.10/site-packages (from matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (0.8.0)
    Requirement already satisfied: h2<5.0.0,>=4.0.0 in /nix/store/mzhi2zpmd8ra76mrd3l39yjb30qdc5vc-python3.10-h2-4.1.0/lib/python3.10/site-packages (from matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (4.1.0)
    Requirement already satisfied: pycryptodome<4.0.0,>=3.10.1 in /nix/store/7wf6wakm8v03k9hicfir8lni793mzfgq-python3.10-pycryptodome-3.17.0/lib/python3.10/site-packages (from matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (3.17)
    Requirement already satisfied: future<0.19.0,>=0.18.2 in /nix/store/54mq3fqbf6rpcrm2bgdin1rfdm2v8g08-python3.10-future-0.18.3/lib/python3.10/site-packages (from matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (0.18.3)
    Requirement already satisfied: cachetools in /nix/store/mjl93g0s7f9mlk8hbp40ip21465mwiq0-python3.10-cachetools-5.3.0/lib/python3.10/site-packages (from matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (5.3.0)
    Requirement already satisfied: peewee<4.0.0,>=3.14.4 in /nix/store/08223a92yfvn03ay47x5hxmi5flhfiqa-python3.10-peewee-3.15.4/lib/python3.10/site-packages (from matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (3.15.4)
    Requirement already satisfied: python-olm<4.0.0,>=3.1.3 in /nix/store/zjs13gr7qadbcixx13q45r6ipy3zyzz0-python3.10-python-olm-3.2.14/lib/python3.10/site-packages (from matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (3.2.14)
    Requirement already satisfied: atomicwrites<2.0.0,>=1.4.0 in /nix/store/f5dl4xybz4pzm2kg2ch8dx4jlfs0b40s-python3.10-atomicwrites-1.4.1/lib/python3.10/site-packages (from matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (1.4.1)
    Requirement already satisfied: multidict<7.0,>=4.5 in /nix/store/70a31iv7nwbnrw8cmxlrgzqn20k8sbld-python3.10-multidict-6.0.4/lib/python3.10/site-packages (from aiohttp->matrix-commander==6.0.1) (6.0.4)
    Requirement already satisfied: frozenlist>=1.1.1 in /nix/store/rqfpx3p554srf0myb51ab2g4981z5inr-python3.10-frozenlist-1.3.3/lib/python3.10/site-packages (from aiohttp->matrix-commander==6.0.1) (1.3.3)
    Requirement already satisfied: async-timeout<5.0,>=4.0.0a3 in /nix/store/jdhykmja86ih19bwlrap4z3kabwv56gm-python3.10-async-timeout-4.0.2/lib/python3.10/site-packages (from aiohttp->matrix-commander==6.0.1) (4.0.2)
    Requirement already satisfied: aiosignal>=1.1.2 in /nix/store/992s5a9nc5n23gi8l84s3gjyi25nnn3z-python3.10-aiosignal-1.3.1/lib/python3.10/site-packages (from aiohttp->matrix-commander==6.0.1) (1.3.1)
    Requirement already satisfied: attrs>=17.3.0 in /nix/store/hmj9b0q59f68hndi8g6553x8hx8man85-python3.10-attrs-22.2.0/lib/python3.10/site-packages (from aiohttp->matrix-commander==6.0.1) (22.2.0)
    Requirement already satisfied: yarl<2.0,>=1.0 in /nix/store/w39dcfyzz9hbgqnmmbkmbx1966aw533h-python3.10-yarl-1.8.2/lib/python3.10/site-packages (from aiohttp->matrix-commander==6.0.1) (1.8.2)
    Requirement already satisfied: charset-normalizer<4.0,>=2.0 in /nix/store/3m22imm3lcrg809s02yin0wyf3cqj9sz-python3.10-charset-normalizer-3.0.1/lib/python3.10/site-packages (from aiohttp->matrix-commander==6.0.1) (3.0.1)
    Requirement already satisfied: hpack<5,>=4.0 in /nix/store/8myg6ibansrj7baf99j4pkbn85xjighj-python3.10-hpack-4.0.0/lib/python3.10/site-packages (from h2<5.0.0,>=4.0.0->matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (4.0.0)
    Requirement already satisfied: hyperframe<7,>=6.0 in /nix/store/65y67985616f7yvkkzsgshqfb4ikwx8s-python3.10-hyperframe-6.0.1/lib/python3.10/site-packages (from h2<5.0.0,>=4.0.0->matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (6.0.1)
    Requirement already satisfied: pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 in /nix/store/iqjm5nirl5sfy3vim2wsg9s2bspz87sj-python3.10-pyrsistent-0.19.3/lib/python3.10/site-packages (from jsonschema<5.0.0,>=4.4.0->matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (0.19.3)
    Requirement already satisfied: cffi>=1.0.0 in /nix/store/788wr3gznqs4azav9qd6r32670nnmni2-python3.10-cffi-1.15.1/lib/python3.10/site-packages (from python-olm<4.0.0,>=3.1.3->matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (1.15.1)
    Requirement already satisfied: idna>=2.0 in /nix/store/i6hl8zl3yb2v2h1xvqsjrzzd9k4gyh7q-python3.10-idna-3.4/lib/python3.10/site-packages (from yarl<2.0,>=1.0->aiohttp->matrix-commander==6.0.1) (3.4)
    Requirement already satisfied: python-socks[asyncio]<3.0.0,>=2.0.0 in /nix/store/5dlm0shjkznll1ddkgywjyhakincm10r-python3.10-python-socks-2.1.1/lib/python3.10/site-packages (from aiohttp-socks->matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (2.1.1)
    Requirement already satisfied: pycparser in /nix/store/9dpi99bcwc5sz7flfxmmhkva1b131wqb-python3.10-pycparser-2.21/lib/python3.10/site-packages (from cffi>=1.0.0->python-olm<4.0.0,>=3.1.3->matrix-nio[e2e]>=0.14.1->matrix-commander==6.0.1) (2.21)
    Installing collected packages: matrix-commander
    Successfully installed matrix-commander-6.0.1
    /build/source
    Finished executing pipInstallPhase
    pythonOutputDistPhase
    Executing pythonOutputDistPhase
    Finished executing pythonOutputDistPhase
    glibPreFixupPhase
    post-installation fixup
    shrinking RPATHs of ELF executables and libraries in /nix/store/jx357d4pmp3rc8inafi1v6r7kanyi0xa-matrix-commander-6.0.1
    checking for references to /build/ in /nix/store/jx357d4pmp3rc8inafi1v6r7kanyi0xa-matrix-commander-6.0.1...
    patching script interpreter paths in /nix/store/jx357d4pmp3rc8inafi1v6r7kanyi0xa-matrix-commander-6.0.1
    stripping (with command strip and flags -S) in  /nix/store/jx357d4pmp3rc8inafi1v6r7kanyi0xa-matrix-commander-6.0.1/lib /nix/store/jx357d4pmp3rc8inafi1v6r7kanyi0xa-matrix-commander-6.0.1/bin
    shrinking RPATHs of ELF executables and libraries in /nix/store/i5vfn1qyhvd7wsd1wxq2ifbykcv14h34-matrix-commander-6.0.1-dist
    checking for references to /build/ in /nix/store/i5vfn1qyhvd7wsd1wxq2ifbykcv14h34-matrix-commander-6.0.1-dist...
    patching script interpreter paths in /nix/store/i5vfn1qyhvd7wsd1wxq2ifbykcv14h34-matrix-commander-6.0.1-dist
    Rewriting #!/nix/store/syz2y6j53y5hpzbs7l0965zwxshi8iyl-python3-3.10.10/bin/python3.10 to #!/nix/store/syz2y6j53y5hpzbs7l0965zwxshi8iyl-python3-3.10.10
    wrapping `/nix/store/jx357d4pmp3rc8inafi1v6r7kanyi0xa-matrix-commander-6.0.1/bin/matrix-commander'...
    Executing pythonRemoveTestsDir
    Finished executing pythonRemoveTestsDir
    running install tests
    no Makefile or custom installCheckPhase, doing nothing
    pythonCatchConflictsPhase
    pythonRemoveBinBytecodePhase
    pythonImportsCheckPhase
    Executing pythonImportsCheckPhase
    /nix/store/jx357d4pmp3rc8inafi1v6r7kanyi0xa-matrix-commander-6.0.1

</details>
    
sent a message to @SuperSandro2000 

    mcn@x270 ~ /nix/store/jx357d4pmp3rc8inafi1v6r7kanyi0xa-matrix-commander-6.0.1/bin/matrix-commander --room '!XXXXXXXXXXXX:xxxx.xxx' -m 'test mit matrix-commander v6.0.1 :thumbsup:'
    2023-03-27 13:19:40,841:     INFO: matrix-commander: This message was sent: "test mit matrix-commander v6.0.1 :thumbsup:" to room "!XXXXXXXXXXXX:xxxx.xxx" as event "$L5S7FvWTUg_eYrT3Mqs-zFTlfiIG-3gJh6m7gDg48tw".

