### PR TITLE
unifi-protect-backup: 0.8.8 -> 0.9.0

### DIFF
--- a/pkgs/applications/backup/unifi-protect-backup/default.nix
+++ b/pkgs/applications/backup/unifi-protect-backup/default.nix
@@ -5,7 +5,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "unifi-protect-backup";
-  version = "0.8.8";
+  version = "0.9.0";
 
   format = "pyproject";
 
@@ -13,7 +13,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "ep1cman";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-Z8qK7LprMyXl5irx9Xrs/RgqvNcFVBqLBSljovr6oiE=";
+    hash = "sha256-yPYzFZ4eI1wvBZgSP4Z90zyS+0vrDtf0uRz60byE5XA=";
   };
 
   pythonRelaxDeps = [
@@ -21,10 +21,6 @@ python3.pkgs.buildPythonApplication rec {
     "aiosqlite"
     "click"
     "pyunifiprotect"
-  ];
-
-  pythonRemoveDeps = [
-    "pylint"
   ];
 
   nativeBuildInputs = with python3.pkgs; [
@@ -36,7 +32,10 @@ python3.pkgs.buildPythonApplication rec {
     aiocron
     aiorun
     aiosqlite
+    apprise
     click
+    expiring-dict
+    python-dateutil
     pyunifiprotect
   ];
 

--- a/pkgs/development/python-modules/expiring-dict/default.nix
+++ b/pkgs/development/python-modules/expiring-dict/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, sortedcontainers
+}:
+
+buildPythonPackage rec {
+  pname = "expiring-dict";
+  version = "1.1.0";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-PEBK2x5DaUaMt+Ub+8nEcNfi6GPv4qHHXU7XBtDc4aY=";
+  };
+
+  propagatedBuildInputs = [
+    sortedcontainers
+  ];
+
+  pythonImportsCheck = [
+    "expiring_dict"
+  ];
+
+  meta = with lib; {
+    description = "Python dict with TTL support for auto-expiring caches";
+    homepage = "https://github.com/dparker2/py-expiring-dict";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ajs124 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3235,6 +3235,8 @@ self: super: with self; {
 
   expecttest = callPackage ../development/python-modules/expecttest { };
 
+  expiring-dict = callPackage ../development/python-modules/expiring-dict { };
+
   expiringdict = callPackage ../development/python-modules/expiringdict { };
 
   explorerscript = callPackage ../development/python-modules/explorerscript { };


### PR DESCRIPTION
###### Description of changes

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).