### PR TITLE
ocamlPackages.pcap-format: 0.5.2 → 0.6.0

### DIFF
--- a/pkgs/development/ocaml-modules/pcap-format/default.nix
+++ b/pkgs/development/ocaml-modules/pcap-format/default.nix
@@ -1,36 +1,32 @@
 { lib, buildDunePackage, fetchurl
-, ppx_cstruct, ppx_tools
-, cstruct, ounit, mmap, stdlib-shims
+, ppx_cstruct
+, cstruct
+, ounit
 }:
 
 buildDunePackage rec {
   pname = "pcap-format";
-  version = "0.5.2";
+  version = "0.6.0";
 
-  minimumOCamlVersion = "4.03";
-
-  # due to cstruct
-  useDune2 = true;
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-pcap/releases/download/${version}/${pname}-${version}.tbz";
-    sha256 = "14c5rpgglyz41jic0fg0xa22d2w1syb86kva22y9fi7aqj9vm31f";
+    url = "https://github.com/mirage/ocaml-pcap/releases/download/v${version}/${pname}-${version}.tbz";
+    hash = "sha256-LUjy8Xm6VsnMq1FHKzmJg7uorkTv7cOTsoLwmtNHkaY=";
   };
 
   buildInputs = [
-    ppx_tools
     ppx_cstruct
   ];
 
   propagatedBuildInputs = [
     cstruct
-    stdlib-shims
   ];
 
   doCheck = true;
   checkInputs = [
     ounit
-    mmap
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

https://github.com/mirage/ocaml-pcap/blob/v0.6.0/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
